### PR TITLE
feat(CC-0031): Add OCI Image Spec annotations to container images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -69,6 +69,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # CC-0031: Generate OCI annotations for python-base
+      - name: Generate metadata for python-base
+        id: meta-python-base
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+          labels: |
+            org.opencontainers.image.title=python-base
+            org.opencontainers.image.description=Python runtime base image for OpenStack services
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=SAP SE
+
       - name: Build and push python-base
         id: build-python-base
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -79,6 +91,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.meta.outputs.owner }}/python-base:latest
             ghcr.io/${{ steps.meta.outputs.owner }}/python-base:${{ github.sha }}
+          labels: ${{ steps.meta-python-base.outputs.labels }}
           cache-from: type=gha,scope=python-base
           cache-to: type=gha,mode=max,scope=python-base
 
@@ -101,6 +114,18 @@ jobs:
           sbom-path: sbom-python-base.cyclonedx.json
           push-to-registry: true
 
+      # CC-0031: Generate OCI annotations for venv-builder
+      - name: Generate metadata for venv-builder
+        id: meta-venv-builder
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
+          labels: |
+            org.opencontainers.image.title=venv-builder
+            org.opencontainers.image.description=Python virtualenv builder image for OpenStack services
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=SAP SE
+
       - name: Build and push venv-builder
         id: build-venv-builder
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -113,6 +138,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:latest
             ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:${{ github.sha }}
+          labels: ${{ steps.meta-venv-builder.outputs.labels }}
           cache-from: type=gha,scope=venv-builder
           cache-to: type=gha,mode=max,scope=venv-builder
 
@@ -280,6 +306,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # CC-0031: Generate OCI annotations for service image.
+      # Uses raw version strategy to override org.opencontainers.image.version
+      # with the upstream OpenStack release version from source-refs.yaml.
+      - name: Generate metadata for service image
+        id: meta-service
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ steps.tags.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.source-ref.outputs.ref }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.service }}
+            org.opencontainers.image.description=OpenStack ${{ matrix.service }} service
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=SAP SE
+
       - name: Build service image
         id: build-service
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -305,6 +347,7 @@ jobs:
             ${{ steps.tags.outputs.composite }}
             ${{ github.ref_name == 'main' && steps.tags.outputs.version || '' }}
             ${{ steps.tags.outputs.sha }}
+          labels: ${{ steps.meta-service.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}
 

--- a/.planwerk/completed/CC-0031-add-oci-image-spec-annotations-to-container-images.json
+++ b/.planwerk/completed/CC-0031-add-oci-image-spec-annotations-to-container-images.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0031",
   "title": "Add OCI Image Spec annotations to container images",
   "slug": "add-oci-image-spec-annotations-to-container-images",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 🔧 small\n**Category:** infrastructure\n**Priority:** medium\n**Source:** Proposed for 'Currently no OCI labels are being set on the container'\n\nAdd standard OCI annotations to python-base, venv-builder, and keystone container images using a two-layer approach:\n\n1. **CI-generated labels via `docker/metadata-action@v5`** (3 new steps in `.github/workflows/build-images.yaml`):\n   - `meta-python-base` step in `build-base-images` job before `build-python-base` step, generating OCI labels (title, description, source, url, version, created, revision, licenses, vendor)\n   - `meta-venv-builder` step in `build-base-images` job before `build-venv-builder` step, same label set\n   - `meta-keystone` step in `build-service-images` job before `build-service` step, with `version` overridden to `${{ steps.source-ref.outputs.ref }}` (upstream release version from source-refs.yaml) via `raw` version strategy\n   - Wire each metadata step's `labels` output into the corresponding `build-push-action` step via `labels: ${{ steps.<meta-step-id>.outputs.labels }}`\n\n2. **Static `LABEL` instructions in Dockerfiles** (3 files):\n   - Add `org.opencontainers.image.title`, `.description`, `.licenses=Apache-2.0`, `.vendor` as static LABELs to `images/python-base/Dockerfile`, `images/venv-builder/Dockerfile`, and `images/keystone/Dockerfile`\n   - These provide baseline metadata for local builds; CI-generated labels override them at push time\n\nExcluded: tag logic changes, custom/vendor-specific labels, base.name/base.digest annotations, Makefile changes, verify job changes.\n\n**Rationale:** Container images currently ship with zero metadata labels. This makes it impossible to trace a running image back to its source commit, repository, license, or build timestamp without external tooling. OCI annotations are the industry standard adopted by registries (Docker Hub, GHCR, Quay), vulnerability scanners, and audit tools. Adding them improves supply chain transparency, simplifies incident response (which commit produced this image?), and aligns with container best practices at minimal cost.\n\n**Affected Areas:**\n- .github/workflows/build-images.yaml\n- images/python-base/Dockerfile\n- images/venv-builder/Dockerfile\n- images/keystone/Dockerfile",
   "stories": [
@@ -256,6 +256,7 @@
       "title": "Add static OCI LABEL instructions to python-base, venv-builder, and keystone Dockerfiles (CC-0031, REQ-001, REQ-005)",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-005"
@@ -266,6 +267,7 @@
       "title": "Add docker/metadata-action steps for python-base and venv-builder in build-base-images job and wire labels output into build-push-action steps (CC-0031, REQ-002, REQ-004, REQ-005, REQ-006)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-002",
         "REQ-004",
@@ -278,6 +280,7 @@
       "title": "Add docker/metadata-action step for keystone in build-service-images job with raw version strategy overriding version to steps.source-ref.outputs.ref, and wire labels into build-service step (CC-0031, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006)",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-002",
         "REQ-003",
@@ -291,6 +294,7 @@
       "title": "Add CC-0031 verification tests to verify_build_images_workflow.sh: metadata-action step existence, labels wiring to build-push-action, keystone raw version strategy, OCI label keys in metadata-action, and static Dockerfile LABEL presence (CC-0031, REQ-001 through REQ-006)",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-002",
@@ -304,6 +308,7 @@
       "title": "Update docs/reference/build-images-workflow.md with OCI Annotations section documenting metadata-action steps, labels wiring, and keystone version override; update docs/reference/container-images.md Dockerfile sections with static LABEL documentation (CC-0031)",
       "level": 3,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-002",
@@ -431,8 +436,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-08T23:07:52.820801"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-08T23:09:51.491534"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-09T09:43:29.823013"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/46",
+  "pr_number": 46,
   "execution_history": [
     {
       "run_id": "22c7d25c-bf7a-462d-a42b-6b54112d6f39",
@@ -444,6 +459,50 @@
           "name": "prepare",
           "duration": 457.42329025268555,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "34d6d22c-5df0-4fa4-b25c-b1deff8b3f08",
+      "timestamp": "2026-03-08T23:30:33.369375",
+      "total_duration": 1097.904107093811,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (3 tasks)",
+          "duration": 234.64822125434875,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (1 tasks)",
+          "duration": 208.9367413520813,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (1 tasks)",
+          "duration": 223.5989978313446,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0031] Code Review",
+          "duration": 169.9121389389038,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0031] Improvements",
+          "duration": 216.22222018241882,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0031] Simplify",
+          "duration": 44.585787534713745,
+          "type": "simplify",
           "status": "done"
         }
       ]

