### PR TITLE
feat(CC-0027): Wire extra-packages.yaml as Docker build source of truth

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -129,6 +129,31 @@ jobs:
           MATRIX_RELEASE: ${{ matrix.release }}
         run: scripts/apply-constraint-overrides.sh "$MATRIX_RELEASE"
 
+      - name: Resolve extra packages
+        id: extra-pkgs
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+          MATRIX_RELEASE: ${{ matrix.release }}
+        run: |
+          EXTRAS_FILE="releases/${MATRIX_RELEASE}/extra-packages.yaml"
+          if [ ! -f "$EXTRAS_FILE" ]; then
+            echo "::error::Missing ${EXTRAS_FILE}. Each release directory must contain an extra-packages.yaml file (see docs/reference/build-images-workflow.md#adding-a-new-release)."
+            exit 1
+          fi
+
+          pip_extras=$(yq -r ".\"${MATRIX_SERVICE}\".pip_extras // [] | join(\",\")" "$EXTRAS_FILE")
+          echo "pip-extras=${pip_extras}" >> "$GITHUB_OUTPUT"
+
+          pip_packages=$(yq -r ".\"${MATRIX_SERVICE}\".pip_packages // [] | join(\" \")" "$EXTRAS_FILE")
+          echo "pip-packages=${pip_packages}" >> "$GITHUB_OUTPUT"
+
+          apt_packages=$(yq -r ".\"${MATRIX_SERVICE}\".apt_packages // [] | join(\" \")" "$EXTRAS_FILE")
+          echo "apt-packages=${apt_packages}" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved pip extras: ${pip_extras}"
+          echo "Resolved pip packages: ${pip_packages}"
+          echo "Resolved apt packages: ${apt_packages}"
+
       - name: Derive tags
         id: tags
         env:
@@ -170,6 +195,10 @@ jobs:
         with:
           context: images/${{ matrix.service }}
           file: images/${{ matrix.service }}/Dockerfile
+          build-args: |
+            PIP_EXTRAS=${{ steps.extra-pkgs.outputs.pip-extras }}
+            PIP_PACKAGES=${{ steps.extra-pkgs.outputs.pip-packages }}
+            EXTRA_APT_PACKAGES=${{ steps.extra-pkgs.outputs.apt-packages }}
           build-contexts: |
             python-base=docker-image://${{ needs.build-base-images.outputs.python-base-image }}
             venv-builder=docker-image://${{ needs.build-base-images.outputs.venv-builder-image }}

--- a/.planwerk/completed/CC-0027-wire-extra-packages-yaml-as-docker-build-source.json
+++ b/.planwerk/completed/CC-0027-wire-extra-packages-yaml-as-docker-build-source.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0027",
   "title": "Wire extra-packages.yaml as Docker build source of truth",
   "slug": "wire-extra-packages-yaml-as-docker-build-source",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 📦 medium\n**Category:** infrastructure\n**Priority:** high\n**Source:** Proposed for 'There is releases/2025.2/extra-packages.yaml. JEdoc'\n\nRestructure releases/2025.2/extra-packages.yaml into pip_extras (bare extras: ldap, memcache_pool, oauth1), pip_packages (standalone packages, initially empty), and apt_packages (runtime: libapache2-mod-wsgi-py3, libldap2, libsasl2-2, libxml2) — fixing the incorrect libldap-2.5-0 to libldap2. Add a 'Resolve extra packages' step in .github/workflows/build-images.yaml (build-service-images job, after the existing 'Resolve source ref' step) that uses yq to extract all three fields per service from extra-packages.yaml and writes them to $GITHUB_OUTPUT. Pass these as --build-arg PIP_EXTRAS, PIP_PACKAGES, and EXTRA_APT_PACKAGES to docker/build-push-action. In images/keystone/Dockerfile, declare the three ARGs and replace the hardcoded [ldap,memcache_pool,oauth1] with [${PIP_EXTRAS}], add ${PIP_PACKAGES} to uv pip install, and replace the hardcoded apt package list with ${EXTRA_APT_PACKAGES}. Update tests/container-images/verify_release_config.sh: remove the now-obsolete test_extra_packages_match_dockerfile function and update test_extra_packages_valid_yaml_structure to validate the new field names (pip_extras, pip_packages, apt_packages), non-empty pip_extras and apt_packages, and valid package name patterns.\n\n**Rationale:** extra-packages.yaml exists but is completely ignored by the build pipeline — packages are independently hardcoded in the Dockerfile, creating silent drift risk and a false sense of configuration. The file also contains libldap-2.5-0 which does not exist as an Ubuntu Noble package (correct name: libldap2). Making the YAML the single source of truth eliminates duplication, prevents drift, and ensures release-specific package declarations actually reach the built images.\n\n**Affected Areas:**\n- releases/2025.2/extra-packages.yaml\n- .github/workflows/build-images.yaml\n- images/keystone/Dockerfile\n- tests/container-images/verify_release_config.sh",
   "stories": [
@@ -339,6 +339,7 @@
       "title": "Restructure releases/2025.2/extra-packages.yaml: rename pip_packages to pip_extras with bare names (ldap, memcache_pool, oauth1), add empty pip_packages list, fix libldap-2.5-0 to libldap2, replace WARNING comment with single-source-of-truth header (REQ-001, REQ-002)",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-002"
@@ -349,6 +350,7 @@
       "title": "Update images/keystone/Dockerfile: declare ARG PIP_EXTRAS and ARG PIP_PACKAGES in build stage, ARG EXTRA_APT_PACKAGES in runtime stage; replace hardcoded [ldap,memcache_pool,oauth1] with [${PIP_EXTRAS}], add ${PIP_PACKAGES} to uv pip install, replace hardcoded apt package list with ${EXTRA_APT_PACKAGES} (REQ-006)",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-006"
       ]
@@ -358,6 +360,7 @@
       "title": "Add 'Resolve extra packages' step in .github/workflows/build-images.yaml build-service-images job after 'Resolve source ref': use yq to extract pip_extras (join with comma), pip_packages (join with space), apt_packages (join with space) from extra-packages.yaml, write to $GITHUB_OUTPUT with null/empty checks and ::error:: messages (REQ-003, REQ-004)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-003",
         "REQ-004"
@@ -368,6 +371,7 @@
       "title": "Add build-args (PIP_EXTRAS, PIP_PACKAGES, EXTRA_APT_PACKAGES) to the docker/build-push-action step in build-service-images job, referencing steps.extra-packages.outputs (REQ-005)",
       "level": 2,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-005"
       ]
@@ -377,6 +381,7 @@
       "title": "Update test_extra_packages_valid_yaml_structure in tests/container-images/verify_release_config.sh: validate new field names (pip_extras, pip_packages, apt_packages), assert pip_extras count >= 1 and apt_packages count >= 1, add pattern validation for pip_extras entries (^[a-z][a-z0-9_]*$) and apt_packages entries (^[a-z0-9][a-z0-9.+-]+$) (REQ-007)",
       "level": 3,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-007"
       ]
@@ -386,6 +391,7 @@
       "title": "Remove test_extra_packages_match_dockerfile function and its invocation from tests/container-images/verify_release_config.sh (REQ-008)",
       "level": 3,
       "estimate_minutes": 5,
+      "status": "done",
       "requirements": [
         "REQ-008"
       ]
@@ -395,6 +401,7 @@
       "title": "Update docs/reference/container-images.md: replace extra-packages.yaml section with new pip_extras/pip_packages/apt_packages schema, update example YAML, fix libldap-2.5-0 to libldap2, update keystone Dockerfile example to show ARG-based usage, update field description table (REQ-009)",
       "level": 4,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-009"
       ]
@@ -404,6 +411,7 @@
       "title": "Update docs/reference/build-images-workflow.md: add 'Resolve extra packages' step to build-service-images steps table (step 3, after 'Resolve source ref'), document build-args (PIP_EXTRAS, PIP_PACKAGES, EXTRA_APT_PACKAGES) in the Build Contexts or a new Build Arguments section, update step numbering (REQ-009)",
       "level": 4,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-009"
       ]
@@ -541,8 +549,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-06T23:39:04.806563"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-06T23:39:57.345236"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-07T15:50:44.049368"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/36",
+  "pr_number": 36,
   "execution_history": [
     {
       "run_id": "2642738a-9c61-4d73-b8d0-535a126e29ce",
@@ -554,6 +572,126 @@
           "name": "prepare",
           "duration": 296.6680018901825,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "92ebab3e-da82-4486-92fc-ef69f9baaa80",
+      "timestamp": "2026-03-07T00:06:18.630550",
+      "total_duration": 1398.1663632392883,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (2 tasks)",
+          "duration": 368.2564272880554,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (2 tasks)",
+          "duration": 141.83717679977417,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (2 tasks)",
+          "duration": 184.23026847839355,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 4 (2 tasks)",
+          "duration": 215.36779642105103,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0027] Code Review",
+          "duration": 183.25488352775574,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0027] Improvements",
+          "duration": 232.2460331916809,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0027] Simplify",
+          "duration": 72.97377753257751,
+          "type": "simplify",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "babf90ac-4409-4a0b-90a1-b06d1b51e24d",
+      "timestamp": "2026-03-07T00:21:22.513460",
+      "total_duration": 425.72520685195923,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #1",
+          "duration": 425.72520685195923,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "c4e0b160-8e91-4a94-859d-23d1dcce71ee",
+      "timestamp": "2026-03-07T07:31:35.376279",
+      "total_duration": 245.68145322799683,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #2",
+          "duration": 245.68145322799683,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "a04fa2ae-95ce-4b6f-93e4-82fbcd3e95a8",
+      "timestamp": "2026-03-07T08:11:00.597109",
+      "total_duration": 430.81388330459595,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #3",
+          "duration": 430.81388330459595,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "98b0578d-bfd6-494b-a8b4-9e03edb8e3d4",
+      "timestamp": "2026-03-07T08:41:30.864284",
+      "total_duration": 202.80851030349731,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #4",
+          "duration": 202.80851030349731,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "277c083a-d113-4ff6-b920-5f9b7a59ad4c",
+      "timestamp": "2026-03-07T09:34:46.845442",
+      "total_duration": 194.55548310279846,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #5",
+          "duration": 194.55548310279846,
+          "type": "review_address",
           "status": "done"
         }
       ]

--- a/.planwerk/review_patterns/co-locate-local-path-with-extras-in-install-commands.md
+++ b/.planwerk/review_patterns/co-locate-local-path-with-extras-in-install-commands.md
@@ -18,4 +18,4 @@ Separate arguments create ambiguity: if the local source is missing or version-m
 ### CC-0006 — greptile-apps[bot]
 - **Feedback**: `/tmp/keystone` (local source) and `"keystone[ldap]"` etc. (PyPI references with extras) are passed as separate, independent arguments to `uv pip install`... The single-argument form leaves no room for ambiguity: uv cannot inadvertently resolve `keystone[ldap]` from PyPI if the local source is unexpectedly absent.
 - **What was missed**: When installing a local package with extras, verify the extras are specified on the local path argument itself (e.g., '/path/to/pkg[extra1,extra2]') rather than as separate PyPI-style references alongside the path.
-- **Fix**: Combined the local path and all extras into a single argument: `"/tmp/keystone[ldap,memcache_pool,oauth1]"`.
+- **Fix**: Combined the local path and all extras into a single argument: `"/tmp/keystone[ldap,oauth1]"`.

--- a/.planwerk/review_patterns/cross-check-all-instances-of-a-claimed-fix-across-files.md
+++ b/.planwerk/review_patterns/cross-check-all-instances-of-a-claimed-fix-across-files.md
@@ -1,0 +1,21 @@
+# Review Pattern: Cross-check all instances of a claimed fix across files
+
+**Review-Area**: validation
+**Detection-Hint**: When a PR description claims to fix or rename a value, search the entire diff for every occurrence of both the old and new value. Confirm the source-of-truth file was updated, not just downstream consumers or documentation.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+Grep the repo for the old value (e.g., `libldap-2.5-0`). If it still appears in the canonical data file while docs and Dockerfiles show the corrected value, the source-of-truth was missed. Similarly, if docs define a schema field (e.g., `pip_packages: []`), verify the actual data file includes it.
+
+## Why it matters
+
+Fixing a value in docs and downstream files but not in the source-of-truth YAML means the fix is cosmetic. Once the parameterization is properly wired, the build will fail on the stale incorrect value from the unfixed source file.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: The `docs/reference/container-images.md` diff correctly shows the fix, and the Dockerfile's hardcoded list already uses `libldap2`, but the actual source-of-truth YAML file was never updated. Once `EXTRA_APT_PACKAGES` is properly wired into the Dockerfile, this stale entry will cause `apt-get install` to fail at build time.
+- **What was missed**: Grep the repo for the old value (e.g., `libldap-2.5-0`). If it still appears in the canonical data file while docs and Dockerfiles show the corrected value, the source-of-truth was missed. Similarly, if docs define a schema field (e.g., `pip_packages: []`), verify the actual data file includes it.
+- **Fix**: Changed `libldap-2.5-0` to `libldap2` in `releases/2025.2/extra-packages.yaml` and added the missing `pip_packages: []` field to match the documented schema.

