### PR TITLE
feat(CC-0014): F002: Add Keystone reconciler integration tests

### DIFF
--- a/.planwerk/completed/CC-0014-f002-add-keystone-reconciler-integration-tests.json
+++ b/.planwerk/completed/CC-0014-f002-add-keystone-reconciler-integration-tests.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0014",
   "title": "F002: Add Keystone reconciler integration tests",
   "slug": "f002-add-keystone-reconciler-integration-tests",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 🏗️ large\n**Category:** backend\n**Priority:** high\n**Feature ID:** CC-0014 (S014 in PLAN.md)\n\n## Summary\n\nAdd envtest integration tests (CC-0014) for the Keystone reconciler exercising the full reconciliation loop against a real API server with etcd. Tests create prerequisite Secrets simulating ESO sync, create a Keystone CR, then drive condition progression through SecretsReady → FernetKeysReady → (ConfigMap created) → DatabaseReady → DeploymentReady → BootstrapReady → Ready by simulating external dependencies (MariaDB readiness, Job completion, Deployment availability). They verify correct creation of all child resources (Deployment, Service, ConfigMap, Jobs, CronJob, Secret, RBAC, PushSecret) and that `status.endpoint` and `status.conditions` (including ObservedGeneration) are populated correctly. Both brownfield and managed database modes are covered.\n\n## Scope\n\n**Included:**\n- New integration test file `operators/keystone/internal/controller/integration_test.go` with `//go:build integration` tag\n- Full reconciliation loop test (brownfield mode): create prereqs → create CR → manager-driven reconcile → verify all 6 conditions reach True\n- Full reconciliation loop test (managed mode): same flow but with `spec.database.clusterRef` + MariaDB CR simulation via `SimulateDatabaseReady`, `SimulateUserReady`, `SimulateGrantReady`\n- Condition progression test: verify each sub-condition transitions False→True in reconciliation order, later conditions remain absent/False until predecessors are satisfied\n- Resource creation verification: assert Deployment (`{name}-api`), Service (`{name}-api`), ConfigMap (immutable, `{name}-config-{hash}`), Jobs (`{name}-db-sync`, `{name}-bootstrap`), CronJob (`{name}-fernet-rotate`), Secret (`{name}-fernet-keys`), ServiceAccount (`{name}-fernet-rotate`), Role (`{name}-fernet-rotate`), RoleBinding (`{name}-fernet-rotate`), PushSecret (`{name}-fernet-keys-backup`) exist after full reconciliation\n- Status field verification: `status.endpoint` matches `http://{name}-api.{namespace}.svc.cluster.local:5000/v3`, `status.conditions` ObservedGeneration matches CR Generation\n- `SimulateDeploymentReady` function in shared simulators package (`internal/common/testutil/simulators/simulators.go`)\n- New `SetupKeystoneEnvTestWithController` helper in `operators/keystone/internal/testutil/envtest_setup.go` that registers the `KeystoneReconciler` via `SetupWithManager` alongside CRDs and webhooks; must also install fake CRDs for MariaDB, ESO, and cert-manager types from the common envtest `fake_crds/` directory and register them in the scheme (via `SharedScheme()` or equivalent)\n- Build tag `integration` consistent with existing CC-0012 tests\n\n**Excluded:**\n- Webhook defaulting/validation testing (already covered by CC-0012 — YAGNI)\n- Error injection / fault tolerance tests (separate feature, not requested)\n- Chainsaw E2E tests (deferred to Phase 7 per PLAN.md)\n- Federation, middleware, plugin, or policyOverrides paths (not part of core reconciliation loop, no current requirement)\n- Performance / stress testing (YAGNI)\n- Deletion / finalizer testing (not implemented in the reconciler, YAGNI)\n- `test-integration` Makefile target wiring (currently a stub, separate infrastructure concern)\n\n## Visualization\n\n```mermaid\nsequenceDiagram\n    participant T as Test\n    participant API as envtest API Server\n    participant R as Keystone Reconciler\n    participant S as Simulators\n\n    T->>API: Create Namespace\n    T->>API: Create ExternalSecrets\n    T->>API: Create Secrets (DB creds, admin creds)\n    S->>API: SimulateExternalSecretSync\n    T->>API: Create Keystone CR\n    Note over R: Manager triggers reconcile\n    R->>API: Check ExternalSecret + Secret\n    R->>API: Set SecretsReady=True\n    R->>API: Create Fernet Keys Secret\n    R->>API: Create SA, Role, RoleBinding\n    R->>API: Create CronJob, PushSecret\n    R->>API: Set FernetKeysReady=True\n    R->>API: Create ConfigMap (immutable, hashed)\n    R->>API: Create db-sync Job\n    R->>API: Set DatabaseReady=False (DBSyncInProgress)\n    S->>API: SimulateJobComplete (db-sync)\n    Note over R: Requeue triggers reconcile\n    R->>API: Set DatabaseReady=True\n    R->>API: Create Deployment + Service\n    R->>API: Set DeploymentReady=False\n    S->>API: SimulateDeploymentReady\n    Note over R: Requeue triggers reconcile\n    R->>API: Set DeploymentReady=True, status.endpoint\n    R->>API: Create bootstrap Job\n    R->>API: Set BootstrapReady=False\n    S->>API: SimulateJobComplete (bootstrap)\n    Note over R: Requeue triggers reconcile\n    R->>API: Set BootstrapReady=True\n    R->>API: Set Ready=True (AllReady)\n    T->>API: Verify all conditions, resources, status\n```\n\n```mermaid\nstateDiagram-v2\n    [*] --> SecretsReady: ESO Secrets exist\n    SecretsReady --> FernetKeysReady: Fernet Secret + RBAC + CronJob + PushSecret created\n    FernetKeysReady --> DatabaseReady: ConfigMap created, db-sync Job completes\n    DatabaseReady --> DeploymentReady: Deployment + Service created, pods available\n    DeploymentReady --> BootstrapReady: Bootstrap Job completes\n    BootstrapReady --> Ready: AllTrue aggregation\n    Ready --> [*]\n```\n\n```mermaid\nflowchart TD\n    subgraph TestFile[\"integration_test.go\"]\n        TFL[\"TestIntegration_FullReconcile_Brownfield\"]\n        TFM[\"TestIntegration_FullReconcile_Managed\"]\n        TCP[\"TestIntegration_ConditionProgression\"]\n        TRC[\"TestIntegration_ResourceCreation\"]\n        TSE[\"TestIntegration_StatusEndpoint\"]\n        TOG[\"TestIntegration_ObservedGeneration\"]\n    end\n    subgraph Helpers[\"testutil/envtest_setup.go\"]\n        SK[\"SetupKeystoneEnvTestWithController (new)\"]\n        SE2[\"SetupKeystoneEnvTest (unchanged)\"]\n    end\n    subgraph Simulators[\"simulators/simulators.go\"]\n        SD[\"SimulateDeploymentReady (new)\"]\n        SE[\"SimulateExternalSecretSync\"]\n        SJ[\"SimulateJobComplete\"]\n        SDB[\"SimulateDatabaseReady\"]\n        SU[\"SimulateUserReady\"]\n        SG[\"SimulateGrantReady\"]\n    end\n    TestFile --> SK\n    TestFile --> Simulators\n```\n\n## Key Components\n\n- **`operators/keystone/internal/controller/integration_test.go`** (new): Main test file with `//go:build integration` tag. Contains 6 test functions using `testing.T` + gomega (dot-imported), consistent with CC-0012 patterns. Each test calls `testutil.SkipIfEnvTestUnavailable(t)`, creates an isolated namespace, uses `gomega.Eventually` for polling condition progression. Brownfield test uses `spec.database.host`; managed test uses `spec.database.clusterRef` and exercises MariaDB CR creation + simulation.\n- **`operators/keystone/internal/testutil/envtest_setup.go`** (modified): New `SetupKeystoneEnvTestWithController(t, addToScheme, registerWebhooks, registerController)` function that extends envtest setup to also register the `KeystoneReconciler` via `SetupWithManager`. Must install additional fake CRDs (MariaDB Database/User/Grant, ESO ExternalSecret/PushSecret) alongside the Keystone CRD, and register their types in the scheme. Existing `SetupKeystoneEnvTest` remains unchanged — CC-0012 webhook tests are unaffected.\n- **`internal/common/testutil/simulators/simulators.go`** (modified): New `SimulateDeploymentReady(ctx, c, key, replicas)` function that sets `status.conditions[Available]=True`, `status.readyReplicas`, and `status.observedGeneration` on an existing Deployment. Follows the established typed-resource simulator pattern (like `SimulateMariaDBReady`).\n- **Existing simulators** (unchanged, consumed): `SimulateExternalSecretSync`, `SimulateJobComplete`, `SimulateDatabaseReady`, `SimulateUserReady`, `SimulateGrantReady` — simulate external controller behavior in envtest where those controllers don't run.\n- **Existing `builders.SecretBuilder`** (unchanged, consumed): Used to construct prerequisite DB credentials Secret (keys: `username`, `password`) and admin credentials Secret (key: `password`).",
   "stories": [
@@ -331,6 +331,7 @@
       "description": "Add SimulateDeploymentReady(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error to internal/common/testutil/simulators/simulators.go. The function gets the existing Deployment, sets status.conditions with DeploymentAvailable=True, status.readyReplicas=replicas, status.observedGeneration=deploy.Generation, then calls c.Status().Update(). Follow the typed-resource pattern used by SimulateJobComplete. Add a unit test in simulators_test.go (non-integration) using the fake client that verifies: (a) readyReplicas is set, (b) Available condition is True, (c) observedGeneration matches generation, (d) IsDeploymentReady returns true after the call. Feature comment: // Feature: CC-0014.",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-001"
       ]
@@ -341,6 +342,7 @@
       "description": "Add SetupKeystoneEnvTestWithController(t testing.TB, addToScheme func(*runtime.Scheme) error, registerWebhooks func(ctrl.Manager) error, registerController func(ctrl.Manager) error) (client.Client, context.Context, context.CancelFunc) to operators/keystone/internal/testutil/envtest_setup.go. This function extends the existing SetupKeystoneEnvTest pattern to additionally: (1) install fake CRDs from internal/common/testutil/fake_crds/ (mariadb-operator/*.yaml, external-secrets/*.yaml, cert-manager/*.yaml) alongside the Keystone CRD, (2) build a scheme that includes Keystone types plus SharedScheme() types (MariaDB, ESO, cert-manager, core K8s), (3) call registerController(mgr) after starting the manager to register the KeystoneReconciler. Use runtime.Caller(0) relative paths to locate fake_crds/. Leave SetupKeystoneEnvTest completely unchanged. Extract shared setup logic into unexported helpers if it reduces duplication without affecting SetupKeystoneEnvTest's behavior.",
       "level": 1,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-002",
         "REQ-009"
@@ -352,6 +354,7 @@
       "description": "Create operators/keystone/internal/controller/integration_test.go with //go:build integration tag. Define shared helpers: (a) setupEnvTestWithController(t) calling testutil.SetupKeystoneEnvTestWithController with keystonev1alpha1.AddToScheme, KeystoneWebhook.SetupWebhookWithManager, and KeystoneReconciler.SetupWithManager; (b) createPrerequisites(t, ctx, c, ns, ks) that creates ExternalSecrets (db, admin), Secrets with correct keys (using builders.SecretBuilder), and calls SimulateExternalSecretSync; (c) driveFullReconciliation(t, ctx, c, ns, ks) that polls for condition progression and calls SimulateJobComplete (db-sync), SimulateDeploymentReady, SimulateJobComplete (bootstrap) at appropriate points. Write TestIntegration_FullReconcile_Brownfield: creates namespace (GenerateName), creates brownfield Keystone CR (spec.database.host), calls createPrerequisites and driveFullReconciliation, then asserts: all 6 conditions are True, status.endpoint is correct, ObservedGeneration matches. Use gomega dot-import and EventuallyCondition from assertions package.",
       "level": 2,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-003",
         "REQ-005",
@@ -365,6 +368,7 @@
       "description": "Add TestIntegration_ConditionProgression to integration_test.go. This test creates a Keystone CR in brownfield mode but drives the reconciliation step-by-step, pausing between phases to verify intermediate condition states. Steps: (1) Create namespace, ExternalSecrets, Secrets but do NOT call SimulateExternalSecretSync yet. Wait for SecretsReady=False (WaitingForDBCredentials). Verify FernetKeysReady/DatabaseReady/DeploymentReady/BootstrapReady are absent. (2) Call SimulateExternalSecretSync for both ExternalSecrets. Wait for SecretsReady=True, then FernetKeysReady=True. Verify DatabaseReady=False (DBSyncInProgress). (3) Call SimulateJobComplete for db-sync. Wait for DatabaseReady=True. Verify DeploymentReady=False (WaitingForDeployment). (4) Call SimulateDeploymentReady. Wait for DeploymentReady=True. Verify BootstrapReady=False (BootstrapInProgress). (5) Call SimulateJobComplete for bootstrap. Wait for BootstrapReady=True, Ready=True (AllReady). Use EventuallyCondition with appropriate timeouts.",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-008"
       ]