--- a/.planwerk/patterns/two-layer-oci-annotation-approach-static-dockerfile-label-ci-metadata-action.md
+++ b/.planwerk/patterns/two-layer-oci-annotation-approach-static-dockerfile-label-ci-metadata-action.md
@@ -1,0 +1,39 @@
+# Pattern: Two-layer OCI annotation approach (static Dockerfile LABEL + CI metadata-action)
+
+**Component**: images/*/Dockerfile + .github/workflows/build-images.yaml
+**Category**: configuration
+**Applies-When**: Adding a new container image to the build pipeline that should carry OCI Image Spec annotations
+
+## Description
+
+Every container image uses a two-layer OCI annotation approach: (1) static LABEL instructions in the Dockerfile provide four baseline annotations (title, description, licenses=Apache-2.0, vendor=SAP SE) that are always present on locally-built images, and (2) a docker/metadata-action step in the CI workflow generates dynamic labels (created, revision, source, url, version) that supplement the static ones at push time. The metadata-action step is placed immediately before the corresponding build-push-action step, and the build-push-action step wires `labels: ${{ steps.<meta-step-id>.outputs.labels }}`. For service images with an upstream software version, the metadata-action uses `type=raw,value=${{ steps.source-ref.outputs.ref }}` to override the version annotation. In multi-stage Dockerfiles, the LABEL instruction is placed in the runtime stage only (build stage labels are discarded).
+
+## Examples
+
+### `images/python-base/Dockerfile:27-32`
+
+```
+# CC-0031: Static OCI Image Spec annotations for local builds.
+# CI-generated labels from docker/metadata-action supplement these at push time.
+LABEL org.opencontainers.image.title="python-base" \
+      org.opencontainers.image.description="Python runtime base image for OpenStack services" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="SAP SE"
+```
+
+### `.github/workflows/build-images.yaml:73-84`
+
+```
+# CC-0031: Generate OCI annotations for python-base
+- name: Generate metadata for python-base
+  id: meta-python-base
+  uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+  with:
+    images: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+    labels: |
+      org.opencontainers.image.title=python-base
+      org.opencontainers.image.description=Python runtime base image for OpenStack services
+      org.opencontainers.image.licenses=Apache-2.0
+      org.opencontainers.image.vendor=SAP SE
+```
+

--- a/.planwerk/reviews/CC-0031-add-oci-image-spec-annotations-to-container-images-review-1.json
+++ b/.planwerk/reviews/CC-0031-add-oci-image-spec-annotations-to-container-images-review-1.json
@@ -1,0 +1,77 @@
+{
+  "summary": "Adds OCI Image Spec annotations to python-base, venv-builder, and keystone container images via a two-layer approach: static LABEL instructions in Dockerfiles for local builds, and docker/metadata-action steps in CI for dynamic labels (created, revision, source, url, version). All three metadata-action uses are SHA-pinned with # v5 comment. The keystone metadata step overrides org.opencontainers.image.version with the upstream release ref via type=raw strategy. 13 new test functions in verify_build_images_workflow.sh validate step existence, labels wiring, version strategy, OCI label keys, and static Dockerfile LABEL presence. Reference docs updated in both build-images-workflow.md and container-images.md. All 142 tests pass (0 failures). No regressions in CC-0007/CC-0029 tests.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "Tests exist for all new functionality", "checked": true},
+    {"item": "All 142 tests pass (0 failures)", "checked": true},
+    {"item": "No regressions in existing CC-0007/CC-0029 tests", "checked": true},
+    {"item": "Edge case: keystone labels verified in runtime stage only (not build stage)", "checked": true},
+    {"item": "Edge case: base images verified to NOT have tags override", "checked": true},
+    {"item": "Test functions follow shell-test-script-structure-with-passfail-counters pattern", "checked": true},
+    {"item": "All test assertions use shared assert_eq/assert_contains/assert_file_contains helpers with PASS/FAIL branches", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing workflow step patterns (SHA pinning, id naming, with inputs)", "checked": true},
+    {"item": "Follows existing Dockerfile LABEL syntax patterns", "checked": true},
+    {"item": "Test functions follow existing yq_raw/yq_count query patterns", "checked": true},
+    {"item": "No code duplication beyond what is inherent in the three-image pattern", "checked": true},
+    {"item": "Clear CC-0031 feature ID comments on all new code blocks", "checked": true},
+    {"item": "No dead code or commented-out code", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No secrets or credentials introduced", "checked": true},
+    {"item": "metadata-action pinned to full SHA (c299e40c65443455700f0fdfc63efafe5b349051)", "checked": true},
+    {"item": "No user input flows into labels (all values are static or from trusted GitHub context)", "checked": true},
+    {"item": "No path traversal or injection risks", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Two-layer approach (static + CI-generated) is minimal and appropriate", "checked": true},
+    {"item": "No changes to tag derivation logic, verify job, SBOM/attestation, or Makefile", "checked": true},
+    {"item": "Metadata steps placed before corresponding build-push-action steps", "checked": true},
+    {"item": "Labels wired via outputs.labels (standard docker/metadata-action pattern)", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "Only four OCI labels per image (title, description, licenses, vendor) — no unnecessary labels", "checked": true},
+    {"item": "No custom scripting — uses docker/metadata-action as intended", "checked": true},
+    {"item": "No future-proofing abstractions", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "yq_count has error handling for yq parse failures", "checked": true},
+    {"item": "yq_raw calls use || true or || echo null for graceful empty-result handling", "checked": true},
+    {"item": "Test script exits non-zero on any FAIL count > 0", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Static Dockerfile labels provide fallback when CI metadata-action is not available", "checked": true},
+    {"item": "Keystone test extracts runtime stage only via sed to avoid false positives from build stage", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "D2 (minor): Rename step ID `meta-keystone` to `meta-service` in build-service-images job — the job uses a matrix strategy and the step generates metadata for `${{ matrix.service }}`, not just keystone. When a second service (e.g., nova) is added to the matrix, a step named `meta-keystone` generating metadata for nova would be confusing. This also applies to the `labels: ${{ steps.meta-keystone.outputs.labels }}` reference in `build-service`. Note: this is cosmetic and does NOT affect correctness since each matrix entry runs in its own runner.",
+    "D2 (minor): The static Dockerfile description for keystone says `OpenStack Keystone identity service` (capitalized, with 'identity'), while the CI metadata-action template produces `OpenStack keystone service` (lowercase, no 'identity'). Since CI labels override static ones at push time, the pushed image will have the generic description. Consider using `OpenStack ${{ matrix.service }} identity service` in the metadata-action template, or accept the simpler generic form and update the Dockerfile to match for consistency."
+  ],
+  "next_steps": [
+    "Merge to main — implementation is complete and all checks pass",
+    "When adding a second service to the matrix, consider renaming meta-keystone to meta-service (see suggested improvements)"
+  ],
+  "detected_patterns": [
+    {
+      "name": "Two-layer OCI annotation approach (static Dockerfile LABEL + CI metadata-action)",
+      "component": "images/*/Dockerfile + .github/workflows/build-images.yaml",
+      "category": "configuration",
+      "applies_when": "Adding a new container image to the build pipeline that should carry OCI Image Spec annotations",
+      "description": "Every container image uses a two-layer OCI annotation approach: (1) static LABEL instructions in the Dockerfile provide four baseline annotations (title, description, licenses=Apache-2.0, vendor=SAP SE) that are always present on locally-built images, and (2) a docker/metadata-action step in the CI workflow generates dynamic labels (created, revision, source, url, version) that supplement the static ones at push time. The metadata-action step is placed immediately before the corresponding build-push-action step, and the build-push-action step wires `labels: ${{ steps.<meta-step-id>.outputs.labels }}`. For service images with an upstream software version, the metadata-action uses `type=raw,value=${{ steps.source-ref.outputs.ref }}` to override the version annotation. In multi-stage Dockerfiles, the LABEL instruction is placed in the runtime stage only (build stage labels are discarded).",
+      "examples": [
+        {
+          "location": "images/python-base/Dockerfile:27-32",
+          "code": "# CC-0031: Static OCI Image Spec annotations for local builds.\n# CI-generated labels from docker/metadata-action supplement these at push time.\nLABEL org.opencontainers.image.title=\"python-base\" \\\n      org.opencontainers.image.description=\"Python runtime base image for OpenStack services\" \\\n      org.opencontainers.image.licenses=\"Apache-2.0\" \\\n      org.opencontainers.image.vendor=\"SAP SE\""
+        },
+        {
+          "location": ".github/workflows/build-images.yaml:73-84",
+          "code": "# CC-0031: Generate OCI annotations for python-base\n- name: Generate metadata for python-base\n  id: meta-python-base\n  uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5\n  with:\n    images: ghcr.io/${{ steps.meta.outputs.owner }}/python-base\n    labels: |\n      org.opencontainers.image.title=python-base\n      org.opencontainers.image.description=Python runtime base image for OpenStack services\n      org.opencontainers.image.licenses=Apache-2.0\n      org.opencontainers.image.vendor=SAP SE"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -1,18 +1,18 @@
 ---
 title: Build Images Workflow
 quadrant: infrastructure
-feature: CC-0007, CC-0029
+feature: CC-0007, CC-0029, CC-0031
 ---
 
 # Build Images Workflow
 
-Reference documentation for the GitHub Actions build-images workflow (CC-0007, CC-0029)
-and the verify-container-images workflow (CC-0028). The build-images workflow builds,
-tags, and publishes container images for OpenStack services to GHCR (GitHub Container
-Registry). Each pushed image receives a CycloneDX SBOM and a Sigstore-signed attestation
-(CC-0029). The verify-container-images workflow runs static verification tests against
-container infrastructure files (Dockerfiles, workflows, release configs) without
-requiring Docker.
+Reference documentation for the GitHub Actions build-images workflow (CC-0007, CC-0029,
+CC-0031) and the verify-container-images workflow (CC-0028). The build-images workflow
+builds, tags, and publishes container images for OpenStack services to GHCR (GitHub
+Container Registry). Each pushed image receives OCI Image Spec annotations (CC-0031),
+a CycloneDX SBOM, and a Sigstore-signed attestation (CC-0029). The
+verify-container-images workflow runs static verification tests against container
+infrastructure files (Dockerfiles, workflows, release configs) without requiring Docker.
 
 ## File Locations
 
@@ -128,18 +128,21 @@ availability.
 | --- | --- | --- | --- |
 | 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork (CC-0007) |
 | 2 | Checkout | `actions/checkout@v6` | Checks out the repository |
-| 3 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
-| 4 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 5 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}` |
-| 6 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
-| 7 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 8 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, `--build-context python-base=docker-image://...` |
-| 9 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
-| 10 | Attest SBOM for venv-builder | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references (CC-0007) |
+| 4 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
+| 5 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
+| 6 | Generate metadata for python-base | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for python-base (CC-0031) |
+| 7 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 6 |
+| 8 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
+| 9 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 10 | Generate metadata for venv-builder | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for venv-builder (CC-0031) |
+| 11 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 10, `--build-context python-base=docker-image://...` |
+| 12 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
+| 13 | Attest SBOM for venv-builder | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
 
 The `venv-builder` build uses a `docker-image://` build context pointing at the
 just-pushed `python-base` image (referenced by digest), ensuring its `FROM python-base`
-directive resolves to the exact image built in step 5.
+directive resolves to the exact image built in step 7.
 
 Each base image is tagged with both `:latest` (mutable convenience tag) and
 `:${{ github.sha }}` (immutable commit-pinned tag). The SHA tag provides an auditable
@@ -216,10 +219,11 @@ Depends on `build-base-images` for image references (REQ-003) and on
 | 7 | Derive tags | Shell | Computes three image tags and the lowercase `image` path (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
 | 8 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
 | 9 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 10 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load (REQ-006) |
-| 11 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
-| 12 | Attest SBOM for service image | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 13 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
+| 10 | Generate metadata for service image | `docker/metadata-action@v5` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy (CC-0031) |
+| 11 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load, labels from step 10 (REQ-006) |
+| 12 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
+| 13 | Attest SBOM for service image | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 14 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
 
 **Build Contexts:**
 
@@ -260,7 +264,7 @@ Validates that built service images are functional by running `verify_keystone.s
 `build-service-images` to test every service independently.
 
 On PRs, the equivalent verification runs as an inline step within `build-service-images`
-(step 13 above) because `--load` makes the image available only on the same runner.
+(step 14 above) because `--load` makes the image available only on the same runner.
 
 | Property | Value |
 | --- | --- |
@@ -372,6 +376,7 @@ convention in `ci.yaml`:
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
 uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4
+uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5 (CC-0031)
 uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
 uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0 (CC-0029)
 uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4 (CC-0029)
@@ -483,6 +488,106 @@ The `verify_build_images_workflow.sh` script validates SBOM/attestation configur
 | `test_sbom_attestation_push_to_registry` | All attestation steps have `push-to-registry: true` |
 | `test_sbom_steps_pr_skip_guard` | All SBOM/attestation steps have `github.event_name != 'pull_request'` guard |
 
+## OCI Annotations
+
+Every container image receives OCI Image Spec annotations (CC-0031) via a two-layer
+approach: static `LABEL` instructions in Dockerfiles provide baseline metadata for local
+builds, while `docker/metadata-action` in CI generates dynamic labels that supplement the
+static ones at push time.
+
+### Static Dockerfile Labels
+
+Each Dockerfile includes a `LABEL` instruction with four OCI annotations that are always
+present, regardless of whether the image is built locally or in CI:
+
+| Label | Value (example for keystone) |
+| --- | --- |
+| `org.opencontainers.image.title` | `keystone` |
+| `org.opencontainers.image.description` | `OpenStack keystone service` |
+| `org.opencontainers.image.licenses` | `Apache-2.0` |
+| `org.opencontainers.image.vendor` | `SAP SE` |
+
+In `python-base` and `venv-builder`, the `LABEL` instruction is placed after the last
+`RUN` instruction. In `keystone`, the `LABEL` is placed in Stage 2 (runtime, `FROM
+python-base`) before the `USER` instruction — Stage 1 (build) labels are discarded by
+Docker's multi-stage build process.
+
+### CI Metadata Action
+
+In CI, each image has a `docker/metadata-action` step that generates OCI-compliant
+labels. The action auto-generates dynamic labels from the GitHub context:
+
+| Auto-generated label | Source |
+| --- | --- |
+| `org.opencontainers.image.created` | Build timestamp (ISO 8601) |
+| `org.opencontainers.image.revision` | `GITHUB_SHA` (40-character Git SHA) |
+| `org.opencontainers.image.source` | GitHub repository URL |
+| `org.opencontainers.image.url` | GitHub repository URL |
+| `org.opencontainers.image.version` | Git-derived version (or raw override for keystone) |
+
+The `labels` input of each metadata-action step provides the four custom labels (title,
+description, licenses, vendor). These supplement the auto-generated labels.
+
+**Metadata-action steps:**
+
+| Step ID | Job | Image input |
+| --- | --- | --- |
+| `meta-python-base` | `build-base-images` | `ghcr.io/${{ steps.meta.outputs.owner }}/python-base` |
+| `meta-venv-builder` | `build-base-images` | `ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder` |
+| `meta-service` | `build-service-images` | `${{ steps.tags.outputs.image }}` |
+
+Each metadata-action step's `outputs.labels` is wired into the corresponding
+`build-push-action` step via the `labels` input. At push time, CI-generated labels
+(created, revision, source, url, version) override any matching static Dockerfile labels,
+while the static labels serve as fallback for local builds where no metadata-action runs.
+
+### Keystone Version Override
+
+By default, `docker/metadata-action` derives `org.opencontainers.image.version` from the
+Git context (branch name or tag). For keystone, this would produce a Git-derived version
+rather than the upstream OpenStack release version (e.g., `28.0.0`).
+
+To ensure the OCI version annotation reflects the actual software version, the
+`meta-service` step uses a `type=raw` tag strategy:
+
+```yaml
+tags: |
+  type=raw,value=${{ steps.source-ref.outputs.ref }}
+```
+
+This overrides the version to match the value from `source-refs.yaml` (e.g., `28.0.0`).
+The base images (`python-base`, `venv-builder`) do not specify a `tags` input and use the
+default Git-derived version strategy, which is appropriate for infrastructure images
+without an upstream software version.
+
+> **Note:** The `tags` input on `docker/metadata-action` controls the
+> `org.opencontainers.image.version` label, not the image tags passed to
+> `docker/build-push-action`. Image tags continue to be computed by the "Derive tags"
+> step (see [Tag Schema](#tag-schema)). The metadata-action's tag strategies only
+> influence the OCI version annotation.
+
+### Test Coverage
+
+The `verify_build_images_workflow.sh` script validates OCI annotation configuration
+(CC-0031):
+
+| Test | Validates |
+| --- | --- |
+| `test_metadata_action_steps_exist_in_build_base_images` | `build-base-images` has `meta-python-base` and `meta-venv-builder` steps using `docker/metadata-action` |
+| `test_metadata_action_step_exists_in_build_service_images` | `build-service-images` has `meta-service` step using `docker/metadata-action` |
+| `test_service_metadata_uses_raw_version_strategy` | `meta-service` step uses `type=raw` with `steps.source-ref.outputs.ref` |
+| `test_base_metadata_steps_have_no_tags_override` | `meta-python-base` and `meta-venv-builder` do not specify a `tags` input |
+| `test_python_base_build_push_has_labels_input` | `build-python-base` step wires `steps.meta-python-base.outputs.labels` |
+| `test_venv_builder_build_push_has_labels_input` | `build-venv-builder` step wires `steps.meta-venv-builder.outputs.labels` |
+| `test_service_build_push_has_labels_input` | `build-service` step wires `steps.meta-service.outputs.labels` |
+| `test_metadata_action_labels_include_oci_title` | All 3 metadata-action steps include `org.opencontainers.image.title` |
+| `test_metadata_action_labels_include_oci_description` | All 3 metadata-action steps include `org.opencontainers.image.description` |
+| `test_metadata_action_labels_include_oci_licenses` | All 3 metadata-action steps include `org.opencontainers.image.licenses=Apache-2.0` |
+| `test_metadata_action_labels_include_oci_vendor` | All 3 metadata-action steps include `org.opencontainers.image.vendor` |
+| `test_dockerfile_static_labels_python_base` | `images/python-base/Dockerfile` has `LABEL` for title, description, licenses, vendor |
+| `test_dockerfile_static_labels_venv_builder` | `images/venv-builder/Dockerfile` has `LABEL` for title, description, licenses, vendor |
+| `test_dockerfile_static_labels_keystone` | `images/keystone/Dockerfile` has `LABEL` for title, description, licenses, vendor in Stage 2 |
+
 ## Adding a New Service
 
 To add a new service (e.g., `nova`) to the build matrix:
@@ -492,6 +597,8 @@ To add a new service (e.g., `nova`) to the build matrix:
 Add a Dockerfile at `images/<service>/Dockerfile` following the two-stage pattern in
 `images/keystone/Dockerfile`. The Dockerfile must use named build contexts
 (`python-base`, `venv-builder`, `<service>`, `upper-constraints`) — not hardcoded paths.
+Include a `LABEL` instruction in the runtime stage with OCI annotations (title,
+description, licenses, vendor) — see [OCI Annotations](#oci-annotations) (CC-0031).
 
 ### 2. Add the source ref
 
@@ -639,7 +746,7 @@ non-zero, the job fails.
 
 | Script | Validates |
 | --- | --- |
-| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029) |
+| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029), OCI annotation configuration (CC-0031) |
 | `verify_deviation_comments.sh` | DEVIATION comments in Dockerfiles cross-reference architecture docs |
 | `verify_release_config.sh` | `source-refs.yaml` and `extra-packages.yaml` structure and content validity |
 | `verify_spdx_headers.sh` | SPDX Apache-2.0 license headers present on all infrastructure files |

--- a/docs/reference/container-images.md
+++ b/docs/reference/container-images.md
@@ -1,7 +1,7 @@
 ---
 title: Container Images
 quadrant: infrastructure
-feature: CC-0006
+feature: CC-0006, CC-0031
 ---
 
 # Container Images
@@ -64,6 +64,12 @@ The foundational runtime image for all OpenStack service containers.
 rather than creating per-service users. This is a deliberate deviation from the architecture
 document — see [Design Deviations](#design-deviations) for rationale.
 
+**OCI labels (CC-0031):** The Dockerfile includes static `LABEL` instructions for baseline
+OCI Image Spec annotations (`title`, `description`, `licenses`, `vendor`). These are
+always present on locally-built images. In CI, `docker/metadata-action` supplements these
+with dynamic labels (created, revision, source, url, version) — see
+[Build Images Workflow — OCI Annotations](build-images-workflow.md#oci-annotations).
+
 ### venv-builder
 
 **Location:** `images/venv-builder/Dockerfile`
@@ -105,6 +111,9 @@ These packages are installed **without** the `--constraint` flag. The `venv-buil
 is release-independent — version constraints are release-specific and applied only in
 service Dockerfiles when installing the actual service.
 
+**OCI labels (CC-0031):** Same static `LABEL` pattern as `python-base` — title, description,
+licenses, and vendor are embedded in the Dockerfile for local build visibility.
+
 ## Service Images
 
 ### keystone
@@ -144,6 +153,12 @@ The Keystone identity service image uses a two-stage build:
 - Contains no build tools (`gcc`, `python3-dev`, `build-essential`, `uv` are absent)
 - Virtualenv at `/var/lib/openstack` with all Keystone dependencies
 - `keystone-manage` CLI available via `PATH`
+
+**OCI labels (CC-0031):** The `LABEL` instruction is placed in Stage 2 (runtime) before
+the `USER` instruction. Labels added in Stage 1 (build) are discarded by Docker's
+multi-stage build process — only the runtime stage labels appear on the final image. In
+CI, `docker/metadata-action` overrides `org.opencontainers.image.version` with the
+upstream OpenStack release version from `source-refs.yaml` via a `type=raw` tag strategy.
 
 ## Named Build Contexts
 

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -47,4 +47,11 @@ RUN if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
     rm -rf /var/lib/apt/lists/*; \
     fi
 
+# CC-0031: Static OCI Image Spec annotations for local builds (runtime stage only).
+# CI-generated labels from docker/metadata-action supplement these at push time.
+LABEL org.opencontainers.image.title="keystone" \
+      org.opencontainers.image.description="OpenStack keystone service" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="SAP SE"
+
 USER openstack

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -23,3 +23,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
 # and image layers. Each service image inherits this user via USER openstack.
 RUN groupadd -g 42424 openstack && \
     useradd -u 42424 -g 42424 -M -d /var/lib/openstack -s /usr/sbin/nologin openstack
+
+# CC-0031: Static OCI Image Spec annotations for local builds.
+# CI-generated labels from docker/metadata-action supplement these at push time.
+LABEL org.opencontainers.image.title="python-base" \
+      org.opencontainers.image.description="Python runtime base image for OpenStack services" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="SAP SE"

--- a/images/venv-builder/Dockerfile
+++ b/images/venv-builder/Dockerfile
@@ -30,3 +30,10 @@ RUN uv pip install --prefix /var/lib/openstack \
     pymysql \
     python-memcached \
     uwsgi
+
+# CC-0031: Static OCI Image Spec annotations for local builds.
+# CI-generated labels from docker/metadata-action supplement these at push time.
+LABEL org.opencontainers.image.title="venv-builder" \
+      org.opencontainers.image.description="Python virtualenv builder image for OpenStack services" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="SAP SE"

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify build-images workflow structure, conventions, and correctness (CC-0007, CC-0029)
+# Verify build-images workflow structure, conventions, and correctness (CC-0007, CC-0029, CC-0031)
 # Requirements: REQ-001 through REQ-017
 # Usage: bash tests/container-images/verify_build_images_workflow.sh
 
@@ -823,6 +823,185 @@ test_sbom_steps_pr_skip_guard() {
   fi
 }
 
+# --- CC-0031: metadata-action steps exist in build-base-images (REQ-002) ---
+test_metadata_action_steps_exist_in_build_base_images() {
+  echo "Test: metadata-action steps exist in build-base-images (CC-0031, REQ-002)"
+
+  local meta_count
+  meta_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("docker/metadata-action"))) | .uses' "$WORKFLOW")
+  assert_eq "build-base-images has 2 docker/metadata-action steps" "2" "$meta_count"
+
+  local python_base_id venv_builder_id
+  python_base_id=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .id' "$WORKFLOW" || true)
+  venv_builder_id=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .id' "$WORKFLOW" || true)
+
+  assert_eq "meta-python-base step exists" "meta-python-base" "$python_base_id"
+  assert_eq "meta-venv-builder step exists" "meta-venv-builder" "$venv_builder_id"
+}
+
+# --- CC-0031: metadata-action step exists in build-service-images (REQ-002) ---
+test_metadata_action_step_exists_in_build_service_images() {
+  echo "Test: metadata-action step exists in build-service-images (CC-0031, REQ-002)"
+
+  local meta_count
+  meta_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("docker/metadata-action"))) | .uses' "$WORKFLOW")
+  assert_eq "build-service-images has 1 docker/metadata-action step" "1" "$meta_count"
+
+  local keystone_id
+  keystone_id=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .id' "$WORKFLOW" || true)
+  assert_eq "meta-service step exists" "meta-service" "$keystone_id"
+}
+
+# --- CC-0031: keystone metadata uses raw version strategy (REQ-003) ---
+test_service_metadata_uses_raw_version_strategy() {
+  echo "Test: service metadata uses raw version strategy (CC-0031, REQ-003)"
+
+  local tags_input
+  tags_input=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .with.tags' "$WORKFLOW" || true)
+
+  assert_contains "meta-service tags input contains type=raw" "$tags_input" "type=raw"
+  assert_contains "meta-service tags input references source-ref output" "$tags_input" "steps.source-ref.outputs.ref"
+}
+
+# --- CC-0031: base metadata steps have no tags override (REQ-004) ---
+test_base_metadata_steps_have_no_tags_override() {
+  echo "Test: base metadata steps have no tags override (CC-0031, REQ-004)"
+
+  local python_base_tags venv_builder_tags
+  python_base_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .with.tags' "$WORKFLOW" || echo "null")
+  venv_builder_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .with.tags' "$WORKFLOW" || echo "null")
+
+  assert_eq "meta-python-base has no tags input" "null" "$python_base_tags"
+  assert_eq "meta-venv-builder has no tags input" "null" "$venv_builder_tags"
+}
+
+# --- CC-0031: python-base build-push-action has labels input (REQ-005) ---
+test_python_base_build_push_has_labels_input() {
+  echo "Test: python-base build-push-action has labels input (CC-0031, REQ-005)"
+
+  local labels
+  labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-python-base") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "build-python-base labels references meta-python-base" "$labels" "steps.meta-python-base.outputs.labels"
+}
+
+# --- CC-0031: venv-builder build-push-action has labels input (REQ-005) ---
+test_venv_builder_build_push_has_labels_input() {
+  echo "Test: venv-builder build-push-action has labels input (CC-0031, REQ-005)"
+
+  local labels
+  labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-venv-builder") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "build-venv-builder labels references meta-venv-builder" "$labels" "steps.meta-venv-builder.outputs.labels"
+}
+
+# --- CC-0031: service build-push-action has labels input (REQ-005) ---
+test_service_build_push_has_labels_input() {
+  echo "Test: service build-push-action has labels input (CC-0031, REQ-005)"
+
+  local labels
+  labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "build-service labels references meta-service" "$labels" "steps.meta-service.outputs.labels"
+}
+
+# --- CC-0031: metadata-action labels include OCI title (REQ-005) ---
+test_metadata_action_labels_include_oci_title() {
+  echo "Test: metadata-action labels include OCI title (CC-0031, REQ-005)"
+
+  local python_labels venv_labels keystone_labels
+  python_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .with.labels' "$WORKFLOW" || true)
+  venv_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .with.labels' "$WORKFLOW" || true)
+  keystone_labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "meta-python-base labels include OCI title" "$python_labels" "org.opencontainers.image.title"
+  assert_contains "meta-venv-builder labels include OCI title" "$venv_labels" "org.opencontainers.image.title"
+  assert_contains "meta-service labels include OCI title" "$keystone_labels" "org.opencontainers.image.title"
+}
+
+# --- CC-0031: metadata-action labels include OCI description (REQ-005) ---
+test_metadata_action_labels_include_oci_description() {
+  echo "Test: metadata-action labels include OCI description (CC-0031, REQ-005)"
+
+  local python_labels venv_labels keystone_labels
+  python_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .with.labels' "$WORKFLOW" || true)
+  venv_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .with.labels' "$WORKFLOW" || true)
+  keystone_labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "meta-python-base labels include OCI description" "$python_labels" "org.opencontainers.image.description"
+  assert_contains "meta-venv-builder labels include OCI description" "$venv_labels" "org.opencontainers.image.description"
+  assert_contains "meta-service labels include OCI description" "$keystone_labels" "org.opencontainers.image.description"
+}
+
+# --- CC-0031: metadata-action labels include OCI licenses (REQ-005) ---
+test_metadata_action_labels_include_oci_licenses() {
+  echo "Test: metadata-action labels include OCI licenses (CC-0031, REQ-005)"
+
+  local python_labels venv_labels keystone_labels
+  python_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .with.labels' "$WORKFLOW" || true)
+  venv_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .with.labels' "$WORKFLOW" || true)
+  keystone_labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "meta-python-base labels include Apache-2.0 license" "$python_labels" "org.opencontainers.image.licenses=Apache-2.0"
+  assert_contains "meta-venv-builder labels include Apache-2.0 license" "$venv_labels" "org.opencontainers.image.licenses=Apache-2.0"
+  assert_contains "meta-service labels include Apache-2.0 license" "$keystone_labels" "org.opencontainers.image.licenses=Apache-2.0"
+}
+
+# --- CC-0031: metadata-action labels include OCI vendor (REQ-005) ---
+test_metadata_action_labels_include_oci_vendor() {
+  echo "Test: metadata-action labels include OCI vendor (CC-0031, REQ-005)"
+
+  local python_labels venv_labels keystone_labels
+  python_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-python-base") | .with.labels' "$WORKFLOW" || true)
+  venv_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "meta-venv-builder") | .with.labels' "$WORKFLOW" || true)
+  keystone_labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "meta-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "meta-python-base labels include vendor" "$python_labels" "org.opencontainers.image.vendor"
+  assert_contains "meta-venv-builder labels include vendor" "$venv_labels" "org.opencontainers.image.vendor"
+  assert_contains "meta-service labels include vendor" "$keystone_labels" "org.opencontainers.image.vendor"
+}
+
+# --- CC-0031: static OCI labels in python-base Dockerfile (REQ-001) ---
+test_dockerfile_static_labels_python_base() {
+  echo "Test: python-base Dockerfile has static OCI labels (CC-0031, REQ-001)"
+
+  local dockerfile="$PROJECT_ROOT/images/python-base/Dockerfile"
+
+  assert_file_contains "python-base has org.opencontainers.image.title" "$dockerfile" 'org.opencontainers.image.title='
+  assert_file_contains "python-base has org.opencontainers.image.description" "$dockerfile" 'org.opencontainers.image.description='
+  assert_file_contains "python-base has org.opencontainers.image.licenses" "$dockerfile" 'org.opencontainers.image.licenses='
+  assert_file_contains "python-base has org.opencontainers.image.vendor" "$dockerfile" 'org.opencontainers.image.vendor='
+}
+
+# --- CC-0031: static OCI labels in venv-builder Dockerfile (REQ-001) ---
+test_dockerfile_static_labels_venv_builder() {
+  echo "Test: venv-builder Dockerfile has static OCI labels (CC-0031, REQ-001)"
+
+  local dockerfile="$PROJECT_ROOT/images/venv-builder/Dockerfile"
+
+  assert_file_contains "venv-builder has org.opencontainers.image.title" "$dockerfile" 'org.opencontainers.image.title='
+  assert_file_contains "venv-builder has org.opencontainers.image.description" "$dockerfile" 'org.opencontainers.image.description='
+  assert_file_contains "venv-builder has org.opencontainers.image.licenses" "$dockerfile" 'org.opencontainers.image.licenses='
+  assert_file_contains "venv-builder has org.opencontainers.image.vendor" "$dockerfile" 'org.opencontainers.image.vendor='
+}
+
+# --- CC-0031: static OCI labels in keystone Dockerfile runtime stage (REQ-001) ---
+test_dockerfile_static_labels_keystone() {
+  echo "Test: keystone Dockerfile has static OCI labels in runtime stage (CC-0031, REQ-001)"
+
+  local dockerfile="$PROJECT_ROOT/images/keystone/Dockerfile"
+
+  # Extract only the runtime stage (Stage 2: from 'FROM python-base' to end of file)
+  # to verify labels are in the correct stage, not the build stage.
+  local runtime_stage
+  runtime_stage=$(sed -n '/^FROM python-base/,$ p' "$dockerfile")
+
+  assert_contains "keystone runtime stage has org.opencontainers.image.title" "$runtime_stage" 'org.opencontainers.image.title='
+  assert_contains "keystone runtime stage has org.opencontainers.image.description" "$runtime_stage" 'org.opencontainers.image.description='
+  assert_contains "keystone runtime stage has org.opencontainers.image.licenses" "$runtime_stage" 'org.opencontainers.image.licenses='
+  assert_contains "keystone runtime stage has org.opencontainers.image.vendor" "$runtime_stage" 'org.opencontainers.image.vendor='
+}
+
 # --- Run all tests ---
 echo "=== Build images workflow verification tests ==="
 echo ""
@@ -923,6 +1102,34 @@ echo ""
 test_sbom_attestation_push_to_registry
 echo ""
 test_sbom_steps_pr_skip_guard
+echo ""
+test_metadata_action_steps_exist_in_build_base_images
+echo ""
+test_metadata_action_step_exists_in_build_service_images
+echo ""
+test_service_metadata_uses_raw_version_strategy
+echo ""
+test_base_metadata_steps_have_no_tags_override
+echo ""
+test_python_base_build_push_has_labels_input
+echo ""
+test_venv_builder_build_push_has_labels_input
+echo ""
+test_service_build_push_has_labels_input
+echo ""
+test_metadata_action_labels_include_oci_title
+echo ""
+test_metadata_action_labels_include_oci_description
+echo ""
+test_metadata_action_labels_include_oci_licenses
+echo ""
+test_metadata_action_labels_include_oci_vendor
+echo ""
+test_dockerfile_static_labels_python_base
+echo ""
+test_dockerfile_static_labels_venv_builder
+echo ""
+test_dockerfile_static_labels_keystone
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 


### PR DESCRIPTION
**Size:** 🔧 small
**Category:** infrastructure
**Priority:** medium
**Source:** Proposed for 'Currently no OCI labels are being set on the container'

Add standard OCI annotations to python-base, venv-builder, and keystone container images using a two-layer approach:

1. **CI-generated labels via `docker/metadata-action@v5`** (3 new steps in `.github/workflows/build-images.yaml`):
   - `meta-python-base` step in `build-base-images` job before `build-python-base` step, generating OCI labels (title, description, source, url, version, created, revision, licenses, vendor)
   - `meta-venv-builder` step in `build-base-images` job before `build-venv-builder` step, same label set
   - `meta-keystone` step in `build-service-images` job before `build-service` step, with `version` overridden to `${{ steps.source-ref.outputs.ref }}` (upstream release version from source-refs.yaml) via `raw` version strategy
   - Wire each metadata step's `labels` output into the corresponding `build-push-action` step via `labels: ${{ steps.<meta-step-id>.outputs.labels }}`

2. **Static `LABEL` instructions in Dockerfiles** (3 files):
   - Add `org.opencontainers.image.title`, `.description`, `.licenses=Apache-2.0`, `.vendor` as static LABELs to `images/python-base/Dockerfile`, `images/venv-builder/Dockerfile`, and `images/keystone/Dockerfile`
   - These provide baseline metadata for local builds; CI-generated labels override them at push time

Excluded: tag logic changes, custom/vendor-specific labels, base.name/base.digest annotations, Makefile changes, verify job changes.

**Rationale:** Container images currently ship with zero metadata labels. This makes it impossible to trace a running image back to its source commit, repository, license, or build timestamp without external tooling. OCI annotations are the industry standard adopted by registries (Docker Hub, GHCR, Quay), vulnerability scanners, and audit tools. Adding them improves supply chain transparency, simplifies incident response (which commit produced this image?), and aligns with container best practices at minimal cost.

**Affected Areas:**
- .github/workflows/build-images.yaml
- images/python-base/Dockerfile
- images/venv-builder/Dockerfile
- images/keystone/Dockerfile