### PR TITLE
feat: add daily GHCR image cleanup workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -9,7 +9,21 @@ name: Build Images
     branches:
       - main
       - stable/**
+    paths:
+      - images/**
+      - releases/**
+      - patches/**
+      - scripts/**
+      - tests/container-images/**
+      - .github/workflows/build-images.yaml
   pull_request:
+    paths:
+      - images/**
+      - releases/**
+      - patches/**
+      - scripts/**
+      - tests/container-images/**
+      - .github/workflows/build-images.yaml
 
 permissions:
   contents: read

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Cleanup Images
+
+"on":
+  schedule:
+    # Daily at 03:00 UTC
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      older-than:
+        description: "Minimum age of images to delete (e.g. '7 days', '1 month')"
+        required: false
+        default: "7 days"
+        type: string
+      keep-n-tagged:
+        description: "Minimum number of tagged images to keep per package"
+        required: false
+        default: "10"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup-base-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [python-base, venv-builder]
+    steps:
+      - name: Delete untagged images
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
+        with:
+          package: ${{ matrix.package }}
+          delete-untagged: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old SHA-tagged images
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
+        with:
+          package: ${{ matrix.package }}
+          exclude-tags: latest
+          keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
+          older-than: ${{ inputs.older-than || '7 days' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup-service-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [keystone]
+    steps:
+      - name: Delete untagged images
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
+        with:
+          package: ${{ matrix.package }}
+          delete-untagged: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old tagged images
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
+        with:
+          package: ${{ matrix.package }}
+          exclude-tags: "*.*.*"
+          keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
+          older-than: ${{ inputs.older-than || '7 days' }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-container-images.yaml
+++ b/.github/workflows/verify-container-images.yaml
@@ -9,7 +9,25 @@ name: Verify Container Images
     branches:
       - main
       - stable/**
+    paths:
+      - images/**
+      - releases/**
+      - patches/**
+      - scripts/**
+      - tests/container-images/**
+      - tests/scripts/**
+      - .github/workflows/build-images.yaml
+      - .github/workflows/verify-container-images.yaml
   pull_request:
+    paths:
+      - images/**
+      - releases/**
+      - patches/**
+      - scripts/**
+      - tests/container-images/**
+      - tests/scripts/**
+      - .github/workflows/build-images.yaml
+      - .github/workflows/verify-container-images.yaml
 
 permissions:
   contents: read


### PR DESCRIPTION
Scheduled daily at 03:00 UTC to delete untagged, ghost, and partial images as well as old SHA-tagged images (older than 7 days, keeping at least 10) for base and service packages. Supports manual dispatch with configurable age and retention count.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com