### PR TITLE
feat(CC-0029): Add CycloneDX SBOM and Sigstore attestation to CI

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -39,6 +39,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+      attestations: write   # CC-0029: GitHub Attestations API
     outputs:
       python-base-image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
       venv-builder-image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
@@ -80,6 +82,25 @@ jobs:
           cache-from: type=gha,scope=python-base
           cache-to: type=gha,mode=max,scope=python-base
 
+      # CC-0029: Generate and attest SBOM for python-base
+      - name: Generate SBOM for python-base
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
+        with:
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom-python-base.cyclonedx.json
+          upload-artifact: false
+
+      - name: Attest SBOM for python-base
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
+        with:
+          subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+          subject-digest: ${{ steps.build-python-base.outputs.digest }}
+          sbom-path: sbom-python-base.cyclonedx.json
+          push-to-registry: true
+
       - name: Build and push venv-builder
         id: build-venv-builder
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -94,6 +115,25 @@ jobs:
             ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:${{ github.sha }}
           cache-from: type=gha,scope=venv-builder
           cache-to: type=gha,mode=max,scope=venv-builder
+
+      # CC-0029: Generate and attest SBOM for venv-builder
+      - name: Generate SBOM for venv-builder
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
+        with:
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom-venv-builder.cyclonedx.json
+          upload-artifact: false
+
+      - name: Attest SBOM for venv-builder
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
+        with:
+          subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
+          subject-digest: ${{ steps.build-venv-builder.outputs.digest }}
+          sbom-path: sbom-venv-builder.cyclonedx.json
+          push-to-registry: true
 
   verify-base-images:
     needs: [build-base-images]
@@ -136,6 +176,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+      attestations: write   # CC-0029: GitHub Attestations API
     strategy:
       fail-fast: false
       matrix:
@@ -224,6 +266,7 @@ jobs:
           IMAGE="ghcr.io/${IMAGE_OWNER}/${MATRIX_SERVICE}"
           COMPOSITE="${VERSION}-p${PATCH_COUNT}-${BRANCH}-${SHORT_SHA}"
 
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "composite=${IMAGE}:${COMPOSITE}" >> "$GITHUB_OUTPUT"
           echo "version=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
           echo "sha=${IMAGE}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
@@ -264,6 +307,25 @@ jobs:
             ${{ steps.tags.outputs.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}
+
+      # CC-0029: Generate and attest SBOM for service image
+      - name: Generate SBOM for service image
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
+        with:
+          image: ${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.service }}.cyclonedx.json
+          upload-artifact: false
+
+      - name: Attest SBOM for service image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.build-service.outputs.digest }}
+          sbom-path: sbom-${{ matrix.service }}.cyclonedx.json
+          push-to-registry: true
 
       - name: Verify service image (PR)
         if: github.event_name == 'pull_request'

--- a/.planwerk/completed/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci.json
+++ b/.planwerk/completed/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0029",
   "title": "Add CycloneDX SBOM and Sigstore attestation to CI",
   "slug": "add-cyclonedx-sbom-and-sigstore-attestation-to-ci",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 📦 medium\n**Category:** infrastructure\n**Priority:** high\n**Source:** Proposed for 'From the start, SBOMs with CycloneDX should be generated for all'\n\nIntegrate SBOM generation and attestation into `.github/workflows/build-images.yaml` for all container images:\n\n1. **`build-base-images` job**: Add `id-token: write` and `attestations: write` permissions. After `build-python-base` and `build-venv-builder` push steps, add two new step pairs each:\n   - `anchore/sbom-action` (SHA-pinned) scanning the pushed image by digest (`steps.build-python-base.outputs.digest` / `steps.build-venv-builder.outputs.digest`), outputting CycloneDX 1.5 JSON (`format: cyclonedx-json`)\n   - `actions/attest-sbom@v2` (SHA-pinned) attesting the SBOM via Sigstore keyless OIDC and pushing attestation to GHCR (`push-to-registry: true`)\n   - Both steps guarded by `if: github.event_name != 'pull_request'`\n\n2. **`build-service-images` job**: Same permissions additions. After the `build-service` step, add one SBOM generation + attestation step pair referencing `steps.build-service.outputs.digest` and `matrix.service` for naming. Same PR-skip guard.\n\n3. **SHA-pinning**: Both new actions must be SHA-pinned with version comments per existing convention enforced by `verify_build_images_workflow.sh`.\n\n4. **Verification tests**: Update `tests/container-images/verify_build_images_workflow.sh` with new test cases validating: SBOM generation steps exist with `anchore/sbom-action` and correct `format: cyclonedx-json` parameter; attestation steps exist with `actions/attest-sbom` and `push-to-registry: true`; `id-token: write` and `attestations: write` permissions on both build jobs; `if: github.event_name != 'pull_request'` guard on all SBOM/attestation steps. Use existing assertion helpers from `tests/lib/assertions.sh`.\n\n**Rationale:** Container images published to GHCR currently lack any software bill of materials or cryptographic attestation, leaving consumers unable to verify image contents or provenance. The architecture doc (`architecture/docs/08-container-images/04-sbom.md`) mandates CycloneDX SBOMs with Sigstore attestation. Without this, the project cannot meet supply chain security requirements, and downstream consumers have no tamper-evident way to audit image dependencies. This is a prerequisite for any future vulnerability scanning or compliance reporting from SBOMs.\n\n**Affected Areas:**\n- .github/workflows/build-images.yaml\n- tests/container-images/verify_build_images_workflow.sh\n- architecture/docs/08-container-images/04-sbom.md",
   "stories": [
@@ -330,6 +330,7 @@
       "title": "Add SBOM permissions and generation/attestation steps for python-base and venv-builder in build-base-images job (REQ-010, REQ-011, REQ-012, REQ-013, REQ-014, REQ-015, REQ-016)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-010",
         "REQ-011",
@@ -345,6 +346,7 @@
       "title": "Add SBOM permissions and generation/attestation steps for service images in build-service-images job, including image output in tags step (REQ-010, REQ-011, REQ-012, REQ-013, REQ-014, REQ-015, REQ-016)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-010",
         "REQ-011",
@@ -360,6 +362,7 @@
       "title": "Add verification tests for SBOM/attestation job permissions (id-token: write, attestations: write) on both build jobs in verify_build_images_workflow.sh (REQ-012, REQ-017)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-012",
         "REQ-017"
@@ -370,6 +373,7 @@
       "title": "Add verification tests for SBOM generation steps (anchore/sbom-action existence, format: cyclonedx-json, digest references) in verify_build_images_workflow.sh (REQ-010, REQ-015, REQ-017)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-010",
         "REQ-015",
@@ -381,6 +385,7 @@
       "title": "Add verification tests for attestation steps (actions/attest-sbom existence, push-to-registry: true) and PR-skip guard on all SBOM/attestation steps in verify_build_images_workflow.sh (REQ-011, REQ-013, REQ-016, REQ-017)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-011",
         "REQ-013",
@@ -393,6 +398,7 @@
       "title": "Update docs/reference/build-images-workflow.md with SBOM generation, attestation steps, required permissions, and PR behavior documentation (REQ-010, REQ-011, REQ-012)",
       "level": 3,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-010",
         "REQ-011",
@@ -490,8 +496,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-08T18:40:40.397267"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-08T18:44:17.904645"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-08T20:34:42.590096"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/43",
+  "pr_number": 43,
   "execution_history": [
     {
       "run_id": "ceed797e-bd55-4e4e-9fea-2980e0c93779",
@@ -503,6 +519,106 @@
           "name": "prepare",
           "duration": 425.0957443714142,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "bb3338bf-0bec-4ed4-856d-185fbb8f5b27",
+      "timestamp": "2026-03-08T19:05:26.938780",
+      "total_duration": 1083.017442703247,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (2 tasks)",
+          "duration": 446.3316185474396,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (3 tasks)",
+          "duration": 142.77218651771545,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (1 tasks)",
+          "duration": 210.4118161201477,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0029] Code Review",
+          "duration": 162.994619846344,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0029] Improvements",
+          "duration": 41.66034173965454,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0029] Simplify",
+          "duration": 78.8468599319458,
+          "type": "simplify",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "8920862b-3dd7-4b2f-8d6d-3b6d0f4d6152",
+      "timestamp": "2026-03-08T19:38:01.244970",
+      "total_duration": 510.2237961292267,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #1",
+          "duration": 510.2237961292267,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "aef17a2f-8426-4c2d-b439-0507d849fc87",
+      "timestamp": "2026-03-08T19:52:03.403453",
+      "total_duration": 303.2073895931244,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #2",
+          "duration": 303.2073895931244,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "1e7acc1e-183f-47cb-a99c-b9d655726509",
+      "timestamp": "2026-03-08T20:03:27.374224",
+      "total_duration": 272.9146456718445,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #3",
+          "duration": 272.9146456718445,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "f2c47dab-208d-471a-9a5a-6e598ddf1feb",
+      "timestamp": "2026-03-08T20:20:22.641990",
+      "total_duration": 353.9953896999359,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #4",
+          "duration": 353.9953896999359,
+          "type": "review_address",
           "status": "done"
         }
       ]

--- a/.planwerk/review_patterns/check-documentation-for-internal-contradictions.md
+++ b/.planwerk/review_patterns/check-documentation-for-internal-contradictions.md
@@ -1,0 +1,21 @@
+# Review Pattern: Check documentation for internal contradictions
+
+**Review-Area**: documentation
+**Detection-Hint**: When a bullet or paragraph gives a reason for some behavior, scan the surrounding section for statements that contradict or narrow that reason. Look for causal claims that are only partially true.
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+Verify that explanations and justifications within the same document are consistent with each other. If paragraph A says X happens because of Y, and paragraph B describes a scenario where Y does not apply but X still happens, the explanation in A is misleading.
+
+## Why it matters
+
+Misleading causal explanations lead readers to wrong mental models. They may assume the behavior would change if the stated cause changes, when in reality the guard is broader than described.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: The parenthetical explanation `(service images are not pushed to GHCR on PRs)` implies the sole reason SBOMs are skipped on PRs is because service images aren't pushed. However, base images **are** always pushed to GHCR on PRs (as the next paragraph correctly states), yet base image SBOM generation is also skipped.
+- **What was missed**: Verify that explanations and justifications within the same document are consistent with each other. If paragraph A says X happens because of Y, and paragraph B describes a scenario where Y does not apply but X still happens, the explanation in A is misleading.
+- **Fix**: Replaced the misleading parenthetical with accurate wording: the `if: github.event_name != 'pull_request'` guard applies uniformly to all SBOM/attestation steps, including for base images which are pushed on PRs.

--- a/.planwerk/review_patterns/distinguish-permission-granted-from-permission-exercised-in-security-docs.md
+++ b/.planwerk/review_patterns/distinguish-permission-granted-from-permission-exercised-in-security-docs.md
@@ -1,0 +1,21 @@
+# Review Pattern: Distinguish permission-granted from permission-exercised in security docs
+
+**Review-Area**: documentation
+**Detection-Hint**: When documentation claims a permission or capability is absent in a certain context, cross-check the actual workflow/config to see if the permission is declared but merely not used (due to conditional guards). Statements like 'no X usage' are inaccurate if X is granted but skipped.
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+Review security-related documentation claims about permissions (OIDC tokens, API scopes, IAM roles) against the actual configuration. Verify whether the doc accurately distinguishes between 'permission not granted' vs 'permission granted but steps are conditionally skipped.'
+
+## Why it matters
+
+Inaccurate security documentation misleads security auditors and operators. Claiming a permission isn't used when it's actually granted (just not exercised) misrepresents the attack surface — a malicious or buggy step could still leverage the granted permission.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: However, `id-token: write` **is** present at the job level on `build-base-images`, which runs on PRs (base images are always pushed). The permission is available to all steps in that job, including on PR runs. It's just that the SBOM steps are guarded so they skip — but the permission itself is unconditionally granted.
+- **What was missed**: Review security-related documentation claims about permissions (OIDC tokens, API scopes, IAM roles) against the actual configuration. Verify whether the doc accurately distinguishes between 'permission not granted' vs 'permission granted but steps are conditionally skipped.'
+- **Fix**: Changed 'No OIDC token requests occur (no `id-token: write` usage)' to 'No OIDC token requests occur — SBOM/attestation steps are skipped so `id-token: write` is not exercised.'

--- a/.planwerk/review_patterns/enforce-consistent-error-handling-pattern-across-all-test-cases.md
+++ b/.planwerk/review_patterns/enforce-consistent-error-handling-pattern-across-all-test-cases.md
@@ -3,7 +3,7 @@
 **Review-Area**: testing
 **Detection-Hint**: When a file already uses a defensive pattern (e.g., capturing exit codes with `|| exit_code=$?`) in some test cases, scan ALL other test cases in the same file for the same invocation pattern without the guard.
 **Severity**: BLOCKING