@@ -375,6 +379,7 @@
       "description": "Add three focused tests to integration_test.go: (1) TestIntegration_ResourceCreation: runs full brownfield reconciliation, then uses AssertResourceExists to verify all 12 child resources exist: Deployment test-keystone-api, Service test-keystone-api, ConfigMap matching test-keystone-config-* (use client.List with label/prefix matching), Jobs test-keystone-db-sync and test-keystone-bootstrap, CronJob test-keystone-fernet-rotate, Secret test-keystone-fernet-keys, ServiceAccount test-keystone-fernet-rotate, Role test-keystone-fernet-rotate, RoleBinding test-keystone-fernet-rotate, PushSecret test-keystone-fernet-keys-backup. (2) TestIntegration_StatusEndpoint: runs full reconciliation, verifies status.endpoint matches expected format. (3) TestIntegration_ObservedGeneration: runs full reconciliation, fetches Keystone CR, iterates all conditions verifying each has ObservedGeneration == ks.Generation.",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-005",
         "REQ-006",
@@ -387,6 +392,7 @@
       "description": "Add TestIntegration_FullReconcile_Managed to integration_test.go. Creates a Keystone CR with spec.database.clusterRef (pointing to a MariaDB cluster name) instead of spec.database.host. Creates prerequisites (ExternalSecrets, Secrets, simulate sync). The reconciler will create MariaDB Database, User, Grant CRs. The test uses gomega.Eventually to wait for these CRs to appear, then calls SimulateDatabaseReady, SimulateUserReady, SimulateGrantReady. Then continues with SimulateJobComplete (db-sync), SimulateDeploymentReady, SimulateJobComplete (bootstrap). Verifies all 6 conditions reach True, status.endpoint is correct. Also verifies MariaDB CRs exist with correct names (same as Keystone CR name).",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-004"
       ]
@@ -483,6 +489,125 @@
       "story": "Platform engineer verifies condition progression order",
       "expected": "Ready=False with reason NotAllReady when BootstrapReady is not yet True; transitions to Ready=True (AllReady) only after all sub-conditions are True",
       "requirement_id": "REQ-008"
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMariaDBReady",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMariaDBReady_idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMariaDBReady_zeroReplicas",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMariaDBReady_notFound",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMemcachedReady",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMemcachedReady_idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMemcachedReady_emptyServerList",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateMemcachedReady_notFound",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateExternalSecretSync",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateExternalSecretSync_idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateExternalSecretSync_notFound",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateJobComplete",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateJobComplete_idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateJobComplete_notFound",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateDeploymentReady",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateDeploymentReady_idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "internal/common/testutil/simulators/simulators_test.go",
+      "test_function": "TestSimulateDeploymentReady_notFound",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
     }
   ],
   "affected_files": [],
@@ -514,8 +639,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-12T10:22:59.599669"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-12T13:29:05.618236"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-16T11:20:21.949523"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/64",
+  "pr_number": 64,
   "execution_history": [
     {
       "run_id": "8c03b308-f8ec-436c-b41a-702727f57730",
@@ -527,6 +662,72 @@
           "name": "prepare",
           "duration": 675.4400234222412,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "19faf5b8-879e-4c84-b4fc-b9a95a073a57",
+      "timestamp": "2026-03-12T14:23:11.944376",
+      "total_duration": 2998.59455370903,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (2 tasks)",
+          "duration": 569.7218241691589,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (4 tasks)",
+          "duration": 1947.4959843158722,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0014] Code Review",
+          "duration": 361.69486808776855,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0014] Improvements",
+          "duration": 58.73964786529541,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0014] Simplify",
+          "duration": 60.94222927093506,
+          "type": "simplify",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "3b0bb7d6-95c7-4745-9aaa-8f737e17cd8c",
+      "timestamp": "2026-03-12T15:10:33.735650",
+      "total_duration": 750.7145166397095,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #1",
+          "duration": 750.7145166397095,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "057133ca-1b86-4cfe-b584-a56c0651fd1b",
+      "timestamp": "2026-03-12T15:48:43.002966",
+      "total_duration": 788.6225287914276,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #2",
+          "duration": 788.6225287914276,
+          "type": "review_address",
           "status": "done"
         }
       ]

--- a/.planwerk/review_patterns/ensure-test-names-accurately-describe-their-coverage-scope.md
+++ b/.planwerk/review_patterns/ensure-test-names-accurately-describe-their-coverage-scope.md
@@ -3,7 +3,7 @@
 **Review-Area**: testing
 **Detection-Hint**: When a test name contains universal quantifiers like 'All', 'Every', 'Runs all', or 'Full', verify that every branch or validation path in the function under test is actually exercised. Cross-reference the test setup with the production code's branches.
 **Severity**: WARNING
-**Occurrences**: 1
+**Occurrences**: 2
 
 ## What to check
 
@@ -19,3 +19,8 @@ Misleadingly named tests give false confidence that all paths are covered and th
 - **Feedback**: The test is named to imply every validation rule is exercised simultaneously, but it only mutates Replicas, RotationSchedule, Plugins, and PolicyOverrides. The two other defense-in-depth checks — cache mutual-exclusivity (REQ-009) and database mutual-exclusivity (REQ-010) — are never put into a broken state here.
 - **What was missed**: For tests claiming comprehensive coverage (e.g., 'RunsAllValidations'), enumerate all validation branches in the function under test and confirm each one is triggered in the test input. Check that the assertion count or error substring checks match the number of distinct validation paths.
 - **Fix**: Expanded TestValidateCreate_RunsAllValidations to include cache and database mutual-exclusivity violations with assertions for both 'cache' and 'database' error substrings, so it now exercises all validation paths.
+
+### CC-0014 — greptile-apps[bot]
+- **Feedback**: `TestSimulateMariaDBReady_zeroReplicas` exists for `SimulateMariaDBReady`, which ensures the zero-replica edge case is handled. `SimulateDeploymentReady` doesn't have an equivalent.
+- **What was missed**: Does a newly added function have the same edge-case test coverage as its analogous siblings in the same package? Specifically check for zero-value and boundary-condition tests.
+- **Fix**: Added `TestSimulateDeploymentReady_zeroReplicas` that creates a deployment, calls `SimulateDeploymentReady` with 0 replicas, and asserts `ReadyReplicas` is 0.

--- a/.planwerk/review_patterns/flag-partially-initialized-structs-with-deferred-field-assignment.md
+++ b/.planwerk/review_patterns/flag-partially-initialized-structs-with-deferred-field-assignment.md
@@ -1,0 +1,21 @@
+# Review Pattern: Flag partially initialized structs with deferred field assignment
+
+**Review-Area**: testing
+**Detection-Hint**: When a struct (especially an object key or identifier) is declared early with some fields empty and filled in many lines later, check whether code between declaration and completion could accidentally use the incomplete struct.
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+Look for struct declarations where required fields (like Name in a NamespacedName) are left zero-valued and assigned far from the declaration site. Verify the struct is not used in the gap, and prefer moving the declaration to the point where all required fields are known.
+
+## Why it matters
+
+An empty Name in a NamespacedName will never match any real object. If a helper call is inserted in the gap between declaration and assignment, it silently operates on nothing — causing confusing test failures or false passes that are hard to diagnose.
+
+## Examples from external reviews
+
+### CC-0014 — greptile-apps[bot]
+- **Feedback**: `key` is initialized with only `Namespace` set at line 345, and `Name` is patched in at line 386 after the CR is created. While the current code is correct, this pattern is fragile: any helper call inserted between lines 345 and 386 that passes `key` would silently operate on a namespaced name with an empty `Name` string.
+- **What was missed**: Look for struct declarations where required fields (like Name in a NamespacedName) are left zero-valued and assigned far from the declaration site. Verify the struct is not used in the gap, and prefer moving the declaration to the point where all required fields are known.
+- **Fix**: Move `key` declaration to immediately after the CR is created: `ks := integrationBrownfieldKeystone("test-keystone", ns.Name); c.Create(ctx, ks); key := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}`.

--- a/.planwerk/review_patterns/test-fixtures-must-mirror-real-repository-structure.md
+++ b/.planwerk/review_patterns/test-fixtures-must-mirror-real-repository-structure.md
@@ -3,7 +3,7 @@
 **Review-Area**: testing
 **Detection-Hint**: When reviewing test setup code that creates temporary directories and files, compare the directory structure created in the test workdir against the actual repository layout. If the test places files at different relative paths than production, it will mask path-related bugs.
 **Severity**: BLOCKING
-**Occurrences**: 1
+**Occurrences**: 3
 
 ## What to check
 
@@ -19,3 +19,13 @@ Tests that use a simplified directory structure give false confidence — they p
 - **Feedback**: Each test workdir places `upper-constraints.txt` directly in the temp dir root rather than under `releases/2025.2/upper-constraints.txt`. Once `CONSTRAINTS` is corrected, the test setup should be updated to stay consistent with the real repository structure.
 - **What was missed**: Check that test workdir file placement (e.g., '$workdir/upper-constraints.txt') matches where the file lives in the real repo (e.g., '$workdir/releases/2025.2/upper-constraints.txt'). A test that passes with a flat structure but would fail against the real repo tree is a false-positive test.
 - **Fix**: Updated test setup to create files under 'releases/2025.2/' subdirectory in the test workdir, matching the real repository layout.
+
+### CC-0014 — greptile-apps[bot]
+- **Feedback**: The function only sets the `Available=True` condition, but a real Kubernetes deployment controller also sets `Progressing=True (reason: NewReplicaSetAvailable)` when a rollout completes. ... if `IsDeploymentReady` is ever updated to also guard on `Progressing`, every integration test that calls `SimulateDeploymentReady` would silently fail.
+- **What was missed**: Does the test simulator set ALL status conditions and fields that the real system sets in that state, not just the minimum subset the current readiness check inspects?
+- **Fix**: Added the `DeploymentProgressing` condition with `Reason: NewReplicaSetAvailable` alongside the existing `DeploymentAvailable` condition in `SimulateDeploymentReady`. Same pattern applied to `SimulateJobComplete` which was missing `StartTime` and `JobSuccessCriteriaMet`.
+
+### CC-0014 — greptile-apps[bot]
+- **Feedback**: `driveFullReconciliation` hardcodes `3` for `SimulateDeploymentReady`. `IsDeploymentReady` checks `Status.ReadyReplicas >= *Spec.Replicas` — so if the `integrationBrownfieldKeystone` fixture is ever changed to a replica count **greater than 3** (e.g., 5), `SimulateDeploymentReady(..., 3)` would set `ReadyReplicas=3`, which is less than `desired=5`, causing `IsDeploymentReady` to return `false`. The test would then silently hang at `waitForCondition`.
+- **What was missed**: Look for numeric literals passed to test simulation/assertion helpers. Trace whether the same value is defined or implied by the object under test (e.g., Spec.Replicas). If so, the helper should read the value from the object rather than hardcoding it.
+- **Fix**: Read the desired replica count from the already-created Deployment spec instead of hardcoding it: `deploy := &appsv1.Deployment{}; c.Get(ctx, deployKey, deploy); replicas := *deploy.Spec.Replicas; SimulateDeploymentReady(ctx, c, deployKey, replicas)`.

--- a/.planwerk/review_patterns/use-standard-library-over-manual-string-operations.md
+++ b/.planwerk/review_patterns/use-standard-library-over-manual-string-operations.md
@@ -1,0 +1,21 @@
+# Review Pattern: Use standard library over manual string operations
+
+**Review-Area**: naming
+**Detection-Hint**: Look for manual length-guard + slice patterns (e.g., `len(s) >= N && s[:N] == prefix`) that replicate what a standard library function already does (`strings.HasPrefix`, `strings.Contains`, etc.).
+**Severity**: WARNING
+**Occurrences**: 1
+
+## What to check
+
+Are there manual string manipulations that could be replaced by standard library calls like strings.HasPrefix, strings.TrimPrefix, strings.Contains?
+
+## Why it matters
+
+Manual slice indices are error-prone: if the prefix constant changes length but the hardcoded index is not updated, the check silently mismatches. Standard library functions are self-documenting and immune to this class of desync bug.
+
+## Examples from external reviews
+
+### CC-0014 — greptile-apps[bot]
+- **Feedback**: The length-guard + manual slice approach is harder to read and could silently mismatch if the prefix constant is ever updated out of sync with the slice index.
+- **What was missed**: Are there manual string manipulations that could be replaced by standard library calls like strings.HasPrefix, strings.TrimPrefix, strings.Contains?
+- **Fix**: Replaced `len(cm.Name) >= N && cm.Name[:N] == "test-keystone-config-"` with `strings.HasPrefix(cm.Name, "test-keystone-config-")` and added the `strings` import.

