### PR TITLE
feat(CC-0030): Add cosign keyless signing to container images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+      id-token: write       # CC-0029, CC-0030: Sigstore OIDC signing for SBOM attestation and cosign signing
       attestations: write   # CC-0029: GitHub Attestations API
     outputs:
       python-base-image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
@@ -68,6 +68,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CC-0030: Install cosign for image signing
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
       # CC-0031: Generate OCI annotations for python-base
       - name: Generate metadata for python-base
@@ -113,6 +116,11 @@ jobs:
           subject-digest: ${{ steps.build-python-base.outputs.digest }}
           sbom-path: sbom-python-base.cyclonedx.json
           push-to-registry: true
+
+      # CC-0030: Sign python-base with cosign keyless signing
+      - name: Sign python-base
+        if: github.event_name != 'pull_request'
+        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
 
       # CC-0031: Generate OCI annotations for venv-builder
       - name: Generate metadata for venv-builder
@@ -161,6 +169,11 @@ jobs:
           sbom-path: sbom-venv-builder.cyclonedx.json
           push-to-registry: true
 
+      # CC-0030: Sign venv-builder with cosign keyless signing
+      - name: Sign venv-builder
+        if: github.event_name != 'pull_request'
+        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+
   verify-base-images:
     needs: [build-base-images]
     runs-on: ubuntu-latest
@@ -202,7 +215,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+      id-token: write       # CC-0029, CC-0030: Sigstore OIDC signing for SBOM attestation and cosign signing
       attestations: write   # CC-0029: GitHub Attestations API
     strategy:
       fail-fast: false
@@ -306,6 +319,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # CC-0030: Install cosign for image signing
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
+
       # CC-0031: Generate OCI annotations for service image.
       # Uses raw version strategy to override org.opencontainers.image.version
       # with the upstream OpenStack release version from source-refs.yaml.
@@ -369,6 +385,11 @@ jobs:
           subject-digest: ${{ steps.build-service.outputs.digest }}
           sbom-path: sbom-${{ matrix.service }}.cyclonedx.json
           push-to-registry: true
+
+      # CC-0030: Sign service image with cosign keyless signing
+      - name: Sign service image
+        if: github.event_name != 'pull_request'
+        run: cosign sign --yes ${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}
 
       - name: Verify service image (PR)
         if: github.event_name == 'pull_request'