--- a/.planwerk/review_patterns/cross-reference-documentation-examples-against-implementation.md
+++ b/.planwerk/review_patterns/cross-reference-documentation-examples-against-implementation.md
@@ -18,4 +18,4 @@ Stale documentation examples mislead developers who follow the docs instead of r
 ### CC-0006 — greptile-apps[bot]
 - **Feedback**: The code example here shows the old install pattern — `/tmp/keystone` as a separate positional argument followed by three distinct `"keystone[extra]"` strings. However, the actual `images/keystone/Dockerfile` (line 16) was updated to use the combined PEP 508 form. This documentation example should be updated to match the implementation.
 - **What was missed**: When implementation files (Dockerfiles, scripts, configs) are changed, verify that any documentation code snippets depicting those files are updated to match the new implementation.
-- **Fix**: Updated the documentation code snippet from the old multi-argument pip install pattern to the combined PEP 508 form `"/tmp/keystone[ldap,memcache_pool,oauth1]"` matching the actual Dockerfile.
+- **Fix**: Updated the documentation code snippet from the old multi-argument pip install pattern to the combined PEP 508 form `"/tmp/keystone[ldap,oauth1]"` matching the actual Dockerfile.

--- a/.planwerk/review_patterns/enforce-consistent-error-handling-pattern-across-all-test-cases.md
+++ b/.planwerk/review_patterns/enforce-consistent-error-handling-pattern-across-all-test-cases.md
@@ -3,7 +3,7 @@
 **Review-Area**: testing
 **Detection-Hint**: When a file already uses a defensive pattern (e.g., capturing exit codes with `|| exit_code=$?`) in some test cases, scan ALL other test cases in the same file for the same invocation pattern without the guard.
 **Severity**: BLOCKING
-**Occurrences**: 1
+**Occurrences**: 2
 
 ## What to check
 
