### PR TITLE
feat: add Renovate custom manager for OpenStack source-refs tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,33 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["releases/.*/source-refs\\.yaml$"],
+      "matchStrings": [
+        "(?m)^(?<depName>[\\w.-]+):\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "git-tags",
+      "packageNameTemplate": "https://opendev.org/openstack/{{{depName}}}",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["releases/**/source-refs.yaml"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["releases/**/source-refs.yaml"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "OpenStack upstream tags"
+    }
   ]
 }

--- a/tests/container-images/verify_release_config.sh
+++ b/tests/container-images/verify_release_config.sh
@@ -41,10 +41,19 @@ test_source_refs_valid_yaml_with_keystone() {
     return
   fi
 
-  # Verify keystone version
+  # Verify keystone version is a valid semver tag
   local keystone_version
   keystone_version=$(yq '.keystone' "$source_refs" | tr -d '"')
-  assert_eq "keystone version is 28.0.0" "28.0.0" "$keystone_version"
+  if [[ "$keystone_version" == "null" || -z "$keystone_version" ]]; then
+    echo "  FAIL: keystone key is missing from source-refs.yaml"
+    FAIL=$((FAIL + 1))
+  elif [[ "$keystone_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "  PASS: keystone version is valid semver ($keystone_version)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: keystone version is not valid semver: $keystone_version"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
 # --- Test 2: extra-packages.yaml has expected structure (CC-0027 REQ-007) ---


### PR DESCRIPTION
Configure Renovate to automatically track git tags for OpenStack components in releases/*/source-refs.yaml. Major updates are disabled (they cross OpenStack release boundaries), minor/patch auto-merge.

Replace hardcoded version assertion in verify_release_config.sh with a semver format check so Renovate updates don't break CI.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com