--- a/.planwerk/completed/CC-0030-add-cosign-keyless-signing-to-container-images.json
+++ b/.planwerk/completed/CC-0030-add-cosign-keyless-signing-to-container-images.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0030",
   "title": "Add cosign keyless signing to container images",
   "slug": "add-cosign-keyless-signing-to-container-images",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 🔧 small\n**Category:** infrastructure\n**Priority:** high\n**Source:** Proposed for 'Now that SBOM should be created and attested'\n\nAdd cosign-based container image signing to `.github/workflows/build-images.yaml` completing the supply chain security chain (build → push → SBOM → attest → sign).\n\n**Workflow changes (build-images.yaml):**\n1. Add `sigstore/cosign-installer` action (SHA-pinned with `# v<N>` comment) as an early step in both `build-base-images` and `build-service-images` jobs\n2. Add `cosign sign --yes` step after SBOM attestation in `build-base-images` for python-base (`@${{ steps.build-python-base.outputs.digest }}`) and venv-builder (`@${{ steps.build-venv-builder.outputs.digest }}`)\n3. Add `cosign sign --yes` step after SBOM attestation in `build-service-images` for service images (`${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}`)\n4. Guard all signing steps with `if: github.event_name != 'pull_request'` (matching existing attestation guards)\n5. No permission changes needed — existing `id-token: write` + `packages: write` are sufficient for keyless Fulcio/Rekor signing\n\n**Test updates (tests/container-images/verify_build_images_workflow.sh):**\n- Add yq-based assertions for `sigstore/cosign-installer` presence in both build jobs\n- Assert `cosign sign` steps exist with correct `if:` guards\n- Assert signing steps reference image digests\n- Follow existing PASS/FAIL counter pattern\n\n**Doc updates (docs/reference/build-images-workflow.md):**\n- Add `cosign verify` command examples with `--certificate-identity-regexp` and `--certificate-oidc-issuer` parameters\n- Place alongside existing `cosign verify-attestation` and `gh attestation verify` commands\n\n**Rationale:** Images currently receive CycloneDX SBOMs and Sigstore attestations (CC-0029) but lack independent identity signing. Image signing adds an identity assertion ('this image was produced by this workflow') on top of existing property assertions ('this image has this SBOM'). This is a standard supply chain security practice that completes the trust chain and enables downstream consumers to verify image provenance via `cosign verify`. Keyless signing via GitHub OIDC avoids key management overhead.\n\n**Affected Areas:**\n- .github/workflows/build-images.yaml\n- tests/container-images/verify_build_images_workflow.sh\n- docs/reference/build-images-workflow.md",
   "stories": [
@@ -328,6 +328,7 @@
       "description": "In .github/workflows/build-images.yaml, add to the build-base-images job: (1) a `sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4` step after the GHCR login step (before any build steps), (2) a 'Sign python-base' step with `cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}` immediately after the 'Attest SBOM for python-base' step, (3) a 'Sign venv-builder' step with `cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}` immediately after the 'Attest SBOM for venv-builder' step. Both signing steps must have `if: github.event_name != 'pull_request'`. Add CC-0030 comment on the id-token permission line. No permission changes.",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-018",
         "REQ-019",
@@ -341,6 +342,7 @@
       "description": "In .github/workflows/build-images.yaml, add to the build-service-images job: (1) a `sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4` step after the GHCR login step (before the build step), (2) a 'Sign service image' step with `cosign sign --yes ${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}` immediately after the 'Attest SBOM for service image' step. The signing step must have `if: github.event_name != 'pull_request'`. Add CC-0030 comment on the id-token permission line. No permission changes.",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-018",
         "REQ-020",
@@ -354,6 +356,7 @@
       "description": "In tests/container-images/verify_build_images_workflow.sh, add test function `test_cosign_installer_in_build_jobs` that: (1) uses yq to count steps matching 'sigstore/cosign-installer' in build-base-images (assert == 1) and build-service-images (assert == 1), (2) verifies the action is SHA-pinned (existing test_actions_pinned_to_sha already covers this generically). Follow existing test pattern (yq_count helper, assert_eq, PASS/FAIL counters). Register the test in the 'Run all tests' section at the bottom of the file. Add CC-0030 to the test function comment header.",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-018",
         "REQ-024"
@@ -365,6 +368,7 @@
       "description": "In tests/container-images/verify_build_images_workflow.sh, add test functions: (1) `test_cosign_sign_steps_exist` — use yq to count steps whose .name matches 'Sign *' and whose .run contains 'cosign sign' in build-base-images (assert == 2) and build-service-images (assert == 1). (2) `test_cosign_sign_steps_pr_skip_guard` — extract .if from all cosign sign steps in both jobs, assert each contains \"github.event_name != 'pull_request'\" (following the pattern of test_sbom_steps_pr_skip_guard). (3) `test_cosign_sign_references_digest` — extract .run from signing steps, assert python-base step contains 'build-python-base.outputs.digest', venv-builder step contains 'build-venv-builder.outputs.digest', service step contains 'build-service.outputs.digest' and 'steps.tags.outputs.image'. Register all tests in the 'Run all tests' section. Add CC-0030 to test comments.",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-019",
         "REQ-020",
@@ -379,6 +383,7 @@
       "description": "In docs/reference/build-images-workflow.md: (1) Add a new '## Image Signing' section after '## SBOM Generation and Attestation' explaining cosign keyless signing (CC-0030), how it complements SBOM attestation (CC-0029), and the keyless OIDC approach. (2) Add a '### Verifying Signatures' subsection with `cosign verify` command example using `--certificate-identity-regexp` (matching the workflow file path pattern) and `--certificate-oidc-issuer https://token.actions.githubusercontent.com`. (3) Update the build-base-images step table to include cosign-installer (after login) and two Sign steps (after respective Attest steps). (4) Update the build-service-images step table to include cosign-installer (after login) and Sign step (after Attest). (5) Update the 'PR vs Push Behavior' table to add an 'Image signing' row showing 'Skipped' for PR and 'cosign keyless signing for every image' for Push. (6) Update the Action Pinning section to include the cosign-installer SHA. (7) Add signing tests to the 'Test Coverage' table.",
       "level": 3,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-025"
       ]