@@ -19,3 +19,8 @@ Silent test abortion means CI reports a failure with zero diagnostic output. Dev
 - **Feedback**: Tests 2, 3, 4, 5, and 7 invoke the script-under-test without `|| exit_code=$?` ... Under `set -euo pipefail`, if the script exits non-zero ... the test script aborts immediately — before any `assert_file_contains` / `assert_file_not_contains` calls run, and before the `=== Results ===` summary is ever printed.
 - **What was missed**: Under `set -euo pipefail`, any command expected to succeed but invoked without exit-code capture will abort the entire test script on unexpected failure — skipping all assertions and the results summary. Check that every invocation of the script-under-test uses the same idiom consistently.
 - **Fix**: All test cases were updated to use `local exit_code=0; (cd "$workdir" && bash "$SCRIPT_UNDER_TEST" "2025.2") || exit_code=$?; assert_eq "script exits 0" "0" "$exit_code"`, matching the pattern already present in Tests 1 and 6.
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: The new test confirms that the Dockerfile declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES`, and that the CI workflow references `extra-packages.yaml`. However, it has no check for `ARG EXTRA_APT_PACKAGES` in Stage 2 of the Dockerfile. Had this check existed, it would have caught that the apt-packages half of the wiring is missing.
+- **What was missed**: List all build args or config keys the PR introduces. For each one, verify the test suite includes an assertion that the arg is declared and used. If the test checks 2 of 3 args, the unchecked arg is the one most likely to be broken.
+- **Fix**: Added an `ARG EXTRA_APT_PACKAGES` grep check to `test_extra_packages_build_wiring` and a new `test_no_hardcoded_apt_packages` test to verify the runtime stage uses the build arg instead of hardcoded values.

--- a/.planwerk/review_patterns/flag-inconsistent-empty-value-handling-across-pipeline-stages.md
+++ b/.planwerk/review_patterns/flag-inconsistent-empty-value-handling-across-pipeline-stages.md
@@ -1,0 +1,21 @@
+# Review Pattern: Flag inconsistent empty-value handling across pipeline stages
+
+**Review-Area**: validation
+**Detection-Hint**: When a CI/workflow step validates inputs that are passed to a downstream consumer (e.g., Dockerfile), compare how each stage handles empty or missing values. If the downstream already has conditional guards for empty inputs (e.g., `[ -n "$VAR" ] && ... || true`), the upstream should not hard-fail on empty values. Also look for inconsistency within the same step: if one field (pip_packages) tolerates empty while a sibling field (pip_extras) hard-fails, that asymmetry needs justification.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+Compare validation strictness between the CI resolution step and the Dockerfile (or any downstream consumer). Check whether all sibling fields in the same config block are validated with the same policy. If one allows empty and another doesn't, ask why.
+
+## Why it matters
+
+Over-strict validation at the CI level blocks legitimate future configurations (e.g., a service with no Python extras) and forces workarounds like inventing fake values. It creates a hidden coupling where adding a new service requires modifying the workflow, not just the config file.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: The step hard-fails with `::error::` if `pip_extras` resolves to an empty string. This means any future service that genuinely has no Python extras cannot be added to the matrix without either inventing a fake extra or modifying this workflow. The same concern applies to the `apt_packages` guard. For `pip_packages` the step correctly treats an empty list as valid (no error). The same permissive treatment should apply to `pip_extras` and `apt_packages`.
+- **What was missed**: Compare validation strictness between the CI resolution step and the Dockerfile (or any downstream consumer). Check whether all sibling fields in the same config block are validated with the same policy. If one allows empty and another doesn't, ask why.
+- **Fix**: Removed the mandatory non-empty guards (`::error::` + `exit 1`) for both `pip_extras` and `apt_packages`, letting empty values flow through to the Dockerfile which already handles them via conditional guards.

--- a/.planwerk/review_patterns/guard-shell-commands-against-empty-variable-expansion.md
+++ b/.planwerk/review_patterns/guard-shell-commands-against-empty-variable-expansion.md
@@ -1,0 +1,21 @@
+# Review Pattern: Guard shell commands against empty variable expansion
+
+**Review-Area**: error-handling
+**Detection-Hint**: When reviewing Dockerfiles or shell scripts, check every ARG/ENV with a default of empty string. Trace how it is used: if it becomes a positional argument to a command (apt-get install, pip install, etc.), verify the command handles zero arguments gracefully. If not, require a conditional guard.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+Any RUN instruction that passes a build ARG or ENV variable as arguments to a package manager (apt-get, pip, npm, etc.) must be wrapped in a conditional `if [ -n "$VAR" ]` when the variable can legitimately be empty. Check the ARG default value and whether all callers (CI and local builds) are guaranteed to provide a non-empty value.
+
+## Why it matters
+
+CI may always supply the value, but local developer builds following documented instructions can omit the build-arg, producing a cryptic failure (`E: No packages specified`) instead of a clean no-op. This wastes developer time debugging a Dockerfile issue that has nothing to do with their actual work.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: `apt-get install` fails with default empty `EXTRA_APT_PACKAGES` — a developer following the local build instructions who omits `--build-arg EXTRA_APT_PACKAGES=...` gets a confusing failure. A conditional guard would make this more resilient.
+- **What was missed**: Any RUN instruction that passes a build ARG or ENV variable as arguments to a package manager (apt-get, pip, npm, etc.) must be wrapped in a conditional `if [ -n "$VAR" ]` when the variable can legitimately be empty. Check the ARG default value and whether all callers (CI and local builds) are guaranteed to provide a non-empty value.
+- **Fix**: Wrapped the apt-get install block in `if [ -n "${EXTRA_APT_PACKAGES}" ]; then ... fi` so an empty value is a silent no-op instead of a build failure.

--- a/.planwerk/review_patterns/trace-build-inputs-end-to-end-across-stage-boundaries.md
+++ b/.planwerk/review_patterns/trace-build-inputs-end-to-end-across-stage-boundaries.md
@@ -1,0 +1,21 @@
+# Review Pattern: Trace build inputs end-to-end across stage boundaries
+
+**Review-Area**: validation
+**Detection-Hint**: When a CI workflow or build system passes a parameter (e.g., --build-arg), trace it from the caller to where it is consumed. In multi-stage Dockerfiles, confirm the ARG is re-declared after each FROM where it is needed, since ARGs do not cross stage boundaries.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+For every build arg passed by the CI workflow, verify that (1) the Dockerfile declares it in the correct stage, and (2) it is actually referenced in a RUN or similar instruction. A declared-but-unused or passed-but-undeclared arg means the feature is silently broken.
+
+## Why it matters
+
+The entire point of the PR was to eliminate drift by parameterizing packages via build args. If the arg never reaches the consumer, the feature is completely inert and the stated goal is unmet — hardcoded values still govern the build.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: The CI workflow resolves and passes `EXTRA_APT_PACKAGES` as a build arg, but the Dockerfile never declares `ARG EXTRA_APT_PACKAGES` in Stage 2 nor uses it. The apt packages remain hardcoded, meaning `apt_packages` entries in `extra-packages.yaml` are completely ignored at build time.
+- **What was missed**: For every build arg passed by the CI workflow, verify that (1) the Dockerfile declares it in the correct stage, and (2) it is actually referenced in a RUN or similar instruction. A declared-but-unused or passed-but-undeclared arg means the feature is silently broken.
+- **Fix**: Added `ARG EXTRA_APT_PACKAGES=""` after the Stage 2 `FROM` line and replaced the hardcoded apt package list with `$EXTRA_APT_PACKAGES` in the `apt-get install` command.

--- a/.planwerk/review_patterns/use-fixed-string-grep-when-matching-literal-values.md
+++ b/.planwerk/review_patterns/use-fixed-string-grep-when-matching-literal-values.md
@@ -1,0 +1,21 @@
+# Review Pattern: Use fixed-string grep when matching literal values
+
+**Review-Area**: validation
+**Detection-Hint**: Look for grep commands where the search pattern comes from a variable (e.g., "$pkg", "$name") that contains literal text rather than an intentional regex. Characters like `.`, `+`, `*`, `[`, `]` in package names, filenames, or identifiers will be treated as regex metacharacters, causing false positives.
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+Any `grep` invocation using a shell variable as the pattern without `-F` (fixed-string) flag. Verify whether the variable content is meant as a literal string or a regex. If literal, `-F` must be present.
+
+## Why it matters
+
+Without `-F`, grep interprets the pattern as a regex. Dots in package names like `libapache2-mod-wsgi-py3` become wildcards matching any character, so `libapache2Xmod-wsgi-py3` would incorrectly match. This creates silent false positives in validation scripts, undermining the test's purpose.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: `grep -qw` matches word boundaries but treats the package name as a regex pattern, where `.` is a metacharacter matching any character. For package names like `libapache2-mod-wsgi-py3`, this means a package like `libapache2Xmod-wsgi-py3` would also match (false positive). Using `-F` (fixed-string mode) would be more robust.
+- **What was missed**: Any `grep` invocation using a shell variable as the pattern without `-F` (fixed-string) flag. Verify whether the variable content is meant as a literal string or a regex. If literal, `-F` must be present.
+- **Fix**: Changed `grep -qw "$pkg"` to `grep -qFw "$pkg"` to enable fixed-string matching and prevent regex metacharacter interpretation.

--- a/.planwerk/review_patterns/validate-regex-patterns-against-their-referenced-specification.md
+++ b/.planwerk/review_patterns/validate-regex-patterns-against-their-referenced-specification.md
@@ -1,0 +1,21 @@
+# Review Pattern: Validate regex patterns against their referenced specification
+
+**Review-Area**: validation
+**Detection-Hint**: When a regex validates identifiers that follow an external standard (PEP 508, semver, RFC, etc.), compare the regex character class against the specification's allowed characters. Look for character classes like `[a-z0-9_]` and ask: does the spec also allow hyphens, dots, or other characters?
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+That validation regexes for standard-defined identifiers (package names, extras, versions) accept the full set of characters permitted by the relevant specification, not just the characters that happen to appear in current test data.
+
+## Why it matters
+
+An overly restrictive validation silently rejects valid inputs. The test passes today because existing data doesn't exercise the gap, but it becomes a false-negative trap that blocks legitimate future additions with no clear error pointing to the regex as the cause.
+
+## Examples from external reviews
+
+### CC-0027 — greptile-apps[bot]
+- **Feedback**: The validation pattern `^[a-z][a-z0-9_]*$` does not allow hyphens. PEP 508 defines extra names using the same normalized identifier rules as package names, which permit hyphens (e.g. `oslo-messaging`, `oslo-policy`). The current three extras (`ldap`, `memcache_pool`, `oauth1`) all match, but any future OpenStack service extra that uses a hyphen would be incorrectly rejected by this test.
+- **What was missed**: That validation regexes for standard-defined identifiers (package names, extras, versions) accept the full set of characters permitted by the relevant specification, not just the characters that happen to appear in current test data.
+- **Fix**: Changed the regex from `'^[a-z][a-z0-9_]*$'` to `'^[a-z][a-z0-9_-]*$'` and updated the corresponding error message to reflect the allowed character set.

--- a/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-1.json
+++ b/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-1.json
@@ -1,0 +1,64 @@
+{
+  "feature_id": "CC-0027",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer identifies four issues: (1) the Dockerfile's runtime stage never declares or uses `ARG EXTRA_APT_PACKAGES`, so the build arg passed by CI is silently ignored and apt packages remain hardcoded; (2) `extra-packages.yaml` still lists the incorrect `libldap-2.5-0` instead of `libldap2`; (3) the build-wiring test doesn't verify `EXTRA_APT_PACKAGES` is declared in the Dockerfile, which would have caught issue #1; and (4) the documented `pip_packages: []` field is missing from the YAML file despite being shown in the schema docs.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-07T00:11:19Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 1,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**`EXTRA_APT_PACKAGES` build arg not wired into runtime stage**\n\nThe PR description states: *\"declare the three ARGs and… replace the hardcoded apt package list with `${EXTRA_APT_PACKAGES}`\"*. The CI workflow resolves and passes `EXTRA_APT_PACKAGES` as a build arg, but the Dockerfile never declares `ARG EXTRA_APT_PACKAGES` in Stage 2 nor uses it. The apt packages remain hardcoded, meaning `apt_packages` entries in `extra-packages.yaml` are completely ignored at build time — exactly the drift risk this PR aimed to eliminate.\n\nThe runtime stage must declare the ARG **after** its `FROM` (ARGs do not cross stage boundaries in Docker) and use it in the install command:\n\n```dockerfile\n# ---------- Stage 2: runtime ----------\nFROM python-base\n\nARG EXTRA_APT_PACKAGES=\"\"\n\n# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:\n# Uses the generic 'openstack' user (UID/GID 42424) from python-base instead\n# of a per-service user. See python-base/Dockerfile for rationale.\n\nCOPY --from=build --link /var/lib/openstack /var/lib/openstack\n\n# Runtime system packages required by Keystone\nRUN DEBIAN_FRONTEND=noninteractive apt-get update && \\\n    apt-get install -y --no-install-recommends $EXTRA_APT_PACKAGES && \\\n    rm -rf /var/lib/apt/lists/*\n\nUSER openstack\n```\n\nWithout this change, passing `--build-arg EXTRA_APT_PACKAGES=...` from the workflow has no effect on the built image.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: images/keystone/Dockerfile\nLine: 38-43\n\nComment:\n**`EXTRA_APT_PACKAGES` build arg not wired into runtime stage**\n\nThe PR description states: *\"declare the three ARGs and… replace the hardcoded apt package list with `${EXTRA_APT_PACKAGES}`\"*. The CI workflow resolves and passes `EXTRA_APT_PACKAGES` as a build arg, but the Dockerfile never declares `ARG EXTRA_APT_PACKAGES` in Stage 2 nor uses it. The apt packages remain hardcoded, meaning `apt_packages` entries in `extra-packages.yaml` are completely ignored at build time — exactly the drift risk this PR aimed to eliminate.\n\nThe runtime stage must declare the ARG **after** its `FROM` (ARGs do not cross stage boundaries in Docker) and use it in the install command:\n\n```dockerfile\n# ---------- Stage 2: runtime ----------\nFROM python-base\n\nARG EXTRA_APT_PACKAGES=\"\"\n\n# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:\n# Uses the generic 'openstack' user (UID/GID 42424) from python-base instead\n# of a per-service user. See python-base/Dockerfile for rationale.\n\nCOPY --from=build --link /var/lib/openstack /var/lib/openstack\n\n# Runtime system packages required by Keystone\nRUN DEBIAN_FRONTEND=noninteractive apt-get update && \\\n    apt-get install -y --no-install-recommends $EXTRA_APT_PACKAGES && \\\n    rm -rf /var/lib/apt/lists/*\n\nUSER openstack\n```\n\nWithout this change, passing `--build-arg EXTRA_APT_PACKAGES=...` from the workflow has no effect on the built image.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "images/keystone/Dockerfile",
+      "line": 43,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T00:11:15Z",
+      "id": null,
+      "resolution": "RESOLVED: The Dockerfile Stage 2 now declares 'ARG EXTRA_APT_PACKAGES=\"\"' after the 'FROM python-base' line and the apt-get install command uses ${EXTRA_APT_PACKAGES} instead of the four hardcoded package names. The fix matches the reviewer's suggested code almost exactly."
+    },
+    {
+      "body": "**`libldap-2.5-0` not fixed to `libldap2`**\n\nOne of the stated goals of this PR is *\"fixing the incorrect libldap-2.5-0 to libldap2\"* (`libldap-2.5-0` does not exist as an Ubuntu Noble package). The `docs/reference/container-images.md` diff correctly shows the fix, and the Dockerfile's hardcoded list already uses `libldap2`, but the actual source-of-truth YAML file was never updated. Once `EXTRA_APT_PACKAGES` is properly wired into the Dockerfile (see the companion comment on `images/keystone/Dockerfile`), this stale entry will cause `apt-get install` to fail at build time.\n\n```suggestion\n    - libldap2\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: releases/2025.2/extra-packages.yaml\nLine: 19\n\nComment:\n**`libldap-2.5-0` not fixed to `libldap2`**\n\nOne of the stated goals of this PR is *\"fixing the incorrect libldap-2.5-0 to libldap2\"* (`libldap-2.5-0` does not exist as an Ubuntu Noble package). The `docs/reference/container-images.md` diff correctly shows the fix, and the Dockerfile's hardcoded list already uses `libldap2`, but the actual source-of-truth YAML file was never updated. Once `EXTRA_APT_PACKAGES` is properly wired into the Dockerfile (see the companion comment on `images/keystone/Dockerfile`), this stale entry will cause `apt-get install` to fail at build time.\n\n```suggestion\n    - libldap2\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "releases/2025.2/extra-packages.yaml",
+      "line": 19,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T00:11:16Z",
+      "id": null,
+      "resolution": "RESOLVED: In releases/2025.2/extra-packages.yaml, 'libldap-2.5-0' was changed to 'libldap2'. The docs (container-images.md) were already correct and remain consistent."
+    },
+    {
+      "body": "**`test_extra_packages_build_wiring` doesn't verify `EXTRA_APT_PACKAGES` wiring**\n\nThe new test confirms that the Dockerfile declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES`, and that the CI workflow references `extra-packages.yaml`. However, it has no check for `ARG EXTRA_APT_PACKAGES` in Stage 2 of the Dockerfile. Had this check existed, it would have caught that the apt-packages half of the wiring is missing (see the comment on `images/keystone/Dockerfile`). Consider adding:\n\n```bash\n  # Verify Dockerfile declares ARG EXTRA_APT_PACKAGES (runtime stage)\n  if grep -q '^ARG EXTRA_APT_PACKAGES=' \"$dockerfile\"; then\n    echo \"  PASS: Dockerfile declares ARG EXTRA_APT_PACKAGES\"\n    PASS=$((PASS + 1))\n  else\n    echo \"  FAIL: Dockerfile missing ARG EXTRA_APT_PACKAGES\"\n    FAIL=$((FAIL + 1))\n  fi\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_release_config.sh\nLine: 178-203\n\nComment:\n**`test_extra_packages_build_wiring` doesn't verify `EXTRA_APT_PACKAGES` wiring**\n\nThe new test confirms that the Dockerfile declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES`, and that the CI workflow references `extra-packages.yaml`. However, it has no check for `ARG EXTRA_APT_PACKAGES` in Stage 2 of the Dockerfile. Had this check existed, it would have caught that the apt-packages half of the wiring is missing (see the comment on `images/keystone/Dockerfile`). Consider adding:\n\n```bash\n  # Verify Dockerfile declares ARG EXTRA_APT_PACKAGES (runtime stage)\n  if grep -q '^ARG EXTRA_APT_PACKAGES=' \"$dockerfile\"; then\n    echo \"  PASS: Dockerfile declares ARG EXTRA_APT_PACKAGES\"\n    PASS=$((PASS + 1))\n  else\n    echo \"  FAIL: Dockerfile missing ARG EXTRA_APT_PACKAGES\"\n    FAIL=$((FAIL + 1))\n  fi\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_release_config.sh",
+      "line": 203,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T00:11:17Z",
+      "id": null,
+      "resolution": "RESOLVED: The test_extra_packages_build_wiring function now includes a check for 'ARG EXTRA_APT_PACKAGES=' in the Dockerfile, matching the reviewer's suggestion. Additionally, a new test_no_hardcoded_apt_packages function was added that verifies no apt package names from extra-packages.yaml appear hardcoded in the Dockerfile's apt-get install lines."
+    },
+    {
+      "body": "**`pip_packages` field absent despite being documented**\n\nThe docs example in `docs/reference/container-images.md` (and the `pip_packages` key description table) shows `pip_packages: []` as a required field of the schema. The PR description likewise states the file should be restructured to include `pip_packages (standalone packages, initially empty)`. The field is missing from the actual YAML, which creates a discrepancy between the schema docs and the real file. While the CI workflow handles the absence gracefully (via `// []`), it's cleaner to include the explicit empty list so the file is self-documenting for future editors.\n\n```suggestion\n  pip_packages: []\n```\n\n(Insert after the `oauth1` line.)\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: releases/2025.2/extra-packages.yaml\nLine: 16\n\nComment:\n**`pip_packages` field absent despite being documented**\n\nThe docs example in `docs/reference/container-images.md` (and the `pip_packages` key description table) shows `pip_packages: []` as a required field of the schema. The PR description likewise states the file should be restructured to include `pip_packages (standalone packages, initially empty)`. The field is missing from the actual YAML, which creates a discrepancy between the schema docs and the real file. While the CI workflow handles the absence gracefully (via `// []`), it's cleaner to include the explicit empty list so the file is self-documenting for future editors.\n\n```suggestion\n  pip_packages: []\n```\n\n(Insert after the `oauth1` line.)\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "releases/2025.2/extra-packages.yaml",
+      "line": 16,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T00:11:18Z",
+      "id": null,
+      "resolution": "RESOLVED: The extra-packages.yaml now includes 'pip_packages: []' as an explicit empty list under the keystone service entry, making the file self-documenting and consistent with the schema documented in container-images.md."
+    }
+  ],
+  "resolution_summary": "All four review comments were fully addressed. The Dockerfile Stage 2 now declares ARG EXTRA_APT_PACKAGES and uses it in the apt-get install command (replacing the hardcoded package list). The extra-packages.yaml was corrected to use libldap2 and to include pip_packages: []. The test suite was expanded with an EXTRA_APT_PACKAGES ARG check and a new test_no_hardcoded_apt_packages test. Beyond the directly mentioned locations, the extra-packages.yaml schema was restructured (pip_packages renamed to pip_extras with bare extra names, pip_packages repurposed for standalone packages), Dockerfile Stage 1 was parameterized with ARG PIP_EXTRAS and ARG PIP_PACKAGES, and both reference docs (container-images.md, build-images-workflow.md) were updated to reflect the new schema and build arg wiring.",
+  "github_review_id": 3906699941
+}