-**Occurrences**: 2
+**Occurrences**: 3
 
 ## What to check
 
@@ -24,3 +24,8 @@ Silent test abortion means CI reports a failure with zero diagnostic output. Dev
 - **Feedback**: The new test confirms that the Dockerfile declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES`, and that the CI workflow references `extra-packages.yaml`. However, it has no check for `ARG EXTRA_APT_PACKAGES` in Stage 2 of the Dockerfile. Had this check existed, it would have caught that the apt-packages half of the wiring is missing.
 - **What was missed**: List all build args or config keys the PR introduces. For each one, verify the test suite includes an assertion that the arg is declared and used. If the test checks 2 of 3 args, the unchecked arg is the one most likely to be broken.
 - **Fix**: Added an `ARG EXTRA_APT_PACKAGES` grep check to `test_extra_packages_build_wiring` and a new `test_no_hardcoded_apt_packages` test to verify the runtime stage uses the build arg instead of hardcoded values.
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: `test_sbom_format_cyclonedx_json` has asymmetric handling of empty results: the base-images branch uses a silent non-count pattern, while the service branch correctly uses `assert_eq`.
+- **What was missed**: Parallel code paths within the same test function should use the same assertion strategy. If one branch uses assert_eq (which handles empty/mismatch as FAIL), all equivalent branches must do the same or provide equivalent explicit failure handling.
+- **Fix**: Added an elif branch to the base-images block to explicitly fail when base_formats is empty, making it consistent with the service branch that already used assert_eq.

--- a/.planwerk/review_patterns/enforce-consistent-patterns-across-sibling-functions.md
+++ b/.planwerk/review_patterns/enforce-consistent-patterns-across-sibling-functions.md
@@ -1,0 +1,21 @@
+# Review Pattern: Enforce consistent patterns across sibling functions
+
+**Review-Area**: validation
+**Detection-Hint**: When a new function follows the same structure as existing sibling functions (same loop+summary pattern, same counter logic), diff the control flow against the existing functions. Any deviation in branching (e.g., `else` vs `elif`) is a red flag.
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+When reviewing a function that mirrors the structure of nearby functions in the same file, compare the branching and counter logic line-by-line. If sibling functions use `elif [ -z "$var" ]` but the new function uses a bare `else`, flag the inconsistency and verify correctness.
+
+## Why it matters
+
+Inconsistency between sibling functions that follow the same pattern is a strong signal of a copy-paste bug. The reviewer already had correct reference implementations in the same file — the bug was catchable by simple comparison.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: Both the `test_sbom_format_cyclonedx_json` and `test_sbom_attestation_push_to_registry` functions correctly avoid this by using `elif [ -z "$base_formats" ]` / `elif [ -z "$base_push_values" ]` instead of a plain `else`, so only the truly unhandled "no results" case increments an extra FAIL. This function should follow the same pattern.
+- **What was missed**: When reviewing a function that mirrors the structure of nearby functions in the same file, compare the branching and counter logic line-by-line. If sibling functions use `elif [ -z "$var" ]` but the new function uses a bare `else`, flag the inconsistency and verify correctness.
+- **Fix**: Aligned both the `base_sbom_ifs` and `service_sbom_ifs` blocks to use the same `elif [ -z ... ]` pattern as the other test functions in the file.

--- a/.planwerk/review_patterns/require-explicit-failure-branch-in-test-passfail-logic.md
+++ b/.planwerk/review_patterns/require-explicit-failure-branch-in-test-passfail-logic.md
@@ -1,0 +1,21 @@
+# Review Pattern: Require explicit failure branch in test pass/fail logic
+
+**Review-Area**: testing
+**Detection-Hint**: Look for if-blocks that increment PASS but have no corresponding else/elif that increments FAIL. Search for patterns like `if <condition>; then ... PASS=$((PASS + 1)) ... fi` without an else clause.
+**Severity**: BLOCKING
+**Occurrences**: 2
+
+## What to check
+
+Every conditional block that increments a PASS counter must also have an else/elif branch that increments FAIL. There must be no code path through a test function that exits without incrementing either counter.
+
+## Why it matters
+
+A test that silently returns without incrementing PASS or FAIL gives a false sense of security. If a yq query returns empty results or a parse error occurs, the test appears to succeed (no FAIL) while actually validating nothing. For security-critical checks like PR-skip guards, this means a misconfiguration could go completely undetected.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: `test_sbom_steps_pr_skip_guard` has a silent failure mode: if the yq query returns empty results (e.g., no steps found, or a parse error), the function increments neither PASS nor FAIL and returns silently.
+- **What was missed**: Every conditional block that increments a PASS counter must also have an else/elif branch that increments FAIL. There must be no code path through a test function that exits without incrementing either counter.
+- **Fix**: Added else branches to three conditional blocks so that empty yq results or failed guard checks explicitly increment FAIL with a descriptive message instead of silently returning.

--- a/.planwerk/review_patterns/verify-documented-commands-work-end-to-end.md
+++ b/.planwerk/review_patterns/verify-documented-commands-work-end-to-end.md
@@ -3,7 +3,7 @@
 **Review-Area**: documentation
 **Detection-Hint**: When docs contain shell commands (especially multi-step build sequences), mentally execute them in order and cross-reference any referenced names (image tags, paths, variables) against the actual source files (Dockerfiles, configs).
 **Severity**: BLOCKING
-**Occurrences**: 2
+**Occurrences**: 3
 
 ## What to check
 
@@ -24,3 +24,8 @@ Users following the docs verbatim get a build failure. The docs become a source 
 - **Feedback**: This always exits 0. `echo $?` captures and prints the exit code of `which gcc` as text, but since `echo` itself exits 0, `sh -c` exits 0, and `docker run` exits 0. A developer who wraps this in an `if` statement or CI script will always see success — even if gcc IS present in the image.
 - **What was missed**: Any documented verification command (especially negative checks like 'verify X is NOT present') must actually exit non-zero when the check fails. Watch for `cmd; echo $?` which prints but discards the exit code, and `cmd || true` which swallows it.
 - **Fix**: Changed from `sh -c 'which gcc; echo $?'` to `which gcc && echo 'FAIL' || echo 'PASS'` which correctly propagates the exit code.
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: The `--type` flag in `cosign verify-attestation` expects a predicate type URI or a recognized shorthand (e.g., `slsaprovenance`, `slsaprovenance1`, `link`, `vuln`). `cyclonedx` is not a standard shorthand in cosign.
+- **What was missed**: Confirm that every flag, argument, and value in documented example commands is actually accepted by the tool. For cosign/sigstore/gh tooling, verify that predicate type shorthands exist and that the recommended verification path matches how attestations are actually stored.
+- **Fix**: Replaced the invalid `cosign verify-attestation --type cyclonedx` example with the recommended `gh attestation` tooling using the correct CycloneDX predicate type URI `https://cyclonedx.org/bom`.

--- a/.planwerk/review_patterns/verify-failpass-counter-consistency-across-branching-paths.md
+++ b/.planwerk/review_patterns/verify-failpass-counter-consistency-across-branching-paths.md
@@ -1,0 +1,21 @@
+# Review Pattern: Verify FAIL/PASS counter consistency across branching paths
+
+**Review-Area**: testing
+**Detection-Hint**: When a loop increments a counter (FAIL) on a condition, and a subsequent if/else block also increments the same counter in the else branch, check whether the else branch can fire after the loop already incremented. Look for `else` branches that catch multiple distinct failure scenarios where one has already been counted.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+In test functions that use a loop to validate items and increment FAIL per bad item, then follow with an if/else summary block: verify the else branch doesn't re-increment FAIL for items already counted in the loop. The else should use `elif [ -z "$var" ]` to only catch the 'no results found' case, not the 'some items failed validation' case.
+
+## Why it matters
+
+Double-counting FAIL inflates the failure count, making test reports inaccurate. It can also mask the true number of distinct failures, undermining trust in the test harness. This is especially insidious because the tests still 'work' — they just report wrong numbers.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: The `else` branch fires for two distinct scenarios: 1. `base_sbom_ifs` is empty — FAIL has not yet been incremented, so incrementing here is correct. 2. `all_guarded=false` — FAIL was **already incremented** inside the while loop (once per step missing the guard). The `else` branch then increments FAIL a second time for the same failure event, overcounting.
+- **What was missed**: In test functions that use a loop to validate items and increment FAIL per bad item, then follow with an if/else summary block: verify the else branch doesn't re-increment FAIL for items already counted in the loop. The else should use `elif [ -z "$var" ]` to only catch the 'no results found' case, not the 'some items failed validation' case.
+- **Fix**: Changed `else` to `elif [ -z "$base_sbom_ifs" ]` so the extra FAIL increment only fires when no results were found at all, matching the pattern already used in `test_sbom_format_cyclonedx_json` and `test_sbom_attestation_push_to_registry`.

--- a/.planwerk/review_patterns/verify-tool-output-format-matches-downstream-parsing.md
+++ b/.planwerk/review_patterns/verify-tool-output-format-matches-downstream-parsing.md
@@ -1,0 +1,21 @@
+# Review Pattern: Verify tool output format matches downstream parsing
+
+**Review-Area**: testing
+**Detection-Hint**: When a command pipeline pipes tool output (e.g., yq, jq) into grep/awk, check whether the grep pattern matches the actual output format. If yq outputs YAML by default but grep looks for JSON-quoted keys like '"uses":', the count will always be 0 and assertions will silently produce wrong results.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+In any shell test that chains a data-extraction tool (yq, jq, xmllint) with grep -c on a specific string pattern, confirm the output format of the upstream tool matches the pattern being grepped. Look for quoted JSON keys in grep when the upstream tool emits YAML, or vice versa.
+
+## Why it matters
+
+The test appears to run without error but always evaluates to 0, meaning it never actually validates the condition it claims to test. This is a false-passing test that provides zero coverage while giving false confidence.
+
+## Examples from external reviews
+
+### CC-0029 — greptile-apps[bot]
+- **Feedback**: `test_sbom_attestation_steps_exist` has the same root problem as `test_sbom_generation_steps_exist` above: it greps for the JSON-format key `"uses":` in what is likely YAML output from `yq`. Both `base_attest_count` and `service_attest_count` will evaluate to `"0"` and fail their assertions.
+- **What was missed**: In any shell test that chains a data-extraction tool (yq, jq, xmllint) with grep -c on a specific string pattern, confirm the output format of the upstream tool matches the pattern being grepped. Look for quoted JSON keys in grep when the upstream tool emits YAML, or vice versa.
+- **Fix**: Changed from `grep -c '"uses":'` on raw yq YAML output to using `yq_raw` to extract `.uses` values and `grep -c .` to count non-empty lines, applied across 4 locations in 2 test functions.