--- a/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-1.json
+++ b/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-1.json
@@ -1,0 +1,94 @@
+{
+  "summary": "CC-0014 F002 adds envtest integration tests for the Keystone reconciler. New SimulateDeploymentReady simulator function with unit tests (happy path, idempotent, not-found, IsDeploymentReady cross-validation). New SetupKeystoneEnvTestWithController helper that extends envtest setup with fake CRDs and reconciler registration. Six integration test functions covering brownfield full reconcile, managed full reconcile, condition progression with intermediate state verification, resource creation (all 12 child resources), status endpoint, and ObservedGeneration. Also includes justified bug fixes: SimulateJobComplete updated for K8s 1.35 SuccessCriteriaMet condition, and CacheSpec CEL rule fixed from `self.clusterRef != null` to `has(self.clusterRef)` to match the Database rule pattern and avoid CEL evaluation errors on absent optional fields.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "V1: All unit tests pass (SimulateDeploymentReady, SimulateJobComplete)", "checked": true},
+    {"item": "V2: go vet passes on both internal/common and operators/keystone", "checked": true},
+    {"item": "V3: golangci-lint passes with 0 issues on both packages", "checked": true},
+    {"item": "TE1: Happy path tested — brownfield and managed full reconcile to Ready=True", "checked": true},
+    {"item": "TE2: Edge cases tested — condition progression verifies intermediate False states and absent conditions", "checked": true},
+    {"item": "TE3: Error cases tested — SimulateDeploymentReady not-found, idempotent", "checked": true},
+    {"item": "TE4: Tests independent — each test creates isolated namespace via GenerateName", "checked": true},
+    {"item": "TE5: Test names follow TestIntegration_* convention consistent with CC-0012", "checked": true},
+    {"item": "TE6: Mocking appropriate — simulators replace external controllers (ESO, MariaDB, K8s Deployment controller) that don't run in envtest", "checked": true},
+    {"item": "TE7: Assertions specific — exact condition types, reasons, status values, endpoint URLs, ObservedGeneration equality", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Q1: Functions do one thing — createPrerequisites, waitForCondition, driveFullReconciliation each have single responsibility", "checked": true},
+    {"item": "Q2: Functions are appropriately sized — helpers are concise, test functions are longer but sequential test steps", "checked": true},
+    {"item": "Q3: Shared helpers extract common logic (createPrerequisites, driveFullReconciliation, waitForCondition)", "checked": true},
+    {"item": "Q4: Clear naming — integrationBrownfieldKeystone, integrationManagedKeystone, waitForCondition, driveFullReconciliation", "checked": true},
+    {"item": "Q5: No excessive nesting — guard clauses and gomega Eventually used appropriately", "checked": true},
+    {"item": "Q6: No magic numbers — timeout constants (30s, 500ms) and resource names are descriptive", "checked": true},
+    {"item": "Q7: No dead code — all helpers are used by tests", "checked": true},
+    {"item": "P2: Uses existing utilities — simulators, testutil, commonenvtest", "checked": true},
+    {"item": "P5: File locations match project conventions — integration_test.go in controller package, envtest_setup.go in testutil", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "S1-S6: No security concerns in test-only code — test passwords are test data, no injection risks, no external API calls", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "C1: Implements exactly what was requested — all 6 test functions per plan", "checked": true},
+    {"item": "C2: All acceptance criteria met — brownfield, managed, condition progression, resource creation, endpoint, ObservedGeneration", "checked": true},
+    {"item": "C5: No regression — SetupKeystoneEnvTest unchanged, CC-0012 webhook tests unaffected", "checked": true},
+    {"item": "FC1: All tasks and requirements from plan implemented", "checked": true},
+    {"item": "FC2: No stubs, placeholders, or TODOs remain", "checked": true},
+    {"item": "FC3: All test functions are fully working with real assertions", "checked": true},
+    {"item": "FC4: Behaviors described in feature spec work end-to-end", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code beyond acceptable SetupKeystoneEnvTest/SetupKeystoneEnvTestWithController duplication (by design per plan)", "checked": true},
+    {"item": "No unnecessary abstractions — helpers are used by multiple tests", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "SkipIfEnvTestUnavailable called as first line in each test", "checked": true},
+    {"item": "t.Fatalf used for unrecoverable setup failures", "checked": true},
+    {"item": "gomega Eventually with timeouts for async condition polling", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Direct (non-caching) client used for test assertions to avoid stale reads", "checked": true},
+    {"item": "mgrStopped channel prevents port-conflict races between tests", "checked": true},
+    {"item": "Metrics and health probe listeners disabled to avoid port collisions", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [
+    {
+      "severity": "INFO",
+      "description": "CacheSpec CEL rule changed from `self.clusterRef != null` to `has(self.clusterRef)` — justified bug fix discovered during integration testing. Aligns with Database rule pattern and avoids CEL evaluation errors on absent optional fields with omitempty. Semantically correct per CEL spec.",
+      "location": "operators/keystone/api/v1alpha1/keystone_types.go:53",
+      "fix": "No fix needed — change is correct."
+    },
+    {
+      "severity": "INFO",
+      "description": "SimulateJobComplete updated to emit both JobSuccessCriteriaMet and JobComplete conditions with StartTime — matches real K8s 1.35 Job controller behavior. Backward-compatible since IsJobComplete only checks for JobComplete.",
+      "location": "internal/common/testutil/simulators/simulators.go:150-170",
+      "fix": "No fix needed — change improves simulator fidelity."
+    }
+  ],
+  "issues_found": [
+    {
+      "id": "D3-1",
+      "severity": "minor",
+      "check_id": "D3",
+      "file": "internal/common/testutil/simulators/simulators.go",
+      "line": 168,
+      "description": "Message field in second JobCondition struct literal has one extra space before the string value compared to the first condition (line 161). `Message:             ` (13 spaces) vs `Message:            ` (12 spaces). Cosmetic alignment inconsistency.",
+      "fix": "Remove the extra space on line 168 to align with the first condition: `Message:            \"Job completed successfully\",`"
+    },
+    {
+      "id": "D2-1",
+      "severity": "minor",
+      "check_id": "D2",
+      "description": "commonFakeCRDsDirs() at envtest_setup.go:204 does not include the len(dirs)==0 panic guard that the canonical fakeCRDsDirs() in internal/common/testutil/envtest/setup.go:134 has. Not a functional issue since envtest would fail at CRD installation if no CRDs are found, but it is an inconsistency with the reference implementation.",
+      "file": "operators/keystone/internal/testutil/envtest_setup.go",
+      "line": 224,
+      "fix": "Add a panic guard after the loop: `if len(dirs) == 0 { panic(fmt.Sprintf(\"testutil: no subdirectories found in fake_crds directory %s\", root)) }`"
+    }
+  ],
+  "suggested_improvements": [
+    "Consider adding the len(dirs)==0 panic guard to commonFakeCRDsDirs() for consistency with the canonical fakeCRDsDirs() implementation.",
+    "Fix the extra space in SimulateJobComplete Message field alignment (line 168)."
+  ],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-2.json
+++ b/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-2.json
@@ -1,0 +1,56 @@
+{
+  "feature_id": "CC-0014",
+  "title": "F002: Add Keystone reconciler integration tests",
+  "date": "2026-03-12",
+  "summary": "Review of external review #1 fixes: all three greptile-apps[bot] comments addressed correctly. (1) SimulateDeploymentReady now includes both DeploymentProgressing and DeploymentAvailable conditions, matching real K8s controller behavior. (2) Manual string-prefix check replaced with strings.HasPrefix. (3) TestSimulateDeploymentReady_zeroReplicas added for edge-case coverage. All unit tests pass, golangci-lint clean, go vet clean. Changes are minimal, correctly scoped, and follow established patterns.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "Unit tests exist and pass for SimulateDeploymentReady (5 tests)", "checked": true},
+    {"item": "Integration tests cover brownfield and managed modes", "checked": true},
+    {"item": "Condition progression test verifies intermediate states", "checked": true},
+    {"item": "Edge case covered: zero replicas test added", "checked": true},
+    {"item": "Assertions are specific (exact values, not just 'no error')", "checked": true},
+    {"item": "Tests independent (namespace isolation via GenerateName)", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing simulator patterns (Get -> set status -> Status().Update())", "checked": true},
+    {"item": "Gomega dot-import and NewGomegaWithT(t) pattern followed", "checked": true},
+    {"item": "SkipIfEnvTestUnavailable guard present in all integration tests", "checked": true},
+    {"item": "Goroutine-await channel pattern for test manager lifecycle", "checked": true},
+    {"item": "Direct (non-caching) client used for test assertions", "checked": true},
+    {"item": "strings.HasPrefix used instead of manual slice comparison", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No hardcoded secrets (test uses obviously fake values)", "checked": true},
+    {"item": "No injection vulnerabilities (test-only code)", "checked": true},
+    {"item": "InsecureSkipVerify scoped to envtest self-signed certs with nolint annotation", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Simulator in shared package (internal/common/testutil/simulators/)", "checked": true},
+    {"item": "Envtest helper in operator-specific testutil package", "checked": true},
+    {"item": "No circular dependencies introduced", "checked": true},
+    {"item": "SetupKeystoneEnvTest unchanged (CC-0012 tests unaffected)", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code in the diff", "checked": true},
+    {"item": "No unnecessary features added", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "t.Fatalf used for setup failures that prevent test execution", "checked": true},
+    {"item": "Eventually with timeouts prevents infinite waits", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Simulator validates resource exists before updating status", "checked": true},
+    {"item": "Error wrapping includes resource namespace/name context", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "integration_test.go:434 — The conditional guard `if readyCond != nil` around the Ready-condition assertion in TestIntegration_ConditionProgression means the assertion is vacuous when Ready is absent (the expected case). Consider replacing with `g.Expect(meta.IsStatusConditionTrue(ksState.Status.Conditions, \"Ready\")).To(BeFalse())` which handles both nil and present-but-False cases unconditionally. (Pre-existing code, not in this diff — noted for future improvement.)",
+    "integration_test.go — The timeout values 30*time.Second and 500*time.Millisecond are repeated ~15 times. Consider extracting to package-level test constants for easier tuning in CI. (Pre-existing code, not in this diff.)",
+    "integration_test.go:620,627 — The 60s timeout for MariaDB User/Grant CR polling (vs 30s elsewhere) would benefit from a brief comment explaining why the longer timeout is needed (accommodates 30s RequeueAfter delay). (Pre-existing code, not in this diff.)"
+  ],
+  "next_steps": [],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-3.json
+++ b/.planwerk/reviews/CC-0014-f002-add-keystone-reconciler-integration-tests-review-3.json
@@ -1,0 +1,48 @@
+{
+  "feature_id": "CC-0014",
+  "title": "F002: Add Keystone reconciler integration tests",
+  "date": "2026-03-12",
+  "verdict": "APPROVED",
+  "summary": "The diff correctly addresses both external review comments from greptile-apps[bot]: (1) hardcoded replica count replaced with dynamic reading from Deployment spec in driveFullReconciliation and TestIntegration_FullReconcile_Managed, (2) fragile key declaration with empty Name moved to after CR creation in TestIntegration_ConditionProgression. go vet and golangci-lint pass cleanly (0 issues). Two well-documented review patterns were added capturing the lessons learned.",
+  "tests_checklist": [
+    {"item": "Tests exist and are structured correctly (//go:build integration, SkipIfEnvTestUnavailable, gomega dot-import)", "checked": true},
+    {"item": "Both brownfield and managed database modes tested end-to-end", "checked": true},
+    {"item": "Condition progression test verifies intermediate states, not just final state", "checked": true},
+    {"item": "Resource creation verification covers all 12 child resources", "checked": true},
+    {"item": "Edge cases covered (nil Spec.Replicas defaults to 1)", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing CC-0012 integration test patterns", "checked": true},
+    {"item": "Dynamic replica reading handles nil Spec.Replicas correctly", "checked": true},
+    {"item": "key declaration initializes all fields atomically", "checked": true},
+    {"item": "No dead code or commented-out code", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No secrets hardcoded (test fixtures use placeholder values)", "checked": true},
+    {"item": "No injection risks (test-only code, no user input)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible", "checked": true},
+    {"item": "Changes are minimal and scoped to reviewer feedback", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code beyond threshold (replica reading in 2 locations is acceptable)", "checked": true},
+    {"item": "No unused code introduced", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Errors detected early via gomega assertions", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Nil Spec.Replicas handled with fallback to 1", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "PC3 consistency gap: TestIntegration_ConditionProgression (line 438) still hardcodes `3` for SimulateDeploymentReady while driveFullReconciliation (line 269-275) and TestIntegration_FullReconcile_Managed (line 660-666) now dynamically read from deploy.Spec.Replicas. Apply the same dynamic reading pattern for full consistency. Not blocking because line 438 was not in the diff scope and the hardcoded value is currently correct (fixture sets Replicas: 3)."
+  ],
+  "next_steps": [
+    "Consider applying the dynamic replica reading to TestIntegration_ConditionProgression line 438 for consistency with the other two call sites"
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0014-github-review-by-greptile-apps-bot-external-1.json
+++ b/.planwerk/reviews/CC-0014-github-review-by-greptile-apps-bot-external-1.json
@@ -1,0 +1,55 @@
+{
+  "feature_id": "CC-0014",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer requests three changes: (1) Add a `Progressing=True` condition alongside the existing `Available=True` condition in `SimulateDeploymentReady` to better match real Kubernetes deployment controller behavior. (2) Replace the manual string length-guard and slice-based prefix check with `strings.HasPrefix` in the integration test. (3) Add a `TestSimulateDeploymentReady_zeroReplicas` test case to cover the zero-replicas edge case, mirroring the existing `TestSimulateMariaDBReady_zeroReplicas`.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-12T14:49:44Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 1,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**Missing `Progressing` condition in `SimulateDeploymentReady`**\n\nThe function only sets the `Available=True` condition, but a real Kubernetes deployment controller also sets `Progressing=True (reason: NewReplicaSetAvailable)` when a rollout completes. The current `IsDeploymentReady` implementation only checks for `Available=True` and `ReadyReplicas`, so tests pass today — but if `IsDeploymentReady` is ever updated to also guard on `Progressing`, every integration test that calls `SimulateDeploymentReady` would silently fail.\n\nFor better production fidelity and resilience against future changes, add the `Progressing` condition alongside `Available`:\n\n```suggestion\n\tdeploy.Status.ReadyReplicas = replicas\n\tdeploy.Status.AvailableReplicas = replicas\n\tdeploy.Status.Replicas = replicas\n\tdeploy.Status.UpdatedReplicas = replicas\n\tdeploy.Status.ObservedGeneration = deploy.Generation\n\tdeploy.Status.Conditions = []appsv1.DeploymentCondition{\n\t\t{\n\t\t\tType:               appsv1.DeploymentProgressing,\n\t\t\tStatus:             corev1.ConditionTrue,\n\t\t\tReason:             \"NewReplicaSetAvailable\",\n\t\t\tMessage:            \"ReplicaSet has successfully progressed\",\n\t\t\tLastTransitionTime: metav1.Now(),\n\t\t},\n\t\t{\n\t\t\tType:               appsv1.DeploymentAvailable,\n\t\t\tStatus:             corev1.ConditionTrue,\n\t\t\tReason:             \"MinimumReplicasAvailable\",\n\t\t\tMessage:            \"Deployment has minimum availability\",\n\t\t\tLastTransitionTime: metav1.Now(),\n\t\t},\n\t}\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: internal/common/testutil/simulators/simulators.go\nLine: 286-300\n\nComment:\n**Missing `Progressing` condition in `SimulateDeploymentReady`**\n\nThe function only sets the `Available=True` condition, but a real Kubernetes deployment controller also sets `Progressing=True (reason: NewReplicaSetAvailable)` when a rollout completes. The current `IsDeploymentReady` implementation only checks for `Available=True` and `ReadyReplicas`, so tests pass today — but if `IsDeploymentReady` is ever updated to also guard on `Progressing`, every integration test that calls `SimulateDeploymentReady` would silently fail.\n\nFor better production fidelity and resilience against future changes, add the `Progressing` condition alongside `Available`:\n\n```suggestion\n\tdeploy.Status.ReadyReplicas = replicas\n\tdeploy.Status.AvailableReplicas = replicas\n\tdeploy.Status.Replicas = replicas\n\tdeploy.Status.UpdatedReplicas = replicas\n\tdeploy.Status.ObservedGeneration = deploy.Generation\n\tdeploy.Status.Conditions = []appsv1.DeploymentCondition{\n\t\t{\n\t\t\tType:               appsv1.DeploymentProgressing,\n\t\t\tStatus:             corev1.ConditionTrue,\n\t\t\tReason:             \"NewReplicaSetAvailable\",\n\t\t\tMessage:            \"ReplicaSet has successfully progressed\",\n\t\t\tLastTransitionTime: metav1.Now(),\n\t\t},\n\t\t{\n\t\t\tType:               appsv1.DeploymentAvailable,\n\t\t\tStatus:             corev1.ConditionTrue,\n\t\t\tReason:             \"MinimumReplicasAvailable\",\n\t\t\tMessage:            \"Deployment has minimum availability\",\n\t\t\tLastTransitionTime: metav1.Now(),\n\t\t},\n\t}\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "internal/common/testutil/simulators/simulators.go",
+      "line": 300,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-12T14:49:41Z",
+      "id": null,
+      "resolution": "SimulateDeploymentReady now includes both the DeploymentProgressing (Reason: NewReplicaSetAvailable) and DeploymentAvailable conditions in its status, exactly matching the reviewer's suggested code block (simulators.go:291-306)."
+    },
+    {
+      "body": "**Manual string-prefix check is error-prone; use `strings.HasPrefix`**\n\nThe length-guard + manual slice approach is harder to read and could silently mismatch if the prefix constant is ever updated out of sync with the slice index:\n\n```suggestion\n\tfor _, cm := range configMaps.Items {\n\t\tif strings.HasPrefix(cm.Name, \"test-keystone-config-\") {\n\t\t\tfoundConfigMap = true\n\t\t\tg.Expect(cm.Immutable).NotTo(BeNil(), \"ConfigMap should be immutable\")\n\t\t\tg.Expect(*cm.Immutable).To(BeTrue(), \"ConfigMap should be immutable\")\n\t\t\tbreak\n\t\t}\n\t}\n```\n\nThis also requires adding `\"strings\"` to the import block.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: operators/keystone/internal/controller/integration_test.go\nLine: 482-489\n\nComment:\n**Manual string-prefix check is error-prone; use `strings.HasPrefix`**\n\nThe length-guard + manual slice approach is harder to read and could silently mismatch if the prefix constant is ever updated out of sync with the slice index:\n\n```suggestion\n\tfor _, cm := range configMaps.Items {\n\t\tif strings.HasPrefix(cm.Name, \"test-keystone-config-\") {\n\t\t\tfoundConfigMap = true\n\t\t\tg.Expect(cm.Immutable).NotTo(BeNil(), \"ConfigMap should be immutable\")\n\t\t\tg.Expect(*cm.Immutable).To(BeTrue(), \"ConfigMap should be immutable\")\n\t\t\tbreak\n\t\t}\n\t}\n```\n\nThis also requires adding `\"strings\"` to the import block.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "operators/keystone/internal/controller/integration_test.go",
+      "line": 489,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-12T14:49:42Z",
+      "id": null,
+      "resolution": "The manual length-guard + slice prefix check was replaced with strings.HasPrefix(cm.Name, \"test-keystone-config-\") in integration_test.go:484, and the \"strings\" import was added to the file's import block (line 13)."
+    },
+    {
+      "body": "**Missing zero-replicas test for `SimulateDeploymentReady`**\n\n`TestSimulateMariaDBReady_zeroReplicas` exists for `SimulateMariaDBReady`, which ensures the zero-replica edge case is handled. `SimulateDeploymentReady` doesn't have an equivalent. This matters because `IsDeploymentReady` compares `ReadyReplicas < desired` — passing `replicas=0` while `spec.Replicas=3` would make `IsDeploymentReady` return `false`, which could silently confuse callers.\n\nA minimal companion test:\n\n```go\nfunc TestSimulateDeploymentReady_zeroReplicas(t *testing.T) {\n    g := NewGomegaWithT(t)\n    deploy := &appsv1.Deployment{\n        ObjectMeta: metav1.ObjectMeta{Name: \"test-deploy\", Namespace: \"default\", Generation: 1},\n    }\n    c := fake.NewClientBuilder().WithScheme(newScheme()).\n        WithObjects(deploy).WithStatusSubresource(deploy).Build()\n    g.Expect(SimulateDeploymentReady(context.Background(), c, client.ObjectKeyFromObject(deploy), 0)).To(Succeed())\n    updated := &appsv1.Deployment{}\n    g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(deploy), updated)).To(Succeed())\n    g.Expect(updated.Status.ReadyReplicas).To(BeEquivalentTo(0))\n}\n```\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: internal/common/testutil/simulators/simulators_test.go\nLine: 469-493\n\nComment:\n**Missing zero-replicas test for `SimulateDeploymentReady`**\n\n`TestSimulateMariaDBReady_zeroReplicas` exists for `SimulateMariaDBReady`, which ensures the zero-replica edge case is handled. `SimulateDeploymentReady` doesn't have an equivalent. This matters because `IsDeploymentReady` compares `ReadyReplicas < desired` — passing `replicas=0` while `spec.Replicas=3` would make `IsDeploymentReady` return `false`, which could silently confuse callers.\n\nA minimal companion test:\n\n```go\nfunc TestSimulateDeploymentReady_zeroReplicas(t *testing.T) {\n    g := NewGomegaWithT(t)\n    deploy := &appsv1.Deployment{\n        ObjectMeta: metav1.ObjectMeta{Name: \"test-deploy\", Namespace: \"default\", Generation: 1},\n    }\n    c := fake.NewClientBuilder().WithScheme(newScheme()).\n        WithObjects(deploy).WithStatusSubresource(deploy).Build()\n    g.Expect(SimulateDeploymentReady(context.Background(), c, client.ObjectKeyFromObject(deploy), 0)).To(Succeed())\n    updated := &appsv1.Deployment{}\n    g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(deploy), updated)).To(Succeed())\n    g.Expect(updated.Status.ReadyReplicas).To(BeEquivalentTo(0))\n}\n```\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "internal/common/testutil/simulators/simulators_test.go",
+      "line": 493,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-12T14:49:43Z",
+      "id": null,
+      "resolution": "TestSimulateDeploymentReady_zeroReplicas was added at simulators_test.go:500-522, matching the reviewer's suggested test: it creates a Deployment, calls SimulateDeploymentReady with replicas=0, and asserts ReadyReplicas is 0."
+    }
+  ],
+  "resolution_summary": "All three review comments were addressed exactly as suggested. Comment [0] added the Progressing condition to SimulateDeploymentReady, comment [1] replaced the manual string-prefix check with strings.HasPrefix (plus the \"strings\" import), and comment [2] added the TestSimulateDeploymentReady_zeroReplicas test. Additionally, SimulateJobComplete in simulators.go was enhanced with a StartTime field and a JobSuccessCriteriaMet condition — this follows the same production-fidelity pattern from comment [0] (adding missing conditions that a real Kubernetes controller sets) applied to an existing simulator in the same file.",
+  "github_review_id": 3937262209
+}

--- a/.planwerk/reviews/CC-0014-github-review-by-greptile-apps-bot-external-2.json
+++ b/.planwerk/reviews/CC-0014-github-review-by-greptile-apps-bot-external-2.json
@@ -1,0 +1,46 @@
+{
+  "feature_id": "CC-0014",
+  "title": "GitHub Review by greptile-apps[bot]",
+  "summary": "The reviewer wants two changes in the integration tests: (1) Replace the hardcoded replica count of `3` in `SimulateDeploymentReady` with a dynamic read from the actual Deployment spec, both in `driveFullReconciliation` (line 268) and `TestIntegration_FullReconcile_Managed` (line 654). (2) Move the `key` variable declaration (line 345) so it's initialized with both `Namespace` and `Name` immediately after the CR is created, rather than declaring it early with an empty `Name` that gets patched in later.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "greptile-apps[bot]",
+  "date": "2026-03-12T15:19:36Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 2,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "**Hardcoded replica count couples helper to fixture**\n\n`driveFullReconciliation` hardcodes `3` for `SimulateDeploymentReady`. `IsDeploymentReady` checks `Status.ReadyReplicas >= *Spec.Replicas` — so if the `integrationBrownfieldKeystone` fixture is ever changed to a replica count **greater than 3** (e.g., 5), `SimulateDeploymentReady(..., 3)` would set `ReadyReplicas=3`, which is less than `desired=5`, causing `IsDeploymentReady` to return `false`. The test would then silently hang at `waitForCondition(..., \"DeploymentReady\", ConditionTrue, ...)` until the timeout, with no indication that the hardcoded replica count is the cause.\n\nThe fix is to dynamically read the desired replica count from the already-created Deployment spec:\n\n```go\n// Wait for the Deployment to appear and simulate its readiness.\ndeployKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf(\"%s-api\", ksName)}\ng.Eventually(func() error {\n    return c.Get(ctx, deployKey, &appsv1.Deployment{})\n}, eventuallyTimeout, pollInterval).Should(Succeed(), \"Deployment should appear\")\n\ndeploy := &appsv1.Deployment{}\ng.Expect(c.Get(ctx, deployKey, deploy)).To(Succeed())\nreplicas := int32(1)\nif deploy.Spec.Replicas != nil {\n    replicas = *deploy.Spec.Replicas\n}\ng.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, replicas)).To(Succeed(), \"simulate Deployment ready\")\n```\n\nThe same change should be applied to the equivalent call in `TestIntegration_FullReconcile_Managed` at line 654.\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: operators/keystone/internal/controller/integration_test.go\nLine: 265-268\n\nComment:\n**Hardcoded replica count couples helper to fixture**\n\n`driveFullReconciliation` hardcodes `3` for `SimulateDeploymentReady`. `IsDeploymentReady` checks `Status.ReadyReplicas >= *Spec.Replicas` — so if the `integrationBrownfieldKeystone` fixture is ever changed to a replica count **greater than 3** (e.g., 5), `SimulateDeploymentReady(..., 3)` would set `ReadyReplicas=3`, which is less than `desired=5`, causing `IsDeploymentReady` to return `false`. The test would then silently hang at `waitForCondition(..., \"DeploymentReady\", ConditionTrue, ...)` until the timeout, with no indication that the hardcoded replica count is the cause.\n\nThe fix is to dynamically read the desired replica count from the already-created Deployment spec:\n\n```go\n// Wait for the Deployment to appear and simulate its readiness.\ndeployKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf(\"%s-api\", ksName)}\ng.Eventually(func() error {\n    return c.Get(ctx, deployKey, &appsv1.Deployment{})\n}, eventuallyTimeout, pollInterval).Should(Succeed(), \"Deployment should appear\")\n\ndeploy := &appsv1.Deployment{}\ng.Expect(c.Get(ctx, deployKey, deploy)).To(Succeed())\nreplicas := int32(1)\nif deploy.Spec.Replicas != nil {\n    replicas = *deploy.Spec.Replicas\n}\ng.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, replicas)).To(Succeed(), \"simulate Deployment ready\")\n```\n\nThe same change should be applied to the equivalent call in `TestIntegration_FullReconcile_Managed` at line 654.\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "operators/keystone/internal/controller/integration_test.go",
+      "line": 268,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-12T15:19:34Z",
+      "id": null,
+      "resolution": "NOT ADDRESSED: SimulateDeploymentReady still uses hardcoded 3 in all three locations: driveFullReconciliation (line 274), TestIntegration_ConditionProgression (line 439), and TestIntegration_FullReconcile_Managed (line 660). The reviewer requested dynamically reading the replica count from the Deployment spec."
+    },
+    {
+      "body": "**`key` declared with empty `Name` field is error-prone**\n\n`key` is initialized with only `Namespace` set at line 345, and `Name` is patched in at line 386 after the CR is created. While the current code is correct (every `waitForCondition` and `c.Get` call using `key` comes after line 386), this pattern is fragile: any helper call inserted between lines 345 and 386 that passes `key` would silently operate on a namespaced name with an empty `Name` string, which would never match any real object — causing a confusing test failure or a false pass.\n\nInitialise `key` immediately after the CR name is known:\n\n```suggestion\n\t// Create the Keystone CR.\n\tks := integrationBrownfieldKeystone(\"test-keystone\", ns.Name)\n\tg.Expect(c.Create(ctx, ks)).To(Succeed())\n\tkey := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}\n```\n\n(Remove the early declaration at line 345.)\n\n<details><summary>Prompt To Fix With AI</summary>\n\n`````markdown\nThis is a comment left during a code review.\nPath: operators/keystone/internal/controller/integration_test.go\nLine: 344-346\n\nComment:\n**`key` declared with empty `Name` field is error-prone**\n\n`key` is initialized with only `Namespace` set at line 345, and `Name` is patched in at line 386 after the CR is created. While the current code is correct (every `waitForCondition` and `c.Get` call using `key` comes after line 386), this pattern is fragile: any helper call inserted between lines 345 and 386 that passes `key` would silently operate on a namespaced name with an empty `Name` string, which would never match any real object — causing a confusing test failure or a false pass.\n\nInitialise `key` immediately after the CR name is known:\n\n```suggestion\n\t// Create the Keystone CR.\n\tks := integrationBrownfieldKeystone(\"test-keystone\", ns.Name)\n\tg.Expect(c.Create(ctx, ks)).To(Succeed())\n\tkey := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}\n```\n\n(Remove the early declaration at line 345.)\n\nHow can I resolve this? If you propose a fix, please make it concise.\n`````\n</details>",
+      "path": "operators/keystone/internal/controller/integration_test.go",
+      "line": 346,
+      "author": "greptile-apps[bot]",
+      "created_at": "2026-03-12T15:19:35Z",
+      "id": null,
+      "resolution": "NOT ADDRESSED: key is still declared with empty Name at line 351 (key := types.NamespacedName{Namespace: ns.Name}) and patched later at line 392 (key.Name = ks.Name). The reviewer requested moving the declaration to after CR creation so both Name and Namespace are set together."
+    }
+  ],
+  "resolution_summary": "Neither review comment was addressed. The fix commit d289571 made unrelated improvements: extracting magic timeout/interval numbers into named constants (eventuallyTimeout, eventuallyLongTimeout, pollInterval), replacing a manual string prefix check with strings.HasPrefix, and simplifying a Ready condition check to use meta.IsStatusConditionTrue. However, the two specific issues raised by the reviewer — hardcoded replica count 3 in SimulateDeploymentReady and the fragile key declaration with empty Name — remain unchanged in the current code.",
+  "github_review_id": 3937515978
+}

--- a/internal/common/testutil/simulators/simulators.go
+++ b/internal/common/testutil/simulators/simulators.go
@@ -14,6 +14,7 @@ import (
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	esov1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -149,8 +150,17 @@ func SimulateJobComplete(ctx context.Context, c client.Client, key client.Object
 
 	job.Status.Succeeded = 1
 	now := metav1.Now()
+	startTime := metav1.NewTime(now.Add(-1 * time.Second))
+	job.Status.StartTime = &startTime
 	job.Status.CompletionTime = &now
 	job.Status.Conditions = []batchv1.JobCondition{
+		{
+			Type:               batchv1.JobSuccessCriteriaMet,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: now,
+			Reason:             "Completed",
+			Message:            "Job completed successfully",
+		},
 		{
 			Type:               batchv1.JobComplete,
 			Status:             corev1.ConditionTrue,
@@ -261,4 +271,40 @@ func SimulateCertificateReady(ctx context.Context, c client.Client, key client.O
 	}
 
 	return c.Status().Update(ctx, cert)
+}
+
+// Feature: CC-0014
+
+// SimulateDeploymentReady updates a Deployment resource's status to indicate
+// availability by setting the Available condition to True, readyReplicas, and
+// observedGeneration to match the Deployment's Generation (CC-0014, REQ-001).
+func SimulateDeploymentReady(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(ctx, key, deploy); err != nil {
+		return fmt.Errorf("getting Deployment %s: %w", key, err)
+	}
+
+	deploy.Status.ReadyReplicas = replicas
+	deploy.Status.AvailableReplicas = replicas
+	deploy.Status.Replicas = replicas
+	deploy.Status.UpdatedReplicas = replicas
+	deploy.Status.ObservedGeneration = deploy.Generation
+	deploy.Status.Conditions = []appsv1.DeploymentCondition{
+		{
+			Type:               appsv1.DeploymentProgressing,
+			Status:             corev1.ConditionTrue,
+			Reason:             "NewReplicaSetAvailable",
+			Message:            "ReplicaSet has successfully progressed",
+			LastTransitionTime: metav1.Now(),
+		},
+		{
+			Type:               appsv1.DeploymentAvailable,
+			Status:             corev1.ConditionTrue,
+			Reason:             "MinimumReplicasAvailable",
+			Message:            "Deployment has minimum availability",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	return c.Status().Update(ctx, deploy)
 }

--- a/internal/common/testutil/simulators/simulators_test.go
+++ b/internal/common/testutil/simulators/simulators_test.go
@@ -12,6 +12,8 @@ import (
 
 	esov1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	"github.com/c5c3/forge/internal/common/deployment"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +41,7 @@ func newScheme() *runtime.Scheme {
 	_ = corev1.AddToScheme(s)
 	_ = batchv1.AddToScheme(s)
 	_ = mariadbv1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
 	_ = esov1beta1.AddToScheme(s)
 	return s
 }
@@ -328,10 +331,15 @@ func TestSimulateJobComplete(t *testing.T) {
 	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(job), updated)).To(Succeed())
 
 	g.Expect(updated.Status.Succeeded).To(BeEquivalentTo(1))
+	g.Expect(updated.Status.StartTime).NotTo(BeNil())
 	g.Expect(updated.Status.CompletionTime).NotTo(BeNil())
-	g.Expect(updated.Status.Conditions).To(HaveLen(1))
+	g.Expect(updated.Status.Conditions).To(HaveLen(2))
 
-	cond := updated.Status.Conditions[0]
+	// SuccessCriteriaMet must come before Complete (K8s 1.35 requirement).
+	g.Expect(updated.Status.Conditions[0].Type).To(Equal(batchv1.JobSuccessCriteriaMet))
+	g.Expect(updated.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+
+	cond := updated.Status.Conditions[1]
 	g.Expect(cond.Type).To(Equal(batchv1.JobComplete))
 	g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
 	g.Expect(cond.Reason).To(Equal("Completed"))
@@ -362,7 +370,7 @@ func TestSimulateJobComplete_idempotent(t *testing.T) {
 	updated := &batchv1.Job{}
 	g.Expect(c.Get(ctx, key, updated)).To(Succeed())
 
-	g.Expect(updated.Status.Conditions).To(HaveLen(1), "expected exactly 1 condition after two calls")
+	g.Expect(updated.Status.Conditions).To(HaveLen(2), "expected exactly 2 conditions after two calls")
 }
 
 func TestSimulateJobComplete_notFound(t *testing.T) {
@@ -375,4 +383,140 @@ func TestSimulateJobComplete_notFound(t *testing.T) {
 	key := client.ObjectKey{Name: "missing", Namespace: "default"}
 	err := SimulateJobComplete(context.Background(), c, key)
 	g.Expect(err).To(HaveOccurred())
+}
+
+// Feature: CC-0014
+
+// --- SimulateDeploymentReady ---
+
+func TestSimulateDeploymentReady(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deploy",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(deploy).
+		WithStatusSubresource(deploy).
+		Build()
+
+	err := SimulateDeploymentReady(context.Background(), c, client.ObjectKeyFromObject(deploy), 3)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &appsv1.Deployment{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(deploy), updated)).To(Succeed())
+
+	g.Expect(updated.Status.ReadyReplicas).To(BeEquivalentTo(3))
+	g.Expect(updated.Status.AvailableReplicas).To(BeEquivalentTo(3))
+	g.Expect(updated.Status.Replicas).To(BeEquivalentTo(3))
+	g.Expect(updated.Status.UpdatedReplicas).To(BeEquivalentTo(3))
+	g.Expect(updated.Status.ObservedGeneration).To(Equal(int64(1)))
+	g.Expect(updated.Status.Conditions).To(HaveLen(2))
+
+	progressingCond := updated.Status.Conditions[0]
+	g.Expect(progressingCond.Type).To(Equal(appsv1.DeploymentProgressing))
+	g.Expect(progressingCond.Status).To(Equal(corev1.ConditionTrue))
+	g.Expect(progressingCond.Reason).To(Equal("NewReplicaSetAvailable"))
+
+	availableCond := updated.Status.Conditions[1]
+	g.Expect(availableCond.Type).To(Equal(appsv1.DeploymentAvailable))
+	g.Expect(availableCond.Status).To(Equal(corev1.ConditionTrue))
+	g.Expect(availableCond.Reason).To(Equal("MinimumReplicasAvailable"))
+}
+
+func TestSimulateDeploymentReady_idempotent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deploy",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(deploy).
+		WithStatusSubresource(deploy).
+		Build()
+
+	ctx := context.Background()
+	key := client.ObjectKeyFromObject(deploy)
+
+	g.Expect(SimulateDeploymentReady(ctx, c, key, 3)).To(Succeed())
+	g.Expect(SimulateDeploymentReady(ctx, c, key, 3)).To(Succeed())
+
+	updated := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, key, updated)).To(Succeed())
+
+	g.Expect(updated.Status.Conditions).To(HaveLen(2), "expected exactly 2 conditions after two calls")
+}
+
+func TestSimulateDeploymentReady_notFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		Build()
+
+	key := client.ObjectKey{Name: "missing", Namespace: "default"}
+	err := SimulateDeploymentReady(context.Background(), c, key, 3)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestSimulateDeploymentReady_IsDeploymentReadyReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deploy",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(deploy).
+		WithStatusSubresource(deploy).
+		Build()
+
+	err := SimulateDeploymentReady(context.Background(), c, client.ObjectKeyFromObject(deploy), 3)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &appsv1.Deployment{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(deploy), updated)).To(Succeed())
+
+	g.Expect(deployment.IsDeploymentReady(updated)).To(BeTrue())
+}
+
+func TestSimulateDeploymentReady_zeroReplicas(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deploy",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(deploy).
+		WithStatusSubresource(deploy).
+		Build()
+
+	g.Expect(SimulateDeploymentReady(context.Background(), c, client.ObjectKeyFromObject(deploy), 0)).To(Succeed())
+
+	updated := &appsv1.Deployment{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(deploy), updated)).To(Succeed())
+	g.Expect(updated.Status.ReadyReplicas).To(BeEquivalentTo(0))
 }

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -50,7 +50,7 @@ type KeystoneSpec struct {
 
 	// Cache defines the Memcached cache configuration.
 	// Supports managed (clusterRef) and brownfield (servers) modes.
-	// +kubebuilder:validation:XValidation:rule="(self.clusterRef != null) != (has(self.servers) && size(self.servers) > 0)",message="exactly one of clusterRef or servers must be set"
+	// +kubebuilder:validation:XValidation:rule="has(self.clusterRef) != (has(self.servers) && size(self.servers) > 0)",message="exactly one of clusterRef or servers must be set"
 	Cache commonv1.CacheSpec `json:"cache"`
 
 	// Fernet configures Fernet key rotation.

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -124,7 +124,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: exactly one of clusterRef or servers must be set
-                  rule: (self.clusterRef != null) != (has(self.servers) && size(self.servers)
+                  rule: has(self.clusterRef) != (has(self.servers) && size(self.servers)
                     > 0)
               database:
                 description: |-

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -1,0 +1,696 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+// Package controller contains integration tests for the Keystone reconciler (CC-0014, F002).
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	esov1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/c5c3/forge/internal/common/testutil/simulators"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
+	"github.com/c5c3/forge/operators/keystone/internal/testutil"
+)
+
+// Feature: CC-0014
+
+// Test timeout constants for CI tuning (CC-0014).
+const (
+	// eventuallyTimeout is the default polling timeout for Eventually assertions.
+	eventuallyTimeout = 30 * time.Second
+	// eventuallyLongTimeout is used for MariaDB User/Grant CR polling, which
+	// depends on the controller's 30s RequeueAfter delay to discover readiness
+	// changes on unwatched MariaDB types.
+	eventuallyLongTimeout = 60 * time.Second
+	// pollInterval is the polling interval for Eventually assertions.
+	pollInterval = 500 * time.Millisecond
+)
+
+// --- Shared Helpers ---
+
+// setupEnvTestWithController wraps testutil.SetupKeystoneEnvTestWithController with
+// the v1alpha1 scheme, webhook, and controller registration callbacks (CC-0014).
+func setupEnvTestWithController(t testing.TB) (client.Client, context.Context, context.CancelFunc) {
+	t.Helper()
+	return testutil.SetupKeystoneEnvTestWithController(t,
+		keystonev1alpha1.AddToScheme,
+		func(mgr ctrl.Manager) error {
+			return (&keystonev1alpha1.KeystoneWebhook{}).SetupWebhookWithManager(mgr)
+		},
+		func(mgr ctrl.Manager) error {
+			r := &KeystoneReconciler{
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("keystone-controller"),
+			}
+			return ctrl.NewControllerManagedBy(mgr).
+				For(&keystonev1alpha1.Keystone{}).
+				Owns(&appsv1.Deployment{}).
+				Owns(&corev1.Service{}).
+				Owns(&corev1.ConfigMap{}).
+				Owns(&batchv1.Job{}).
+				Owns(&batchv1.CronJob{}).
+				Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
+					secretToKeystoneMapper(mgr.GetClient()),
+				)).
+				WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
+				Complete(r)
+		},
+	)
+}
+
+// integrationBrownfieldKeystone returns a valid Keystone CR for brownfield mode integration
+// tests (spec.database.host set, no clusterRef) (CC-0014).
+func integrationBrownfieldKeystone(name, namespace string) *keystonev1alpha1.Keystone {
+	return &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: keystonev1alpha1.KeystoneSpec{
+			Replicas: 3,
+			Image:    commonv1.ImageSpec{Repository: "ghcr.io/c5c3/keystone", Tag: "2025.2"},
+			Database: commonv1.DatabaseSpec{
+				Host:      "db.example.com",
+				Port:      3306,
+				Database:  "keystone",
+				SecretRef: commonv1.SecretRefSpec{Name: "keystone-db"},
+			},
+			Cache: commonv1.CacheSpec{
+				Backend: "dogpile.cache.pymemcache",
+				Servers: []string{"mc:11211"},
+			},
+			Fernet: keystonev1alpha1.FernetSpec{
+				RotationSchedule: "0 0 * * 0",
+				MaxActiveKeys:    3,
+			},
+			Bootstrap: keystonev1alpha1.BootstrapSpec{
+				AdminUser:              "admin",
+				AdminPasswordSecretRef: commonv1.SecretRefSpec{Name: "keystone-admin"},
+				Region:                 "RegionOne",
+			},
+		},
+	}
+}
+
+// integrationManagedKeystone returns a valid Keystone CR for managed mode integration tests
+// (spec.database.clusterRef set, no host) (CC-0014).
+func integrationManagedKeystone(name, namespace string) *keystonev1alpha1.Keystone {
+	return &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: keystonev1alpha1.KeystoneSpec{
+			Replicas: 3,
+			Image:    commonv1.ImageSpec{Repository: "ghcr.io/c5c3/keystone", Tag: "2025.2"},
+			Database: commonv1.DatabaseSpec{
+				ClusterRef: &corev1.LocalObjectReference{Name: "mariadb"},
+				Port:       3306,
+				Database:   "keystone",
+				SecretRef:  commonv1.SecretRefSpec{Name: "keystone-db"},
+			},
+			Cache: commonv1.CacheSpec{
+				Backend: "dogpile.cache.pymemcache",
+				Servers: []string{"mc:11211"},
+			},
+			Fernet: keystonev1alpha1.FernetSpec{
+				RotationSchedule: "0 0 * * 0",
+				MaxActiveKeys:    3,
+			},
+			Bootstrap: keystonev1alpha1.BootstrapSpec{
+				AdminUser:              "admin",
+				AdminPasswordSecretRef: commonv1.SecretRefSpec{Name: "keystone-admin"},
+				Region:                 "RegionOne",
+			},
+		},
+	}
+}
+
+// createPrerequisites creates the ExternalSecret and Secret resources that the
+// Keystone reconciler expects to find. It creates the DB credentials ExternalSecret
+// and Secret (username+password), the admin credentials ExternalSecret and Secret
+// (password), and calls SimulateExternalSecretSync for both (CC-0014).
+func createPrerequisites(t testing.TB, ctx context.Context, c client.Client, ns string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	// Create DB credentials ExternalSecret and Secret.
+	dbES := &esov1beta1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-db", Namespace: ns},
+		Spec: esov1beta1.ExternalSecretSpec{
+			SecretStoreRef: esov1beta1.SecretStoreRef{
+				Kind: "ClusterSecretStore",
+				Name: "openbao",
+			},
+			Target: esov1beta1.ExternalSecretTarget{
+				Name: "keystone-db",
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, dbES)).To(Succeed(), "create DB ExternalSecret")
+
+	dbSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-db", Namespace: ns},
+		Data: map[string][]byte{
+			"username": []byte("keystone"),
+			"password": []byte("secret"),
+		},
+	}
+	g.Expect(c.Create(ctx, dbSecret)).To(Succeed(), "create DB Secret")
+
+	// Create admin credentials ExternalSecret and Secret.
+	adminES := &esov1beta1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-admin", Namespace: ns},
+		Spec: esov1beta1.ExternalSecretSpec{
+			SecretStoreRef: esov1beta1.SecretStoreRef{
+				Kind: "ClusterSecretStore",
+				Name: "openbao",
+			},
+			Target: esov1beta1.ExternalSecretTarget{
+				Name: "keystone-admin",
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, adminES)).To(Succeed(), "create admin ExternalSecret")
+
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-admin", Namespace: ns},
+		Data:       map[string][]byte{"password": []byte("admin-password")},
+	}
+	g.Expect(c.Create(ctx, adminSecret)).To(Succeed(), "create admin Secret")
+
+	// Simulate ESO sync for both ExternalSecrets.
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c, client.ObjectKey{Namespace: ns, Name: "keystone-db"})).
+		To(Succeed(), "simulate DB ExternalSecret sync")
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c, client.ObjectKey{Namespace: ns, Name: "keystone-admin"})).
+		To(Succeed(), "simulate admin ExternalSecret sync")
+}
+
+// waitForCondition polls the Keystone CR until the named condition reaches the
+// expected status, or the timeout is reached. Returns the condition.
+func waitForCondition(t testing.TB, ctx context.Context, c client.Client, key types.NamespacedName, condType string, expectedStatus metav1.ConditionStatus, timeout time.Duration) *metav1.Condition {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	var cond *metav1.Condition
+	g.Eventually(func() metav1.ConditionStatus {
+		ks := &keystonev1alpha1.Keystone{}
+		if err := c.Get(ctx, key, ks); err != nil {
+			return ""
+		}
+		cond = meta.FindStatusCondition(ks.Status.Conditions, condType)
+		if cond == nil {
+			return ""
+		}
+		return cond.Status
+	}, timeout, pollInterval).Should(Equal(expectedStatus),
+		fmt.Sprintf("condition %s should reach %s", condType, expectedStatus))
+
+	return cond
+}
+
+// driveFullReconciliation simulates external dependencies to drive the
+// reconciler through all phases to Ready=True. It waits for each phase's
+// resources to appear before simulating their readiness (CC-0014).
+func driveFullReconciliation(t testing.TB, ctx context.Context, c client.Client, ksName, ns string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	key := types.NamespacedName{Name: ksName, Namespace: ns}
+
+	// Wait for SecretsReady=True (prerequisites already created).
+	waitForCondition(t, ctx, c, key, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for FernetKeysReady=True (reconciler creates fernet keys automatically).
+	waitForCondition(t, ctx, c, key, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for the db-sync Job to appear and simulate its completion.
+	dbSyncKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-db-sync", ksName)}
+	g.Eventually(func() error {
+		return c.Get(ctx, dbSyncKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "db-sync Job should appear")
+	g.Expect(simulators.SimulateJobComplete(ctx, c, dbSyncKey)).To(Succeed(), "simulate db-sync Job completion")
+
+	// Wait for DatabaseReady=True.
+	waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for the Deployment to appear and simulate its readiness.
+	deployKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-api", ksName)}
+	deploy := &appsv1.Deployment{}
+	g.Eventually(func() error {
+		return c.Get(ctx, deployKey, deploy)
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "Deployment should appear")
+	g.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, ptr.Deref(deploy.Spec.Replicas, 1))).To(Succeed(), "simulate Deployment ready")
+
+	// Wait for DeploymentReady=True.
+	waitForCondition(t, ctx, c, key, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for the bootstrap Job to appear and simulate its completion.
+	bootstrapKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-bootstrap", ksName)}
+	g.Eventually(func() error {
+		return c.Get(ctx, bootstrapKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "bootstrap Job should appear")
+	g.Expect(simulators.SimulateJobComplete(ctx, c, bootstrapKey)).To(Succeed(), "simulate bootstrap Job completion")
+
+	// Wait for BootstrapReady=True and then Ready=True.
+	waitForCondition(t, ctx, c, key, "BootstrapReady", metav1.ConditionTrue, eventuallyTimeout)
+	waitForCondition(t, ctx, c, key, "Ready", metav1.ConditionTrue, eventuallyTimeout)
+}
+
+// --- Task 2.1: Full reconcile brownfield test (REQ-003, REQ-005, REQ-006, REQ-007) ---
+
+func TestIntegration_FullReconcile_Brownfield(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	// Create isolated namespace.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-brownfield-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	// Create prerequisites.
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	// Create brownfield Keystone CR.
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	// Drive the full reconciliation to Ready=True.
+	driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+	// Fetch the final state.
+	key := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}
+	updated := &keystonev1alpha1.Keystone{}
+	g.Expect(c.Get(ctx, key, updated)).To(Succeed())
+
+	// Verify all 6 conditions are True.
+	for _, condType := range []string{"SecretsReady", "FernetKeysReady", "DatabaseReady", "DeploymentReady", "BootstrapReady", "Ready"} {
+		cond := meta.FindStatusCondition(updated.Status.Conditions, condType)
+		g.Expect(cond).NotTo(BeNil(), "condition %s should exist", condType)
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "condition %s should be True", condType)
+	}
+
+	// Verify Ready condition has reason AllReady (REQ-003).
+	readyCond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	g.Expect(readyCond.Reason).To(Equal("AllReady"))
+
+	// Verify status.endpoint (REQ-006).
+	expectedEndpoint := fmt.Sprintf("http://%s-api.%s.svc.cluster.local:5000/v3", ks.Name, ns.Name)
+	g.Expect(updated.Status.Endpoint).To(Equal(expectedEndpoint), "status.endpoint should be set correctly")
+
+	// Verify ObservedGeneration on all conditions (REQ-007).
+	for _, cond := range updated.Status.Conditions {
+		g.Expect(cond.ObservedGeneration).To(Equal(updated.Generation),
+			"condition %s ObservedGeneration should match CR generation", cond.Type)
+	}
+}
+
+// --- Task 2.2: Condition progression test (REQ-008) ---
+
+func TestIntegration_ConditionProgression(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-progression-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	// Phase 0: Create ExternalSecrets and Secrets but do NOT simulate sync yet.
+	// The reconciler should see SecretsReady=False because ESO hasn't set the
+	// Ready condition on the ExternalSecret.
+	dbES := &esov1beta1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-db", Namespace: ns.Name},
+		Spec: esov1beta1.ExternalSecretSpec{
+			SecretStoreRef: esov1beta1.SecretStoreRef{Kind: "ClusterSecretStore", Name: "openbao"},
+			Target:         esov1beta1.ExternalSecretTarget{Name: "keystone-db"},
+		},
+	}
+	g.Expect(c.Create(ctx, dbES)).To(Succeed())
+
+	dbSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-db", Namespace: ns.Name},
+		Data: map[string][]byte{
+			"username": []byte("keystone"),
+			"password": []byte("secret"),
+		},
+	}
+	g.Expect(c.Create(ctx, dbSecret)).To(Succeed())
+
+	adminES := &esov1beta1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-admin", Namespace: ns.Name},
+		Spec: esov1beta1.ExternalSecretSpec{
+			SecretStoreRef: esov1beta1.SecretStoreRef{Kind: "ClusterSecretStore", Name: "openbao"},
+			Target:         esov1beta1.ExternalSecretTarget{Name: "keystone-admin"},
+		},
+	}
+	g.Expect(c.Create(ctx, adminES)).To(Succeed())
+
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-admin", Namespace: ns.Name},
+		Data:       map[string][]byte{"password": []byte("admin-password")},
+	}
+	g.Expect(c.Create(ctx, adminSecret)).To(Succeed())
+
+	// Create the Keystone CR.
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+	key := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}
+
+	// Phase 1: SecretsReady should be False; later conditions absent.
+	waitForCondition(t, ctx, c, key, "SecretsReady", metav1.ConditionFalse, eventuallyTimeout)
+
+	g.Consistently(func(ig Gomega) {
+		ksState := &keystonev1alpha1.Keystone{}
+		ig.Expect(c.Get(ctx, key, ksState)).To(Succeed())
+		ig.Expect(meta.FindStatusCondition(ksState.Status.Conditions, "FernetKeysReady")).To(BeNil(),
+			"FernetKeysReady should be absent when SecretsReady is False")
+		ig.Expect(meta.FindStatusCondition(ksState.Status.Conditions, "DatabaseReady")).To(BeNil(),
+			"DatabaseReady should be absent when SecretsReady is False")
+		ig.Expect(meta.FindStatusCondition(ksState.Status.Conditions, "DeploymentReady")).To(BeNil(),
+			"DeploymentReady should be absent when SecretsReady is False")
+		ig.Expect(meta.FindStatusCondition(ksState.Status.Conditions, "BootstrapReady")).To(BeNil(),
+			"BootstrapReady should be absent when SecretsReady is False")
+	}, 2*time.Second, pollInterval).Should(Succeed())
+
+	// Phase 2: Simulate ESO sync → SecretsReady=True, FernetKeysReady=True.
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c, client.ObjectKey{Namespace: ns.Name, Name: "keystone-db"})).
+		To(Succeed())
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c, client.ObjectKey{Namespace: ns.Name, Name: "keystone-admin"})).
+		To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+	waitForCondition(t, ctx, c, key, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// DatabaseReady should appear as False (DBSyncInProgress).
+	dbCond := waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionFalse, eventuallyTimeout)
+	g.Expect(dbCond.Reason).To(Equal("DBSyncInProgress"), "DatabaseReady reason should be DBSyncInProgress")
+
+	// Phase 3: Simulate db-sync completion → DatabaseReady=True.
+	dbSyncKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-db-sync", ks.Name)}
+	g.Eventually(func() error {
+		return c.Get(ctx, dbSyncKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateJobComplete(ctx, c, dbSyncKey)).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// DeploymentReady should appear as False (WaitingForDeployment).
+	deployCond := waitForCondition(t, ctx, c, key, "DeploymentReady", metav1.ConditionFalse, eventuallyTimeout)
+	g.Expect(deployCond.Reason).To(Equal("WaitingForDeployment"), "DeploymentReady reason should be WaitingForDeployment")
+
+	// Phase 4: Simulate Deployment ready → DeploymentReady=True.
+	deployKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-api", ks.Name)}
+	deploy := &appsv1.Deployment{}
+	g.Eventually(func() error {
+		return c.Get(ctx, deployKey, deploy)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, ptr.Deref(deploy.Spec.Replicas, 1))).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// BootstrapReady should appear as False (BootstrapInProgress).
+	bootstrapCond := waitForCondition(t, ctx, c, key, "BootstrapReady", metav1.ConditionFalse, eventuallyTimeout)
+	g.Expect(bootstrapCond.Reason).To(Equal("BootstrapInProgress"), "BootstrapReady reason should be BootstrapInProgress")
+
+	// Ready should NOT be True while BootstrapReady is False. Using
+	// meta.IsStatusConditionTrue handles both the nil case (condition absent)
+	// and the present-but-False case unconditionally (CC-0014).
+	g.Consistently(func(ig Gomega) {
+		ksState := &keystonev1alpha1.Keystone{}
+		ig.Expect(c.Get(ctx, key, ksState)).To(Succeed())
+		ig.Expect(meta.IsStatusConditionTrue(ksState.Status.Conditions, "Ready")).To(BeFalse(),
+			"Ready condition should not be True while BootstrapReady is False")
+	}, 2*time.Second, pollInterval).Should(Succeed())
+
+	// Phase 5: Simulate bootstrap completion → BootstrapReady=True, Ready=True.
+	bootstrapKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-bootstrap", ks.Name)}
+	g.Eventually(func() error {
+		return c.Get(ctx, bootstrapKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateJobComplete(ctx, c, bootstrapKey)).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "BootstrapReady", metav1.ConditionTrue, eventuallyTimeout)
+	readyFinal := waitForCondition(t, ctx, c, key, "Ready", metav1.ConditionTrue, eventuallyTimeout)
+	g.Expect(readyFinal.Reason).To(Equal("AllReady"))
+}
+
+// --- Task 2.3: Resource creation, status endpoint, and observed generation tests (REQ-005, REQ-006, REQ-007) ---
+
+func TestIntegration_ResourceCreation(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-resources-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+	// Verify all child resources exist (REQ-005).
+
+	// Deployment.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-api"}, &appsv1.Deployment{})).
+		To(Succeed(), "Deployment test-keystone-api should exist")
+
+	// Service.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-api"}, &corev1.Service{})).
+		To(Succeed(), "Service test-keystone-api should exist")
+
+	// ConfigMap (immutable, hashed name: test-keystone-config-{hash}).
+	configMaps := &corev1.ConfigMapList{}
+	g.Expect(c.List(ctx, configMaps, client.InNamespace(ns.Name))).To(Succeed())
+	var matchingCMs []corev1.ConfigMap
+	for _, cm := range configMaps.Items {
+		if strings.HasPrefix(cm.Name, "test-keystone-config-") {
+			matchingCMs = append(matchingCMs, cm)
+		}
+	}
+	g.Expect(matchingCMs).To(HaveLen(1), "expected exactly one immutable ConfigMap with prefix test-keystone-config-")
+	g.Expect(matchingCMs[0].Immutable).NotTo(BeNil(), "ConfigMap should be immutable")
+	g.Expect(*matchingCMs[0].Immutable).To(BeTrue(), "ConfigMap should be immutable")
+
+	// Jobs.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-db-sync"}, &batchv1.Job{})).
+		To(Succeed(), "Job test-keystone-db-sync should exist")
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-bootstrap"}, &batchv1.Job{})).
+		To(Succeed(), "Job test-keystone-bootstrap should exist")
+
+	// CronJob.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-rotate"}, &batchv1.CronJob{})).
+		To(Succeed(), "CronJob test-keystone-fernet-rotate should exist")
+
+	// Secret (fernet keys).
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-keys"}, &corev1.Secret{})).
+		To(Succeed(), "Secret test-keystone-fernet-keys should exist")
+
+	// RBAC resources.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-rotate"}, &corev1.ServiceAccount{})).
+		To(Succeed(), "ServiceAccount test-keystone-fernet-rotate should exist")
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-rotate"}, &rbacv1.Role{})).
+		To(Succeed(), "Role test-keystone-fernet-rotate should exist")
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-rotate"}, &rbacv1.RoleBinding{})).
+		To(Succeed(), "RoleBinding test-keystone-fernet-rotate should exist")
+
+	// PushSecret.
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-keys-backup"}, &esov1alpha1.PushSecret{})).
+		To(Succeed(), "PushSecret test-keystone-fernet-keys-backup should exist")
+}
+
+func TestIntegration_StatusEndpoint(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-endpoint-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+	// Verify status.endpoint (REQ-006).
+	updated := &keystonev1alpha1.Keystone{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: ks.Name, Namespace: ns.Name}, updated)).To(Succeed())
+
+	expectedEndpoint := fmt.Sprintf("http://%s-api.%s.svc.cluster.local:5000/v3", ks.Name, ns.Name)
+	g.Expect(updated.Status.Endpoint).To(Equal(expectedEndpoint), "status.endpoint should match expected format")
+}
+
+func TestIntegration_ObservedGeneration(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-obsgen-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+	// Verify ObservedGeneration on all conditions (REQ-007).
+	updated := &keystonev1alpha1.Keystone{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: ks.Name, Namespace: ns.Name}, updated)).To(Succeed())
+
+	for _, cond := range updated.Status.Conditions {
+		g.Expect(cond.ObservedGeneration).To(Equal(updated.Generation),
+			"condition %s ObservedGeneration should match CR generation", cond.Type)
+	}
+}
+
+// --- Task 2.4: Full reconcile managed mode test (REQ-004) ---
+
+func TestIntegration_FullReconcile_Managed(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-managed-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	// Create prerequisites (same as brownfield — secrets are still needed).
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	// Create managed-mode Keystone CR (uses spec.database.clusterRef).
+	ks := integrationManagedKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	key := types.NamespacedName{Name: ks.Name, Namespace: ns.Name}
+
+	// Wait for SecretsReady=True.
+	waitForCondition(t, ctx, c, key, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for FernetKeysReady=True.
+	waitForCondition(t, ctx, c, key, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// In managed mode, the reconciler creates MariaDB CRs sequentially:
+	// Database first, then User and Grant only after Database is ready.
+
+	// Wait for Database CR to appear and verify DatabaseReady=False.
+	dbKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name}
+	g.Eventually(func() error {
+		return c.Get(ctx, dbKey, &mariadbv1alpha1.Database{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "MariaDB Database CR should appear")
+
+	dbReadyCond := waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionFalse, eventuallyTimeout)
+	g.Expect(dbReadyCond.Reason).To(Equal("WaitingForDatabase"))
+
+	// Simulate Database ready — this unblocks User/Grant creation.
+	g.Expect(simulators.SimulateDatabaseReady(ctx, c, dbKey)).To(Succeed(), "simulate Database ready")
+
+	// The controller does not watch MariaDB types, so it relies on
+	// RequeueAfter (30s) to discover readiness changes. The reconciler
+	// creates User only after Database is ready, and Grant only after
+	// User is ready, so we must simulate each sequentially.
+
+	// Wait for User CR to appear, then simulate User ready.
+	userKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name}
+	g.Eventually(func() error {
+		return c.Get(ctx, userKey, &mariadbv1alpha1.User{})
+	}, eventuallyLongTimeout, pollInterval).Should(Succeed(), "MariaDB User CR should appear")
+	g.Expect(simulators.SimulateUserReady(ctx, c, userKey)).To(Succeed(), "simulate User ready")
+
+	// Wait for Grant CR to appear (created after User is ready), then simulate Grant ready.
+	grantKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name}
+	g.Eventually(func() error {
+		return c.Get(ctx, grantKey, &mariadbv1alpha1.Grant{})
+	}, eventuallyLongTimeout, pollInterval).Should(Succeed(), "MariaDB Grant CR should appear")
+	g.Expect(simulators.SimulateGrantReady(ctx, c, grantKey)).To(Succeed(), "simulate Grant ready")
+
+	// Wait for the db-sync Job to appear and simulate its completion.
+	dbSyncKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-db-sync", ks.Name)}
+	g.Eventually(func() error {
+		return c.Get(ctx, dbSyncKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "db-sync Job should appear")
+	g.Expect(simulators.SimulateJobComplete(ctx, c, dbSyncKey)).To(Succeed())
+
+	// Wait for DatabaseReady=True.
+	waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for Deployment and simulate readiness.
+	deployKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-api", ks.Name)}
+	deploy := &appsv1.Deployment{}
+	g.Eventually(func() error {
+		return c.Get(ctx, deployKey, deploy)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, ptr.Deref(deploy.Spec.Replicas, 1))).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Wait for bootstrap Job and simulate completion.
+	bootstrapKey := client.ObjectKey{Namespace: ns.Name, Name: fmt.Sprintf("%s-bootstrap", ks.Name)}
+	g.Eventually(func() error {
+		return c.Get(ctx, bootstrapKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateJobComplete(ctx, c, bootstrapKey)).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "BootstrapReady", metav1.ConditionTrue, eventuallyTimeout)
+	waitForCondition(t, ctx, c, key, "Ready", metav1.ConditionTrue, eventuallyTimeout)
+
+	// Fetch final state and verify.
+	updated := &keystonev1alpha1.Keystone{}
+	g.Expect(c.Get(ctx, key, updated)).To(Succeed())
+
+	// All 6 conditions should be True.
+	for _, condType := range []string{"SecretsReady", "FernetKeysReady", "DatabaseReady", "DeploymentReady", "BootstrapReady", "Ready"} {
+		cond := meta.FindStatusCondition(updated.Status.Conditions, condType)
+		g.Expect(cond).NotTo(BeNil(), "condition %s should exist", condType)
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "condition %s should be True", condType)
+	}
+
+	// Ready reason should be AllReady.
+	readyCond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	g.Expect(readyCond.Reason).To(Equal("AllReady"))
+
+	// Status endpoint should be set.
+	expectedEndpoint := fmt.Sprintf("http://%s-api.%s.svc.cluster.local:5000/v3", ks.Name, ns.Name)
+	g.Expect(updated.Status.Endpoint).To(Equal(expectedEndpoint))
+
+	// Verify MariaDB CRs still exist with correct names.
+	g.Expect(c.Get(ctx, dbKey, &mariadbv1alpha1.Database{})).To(Succeed(), "MariaDB Database CR should still exist")
+	g.Expect(c.Get(ctx, userKey, &mariadbv1alpha1.User{})).To(Succeed(), "MariaDB User CR should still exist")
+	g.Expect(c.Get(ctx, grantKey, &mariadbv1alpha1.Grant{})).To(Succeed(), "MariaDB Grant CR should still exist")
+}

--- a/operators/keystone/internal/testutil/envtest_setup.go
+++ b/operators/keystone/internal/testutil/envtest_setup.go
@@ -10,11 +10,16 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	esov1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -191,4 +196,165 @@ func buildScheme(addToScheme func(*k8sruntime.Scheme) error) *k8sruntime.Scheme 
 	utilruntime.Must(apiextensionsv1.AddToScheme(s))
 	utilruntime.Must(addToScheme(s))
 	return s
+}
+
+// commonFakeCRDsDirs returns absolute paths to the fake CRD directories
+// in the shared test infrastructure. Resolved relative to this source file
+// using runtime.Caller(0) (CC-0014, REQ-002).
+func commonFakeCRDsDirs() []string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("testutil: runtime.Caller failed to determine source file path")
+	}
+	// Navigate from operators/keystone/internal/testutil/ → repo root → internal/common/testutil/fake_crds/
+	base := filepath.Dir(thisFile)
+	root := filepath.Join(base, "..", "..", "..", "..", "internal", "common", "testutil", "fake_crds")
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		panic(fmt.Sprintf("testutil: failed to read fake_crds directory %s: %v", root, err))
+	}
+
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(root, e.Name()))
+		}
+	}
+	if len(dirs) == 0 {
+		panic(fmt.Sprintf("testutil: no subdirectories found in fake_crds directory %s", root))
+	}
+	return dirs
+}
+
+// buildControllerScheme creates a runtime.Scheme that includes all types
+// needed by the KeystoneReconciler: Keystone API types, core K8s types,
+// and all external operator types (MariaDB, ESO, cert-manager).
+// It is created fresh per test (CC-0014, REQ-002).
+func buildControllerScheme(addToScheme func(*k8sruntime.Scheme) error) *k8sruntime.Scheme {
+	s := k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	// External operator types needed by the reconciler.
+	utilruntime.Must(mariadbv1alpha1.AddToScheme(s))
+	utilruntime.Must(esov1beta1.AddToScheme(s))
+	utilruntime.Must(esov1alpha1.AddToScheme(s))
+	utilruntime.Must(certmanagerv1.AddToScheme(s))
+	// Keystone types.
+	utilruntime.Must(addToScheme(s))
+	return s
+}
+
+// SetupKeystoneEnvTestWithController starts an envtest API server with the
+// Keystone CRD, webhook configurations, fake CRDs for external operators
+// (MariaDB, ESO, cert-manager), and a controller-runtime Manager running the
+// KeystoneReconciler. It returns a direct (non-caching) client, a context,
+// and its cancel function. The environment is torn down automatically via
+// t.Cleanup() (CC-0014, REQ-002).
+//
+// Parameters:
+//   - addToScheme registers the Keystone API types with the runtime scheme.
+//   - registerWebhooks sets up webhook handlers with the manager.
+//   - registerController registers the KeystoneReconciler via SetupWithManager.
+func SetupKeystoneEnvTestWithController(
+	t testing.TB,
+	addToScheme func(*k8sruntime.Scheme) error,
+	registerWebhooks func(ctrl.Manager) error,
+	registerController func(ctrl.Manager) error,
+) (client.Client, context.Context, context.CancelFunc) {
+	t.Helper()
+
+	crdDir, webhookDir := keystonePaths()
+
+	// Combine Keystone CRD dir with common fake CRD dirs.
+	crdDirs := append([]string{crdDir}, commonFakeCRDsDirs()...)
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     crdDirs,
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{webhookDir},
+		},
+	}
+
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start Keystone envtest environment: %v", err)
+	}
+
+	s := buildControllerScheme(addToScheme)
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: s,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    env.WebhookInstallOptions.LocalServingHost,
+			Port:    env.WebhookInstallOptions.LocalServingPort,
+			CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+		}),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
+		}
+		t.Fatalf("failed to create controller-runtime manager: %v", err)
+	}
+
+	if err := registerWebhooks(mgr); err != nil {
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
+		}
+		t.Fatalf("failed to register Keystone webhooks: %v", err)
+	}
+
+	if err := registerController(mgr); err != nil {
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
+		}
+		t.Fatalf("failed to register Keystone controller: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mgrStopped := make(chan struct{})
+	go func() {
+		defer close(mgrStopped)
+		if err := mgr.Start(ctx); err != nil {
+			t.Errorf("manager exited with error: %v", err)
+		}
+	}()
+
+	if err := waitForWebhookServer(
+		env.WebhookInstallOptions.LocalServingHost,
+		env.WebhookInstallOptions.LocalServingPort,
+		10*time.Second,
+	); err != nil {
+		cancel()
+		<-mgrStopped
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
+		}
+		t.Fatalf("webhook server did not become ready: %v", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: s})
+	if err != nil {
+		cancel()
+		<-mgrStopped
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
+		}
+		t.Fatalf("failed to create direct client: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		<-mgrStopped
+		if err := env.Stop(); err != nil {
+			t.Errorf("failed to stop Keystone envtest environment: %v", err)
+		}
+	})
+
+	return c, ctx, cancel
 }


