### PR TITLE
feat(CC-0028): Integrate container image test scripts into CI

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -81,8 +81,42 @@ jobs:
           cache-from: type=gha,scope=venv-builder
           cache-to: type=gha,mode=max,scope=venv-builder
 
-  build-service-images:
+  verify-base-images:
     needs: [build-base-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull base images
+        env:
+          PYTHON_BASE_IMAGE: ${{ needs.build-base-images.outputs.python-base-image }}
+          VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
+        run: |
+          docker pull "$PYTHON_BASE_IMAGE"
+          docker pull "$VENV_BUILDER_IMAGE"
+
+      - name: Verify python-base image
+        env:
+          PYTHON_BASE_IMAGE: ${{ needs.build-base-images.outputs.python-base-image }}
+        run: bash tests/container-images/verify_python_base.sh "$PYTHON_BASE_IMAGE"
+
+      - name: Verify venv-builder image
+        env:
+          VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
+        run: bash tests/container-images/verify_venv_builder.sh "$VENV_BUILDER_IMAGE"
+
+  build-service-images:
+    needs: [build-base-images, verify-base-images]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -217,14 +251,13 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}
 
-      - name: Smoke test (PR)
+      - name: Verify service image (PR)
         if: github.event_name == 'pull_request'
         env:
           IMAGE_REF: ${{ steps.tags.outputs.composite }}
-          MATRIX_SERVICE: ${{ matrix.service }}
-        run: docker run --rm "$IMAGE_REF" "${MATRIX_SERVICE}-manage" --version
+        run: bash tests/container-images/verify_keystone.sh "$IMAGE_REF"
 
-  smoke-test:
+  verify-service-images:
     if: github.event_name != 'pull_request'
     needs: [build-service-images]
     runs-on: ubuntu-latest
@@ -248,7 +281,7 @@ jobs:
 
       # NOTE: This tag derivation MUST stay in sync with the 'Derive tags' step
       # in build-service-images. If the tag format changes there, update this
-      # step too — otherwise smoke-test pulls a ref that was never pushed.
+      # step too — otherwise verify-service-images pulls a ref that was never pushed.
       - name: Derive image ref
         id: tags
         env:
@@ -273,10 +306,9 @@ jobs:
           IMAGE="ghcr.io/${IMAGE_OWNER}/${MATRIX_SERVICE}"
           echo "image-ref=${IMAGE}:${VERSION}-p${PATCH_COUNT}-${BRANCH}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Pull and test image
+      - name: Pull and verify service image
         env:
           IMAGE_REF: ${{ steps.tags.outputs.image-ref }}
-          MATRIX_SERVICE: ${{ matrix.service }}
         run: |
           docker pull "$IMAGE_REF"
-          docker run --rm "$IMAGE_REF" "${MATRIX_SERVICE}-manage" --version
+          bash tests/container-images/verify_keystone.sh "$IMAGE_REF"