--- a/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-1.json
+++ b/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-1.json
@@ -1,0 +1,59 @@
+{
+  "summary": "Adds CycloneDX SBOM generation (anchore/sbom-action) and Sigstore attestation (actions/attest-sbom) to the build-images workflow for all three image types (python-base, venv-builder, service). Both actions are SHA-pinned with version comments. id-token:write and attestations:write permissions added to build jobs only. All 6 SBOM/attestation steps guarded with PR-skip condition. 9 new test functions validate permissions, step existence, format, digest references, push-to-registry, and PR guards — all 105 tests pass. Reference docs updated with comprehensive SBOM/attestation section. Docs also corrected stale action version references (v3→v4, v6→v7) to match actual workflow SHAs.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "Tests exist and pass (105/105, 0 failures)", "checked": true},
+    {"item": "SBOM permission tests cover both build jobs and negative case for verify jobs", "checked": true},
+    {"item": "SBOM step existence validated (2 in base, 1 in service for both generation and attestation)", "checked": true},
+    {"item": "CycloneDX format validated for all SBOM steps", "checked": true},
+    {"item": "Digest reference correctness validated for all 3 image types", "checked": true},
+    {"item": "push-to-registry: true validated for all attestation steps", "checked": true},
+    {"item": "PR-skip guard validated on all SBOM/attestation steps in both jobs", "checked": true},
+    {"item": "Existing tests (test_actions_pinned_to_sha, test_actions_have_version_comments, test_run_blocks_use_env_vars) pass unmodified", "checked": true},
+    {"item": "All new test functions invoked in run-all-tests section", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns (yq_raw helper, assert_eq/assert_contains, while-loop for multi-value checks)", "checked": true},
+    {"item": "No code duplication — shared assertion helpers from tests/lib/assertions.sh used consistently", "checked": true},
+    {"item": "Clear naming — test functions named descriptively with CC-0029 and REQ references", "checked": true},
+    {"item": "No dead code or commented-out code", "checked": true},
+    {"item": "Step names descriptive and consistent (Generate SBOM for X / Attest SBOM for X)", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "id-token:write and attestations:write scoped to build jobs only — not verify jobs (least privilege)", "checked": true},
+    {"item": "No secrets or credentials exposed in workflow steps", "checked": true},
+    {"item": "SHA-pinned actions prevent supply-chain attacks via tag mutation", "checked": true},
+    {"item": "SBOM/attestation steps use Sigstore keyless OIDC — no managed signing keys", "checked": true},
+    {"item": "Service image SBOM uses steps.tags.outputs.image (from env vars, not direct expression injection)", "checked": true},
+    {"item": "New image output added via env var interpolation, consistent with existing expression injection defense pattern", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Implementation aligns with architecture/docs/08-container-images/04-sbom.md GitHub Actions Integration section", "checked": true},
+    {"item": "CycloneDX JSON format matches architecture doc specification", "checked": true},
+    {"item": "Sigstore keyless OIDC signing matches architecture doc design", "checked": true},
+    {"item": "PR-skip behavior matches architecture doc (No SBOM on PRs)", "checked": true},
+    {"item": "Solution is minimal — no scope creep beyond SBOM generation and attestation", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated workflow steps — each image type has exactly one SBOM+attest pair", "checked": true},
+    {"item": "No unnecessary abstractions or indirection", "checked": true},
+    {"item": "image output added to tags step only because SBOM step needs it (justified addition)", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "SBOM generation references image by digest — fails immediately if build step didn't produce output", "checked": true},
+    {"item": "Attestation references SBOM file by name — fails if generation step didn't run", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "PR guard prevents unnecessary SBOM/attestation on ephemeral builds", "checked": true},
+    {"item": "Verification tests validate negative case (verify jobs do NOT have SBOM permissions)", "checked": true},
+    {"item": "yq queries use 2>/dev/null || echo fallback to handle missing keys gracefully in tests", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "D2 (minor): The cosign verify-attestation example in docs/reference/build-images-workflow.md uses --certificate-identity-regexp '.*' which accepts any signer identity. Consider using a more specific pattern like the architecture doc's 'https://github.com/c5c3/.*' to guide consumers toward secure verification defaults. Not blocking — it's a generic placeholder example."
+  ],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-2.json
+++ b/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-2.json
@@ -1,0 +1,55 @@
+{
+  "feature_id": "CC-0029",
+  "title": "Add CycloneDX SBOM and Sigstore attestation to CI",
+  "date": "2026-03-08",
+  "summary": "Addresses two external review findings: (1) fixes yq output format mismatch in grep assertions — changed from grep -c '\"uses\":' on YAML output to yq_raw + grep -c . across 4 locations in 2 test functions; (2) corrects documentation to distinguish permission-granted from permission-exercised for id-token: write on PR builds. Both fixes are accurate, complete, and all 105 tests pass.",
+  "verdict": "APPROVED",
+  "review_steps": {
+    "1_INTENT": "Address greptile-apps[bot] external review feedback: fix false-passing yq/grep format mismatch in test assertions and correct misleading permission documentation for PR builds.",
+    "2_SCOPE": "Changes are tightly scoped to exactly the 2 files with substantive fixes (verify_build_images_workflow.sh, build-images-workflow.md) plus 3 planwerk tracking/pattern files. No scope creep.",
+    "3_VERIFICATION": "bash tests/container-images/verify_build_images_workflow.sh — 105 passed, 0 failed. Not applicable: mypy, ruff, golangci-lint (shell script + markdown changes only).",
+    "4_PATTERNS": "yq_raw helper is used consistently across all 71 yq invocations in the test file. No instances of the old grep -c '\"uses\":' pattern remain. The || echo \"0\" fallback is pre-existing and consistent with the pattern elsewhere in the file.",
+    "5_TESTS": "All 4 counting assertions in test_sbom_generation_steps_exist and test_sbom_attestation_steps_exist now correctly count action occurrences using yq_raw to extract .uses values as raw strings, then grep -c . to count non-empty lines.",
+    "6_SECURITY": "Documentation now accurately describes the security posture: id-token: write IS granted at job level on PRs but not exercised because SBOM/attestation steps are skipped. This is an important distinction for security auditors assessing attack surface.",
+    "7_COMPLEXITY": "Minimal changes — 4 line substitutions in tests, 1 line change in docs. Simplest possible fix.",
+    "8_COMPLETENESS": "Both external review findings fully addressed. No stubs or TODOs remain.",
+    "9_PROMPT_QUALITY": "No new prompt files. N/A."
+  },
+  "tests_checklist": [
+    {"item": "All 105 existing tests pass", "checked": true},
+    {"item": "Fixed yq/grep format mismatch in 4 counting assertions", "checked": true},
+    {"item": "No remaining instances of old grep -c '\"uses\":' anti-pattern", "checked": true},
+    {"item": "test_sbom_generation_steps_exist correctly counts 2 base + 1 service SBOM steps", "checked": true},
+    {"item": "test_sbom_attestation_steps_exist correctly counts 2 base + 1 service attestation steps", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Uses existing yq_raw helper consistently (71 invocations, no plain yq calls)", "checked": true},
+    {"item": "grep -c . pattern is idiomatic for counting non-empty output lines", "checked": true},
+    {"item": "Change is minimal — 4 line substitutions in tests, 1 in docs", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "Documentation accurately distinguishes permission-granted from permission-exercised", "checked": true},
+    {"item": "id-token: write scope correctly described as granted but not exercised on PRs", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is minimal fix for the reported issues", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code introduced", "checked": true},
+    {"item": "No unnecessary abstractions added", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Test assertions fail correctly when counts mismatch", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "yq stderr redirected to /dev/null with fallback || echo \"0\"", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "Minor: The `|| echo \"0\"` fallback on grep -c . produces double output (\"0\\n0\") in the zero-match case because grep -c already outputs \"0\" before exiting 1. Consider `|| true` instead of `|| echo \"0\"` since grep -c already writes the count. This is pre-existing (not introduced by this change) and only affects error message clarity, not test correctness."
+  ],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-3.json
+++ b/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-3.json
@@ -1,0 +1,48 @@
+{
+  "feature_id": "CC-0029",
+  "title": "Add CycloneDX SBOM and Sigstore attestation to CI",
+  "date": "2026-03-08",
+  "summary": "Review #2 feedback from greptile-apps[bot] was addressed: else/elif branches added to test_sbom_format_cyclonedx_json and test_sbom_steps_pr_skip_guard to prevent silent failure modes when yq queries return empty results. New review pattern 'require-explicit-failure-branch-in-test-passfail-logic' correctly captures the lesson. However, the identical pattern in test_sbom_attestation_push_to_registry (line 717-720) was missed — it still has a PASS-only if-block with no else/elif for FAIL when base_push_values is empty.",
+  "verdict": "NEEDS_CHANGES",
+  "tests_checklist": [
+    {"item": "All 105 tests pass", "checked": true},
+    {"item": "External review feedback (test_sbom_format_cyclonedx_json elif) addressed", "checked": true},
+    {"item": "External review feedback (test_sbom_steps_pr_skip_guard else branches) addressed", "checked": true},
+    {"item": "Same fix applied consistently to all identical patterns in CC-0029 test functions", "checked": false}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns", "checked": true},
+    {"item": "Changes are minimal and targeted", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No secrets or credentials exposed", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code introduced", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Errors detected early with explicit FAIL branches", "checked": false}
+  ],
+  "defensive_checklist": [
+    {"item": "All external inputs validated", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "id": "PC3",
+      "severity": "major",
+      "description": "test_sbom_attestation_push_to_registry has same silent failure mode that was just fixed in test_sbom_format_cyclonedx_json and test_sbom_steps_pr_skip_guard. The if-block at line 717 increments PASS but has no else/elif to increment FAIL when base_push_values is empty. This directly violates the new review pattern 'require-explicit-failure-branch-in-test-passfail-logic' created in this same diff.",
+      "location": "tests/container-images/verify_build_images_workflow.sh:717-720",
+      "fix": "Add an else branch: `else\\n    echo \"  FAIL: build-base-images attestation push-to-registry not found or not true\"\\n    FAIL=$((FAIL + 1))` after the PASS block at line 719, replacing the bare `fi` at line 720."
+    }
+  ],
+  "suggested_improvements": [],
+  "next_steps": [
+    "Add else branch to test_sbom_attestation_push_to_registry (line 717-720) matching the pattern applied to test_sbom_steps_pr_skip_guard"
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-4.json
+++ b/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-4.json
@@ -1,0 +1,44 @@
+{
+  "summary": "Fixes FAIL counter double-counting bug in test_sbom_steps_pr_skip_guard by changing bare `else` to `elif [ -z \"$var\" ]` in both base and service blocks, aligning with the pattern already used by test_sbom_format_cyclonedx_json and test_sbom_attestation_push_to_registry. Two new review pattern files document the lessons learned from external review #3.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "All 105 tests pass (0 failures)", "checked": true},
+    {"item": "Edge cases covered: empty yq result vs loop-incremented FAIL are now distinct branches", "checked": true},
+    {"item": "Existing tests (test_actions_pinned_to_sha, test_actions_have_version_comments, test_run_blocks_use_env_vars) pass without modification", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing elif [ -z ] pattern from sibling functions", "checked": true},
+    {"item": "Minimal change — only 2 lines modified in test file", "checked": true},
+    {"item": "No dead code or unused variables introduced", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No user input handling — test infrastructure only", "checked": true},
+    {"item": "No secrets, credentials, or sensitive data", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible (2-line fix)", "checked": true},
+    {"item": "No structural changes to test framework", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code introduced", "checked": true},
+    {"item": "No unnecessary abstractions", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "FAIL counter now accurately reflects distinct failure events", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "elif guard prevents double-counting when loop already incremented FAIL", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": [],
+  "metadata": {
+    "feature_id": "CC-0029",
+    "title": "Add CycloneDX SBOM and Sigstore attestation to CI",
+    "date": "2026-03-08",
+    "verdict": "APPROVED"
+  }
+}

--- a/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-5.json
+++ b/.planwerk/reviews/CC-0029-add-cyclonedx-sbom-and-sigstore-attestation-to-ci-review-5.json
@@ -1,0 +1,40 @@
+{
+  "feature_id": "CC-0029",
+  "title": "Add CycloneDX SBOM and Sigstore attestation to CI",
+  "date": "2026-03-08",
+  "summary": "Review of changes addressing external review #4 feedback from greptile-apps[bot]. Two documentation fixes in docs/reference/build-images-workflow.md: (1) replaced misleading parenthetical about PR SBOM behavior with accurate explanation of the uniform `if: github.event_name != 'pull_request'` guard, (2) replaced invalid `cosign verify-attestation --type cyclonedx` example with correct `gh attestation verify` commands using the proper CycloneDX predicate type URI. Two review pattern files were added/updated to capture the lessons learned. All 105 verification tests pass.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "All 105 verification tests pass (verify_build_images_workflow.sh)", "checked": true},
+    {"item": "No test modifications required for this doc-only change", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Documentation changes are accurate and internally consistent", "checked": true},
+    {"item": "Review pattern files follow established format", "checked": true},
+    {"item": "Changes are minimal and scoped to reviewer feedback", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No security-sensitive changes (documentation only)", "checked": true},
+    {"item": "Documented verification commands use correct tooling (gh attestation vs cosign)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Documentation aligns with implemented workflow behavior", "checked": true},
+    {"item": "PR behavior explanation is now consistent across all bullet points", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated content introduced", "checked": true},
+    {"item": "Review pattern files capture reusable review knowledge", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Not applicable (documentation-only changes)", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Not applicable (documentation-only changes)", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-1.json
+++ b/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-1.json
@@ -1,0 +1,46 @@
+{
+  "feature_id": "CC-0029",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer flags two issues: (1) In `verify_build_images_workflow.sh`, the `test_sbom_attestation_steps_exist` function has the same bug as a previously noted one—`grep -c '\"uses\":'` looks for JSON-formatted keys in YAML output from `yq`, so counts will always be \"0\"; fix by piping `.uses` through `grep -c .` instead. (2) In `build-images-workflow.md`, the claim that \"no `id-token: write` usage\" occurs on PRs is misleading since the permission is unconditionally granted at job level—it should say the SBOM/attestation steps are skipped so the permission is not *exercised*.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-08T19:27:44Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 1,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**Same `grep -c '\"uses\":'` fragility in attestation step counter**\n\n`test_sbom_attestation_steps_exist` has the same root problem as `test_sbom_generation_steps_exist` above: it greps for the JSON-format key `\"uses\":` in what is likely YAML output from `yq`. Both `base_attest_count` and `service_attest_count` will evaluate to `\"0\"` and fail their assertions.\n\n```bash\n# Instead of:\nbase_attest_count=$(yq '.jobs[\"build-base-images\"][\"steps\"][] | select(.uses and (.uses | test(\"actions/attest-sbom\")))' \"$WORKFLOW\" 2>/dev/null | grep -c '\"uses\":' || echo \"0\")\n\n# Use:\nbase_attest_count=$(yq_raw '.jobs[\"build-base-images\"][\"steps\"][] | select(.uses and (.uses | test(\"actions/attest-sbom\"))) | .uses' \"$WORKFLOW\" 2>/dev/null | grep -c . || echo \"0\")\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_build_images_workflow.sh\nLine: 621-632\n\nComment:\n**Same `grep -c '\"uses\":'` fragility in attestation step counter**\n\n`test_sbom_attestation_steps_exist` has the same root problem as `test_sbom_generation_steps_exist` above: it greps for the JSON-format key `\"uses\":` in what is likely YAML output from `yq`. Both `base_attest_count` and `service_attest_count` will evaluate to `\"0\"` and fail their assertions.\n\n```bash\n# Instead of:\nbase_attest_count=$(yq '.jobs[\"build-base-images\"][\"steps\"][] | select(.uses and (.uses | test(\"actions/attest-sbom\")))' \"$WORKFLOW\" 2>/dev/null | grep -c '\"uses\":' || echo \"0\")\n\n# Use:\nbase_attest_count=$(yq_raw '.jobs[\"build-base-images\"][\"steps\"][] | select(.uses and (.uses | test(\"actions/attest-sbom\"))) | .uses' \"$WORKFLOW\" 2>/dev/null | grep -c . || echo \"0\")\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_build_images_workflow.sh",
+      "line": 632,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T19:27:42Z",
+      "id": null,
+      "resolution": "Fixed: Replaced `yq` + `grep -c '\"uses\":'` with `yq_raw ... | .uses` + `grep -c .` in both `base_attest_count` and `service_attest_count` within `test_sbom_attestation_steps_exist` (lines 687, 692). The same fix was also applied to the identical fragile pattern in `test_sbom_generation_steps_exist` (lines 623, 628), which the reviewer flagged as having the same root problem."
+    },
+    {
+      "body": "**Documentation claim about OIDC on PRs is inaccurate**\n\nThe doc says:\n> No OIDC token requests occur (no `id-token: write` usage).\n\nHowever, `id-token: write` **is** present at the job level on `build-base-images`, which runs on PRs (base images are always pushed). The permission is available to all steps in that job, including on PR runs. It's just that the SBOM steps are guarded so they skip — but the permission itself is unconditionally granted.\n\nA more precise phrasing would be:\n\n```suggestion\n- No OIDC token requests occur — SBOM/attestation steps are skipped so `id-token: write` is not exercised.\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: docs/reference/build-images-workflow.md\nLine: 414-416\n\nComment:\n**Documentation claim about OIDC on PRs is inaccurate**\n\nThe doc says:\n> No OIDC token requests occur (no `id-token: write` usage).\n\nHowever, `id-token: write` **is** present at the job level on `build-base-images`, which runs on PRs (base images are always pushed). The permission is available to all steps in that job, including on PR runs. It's just that the SBOM steps are guarded so they skip — but the permission itself is unconditionally granted.\n\nA more precise phrasing would be:\n\n```suggestion\n- No OIDC token requests occur — SBOM/attestation steps are skipped so `id-token: write` is not exercised.\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "docs/reference/build-images-workflow.md",
+      "line": 416,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T19:27:43Z",
+      "id": null,
+      "resolution": "Fixed: Changed line 418 in docs/reference/build-images-workflow.md from 'No OIDC token requests occur (no `id-token: write` usage).' to 'No OIDC token requests occur — SBOM/attestation steps are skipped so `id-token: write` is not exercised.' — exactly matching the reviewer's suggested phrasing."
+    }
+  ],
+  "resolution_summary": "Both review comments were addressed via uncommitted (staged) changes. Comment [0] about grep fragility was fixed in test_sbom_attestation_steps_exist and also applied to the same pattern in test_sbom_generation_steps_exist (which had the identical bug). Comment [1] about inaccurate OIDC documentation was fixed with the reviewer's suggested phrasing. The grep -c '\"uses\":' fix was applied to 4 total locations across 2 test functions (test_sbom_generation_steps_exist and test_sbom_attestation_steps_exist), because test_sbom_generation_steps_exist had the same fragile yq/grep pattern — this additional change beyond what the reviewer explicitly commented on is traceable to comment [0].",
+  "github_review_id": 3911922630
+}

--- a/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-2.json
+++ b/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-2.json
@@ -1,0 +1,46 @@
+{
+  "feature_id": "CC-0029",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer identified silent failure modes in three test functions where empty yq query results cause neither PASS nor FAIL counters to increment, making the tests silently skip instead of explicitly failing. They want `else`/`elif` branches added to `test_sbom_steps_pr_skip_guard` (both base and service blocks) and `test_sbom_format_cyclonedx_json` (base-images block) so that empty or missing results always increment FAIL with a descriptive message.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-08T19:44:53Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 2,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "`test_sbom_steps_pr_skip_guard` has a silent failure mode: if the yq query returns empty results (e.g., no steps found, or a parse error), the function increments neither PASS nor FAIL and returns silently. \n\nThis happens because:\n- `base_sbom_ifs` would be empty\n- The condition `if $all_guarded && [ -n \"$base_sbom_ifs\" ]` (line 743) evaluates to false\n- Neither counter is incremented\n\nFor a security-critical test like the PR-skip guard, an empty result should explicitly fail. Add an `else` branch:\n\n```bash\nif $all_guarded && [ -n \"$base_sbom_ifs\" ]; then\n  echo \"  PASS: all build-base-images SBOM/attestation steps have PR-skip guard\"\n  PASS=$((PASS + 1))\nelse\n  echo \"  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard\"\n  FAIL=$((FAIL + 1))\nfi\n```\n\nApply the same fix to the `service_sbom_ifs` block (lines 762–765).\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_build_images_workflow.sh\nLine: 726-766\n\nComment:\n`test_sbom_steps_pr_skip_guard` has a silent failure mode: if the yq query returns empty results (e.g., no steps found, or a parse error), the function increments neither PASS nor FAIL and returns silently. \n\nThis happens because:\n- `base_sbom_ifs` would be empty\n- The condition `if $all_guarded && [ -n \"$base_sbom_ifs\" ]` (line 743) evaluates to false\n- Neither counter is incremented\n\nFor a security-critical test like the PR-skip guard, an empty result should explicitly fail. Add an `else` branch:\n\n```bash\nif $all_guarded && [ -n \"$base_sbom_ifs\" ]; then\n  echo \"  PASS: all build-base-images SBOM/attestation steps have PR-skip guard\"\n  PASS=$((PASS + 1))\nelse\n  echo \"  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard\"\n  FAIL=$((FAIL + 1))\nfi\n```\n\nApply the same fix to the `service_sbom_ifs` block (lines 762–765).\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_build_images_workflow.sh",
+      "line": 766,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T19:44:51Z",
+      "id": null,
+      "resolution": "Fixed: Added else branches to both the base_sbom_ifs block (line ~746) and the service_sbom_ifs block (line ~768) in test_sbom_steps_pr_skip_guard. Both now explicitly FAIL with a descriptive message ('SBOM/attestation steps not found or missing PR guard') when the yq query returns empty results or no steps have the PR-skip guard, exactly matching the reviewer's suggested code."
+    },
+    {
+      "body": "`test_sbom_format_cyclonedx_json` has asymmetric handling of empty results: the base-images branch uses a silent non-count pattern, while the service branch correctly uses `assert_eq`.\n\nThe base-images branch (lines 650–653):\n```bash\nif $all_cyclonedx && [ -n \"$base_formats\" ]; then\n  echo \"  PASS: all build-base-images SBOM steps use cyclonedx-json\"\n  PASS=$((PASS + 1))\nfi\n```\n\nIf `base_formats` is empty, neither counter increments. The service branch avoids this by using `assert_eq` (line 658), which increments FAIL when the value is empty.\n\nMake the base-images branch consistent by adding an explicit failure case:\n\n```bash\nif $all_cyclonedx && [ -n \"$base_formats\" ]; then\n  echo \"  PASS: all build-base-images SBOM steps use cyclonedx-json\"\n  PASS=$((PASS + 1))\nelif [ -z \"$base_formats\" ]; then\n  echo \"  FAIL: build-base-images SBOM format check found no steps\"\n  FAIL=$((FAIL + 1))\nfi\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_build_images_workflow.sh\nLine: 633-659\n\nComment:\n`test_sbom_format_cyclonedx_json` has asymmetric handling of empty results: the base-images branch uses a silent non-count pattern, while the service branch correctly uses `assert_eq`.\n\nThe base-images branch (lines 650–653):\n```bash\nif $all_cyclonedx && [ -n \"$base_formats\" ]; then\n  echo \"  PASS: all build-base-images SBOM steps use cyclonedx-json\"\n  PASS=$((PASS + 1))\nfi\n```\n\nIf `base_formats` is empty, neither counter increments. The service branch avoids this by using `assert_eq` (line 658), which increments FAIL when the value is empty.\n\nMake the base-images branch consistent by adding an explicit failure case:\n\n```bash\nif $all_cyclonedx && [ -n \"$base_formats\" ]; then\n  echo \"  PASS: all build-base-images SBOM steps use cyclonedx-json\"\n  PASS=$((PASS + 1))\nelif [ -z \"$base_formats\" ]; then\n  echo \"  FAIL: build-base-images SBOM format check found no steps\"\n  FAIL=$((FAIL + 1))\nfi\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_build_images_workflow.sh",
+      "line": 659,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T19:44:52Z",
+      "id": null,
+      "resolution": "Fixed: Added an elif [ -z \"$base_formats\" ] branch (line ~653) to the base-images block in test_sbom_format_cyclonedx_json. When base_formats is empty, the test now explicitly FAILs with 'build-base-images SBOM format check found no steps', making it consistent with the service branch's assert_eq pattern, exactly matching the reviewer's suggested code."
+    }
+  ],
+  "resolution_summary": "Both review comments were addressed in staged (uncommitted) changes to tests/container-images/verify_build_images_workflow.sh. The fixes add explicit else/elif failure branches to three conditional blocks that previously had silent failure modes when yq queries returned empty results. No changes were made to files or locations outside those directly mentioned in the review feedback.",
+  "github_review_id": 3911936746
+}

--- a/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-3.json
+++ b/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-3.json
@@ -1,0 +1,36 @@
+{
+  "feature_id": "CC-0029",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer identified that the `else` branch in the SBOM PR-guard test double-counts FAIL: once inside the `while` loop for each unguarded step, then again in the `else` branch. Fix by changing `else` to `elif [ -z \"$base_sbom_ifs\" ]` (and likewise for the `service_sbom_ifs` block) so only the \"no results found\" case gets an extra FAIL, matching the pattern used in `test_sbom_format_cyclonedx_json` and `test_sbom_attestation_push_to_registry`.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-08T19:57:06Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 3,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**`else` branch double-counts FAIL when a guard is missing**\n\nThe `else` branch fires for two distinct scenarios:\n\n1. `base_sbom_ifs` is empty — FAIL has not yet been incremented, so incrementing here is correct.\n2. `all_guarded=false` — FAIL was **already incremented** inside the while loop (once per step missing the guard). The `else` branch then increments FAIL a second time for the same failure event, overcounting.\n\nBoth the `test_sbom_format_cyclonedx_json` and `test_sbom_attestation_push_to_registry` functions correctly avoid this by using `elif [ -z \"$base_formats\" ]` / `elif [ -z \"$base_push_values\" ]` instead of a plain `else`, so only the truly unhandled \"no results\" case increments an extra FAIL. This function should follow the same pattern.\n\nThe same double-count problem exists for the `service_sbom_ifs` block (lines 761–777).\n\n```suggestion\n  if $all_guarded && [ -n \"$base_sbom_ifs\" ]; then\n    echo \"  PASS: all build-base-images SBOM/attestation steps have PR-skip guard\"\n    PASS=$((PASS + 1))\n  elif [ -z \"$base_sbom_ifs\" ]; then\n    echo \"  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard\"\n    FAIL=$((FAIL + 1))\n  fi\n\n  # All SBOM steps in build-service-images must have PR guard\n  local service_sbom_ifs\n  service_sbom_ifs=$(yq_raw '.jobs[\"build-service-images\"][\"steps\"][] | select(.uses and (.uses | test(\"anchore/sbom-action|actions/attest-sbom\"))) | .if' \"$WORKFLOW\" 2>/dev/null || true)\n\n  local service_all_guarded=true\n  while IFS= read -r val; do\n    [ -z \"$val\" ] && continue\n    if [[ \"$val\" != *\"github.event_name != 'pull_request'\"* ]]; then\n      echo \"  FAIL: build-service-images SBOM/attestation step missing PR guard: $val\"\n      FAIL=$((FAIL + 1))\n      service_all_guarded=false\n    fi\n  done <<< \"$service_sbom_ifs\"\n\n  if $service_all_guarded && [ -n \"$service_sbom_ifs\" ]; then\n    echo \"  PASS: all build-service-images SBOM/attestation steps have PR-skip guard\"\n    PASS=$((PASS + 1))\n  elif [ -z \"$service_sbom_ifs\" ]; then\n    echo \"  FAIL: build-service-images SBOM/attestation steps not found or missing PR guard\"\n    FAIL=$((FAIL + 1))\n  fi\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: tests/container-images/verify_build_images_workflow.sh\nLine: 749-777\n\nComment:\n**`else` branch double-counts FAIL when a guard is missing**\n\nThe `else` branch fires for two distinct scenarios:\n\n1. `base_sbom_ifs` is empty — FAIL has not yet been incremented, so incrementing here is correct.\n2. `all_guarded=false` — FAIL was **already incremented** inside the while loop (once per step missing the guard). The `else` branch then increments FAIL a second time for the same failure event, overcounting.\n\nBoth the `test_sbom_format_cyclonedx_json` and `test_sbom_attestation_push_to_registry` functions correctly avoid this by using `elif [ -z \"$base_formats\" ]` / `elif [ -z \"$base_push_values\" ]` instead of a plain `else`, so only the truly unhandled \"no results\" case increments an extra FAIL. This function should follow the same pattern.\n\nThe same double-count problem exists for the `service_sbom_ifs` block (lines 761–777).\n\n```suggestion\n  if $all_guarded && [ -n \"$base_sbom_ifs\" ]; then\n    echo \"  PASS: all build-base-images SBOM/attestation steps have PR-skip guard\"\n    PASS=$((PASS + 1))\n  elif [ -z \"$base_sbom_ifs\" ]; then\n    echo \"  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard\"\n    FAIL=$((FAIL + 1))\n  fi\n\n  # All SBOM steps in build-service-images must have PR guard\n  local service_sbom_ifs\n  service_sbom_ifs=$(yq_raw '.jobs[\"build-service-images\"][\"steps\"][] | select(.uses and (.uses | test(\"anchore/sbom-action|actions/attest-sbom\"))) | .if' \"$WORKFLOW\" 2>/dev/null || true)\n\n  local service_all_guarded=true\n  while IFS= read -r val; do\n    [ -z \"$val\" ] && continue\n    if [[ \"$val\" != *\"github.event_name != 'pull_request'\"* ]]; then\n      echo \"  FAIL: build-service-images SBOM/attestation step missing PR guard: $val\"\n      FAIL=$((FAIL + 1))\n      service_all_guarded=false\n    fi\n  done <<< \"$service_sbom_ifs\"\n\n  if $service_all_guarded && [ -n \"$service_sbom_ifs\" ]; then\n    echo \"  PASS: all build-service-images SBOM/attestation steps have PR-skip guard\"\n    PASS=$((PASS + 1))\n  elif [ -z \"$service_sbom_ifs\" ]; then\n    echo \"  FAIL: build-service-images SBOM/attestation steps not found or missing PR guard\"\n    FAIL=$((FAIL + 1))\n  fi\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "tests/container-images/verify_build_images_workflow.sh",
+      "line": 777,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T19:57:05Z",
+      "id": null,
+      "resolution": ""
+    }
+  ],
+  "github_review_id": 3911947480
+}

--- a/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-4.json
+++ b/.planwerk/reviews/CC-0029-github-review-by-greptile-apps-bot-external-4.json
@@ -1,0 +1,46 @@
+{
+  "feature_id": "CC-0029",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer wants two changes to the SBOM/attestation docs: (1) Reword the PR behavior bullet to explain that the `if: github.event_name != 'pull_request'` guard skips SBOMs uniformly for all images, not just because service images aren't pushed—since base images are pushed on PRs but still skip SBOM generation. (2) Fix the `cosign verify-attestation --type cyclonedx` example, as `cyclonedx` isn't a valid cosign shorthand—use the full predicate URI `https://cyclonedx.org/bom` or recommend `gh attestation` tooling instead.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-08T20:09:28Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 4,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**Misleading parenthetical in PR Behavior bullet**\n\nThe parenthetical explanation `(service images are not pushed to GHCR on PRs)` implies the sole reason SBOMs are skipped on PRs is because service images aren't pushed. However, base images **are** always pushed to GHCR on PRs (as the next paragraph correctly states), yet base image SBOM generation is also skipped. The parenthetical therefore gives an inaccurate picture of the general rule.\n\nThe next paragraph explains the actual reason correctly: the PR guard applies uniformly to all SBOM/attestation steps regardless of whether the image is pushed. The first bullet should reflect this:\n\n```suggestion\n- No SBOMs are generated or attested — the `if: github.event_name != 'pull_request'` guard applies uniformly to all SBOM/attestation steps, including for base images which are pushed on PRs.\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: docs/reference/build-images-workflow.md\nLine: 417\n\nComment:\n**Misleading parenthetical in PR Behavior bullet**\n\nThe parenthetical explanation `(service images are not pushed to GHCR on PRs)` implies the sole reason SBOMs are skipped on PRs is because service images aren't pushed. However, base images **are** always pushed to GHCR on PRs (as the next paragraph correctly states), yet base image SBOM generation is also skipped. The parenthetical therefore gives an inaccurate picture of the general rule.\n\nThe next paragraph explains the actual reason correctly: the PR guard applies uniformly to all SBOM/attestation steps regardless of whether the image is pushed. The first bullet should reflect this:\n\n```suggestion\n- No SBOMs are generated or attested — the `if: github.event_name != 'pull_request'` guard applies uniformly to all SBOM/attestation steps, including for base images which are pushed on PRs.\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "docs/reference/build-images-workflow.md",
+      "line": 417,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T20:09:26Z",
+      "id": null,
+      "resolution": "Line 417: The misleading parenthetical '(service images are not pushed to GHCR on PRs)' was replaced with the reviewer's suggested wording: 'No SBOMs are generated or attested — the `if: github.event_name != 'pull_request'` guard applies uniformly to all SBOM/attestation steps, including for base images which are pushed on PRs.' This accurately conveys that the PR guard applies uniformly regardless of whether images are pushed."
+    },
+    {
+      "body": "**`cosign verify-attestation --type cyclonedx` may not be valid**\n\nThe `--type` flag in `cosign verify-attestation` expects a predicate type URI or a recognized shorthand (e.g., `slsaprovenance`, `slsaprovenance1`, `link`, `vuln`). `cyclonedx` is not a standard shorthand in cosign; the correct predicate type URI for a CycloneDX SBOM is typically `https://cyclonedx.org/bom`.\n\nAdditionally, attestations created by `actions/attest-sbom` are stored as GitHub Attestations using DSSE bundles. The recommended extraction path for GitHub Attestations is through the GitHub Attestation API or `gh attestation` tooling rather than raw `cosign verify-attestation`.\n\nIf a cosign-based extraction example is intended, consider replacing `--type cyclonedx` with the full predicate type URI that `actions/attest-sbom` actually writes, or add a note that this command requires verifying the exact predicate type used by the action at runtime.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: docs/reference/build-images-workflow.md\nLine: 452-457\n\nComment:\n**`cosign verify-attestation --type cyclonedx` may not be valid**\n\nThe `--type` flag in `cosign verify-attestation` expects a predicate type URI or a recognized shorthand (e.g., `slsaprovenance`, `slsaprovenance1`, `link`, `vuln`). `cyclonedx` is not a standard shorthand in cosign; the correct predicate type URI for a CycloneDX SBOM is typically `https://cyclonedx.org/bom`.\n\nAdditionally, attestations created by `actions/attest-sbom` are stored as GitHub Attestations using DSSE bundles. The recommended extraction path for GitHub Attestations is through the GitHub Attestation API or `gh attestation` tooling rather than raw `cosign verify-attestation`.\n\nIf a cosign-based extraction example is intended, consider replacing `--type cyclonedx` with the full predicate type URI that `actions/attest-sbom` actually writes, or add a note that this command requires verifying the exact predicate type used by the action at runtime.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "docs/reference/build-images-workflow.md",
+      "line": 457,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-08T20:09:27Z",
+      "id": null,
+      "resolution": "Lines 452-457: The invalid `cosign verify-attestation --type cyclonedx` example was completely removed and replaced with two `gh attestation` commands: (1) `gh attestation verify` for basic verification, and (2) `gh attestation verify --format json | jq` to extract the SBOM predicate using the correct predicate type URI `https://cyclonedx.org/bom`. This addresses both concerns — using the recommended GitHub Attestation tooling instead of raw cosign, and using the correct CycloneDX predicate type URI."
+    }
+  ],
+  "resolution_summary": "Both review comments on docs/reference/build-images-workflow.md were addressed. The misleading parenthetical about PR behavior was replaced with accurate wording explaining the uniform PR guard, and the invalid cosign verify-attestation example was replaced with the recommended gh attestation tooling using the correct CycloneDX predicate type URI. All changes were confined to the file mentioned in the review feedback.",
+  "github_review_id": 3911963449
+}

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -1,16 +1,18 @@
 ---
 title: Build Images Workflow
 quadrant: infrastructure
-feature: CC-0007
+feature: CC-0007, CC-0029
 ---
 
 # Build Images Workflow
 
-Reference documentation for the GitHub Actions build-images workflow (CC-0007) and the
-verify-container-images workflow (CC-0028). The build-images workflow builds, tags, and
-publishes container images for OpenStack services to GHCR (GitHub Container Registry).
-The verify-container-images workflow runs static verification tests against container
-infrastructure files (Dockerfiles, workflows, release configs) without requiring Docker.
+Reference documentation for the GitHub Actions build-images workflow (CC-0007, CC-0029)
+and the verify-container-images workflow (CC-0028). The build-images workflow builds,
+tags, and publishes container images for OpenStack services to GHCR (GitHub Container
+Registry). Each pushed image receives a CycloneDX SBOM and a Sigstore-signed attestation
+(CC-0029). The verify-container-images workflow runs static verification tests against
+container infrastructure files (Dockerfiles, workflows, release configs) without
+requiring Docker.
 
 ## File Locations
 
@@ -42,8 +44,8 @@ single-arch images loaded locally for testing (see [PR vs Push Behavior](#pr-vs-
 
 ## Permissions
 
-Top-level permissions grant least privilege (REQ-008). Registry write access is scoped
-to the build jobs that push images:
+Top-level permissions grant least privilege (REQ-008). Registry write access and
+attestation permissions are scoped to the build jobs only:
 
 ```yaml
 # Top-level (applies to all jobs)
@@ -54,6 +56,8 @@ permissions:
 permissions:
   contents: read
   packages: write
+  id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+  attestations: write   # CC-0029: GitHub Attestations API
 
 # Verification jobs (verify-base-images, verify-service-images)
 permissions:
@@ -62,10 +66,15 @@ permissions:
 ```
 
 `contents: read` allows repository checkout. `packages: write` is granted only to
-`build-base-images` and `build-service-images` for pushing images to GHCR. The
-verification jobs (`verify-base-images`, `verify-service-images`) receive
-`contents: read` (required for checkout and test scripts) and `packages: read`
-(for pulling images from GHCR), following the principle of least privilege (CC-0028).
+`build-base-images` and `build-service-images` for pushing images to GHCR.
+`id-token: write` enables Sigstore keyless OIDC signing — the GitHub Actions runner
+requests a short-lived OIDC token bound to the workflow identity, which Sigstore uses to
+sign the attestation without managing keys (CC-0029). `attestations: write` grants
+access to the GitHub Attestations API for storing signed attestations. The verification
+jobs (`verify-base-images`, `verify-service-images`) do **not** receive `id-token` or
+`attestations` permissions — they only need `contents: read` (for checkout and test
+scripts) and `packages: read` (for pulling images from GHCR), following the principle of
+least privilege (CC-0028).
 
 ## Concurrency
 
@@ -119,10 +128,14 @@ availability.
 | --- | --- | --- | --- |
 | 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork (CC-0007) |
 | 2 | Checkout | `actions/checkout@v6` | Checks out the repository |
-| 3 | Set up Buildx | `docker/setup-buildx-action@v3` | Enables multi-platform builds |
-| 4 | Login to GHCR | `docker/login-action@v3` | Authenticates with `GITHUB_TOKEN` |
-| 5 | Build python-base | `docker/build-push-action@v6` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}` |
-| 6 | Build venv-builder | `docker/build-push-action@v6` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, `--build-context python-base=docker-image://...` |
+| 3 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
+| 4 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
+| 5 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}` |
+| 6 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
+| 7 | Attest SBOM for python-base | `actions/attest-sbom@v2` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 8 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, `--build-context python-base=docker-image://...` |
+| 9 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
+| 10 | Attest SBOM for venv-builder | `actions/attest-sbom@v2` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
 
 The `venv-builder` build uses a `docker-image://` build context pointing at the
 just-pushed `python-base` image (referenced by digest), ensuring its `FROM python-base`
@@ -200,11 +213,13 @@ Depends on `build-base-images` for image references (REQ-003) and on
 | 4 | Apply patches | Shell (conditional) | Runs `git apply` for patches in `patches/<service>/<release>/` — skipped if no `.patch` files exist |
 | 5 | Apply constraint overrides | Shell | Runs `scripts/apply-constraint-overrides.sh <release>` (idempotent) |
 | 6 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards (CC-0027). |
-| 7 | Derive tags | Shell | Computes three image tags (see [Tag Schema](#tag-schema)) (REQ-005) |
-| 8 | Set up Buildx | `docker/setup-buildx-action@v3` | Enables multi-platform builds |
-| 9 | Login to GHCR | `docker/login-action@v3` | Authenticates with `GITHUB_TOKEN` |
-| 10 | Build service image | `docker/build-push-action@v6` | Builds with four named build contexts and three build args, conditional platform/push/load (REQ-006) |
-| 11 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
+| 7 | Derive tags | Shell | Computes three image tags and the lowercase `image` path (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
+| 8 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
+| 9 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
+| 10 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load (REQ-006) |
+| 11 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
+| 12 | Attest SBOM for service image | `actions/attest-sbom@v2` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 13 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
 
 **Build Contexts:**
 
@@ -245,7 +260,7 @@ Validates that built service images are functional by running `verify_keystone.s
 `build-service-images` to test every service independently.
 
 On PRs, the equivalent verification runs as an inline step within `build-service-images`
-(step 11 above) because `--load` makes the image available only on the same runner.
+(step 13 above) because `--load` makes the image available only on the same runner.
 
 | Property | Value |
 | --- | --- |
@@ -312,6 +327,9 @@ The workflow behaves differently depending on the trigger event (REQ-006):
 | Service image platforms | `linux/amd64` only | `linux/amd64,linux/arm64` |
 | Service image push | No (`push: false`, `load: true`) | Yes (`push: true`) |
 | Service image tags | Computed but not published | Published to GHCR |
+| SBOM generation | Skipped (CC-0029) | CycloneDX JSON for every image |
+| SBOM attestation | Skipped (CC-0029) | Sigstore-signed, pushed to GHCR |
+| OIDC token request | None | Requested for Sigstore signing |
 | Service image verification | Inline step in `build-service-images` | Separate `verify-service-images` job |
 | Verification image source | Locally loaded image (same runner) | Pulled from GHCR |
 
@@ -351,14 +369,119 @@ All actions are pinned to full commit SHAs with version comments (REQ-008), matc
 convention in `ci.yaml`:
 
 ```yaml
-uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4
+uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
+uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0 (CC-0029)
+uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b  # v2 (CC-0029)
 ```
 
 This prevents supply-chain attacks via tag mutation while remaining auditable through
 version comments.
+
+## SBOM Generation and Attestation
+
+Every container image pushed to GHCR on non-PR events receives a CycloneDX SBOM and a
+Sigstore-signed attestation (CC-0029). This enables consumers to audit image contents,
+check for known vulnerabilities, and verify that images have not been tampered with since
+build time.
+
+### How It Works
+
+After each `docker/build-push-action` step pushes an image to GHCR, two additional steps
+run:
+
+1. **SBOM generation** (`anchore/sbom-action`) — Syft scans the pushed image (referenced
+   by digest) and produces a CycloneDX JSON file covering both OS packages (dpkg) and
+   Python packages (dist-info).
+
+2. **SBOM attestation** (`actions/attest-sbom`) — The CycloneDX file is signed via
+   Sigstore keyless OIDC (using the GitHub Actions workflow identity) and pushed to GHCR
+   as an OCI referrer artifact alongside the image. No signing keys are managed; the OIDC
+   token binds the attestation to the specific workflow run.
+
+This pattern is applied to all three image types:
+
+| Image | SBOM output file | Job |
+| --- | --- | --- |
+| `python-base` | `sbom-python-base.cyclonedx.json` | `build-base-images` |
+| `venv-builder` | `sbom-venv-builder.cyclonedx.json` | `build-base-images` |
+| Service (e.g., `keystone`) | `sbom-${{ matrix.service }}.cyclonedx.json` | `build-service-images` |
+
+### PR Behavior
+
+All SBOM generation and attestation steps are guarded with
+`if: github.event_name != 'pull_request'`. On pull requests:
+
+- No SBOMs are generated or attested — the `if: github.event_name != 'pull_request'` guard applies uniformly to all SBOM/attestation steps, including for base images which are pushed on PRs.
+- No OIDC token requests occur — SBOM/attestation steps are skipped so `id-token: write` is not exercised.
+- No attestations are created for ephemeral PR builds.
+- PR CI time is not increased by SBOM/attestation steps.
+
+Base images are always pushed to GHCR (even on PRs) because downstream service builds
+reference them via `docker-image://` URIs. However, SBOM generation and attestation for
+base images are still skipped on PRs — the PR guard applies to all SBOM/attestation
+steps uniformly.
+
+### Required Permissions
+
+SBOM attestation requires two additional job-level permissions beyond the existing
+`contents: read` and `packages: write`:
+
+| Permission | Purpose |
+| --- | --- |
+| `id-token: write` | Allows the GitHub Actions runner to request a short-lived Sigstore OIDC token for keyless signing |
+| `attestations: write` | Grants access to the GitHub Attestations API for storing signed attestations |
+
+These permissions are granted only to `build-base-images` and `build-service-images`.
+Verification jobs (`verify-base-images`, `verify-service-images`) do not receive these
+permissions.
+
+### Verifying Attestations
+
+To verify that an image has a valid Sigstore-signed attestation:
+
+```bash
+gh attestation verify oci://ghcr.io/<owner>/<service>:<tag> --owner <owner>
+```
+
+To extract the SBOM predicate from the attestation, first inspect the raw
+output to find the exact `predicateType` URI used in your environment:
+
+```bash
+gh attestation verify oci://ghcr.io/<owner>/<service>:<tag> \
+  --owner <owner> \
+  --format json | jq '.[].verificationResult.statement.predicateType'
+```
+
+Then filter for that predicate type (the URI below may differ by action version):
+
+```bash
+gh attestation verify oci://ghcr.io/<owner>/<service>:<tag> \
+  --owner <owner> \
+  --format json | jq -r '
+    [ .[] | select(.verificationResult.statement.predicateType | test("cyclonedx")) ]
+    | if length == 0 then error("no CycloneDX attestation found") else .[0].verificationResult.statement.predicate end
+  '
+```
+
+### Test Coverage
+
+The `verify_build_images_workflow.sh` script validates SBOM/attestation configuration
+(CC-0029):
+
+| Test | Validates |
+| --- | --- |
+| `test_sbom_permissions_on_build_base_images` | `id-token: write` and `attestations: write` on `build-base-images` |
+| `test_sbom_permissions_on_build_service_images` | `id-token: write` and `attestations: write` on `build-service-images` |
+| `test_verify_jobs_no_sbom_permissions` | Verification jobs do **not** have `id-token` or `attestations` permissions |
+| `test_sbom_generation_steps_exist` | SBOM generation steps exist in both build jobs |
+| `test_sbom_format_cyclonedx_json` | All SBOM steps specify `format: cyclonedx-json` |
+| `test_sbom_generation_references_digest` | SBOM steps reference the correct digest output |
+| `test_sbom_attestation_steps_exist` | Attestation steps exist in both build jobs |
+| `test_sbom_attestation_push_to_registry` | All attestation steps have `push-to-registry: true` |
+| `test_sbom_steps_pr_skip_guard` | All SBOM/attestation steps have `github.event_name != 'pull_request'` guard |
 
 ## Adding a New Service
 
@@ -516,7 +639,7 @@ non-zero, the job fails.
 
 | Script | Validates |
 | --- | --- |
-| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy |
+| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029) |
 | `verify_deviation_comments.sh` | DEVIATION comments in Dockerfiles cross-reference architecture docs |
 | `verify_release_config.sh` | `source-refs.yaml` and `extra-packages.yaml` structure and content validity |
 | `verify_spdx_headers.sh` | SPDX Apache-2.0 license headers present on all infrastructure files |
@@ -538,7 +661,7 @@ signals in GitHub's check status UI. The Docker-based image verification tests
 
 ## Verification Coverage Summary
 
-The following table summarizes which test scripts run where (CC-0028):
+The following table summarizes which test scripts run where (CC-0028, CC-0029):
 
 | Test Script | verify-container-images.yaml | build-images.yaml | Requires Docker |
 | --- | --- | --- | --- |

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify build-images workflow structure, conventions, and correctness (CC-0007)
-# Requirements: REQ-001 through REQ-009
+# Verify build-images workflow structure, conventions, and correctness (CC-0007, CC-0029)
+# Requirements: REQ-001 through REQ-017
 # Usage: bash tests/container-images/verify_build_images_workflow.sh
 
 set -euo pipefail
@@ -22,6 +22,14 @@ source "$SCRIPT_DIR/../lib/assertions.sh"
 # Helper: query yq with raw output (strips quotes from strings)
 yq_raw() {
   yq -r "$@"
+}
+
+# Helper: run a yq query and count matching lines.
+# Fails loudly on yq parse errors instead of silently returning 0.
+yq_count() {
+  local output
+  output=$(yq -r "$@") || { echo "ERROR: yq failed for query: $1" >&2; return 1; }
+  echo "$output" | grep -c . || echo "0"
 }
 
 # --- REQ-008: SPDX header matching ci.yaml convention ---
@@ -49,7 +57,7 @@ test_permissions_block() {
 
   # Top-level permissions should have contents: read only (least privilege)
   local top_perms
-  top_perms=$(yq_raw '.permissions' "$WORKFLOW" 2>/dev/null || true)
+  top_perms=$(yq_raw '.permissions' "$WORKFLOW" || true)
 
   assert_contains "top-level permissions has contents: read" "$top_perms" "read"
 }
@@ -60,9 +68,9 @@ test_job_permissions_scoping() {
 
   # build-base-images and build-service-images need packages: write
   local base_perms service_perms verify_service_perms
-  base_perms=$(yq_raw '.jobs["build-base-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  service_perms=$(yq_raw '.jobs["build-service-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_service_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  base_perms=$(yq_raw '.jobs["build-base-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
+  service_perms=$(yq_raw '.jobs["build-service-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
+  verify_service_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
 
   assert_eq "build-base-images has packages: write" "write" "$base_perms"
   assert_eq "build-service-images has packages: write" "write" "$service_perms"
@@ -70,7 +78,7 @@ test_job_permissions_scoping() {
 
   # verify-service-images also needs contents: read for checkout (source-refs.yaml + patch counting)
   local verify_service_contents_perms
-  verify_service_contents_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["contents"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  verify_service_contents_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["contents"]' "$WORKFLOW" || echo "null")
   assert_eq "verify-service-images has contents: read (for checkout)" "read" "$verify_service_contents_perms"
 }
 
@@ -111,11 +119,11 @@ test_verify_base_images_job() {
   echo "Test: verify-base-images job structure (REQ-004)"
 
   local needs
-  needs=$(yq_raw '.jobs["verify-base-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
+  needs=$(yq_raw '.jobs["verify-base-images"]["needs"][]' "$WORKFLOW" || true)
   assert_contains "verify-base-images needs build-base-images" "$needs" "build-base-images"
 
   local timeout
-  timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
   if [ "$timeout" != "null" ] && [ -n "$timeout" ]; then
     echo "  PASS: verify-base-images has timeout-minutes: $timeout"
     PASS=$((PASS + 1))
@@ -125,15 +133,15 @@ test_verify_base_images_job() {
   fi
 
   local runner
-  runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
   assert_eq "verify-base-images uses ubuntu-latest" "ubuntu-latest" "$runner"
 
   local pkg_perms
-  pkg_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["packages"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  pkg_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
   assert_eq "verify-base-images has packages: read" "read" "$pkg_perms"
 
   local contents_perms
-  contents_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["contents"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  contents_perms=$(yq_raw '.jobs["verify-base-images"]["permissions"]["contents"]' "$WORKFLOW" || echo "null")
   assert_eq "verify-base-images has contents: read (for checkout)" "read" "$contents_perms"
 }
 
@@ -143,7 +151,7 @@ test_base_images_multi_arch() {
 
   # Both build-push-action steps in build-base-images must specify platforms: linux/amd64,linux/arm64
   local platforms
-  platforms=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.platforms) | .with.platforms' "$WORKFLOW" 2>/dev/null || true)
+  platforms=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.platforms) | .with.platforms' "$WORKFLOW" || true)
 
   if [ -z "$platforms" ]; then
     echo "  FAIL: build-base-images has no platforms values"
@@ -172,8 +180,8 @@ test_base_image_digest_outputs() {
   echo "Test: base image outputs contain digest references (REQ-003)"
 
   local python_output venv_output
-  python_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-image"]' "$WORKFLOW" 2>/dev/null || true)
-  venv_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["venv-builder-image"]' "$WORKFLOW" 2>/dev/null || true)
+  python_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-image"]' "$WORKFLOW" || true)
+  venv_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["venv-builder-image"]' "$WORKFLOW" || true)
 
   assert_contains "python-base-image output references digest" "$python_output" "outputs.digest"
   assert_contains "venv-builder-image output references digest" "$venv_output" "outputs.digest"
@@ -184,7 +192,7 @@ test_service_images_depend_on_base() {
   echo "Test: build-service-images depends on build-base-images and verify-base-images (REQ-003, REQ-004)"
 
   local needs
-  needs=$(yq_raw '.jobs["build-service-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
+  needs=$(yq_raw '.jobs["build-service-images"]["needs"][]' "$WORKFLOW" || true)
 
   assert_contains "build-service-images needs build-base-images" "$needs" "build-base-images"
   assert_contains "build-service-images needs verify-base-images" "$needs" "verify-base-images"
@@ -195,8 +203,8 @@ test_matrix_includes_service_and_release() {
   echo "Test: matrix includes service and release (REQ-004)"
 
   local services releases
-  services=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" 2>/dev/null || true)
-  releases=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["release"][]' "$WORKFLOW" 2>/dev/null || true)
+  services=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" || true)
+  releases=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["release"][]' "$WORKFLOW" || true)
 
   assert_contains "matrix includes keystone service" "$services" "keystone"
   assert_contains "matrix includes 2025.2 release" "$releases" "2025.2"
@@ -207,7 +215,7 @@ test_source_ref_resolution_step() {
   echo "Test: source ref resolution step with yq (REQ-004)"
 
   local source_ref_step
-  source_ref_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "source-ref") | .run' "$WORKFLOW" 2>/dev/null || true)
+  source_ref_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "source-ref") | .run' "$WORKFLOW" || true)
 
   assert_contains "source-ref step uses yq to resolve ref" "$source_ref_step" "yq"
   assert_contains "source-ref step reads source-refs.yaml" "$source_ref_step" "source-refs.yaml"
@@ -218,7 +226,7 @@ test_patch_application_step() {
   echo "Test: conditional patch application with hashFiles guard (REQ-004)"
 
   local patch_if
-  patch_if=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Apply patches") | .if' "$WORKFLOW" 2>/dev/null || true)
+  patch_if=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Apply patches") | .if' "$WORKFLOW" || true)
 
   assert_contains "patch step uses hashFiles guard" "$patch_if" "hashFiles"
 }
@@ -228,7 +236,7 @@ test_constraint_overrides_step() {
   echo "Test: constraint overrides step references apply-constraint-overrides.sh (REQ-004)"
 
   local overrides_run
-  overrides_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Apply constraint overrides") | .run' "$WORKFLOW" 2>/dev/null || true)
+  overrides_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Apply constraint overrides") | .run' "$WORKFLOW" || true)
 
   assert_contains "constraint overrides step runs apply-constraint-overrides.sh" "$overrides_run" "apply-constraint-overrides.sh"
 }
@@ -238,7 +246,7 @@ test_build_contexts_for_service_images() {
   echo "Test: build-contexts for service images (REQ-004)"
 
   local build_contexts
-  build_contexts=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with["build-contexts"]' "$WORKFLOW" 2>/dev/null || true)
+  build_contexts=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with["build-contexts"]' "$WORKFLOW" || true)
 
   assert_contains "build-context includes python-base" "$build_contexts" "python-base="
   assert_contains "build-context includes venv-builder" "$build_contexts" "venv-builder="
@@ -251,7 +259,7 @@ test_tag_schema_composite() {
   echo "Test: tag schema composite (REQ-005)"
 
   local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
 
   assert_contains "composite tag has version component" "$tags_step" 'VERSION'
   assert_contains "composite tag has patch count (pN)" "$tags_step" '-p${PATCH_COUNT}'
@@ -264,7 +272,7 @@ test_branch_sanitization() {
   echo "Test: branch sanitization replaces slashes with dashes (REQ-005)"
 
   local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
 
   # GITHUB_REF_NAME//\//-  is the bash pattern substitution for slash-to-dash
   assert_contains "branch sanitization uses slash-to-dash replacement" "$tags_step" 'GITHUB_REF_NAME//\//-'
@@ -275,10 +283,11 @@ test_version_and_sha_outputs() {
   echo "Test: version= and sha= outputs emitted (REQ-005)"
 
   local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
 
   assert_contains "version output emitted" "$tags_step" 'echo "version='
   assert_contains "sha output emitted" "$tags_step" 'echo "sha='
+  assert_contains "image output emitted" "$tags_step" 'echo "image='
 }
 
 # --- REQ-006: PR uses single-arch, load, and conditional push/platforms ---
@@ -286,9 +295,9 @@ test_pr_single_arch_load() {
   echo "Test: PR uses single-arch, load, and conditional push/platforms (REQ-006)"
 
   local platforms load_val push_val
-  platforms=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.platforms' "$WORKFLOW" 2>/dev/null || true)
-  load_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.load' "$WORKFLOW" 2>/dev/null || true)
-  push_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.push' "$WORKFLOW" 2>/dev/null || true)
+  platforms=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.platforms' "$WORKFLOW" || true)
+  load_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.load' "$WORKFLOW" || true)
+  push_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.push' "$WORKFLOW" || true)
 
   assert_contains "platforms uses pull_request conditional for single-arch" "$platforms" "pull_request"
   assert_contains "platforms includes linux/amd64 for PR" "$platforms" "linux/amd64"
@@ -310,7 +319,7 @@ test_verify_service_images_depends_on_service_images() {
   echo "Test: verify-service-images depends on build-service-images (REQ-007)"
 
   local needs
-  needs=$(yq_raw '.jobs["verify-service-images"]["needs"][]' "$WORKFLOW" 2>/dev/null || true)
+  needs=$(yq_raw '.jobs["verify-service-images"]["needs"][]' "$WORKFLOW" || true)
 
   assert_contains "verify-service-images needs build-service-images" "$needs" "build-service-images"
 }
@@ -320,7 +329,7 @@ test_verify_service_images_has_matrix() {
   echo "Test: verify-service-images has its own matrix strategy (REQ-007)"
 
   local services
-  services=$(yq_raw '.jobs["verify-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" 2>/dev/null || true)
+  services=$(yq_raw '.jobs["verify-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" || true)
 
   assert_contains "verify-service-images matrix includes keystone" "$services" "keystone"
 }
@@ -330,7 +339,7 @@ test_verify_service_images_derives_image_ref() {
   echo "Test: verify-service-images derives image ref via tags step (REQ-007)"
 
   local derive_step
-  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
 
   assert_contains "verify-service-images derives VERSION from source-refs.yaml" "$derive_step" "source-refs.yaml"
   assert_contains "verify-service-images computes image-ref output" "$derive_step" "image-ref="
@@ -391,10 +400,10 @@ test_timeout_minutes_on_all_jobs() {
   echo "Test: all jobs have timeout-minutes (REQ-008)"
 
   local base_timeout verify_base_timeout service_timeout verify_service_timeout
-  base_timeout=$(yq_raw '.jobs["build-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_base_timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  service_timeout=$(yq_raw '.jobs["build-service-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_service_timeout=$(yq_raw '.jobs["verify-service-images"]["timeout-minutes"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  base_timeout=$(yq_raw '.jobs["build-base-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
+  verify_base_timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
+  service_timeout=$(yq_raw '.jobs["build-service-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
+  verify_service_timeout=$(yq_raw '.jobs["verify-service-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
 
   if [ "$base_timeout" != "null" ] && [ -n "$base_timeout" ]; then
     echo "  PASS: build-base-images has timeout-minutes: $base_timeout"
@@ -434,10 +443,10 @@ test_runs_on_ubuntu_latest() {
   echo "Test: all jobs use runs-on: ubuntu-latest (REQ-008)"
 
   local base_runner verify_base_runner service_runner verify_service_runner
-  base_runner=$(yq_raw '.jobs["build-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_base_runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  service_runner=$(yq_raw '.jobs["build-service-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_service_runner=$(yq_raw '.jobs["verify-service-images"]["runs-on"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  base_runner=$(yq_raw '.jobs["build-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  verify_base_runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  service_runner=$(yq_raw '.jobs["build-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  verify_service_runner=$(yq_raw '.jobs["verify-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
 
   assert_eq "build-base-images uses ubuntu-latest" "ubuntu-latest" "$base_runner"
   assert_eq "verify-base-images uses ubuntu-latest" "ubuntu-latest" "$verify_base_runner"
@@ -453,7 +462,7 @@ test_base_images_always_push() {
   # and that push is not conditioned on event_name (unlike service images).
   # Use the raw YAML file to verify the literal "push: true" value.
   local push_values
-  push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.push) | .with.push' "$WORKFLOW" 2>/dev/null || true)
+  push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.push) | .with.push' "$WORKFLOW" || true)
 
   if [ -z "$push_values" ]; then
     echo "  FAIL: build-base-images has no push values"
@@ -491,7 +500,7 @@ test_fork_pr_rejection_step_exists() {
   echo "Test: fork PR rejection step exists in build-base-images (CC-0007)"
 
   local reject_step_if
-  reject_step_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Reject fork PRs") | .if' "$WORKFLOW" 2>/dev/null || true)
+  reject_step_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Reject fork PRs") | .if' "$WORKFLOW" || true)
 
   assert_contains "Reject fork PRs step exists with pull_request condition" "$reject_step_if" "pull_request"
   assert_contains "Reject fork PRs step checks head repo full_name" "$reject_step_if" "github.event.pull_request.head.repo.full_name"
@@ -503,8 +512,8 @@ test_base_images_have_sha_tags() {
   echo "Test: base images have SHA tags for commit traceability (CC-0007)"
 
   local python_tags venv_tags
-  python_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-python-base") | .with.tags' "$WORKFLOW" 2>/dev/null || true)
-  venv_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-venv-builder") | .with.tags' "$WORKFLOW" 2>/dev/null || true)
+  python_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-python-base") | .with.tags' "$WORKFLOW" || true)
+  venv_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-venv-builder") | .with.tags' "$WORKFLOW" || true)
 
   assert_contains "python-base tags include github.sha" "$python_tags" 'github.sha'
   assert_contains "venv-builder tags include github.sha" "$venv_tags" 'github.sha'
@@ -515,7 +524,7 @@ test_version_tag_restricted_to_main() {
   echo "Test: version-only tag restricted to main branch (CC-0007)"
 
   local tags_block
-  tags_block=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.tags' "$WORKFLOW" 2>/dev/null || true)
+  tags_block=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.tags' "$WORKFLOW" || true)
 
   assert_contains "version tag line contains ref_name == main conditional" "$tags_block" "github.ref_name == 'main'"
 }
@@ -525,8 +534,8 @@ test_matrix_jobs_fail_fast_false() {
   echo "Test: matrix jobs use fail-fast: false (CC-0007)"
 
   local service_fail_fast verify_service_fail_fast
-  service_fail_fast=$(yq_raw '.jobs["build-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" 2>/dev/null || echo "null")
-  verify_service_fail_fast=$(yq_raw '.jobs["verify-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" 2>/dev/null || echo "null")
+  service_fail_fast=$(yq_raw '.jobs["build-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" || echo "null")
+  verify_service_fail_fast=$(yq_raw '.jobs["verify-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" || echo "null")
 
   assert_eq "build-service-images has fail-fast: false" "false" "$service_fail_fast"
   assert_eq "verify-service-images has fail-fast: false" "false" "$verify_service_fail_fast"
@@ -537,7 +546,7 @@ test_source_ref_null_guard() {
   echo "Test: source-ref step validates yq output against null/empty (CC-0007)"
 
   local source_ref_run
-  source_ref_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "source-ref") | .run' "$WORKFLOW" 2>/dev/null || true)
+  source_ref_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "source-ref") | .run' "$WORKFLOW" || true)
 
   assert_contains "source-ref step checks for null string" "$source_ref_run" '"null"'
   assert_contains "source-ref step checks for empty value" "$source_ref_run" '-z "$ref"'
@@ -556,7 +565,7 @@ test_verify_service_images_null_guard() {
   echo "Test: verify-service-images validates yq output against null/empty (CC-0007)"
 
   local derive_step
-  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" 2>/dev/null || true)
+  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
 
   assert_contains "verify-service-images derive step checks for null string" "$derive_step" '"null"'
   assert_contains "verify-service-images derive step exits on invalid ref" "$derive_step" "exit 1"
@@ -569,6 +578,249 @@ test_run_blocks_use_env_vars() {
   assert_file_not_contains "resolve source ref run uses env vars (no direct matrix interpolation)" "$WORKFLOW" 'yq .*\${{ matrix'
   assert_file_not_contains "apply patches run uses env vars (no direct matrix interpolation)" "$WORKFLOW" 'git -C.*\${{ matrix'
   assert_file_not_contains "apply overrides run uses env vars (no direct matrix interpolation)" "$WORKFLOW" 'apply-constraint-overrides.sh \${{ matrix'
+}
+
+# --- CC-0029: SBOM permissions on build-base-images (REQ-012) ---
+test_sbom_permissions_on_build_base_images() {
+  echo "Test: SBOM permissions on build-base-images (CC-0029, REQ-012)"
+
+  local id_token attestations
+  id_token=$(yq_raw '.jobs["build-base-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  attestations=$(yq_raw '.jobs["build-base-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+
+  assert_eq "build-base-images has id-token: write" "write" "$id_token"
+  assert_eq "build-base-images has attestations: write" "write" "$attestations"
+}
+
+# --- CC-0029: SBOM permissions on build-service-images (REQ-012) ---
+test_sbom_permissions_on_build_service_images() {
+  echo "Test: SBOM permissions on build-service-images (CC-0029, REQ-012)"
+
+  local id_token attestations
+  id_token=$(yq_raw '.jobs["build-service-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  attestations=$(yq_raw '.jobs["build-service-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+
+  assert_eq "build-service-images has id-token: write" "write" "$id_token"
+  assert_eq "build-service-images has attestations: write" "write" "$attestations"
+}
+
+# --- CC-0029: Verify jobs do NOT have SBOM permissions (REQ-012) ---
+test_verify_jobs_no_sbom_permissions() {
+  echo "Test: verify jobs do not have SBOM permissions (CC-0029, REQ-012)"
+
+  local verify_base_id_token verify_base_attestations
+  verify_base_id_token=$(yq_raw '.jobs["verify-base-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  verify_base_attestations=$(yq_raw '.jobs["verify-base-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+
+  assert_eq "verify-base-images has no id-token permission" "null" "$verify_base_id_token"
+  assert_eq "verify-base-images has no attestations permission" "null" "$verify_base_attestations"
+
+  local verify_service_id_token verify_service_attestations
+  verify_service_id_token=$(yq_raw '.jobs["verify-service-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  verify_service_attestations=$(yq_raw '.jobs["verify-service-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+
+  assert_eq "verify-service-images has no id-token permission" "null" "$verify_service_id_token"
+  assert_eq "verify-service-images has no attestations permission" "null" "$verify_service_attestations"
+}
+
+# --- CC-0029: SBOM generation steps exist (REQ-010) ---
+test_sbom_generation_steps_exist() {
+  echo "Test: SBOM generation steps exist in both build jobs (CC-0029, REQ-010)"
+
+  # build-base-images should have 2 SBOM generation steps (python-base, venv-builder)
+  local base_sbom_count
+  base_sbom_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
+  assert_eq "build-base-images has 2 SBOM generation steps" "2" "$base_sbom_count"
+
+  # build-service-images should have 1 SBOM generation step
+  local service_sbom_count
+  service_sbom_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
+  assert_eq "build-service-images has 1 SBOM generation step" "1" "$service_sbom_count"
+}
+
+# --- CC-0029: SBOM format is cyclonedx-json (REQ-010) ---
+test_sbom_format_cyclonedx_json() {
+  echo "Test: SBOM format is cyclonedx-json (CC-0029, REQ-010)"
+
+  # All SBOM generation steps in build-base-images must use cyclonedx-json
+  local base_formats
+  base_formats=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
+
+  local all_cyclonedx=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [ "$val" != "cyclonedx-json" ]; then
+      echo "  FAIL: build-base-images SBOM format is not cyclonedx-json: $val"
+      FAIL=$((FAIL + 1))
+      all_cyclonedx=false
+    fi
+  done <<< "$base_formats"
+
+  if $all_cyclonedx && [ -n "$base_formats" ]; then
+    echo "  PASS: all build-base-images SBOM steps use cyclonedx-json"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_formats" ]; then
+    echo "  FAIL: build-base-images SBOM format check found no steps"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # build-service-images SBOM step
+  local service_format
+  service_format=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
+  assert_eq "build-service-images SBOM format is cyclonedx-json" "cyclonedx-json" "$service_format"
+}
+
+# --- CC-0029: SBOM generation steps disable artifact upload (REQ-010) ---
+test_sbom_no_artifact_upload() {
+  echo "Test: SBOM generation steps set upload-artifact: false (CC-0029, REQ-010)"
+
+  # All SBOM generation steps in build-base-images must set upload-artifact: false
+  local base_upload_values
+  base_upload_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
+
+  local all_false=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [ "$val" != "false" ]; then
+      echo "  FAIL: build-base-images SBOM step does not set upload-artifact: false: $val"
+      FAIL=$((FAIL + 1))
+      all_false=false
+    fi
+  done <<< "$base_upload_values"
+
+  if $all_false && [ -n "$base_upload_values" ]; then
+    echo "  PASS: all build-base-images SBOM steps set upload-artifact: false"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_upload_values" ]; then
+    echo "  FAIL: no build-base-images SBOM steps found for upload-artifact check"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # build-service-images SBOM step
+  local service_upload
+  service_upload=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
+  assert_eq "build-service-images SBOM step sets upload-artifact: false" "false" "$service_upload"
+}
+
+# --- CC-0029: SBOM generation references correct digest (REQ-015) ---
+test_sbom_generation_references_digest() {
+  echo "Test: SBOM generation steps reference correct digest (CC-0029, REQ-015)"
+
+  # python-base SBOM references build-python-base digest
+  local python_base_image
+  python_base_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Generate SBOM for python-base") | .with.image' "$WORKFLOW" || true)
+  assert_contains "python-base SBOM references build-python-base digest" "$python_base_image" "build-python-base.outputs.digest"
+
+  # venv-builder SBOM references build-venv-builder digest
+  local venv_builder_image
+  venv_builder_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Generate SBOM for venv-builder") | .with.image' "$WORKFLOW" || true)
+  assert_contains "venv-builder SBOM references build-venv-builder digest" "$venv_builder_image" "build-venv-builder.outputs.digest"
+
+  # service SBOM references build-service digest
+  local service_image
+  service_image=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Generate SBOM for service image") | .with.image' "$WORKFLOW" || true)
+  assert_contains "service SBOM uses tags.outputs.image" "$service_image" "steps.tags.outputs.image"
+  assert_contains "service SBOM references build-service digest" "$service_image" "build-service.outputs.digest"
+}
+
+# --- CC-0029: SBOM attestation steps exist (REQ-011) ---
+test_sbom_attestation_steps_exist() {
+  echo "Test: SBOM attestation steps exist in both build jobs (CC-0029, REQ-011)"
+
+  # build-base-images should have 2 attestation steps
+  local base_attest_count
+  base_attest_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-sbom"))) | .uses' "$WORKFLOW")
+  assert_eq "build-base-images has 2 attestation steps" "2" "$base_attest_count"
+
+  # build-service-images should have 1 attestation step
+  local service_attest_count
+  service_attest_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-sbom"))) | .uses' "$WORKFLOW")
+  assert_eq "build-service-images has 1 attestation step" "1" "$service_attest_count"
+}
+
+# --- CC-0029: SBOM attestation push-to-registry (REQ-016) ---
+test_sbom_attestation_push_to_registry() {
+  echo "Test: SBOM attestation push-to-registry is true (CC-0029, REQ-016)"
+
+  # All attestation steps in build-base-images
+  local base_push_values
+  base_push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-sbom"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+
+  local all_true=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [ "$val" != "true" ]; then
+      echo "  FAIL: build-base-images attestation push-to-registry is not true: $val"
+      FAIL=$((FAIL + 1))
+      all_true=false
+    fi
+  done <<< "$base_push_values"
+
+  if $all_true && [ -n "$base_push_values" ]; then
+    echo "  PASS: all build-base-images attestation steps have push-to-registry: true"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_push_values" ]; then
+    echo "  FAIL: no build-base-images attestation steps found (empty yq result)"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # build-service-images attestation step
+  local service_push
+  service_push=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-sbom"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+  assert_eq "build-service-images attestation push-to-registry is true" "true" "$service_push"
+}
+
+# --- CC-0029: SBOM/attestation steps have PR-skip guard (REQ-013) ---
+test_sbom_steps_pr_skip_guard() {
+  echo "Test: SBOM/attestation steps have PR-skip guard (CC-0029, REQ-013)"
+
+  # All SBOM steps in build-base-images must have PR guard
+  local base_sbom_ifs
+  base_sbom_ifs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action|actions/attest-sbom"))) | .if' "$WORKFLOW" || true)
+
+  local all_guarded=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
+      echo "  FAIL: build-base-images SBOM/attestation step missing PR guard: $val"
+      FAIL=$((FAIL + 1))
+      all_guarded=false
+    fi
+  done <<< "$base_sbom_ifs"
+
+  if $all_guarded && [ -n "$base_sbom_ifs" ]; then
+    echo "  PASS: all build-base-images SBOM/attestation steps have PR-skip guard"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_sbom_ifs" ]; then
+    echo "  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  FAIL: some build-base-images SBOM/attestation steps missing PR-skip guard (see above)"
+  fi
+
+  # All SBOM steps in build-service-images must have PR guard
+  local service_sbom_ifs
+  service_sbom_ifs=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action|actions/attest-sbom"))) | .if' "$WORKFLOW" || true)
+
+  local service_all_guarded=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
+      echo "  FAIL: build-service-images SBOM/attestation step missing PR guard: $val"
+      FAIL=$((FAIL + 1))
+      service_all_guarded=false
+    fi
+  done <<< "$service_sbom_ifs"
+
+  if $service_all_guarded && [ -n "$service_sbom_ifs" ]; then
+    echo "  PASS: all build-service-images SBOM/attestation steps have PR-skip guard"
+    PASS=$((PASS + 1))
+  elif [ -z "$service_sbom_ifs" ]; then
+    echo "  FAIL: build-service-images SBOM/attestation steps not found or missing PR guard"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  FAIL: some build-service-images SBOM/attestation steps missing PR-skip guard (see above)"
+  fi
 }
 
 # --- Run all tests ---
@@ -651,6 +903,26 @@ echo ""
 test_verify_service_images_tag_derivation_sync_comment
 echo ""
 test_verify_service_images_null_guard
+echo ""
+test_sbom_permissions_on_build_base_images
+echo ""
+test_sbom_permissions_on_build_service_images
+echo ""
+test_verify_jobs_no_sbom_permissions
+echo ""
+test_sbom_generation_steps_exist
+echo ""
+test_sbom_format_cyclonedx_json
+echo ""
+test_sbom_no_artifact_upload
+echo ""
+test_sbom_generation_references_digest
+echo ""
+test_sbom_attestation_steps_exist
+echo ""
+test_sbom_attestation_push_to_registry
+echo ""
+test_sbom_steps_pr_skip_guard
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 


### PR DESCRIPTION
**Size:** 📦 medium
**Category:** infrastructure
**Priority:** high
**Source:** Proposed for 'From the start, SBOMs with CycloneDX should be generated for all'

Integrate SBOM generation and attestation into `.github/workflows/build-images.yaml` for all container images:

1. **`build-base-images` job**: Add `id-token: write` and `attestations: write` permissions. After `build-python-base` and `build-venv-builder` push steps, add two new step pairs each:
   - `anchore/sbom-action` (SHA-pinned) scanning the pushed image by digest (`steps.build-python-base.outputs.digest` / `steps.build-venv-builder.outputs.digest`), outputting CycloneDX 1.5 JSON (`format: cyclonedx-json`)
   - `actions/attest-sbom@v2` (SHA-pinned) attesting the SBOM via Sigstore keyless OIDC and pushing attestation to GHCR (`push-to-registry: true`)
   - Both steps guarded by `if: github.event_name != 'pull_request'`

2. **`build-service-images` job**: Same permissions additions. After the `build-service` step, add one SBOM generation + attestation step pair referencing `steps.build-service.outputs.digest` and `matrix.service` for naming. Same PR-skip guard.

3. **SHA-pinning**: Both new actions must be SHA-pinned with version comments per existing convention enforced by `verify_build_images_workflow.sh`.

4. **Verification tests**: Update `tests/container-images/verify_build_images_workflow.sh` with new test cases validating: SBOM generation steps exist with `anchore/sbom-action` and correct `format: cyclonedx-json` parameter; attestation steps exist with `actions/attest-sbom` and `push-to-registry: true`; `id-token: write` and `attestations: write` permissions on both build jobs; `if: github.event_name != 'pull_request'` guard on all SBOM/attestation steps. Use existing assertion helpers from `tests/lib/assertions.sh`.

**Rationale:** Container images published to GHCR currently lack any software bill of materials or cryptographic attestation, leaving consumers unable to verify image contents or provenance. The architecture doc (`architecture/docs/08-container-images/04-sbom.md`) mandates CycloneDX SBOMs with Sigstore attestation. Without this, the project cannot meet supply chain security requirements, and downstream consumers have no tamper-evident way to audit image dependencies. This is a prerequisite for any future vulnerability scanning or compliance reporting from SBOMs.

**Affected Areas:**
- .github/workflows/build-images.yaml
- tests/container-images/verify_build_images_workflow.sh
- architecture/docs/08-container-images/04-sbom.md