### PR DESCRIPTION
**Size:** 🏗️ large
**Category:** backend
**Priority:** high
**Feature ID:** CC-0014 (S014 in PLAN.md)

## Summary

Add envtest integration tests (CC-0014) for the Keystone reconciler exercising the full reconciliation loop against a real API server with etcd. Tests create prerequisite Secrets simulating ESO sync, create a Keystone CR, then drive condition progression through SecretsReady → FernetKeysReady → (ConfigMap created) → DatabaseReady → DeploymentReady → BootstrapReady → Ready by simulating external dependencies (MariaDB readiness, Job completion, Deployment availability). They verify correct creation of all child resources (Deployment, Service, ConfigMap, Jobs, CronJob, Secret, RBAC, PushSecret) and that `status.endpoint` and `status.conditions` (including ObservedGeneration) are populated correctly. Both brownfield and managed database modes are covered.

## Scope

**Included:**
- New integration test file `operators/keystone/internal/controller/integration_test.go` with `//go:build integration` tag
- Full reconciliation loop test (brownfield mode): create prereqs → create CR → manager-driven reconcile → verify all 6 conditions reach True
- Full reconciliation loop test (managed mode): same flow but with `spec.database.clusterRef` + MariaDB CR simulation via `SimulateDatabaseReady`, `SimulateUserReady`, `SimulateGrantReady`
- Condition progression test: verify each sub-condition transitions False→True in reconciliation order, later conditions remain absent/False until predecessors are satisfied
- Resource creation verification: assert Deployment (`{name}-api`), Service (`{name}-api`), ConfigMap (immutable, `{name}-config-{hash}`), Jobs (`{name}-db-sync`, `{name}-bootstrap`), CronJob (`{name}-fernet-rotate`), Secret (`{name}-fernet-keys`), ServiceAccount (`{name}-fernet-rotate`), Role (`{name}-fernet-rotate`), RoleBinding (`{name}-fernet-rotate`), PushSecret (`{name}-fernet-keys-backup`) exist after full reconciliation
- Status field verification: `status.endpoint` matches `http://{name}-api.{namespace}.svc.cluster.local:5000/v3`, `status.conditions` ObservedGeneration matches CR Generation
- `SimulateDeploymentReady` function in shared simulators package (`internal/common/testutil/simulators/simulators.go`)
- New `SetupKeystoneEnvTestWithController` helper in `operators/keystone/internal/testutil/envtest_setup.go` that registers the `KeystoneReconciler` via `SetupWithManager` alongside CRDs and webhooks; must also install fake CRDs for MariaDB, ESO, and cert-manager types from the common envtest `fake_crds/` directory and register them in the scheme (via `SharedScheme()` or equivalent)
- Build tag `integration` consistent with existing CC-0012 tests