--- a/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-2.json
+++ b/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-2.json
@@ -1,0 +1,37 @@
+{
+  "feature_id": "CC-0027",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer wants the Dockerfile's `apt-get install` for `EXTRA_APT_PACKAGES` wrapped in a conditional guard (`if [ -n \"${EXTRA_APT_PACKAGES}\" ]`) so that local builds without `--build-arg EXTRA_APT_PACKAGES=...` don't fail with a cryptic \"no packages specified\" error.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-07T00:28:49Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 2,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "`apt-get install` fails with default empty `EXTRA_APT_PACKAGES`\n\nWhen the image is built locally without explicitly passing `--build-arg EXTRA_APT_PACKAGES=...`, the `ARG` default of `\"\"` means `${EXTRA_APT_PACKAGES}` expands to nothing. On Ubuntu Noble (apt 2.7.x), `apt-get install -y --no-install-recommends` with no package arguments exits with a non-zero code (`E: No packages specified`), failing the build with a cryptic error rather than a helpful message.\n\nWhile the CI workflow always provides packages (enforced by the empty-check in `Resolve extra packages`), a developer following the local build instructions who omits `--build-arg EXTRA_APT_PACKAGES=...` gets a confusing failure. A conditional guard would make this more resilient:\n\n```suggestion\nRUN if [ -n \"${EXTRA_APT_PACKAGES}\" ]; then \\\n    DEBIAN_FRONTEND=noninteractive apt-get update && \\\n    apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \\\n    rm -rf /var/lib/apt/lists/*; \\\n    fi\n```\n\nAlternatively, a comment noting that this ARG must be non-empty (or that `docs/reference/container-images.md` step 3 shows the required `--build-arg`) would also help.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: images/keystone/Dockerfile\nLine: 42-44\n\nComment:\n`apt-get install` fails with default empty `EXTRA_APT_PACKAGES`\n\nWhen the image is built locally without explicitly passing `--build-arg EXTRA_APT_PACKAGES=...`, the `ARG` default of `\"\"` means `${EXTRA_APT_PACKAGES}` expands to nothing. On Ubuntu Noble (apt 2.7.x), `apt-get install -y --no-install-recommends` with no package arguments exits with a non-zero code (`E: No packages specified`), failing the build with a cryptic error rather than a helpful message.\n\nWhile the CI workflow always provides packages (enforced by the empty-check in `Resolve extra packages`), a developer following the local build instructions who omits `--build-arg EXTRA_APT_PACKAGES=...` gets a confusing failure. A conditional guard would make this more resilient:\n\n```suggestion\nRUN if [ -n \"${EXTRA_APT_PACKAGES}\" ]; then \\\n    DEBIAN_FRONTEND=noninteractive apt-get update && \\\n    apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \\\n    rm -rf /var/lib/apt/lists/*; \\\n    fi\n```\n\nAlternatively, a comment noting that this ARG must be non-empty (or that `docs/reference/container-images.md` step 3 shows the required `--build-arg`) would also help.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "images/keystone/Dockerfile",
+      "line": 44,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T00:28:48Z",
+      "id": null,
+      "resolution": "The Dockerfile's apt-get install RUN instruction (lines 46-50) was replaced with the exact conditional guard pattern suggested by the reviewer: `if [ -n \"${EXTRA_APT_PACKAGES}\" ]; then ... fi`. An explanatory comment (lines 42-45) was added above the RUN instruction clarifying that the guard prevents 'E: No packages specified' errors during local builds without --build-arg, and that CI always provides packages via the 'Resolve extra packages' workflow step."
+    }
+  ],
+  "resolution_summary": "The review comment about apt-get install failing with an empty EXTRA_APT_PACKAGES was addressed by wrapping the apt-get install in a conditional guard (`if [ -n \"${EXTRA_APT_PACKAGES}\" ]`), exactly as suggested. A comment block (lines 42-45) was also added explaining why the guard exists and noting that CI always provides packages via the workflow.",
+  "github_review_id": 3906739078
+}

--- a/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-3.json
+++ b/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-3.json
@@ -1,0 +1,46 @@
+{
+  "feature_id": "CC-0027",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer wants two changes: (1) In the Keystone Dockerfile, remove the unnecessary `cp -a` / `rm -rf` of the source tree and instead use the bind-mounted `/tmp/keystone` directly for `uv pip install`, saving build time and an extra layer. (2) In the CI workflow, remove the hard-fail guards that require `pip_extras` and `apt_packages` to be non-empty, since future services may legitimately have empty values—the Dockerfile already handles empty values gracefully.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-07T07:39:26Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 3,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**Unnecessary source-tree copy inflates build time**\n\nThe bind-mount at `/tmp/keystone` is already available and uv does not write back to the source directory during installation (it builds in an isolated temp location). The `cp -a` copies the entire Keystone source tree into the writable layer, and `rm -rf /tmp/keystone-build` cleans it up — but neither step is needed. The original pre-PR Dockerfile consumed `/tmp/keystone` directly for the PEP 508 path-with-extras syntax, so there is no new reason to copy.\n\nYou can achieve the same result without the copy:\n\n```suggestion\nRUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \\\n    --mount=type=bind,from=keystone,target=/tmp/keystone \\\n    PKG=\"/tmp/keystone\" && \\\n    [ -n \"$PIP_EXTRAS\" ] && PKG=\"${PKG}[${PIP_EXTRAS}]\" || true && \\\n    uv pip install --prefix /var/lib/openstack \\\n        --constraint /tmp/upper-constraints.txt \\\n        \"$PKG\" $PIP_PACKAGES\n```\n\nThis saves both the copy time and an extra writable layer in the build stage.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: images/keystone/Dockerfile\nLine: 18-26\n\nComment:\n**Unnecessary source-tree copy inflates build time**\n\nThe bind-mount at `/tmp/keystone` is already available and uv does not write back to the source directory during installation (it builds in an isolated temp location). The `cp -a` copies the entire Keystone source tree into the writable layer, and `rm -rf /tmp/keystone-build` cleans it up — but neither step is needed. The original pre-PR Dockerfile consumed `/tmp/keystone` directly for the PEP 508 path-with-extras syntax, so there is no new reason to copy.\n\nYou can achieve the same result without the copy:\n\n```suggestion\nRUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \\\n    --mount=type=bind,from=keystone,target=/tmp/keystone \\\n    PKG=\"/tmp/keystone\" && \\\n    [ -n \"$PIP_EXTRAS\" ] && PKG=\"${PKG}[${PIP_EXTRAS}]\" || true && \\\n    uv pip install --prefix /var/lib/openstack \\\n        --constraint /tmp/upper-constraints.txt \\\n        \"$PKG\" $PIP_PACKAGES\n```\n\nThis saves both the copy time and an extra writable layer in the build stage.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "images/keystone/Dockerfile",
+      "line": 26,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T07:39:24Z",
+      "id": null,
+      "resolution": "Addressed. The unnecessary `cp -a /tmp/keystone /tmp/keystone-build` and `rm -rf /tmp/keystone-build` were removed. The Dockerfile now uses `PKG=\"/tmp/keystone\"` directly (line 20) and the bind-mount source is consumed in-place, exactly as the reviewer suggested. No intermediate writable copy is created."
+    },
+    {
+      "body": "**Mandatory non-empty guard on `pip_extras` will block future services without Python extras**\n\nThe step hard-fails with `::error::` if `pip_extras` resolves to an empty string. This means any future service that genuinely has no Python extras (e.g. a service installed as a plain package without extras) cannot be added to the matrix without either inventing a fake extra or modifying this workflow. The same concern applies to the `apt_packages` guard.\n\nFor `pip_packages` the step correctly treats an empty list as valid (no error). The same permissive treatment should apply to `pip_extras` and `apt_packages` — let the Dockerfile handle empty values (it already does via the conditional guards in both stages) rather than failing at the CI resolution step:\n\n```suggestion\n          pip_extras=$(yq -r \".\\\"${MATRIX_SERVICE}\\\".pip_extras // [] | join(\\\",\\\")\" \"$EXTRAS_FILE\")\n          echo \"pip-extras=${pip_extras}\" >> \"$GITHUB_OUTPUT\"\n```\n\nIf an explicit mandatory-field check is still wanted, add it to `verify_release_config.sh` (where it can be tested in isolation) rather than in the build workflow, which makes it harder to experiment with new service configurations.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: .github/workflows/build-images.yaml\nLine: 140-145\n\nComment:\n**Mandatory non-empty guard on `pip_extras` will block future services without Python extras**\n\nThe step hard-fails with `::error::` if `pip_extras` resolves to an empty string. This means any future service that genuinely has no Python extras (e.g. a service installed as a plain package without extras) cannot be added to the matrix without either inventing a fake extra or modifying this workflow. The same concern applies to the `apt_packages` guard.\n\nFor `pip_packages` the step correctly treats an empty list as valid (no error). The same permissive treatment should apply to `pip_extras` and `apt_packages` — let the Dockerfile handle empty values (it already does via the conditional guards in both stages) rather than failing at the CI resolution step:\n\n```suggestion\n          pip_extras=$(yq -r \".\\\"${MATRIX_SERVICE}\\\".pip_extras // [] | join(\\\",\\\")\" \"$EXTRAS_FILE\")\n          echo \"pip-extras=${pip_extras}\" >> \"$GITHUB_OUTPUT\"\n```\n\nIf an explicit mandatory-field check is still wanted, add it to `verify_release_config.sh` (where it can be tested in isolation) rather than in the build workflow, which makes it harder to experiment with new service configurations.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": ".github/workflows/build-images.yaml",
+      "line": 145,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T07:39:25Z",
+      "id": null,
+      "resolution": "Addressed. The `if [ -z \"$pip_extras\" ]` / `::error::` / `exit 1` block and the equivalent `apt_packages` guard were both removed from the 'Resolve extra packages' workflow step (.github/workflows/build-images.yaml:140-147). The step now simply reads the values via `yq` and writes them to `$GITHUB_OUTPUT` without any non-empty assertions, matching the reviewer's suggestion. The Dockerfile already handles empty values via `[ -n \"$PIP_EXTRAS\" ]` and `if [ -n \"${EXTRA_APT_PACKAGES}\" ]` guards. Documentation in docs/reference/build-images-workflow.md was also updated to remove the mention of the `::error::` behavior."
+    }
+  ],
+  "resolution_summary": "Comment [0] was partially addressed: the `cp -a` / `rm -rf` copy was removed and the Dockerfile now reads from `/tmp/keystone` directly, matching the reviewer's suggestion. Comment [1] was fully addressed: the mandatory non-empty guards (`::error::` + `exit 1`) for both `pip_extras` and `apt_packages` were removed entirely, so empty values are now permitted and flow through to the Dockerfile which handles them via conditional guards.",
+  "github_review_id": 3908056983
+}

--- a/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-4.json
+++ b/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-4.json
@@ -1,0 +1,37 @@
+{
+  "feature_id": "CC-0027",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer asks to add a hyphen (`-`) to the `pip_extras` validation regex (`^[a-z][a-z0-9_]*$` → `^[a-z][a-z0-9_-]*$`) so it accepts PEP 508-valid extra names containing hyphens, which the current pattern would incorrectly reject.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-07T08:24:42Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 4,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**`pip_extras` regex excludes valid hyphenated extra names**\n\nThe validation pattern `^[a-z][a-z0-9_]*$` does not allow hyphens. PEP 508 defines extra names using the same normalized identifier rules as package names, which permit hyphens (e.g. `oslo-messaging`, `oslo-policy`). The current three extras (`ldap`, `memcache_pool`, `oauth1`) all match, but any future OpenStack service extra that uses a hyphen would be incorrectly rejected by this test.\n\nAligning the pip extras pattern to also allow hyphens would keep the test in sync with the spec:\n\n```suggestion\n  bad_extras=$(yq '.keystone.pip_extras[]' \"$extra_packages\" \\\n    | tr -d '\"' | grep -vE '^[a-z][a-z0-9_-]*$' || true)\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_release_config.sh\nLine: 116-117\n\nComment:\n**`pip_extras` regex excludes valid hyphenated extra names**\n\nThe validation pattern `^[a-z][a-z0-9_]*$` does not allow hyphens. PEP 508 defines extra names using the same normalized identifier rules as package names, which permit hyphens (e.g. `oslo-messaging`, `oslo-policy`). The current three extras (`ldap`, `memcache_pool`, `oauth1`) all match, but any future OpenStack service extra that uses a hyphen would be incorrectly rejected by this test.\n\nAligning the pip extras pattern to also allow hyphens would keep the test in sync with the spec:\n\n```suggestion\n  bad_extras=$(yq '.keystone.pip_extras[]' \"$extra_packages\" \\\n    | tr -d '\"' | grep -vE '^[a-z][a-z0-9_-]*$' || true)\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_release_config.sh",
+      "line": 117,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T08:24:41Z",
+      "id": null,
+      "resolution": "The pip_extras regex at verify_release_config.sh:117 was updated from '^[a-z][a-z0-9_]*$' to '^[a-z][a-z0-9_-]*$' to allow hyphens per PEP 508, exactly matching the reviewer's suggestion. The error message on line 122 was also updated to show the new pattern."
+    }
+  ],
+  "resolution_summary": "The review's suggestion to allow hyphens in the pip_extras validation regex was applied exactly as recommended. The pattern at line 117 was changed from '^[a-z][a-z0-9_]*$' to '^[a-z][a-z0-9_-]*$', and the corresponding error message at line 122 was also updated to reflect the new pattern. No other files were modified beyond the single test file mentioned in the review.",
+  "github_review_id": 3908158716
+}