@@ -467,8 +472,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-08T22:58:51.816431"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-09T09:52:12.859561"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-09T12:40:01.321666"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/48",
+  "pr_number": 48,
   "execution_history": [
     {
       "run_id": "325eaae1-7927-40c8-b254-b89dca8212fe",
@@ -480,6 +495,50 @@
           "name": "prepare",
           "duration": 217.42436289787292,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "e377a8c0-b2e3-4d44-8dd1-49e936d50382",
+      "timestamp": "2026-03-09T10:15:59.183047",
+      "total_duration": 1265.8120942115784,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (2 tasks)",
+          "duration": 494.63353538513184,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (2 tasks)",
+          "duration": 278.54264545440674,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (1 tasks)",
+          "duration": 140.81128668785095,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0030] Code Review",
+          "duration": 220.3424355983734,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0030] Improvements",
+          "duration": 45.09988260269165,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0030] Simplify",
+          "duration": 86.38230848312378,
+          "type": "simplify",
           "status": "done"
         }
       ]

--- a/.planwerk/reviews/CC-0030-add-cosign-keyless-signing-to-container-images-review-1.json
+++ b/.planwerk/reviews/CC-0030-add-cosign-keyless-signing-to-container-images-review-1.json
@@ -1,0 +1,97 @@
+{
+  "feature_id": "CC-0030",
+  "title": "Add cosign keyless signing to container images",
+  "date": "2026-03-09",
+  "summary": "Adds cosign keyless signing to all container images in the build-images workflow, completing the supply chain security chain (build, push, SBOM, attest, sign). The sigstore/cosign-installer action is SHA-pinned and installed in both build jobs. Three cosign sign steps (python-base, venv-builder, service) use digest-based references and --yes flag for non-interactive mode. All signing steps are guarded with the same PR-skip condition as SBOM/attestation. Seven new test functions validate installer presence, step counts, PR guards, digest references, --yes flag usage, and permission comments. Documentation adds a complete Cosign Image Signing section with verify command examples and updated step/permission/behavior tables.",
+  "verdict": "APPROVED",
+  "review_process": {
+    "intent": "CC-0030 adds cosign keyless signing as the final step in the supply chain security chain for container images. Plan specifies: cosign-installer in both build jobs, sign steps after SBOM attestation, PR-skip guards, tests, and docs.",
+    "scope": "Changes limited to 4 files: build-images.yaml (workflow), verify_build_images_workflow.sh (tests), build-images-workflow.md (docs), progress tracker JSON. No scope creep.",
+    "verification": "All 158 tests pass (0 failures). No lintable source code (shell/YAML only). shellcheck not applicable to yq-based assertion scripts.",
+    "patterns": "Follows existing patterns exactly: SHA-pinned actions with version comments, PR-skip guard pattern, yq-based workflow test assertions, PASS/FAIL counter test structure.",
+    "tests": "7 new test functions covering all review criteria: installer presence (2 jobs), step counts, PR guards, digest references, --yes flag, permission comments. All code paths increment PASS or FAIL counters.",
+    "security": "cosign sign uses --yes (non-interactive), digest-based image references (immutable, no mutable tags), no new secrets or credentials, SHA-pinned action, reuses existing id-token: write permission.",
+    "complexity": "Minimal. Each sign step is a one-line shell command. cosign-installer is a zero-config action. No over-engineering.",
+    "completeness": "All 5 tasks (1.1, 1.2, 2.1, 2.2, 3.1) fully implemented. No stubs or placeholders.",
+    "prompt_quality": "No new prompt files. N/A."
+  },
+  "tests_checklist": [
+    {"item": "Tests exist and pass (158/158)", "checked": true},
+    {"item": "cosign-installer presence tested in both build jobs", "checked": true},
+    {"item": "Sign step counts tested (2 base + 1 service)", "checked": true},
+    {"item": "PR-skip guard tested on all sign steps", "checked": true},
+    {"item": "Digest references tested for all 3 sign steps", "checked": true},
+    {"item": "--yes flag tested on all sign steps", "checked": true},
+    {"item": "Permission comment CC-0030 reference tested", "checked": true},
+    {"item": "Existing tests still pass after changes", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing code patterns", "checked": true},
+    {"item": "No code duplication", "checked": true},
+    {"item": "Clear naming conventions", "checked": true},
+    {"item": "Minimal complexity", "checked": true},
+    {"item": "CC-0030 feature ID referenced in all comments", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "Digest-based image references (no mutable tags)", "checked": true},
+    {"item": "--yes flag for non-interactive signing", "checked": true},
+    {"item": "No new secrets or credentials", "checked": true},
+    {"item": "cosign-installer SHA-pinned with version comment", "checked": true},
+    {"item": "Reuses existing id-token: write (no permission escalation)", "checked": true},
+    {"item": "PR builds skip signing (no signing artifacts for ephemeral builds)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible", "checked": true},
+    {"item": "Step ordering correct (installer before sign, sign after attest)", "checked": true},
+    {"item": "Consistent with existing SBOM/attestation pattern", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code", "checked": true},
+    {"item": "No unnecessary abstractions", "checked": true},
+    {"item": "No unused code", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Errors detected early (test assertions are specific)", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "All external inputs validated (N/A — no user inputs)", "checked": true},
+    {"item": "Test functions handle empty yq results with explicit FAIL", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    {
+      "severity": "minor",
+      "check_id": "D4",
+      "description": "YAML snippet in Permissions section not updated with CC-0030 reference",
+      "location": "docs/reference/build-images-workflow.md:59",
+      "detail": "The YAML example block in the Permissions section still shows `id-token: write # CC-0029: Sigstore OIDC signing for SBOM attestation` while the actual workflow file and the permissions table at line 446 show `CC-0029, CC-0030`. Update the snippet comment to match: `id-token: write # CC-0029, CC-0030: Sigstore OIDC signing for SBOM attestation and cosign signing`.",
+      "fix": "Update line 59 of docs/reference/build-images-workflow.md to: `id-token: write       # CC-0029, CC-0030: Sigstore OIDC signing for SBOM attestation and cosign signing`"
+    }
+  ],
+  "external_review_patterns_checked": [
+    {
+      "pattern": "Enforce consistent error-handling pattern across all test cases",
+      "result": "PASS",
+      "detail": "All 7 new test functions use yq_count (with built-in error handling) or yq_raw with || true to prevent set -e from aborting. No command substitutions without exit-code capture."
+    },
+    {
+      "pattern": "Require explicit failure branch in test pass/fail logic",
+      "result": "PASS",
+      "detail": "All conditional blocks in new tests have both PASS and FAIL branches. The while-loop + if/elif pattern in test_cosign_sign_steps_pr_guard and test_cosign_sign_uses_yes_flag covers all code paths: empty input (elif FAIL), all pass (if PASS), some fail (FAIL in loop body)."
+    },
+    {
+      "pattern": "Unsanitized shell command output used in structured strings",
+      "result": "N/A",
+      "detail": "No shell command output is used in Docker tags, URLs, or structured strings in the new code."
+    },
+    {
+      "pattern": "Verify documented commands work end-to-end",
+      "result": "PASS",
+      "detail": "The cosign verify command in docs uses correct flags (--certificate-oidc-issuer, --certificate-identity-regexp) with standard placeholder format. The command structure matches cosign's documented API for GitHub Actions keyless verification."
+    }
+  ],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -1,13 +1,13 @@
 ---
 title: Build Images Workflow
 quadrant: infrastructure
-feature: CC-0007, CC-0029, CC-0031
+feature: CC-0007, CC-0029, CC-0030, CC-0031
 ---
 
 # Build Images Workflow
 
 Reference documentation for the GitHub Actions build-images workflow (CC-0007, CC-0029,
-CC-0031) and the verify-container-images workflow (CC-0028). The build-images workflow
+CC-0030, CC-0031) and the verify-container-images workflow (CC-0028). The build-images workflow
 builds, tags, and publishes container images for OpenStack services to GHCR (GitHub
 Container Registry). Each pushed image receives OCI Image Spec annotations (CC-0031),
 a CycloneDX SBOM, and a Sigstore-signed attestation (CC-0029). The
@@ -56,7 +56,7 @@ permissions:
 permissions:
   contents: read
   packages: write
-  id-token: write       # CC-0029: Sigstore OIDC signing for SBOM attestation
+  id-token: write       # CC-0029, CC-0030: Sigstore OIDC signing for SBOM attestation and cosign signing
   attestations: write   # CC-0029: GitHub Attestations API
 
 # Verification jobs (verify-base-images, verify-service-images)
@@ -131,14 +131,17 @@ availability.
 | 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references (CC-0007) |
 | 4 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
 | 5 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 6 | Generate metadata for python-base | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for python-base (CC-0031) |
-| 7 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 6 |
-| 8 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
-| 9 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 10 | Generate metadata for venv-builder | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for venv-builder (CC-0031) |
-| 11 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 10, `--build-context python-base=docker-image://...` |
-| 12 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
-| 13 | Attest SBOM for venv-builder | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 6 | Install cosign | `sigstore/cosign-installer@v4` | Installs cosign for image signing (CC-0030) |
+| 7 | Generate metadata for python-base | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for python-base (CC-0031) |
+| 8 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 7 |
+| 9 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
+| 10 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 11 | Sign python-base | Shell | Skipped on PRs. Signs python-base by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
+| 12 | Generate metadata for venv-builder | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for venv-builder (CC-0031) |
+| 13 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 12, `--build-context python-base=docker-image://...` |
+| 14 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
+| 15 | Attest SBOM for venv-builder | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 16 | Sign venv-builder | Shell | Skipped on PRs. Signs venv-builder by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
 
 The `venv-builder` build uses a `docker-image://` build context pointing at the
 just-pushed `python-base` image (referenced by digest), ensuring its `FROM python-base`
@@ -219,11 +222,13 @@ Depends on `build-base-images` for image references (REQ-003) and on
 | 7 | Derive tags | Shell | Computes three image tags and the lowercase `image` path (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
 | 8 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
 | 9 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 10 | Generate metadata for service image | `docker/metadata-action@v5` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy (CC-0031) |
-| 11 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load, labels from step 10 (REQ-006) |
-| 12 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
-| 13 | Attest SBOM for service image | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 14 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
+| 10 | Install cosign | `sigstore/cosign-installer@v4` | Installs cosign for image signing (CC-0030) |
+| 11 | Generate metadata for service image | `docker/metadata-action@v5` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy (CC-0031) |
+| 12 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load, labels from step 11 (REQ-006) |
+| 13 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
+| 14 | Attest SBOM for service image | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 15 | Sign service image | Shell | Skipped on PRs. Signs service image by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
+| 16 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_keystone.sh` with the locally loaded image ref (CC-0028) |
 
 **Build Contexts:**
 
@@ -333,7 +338,8 @@ The workflow behaves differently depending on the trigger event (REQ-006):
 | Service image tags | Computed but not published | Published to GHCR |
 | SBOM generation | Skipped (CC-0029) | CycloneDX JSON for every image |
 | SBOM attestation | Skipped (CC-0029) | Sigstore-signed, pushed to GHCR |
-| OIDC token request | None | Requested for Sigstore signing |
+| Cosign signing | Skipped (CC-0030) | Keyless signature for every image |
+| OIDC token request | None | Requested for Sigstore signing (CC-0029, CC-0030) |
 | Service image verification | Inline step in `build-service-images` | Separate `verify-service-images` job |
 | Verification image source | Locally loaded image (same runner) | Pulled from GHCR |
 
@@ -380,6 +386,7 @@ uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5 (CC-
 uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
 uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0 (CC-0029)
 uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4 (CC-0029)
+uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4 (CC-0030)
 ```
 
 This prevents supply-chain attacks via tag mutation while remaining auditable through
@@ -436,7 +443,7 @@ SBOM attestation requires two additional job-level permissions beyond the existi
 
 | Permission | Purpose |
 | --- | --- |
-| `id-token: write` | Allows the GitHub Actions runner to request a short-lived Sigstore OIDC token for keyless signing |
+| `id-token: write` | Allows the GitHub Actions runner to request a short-lived Sigstore OIDC token for keyless signing (CC-0029, CC-0030) |
 | `attestations: write` | Grants access to the GitHub Attestations API for storing signed attestations |
 
 These permissions are granted only to `build-base-images` and `build-service-images`.
@@ -487,6 +494,73 @@ The `verify_build_images_workflow.sh` script validates SBOM/attestation configur
 | `test_sbom_attestation_steps_exist` | Attestation steps exist in both build jobs |
 | `test_sbom_attestation_push_to_registry` | All attestation steps have `push-to-registry: true` |
 | `test_sbom_steps_pr_skip_guard` | All SBOM/attestation steps have `github.event_name != 'pull_request'` guard |
+
+## Cosign Image Signing
+
+Every container image pushed to GHCR on non-PR events is signed with cosign keyless
+signing (CC-0030). This provides an independent signature layer alongside the SBOM
+attestation (CC-0029), enabling consumers to verify image provenance using standard
+Sigstore tooling.
+
+### How It Works
+
+Each build job (`build-base-images`, `build-service-images`) installs cosign via
+`sigstore/cosign-installer` and runs `cosign sign --yes` after the image is pushed:
+
+1. **cosign-installer** (`sigstore/cosign-installer@v4`) — Installs the `cosign` binary
+   on the runner.
+
+2. **cosign sign** — Signs the image by digest using Sigstore keyless OIDC. The `--yes`
+   flag confirms non-interactive mode. No signing keys are managed; the GitHub Actions
+   OIDC token binds the signature to the specific workflow run.
+
+This pattern is applied to all three image types:
+
+| Image | Job | Digest source |
+| --- | --- | --- |
+| `python-base` | `build-base-images` | `steps.build-python-base.outputs.digest` |
+| `venv-builder` | `build-base-images` | `steps.build-venv-builder.outputs.digest` |
+| Service (e.g., `keystone`) | `build-service-images` | `steps.build-service.outputs.digest` |
+
+### PR Behavior
+
+All cosign sign steps are guarded with `if: github.event_name != 'pull_request'`. On
+pull requests:
+
+- No images are signed — the PR guard applies to all cosign sign steps.
+- No OIDC token requests occur for signing.
+- The `id-token: write` permission (shared with SBOM attestation) is not exercised.
+
+### Required Permissions
+
+Cosign keyless signing reuses the same `id-token: write` permission required by SBOM
+attestation (CC-0029). No additional permissions are needed.
+
+### Verifying Signatures
+
+To verify that an image has a valid cosign signature:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "https://github.com/<owner>/<repo>/.github/workflows/build-images.yaml@refs/.*" \
+  ghcr.io/<owner>/<service>@sha256:<digest>
+```
+
+### Test Coverage
+
+The `verify_build_images_workflow.sh` script validates cosign signing configuration
+(CC-0030):
+
+| Test | Validates |
+| --- | --- |
+| `test_cosign_installer_in_build_base_images` | `sigstore/cosign-installer` step exists in `build-base-images` |
+| `test_cosign_installer_in_build_service_images` | `sigstore/cosign-installer` step exists in `build-service-images` |
+| `test_cosign_sign_steps_count` | 2 sign steps in `build-base-images`, 1 in `build-service-images` |
+| `test_cosign_sign_steps_pr_guard` | All sign steps have `github.event_name != 'pull_request'` guard |
+| `test_cosign_sign_steps_reference_digest` | Sign steps reference the correct digest output |
+| `test_cosign_sign_uses_yes_flag` | All sign steps use the `--yes` flag |
+| `test_cosign_id_token_permission_comment` | `id-token: write` comment references CC-0030 |
 
 ## OCI Annotations
 
@@ -746,7 +820,7 @@ non-zero, the job fails.
 
 | Script | Validates |
 | --- | --- |
-| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029), OCI annotation configuration (CC-0031) |
+| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029), cosign signing configuration (CC-0030), OCI annotation configuration (CC-0031) |
 | `verify_deviation_comments.sh` | DEVIATION comments in Dockerfiles cross-reference architecture docs |
 | `verify_release_config.sh` | `source-refs.yaml` and `extra-packages.yaml` structure and content validity |
 | `verify_spdx_headers.sh` | SPDX Apache-2.0 license headers present on all infrastructure files |

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify build-images workflow structure, conventions, and correctness (CC-0007, CC-0029, CC-0031)
-# Requirements: REQ-001 through REQ-017
+# Verify build-images workflow structure, conventions, and correctness (CC-0007, CC-0029, CC-0030, CC-0031)
+# Requirements: REQ-001 through REQ-025
 # Usage: bash tests/container-images/verify_build_images_workflow.sh
 
 set -euo pipefail
@@ -1002,6 +1002,149 @@ test_dockerfile_static_labels_keystone() {
   assert_contains "keystone runtime stage has org.opencontainers.image.vendor" "$runtime_stage" 'org.opencontainers.image.vendor='
 }
 
+# --- CC-0030: cosign-installer step in build-base-images (REQ-018) ---
+test_cosign_installer_in_build_base_images() {
+  echo "Test: cosign-installer step exists in build-base-images (CC-0030, REQ-018)"
+
+  local installer_count
+  installer_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
+  assert_eq "build-base-images has 1 cosign-installer step" "1" "$installer_count"
+}
+
+# --- CC-0030: cosign-installer step in build-service-images (REQ-018) ---
+test_cosign_installer_in_build_service_images() {
+  echo "Test: cosign-installer step exists in build-service-images (CC-0030, REQ-018)"
+
+  local installer_count
+  installer_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
+  assert_eq "build-service-images has 1 cosign-installer step" "1" "$installer_count"
+}
+
+# --- CC-0030: cosign sign steps exist in both build jobs (REQ-019, REQ-020) ---
+test_cosign_sign_steps_count() {
+  echo "Test: cosign sign steps exist in both build jobs (CC-0030, REQ-019, REQ-020)"
+
+  # build-base-images should have 2 sign steps (python-base and venv-builder)
+  local base_sign_count
+  base_sign_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
+  assert_eq "build-base-images has 2 cosign sign steps" "2" "$base_sign_count"
+
+  # build-service-images should have 1 sign step
+  local service_sign_count
+  service_sign_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
+  assert_eq "build-service-images has 1 cosign sign step" "1" "$service_sign_count"
+}
+
+# --- CC-0030: cosign sign steps have PR-skip guard (REQ-021) ---
+test_cosign_sign_steps_pr_guard() {
+  echo "Test: cosign sign steps have PR-skip guard (CC-0030, REQ-021)"
+
+  # All cosign sign steps in build-base-images must have PR guard
+  local base_sign_ifs
+  base_sign_ifs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .if' "$WORKFLOW" || true)
+
+  local all_guarded=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
+      echo "  FAIL: build-base-images cosign sign step missing PR guard: $val"
+      FAIL=$((FAIL + 1))
+      all_guarded=false
+    fi
+  done <<< "$base_sign_ifs"
+
+  if $all_guarded && [ -n "$base_sign_ifs" ]; then
+    echo "  PASS: all build-base-images cosign sign steps have PR-skip guard"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_sign_ifs" ]; then
+    echo "  FAIL: build-base-images cosign sign steps not found or missing PR guard"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # All cosign sign steps in build-service-images must have PR guard
+  local service_sign_ifs
+  service_sign_ifs=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .if' "$WORKFLOW" || true)
+
+  local service_all_guarded=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
+      echo "  FAIL: build-service-images cosign sign step missing PR guard: $val"
+      FAIL=$((FAIL + 1))
+      service_all_guarded=false
+    fi
+  done <<< "$service_sign_ifs"
+
+  if $service_all_guarded && [ -n "$service_sign_ifs" ]; then
+    echo "  PASS: all build-service-images cosign sign steps have PR-skip guard"
+    PASS=$((PASS + 1))
+  elif [ -z "$service_sign_ifs" ]; then
+    echo "  FAIL: build-service-images cosign sign steps not found or missing PR guard"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- CC-0030: cosign sign steps reference digest (REQ-022) ---
+test_cosign_sign_steps_reference_digest() {
+  echo "Test: cosign sign steps reference correct digest (CC-0030, REQ-022)"
+
+  # python-base sign references build-python-base digest
+  local python_base_run
+  python_base_run=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Sign python-base") | .run' "$WORKFLOW" || true)
+  assert_contains "python-base sign references build-python-base digest" "$python_base_run" "build-python-base.outputs.digest"
+
+  # venv-builder sign references build-venv-builder digest
+  local venv_builder_run
+  venv_builder_run=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Sign venv-builder") | .run' "$WORKFLOW" || true)
+  assert_contains "venv-builder sign references build-venv-builder digest" "$venv_builder_run" "build-venv-builder.outputs.digest"
+
+  # service sign references build-service digest
+  local service_run
+  service_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Sign service image") | .run' "$WORKFLOW" || true)
+  assert_contains "service sign uses tags.outputs.image" "$service_run" "steps.tags.outputs.image"
+  assert_contains "service sign references build-service digest" "$service_run" "build-service.outputs.digest"
+}
+
+# --- CC-0030: cosign sign uses --yes flag (REQ-022) ---
+test_cosign_sign_uses_yes_flag() {
+  echo "Test: cosign sign steps use --yes flag (CC-0030, REQ-022)"
+
+  # All cosign sign run commands in build-base-images must contain --yes
+  local base_runs
+  base_runs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
+
+  local all_yes=true
+  while IFS= read -r val; do
+    [ -z "$val" ] && continue
+    if [[ "$val" != *"--yes"* ]]; then
+      echo "  FAIL: build-base-images cosign sign step missing --yes flag: $val"
+      FAIL=$((FAIL + 1))
+      all_yes=false
+    fi
+  done <<< "$base_runs"
+
+  if $all_yes && [ -n "$base_runs" ]; then
+    echo "  PASS: all build-base-images cosign sign steps use --yes flag"
+    PASS=$((PASS + 1))
+  elif [ -z "$base_runs" ]; then
+    echo "  FAIL: no build-base-images cosign sign steps found"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # service sign must contain --yes
+  local service_run
+  service_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
+  assert_contains "build-service-images cosign sign uses --yes flag" "$service_run" "--yes"
+}
+
+# --- CC-0030: id-token permission comment references CC-0030 (REQ-018) ---
+test_cosign_id_token_permission_comment() {
+  echo "Test: id-token permission comment references CC-0030 (CC-0030, REQ-018)"
+
+  # The id-token: write line itself (not other comments) should reference CC-0030
+  assert_file_contains "id-token permission references CC-0030" "$WORKFLOW" "id-token:.*CC-0030"
+}
+
 # --- Run all tests ---
 echo "=== Build images workflow verification tests ==="
 echo ""
@@ -1130,6 +1273,20 @@ echo ""
 test_dockerfile_static_labels_venv_builder
 echo ""
 test_dockerfile_static_labels_keystone
+echo ""
+test_cosign_installer_in_build_base_images
+echo ""
+test_cosign_installer_in_build_service_images
+echo ""
+test_cosign_sign_steps_count
+echo ""
+test_cosign_sign_steps_pr_guard
+echo ""
+test_cosign_sign_steps_reference_digest
+echo ""
+test_cosign_sign_uses_yes_flag
+echo ""
+test_cosign_id_token_permission_comment
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 


### PR DESCRIPTION
**Size:** 🔧 small
**Category:** infrastructure
**Priority:** high
**Source:** Proposed for 'Now that SBOM should be created and attested'

Add cosign-based container image signing to `.github/workflows/build-images.yaml` completing the supply chain security chain (build → push → SBOM → attest → sign).

**Workflow changes (build-images.yaml):**
1. Add `sigstore/cosign-installer` action (SHA-pinned with `# v<N>` comment) as an early step in both `build-base-images` and `build-service-images` jobs
2. Add `cosign sign --yes` step after SBOM attestation in `build-base-images` for python-base (`@${{ steps.build-python-base.outputs.digest }}`) and venv-builder (`@${{ steps.build-venv-builder.outputs.digest }}`)
3. Add `cosign sign --yes` step after SBOM attestation in `build-service-images` for service images (`${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}`)
4. Guard all signing steps with `if: github.event_name != 'pull_request'` (matching existing attestation guards)
5. No permission changes needed — existing `id-token: write` + `packages: write` are sufficient for keyless Fulcio/Rekor signing

**Test updates (tests/container-images/verify_build_images_workflow.sh):**
- Add yq-based assertions for `sigstore/cosign-installer` presence in both build jobs
- Assert `cosign sign` steps exist with correct `if:` guards
- Assert signing steps reference image digests
- Follow existing PASS/FAIL counter pattern

**Doc updates (docs/reference/build-images-workflow.md):**
- Add `cosign verify` command examples with `--certificate-identity-regexp` and `--certificate-oidc-issuer` parameters
- Place alongside existing `cosign verify-attestation` and `gh attestation verify` commands

**Rationale:** Images currently receive CycloneDX SBOMs and Sigstore attestations (CC-0029) but lack independent identity signing. Image signing adds an identity assertion ('this image was produced by this workflow') on top of existing property assertions ('this image has this SBOM'). This is a standard supply chain security practice that completes the trust chain and enables downstream consumers to verify image provenance via `cosign verify`. Keyless signing via GitHub OIDC avoids key management overhead.

**Affected Areas:**
- .github/workflows/build-images.yaml
- tests/container-images/verify_build_images_workflow.sh
- docs/reference/build-images-workflow.md