**Excluded:**
- Webhook defaulting/validation testing (already covered by CC-0012 — YAGNI)
- Error injection / fault tolerance tests (separate feature, not requested)
- Chainsaw E2E tests (deferred to Phase 7 per PLAN.md)
- Federation, middleware, plugin, or policyOverrides paths (not part of core reconciliation loop, no current requirement)
- Performance / stress testing (YAGNI)
- Deletion / finalizer testing (not implemented in the reconciler, YAGNI)
- `test-integration` Makefile target wiring (currently a stub, separate infrastructure concern)

## Visualization

```mermaid
sequenceDiagram
    participant T as Test
    participant API as envtest API Server
    participant R as Keystone Reconciler
    participant S as Simulators

    T->>API: Create Namespace
    T->>API: Create ExternalSecrets
    T->>API: Create Secrets (DB creds, admin creds)
    S->>API: SimulateExternalSecretSync
    T->>API: Create Keystone CR
    Note over R: Manager triggers reconcile
    R->>API: Check ExternalSecret + Secret
    R->>API: Set SecretsReady=True
    R->>API: Create Fernet Keys Secret
    R->>API: Create SA, Role, RoleBinding
    R->>API: Create CronJob, PushSecret
    R->>API: Set FernetKeysReady=True
    R->>API: Create ConfigMap (immutable, hashed)
    R->>API: Create db-sync Job
    R->>API: Set DatabaseReady=False (DBSyncInProgress)
    S->>API: SimulateJobComplete (db-sync)
    Note over R: Requeue triggers reconcile
    R->>API: Set DatabaseReady=True
    R->>API: Create Deployment + Service
    R->>API: Set DeploymentReady=False
    S->>API: SimulateDeploymentReady
    Note over R: Requeue triggers reconcile
    R->>API: Set DeploymentReady=True, status.endpoint
    R->>API: Create bootstrap Job
    R->>API: Set BootstrapReady=False
    S->>API: SimulateJobComplete (bootstrap)
    Note over R: Requeue triggers reconcile
    R->>API: Set BootstrapReady=True
    R->>API: Set Ready=True (AllReady)
    T->>API: Verify all conditions, resources, status
```