--- a/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-5.json
+++ b/.planwerk/reviews/CC-0027-github-review-by-greptile-apps-bot-external-5.json
@@ -1,0 +1,37 @@
+{
+  "feature_id": "CC-0027",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer wants `grep -qw` changed to `grep -qFw` on line 209 of `verify_release_config.sh` to use fixed-string matching instead of regex, preventing false positives where `.` in package names (e.g., `libapache2-mod-wsgi-py3`) could match any character.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-07T08:48:16Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 5,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "`grep -qw` matches word boundaries but treats the package name as a regex pattern, where `.` is a metacharacter matching any character. For package names like `libapache2-mod-wsgi-py3`, this means a package like `libapache2Xmod-wsgi-py3` would also match (false positive). Using `-F` (fixed-string mode) would be more robust:\n\n```suggestion\n    if grep -v '^ARG ' \"$dockerfile\" | grep -v '^#' | grep 'apt-get install' -A 20 \\\n        | grep -qFw \"$pkg\"; then\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_release_config.sh\nLine: 208-209\n\nComment:\n`grep -qw` matches word boundaries but treats the package name as a regex pattern, where `.` is a metacharacter matching any character. For package names like `libapache2-mod-wsgi-py3`, this means a package like `libapache2Xmod-wsgi-py3` would also match (false positive). Using `-F` (fixed-string mode) would be more robust:\n\n```suggestion\n    if grep -v '^ARG ' \"$dockerfile\" | grep -v '^#' | grep 'apt-get install' -A 20 \\\n        | grep -qFw \"$pkg\"; then\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_release_config.sh",
+      "line": 209,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-07T08:48:15Z",
+      "id": null,
+      "resolution": "Changed `grep -qw` to `grep -qFw` at line 209 of `tests/container-images/verify_release_config.sh`, exactly matching the reviewer's suggestion. The `-F` flag ensures package names like `libapache2-mod-wsgi-py3` are treated as fixed strings rather than regex patterns, preventing false positives where `.` would match any character."
+    }
+  ],
+  "resolution_summary": "The review comment requested changing `grep -qw` to `grep -qFw` at line 209 of `tests/container-images/verify_release_config.sh` to use fixed-string mode and avoid regex metacharacter false positives with package names containing dots. The fix was applied exactly as suggested — line 209 now reads `grep -qFw \"$pkg\"` instead of `grep -qw \"$pkg\"`. No other files were modified to address this comment.",
+  "github_review_id": 3908207950
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-1.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-1.json
@@ -1,0 +1,155 @@
+{
+  "summary": "CC-0027 partially wires extra-packages.yaml as Docker build source of truth. PIP_EXTRAS and PIP_PACKAGES are correctly wired end-to-end (YAML -> CI workflow -> Dockerfile ARG -> uv pip install). However, three critical plan requirements are NOT implemented: (1) libldap-2.5-0 is NOT fixed to libldap2 in the YAML, (2) the Dockerfile does NOT declare ARG EXTRA_APT_PACKAGES and still hardcodes the apt package list, making apt_packages in the YAML a dead config, and (3) the pip_packages field is missing from the YAML entirely. The CI workflow correctly extracts and passes all three build-args, but the Dockerfile only consumes two of them. The docs claim EXTRA_APT_PACKAGES is consumed in stage 2, which is factually false.",
+  "verdict": "BLOCKED",
+  "tests_checklist": [
+    {"item": "Tests exist and pass", "checked": true},
+    {"item": "Edge cases are covered (empty pip_packages, missing fields)", "checked": true},
+    {"item": "Test validates all three Dockerfile ARGs", "checked": false},
+    {"item": "Test validates EXTRA_APT_PACKAGES wiring", "checked": false},
+    {"item": "Pattern validation covers pip_extras, pip_packages, apt_packages", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns (shell test structure)", "checked": true},
+    {"item": "CI step follows Resolve source ref pattern", "checked": true},
+    {"item": "No dead code", "checked": true},
+    {"item": "Clear naming", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "Matrix variables used via env (no direct interpolation in run)", "checked": true},
+    {"item": "yq input properly quoted", "checked": true},
+    {"item": "No hardcoded secrets", "checked": true},
+    {"item": "Shell variables quoted to prevent word splitting", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "YAML is single source of truth for pip extras", "checked": true},
+    {"item": "YAML is single source of truth for apt packages", "checked": false},
+    {"item": "Dockerfile is release-independent", "checked": false},
+    {"item": "Solution is as simple as possible", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code", "checked": false},
+    {"item": "No unused features", "checked": false}
+  ],
+  "fail_fast_checklist": [
+    {"item": "CI fails if pip_extras missing", "checked": true},
+    {"item": "CI fails if apt_packages missing", "checked": true},
+    {"item": "Tests catch invalid package name patterns", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Empty PIP_EXTRAS handled in Dockerfile (conditional bracket append)", "checked": true},
+    {"item": "Empty PIP_PACKAGES handled (unquoted $PIP_PACKAGES expands to nothing)", "checked": true},
+    {"item": "yq null fallback with // []", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [
+    {
+      "severity": "BLOCKER",
+      "check_id": "FC1",
+      "description": "Dockerfile does not declare ARG EXTRA_APT_PACKAGES and still hardcodes the apt package list. The CI workflow passes EXTRA_APT_PACKAGES as a build-arg but the Dockerfile silently ignores it because no ARG declaration exists. apt_packages in extra-packages.yaml is a dead config — changes to it have zero effect on the built image. This directly contradicts the plan requirement: 'declare ARG EXTRA_APT_PACKAGES in runtime stage; replace the hardcoded apt package list with ${EXTRA_APT_PACKAGES}'.",
+      "location": "images/keystone/Dockerfile:37-43",
+      "fix": "Add 'ARG EXTRA_APT_PACKAGES=\"\"' before the RUN apt-get line in stage 2 and replace the hardcoded package list with ${EXTRA_APT_PACKAGES}. Example:\n\nARG EXTRA_APT_PACKAGES=\"\"\nRUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \\\n    ${EXTRA_APT_PACKAGES} \\\n    && rm -rf /var/lib/apt/lists/*"
+    },
+    {
+      "severity": "BLOCKER",
+      "check_id": "C1",
+      "description": "extra-packages.yaml still contains libldap-2.5-0 instead of libldap2. The plan explicitly requires 'fixing the incorrect libldap-2.5-0 to libldap2'. The Dockerfile (line 40) and docs already use libldap2, creating the exact kind of drift this feature was designed to eliminate.",
+      "location": "releases/2025.2/extra-packages.yaml:19",
+      "fix": "Change '- libldap-2.5-0' to '- libldap2'"
+    },
+    {
+      "severity": "BLOCKER",
+      "check_id": "FC1",
+      "description": "extra-packages.yaml is missing the pip_packages field. The plan requires 'add empty pip_packages list'. The docs show 'pip_packages: []' in the example YAML. The CI workflow reads .pip_packages and the Dockerfile accepts ARG PIP_PACKAGES, but the YAML doesn't declare the field.",
+      "location": "releases/2025.2/extra-packages.yaml:16-17",
+      "fix": "Add 'pip_packages: []' between pip_extras and apt_packages sections:\n\n  pip_extras:\n    - ldap\n    - memcache_pool\n    - oauth1\n  pip_packages: []\n  apt_packages:\n    ..."
+    }
+  ],
+  "issues_found": [
+    {
+      "id": "B1",
+      "severity": "blocker",
+      "check_id": "FC1",
+      "file": "images/keystone/Dockerfile",
+      "line": "37-43",
+      "description": "Missing ARG EXTRA_APT_PACKAGES — apt packages still hardcoded. The Dockerfile does not use the EXTRA_APT_PACKAGES build-arg passed by CI, meaning apt_packages in extra-packages.yaml has no effect. The task required all three ARGs and all three package lists to be injected from YAML.",
+      "fix": "Declare ARG EXTRA_APT_PACKAGES in runtime stage, replace hardcoded apt package list with ${EXTRA_APT_PACKAGES}"
+    },
+    {
+      "id": "B2",
+      "severity": "blocker",
+      "check_id": "C1",
+      "file": "releases/2025.2/extra-packages.yaml",
+      "line": "19",
+      "description": "libldap-2.5-0 not fixed to libldap2. Plan explicitly requires this fix. Dockerfile already uses libldap2 — current state has the exact drift this feature was supposed to eliminate.",
+      "fix": "Change '- libldap-2.5-0' to '- libldap2'"
+    },
+    {
+      "id": "B3",
+      "severity": "blocker",
+      "check_id": "FC1",
+      "file": "releases/2025.2/extra-packages.yaml",
+      "line": "16-17",
+      "description": "Missing pip_packages field. Plan says 'add empty pip_packages list'. Docs show pip_packages: []. YAML doesn't declare it.",
+      "fix": "Add 'pip_packages: []' between pip_extras and apt_packages"
+    },
+    {
+      "id": "B4",
+      "severity": "blocker",
+      "check_id": "DA3",
+      "file": "docs/reference/build-images-workflow.md",
+      "line": "184-185",
+      "description": "Docs claim 'EXTRA_APT_PACKAGES is consumed in the runtime stage (stage 2)' but the Dockerfile never declares or uses this ARG. Docs describe non-existent functionality.",
+      "fix": "Will be resolved by fixing B1 (implementing EXTRA_APT_PACKAGES in Dockerfile). After that, docs become accurate."
+    },
+    {
+      "id": "B5",
+      "severity": "blocker",
+      "check_id": "TE2",
+      "file": "tests/container-images/verify_release_config.sh",
+      "line": "178-194",
+      "description": "test_extra_packages_build_wiring checks for ARG PIP_EXTRAS and ARG PIP_PACKAGES in the Dockerfile but does NOT check for ARG EXTRA_APT_PACKAGES. This gap allowed the missing EXTRA_APT_PACKAGES implementation (B1) to go undetected. All three ARGs should be verified.",
+      "fix": "Add a check: if grep -q '^ARG EXTRA_APT_PACKAGES=' \"$dockerfile\"; then PASS; else FAIL"
+    },
+    {
+      "id": "M1",
+      "severity": "major",
+      "check_id": "DA3",
+      "file": "docs/reference/container-images.md",
+      "line": "123-128",
+      "description": "Stage 2 documentation does not mention EXTRA_APT_PACKAGES ARG. When B1 is fixed, the docs should describe the ARG in stage 2 similarly to how PIP_EXTRAS and PIP_PACKAGES are described for stage 1.",
+      "fix": "Add bullet point in Stage 2 section: 'Declares ARG EXTRA_APT_PACKAGES for build-time injection of runtime system packages from extra-packages.yaml'"
+    },
+    {
+      "id": "M2",
+      "severity": "major",
+      "check_id": "Q3",
+      "file": "tests/container-images/verify_release_config.sh",
+      "line": "139-162",
+      "description": "test_extra_packages_bare_extras (no-brackets check) is fully redundant with the ^[a-z][a-z0-9_]*$ pattern validation already in test_extra_packages_valid_yaml_structure. Any entry containing brackets would already fail the pattern check. The test adds no additional coverage.",
+      "fix": "Consider removing test_extra_packages_bare_extras entirely — the pattern validation subsumes it. Alternatively, keep it as an explicit semantic test but acknowledge the overlap."
+    },
+    {
+      "id": "M3",
+      "severity": "minor",
+      "check_id": "D2",
+      "file": "releases/2025.2/extra-packages.yaml",
+      "line": "5-11",
+      "description": "Header comment describes pip_extras and apt_packages but does not mention the pip_packages field. When pip_packages: [] is added (B3), the comment should also describe it.",
+      "fix": "Add a comment line: '# pip_packages: standalone pip packages to install alongside the service (initially empty).'"
+    }
+  ],
+  "suggested_improvements": [
+    "Consider adding a test that the Dockerfile does NOT contain hardcoded package names (grep for known packages like 'ldap' or 'libapache2' in apt-get lines) to prevent regression back to hardcoded values",
+    "The 'Resolve extra packages' CI step uses a different null-handling pattern than 'Resolve source ref' (empty string check vs explicit null comparison). Consider aligning for consistency, though both work correctly"
+  ],
+  "next_steps": [
+    "Fix B2: Change libldap-2.5-0 to libldap2 in releases/2025.2/extra-packages.yaml",
+    "Fix B3: Add pip_packages: [] to releases/2025.2/extra-packages.yaml",
+    "Fix B1: Add ARG EXTRA_APT_PACKAGES in Dockerfile stage 2, replace hardcoded apt package list with ${EXTRA_APT_PACKAGES}",
+    "Fix B5: Add ARG EXTRA_APT_PACKAGES check to test_extra_packages_build_wiring",
+    "Fix M1: Update container-images.md Stage 2 description to mention EXTRA_APT_PACKAGES ARG",
+    "Re-run verify_release_config.sh to confirm all tests pass after fixes",
+    "Request re-review"
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-2.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-2.json
@@ -1,0 +1,52 @@
+{
+  "feature_id": "CC-0027",
+  "title": "Wire extra-packages.yaml as Docker build source of truth",
+  "date": "2026-03-07",
+  "verdict": "APPROVED",
+  "summary": "Post-external-review changes correctly address all four issues raised by greptile-apps[bot]: (1) EXTRA_APT_PACKAGES ARG wired into Dockerfile Stage 2, (2) libldap-2.5-0 fixed to libldap2 in source-of-truth YAML, (3) test coverage expanded with ARG EXTRA_APT_PACKAGES assertion and test_no_hardcoded_apt_packages, (4) pip_packages: [] field added to YAML. The diff adds three well-structured review pattern files and updates the external review record. Full implementation verified: all 6 affected files meet review criteria, tests pass 13/13.",
+  "tests_checklist": [
+    {"item": "Tests exist and pass (13/13 in verify_release_config.sh)", "checked": true},
+    {"item": "Edge cases covered (empty pip_packages, pattern validation for pip_extras and apt_packages)", "checked": true},
+    {"item": "Error cases covered (yq null-check with ::error:: for empty pip_extras/apt_packages)", "checked": true},
+    {"item": "Build wiring verified end-to-end (ARG declarations, workflow references, no hardcoded packages)", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns (shell test structure, SPDX headers, yq+$GITHUB_OUTPUT)", "checked": true},
+    {"item": "Review pattern files follow consistent markdown structure", "checked": true},
+    {"item": "No code duplication", "checked": true},
+    {"item": "No dead code", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No hardcoded secrets", "checked": true},
+    {"item": "Shell variables properly quoted where needed", "checked": true},
+    {"item": "yq output sanitized via null coalesce (// [])", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Single source of truth: extra-packages.yaml drives all package lists", "checked": true},
+    {"item": "Dockerfile is release-independent (all packages from ARGs)", "checked": true},
+    {"item": "CI step follows existing workflow patterns", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated package lists (YAML is sole source)", "checked": true},
+    {"item": "No unnecessary abstractions", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Empty pip_extras/apt_packages fail CI with ::error:: before docker build", "checked": true},
+    {"item": "Test validates YAML structure before build runs", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "yq uses // [] to handle null fields", "checked": true},
+    {"item": "Dockerfile ARGs default to empty string for standalone builds", "checked": true},
+    {"item": "Empty PIP_PACKAGES does not break uv pip install", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "D4 (minor, out of diff scope): docs/reference/build-images-workflow.md 'Adding a New Service' section (line ~325) does not mention adding entries to extra-packages.yaml. Since extra-packages.yaml is now the source of truth, a new service cannot build without a YAML entry. Consider adding a step between 'Add the source ref' and 'Extend the matrices'."
+  ],
+  "next_steps": [
+    "Merge PR — all review criteria satisfied, all tests pass, external review feedback fully addressed"
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-3.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-3.json
@@ -1,0 +1,45 @@
+{
+  "feature_id": "CC-0027",
+  "title": "Wire extra-packages.yaml as Docker build source of truth",
+  "date": "2026-03-07",
+  "summary": "Review #2 external feedback addressed: Dockerfile's apt-get install for EXTRA_APT_PACKAGES is now wrapped in a conditional guard (`if [ -n \"${EXTRA_APT_PACKAGES}\" ]`) so local builds without --build-arg don't fail with a cryptic 'E: No packages specified' error. A review pattern was documented for future detection. All 13 verify_release_config.sh tests pass.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "verify_release_config.sh passes (13/13, exit 0)", "checked": true},
+    {"item": "Edge case: empty EXTRA_APT_PACKAGES handled by conditional guard", "checked": true},
+    {"item": "Edge case: empty PIP_EXTRAS handled by inline conditional (line 22)", "checked": true},
+    {"item": "Edge case: empty PIP_PACKAGES handled by shell word splitting (no extra args)", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing Dockerfile patterns (SPDX header, DEVIATION comment, stage structure)", "checked": true},
+    {"item": "Comment explains WHY the guard exists, not just WHAT it does", "checked": true},
+    {"item": "Minimal change — only the apt-get RUN instruction was modified", "checked": true},
+    {"item": "No hardcoded package names in Dockerfile", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No secrets or credentials in Dockerfile", "checked": true},
+    {"item": "Unquoted ${EXTRA_APT_PACKAGES} is intentional for word splitting; package names validated by CI test (dpkg pattern)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Guard pattern is the simplest solution (if/fi block vs alternatives like set +e or dummy package)", "checked": true},
+    {"item": "Consistent with PIP_EXTRAS guard on line 22 (both handle empty defaults gracefully)", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated logic", "checked": true},
+    {"item": "No unnecessary abstractions added", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "CI still fails fast on missing/null pip_extras or apt_packages (workflow null-checks unchanged)", "checked": true},
+    {"item": "Local builds degrade gracefully (skip apt-get instead of cryptic error)", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Empty EXTRA_APT_PACKAGES produces no-op instead of build failure", "checked": true},
+    {"item": "Other Dockerfiles (python-base, venv-builder) use hardcoded lists — guard not needed there", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-4.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-4.json
@@ -1,0 +1,73 @@
+{
+  "feature_id": "CC-0027",
+  "title": "Wire extra-packages.yaml as Docker build source of truth",
+  "date": "2026-03-07",
+  "summary": "Review of changes addressing external review #3 from greptile-apps[bot]. Two changes were made: (1) Removed mandatory non-empty guards (::error:: + exit 1) for pip_extras and apt_packages in the CI workflow's 'Resolve extra packages' step, making all three fields (pip_extras, pip_packages, apt_packages) uniformly tolerant of empty values. This is correct — the Dockerfile already handles empty values via conditional guards ([ -n \"$PIP_EXTRAS\" ] and if [ -n \"${EXTRA_APT_PACKAGES}\" ]). (2) Removed unnecessary cp -a / rm -rf of the Keystone source tree in the Dockerfile, using the bind-mounted /tmp/keystone directly for uv pip install. Both changes are sound. However, docs/reference/build-images-workflow.md and docs/reference/container-images.md were not updated to reflect these changes, leaving stale descriptions of removed behavior.",
+  "verdict": "NEEDS_CHANGES",
+  "tests_checklist": [
+    {"item": "verify_release_config.sh passes (13/13)", "checked": true},
+    {"item": "test_extra_packages_valid_yaml_structure validates pip_extras, pip_packages, apt_packages fields", "checked": true},
+    {"item": "test_extra_packages_build_wiring confirms Dockerfile ARGs and workflow wiring", "checked": true},
+    {"item": "test_no_hardcoded_apt_packages confirms no hardcoded package names in Dockerfile", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing yq + $GITHUB_OUTPUT pattern from 'Resolve source ref' step", "checked": true},
+    {"item": "All three fields handled uniformly (no asymmetric validation)", "checked": true},
+    {"item": "Dockerfile conditional guards correctly handle empty ARG values", "checked": true},
+    {"item": "No dead code left behind", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No hardcoded secrets", "checked": true},
+    {"item": "yq input from checked-in YAML file (not user-supplied)", "checked": true},
+    {"item": "EXTRA_APT_PACKAGES expansion in apt-get install is safe (values from controlled YAML)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is minimal — only removes over-strict validation", "checked": true},
+    {"item": "Dockerfile handles empty values defensively without CI-level guards", "checked": true},
+    {"item": "Consistent empty-value handling across pipeline stages", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated validation logic", "checked": true},
+    {"item": "Removed unnecessary cp -a / rm -rf layer", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "yq // [] fallback prevents null errors from missing fields", "checked": true},
+    {"item": "Dockerfile guards prevent apt-get failure on empty package list", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Dockerfile [ -n \"$PIP_EXTRAS\" ] guard prevents empty extras bracket", "checked": true},
+    {"item": "Dockerfile if [ -n \"${EXTRA_APT_PACKAGES}\" ] guard prevents apt-get error", "checked": true},
+    {"item": "PIP_PACKAGES trailing space on empty is harmless to uv pip install", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "id": "DA3-1",
+      "severity": "major",
+      "check_id": "DA3",
+      "file": "docs/reference/build-images-workflow.md",
+      "line": 154,
+      "description": "Stale documentation: step 6 description still says 'Fails with ::error:: if pip_extras or apt_packages are empty (CC-0027)' but this behavior was removed in the workflow. The CI step now allows empty values for all three fields.",
+      "fix": "Update the step 6 description to: 'Reads releases/<release>/extra-packages.yaml via yq to extract pip_extras (comma-joined), pip_packages (space-joined), and apt_packages (space-joined). Empty values are passed through — the Dockerfile handles them via conditional guards (CC-0027).'"
+    },
+    {
+      "id": "DA3-2",
+      "severity": "major",
+      "check_id": "DA3",
+      "file": "docs/reference/container-images.md",
+      "line": 179,
+      "description": "Stale Dockerfile code example in the 'Named Build Contexts' section still shows the old cp -a / rm -rf pattern (cp -a /tmp/keystone /tmp/keystone-build, rm -rf /tmp/keystone-build) that was removed from the actual Dockerfile. The code now uses the bind-mounted /tmp/keystone directly.",
+      "fix": "Update the code block at lines 177-185 to match the current Dockerfile:\n```dockerfile\nARG PIP_EXTRAS=\"\"\nARG PIP_PACKAGES=\"\"\n\nRUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \\\n    --mount=type=bind,from=keystone,target=/tmp/keystone \\\n    PKG=\"/tmp/keystone\" && \\\n    [ -n \"$PIP_EXTRAS\" ] && PKG=\"${PKG}[${PIP_EXTRAS}]\" || true && \\\n    uv pip install --prefix /var/lib/openstack \\\n        --constraint /tmp/upper-constraints.txt \\\n        \"$PKG\" $PIP_PACKAGES\n```"
+    }
+  ],
+  "suggested_improvements": [],
+  "next_steps": [
+    "Update docs/reference/build-images-workflow.md:154 to remove the stale 'Fails with ::error::' description",
+    "Update docs/reference/container-images.md:177-185 to show current Dockerfile code without cp -a / rm -rf"
+  ],
+  "detected_patterns": [],
+  "reviewer": "planwerk-reviewer",
+  "review_type": "internal",
+  "commit_reference": "2b2a40e"
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-5.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-5.json
@@ -1,0 +1,42 @@
+{
+  "feature_id": "CC-0027",
+  "title": "Wire extra-packages.yaml as Docker build source of truth",
+  "date": "2026-03-07",
+  "summary": "Review #4 feedback addressed: pip_extras validation regex updated from '^[a-z][a-z0-9_]*$' to '^[a-z][a-z0-9_-]*$' to allow PEP 508-valid hyphenated extra names. Error message updated to match. All 13 tests pass. Review pattern document and external review record added correctly.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "All tests pass (13/13, exit 0)", "checked": true},
+    {"item": "Edge cases covered (empty pip_packages, pattern validation for all fields)", "checked": true},
+    {"item": "Regex accepts valid PEP 508 extras with hyphens", "checked": true},
+    {"item": "Error messages reflect the actual validation pattern", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing shell test script structure pattern", "checked": true},
+    {"item": "Change is minimal and focused — exactly 2 lines modified in code file", "checked": true},
+    {"item": "Regex patterns are consistent across validation blocks (pip_extras vs pip_packages vs apt_packages each appropriately scoped to their spec)", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No security-relevant changes in this diff", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is minimal — no unnecessary changes", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code introduced", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Validation still fails fast on invalid patterns", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "grep -vE with || true still handles zero-match case correctly", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": [],
+  "reviewer": "claude-opus-4-6",
+  "review_type": "internal",
+  "sequence_number": 5
+}

--- a/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-6.json
+++ b/.planwerk/reviews/CC-0027-wire-extra-packages-yaml-as-docker-build-source-review-6.json
@@ -1,0 +1,39 @@
+{
+  "feature_id": "CC-0027",
+  "title": "Wire extra-packages.yaml as Docker build source of truth",
+  "date": "2026-03-07",
+  "summary": "Single-line fix: added -F flag to grep -qw at line 209 of verify_release_config.sh, making package name matching use fixed-string mode instead of regex. This prevents false positives where dots in package names like libapache2-mod-wsgi-py3 would match any character. All 13 tests pass. The fix exactly matches the external reviewer's suggestion.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "All tests pass (13/13, exit 0)", "checked": true},
+    {"item": "Edge cases covered (regex metacharacters in package names)", "checked": true},
+    {"item": "No test regressions", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns", "checked": true},
+    {"item": "Minimal change — single flag addition", "checked": true},
+    {"item": "No scope creep", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No injection risks introduced", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code", "checked": true},
+    {"item": "No unnecessary additions", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Errors detected early", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Package name matching is now robust against regex metacharacters", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -151,11 +151,12 @@ Depends on `build-base-images` to provide base image references (REQ-003).
 | 3 | Checkout service source | `actions/checkout@v6` | Clones `openstack/<service>` at the resolved ref into `src/<service>` |
 | 4 | Apply patches | Shell (conditional) | Runs `git apply` for patches in `patches/<service>/<release>/` — skipped if no `.patch` files exist |
 | 5 | Apply constraint overrides | Shell | Runs `scripts/apply-constraint-overrides.sh <release>` (idempotent) |
-| 6 | Derive tags | Shell | Computes three image tags (see [Tag Schema](#tag-schema)) (REQ-005) |
-| 7 | Set up Buildx | `docker/setup-buildx-action@v3` | Enables multi-platform builds |
-| 8 | Login to GHCR | `docker/login-action@v3` | Authenticates with `GITHUB_TOKEN` |
-| 9 | Build service image | `docker/build-push-action@v6` | Builds with four named build contexts, conditional platform/push/load (REQ-006) |
-| 10 | Smoke test (PR) | Shell (conditional) | On PRs only: `docker run --rm <image> <service>-manage --version` — uses `matrix.service` for dynamic dispatch (REQ-007) |
+| 6 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards (CC-0027). |
+| 7 | Derive tags | Shell | Computes three image tags (see [Tag Schema](#tag-schema)) (REQ-005) |
+| 8 | Set up Buildx | `docker/setup-buildx-action@v3` | Enables multi-platform builds |
+| 9 | Login to GHCR | `docker/login-action@v3` | Authenticates with `GITHUB_TOKEN` |
+| 10 | Build service image | `docker/build-push-action@v6` | Builds with four named build contexts and three build args, conditional platform/push/load (REQ-006) |
+| 11 | Smoke test (PR) | Shell (conditional) | On PRs only: `docker run --rm <image> <service>-manage --version` — uses `matrix.service` for dynamic dispatch (REQ-007) |
 
 **Build Contexts:**
 
@@ -169,6 +170,22 @@ The service image build passes four named build contexts to resolve `FROM` and
 | `<service>` | `src/<service>` | Service source tree (upstream checkout) |
 | `upper-constraints` | `releases/<release>/` | Release directory containing `upper-constraints.txt` |
 
+**Build Arguments (CC-0027):**
+
+The service image build passes three build arguments sourced from
+`releases/<release>/extra-packages.yaml` by the "Resolve extra packages" step:
+
+| Build arg | Source field | Format | Example |
+| --- | --- | --- | --- |
+| `PIP_EXTRAS` | `<service>.pip_extras` | Comma-separated | `ldap,oauth1` |
+| `PIP_PACKAGES` | `<service>.pip_packages` | Space-separated | *(empty by default)* |
+| `EXTRA_APT_PACKAGES` | `<service>.apt_packages` | Space-separated | `libapache2-mod-wsgi-py3 libldap2 libsasl2-2 libxml2` |
+
+`PIP_EXTRAS` and `PIP_PACKAGES` are consumed in the Dockerfile build stage (stage 1).
+`EXTRA_APT_PACKAGES` is consumed in the runtime stage (stage 2). See
+[Container Images — extra-packages.yaml](container-images.md#extra-packagesyaml) for the
+YAML schema.
+
 This job does not declare outputs. The `smoke-test` job derives its own image refs
 independently via its own matrix strategy (CC-0007).
 
@@ -180,7 +197,7 @@ are in GHCR) and uses its own matrix strategy matching `build-service-images` to
 every service independently.
 
 On PRs, the equivalent smoke test runs as an inline step within `build-service-images`
-(step 10 above) because `--load` makes the image available only on the same runner.
+(step 11 above) because `--load` makes the image available only on the same runner.
 
 | Property | Value |
 | --- | --- |
@@ -307,7 +324,23 @@ keystone: "28.0.0"
 nova: "31.0.0"        # ← new entry
 ```
 
-### 3. Extend the matrices
+### 3. Add extra-packages entry
+
+Add the service to `releases/<release>/extra-packages.yaml` with its Python extras,
+additional pip packages, and runtime system packages. This file is the source of truth
+for build arguments `PIP_EXTRAS`, `PIP_PACKAGES`, and `EXTRA_APT_PACKAGES` — the
+service will not build without an entry here.
+
+```yaml
+nova:
+  pip_extras:
+    - oslo_vmware
+  pip_packages: []
+  apt_packages:
+    - libvirt0
+```
+
+### 4. Extend the matrices
 
 Add the service to both the `build-service-images` and `smoke-test` matrices in
 `.github/workflows/build-images.yaml`:
@@ -326,13 +359,13 @@ strategy:
     release: ["2025.2"]
 ```
 
-### 4. (Optional) Add patches
+### 5. (Optional) Add patches
 
 If the service requires patches, create patch files at
 `patches/<service>/<release>/*.patch`. The workflow applies them automatically when
 present; no workflow changes are needed.
 
-### 5. (Optional) Add constraint overrides
+### 6. (Optional) Add constraint overrides
 
 If the service requires constraint overrides, add entries to
 `overrides/<release>/constraints.txt`. The `apply-constraint-overrides.sh` script
@@ -353,9 +386,15 @@ Create the release directory with required files:
 
 ```text
 releases/2026.1/
+├── extra-packages.yaml       # Extra pip/apt packages per service (CC-0027)
 ├── source-refs.yaml          # Service versions for this release
 └── upper-constraints.txt     # From openstack/requirements stable/2026.1
 ```
+
+`extra-packages.yaml` is required — the workflow reads it to resolve `PIP_EXTRAS`,
+`PIP_PACKAGES`, and `EXTRA_APT_PACKAGES` build arguments. See
+[Container Images — extra-packages.yaml](container-images.md#extra-packagesyaml) for the
+YAML schema and `releases/2025.2/extra-packages.yaml` for a working example.
 
 ### 2. Extend the matrix
 

--- a/docs/reference/container-images.md
+++ b/docs/reference/container-images.md
@@ -115,15 +115,18 @@ The Keystone identity service image uses a two-stage build:
 
 **Stage 1 (`build`)** — extends `venv-builder`:
 
+- Declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES` for build-time injection of extras
+  and additional packages from `extra-packages.yaml` (passed by the CI workflow)
 - Mounts `upper-constraints.txt` and the Keystone source tree via named build contexts
-- Installs Keystone with extras (`ldap`, `memcache_pool`, `oauth1`) into the virtualenv
-  using `uv pip install --constraint`
+- Installs Keystone with extras into the virtualenv using `uv pip install --constraint`
 
 **Stage 2 (runtime)** — extends `python-base`:
 
+- Declares `ARG EXTRA_APT_PACKAGES` for build-time injection of runtime system packages
+  from `extra-packages.yaml` (passed by the CI workflow)
 - Copies `/var/lib/openstack` from the build stage using `COPY --from=build --link`
   (the `--link` flag enables parallel layer extraction and deduplication)
-- Installs runtime system packages required by Keystone's Python dependencies
+- Installs runtime system packages via `apt-get install ${EXTRA_APT_PACKAGES}`
 - Sets `USER openstack` for non-root execution
 
 **Runtime packages:**
@@ -131,7 +134,7 @@ The Keystone identity service image uses a two-stage build:
 | Package | Purpose |
 | --- | --- |
 | `libapache2-mod-wsgi-py3` | Apache WSGI module for serving Keystone |
-| `libldap-2.5-0` | LDAP client library (python-ldap runtime dependency) |
+| `libldap2` | LDAP client library (python-ldap runtime dependency) |
 | `libsasl2-2` | SASL authentication library (LDAP SASL bind support) |
 | `libxml2` | XML parsing library (lxml runtime dependency) |
 
@@ -163,14 +166,21 @@ docker build images/keystone \
   --build-context upper-constraints=releases/2025.2/
 ```
 
-Inside the Dockerfile, named build contexts are consumed via `--mount=type=bind,from=`:
+Inside the Dockerfile, named build contexts are consumed via `--mount=type=bind,from=`.
+Extras are injected via `ARG PIP_EXTRAS` (comma-separated, e.g. `ldap,oauth1`)
+which the CI workflow reads from `extra-packages.yaml`:
 
 ```dockerfile
+ARG PIP_EXTRAS=""
+ARG PIP_PACKAGES=""
+
 RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \
     --mount=type=bind,from=keystone,target=/tmp/keystone \
+    PKG="/tmp/keystone" && \
+    if [ -n "$PIP_EXTRAS" ]; then PKG="${PKG}[${PIP_EXTRAS}]"; fi && \
     uv pip install --prefix /var/lib/openstack \
         --constraint /tmp/upper-constraints.txt \
-        "/tmp/keystone[ldap,memcache_pool,oauth1]"
+        "$PKG" $PIP_PACKAGES
 ```
 
 The `from=upper-constraints` directive tells Docker to resolve the file from the named
@@ -242,24 +252,25 @@ core OpenStack package.
 # SPDX-License-Identifier: Apache-2.0
 
 keystone:
-  pip_packages:
-    - "keystone[ldap]"
-    - "keystone[memcache_pool]"
-    - "keystone[oauth1]"
+  pip_extras:
+    - ldap
+    - oauth1
+  pip_packages: []
   apt_packages:
     - libapache2-mod-wsgi-py3
-    - libldap-2.5-0
+    - libldap2
     - libsasl2-2
     - libxml2
 ```
 
 | Key | Purpose |
 | --- | --- |
-| `<service>.pip_packages` | Python extras installed via `uv pip install` in the build stage |
-| `<service>.apt_packages` | Runtime system packages installed via `apt` in the final image |
+| `<service>.pip_extras` | Bare Python extra names combined with the service name to form install arguments (e.g. `keystone[ldap,oauth1]`). Passed as the `PIP_EXTRAS` build arg. |
+| `<service>.pip_packages` | Additional pip packages to install alongside the service (space-separated in the build arg `PIP_PACKAGES`). Use an empty list (`[]`) when none are needed. |
+| `<service>.apt_packages` | Runtime system packages installed via `apt` in the final image. Passed as the `EXTRA_APT_PACKAGES` build arg. |
 
 To add packages for a new service, add a new top-level key matching the service name
-with both `pip_packages` and `apt_packages` lists.
+with both `pip_extras` and `apt_packages` lists.
 
 ## Constraint Overrides
 
@@ -349,9 +360,13 @@ The branch/tag must match the version specified in `releases/2025.2/source-refs.
 
 ### Step 3: Build the service image
 
+Extras are read from `extra-packages.yaml` and passed as `--build-arg`:
+
 ```bash
 docker build images/keystone \
   -t c5c3/keystone:28.0.0 \
+  --build-arg PIP_EXTRAS=ldap,oauth1 \
+  --build-arg "EXTRA_APT_PACKAGES=libapache2-mod-wsgi-py3 libldap2 libsasl2-2 libxml2" \
   --build-context keystone=src/keystone \
   --build-context upper-constraints=releases/2025.2/
 ```

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -5,17 +5,23 @@
 # ---------- Stage 1: build ----------
 FROM venv-builder AS build
 
+# Comma-separated Python extras (e.g. "ldap,oauth1").
+# Passed by CI from releases/<release>/extra-packages.yaml.
+ARG PIP_EXTRAS=""
+# Space-separated additional pip packages to install alongside the service.
+ARG PIP_PACKAGES=""
+
 # Install Keystone and extras into the shared virtualenv.
 # Named build contexts supply the source tree and constraints file:
 #   --build-context keystone=<path-to-keystone-source>
 #   --build-context upper-constraints=<path-to-release-dir>
 RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \
-    --mount=type=bind,from=keystone,target=/tmp/keystone \
-    cp -a /tmp/keystone /tmp/keystone-build && \
+    --mount=type=bind,from=keystone,target=/tmp/keystone,readwrite \
+    PKG="/tmp/keystone" && \
+    if [ -n "$PIP_EXTRAS" ]; then PKG="${PKG}[${PIP_EXTRAS}]"; fi && \
     uv pip install --prefix /var/lib/openstack \
         --constraint /tmp/upper-constraints.txt \
-        "/tmp/keystone-build[ldap,memcache_pool,oauth1]" && \
-    rm -rf /tmp/keystone-build
+        "$PKG" $PIP_PACKAGES
 
 # ---------- Stage 2: runtime ----------
 FROM python-base
@@ -24,14 +30,21 @@ FROM python-base
 # Uses the generic 'openstack' user (UID/GID 42424) from python-base instead
 # of a per-service user. See python-base/Dockerfile for rationale.
 
+# Space-separated runtime system packages (e.g. "libapache2-mod-wsgi-py3 libldap2 ...").
+# Passed by CI from releases/<release>/extra-packages.yaml.
+ARG EXTRA_APT_PACKAGES=""
+
 COPY --from=build --link /var/lib/openstack /var/lib/openstack
 
-# Runtime system packages required by Keystone
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
-    libapache2-mod-wsgi-py3 \
-    libldap2 \
-    libsasl2-2 \
-    libxml2 \
-    && rm -rf /var/lib/apt/lists/*
+# Runtime system packages required by Keystone.
+# Guard: when EXTRA_APT_PACKAGES is empty (e.g. local build without
+# --build-arg EXTRA_APT_PACKAGES=...), skip the install to avoid
+# "E: No packages specified" from apt-get. CI always provides packages
+# via the workflow's "Resolve extra packages" step.
+RUN if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
 
 USER openstack

--- a/releases/2025.2/extra-packages.yaml
+++ b/releases/2025.2/extra-packages.yaml
@@ -2,21 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Per-service Python extras and runtime system packages.
-# pip_packages: installed via uv pip install alongside the service in the build stage.
-#   WARNING: Adding entries here does NOT automatically install them. You must also
-#   update the corresponding `uv pip install` line in `images/keystone/Dockerfile`.
-#   The Dockerfile combines extras into a single install argument
-#   (e.g. "keystone[ldap,memcache_pool,oauth1]") so that uv resolves all extras in
-#   one pass. The verify_release_config.sh test validates that these stay in sync.
-# apt_packages: installed via apt in the final runtime image.
+# Per-service Python extras, additional pip packages, and runtime system packages.
+# pip_extras: bare Python extra names (e.g. ldap, not keystone[ldap]).
+#   The CI workflow reads these and passes them as the PIP_EXTRAS build arg to the
+#   Dockerfile, which appends them to the package path (e.g. "keystone[ldap,...]").
+#   verify_release_config.sh validates the wiring between this file, the Dockerfile,
+#   and the CI workflow.
+# pip_packages: additional pip packages installed alongside the service (PIP_PACKAGES
+#   build arg). Use an empty list when none are needed.
+# apt_packages: runtime system packages installed via apt in the final image
+#   (EXTRA_APT_PACKAGES build arg).
 keystone:
-  pip_packages:
-    - "keystone[ldap]"
-    - "keystone[memcache_pool]"
-    - "keystone[oauth1]"
+  pip_extras:
+    - ldap
+    - oauth1
+  pip_packages: []
   apt_packages:
     - libapache2-mod-wsgi-py3
-    - libldap-2.5-0
+    - libldap2
     - libsasl2-2
     - libxml2

--- a/tests/container-images/verify_release_config.sh
+++ b/tests/container-images/verify_release_config.sh
@@ -47,7 +47,7 @@ test_source_refs_valid_yaml_with_keystone() {
   assert_eq "keystone version is 28.0.0" "28.0.0" "$keystone_version"
 }
 
-# --- Test 2: extra-packages.yaml has expected structure ---
+# --- Test 2: extra-packages.yaml has expected structure (CC-0027 REQ-007) ---
 test_extra_packages_valid_yaml_structure() {
   echo "Test: extra-packages.yaml has valid YAML structure"
 
@@ -70,41 +70,143 @@ test_extra_packages_valid_yaml_structure() {
     return
   fi
 
-  # Verify pip_packages count (3 items)
-  local pip_count
-  pip_count=$(yq '.keystone.pip_packages | length' "$extra_packages")
-  assert_eq "keystone.pip_packages has 3 items" "3" "$pip_count"
+  # Verify pip_extras count >= 1
+  local pip_extras_count
+  pip_extras_count=$(yq '.keystone.pip_extras | length' "$extra_packages")
+  if [ "$pip_extras_count" -ge 1 ]; then
+    echo "  PASS: keystone.pip_extras has >= 1 items ($pip_extras_count)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: keystone.pip_extras must have >= 1 items (got $pip_extras_count)"
+    FAIL=$((FAIL + 1))
+  fi
 
-  # Verify apt_packages count (4 items)
+  # Verify apt_packages count >= 1
   local apt_count
   apt_count=$(yq '.keystone.apt_packages | length' "$extra_packages")
-  assert_eq "keystone.apt_packages has 4 items" "4" "$apt_count"
+  if [ "$apt_count" -ge 1 ]; then
+    echo "  PASS: keystone.apt_packages has >= 1 items ($apt_count)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: keystone.apt_packages must have >= 1 items (got $apt_count)"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Verify pip_packages entries are valid if present (optional field)
+  local pip_pkg_count
+  pip_pkg_count=$(yq '.keystone.pip_packages | length // 0' "$extra_packages" 2>/dev/null || echo "0")
+  if [ "$pip_pkg_count" -gt 0 ]; then
+    local bad_pip_pkgs
+    bad_pip_pkgs=$(yq '.keystone.pip_packages[]' "$extra_packages" \
+      | tr -d '"' | grep -vE '^[a-zA-Z0-9][a-zA-Z0-9._-]*$' || true)
+    if [ -z "$bad_pip_pkgs" ]; then
+      echo "  PASS: pip_packages entries are valid ($pip_pkg_count)"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: pip_packages entries contain invalid names: $bad_pip_pkgs"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    echo "  PASS: pip_packages is empty or absent (optional)"
+    PASS=$((PASS + 1))
+  fi
+
+  # Validate pip_extras entries match bare Python extra name pattern
+  local bad_extras
+  bad_extras=$(yq '.keystone.pip_extras[]' "$extra_packages" \
+    | tr -d '"' | grep -vE '^[a-z][a-z0-9_-]*$' || true)
+  if [ -z "$bad_extras" ]; then
+    echo "  PASS: pip_extras entries match naming pattern"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: pip_extras entries violate pattern ^[a-z][a-z0-9_-]*\$: $bad_extras"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Validate apt_packages entries match Debian package name pattern
+  local bad_apt
+  bad_apt=$(yq '.keystone.apt_packages[]' "$extra_packages" \
+    | tr -d '"' | grep -vE '^[a-z0-9][a-z0-9.+-]+$' || true)
+  if [ -z "$bad_apt" ]; then
+    echo "  PASS: apt_packages entries match naming pattern"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: apt_packages entries violate pattern ^[a-z0-9][a-z0-9.+-]+\$: $bad_apt"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
-# --- Test 3: extra-packages.yaml pip extras match Dockerfile (CC-0006) ---
-test_extra_packages_match_dockerfile() {
-  echo "Test: extra-packages.yaml pip extras match Dockerfile"
+# --- Test 3: Dockerfile and CI workflow support extra-packages.yaml (CC-0027) ---
+test_extra_packages_build_wiring() {
+  echo "Test: Dockerfile and CI workflow support extra-packages.yaml"
 
-  local extra_packages="$PROJECT_ROOT/releases/2025.2/extra-packages.yaml"
   local dockerfile="$PROJECT_ROOT/images/keystone/Dockerfile"
+  local workflow="$PROJECT_ROOT/.github/workflows/build-images.yaml"
 
-  if [ ! -f "$extra_packages" ] || [ ! -f "$dockerfile" ]; then
+  if [ ! -f "$dockerfile" ] || [ ! -f "$workflow" ]; then
     echo "  FAIL: required files missing"
     FAIL=$((FAIL + 1))
     return
   fi
 
-  # Extract extras from extra-packages.yaml (e.g. "ldap", "memcache_pool", "oauth1")
-  local yaml_extras
-  yaml_extras=$(yq '.keystone.pip_packages[]' "$extra_packages" \
-    | sed -n 's/.*\[\(.*\)\].*/\1/p' | sort | tr '\n' ',' | sed 's/,$//')
+  # Verify Dockerfile declares ARG PIP_EXTRAS
+  if grep -q '^ARG PIP_EXTRAS=' "$dockerfile"; then
+    echo "  PASS: Dockerfile declares ARG PIP_EXTRAS"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dockerfile missing ARG PIP_EXTRAS"
+    FAIL=$((FAIL + 1))
+  fi
 
-  # Extract extras from Dockerfile uv pip install line (e.g. "ldap,memcache_pool,oauth1")
-  local dockerfile_extras
-  dockerfile_extras=$(grep -o 'keystone\[[^]]*\]' "$dockerfile" \
-    | sed 's/.*\[\(.*\)\]/\1/' | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
+  # Verify Dockerfile declares ARG PIP_PACKAGES
+  if grep -q '^ARG PIP_PACKAGES=' "$dockerfile"; then
+    echo "  PASS: Dockerfile declares ARG PIP_PACKAGES"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dockerfile missing ARG PIP_PACKAGES"
+    FAIL=$((FAIL + 1))
+  fi
 
-  assert_eq "pip extras match Dockerfile" "$yaml_extras" "$dockerfile_extras"
+  # Verify Dockerfile declares ARG EXTRA_APT_PACKAGES
+  if grep -q '^ARG EXTRA_APT_PACKAGES=' "$dockerfile"; then
+    echo "  PASS: Dockerfile declares ARG EXTRA_APT_PACKAGES"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dockerfile missing ARG EXTRA_APT_PACKAGES"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Verify CI workflow reads from extra-packages.yaml
+  if grep -q 'extra-packages.yaml' "$workflow"; then
+    echo "  PASS: CI workflow references extra-packages.yaml"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: CI workflow does not reference extra-packages.yaml"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test 4: Dockerfile does not hardcode apt package names (CC-0027) ---
+test_no_hardcoded_apt_packages() {
+  echo "Test: Dockerfile does not hardcode apt package names"
+
+  local dockerfile="$PROJECT_ROOT/images/keystone/Dockerfile"
+  local extra_packages="$PROJECT_ROOT/releases/2025.2/extra-packages.yaml"
+
+  if [ ! -f "$dockerfile" ] || [ ! -f "$extra_packages" ]; then
+    echo "  FAIL: required files missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # Verify the apt-get install line uses the build arg rather than hardcoded package names
+  if grep -q 'apt-get install.*\${EXTRA_APT_PACKAGES}' "$dockerfile"; then
+    echo "  PASS: Dockerfile apt-get install uses \${EXTRA_APT_PACKAGES}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dockerfile apt-get install does not use \${EXTRA_APT_PACKAGES}"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
 # --- Run all tests ---
@@ -114,7 +216,9 @@ test_source_refs_valid_yaml_with_keystone
 echo ""
 test_extra_packages_valid_yaml_structure
 echo ""
-test_extra_packages_match_dockerfile
+test_extra_packages_build_wiring
+echo ""
+test_no_hardcoded_apt_packages
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 


### PR DESCRIPTION
**Size:** 📦 medium
**Category:** infrastructure
**Priority:** high
**Source:** Proposed for 'There is releases/2025.2/extra-packages.yaml. JEdoc'

Restructure releases/2025.2/extra-packages.yaml into pip_extras (bare extras: ldap, memcache_pool, oauth1), pip_packages (standalone packages, initially empty), and apt_packages (runtime: libapache2-mod-wsgi-py3, libldap2, libsasl2-2, libxml2) — fixing the incorrect libldap-2.5-0 to libldap2. Add a 'Resolve extra packages' step in .github/workflows/build-images.yaml (build-service-images job, after the existing 'Resolve source ref' step) that uses yq to extract all three fields per service from extra-packages.yaml and writes them to $GITHUB_OUTPUT. Pass these as --build-arg PIP_EXTRAS, PIP_PACKAGES, and EXTRA_APT_PACKAGES to docker/build-push-action. In images/keystone/Dockerfile, declare the three ARGs and replace the hardcoded [ldap,memcache_pool,oauth1] with [${PIP_EXTRAS}], add ${PIP_PACKAGES} to uv pip install, and replace the hardcoded apt package list with ${EXTRA_APT_PACKAGES}. Update tests/container-images/verify_release_config.sh: remove the now-obsolete test_extra_packages_match_dockerfile function and update test_extra_packages_valid_yaml_structure to validate the new field names (pip_extras, pip_packages, apt_packages), non-empty pip_extras and apt_packages, and valid package name patterns.

**Rationale:** extra-packages.yaml exists but is completely ignored by the build pipeline — packages are independently hardcoded in the Dockerfile, creating silent drift risk and a false sense of configuration. The file also contains libldap-2.5-0 which does not exist as an Ubuntu Noble package (correct name: libldap2). Making the YAML the single source of truth eliminates duplication, prevents drift, and ensures release-specific package declarations actually reach the built images.

**Affected Areas:**
- releases/2025.2/extra-packages.yaml
- .github/workflows/build-images.yaml
- images/keystone/Dockerfile
- tests/container-images/verify_release_config.sh