--- a/.github/workflows/verify-container-images.yaml
+++ b/.github/workflows/verify-container-images.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Verify Container Images
+
+"on":
+  push:
+    branches:
+      - main
+      - stable/**
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify-static-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.45.1
+          YQ_SHA256: 654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049
+        run: |
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum --check --strict
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Verify build-images workflow structure
+        run: bash tests/container-images/verify_build_images_workflow.sh
+
+      - name: Verify deviation comments
+        run: bash tests/container-images/verify_deviation_comments.sh
+
+      - name: Verify release config
+        run: bash tests/container-images/verify_release_config.sh
+
+      - name: Verify SPDX headers
+        run: bash tests/container-images/verify_spdx_headers.sh
+
+      - name: Test apply-constraint-overrides
+        run: bash tests/scripts/test_apply_constraint_overrides.sh

--- a/.planwerk/completed/CC-0028-integrate-container-image-test-scripts-into-ci.json
+++ b/.planwerk/completed/CC-0028-integrate-container-image-test-scripts-into-ci.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0028",
   "title": "Integrate container image test scripts into CI",
   "slug": "integrate-container-image-test-scripts-into-ci",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 📦 medium\n**Category:** infrastructure\n**Priority:** high\n**Source:** Proposed for 'The tests under tests/container-images/ are currently'\n\n1. Create `.github/workflows/verify-container-images.yaml` — a new single-job workflow triggered on push (main, stable/**) and pull_request that installs yq and runs 5 static test scripts sequentially: verify_build_images_workflow.sh, verify_deviation_comments.sh, verify_release_config.sh, verify_spdx_headers.sh, test_apply_constraint_overrides.sh. Follow existing conventions (SPDX header, SHA-pinned actions/checkout, permissions: contents: read, concurrency ${{ github.ref }}-${{ github.workflow }} with cancel-in-progress only on PR, timeout-minutes, runs-on: ubuntu-latest).\n\n2. Modify `.github/workflows/build-images.yaml` — add a verification step/job after build-base-images that runs verify_python_base.sh and verify_venv_builder.sh with digest-tagged image refs from job outputs. Replace the inline PR smoke test (~lines 191–196) and the push-only smoke-test job (~lines 198–254) with verify_keystone.sh; push path retains docker pull from GHCR before invocation, PR path uses local --load image.\n\n3. Fix test script issues — add assert_not_empty to tests/lib/assertions.sh; refactor verify_keystone.sh manual pass/fail block (lines 31–37) to use it and align default image tag with CI tags; fix stale uv version in verify_venv_builder.sh (0.6.3 → match Dockerfile); evaluate/harden sed-based extras extraction in verify_release_config.sh (lines 97–108).\n\n4. Update docs/reference/build-images-workflow.md to document test integration, verification coverage, and the new workflow.\n\n**Rationale:** Eight test scripts exist but zero are executed in CI, meaning container image structure validation, SPDX compliance checks, release config validation, and Dockerfile convention enforcement provide no automated protection. Bugs like the stale uv version expectation in verify_venv_builder.sh (tests for 0.6.3 while Dockerfile uses 0.10.8) would fail immediately if CI ran the scripts, proving the gap is real. Integrating these scripts catches regressions at PR time, replaces the limited inline smoke test (single --version check) with comprehensive verification (non-root user, no build tools, runtime packages), and ensures the existing test investment delivers value.\n\n**Affected Areas:**\n- .github/workflows/verify-container-images.yaml\n- .github/workflows/build-images.yaml\n- tests/lib/assertions.sh\n- tests/container-images/verify_keystone.sh\n- tests/container-images/verify_venv_builder.sh\n- tests/container-images/verify_release_config.sh\n- docs/reference/build-images-workflow.md",
   "stories": [
@@ -370,6 +370,7 @@
       "description": "Add assert_not_empty function to tests/lib/assertions.sh following the existing pattern (description, value params; increment PASS/FAIL; print result). Place it after the existing assert_eq function. Function signature: assert_not_empty description value. Passes when value is non-empty, fails when empty with message '(expected non-empty value)'.",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-006"
       ]
@@ -380,6 +381,7 @@
       "description": "In tests/container-images/verify_venv_builder.sh, update test_uv_version_is_pinned to expect 0.10.8 instead of 0.6.3. Change the echo description, the assert_contains call, and the assert_contains description string. The Dockerfile at images/venv-builder/Dockerfile uses COPY --from=ghcr.io/astral-sh/uv:0.10.8.",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-007"
       ]
@@ -390,6 +392,7 @@
       "description": "In tests/container-images/verify_keystone.sh: (1) Replace the manual if/else block in test_keystone_manage_version (lines 35-40: 'if [ -n \"$version\" ]' block) with a single call to assert_not_empty 'version output is non-empty' \"$version\". (2) Keep the default IMAGE as c5c3/keystone:28.0.0 since it matches the local build instructions in docs/reference/container-images.md. The CI workflow will always pass an explicit image ref.",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-006",
         "REQ-008"
@@ -401,6 +404,7 @@
       "description": "In tests/container-images/verify_build_images_workflow.sh: (1) Update test_three_jobs_defined to expect 4 jobs: build-base-images, verify-base-images, build-service-images, verify-service-images (rename function to test_four_jobs_defined or similar). (2) Add test for verify-base-images job: needs build-base-images, has timeout-minutes, runs-on ubuntu-latest, permissions packages: read. (3) Update test_smoke_test_* functions to reference verify-service-images instead of smoke-test. (4) Remove tests for the old smoke-test job structure that will no longer exist. (5) Add test for verify-service-images job: needs build-service-images, has timeout-minutes.",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-004",
@@ -413,6 +417,7 @@
       "description": "Create new workflow file .github/workflows/verify-container-images.yaml with: (1) SPDX header matching ci.yaml. (2) Triggers: push to main and stable/**, pull_request. (3) permissions: contents: read. (4) Concurrency: ${{ github.ref }}-${{ github.workflow }} with cancel-in-progress on PR only. (5) Single job 'verify-static-tests' with runs-on: ubuntu-latest, timeout-minutes: 10. (6) Steps: checkout (SHA-pinned actions/checkout@de0fac2e...  # v6), install yq (via snap or wget), then run each of the 5 scripts sequentially: verify_build_images_workflow.sh, verify_deviation_comments.sh, verify_release_config.sh, verify_spdx_headers.sh, test_apply_constraint_overrides.sh.",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-002",
@@ -425,6 +430,7 @@
       "description": "Add a new verify-base-images job to .github/workflows/build-images.yaml: (1) needs: [build-base-images]. (2) runs-on: ubuntu-latest, timeout-minutes: 10. (3) permissions: contents: read, packages: read. (4) Steps: checkout (SHA-pinned), login to GHCR, docker pull both digest-tagged base images from build-base-images outputs, run verify_python_base.sh with python-base-image digest ref, run verify_venv_builder.sh with venv-builder-image digest ref. (5) Update build-service-images needs to include verify-base-images: needs: [build-base-images, verify-base-images].",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-004",
         "REQ-010"
@@ -436,6 +442,7 @@
       "description": "Modify .github/workflows/build-images.yaml: (1) Replace the inline 'Smoke test (PR)' step in build-service-images with a step that runs 'bash tests/container-images/verify_keystone.sh \"$IMAGE_REF\"' using the composite tag, conditioned on github.event_name == 'pull_request'. (2) Replace the entire smoke-test job with a new verify-service-images job: needs [build-service-images], if github.event_name != 'pull_request', runs-on ubuntu-latest, timeout-minutes 10, permissions contents: read + packages: read, same matrix strategy. Steps: checkout (SHA-pinned), GHCR login, derive image ref (same tag derivation as current smoke-test), docker pull, run verify_keystone.sh with the pulled image ref. Use env vars for matrix values in run blocks (expression injection defense).",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-005",
         "REQ-010"
@@ -447,6 +454,7 @@
       "description": "Update docs/reference/build-images-workflow.md: (1) Add a new top-level section 'Verification Workflows' or 'Test Integration' documenting verify-container-images.yaml: trigger events, yq prerequisite, list of 5 static scripts with what each validates. (2) Update the Jobs section to show 4 jobs in build-images.yaml: build-base-images -> verify-base-images -> build-service-images -> verify-service-images. Update the ASCII dependency diagram. (3) Update the verify-base-images job description: what it tests, how images are referenced by digest. (4) Replace smoke-test documentation with verify-service-images documentation. (5) Update 'Adding a New Service' section to mention creating a verification script under tests/container-images/. (6) Add a verification coverage table mapping scripts to what they validate.",
       "level": 3,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-009"
       ]
@@ -572,8 +580,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-07T19:07:59.686481"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-07T19:10:35.201674"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-07T20:39:07.283917"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/38",
+  "pr_number": 38,
   "execution_history": [
     {
       "run_id": "c5b57d5b-c88f-487d-a22a-f491298d8500",
@@ -585,6 +603,50 @@
           "name": "prepare",
           "duration": 283.10997247695923,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "e5dee5d2-8fe2-4642-aa44-0448a0a6b595",
+      "timestamp": "2026-03-07T19:38:47.905893",
+      "total_duration": 1480.6532340049744,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (4 tasks)",
+          "duration": 508.58499550819397,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (3 tasks)",
+          "duration": 310.1301865577698,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (1 tasks)",
+          "duration": 256.0541207790375,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0028] Code Review",
+          "duration": 203.03686046600342,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0028] Improvements",
+          "duration": 114.6989221572876,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0028] Simplify",
+          "duration": 88.14814853668213,
+          "type": "simplify",
           "status": "done"
         }
       ]

--- a/.planwerk/reviews/CC-0028-integrate-container-image-test-scripts-into-ci-review-1.json
+++ b/.planwerk/reviews/CC-0028-integrate-container-image-test-scripts-into-ci-review-1.json
@@ -1,0 +1,92 @@
+{
+  "feature_id": "CC-0028",
+  "title": "Integrate container image test scripts into CI",
+  "date": "2026-03-07",
+  "summary": "Integrates 8 existing container image test scripts into CI by creating a new verify-container-images.yaml workflow for 5 static tests, adding verify-base-images and verify-service-images jobs to build-images.yaml, replacing the smoke-test job with verify_keystone.sh, adding assert_not_empty to assertions.sh, fixing the stale uv version in verify_venv_builder.sh (0.6.3 → 0.10.8), refactoring verify_keystone.sh to use assert_not_empty, updating verify_build_images_workflow.sh for the new 4-job structure, and documenting the full verification coverage in build-images-workflow.md.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "All 5 static test scripts pass (133 total assertions, 0 failures)", "checked": true},
+    {"item": "verify_build_images_workflow.sh updated for 4-job structure (83 assertions)", "checked": true},
+    {"item": "verify_venv_builder.sh expects uv 0.10.8 matching Dockerfile", "checked": true},
+    {"item": "verify_keystone.sh uses assert_not_empty instead of manual pass/fail", "checked": true},
+    {"item": "New test_verify_base_images_job function covers needs, timeout, runner, permissions", "checked": true},
+    {"item": "Edge cases: test scripts handle yq failures with || echo null fallbacks", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing shell test script PASS/FAIL counter pattern", "checked": true},
+    {"item": "assert_not_empty follows assert_eq/assert_contains function signature convention", "checked": true},
+    {"item": "verify-container-images.yaml follows SPDX header and structure convention", "checked": true},
+    {"item": "Consistent naming: smoke-test → verify-service-images rename applied throughout", "checked": true},
+    {"item": "No dead code or commented-out code", "checked": true},
+    {"item": "Functions do one thing, within size limits", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No direct ${{ matrix.* }} interpolation in run: blocks (expression injection defense)", "checked": true},
+    {"item": "Verification jobs use packages: read not packages: write (least privilege)", "checked": true},
+    {"item": "All actions SHA-pinned with version comments", "checked": true},
+    {"item": "No hardcoded secrets", "checked": true},
+    {"item": "GHCR login uses GITHUB_TOKEN (not PAT)", "checked": true},
+    {"item": "Top-level permissions restricted to contents: read", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Static tests separated from Docker-based tests in different workflows", "checked": true},
+    {"item": "Dependency chain correct: build-base → verify-base → build-service → verify-service", "checked": true},
+    {"item": "PR inline step vs push job split maintained for service verification", "checked": true},
+    {"item": "Solution is minimal — reuses existing scripts without modification (except planned fixes)", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code — assert_not_empty reuses PASS/FAIL counter pattern", "checked": true},
+    {"item": "No unnecessary abstractions added", "checked": true},
+    {"item": "No future-proofing beyond current requirements", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "verify-base-images blocks build-service-images (catches base image regressions early)", "checked": true},
+    {"item": "Test scripts exit 1 on any FAIL count > 0", "checked": true},
+    {"item": "yq null/empty validation in source-ref and tag derivation steps", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "set -euo pipefail in all test scripts", "checked": true},
+    {"item": "Exit code guard pattern (|| exit_code=$?) used consistently in Docker-based tests", "checked": true},
+    {"item": "yq commands use 2>/dev/null with || fallback", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "id": "D2-1",
+      "severity": "minor",
+      "check_id": "Q4",
+      "file": "tests/container-images/verify_build_images_workflow.sh",
+      "lines": "65,393,436,525",
+      "description": "Local variables still use smoke_* naming (smoke_perms, smoke_timeout, smoke_runner, smoke_fail_fast) despite now referencing verify-service-images job. Naming does not match the entity they reference.",
+      "fix": "Rename local variables to verify_service_perms, verify_service_timeout, verify_service_runner, verify_service_fail_fast. Cosmetic only — does not affect functionality."
+    },
+    {
+      "id": "D2-2",
+      "severity": "minor",
+      "check_id": "D2",
+      "file": "docs/reference/build-images-workflow.md",
+      "lines": "122-123",
+      "description": "The build-base-images steps table references docker/login-action as v3 and docker/setup-buildx-action as v3, but the workflow file now uses v4 SHAs for docker/login-action. This predates this PR's changes (the table is from CC-0007) and is technically out of scope, but the new verify-base-images and verify-service-images documentation correctly references v4.",
+      "fix": "Out of scope for CC-0028. Could be addressed in a separate documentation sync PR."
+    },
+    {
+      "id": "D2-3",
+      "severity": "minor",
+      "check_id": "PF4",
+      "file": ".github/workflows/verify-container-images.yaml",
+      "lines": "31-33",
+      "description": "yq binary download does not verify SHA256 checksum. While the URL is pinned to a specific version (v4.45.1) and uses HTTPS, checksum verification would add defense-in-depth against supply chain compromise.",
+      "fix": "Add a checksum verification step after download: echo '<expected_sha256>  /usr/local/bin/yq' | sha256sum -c. Low priority — common pattern in GHA workflows to skip this."
+    }
+  ],
+  "suggested_improvements": [
+    "Consider adding SHA256 checksum verification for the yq binary download in verify-container-images.yaml (defense-in-depth)",
+    "Rename smoke_* local variables in verify_build_images_workflow.sh to verify_service_* for naming consistency"
+  ],
+  "next_steps": [
+    "Merge PR after approval — all blocking and major checks pass",
+    "Monitor first CI run on main to confirm all test scripts execute successfully in the GitHub Actions environment"
+  ],
+  "detected_patterns": []
+}

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -6,16 +6,21 @@ feature: CC-0007
 
 # Build Images Workflow
 
-Reference documentation for the GitHub Actions build-images workflow (CC-0007). This
-workflow builds, tags, and publishes container images for OpenStack services to GHCR
-(GitHub Container Registry).
+Reference documentation for the GitHub Actions build-images workflow (CC-0007) and the
+verify-container-images workflow (CC-0028). The build-images workflow builds, tags, and
+publishes container images for OpenStack services to GHCR (GitHub Container Registry).
+The verify-container-images workflow runs static verification tests against container
+infrastructure files (Dockerfiles, workflows, release configs) without requiring Docker.
 
-## File Location
+## File Locations
 
-`.github/workflows/build-images.yaml`
+| Workflow | Path |
+| --- | --- |
+| Build Images | `.github/workflows/build-images.yaml` |
+| Verify Container Images | `.github/workflows/verify-container-images.yaml` |
 
-The file uses the `.yaml` extension and quotes the trigger key as `"on"` to prevent
-YAML boolean interpretation (REQ-008). It starts with the standard SPDX license header
+Both files use the `.yaml` extension and quote the trigger key as `"on"` to prevent
+YAML boolean interpretation (REQ-008). They start with the standard SPDX license header
 (matching `ci.yaml`).
 
 ## Trigger Events
@@ -50,7 +55,7 @@ permissions:
   contents: read
   packages: write
 
-# smoke-test job
+# Verification jobs (verify-base-images, verify-service-images)
 permissions:
   contents: read
   packages: read
@@ -58,9 +63,9 @@ permissions:
 
 `contents: read` allows repository checkout. `packages: write` is granted only to
 `build-base-images` and `build-service-images` for pushing images to GHCR. The
-`smoke-test` job receives `contents: read` (required for its checkout step to access
-`source-refs.yaml` and count patches) and `packages: read` (for pulling the image
-from GHCR), following the principle of least privilege.
+verification jobs (`verify-base-images`, `verify-service-images`) receive
+`contents: read` (required for checkout and test scripts) and `packages: read`
+(for pulling images from GHCR), following the principle of least privilege (CC-0028).
 
 ## Concurrency
 
@@ -78,13 +83,20 @@ ensuring every merge commit produces a complete set of images.
 
 ## Jobs
 
-The workflow defines three jobs with a linear dependency chain:
+The workflow defines four jobs with a linear dependency chain (CC-0028):
 
 ```text
-build-base-images  ──>  build-service-images  ──>  smoke-test (push only)
-                                │
-                                └── Smoke test (PR, inline step)
+build-base-images ──> verify-base-images ──> build-service-images ──> verify-service-images (push only)
+                                                      │
+                                                      └── verify_keystone.sh (PR, inline step)
 ```
+
+The `verify-base-images` job validates base image properties (Python version, user
+UID/GID, PATH, uv version) before service image builds begin. This catches base image
+regressions before they cascade into service image failures. On push events, the
+`verify-service-images` job validates service images pulled from GHCR. On PRs, the
+equivalent verification runs as an inline step within `build-service-images` because
+`--load` makes the image available only on the same runner.
 
 ### build-base-images
 
@@ -127,19 +139,55 @@ mapping from any base image in GHCR back to the commit that produced it (CC-0007
 | `python-base-image` | `ghcr.io/<owner>/python-base@sha256:<digest>` | `ghcr.io/c5c3/python-base@sha256:abc123...` |
 | `venv-builder-image` | `ghcr.io/<owner>/venv-builder@sha256:<digest>` | `ghcr.io/c5c3/venv-builder@sha256:def456...` |
 
-These outputs are consumed by `build-service-images` via `needs.build-base-images.outputs`
-(REQ-003).
+These outputs are consumed by `verify-base-images` and `build-service-images` via
+`needs.build-base-images.outputs` (REQ-003).
+
+### verify-base-images
+
+Validates that just-built base images meet expected properties before service image
+builds begin (CC-0028). Runs after `build-base-images` and blocks
+`build-service-images`, forming the dependency chain:
+`build-base-images` → `verify-base-images` → `build-service-images`.
+
+| Property | Value |
+| --- | --- |
+| `runs-on` | `ubuntu-latest` |
+| `timeout-minutes` | `10` |
+| `needs` | `[build-base-images]` |
+| Permissions | `contents: read`, `packages: read` |
+
+**Steps:**
+
+| # | Step | Action / Command | Details |
+| --- | --- | --- | --- |
+| 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts) |
+| 2 | Login to GHCR | `docker/login-action@v4` | Authenticates to pull base images |
+| 3 | Pull base images | Shell | Pulls both `python-base` and `venv-builder` by digest from `build-base-images` outputs |
+| 4 | Verify python-base | Shell | Runs `verify_python_base.sh` with the digest-tagged image ref |
+| 5 | Verify venv-builder | Shell | Runs `verify_venv_builder.sh` with the digest-tagged image ref |
+
+**Test scripts executed:**
+
+| Script | Validates |
+| --- | --- |
+| `tests/container-images/verify_python_base.sh` | Python version, `openstack` user (UID/GID 42424), PATH includes `/opt/openstack/bin`, virtualenv at `/opt/openstack` |
+| `tests/container-images/verify_venv_builder.sh` | uv version (0.10.8), pip available, virtualenv at `/var/lib/openstack` |
+
+The job receives image references via `needs.build-base-images.outputs` (digest-pinned),
+ensuring the exact images that were just built are the ones being tested.
 
 ### build-service-images
 
 Builds service images using a matrix strategy over `service x release` (REQ-004).
-Depends on `build-base-images` to provide base image references (REQ-003).
+Depends on `build-base-images` for image references (REQ-003) and on
+`verify-base-images` to ensure base images are valid before building on top of them
+(CC-0028).
 
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
 | `timeout-minutes` | `30` |
-| `needs` | `[build-base-images]` |
+| `needs` | `[build-base-images, verify-base-images]` |
 | Matrix | `service: [keystone]`, `release: ["2025.2"]` |
 
 **Steps:**
@@ -156,7 +204,7 @@ Depends on `build-base-images` to provide base image references (REQ-003).
 | 8 | Set up Buildx | `docker/setup-buildx-action@v3` | Enables multi-platform builds |
 | 9 | Login to GHCR | `docker/login-action@v3` | Authenticates with `GITHUB_TOKEN` |
 | 10 | Build service image | `docker/build-push-action@v6` | Builds with four named build contexts and three build args, conditional platform/push/load (REQ-006) |
-| 11 | Smoke test (PR) | Shell (conditional) | On PRs only: `docker run --rm <image> <service>-manage --version` — uses `matrix.service` for dynamic dispatch (REQ-007) |
+| 11 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
 
 **Build Contexts:**
 
@@ -186,17 +234,17 @@ The service image build passes three build arguments sourced from
 [Container Images — extra-packages.yaml](container-images.md#extra-packagesyaml) for the
 YAML schema.
 
-This job does not declare outputs. The `smoke-test` job derives its own image refs
-independently via its own matrix strategy (CC-0007).
+This job does not declare outputs. The `verify-service-images` job derives its own image
+refs independently via its own matrix strategy (CC-0007).
 
-### smoke-test
+### verify-service-images
 
-Validates that built service images are functional by running
-`<service>-manage --version` (REQ-007). This job runs only on push events (when images
-are in GHCR) and uses its own matrix strategy matching `build-service-images` to test
-every service independently.
+Validates that built service images are functional by running `verify_keystone.sh`
+(CC-0028). This job replaces the former `smoke-test` job and runs only on push events
+(when images are in GHCR). It uses its own matrix strategy matching
+`build-service-images` to test every service independently.
 
-On PRs, the equivalent smoke test runs as an inline step within `build-service-images`
+On PRs, the equivalent verification runs as an inline step within `build-service-images`
 (step 11 above) because `--load` makes the image available only on the same runner.
 
 | Property | Value |
@@ -205,20 +253,26 @@ On PRs, the equivalent smoke test runs as an inline step within `build-service-i
 | `timeout-minutes` | `10` |
 | `needs` | `[build-service-images]` |
 | `if` | `github.event_name != 'pull_request'` |
+| Permissions | `contents: read`, `packages: read` |
 | Matrix | `service: [keystone]`, `release: ["2025.2"]` |
 
 **Steps:**
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for `source-refs.yaml` and patch counting) |
-| 2 | Login to GHCR | `docker/login-action@v3` | Authenticates to pull the image |
+| 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts, `source-refs.yaml`, and patch counting) |
+| 2 | Login to GHCR | `docker/login-action@v4` | Authenticates to pull the image |
 | 3 | Derive image ref | Shell | Reconstructs the composite tag from the same inputs as `build-service-images` |
-| 4 | Pull and test | Shell | `docker pull <image-ref>` then `docker run --rm <image-ref> <service>-manage --version` |
+| 4 | Pull and verify | Shell | `docker pull <image-ref>` then runs `verify_keystone.sh` with the pulled image ref |
 
-The job fails the workflow if `<service>-manage --version` returns a non-zero exit code.
-The management command is derived dynamically from `matrix.service`, so new services are
-automatically tested when added to the matrix.
+**Test script executed:**
+
+| Script | Validates |
+| --- | --- |
+| `tests/container-images/verify_keystone.sh` | `keystone-manage --version` exits 0, runs as `openstack` user, no build tools (gcc, python3-dev, uv), runtime apt packages installed |
+
+The job fails the workflow if `verify_keystone.sh` exits non-zero. The tag derivation
+step must stay in sync with the "Derive tags" step in `build-service-images`.
 
 ## Tag Schema
 
@@ -254,11 +308,12 @@ The workflow behaves differently depending on the trigger event (REQ-006):
 | Aspect | Pull Request | Push (main / stable/**) |
 | --- | --- | --- |
 | Base images | Multi-arch, pushed to GHCR | Multi-arch, pushed to GHCR |
+| Base image verification | `verify-base-images` job (always runs) | `verify-base-images` job (always runs) |
 | Service image platforms | `linux/amd64` only | `linux/amd64,linux/arm64` |
 | Service image push | No (`push: false`, `load: true`) | Yes (`push: true`) |
 | Service image tags | Computed but not published | Published to GHCR |
-| Smoke test location | Inline step in `build-service-images` | Separate `smoke-test` job |
-| Smoke test image source | Locally loaded image (same runner) | Pulled from GHCR |
+| Service image verification | Inline step in `build-service-images` | Separate `verify-service-images` job |
+| Verification image source | Locally loaded image (same runner) | Pulled from GHCR |
 
 **Why base images are always pushed:** Service Dockerfiles reference base images via
 `docker-image://` URIs in build contexts. This Docker BuildKit feature requires the
@@ -268,7 +323,7 @@ registry-independent.
 
 **Why PRs use single-arch:** `docker/build-push-action` with `load: true` only supports
 single-platform builds. Multi-platform images cannot be loaded into the local Docker
-daemon. Since the smoke test needs the image locally, PRs build only `linux/amd64`.
+daemon. Since the verification step needs the image locally, PRs build only `linux/amd64`.
 
 ## GHA Caching
 
@@ -342,8 +397,8 @@ nova:
 
 ### 4. Extend the matrices
 
-Add the service to both the `build-service-images` and `smoke-test` matrices in
-`.github/workflows/build-images.yaml`:
+Add the service to both the `build-service-images` and `verify-service-images` matrices
+in `.github/workflows/build-images.yaml`:
 
 ```yaml
 # build-service-images job:
@@ -352,7 +407,7 @@ strategy:
     service: [keystone, nova]    # ← add here
     release: ["2025.2"]
 
-# smoke-test job (must mirror build-service-images):
+# verify-service-images job (must mirror build-service-images):
 strategy:
   matrix:
     service: [keystone, nova]    # ← add here too
@@ -371,10 +426,12 @@ If the service requires constraint overrides, add entries to
 `overrides/<release>/constraints.txt`. The `apply-constraint-overrides.sh` script
 processes them automatically.
 
-The tag derivation, build context resolution, and smoke test commands all use matrix
-variables and work automatically for new services. The smoke test dynamically constructs
-`<service>-manage --version` from `matrix.service`. The `smoke-test` job derives its own
-image refs independently via its own matrix strategy.
+The tag derivation, build context resolution, and verification steps all use matrix
+variables and work automatically for new services. The `verify-service-images` job
+derives its own image refs independently via its own matrix strategy. Note that adding a
+new service also requires creating a corresponding `verify_<service>.sh` test script in
+`tests/container-images/` and updating the inline PR verification step in
+`build-service-images` accordingly.
 
 ## Adding a New Release
 
@@ -410,6 +467,89 @@ strategy:
 ### 3. (Optional) Add patches and overrides
 
 Create `patches/<service>/2026.1/` and `overrides/2026.1/constraints.txt` as needed.
+
+## Verify Container Images Workflow
+
+A separate workflow (`.github/workflows/verify-container-images.yaml`) runs static
+verification tests against container infrastructure files without requiring Docker
+(CC-0028). This workflow validates Dockerfiles, workflow structure, SPDX compliance,
+release configuration, and constraint override scripts.
+
+### Trigger Events
+
+The workflow triggers on the same events as `build-images.yaml`:
+
+| Event | Scope | Description |
+| --- | --- | --- |
+| `push` | `branches: [main, stable/**]` | Runs on every push to `main` or any `stable/**` branch |
+| `pull_request` | all branches | Runs on every pull request |
+
+### Permissions and Concurrency
+
+Top-level permissions are `contents: read` (least privilege). The concurrency group
+follows the standard pattern: `${{ github.ref }}-${{ github.workflow }}` with
+`cancel-in-progress` limited to pull request events.
+
+### Job: verify-static-tests
+
+A single job that runs all static test scripts sequentially. If any script exits
+non-zero, the job fails.
+
+| Property | Value |
+| --- | --- |
+| `runs-on` | `ubuntu-latest` |
+| `timeout-minutes` | `10` |
+
+**Steps:**
+
+| # | Step | Action / Command | Details |
+| --- | --- | --- | --- |
+| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 2 | Install yq | Shell | Downloads `yq` binary from GitHub releases (version-pinned via `YQ_VERSION` env var) |
+| 3 | Verify build-images workflow structure | Shell | Runs `tests/container-images/verify_build_images_workflow.sh` |
+| 4 | Verify deviation comments | Shell | Runs `tests/container-images/verify_deviation_comments.sh` |
+| 5 | Verify release config | Shell | Runs `tests/container-images/verify_release_config.sh` |
+| 6 | Verify SPDX headers | Shell | Runs `tests/container-images/verify_spdx_headers.sh` |
+| 7 | Test apply-constraint-overrides | Shell | Runs `tests/scripts/test_apply_constraint_overrides.sh` |
+
+**Test scripts executed:**
+
+| Script | Validates |
+| --- | --- |
+| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy |
+| `verify_deviation_comments.sh` | DEVIATION comments in Dockerfiles cross-reference architecture docs |
+| `verify_release_config.sh` | `source-refs.yaml` and `extra-packages.yaml` structure and content validity |
+| `verify_spdx_headers.sh` | SPDX Apache-2.0 license headers present on all infrastructure files |
+| `test_apply_constraint_overrides.sh` | `scripts/apply-constraint-overrides.sh` correctly applies constraint overrides |
+
+yq is installed before the test scripts because `verify_build_images_workflow.sh` and
+`verify_release_config.sh` use `yq` to parse YAML files. The installation uses a direct
+binary download from the mikefarah/yq GitHub releases (more reliable across runner
+updates than snap).
+
+### Relationship to build-images.yaml
+
+The verify-container-images workflow is intentionally separate from `build-images.yaml`
+because it tests container _infrastructure_ (file structure, conventions, configs) rather
+than the container _images_ themselves. Separate workflows provide clear, independent
+signals in GitHub's check status UI. The Docker-based image verification tests
+(`verify_python_base.sh`, `verify_venv_builder.sh`, `verify_keystone.sh`) run inside
+`build-images.yaml` where the images are actually built.
+
+## Verification Coverage Summary
+
+The following table summarizes which test scripts run where (CC-0028):
+
+| Test Script | verify-container-images.yaml | build-images.yaml | Requires Docker |
+| --- | --- | --- | --- |
+| `verify_build_images_workflow.sh` | verify-static-tests | — | No |
+| `verify_deviation_comments.sh` | verify-static-tests | — | No |
+| `verify_release_config.sh` | verify-static-tests | — | No |
+| `verify_spdx_headers.sh` | verify-static-tests | — | No |
+| `test_apply_constraint_overrides.sh` | verify-static-tests | — | No |
+| `verify_python_base.sh` | — | verify-base-images | Yes |
+| `verify_venv_builder.sh` | — | verify-base-images | Yes |
+| `verify_keystone.sh` | — | build-service-images (PR) / verify-service-images (push) | Yes |
 
 ## SPDX Header
 

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -59,19 +59,19 @@ test_job_permissions_scoping() {
   echo "Test: job-level permissions scoping (REQ-008)"
 
   # build-base-images and build-service-images need packages: write
-  local base_perms service_perms smoke_perms
+  local base_perms service_perms verify_service_perms
   base_perms=$(yq_raw '.jobs["build-base-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
   service_perms=$(yq_raw '.jobs["build-service-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  smoke_perms=$(yq_raw '.jobs["smoke-test"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_service_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
 
   assert_eq "build-base-images has packages: write" "write" "$base_perms"
   assert_eq "build-service-images has packages: write" "write" "$service_perms"
-  assert_eq "smoke-test has packages: read (least privilege)" "read" "$smoke_perms"
+  assert_eq "verify-service-images has packages: read (least privilege)" "read" "$verify_service_perms"
 
-  # smoke-test also needs contents: read for checkout (source-refs.yaml + patch counting)
-  local smoke_contents_perms
-  smoke_contents_perms=$(yq_raw '.jobs["smoke-test"]["permissions"]["contents"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  assert_eq "smoke-test has contents: read (for checkout)" "read" "$smoke_contents_perms"
+  # verify-service-images also needs contents: read for checkout (source-refs.yaml + patch counting)
+  local verify_service_contents_perms
+  verify_service_contents_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["contents"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  assert_eq "verify-service-images has contents: read (for checkout)" "read" "$verify_service_contents_perms"
 }
 
 # --- REQ-008: Concurrency control ---
@@ -96,13 +96,45 @@ test_pull_request_trigger() {
   assert_file_contains "pull_request trigger present" "$WORKFLOW" "pull_request"
 }
 
-# --- REQ-002, REQ-003, REQ-007: Three jobs defined ---
-test_three_jobs_defined() {
-  echo "Test: three jobs defined (REQ-002, REQ-003, REQ-007)"
+# --- REQ-002, REQ-003, REQ-004, REQ-005, REQ-007: Four jobs defined ---
+test_four_jobs_defined() {
+  echo "Test: four jobs defined (REQ-002, REQ-003, REQ-004, REQ-005)"
 
   assert_file_contains "build-base-images job defined" "$WORKFLOW" "build-base-images:"
+  assert_file_contains "verify-base-images job defined" "$WORKFLOW" "verify-base-images:"
   assert_file_contains "build-service-images job defined" "$WORKFLOW" "build-service-images:"
-  assert_file_contains "smoke-test job defined" "$WORKFLOW" "smoke-test:"
+  assert_file_contains "verify-service-images job defined" "$WORKFLOW" "verify-service-images:"
+}
+
+# --- REQ-004: verify-base-images job depends on build-base-images ---
+test_verify_base_images_job() {
+  echo "Test: verify-base-images job structure (REQ-004)"
+
+  local needs
+  needs=$(yq_raw '.jobs["verify-base-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
+  assert_contains "verify-base-images needs build-base-images" "$needs" "build-base-images"
+
+  local timeout
+  timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  if [ "$timeout" != "null" ] && [ -n "$timeout" ]; then
+    echo "  PASS: verify-base-images has timeout-minutes: $timeout"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: verify-base-images missing timeout-minutes"
+    FAIL=$((FAIL + 1))
+  fi
+
+  local runner
+  runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  assert_eq "verify-base-images uses ubuntu-latest" "ubuntu-latest" "$runner"
+
+  local pkg_perms
+  pkg_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  assert_eq "verify-base-images has packages: read" "read" "$pkg_perms"
+
+  local contents_perms
+  contents_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["contents"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  assert_eq "verify-base-images has contents: read (for checkout)" "read" "$contents_perms"
 }
 
 # --- REQ-002: Base images build with multi-arch platforms ---
@@ -147,14 +179,15 @@ test_base_image_digest_outputs() {
   assert_contains "venv-builder-image output references digest" "$venv_output" "outputs.digest"
 }
 
-# --- REQ-003: build-service-images depends on build-base-images ---
+# --- REQ-003, REQ-004: build-service-images depends on build-base-images and verify-base-images ---
 test_service_images_depend_on_base() {
-  echo "Test: build-service-images depends on build-base-images (REQ-003)"
+  echo "Test: build-service-images depends on build-base-images and verify-base-images (REQ-003, REQ-004)"
 
   local needs
   needs=$(yq_raw '.jobs["build-service-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
 
   assert_contains "build-service-images needs build-base-images" "$needs" "build-base-images"
+  assert_contains "build-service-images needs verify-base-images" "$needs" "verify-base-images"
 }
 
 # --- REQ-004: Matrix includes service and release ---
@@ -263,44 +296,44 @@ test_pr_single_arch_load() {
   assert_contains "push conditioned on not pull_request" "$push_val" "pull_request"
 }
 
-# --- REQ-007: Smoke test uses dynamic service-manage command ---
-test_smoke_test_command() {
-  echo "Test: smoke test uses dynamic service-manage command (REQ-007)"
+# --- REQ-007: verify-service-images uses verify_keystone.sh ---
+test_verify_service_images_command() {
+  echo "Test: verify-service-images uses verify_keystone.sh (REQ-007)"
 
-  # PR smoke test uses MATRIX_SERVICE env var for dynamic dispatch
-  assert_file_contains "PR smoke test uses MATRIX_SERVICE env var" "$WORKFLOW" 'MATRIX_SERVICE: \${{ matrix.service }}'
-  assert_file_contains "smoke test uses dynamic manage command" "$WORKFLOW" '${MATRIX_SERVICE}-manage'
+  # verify-service-images uses MATRIX_SERVICE env var for tag derivation
+  assert_file_contains "verify-service-images uses MATRIX_SERVICE env var" "$WORKFLOW" 'MATRIX_SERVICE: \${{ matrix.service }}'
+  assert_file_contains "verify-service-images runs verify_keystone.sh" "$WORKFLOW" 'verify_keystone.sh'
 }
 
-# --- REQ-007: smoke-test depends on build-service-images ---
-test_smoke_test_depends_on_service_images() {
-  echo "Test: smoke-test depends on build-service-images (REQ-007)"
+# --- REQ-007: verify-service-images depends on build-service-images ---
+test_verify_service_images_depends_on_service_images() {
+  echo "Test: verify-service-images depends on build-service-images (REQ-007)"
 
   local needs
-  needs=$(yq_raw '.jobs["smoke-test"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
+  needs=$(yq_raw '.jobs["verify-service-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
 
-  assert_contains "smoke-test needs build-service-images" "$needs" "build-service-images"
+  assert_contains "verify-service-images needs build-service-images" "$needs" "build-service-images"
 }
 
-# --- REQ-007: smoke-test has its own matrix strategy for multi-service support ---
-test_smoke_test_has_matrix() {
-  echo "Test: smoke-test has its own matrix strategy (REQ-007)"
+# --- REQ-007: verify-service-images has its own matrix strategy for multi-service support ---
+test_verify_service_images_has_matrix() {
+  echo "Test: verify-service-images has its own matrix strategy (REQ-007)"
 
   local services
-  services=$(yq_raw '.jobs["smoke-test"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" 2>/dev/null || true)
+  services=$(yq_raw '.jobs["verify-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" 2>/dev/null || true)
 
-  assert_contains "smoke-test matrix includes keystone" "$services" "keystone"
+  assert_contains "verify-service-images matrix includes keystone" "$services" "keystone"
 }
 
-# --- REQ-007: smoke-test derives image ref independently ---
-test_smoke_test_derives_image_ref() {
-  echo "Test: smoke-test derives image ref via tags step (REQ-007)"
+# --- REQ-007: verify-service-images derives image ref independently ---
+test_verify_service_images_derives_image_ref() {
+  echo "Test: verify-service-images derives image ref via tags step (REQ-007)"
 
   local derive_step
-  derive_step=$(yq_raw '.jobs["smoke-test"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
 
-  assert_contains "smoke-test derives VERSION from source-refs.yaml" "$derive_step" "source-refs.yaml"
-  assert_contains "smoke-test computes image-ref output" "$derive_step" "image-ref="
+  assert_contains "verify-service-images derives VERSION from source-refs.yaml" "$derive_step" "source-refs.yaml"
+  assert_contains "verify-service-images computes image-ref output" "$derive_step" "image-ref="
 }
 
 # --- REQ-008: All actions pinned to 40-char hex SHA ---
@@ -357,16 +390,25 @@ test_gha_caching_present() {
 test_timeout_minutes_on_all_jobs() {
   echo "Test: all jobs have timeout-minutes (REQ-008)"
 
-  local base_timeout service_timeout smoke_timeout
+  local base_timeout verify_base_timeout service_timeout verify_service_timeout
   base_timeout=$(yq_raw '.jobs["build-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_base_timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
   service_timeout=$(yq_raw '.jobs["build-service-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  smoke_timeout=$(yq_raw '.jobs["smoke-test"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_service_timeout=$(yq_raw '.jobs["verify-service-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
 
   if [ "$base_timeout" != "null" ] && [ -n "$base_timeout" ]; then
     echo "  PASS: build-base-images has timeout-minutes: $base_timeout"
     PASS=$((PASS + 1))
   else
     echo "  FAIL: build-base-images missing timeout-minutes"
+    FAIL=$((FAIL + 1))
+  fi
+
+  if [ "$verify_base_timeout" != "null" ] && [ -n "$verify_base_timeout" ]; then
+    echo "  PASS: verify-base-images has timeout-minutes: $verify_base_timeout"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: verify-base-images missing timeout-minutes"
     FAIL=$((FAIL + 1))
   fi
 
@@ -378,11 +420,11 @@ test_timeout_minutes_on_all_jobs() {
     FAIL=$((FAIL + 1))
   fi
 
-  if [ "$smoke_timeout" != "null" ] && [ -n "$smoke_timeout" ]; then
-    echo "  PASS: smoke-test has timeout-minutes: $smoke_timeout"
+  if [ "$verify_service_timeout" != "null" ] && [ -n "$verify_service_timeout" ]; then
+    echo "  PASS: verify-service-images has timeout-minutes: $verify_service_timeout"
     PASS=$((PASS + 1))
   else
-    echo "  FAIL: smoke-test missing timeout-minutes"
+    echo "  FAIL: verify-service-images missing timeout-minutes"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -391,14 +433,16 @@ test_timeout_minutes_on_all_jobs() {
 test_runs_on_ubuntu_latest() {
   echo "Test: all jobs use runs-on: ubuntu-latest (REQ-008)"
 
-  local base_runner service_runner smoke_runner
+  local base_runner verify_base_runner service_runner verify_service_runner
   base_runner=$(yq_raw '.jobs["build-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_base_runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
   service_runner=$(yq_raw '.jobs["build-service-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  smoke_runner=$(yq_raw '.jobs["smoke-test"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_service_runner=$(yq_raw '.jobs["verify-service-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
 
   assert_eq "build-base-images uses ubuntu-latest" "ubuntu-latest" "$base_runner"
+  assert_eq "verify-base-images uses ubuntu-latest" "ubuntu-latest" "$verify_base_runner"
   assert_eq "build-service-images uses ubuntu-latest" "ubuntu-latest" "$service_runner"
-  assert_eq "smoke-test uses ubuntu-latest" "ubuntu-latest" "$smoke_runner"
+  assert_eq "verify-service-images uses ubuntu-latest" "ubuntu-latest" "$verify_service_runner"
 }
 
 # --- REQ-002: Base images always push unconditionally ---
@@ -480,12 +524,12 @@ test_version_tag_restricted_to_main() {
 test_matrix_jobs_fail_fast_false() {
   echo "Test: matrix jobs use fail-fast: false (CC-0007)"
 
-  local service_fail_fast smoke_fail_fast
+  local service_fail_fast verify_service_fail_fast
   service_fail_fast=$(yq_raw '.jobs["build-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  smoke_fail_fast=$(yq_raw '.jobs["smoke-test"]["strategy"]["fail-fast"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_service_fail_fast=$(yq_raw '.jobs["verify-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" 2>/dev/null || echo "null")
 
   assert_eq "build-service-images has fail-fast: false" "false" "$service_fail_fast"
-  assert_eq "smoke-test has fail-fast: false" "false" "$smoke_fail_fast"
+  assert_eq "verify-service-images has fail-fast: false" "false" "$verify_service_fail_fast"
 }
 
 # --- CC-0007: Source ref resolution validates yq output against null/empty ---
@@ -500,22 +544,22 @@ test_source_ref_null_guard() {
   assert_contains "source-ref step exits on invalid ref" "$source_ref_run" "exit 1"
 }
 
-# --- CC-0007: smoke-test tag derivation has sync comment referencing build-service-images ---
-test_smoke_test_tag_derivation_sync_comment() {
-  echo "Test: smoke-test tag derivation has sync comment (CC-0007)"
+# --- CC-0007: verify-service-images tag derivation has sync comment referencing build-service-images ---
+test_verify_service_images_tag_derivation_sync_comment() {
+  echo "Test: verify-service-images tag derivation has sync comment (CC-0007)"
 
-  assert_file_contains "smoke-test has sync comment referencing Derive tags step" "$WORKFLOW" "MUST stay in sync with the .Derive tags. step"
+  assert_file_contains "verify-service-images has sync comment referencing Derive tags step" "$WORKFLOW" "MUST stay in sync with the .Derive tags. step"
 }
 
-# --- CC-0007: smoke-test validates yq output against null/empty ---
-test_smoke_test_null_guard() {
-  echo "Test: smoke-test validates yq output against null/empty (CC-0007)"
+# --- CC-0007: verify-service-images validates yq output against null/empty ---
+test_verify_service_images_null_guard() {
+  echo "Test: verify-service-images validates yq output against null/empty (CC-0007)"
 
   local derive_step
-  derive_step=$(yq_raw '.jobs["smoke-test"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
 
-  assert_contains "smoke-test derive step checks for null string" "$derive_step" '"null"'
-  assert_contains "smoke-test derive step exits on invalid ref" "$derive_step" "exit 1"
+  assert_contains "verify-service-images derive step checks for null string" "$derive_step" '"null"'
+  assert_contains "verify-service-images derive step exits on invalid ref" "$derive_step" "exit 1"
 }
 
 # --- REQ-008: Expression injection defense — run: blocks use env vars ---
@@ -544,7 +588,9 @@ test_push_triggers
 echo ""
 test_pull_request_trigger
 echo ""
-test_three_jobs_defined
+test_four_jobs_defined
+echo ""
+test_verify_base_images_job
 echo ""
 test_base_images_multi_arch
 echo ""
@@ -570,13 +616,13 @@ test_version_and_sha_outputs
 echo ""
 test_pr_single_arch_load
 echo ""
-test_smoke_test_command
+test_verify_service_images_command
 echo ""
-test_smoke_test_depends_on_service_images
+test_verify_service_images_depends_on_service_images
 echo ""
-test_smoke_test_has_matrix
+test_verify_service_images_has_matrix
 echo ""
-test_smoke_test_derives_image_ref
+test_verify_service_images_derives_image_ref
 echo ""
 test_actions_pinned_to_sha
 echo ""
@@ -602,9 +648,9 @@ test_matrix_jobs_fail_fast_false
 echo ""
 test_source_ref_null_guard
 echo ""
-test_smoke_test_tag_derivation_sync_comment
+test_verify_service_images_tag_derivation_sync_comment
 echo ""
-test_smoke_test_null_guard
+test_verify_service_images_null_guard
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/container-images/verify_keystone.sh
+++ b/tests/container-images/verify_keystone.sh
@@ -27,14 +27,7 @@ test_keystone_manage_version() {
 
   assert_eq "keystone-manage --version exits 0" "0" "$exit_code"
 
-  # Version string should be non-empty
-  if [ -n "$version" ]; then
-    echo "  PASS: version output is non-empty ($version)"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: version output is empty"
-    FAIL=$((FAIL + 1))
-  fi
+  assert_not_empty "version output is non-empty" "$version"
 }
 
 # --- Test 2: runs as openstack user ---
@@ -58,7 +51,7 @@ test_no_build_tools_in_final_image() {
 
   # python3-dev should not be installed
   local pydev_exit=0
-  docker run --rm "$IMAGE" dpkg -l python3-dev > /dev/null 2>&1 || pydev_exit=$?
+  docker run --rm "$IMAGE" dpkg -s python3-dev > /dev/null 2>&1 || pydev_exit=$?
   assert_nonzero_exit "python3-dev not installed" "$pydev_exit"
 
   # uv should not be present in the final image
@@ -74,7 +67,7 @@ test_runtime_apt_packages_installed() {
   dpkg_output=$(docker run --rm "$IMAGE" dpkg -l 2>&1) || exit_code=$?
 
   assert_eq "dpkg -l exits 0" "0" "$exit_code"
-  for pkg in libapache2-mod-wsgi-py3 libldap-2.5-0 libsasl2-2 libxml2; do
+  for pkg in libapache2-mod-wsgi-py3 libldap2 libsasl2-2 libxml2; do
     assert_contains "$pkg is installed" "$dpkg_output" "$pkg"
   done
 }

--- a/tests/container-images/verify_venv_builder.sh
+++ b/tests/container-images/verify_venv_builder.sh
@@ -19,14 +19,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=tests/lib/assertions.sh
 source "$SCRIPT_DIR/../lib/assertions.sh"
 
-# --- Test 1: uv version is pinned at 0.6.3 ---
+# --- Test 1: uv version is pinned at 0.10.8 ---
 test_uv_version_is_pinned() {
-  echo "Test: uv version is 0.6.3"
+  echo "Test: uv version is 0.10.8"
   local version exit_code=0
   version=$(docker run --rm "$IMAGE" uv --version 2>&1) || exit_code=$?
 
   assert_eq "uv --version exits 0" "0" "$exit_code"
-  assert_contains "uv version is 0.6.3" "$version" "0.6.3"
+  assert_contains "uv version is 0.10.8" "$version" "0.10.8"
 }
 
 # --- Test 2: virtualenv exists at /var/lib/openstack ---

--- a/tests/lib/assertions.sh
+++ b/tests/lib/assertions.sh
@@ -19,6 +19,17 @@ assert_eq() {
   fi
 }
 
+assert_not_empty() {
+  local description="$1" value="$2"
+  if [ -n "$value" ]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description (expected non-empty value)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 assert_contains() {
   local description="$1" haystack="$2" needle="$3"
   if [[ "$haystack" == *"$needle"* ]]; then


### PR DESCRIPTION
**Size:** 📦 medium
**Category:** infrastructure
**Priority:** high
**Source:** Proposed for 'The tests under tests/container-images/ are currently'

1. Create `.github/workflows/verify-container-images.yaml` — a new single-job workflow triggered on push (main, stable/**) and pull_request that installs yq and runs 5 static test scripts sequentially: verify_build_images_workflow.sh, verify_deviation_comments.sh, verify_release_config.sh, verify_spdx_headers.sh, test_apply_constraint_overrides.sh. Follow existing conventions (SPDX header, SHA-pinned actions/checkout, permissions: contents: read, concurrency ${{ github.ref }}-${{ github.workflow }} with cancel-in-progress only on PR, timeout-minutes, runs-on: ubuntu-latest).

2. Modify `.github/workflows/build-images.yaml` — add a verification step/job after build-base-images that runs verify_python_base.sh and verify_venv_builder.sh with digest-tagged image refs from job outputs. Replace the inline PR smoke test (~lines 191–196) and the push-only smoke-test job (~lines 198–254) with verify_keystone.sh; push path retains docker pull from GHCR before invocation, PR path uses local --load image.

3. Fix test script issues — add assert_not_empty to tests/lib/assertions.sh; refactor verify_keystone.sh manual pass/fail block (lines 31–37) to use it and align default image tag with CI tags; fix stale uv version in verify_venv_builder.sh (0.6.3 → match Dockerfile); evaluate/harden sed-based extras extraction in verify_release_config.sh (lines 97–108).

4. Update docs/reference/build-images-workflow.md to document test integration, verification coverage, and the new workflow.

**Rationale:** Eight test scripts exist but zero are executed in CI, meaning container image structure validation, SPDX compliance checks, release config validation, and Dockerfile convention enforcement provide no automated protection. Bugs like the stale uv version expectation in verify_venv_builder.sh (tests for 0.6.3 while Dockerfile uses 0.10.8) would fail immediately if CI ran the scripts, proving the gap is real. Integrating these scripts catches regressions at PR time, replaces the limited inline smoke test (single --version check) with comprehensive verification (non-root user, no build tools, runtime packages), and ensures the existing test investment delivers value.

**Affected Areas:**
- .github/workflows/verify-container-images.yaml
- .github/workflows/build-images.yaml
- tests/lib/assertions.sh
- tests/container-images/verify_keystone.sh
- tests/container-images/verify_venv_builder.sh
- tests/container-images/verify_release_config.sh
- docs/reference/build-images-workflow.md