```mermaid
stateDiagram-v2
    [*] --> SecretsReady: ESO Secrets exist
    SecretsReady --> FernetKeysReady: Fernet Secret + RBAC + CronJob + PushSecret created
    FernetKeysReady --> DatabaseReady: ConfigMap created, db-sync Job completes
    DatabaseReady --> DeploymentReady: Deployment + Service created, pods available
    DeploymentReady --> BootstrapReady: Bootstrap Job completes
    BootstrapReady --> Ready: AllTrue aggregation
    Ready --> [*]
```

```mermaid
flowchart TD
    subgraph TestFile["integration_test.go"]
        TFL["TestIntegration_FullReconcile_Brownfield"]
        TFM["TestIntegration_FullReconcile_Managed"]
        TCP["TestIntegration_ConditionProgression"]
        TRC["TestIntegration_ResourceCreation"]
        TSE["TestIntegration_StatusEndpoint"]
        TOG["TestIntegration_ObservedGeneration"]
    end
    subgraph Helpers["testutil/envtest_setup.go"]
        SK["SetupKeystoneEnvTestWithController (new)"]
        SE2["SetupKeystoneEnvTest (unchanged)"]
    end
    subgraph Simulators["simulators/simulators.go"]
        SD["SimulateDeploymentReady (new)"]
        SE["SimulateExternalSecretSync"]
        SJ["SimulateJobComplete"]
        SDB["SimulateDatabaseReady"]
        SU["SimulateUserReady"]
        SG["SimulateGrantReady"]
    end
    TestFile --> SK
    TestFile --> Simulators
```

## Key Components

- **`operators/keystone/internal/controller/integration_test.go`** (new): Main test file with `//go:build integration` tag. Contains 6 test functions using `testing.T` + gomega (dot-imported), consistent with CC-0012 patterns. Each test calls `testutil.SkipIfEnvTestUnavailable(t)`, creates an isolated namespace, uses `gomega.Eventually` for polling condition progression. Brownfield test uses `spec.database.host`; managed test uses `spec.database.clusterRef` and exercises MariaDB CR creation + simulation.
- **`operators/keystone/internal/testutil/envtest_setup.go`** (modified): New `SetupKeystoneEnvTestWithController(t, addToScheme, registerWebhooks, registerController)` function that extends envtest setup to also register the `KeystoneReconciler` via `SetupWithManager`. Must install additional fake CRDs (MariaDB Database/User/Grant, ESO ExternalSecret/PushSecret) alongside the Keystone CRD, and register their types in the scheme. Existing `SetupKeystoneEnvTest` remains unchanged — CC-0012 webhook tests are unaffected.
- **`internal/common/testutil/simulators/simulators.go`** (modified): New `SimulateDeploymentReady(ctx, c, key, replicas)` function that sets `status.conditions[Available]=True`, `status.readyReplicas`, and `status.observedGeneration` on an existing Deployment. Follows the established typed-resource simulator pattern (like `SimulateMariaDBReady`).
- **Existing simulators** (unchanged, consumed): `SimulateExternalSecretSync`, `SimulateJobComplete`, `SimulateDatabaseReady`, `SimulateUserReady`, `SimulateGrantReady` — simulate external controller behavior in envtest where those controllers don't run.
- **Existing `builders.SecretBuilder`** (unchanged, consumed): Used to construct prerequisite DB credentials Secret (keys: `username`, `password`) and admin credentials Secret (key: `password`).