### PR TITLE
feat(CC-0015): G001: Implement Keystone dependency details

### DIFF
--- a/.planwerk/completed/CC-0015-g001-implement-keystone-dependency-details.json
+++ b/.planwerk/completed/CC-0015-g001-implement-keystone-dependency-details.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0015",
   "title": "G001: Implement Keystone dependency details",
   "slug": "g001-implement-keystone-dependency-details",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "**Size:** 🔨 medium\n**Category:** backend\n**Priority:** high\n**Feature ID:** CC-0015 (S015)\n\n## Summary\n\nS015 completes the detailed dependency interactions for the Keystone reconciler. The core logic — DB connection string assembly (managed/brownfield), memcached server list discovery, Fernet rotation CronJob with writable Secret mount and maxActiveKeys enforcement, and bootstrap Job with admin credentials — was implemented in CC-0013. The remaining gaps are: (1) **Deployment rolling restart mechanism after Fernet key rotation** via a hash-based pod template annotation, (2) **standalone table-driven unit tests** for the pure helper functions (`resolveDatabaseHost`, `dbPort`, `resolveCacheServers`), and (3) **envtest integration tests** verifying CronJob and Job detailed specs.\n\n## Scope\n\n**Included:**\n- Fernet keys hash annotation on Deployment pod template (`keystone.c5c3.io/fernet-keys-hash`) — computed from the `{name}-fernet-keys` Secret data, set on `spec.template.metadata.annotations` in `buildKeystoneDeployment()` (currently has no annotations at line 87-89 of `reconcile_deployment.go`). The existing `secretToKeystoneMapper` watch already triggers reconcile on fernet-keys Secret changes (via UID ownership check at `keystone_controller.go:160-182`).\n- Table-driven unit tests for `resolveDatabaseHost()` — managed mode (`{clusterRef.name}.{ns}.svc:{port}`), brownfield (`{host}:{port}`), port fallback to 3306\n- Table-driven unit tests for `dbPort()` — explicit port, zero/default fallback to 3306\n- Table-driven unit tests for `resolveCacheServers()` — managed mode pod DNS pattern (`memcached-{i}.{name}:11211`), brownfield explicit list join, replicas=0 fallback to 3, nil ClusterRef + empty Servers returning `\"\"`\n- Envtest integration test verifying CronJob detailed spec: schedule, init container `copy-keys`, emptyDir volume, `fernet-keys-src` Secret volume, ServiceAccount `{name}-fernet-rotate`, `OS_fernet_tokens__max_active_keys` env var, image tag\n- Envtest integration test verifying bootstrap Job detailed spec: `keystone-manage bootstrap` command/args, admin-credentials env from SecretKeyRef, `backoffLimit: 4`, `ttlSecondsAfterFinished: 300`, config volume mount\n\n**Excluded:**\n- Refactoring existing sub-reconcilers (complete from CC-0013, YAGNI)\n- Fernet key rotation E2E tests (covered by CC-0016 Chainsaw suite)\n- Credential-keys volume mount management (noted as deferred in `reconcile_deployment.go:160`, separate feature)\n- MariaDB CR status field resolution (current implementation uses service DNS `{name}.{ns}.svc`, which is the correct K8s pattern)\n- ConfigMap hash annotation (already handled by content-hash ConfigMap naming in `reconcileConfig`)\n\n## Visualization\n\n```mermaid\nflowchart TD\n    subgraph FernetRotation[\"Fernet Key Rotation Flow\"]\n        CJ[\"CronJob: fernet-rotate\"]\n        IC[\"Init Container: copy keys to emptyDir\"]\n        MC[\"Main Container: keystone-manage fernet_rotate\"]\n        PY[\"Python script: PATCH Secret via K8s API\"]\n        SEC[\"Secret: fernet-keys\"]\n        WATCH[\"secretToKeystoneMapper triggers reconcile\"]\n        REC[\"Reconciler: compute fernet-keys hash\"]\n        ANN[\"Deployment pod template annotation update\"]\n        ROLL[\"Rolling restart of Keystone pods\"]\n    end\n\n    CJ --> IC\n    IC --> MC\n    MC --> PY\n    PY -->|\"PATCH\"| SEC\n    SEC -->|\"ownership UID match\"| WATCH\n    WATCH --> REC\n    REC -->|\"hash changed\"| ANN\n    ANN --> ROLL\n\n    subgraph DBResolution[\"DB Connection String Assembly\"]\n        MANAGED_DB[\"Managed: ClusterRef set\"]\n        BROWN_DB[\"Brownfield: Host set\"]\n        DNS[\"Service DNS: name.ns.svc:port\"]\n        EXPLICIT[\"Explicit: host:port\"]\n        CONN[\"mysql+pymysql://user:pass@host:port/db\"]\n    end\n\n    MANAGED_DB --> DNS --> CONN\n    BROWN_DB --> EXPLICIT --> CONN\n\n    subgraph CacheResolution[\"Memcached Server Discovery\"]\n        MANAGED_MC[\"Managed: ClusterRef set\"]\n        BROWN_MC[\"Brownfield: Servers list\"]\n        POD_DNS[\"Pod DNS: memcached-i.name:11211\"]\n        EXPLICIT_MC[\"Explicit server list\"]\n        SERVERS[\"Comma-joined server string\"]\n    end\n\n    MANAGED_MC --> POD_DNS --> SERVERS\n    BROWN_MC --> EXPLICIT_MC --> SERVERS\n```\n\n```mermaid\nsequenceDiagram\n    participant CJ as Fernet CronJob\n    participant K8S as K8s API\n    participant SEC as fernet-keys Secret\n    participant REC as Keystone Reconciler\n    participant DEP as Keystone Deployment\n\n    CJ->>CJ: Init: copy Secret keys to emptyDir\n    CJ->>CJ: keystone-manage fernet_rotate\n    CJ->>K8S: PATCH Secret with rotated keys\n    K8S->>SEC: Update Secret data\n    SEC-->>REC: secretToKeystoneMapper watch fires\n    REC->>SEC: Read Secret data, compute SHA-256 hash\n    REC->>DEP: Set pod template annotation with new hash\n    DEP-->>DEP: Rolling restart with new Fernet keys\n```\n\n## Key Components\n\n- **`resolveDatabaseHost()`** (`reconcile_config.go:177`): Pure function resolving DB host — managed mode constructs `{clusterRef.name}.{ns}.svc:{port}`, brownfield uses explicit `{host}:{port}`. Implemented; needs standalone table-driven unit tests.\n- **`dbPort()`** (`reconcile_config.go:188`): Pure function returning port with 3306 default fallback. Implemented; needs edge case unit tests (zero value, explicit value).\n- **`resolveCacheServers()`** (`reconcile_config.go:155`): Pure function constructing memcached endpoint list — managed mode generates `memcached-{i}.{name}:11211` for `replicas` count (default 3), brownfield joins explicit `Servers` list. Implemented; needs standalone table-driven unit tests.\n- **Fernet keys hash annotation** (NEW in `reconcile_deployment.go`): Compute SHA-256 of the `{name}-fernet-keys` Secret data, set as `keystone.c5c3.io/fernet-keys-hash` annotation on `spec.template.metadata.annotations` in `buildKeystoneDeployment()`. Requires `reconcileDeployment()` to read the fernet-keys Secret and pass the hash. This is the missing piece — `buildKeystoneDeployment()` currently sets no pod template annotations (line 87-89).\n- **`fernetRotationCronJob()`** (`reconcile_fernet.go:218`): Complete CronJob spec with init container, emptyDir, `OS_fernet_tokens__max_active_keys` env var, ServiceAccount. Implemented; needs envtest test verifying detailed spec fields.\n- **`buildBootstrapJob()`** (`reconcile_bootstrap.go:69`): Complete Job spec with `backoffLimit: 4`, `ttlSecondsAfterFinished: 300`, admin-credentials env from SecretKeyRef, config ConfigMap volume mount. Implemented; needs envtest test verifying detailed spec fields.",
   "stories": [
@@ -294,6 +294,7 @@
       "description": "Modify `buildKeystoneDeployment()` in `reconcile_deployment.go` to accept a `fernetKeysHash string` parameter and set annotation `keystone.c5c3.io/fernet-keys-hash` on `spec.template.metadata.annotations`. Add a `fernetKeysHash()` helper function that reads the `{name}-fernet-keys` Secret, JSON-marshals the `.Data` map, and computes SHA-256 hex (following the pattern in `internal/common/job/job.go:PodSpecHash()`). Modify `reconcileDeployment()` to call `fernetKeysHash()` and pass the result to `buildKeystoneDeployment()`. If the Secret does not exist, pass an empty string. Update existing unit tests in `reconcile_deployment_test.go` to pass the new parameter and verify the annotation is present with a valid 64-char hex value.",
       "level": 1,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-001",
         "REQ-002",
@@ -306,6 +307,7 @@
       "description": "Add table-driven tests to `reconcile_config_test.go` for `resolveDatabaseHost()` and `dbPort()`. Test cases for `resolveDatabaseHost()`: managed mode with default port (ClusterRef={Name:mariadb}, Port=0 → mariadb.default.svc:3306), managed mode with explicit port (Port=3307 → mariadb.default.svc:3307), brownfield with explicit port (Host=db.example.com, Port=3306 → db.example.com:3306), brownfield with default port (Host=db.example.com, Port=0 → db.example.com:3306). Test cases for `dbPort()`: explicit port (3307 → 3307), zero port (0 → 3306). Follow existing table-driven test pattern from `internal/common/config/config_test.go` using `NewGomegaWithT(t)` and `t.Run()`.",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-003",
         "REQ-004"
@@ -317,6 +319,7 @@
       "description": "Add table-driven tests to `reconcile_config_test.go` for `resolveCacheServers()`. Test cases: brownfield with multiple servers ([mc-0:11211, mc-1:11211] → mc-0:11211,mc-1:11211), brownfield with single server ([mc:11211] → mc:11211), managed mode with default replicas (ClusterRef={Name:memcached}, Replicas=0 → memcached-0.memcached:11211,memcached-1.memcached:11211,memcached-2.memcached:11211), managed mode with custom replicas (Replicas=5 → 5 endpoints), neither ClusterRef nor Servers (→ empty string), managed mode with Replicas=1 (→ single endpoint). Follow table-driven pattern with `NewGomegaWithT(t)` and `t.Run()`.",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-005"
       ]
@@ -327,6 +330,7 @@
       "description": "Add `TestIntegration_CronJobDetailedSpec` to `integration_test.go`. The test creates a brownfield Keystone CR using `integrationBrownfieldKeystone()`, calls `createPrerequisites()`, drives full reconciliation via `driveFullReconciliation()`, then fetches the `{name}-fernet-rotate` CronJob and verifies: (1) schedule matches spec.fernet.rotationSchedule, (2) init container name=copy-keys with correct image and copy command, (3) init container has fernet-keys-src (ReadOnly) and fernet-keys volume mounts, (4) main container name=fernet-rotate with correct image and fernetRotateScript command, (5) env vars: SECRET_NAME={name}-fernet-keys, SECRET_NAMESPACE from fieldRef, OS_fernet_tokens__max_active_keys=3, (6) ServiceAccountName={name}-fernet-rotate, (7) volumes: fernet-keys-src (Secret) and fernet-keys (emptyDir). Follow existing envtest test pattern.",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-006"
       ]
@@ -337,6 +341,7 @@
       "description": "Add `TestIntegration_BootstrapJobDetailedSpec` to `integration_test.go`. The test creates a brownfield Keystone CR, drives full reconciliation (but does NOT simulate bootstrap Job completion so the Job still exists), fetches the `{name}-bootstrap` Job and verifies: (1) container command=[keystone-manage, bootstrap], (2) args include --bootstrap-password $(BOOTSTRAP_PASSWORD), --bootstrap-admin-url, --bootstrap-internal-url, --bootstrap-public-url, --bootstrap-region-id RegionOne, (3) BOOTSTRAP_PASSWORD env from SecretKeyRef with name=keystone-admin and key=password, (4) backoffLimit=4, (5) ttlSecondsAfterFinished=300, (6) config volume mount at /etc/keystone/keystone.conf.d/ (ReadOnly), (7) config volume source is ConfigMap with name prefix {name}-config-. Use a modified `driveFullReconciliation` approach that stops before simulating bootstrap Job completion.",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-007"
       ]
@@ -347,6 +352,7 @@
       "description": "Update `docs/reference/keystone-reconciler.md` in the reconcileDeployment section to document the new `keystone.c5c3.io/fernet-keys-hash` annotation on the Deployment pod template. Add a row to the Deployment Spec table for the annotation. Add a brief explanation in the reconcileDeployment section describing the rolling restart mechanism triggered by fernet-keys Secret changes. Reference CC-0015.",
       "level": 3,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-001"
       ]
@@ -450,6 +456,188 @@
       "story": "Keystone pods restart automatically after Fernet key rotation",
       "expected": "When fernet-keys Secret does not exist, returns empty string without error",
       "requirement_id": "REQ-002"
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_BasicManagedDatabaseAndCache",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_BrownfieldDatabase",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_SpecialCharactersInCredentialsAreURLEncoded",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_BrownfieldCache",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_ManagedCacheCustomReplicas",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_PluginConfig",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_ExtraConfigOverridesDefaults",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_PolicyOverridesInlineRules",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_PolicyOverridesConfigMapRef",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_Middleware",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_ConfigMapNameContainsContentHash",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_config_test.go",
+      "test_function": "TestReconcileConfig_ImmutableConfigMapWithOwnerReference",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_DeploymentAndServiceCreated",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_NotReady_Requeues",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_Ready_SetsEndpoint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_OwnerReferences",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_DeploymentSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_NotReady_ConditionMessageAndGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_Ready_ConditionMessageAndGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_deployment_test.go",
+      "test_function": "TestReconcileDeployment_ServiceCreatedAlongsideDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FullReconcile_Brownfield",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ConditionProgression",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ResourceCreation",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_StatusEndpoint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ObservedGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FullReconcile_Managed",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
     }
   ],
   "affected_files": [],
@@ -481,8 +669,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-03-16T12:57:41.162085"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-16T13:05:29.422140"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-03-17T19:42:36.294780"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/69",
+  "pr_number": 69,
   "execution_history": [
     {
       "run_id": "c0f243ab-4761-4b19-856d-eba53082c14e",
@@ -494,6 +692,64 @@
           "name": "prepare",
           "duration": 301.5310924053192,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "00373997-b837-418c-8b5d-b37addd66f17",
+      "timestamp": "2026-03-16T13:31:57.377882",
+      "total_duration": 1452.5937285423279,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (3 tasks)",
+          "duration": 427.1136112213135,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (2 tasks)",
+          "duration": 522.9120953083038,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (1 tasks)",
+          "duration": 116.40766072273254,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0015] Code Review",
+          "duration": 209.22086548805237,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0015] Improvements",
+          "duration": 66.91467881202698,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0015] Simplify",
+          "duration": 110.02481698989868,
+          "type": "simplify",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "6a428574-4c2a-49ab-82e9-e2988cb9ba10",
+      "timestamp": "2026-03-17T10:53:58.902957",
+      "total_duration": 426.74178433418274,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #1",
+          "duration": 426.74178433418274,
+          "type": "review_address",
           "status": "done"
         }
       ]

--- a/.planwerk/review_patterns/do-not-swallow-errors-by-returning-zero-values-with-nil-error.md
+++ b/.planwerk/review_patterns/do-not-swallow-errors-by-returning-zero-values-with-nil-error.md
@@ -1,0 +1,21 @@
+# Review Pattern: Do not swallow errors by returning zero-values with nil error
+
+**Review-Area**: error-handling
+**Detection-Hint**: Look for error-handling branches that discard a non-nil error and return a zero-value (empty string, nil, 0) paired with a nil error. Especially watch for IsNotFound or similar sentinel-error checks that silently convert a meaningful error into a success path.
+**Severity**: BLOCKING
+**Occurrences**: 1
+
+## What to check
+
+When a function catches a specific error class (e.g., IsNotFound) and returns a default value with nil error, verify that (1) the caller truly cannot distinguish this from a real success, and (2) no useful signal is lost. If the caller would benefit from knowing the error occurred, propagate it and let the caller decide.
+
+## Why it matters
+
+Returning a zero-value with nil error hides failure from callers, making the success path indistinguishable from the error path. This prevents callers from implementing appropriate error-specific logic (e.g., requeueing vs. continuing) and can mask real issues in production.
+
+## Examples from external reviews
+
+### CC-0015 — gndrmnn
+- **Feedback**: Returning an empty string for the hash and indicating no error does not seem to make much sense in this specific case. It is better for this function to return the is-not-found error to the caller.
+- **What was missed**: When a function catches a specific error class (e.g., IsNotFound) and returns a default value with nil error, verify that (1) the caller truly cannot distinguish this from a real success, and (2) no useful signal is lost. If the caller would benefit from knowing the error occurred, propagate it and let the caller decide.
+- **Fix**: Removed the IsNotFound early-return inside fernetKeysHash so all errors are propagated. The caller reconcileDeployment was updated to tolerate not-found errors specifically (continuing with an empty hash) while failing on unexpected errors.

--- a/.planwerk/reviews/CC-0015-g001-implement-keystone-dependency-details-review-1.json
+++ b/.planwerk/reviews/CC-0015-g001-implement-keystone-dependency-details-review-1.json
@@ -1,0 +1,93 @@
+{
+  "metadata": {
+    "feature_id": "CC-0015",
+    "title": "G001: Implement Keystone dependency details",
+    "date": "2026-03-16",
+    "verdict": "NEEDS_CHANGES"
+  },
+  "summary": "CC-0015 implements: (1) fernet-keys hash annotation on Deployment pod template via fernetKeysHash() helper and buildKeystoneDeployment() parameter, (2) table-driven unit tests for resolveDatabaseHost(), dbPort(), and resolveCacheServers(), (3) envtest integration tests for CronJob and bootstrap Job detailed specs, (4) reference documentation updates. All unit tests pass (54 tests, 0 failures). Integration tests compile correctly and use proper skip guards. One golangci-lint violation (QF1008) on new code blocks the merge.",
+  "verdict": "NEEDS_CHANGES",
+  "review_steps": {
+    "1_INTENT": "Plan specifies: fernet-keys hash annotation on Deployment pod template, table-driven unit tests for 3 pure helper functions, envtest integration tests for CronJob and bootstrap Job specs, documentation update. All implemented.",
+    "2_SCOPE": "Changed files: reconcile_deployment.go, reconcile_deployment_test.go, reconcile_config_test.go, integration_test.go, keystone-reconciler.md, progress JSON. All within expected scope. No scope creep detected.",
+    "3_VERIFICATION": "go vet: PASS. go test: 54/54 PASS. golangci-lint: 1 FAIL (QF1008 staticcheck on new code at reconcile_deployment.go:38).",
+    "4_PATTERNS": "Hash pattern matches internal/common/job/job.go PodSpecHash() — same json.Marshal + sha256 + hex.EncodeToString approach. Tests follow gomega NewGomegaWithT pattern. Integration tests follow envtest skip guard + namespace isolation patterns. One deviation: r.Client.Get vs r.Get idiom.",
+    "5_TESTS": "Comprehensive: annotation presence, empty hash, determinism, secret-not-found, end-to-end reconciliation with hash, all helper function edge cases, CronJob spec fields, bootstrap Job spec fields. Good coverage of happy path, edge cases, and error paths.",
+    "6_SECURITY": "No security concerns. Hash is computed from Secret.Data (already in-cluster). No user input validation gaps. No secrets exposed in logs.",
+    "7_COMPLEXITY": "Minimal and appropriate. fernetKeysHash() is a clean 15-line function. buildKeystoneDeployment() change is a 3-line annotation addition. No over-engineering.",
+    "8_COMPLETENESS": "All 6 tasks from the plan are implemented and marked done. Documentation updated. No stubs or TODOs remain in new code.",
+    "9_PROMPT_QUALITY": "N/A — no new prompt files."
+  },
+  "tests_checklist": [
+    {"item": "All existing unit tests pass without regressions (54/54)", "checked": true},
+    {"item": "New fernet hash tests cover annotation presence, empty hash, determinism, not-found", "checked": true},
+    {"item": "Table-driven tests for resolveDatabaseHost cover managed/brownfield/default port", "checked": true},
+    {"item": "Table-driven tests for dbPort cover explicit, zero, and negative values", "checked": true},
+    {"item": "Table-driven tests for resolveCacheServers cover managed/brownfield/empty/single/custom replicas", "checked": true},
+    {"item": "Integration test for CronJob verifies schedule, init container, volumes, env vars, ServiceAccount", "checked": true},
+    {"item": "Integration test for bootstrap Job verifies command, args, env, backoffLimit, ttlSeconds, volumes", "checked": true},
+    {"item": "Tests follow NewGomegaWithT pattern", "checked": true},
+    {"item": "Integration tests use SkipIfEnvTestUnavailable guard", "checked": true},
+    {"item": "Integration tests use namespace isolation with GenerateName", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing hash computation pattern (json.Marshal + sha256 + hex)", "checked": true},
+    {"item": "fernetKeysHash is a focused single-responsibility function", "checked": true},
+    {"item": "Error handling follows existing pattern (IsNotFound returns empty, other errors wrapped)", "checked": true},
+    {"item": "json.Marshal determinism guaranteed for map[string][]byte (Go encoding/json v1 sorts keys)", "checked": true},
+    {"item": "No dead code or commented-out code", "checked": true},
+    {"item": "golangci-lint passes without errors", "checked": false}
+  ],
+  "security_checklist": [
+    {"item": "No secrets exposed in logs or error messages", "checked": true},
+    {"item": "No hardcoded secrets", "checked": true},
+    {"item": "Hash computation uses SHA-256 (appropriate for integrity checking)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is minimal — 3-line annotation + 15-line helper", "checked": true},
+    {"item": "Follows existing PodSpecHash pattern from internal/common/job", "checked": true},
+    {"item": "Integration tests reuse existing helpers (setupEnvTestWithController, createPrerequisites, etc.)", "checked": true},
+    {"item": "driveReconciliationToBootstrapJob follows same structure as driveFullReconciliation", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code", "checked": true},
+    {"item": "No unused code or imports", "checked": true},
+    {"item": "No future-proofing or extra configurability", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "fernetKeysHash returns error early if Secret Get fails (non-NotFound)", "checked": true},
+    {"item": "reconcileDeployment propagates fernetKeysHash error immediately", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Secret not-found handled gracefully (returns empty string)", "checked": true},
+    {"item": "Hash is empty string when Secret doesn't exist, not a sentinel value", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "id": "V3-1",
+      "check_id": "V3",
+      "severity": "blocking",
+      "description": "golangci-lint QF1008 (staticcheck): redundant embedded field 'Client' in selector. The new code at reconcile_deployment.go:38 uses `r.Client.Get(...)` but since KeystoneReconciler embeds client.Client, the idiomatic form is `r.Get(...)`. This is flagged by the project's enabled staticcheck linter and fails CI.",
+      "location": "operators/keystone/internal/controller/reconcile_deployment.go:38",
+      "fix": "Change `r.Client.Get(ctx, types.NamespacedName{...}, &secret)` to `r.Get(ctx, types.NamespacedName{...}, &secret)`. This matches the pattern used in keystone_controller.go:61 and reconcile_fernet.go:68."
+    },
+    {
+      "id": "PC3-1",
+      "check_id": "PC3",
+      "severity": "blocking",
+      "description": "Inconsistent client access pattern in production code. The new fernetKeysHash() uses `r.Client.Get()` while sibling reconcilers use `r.Get()` directly. In production code (non-test), the codebase uses `r.Get()` (keystone_controller.go:61, reconcile_fernet.go:68). The `r.Client.Get()` form is used only in test code where the reconciler is constructed with an explicit Client field. The new production code should follow the production pattern.",
+      "location": "operators/keystone/internal/controller/reconcile_deployment.go:38",
+      "fix": "Same fix as V3-1: change `r.Client.Get` to `r.Get`."
+    }
+  ],
+  "suggested_improvements": [
+    "Minor (D2): The doc comment on fernetKeysHash at line 32-34 mentions CC-0015/REQ-001 but could also note that json.Marshal sorts map keys, which is why the hash is deterministic. The docs in keystone-reconciler.md already document this — consider adding a brief inline comment at line 48 for future readers."
+  ],
+  "next_steps": [
+    "Fix QF1008: change r.Client.Get to r.Get in reconcile_deployment.go:38",
+    "Re-run golangci-lint to confirm clean pass"
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0015-g001-implement-keystone-dependency-details-review-2.json
+++ b/.planwerk/reviews/CC-0015-g001-implement-keystone-dependency-details-review-2.json
@@ -1,0 +1,57 @@
+{
+  "summary": "Addresses external review feedback from gndrmnn: fernetKeysHash no longer swallows IsNotFound errors — all errors are propagated to the caller with wrapping context. The caller reconcileDeployment now distinguishes IsNotFound (tolerated, continues with empty hash) from unexpected errors (returned). Test updated to assert not-found error is returned. New review pattern documented.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "TE1: Happy path tested — TestReconcileDeployment_FernetKeysHashFromSecret verifies hash annotation from real Secret data", "checked": true},
+    {"item": "TE2: Edge cases tested — TestFernetKeysHash_SecretNotFound verifies not-found error propagation; TestBuildKeystoneDeployment_FernetKeysHashAnnotation_EmptyHash verifies empty hash", "checked": true},
+    {"item": "TE3: Error cases tested — TestFernetKeysHash_SecretNotFound asserts apierrors.IsNotFound(err) is true", "checked": true},
+    {"item": "TE4: Tests independent — each test creates its own reconciler and scheme", "checked": true},
+    {"item": "TE5: Test names descriptive and follow existing convention", "checked": true},
+    {"item": "TE6: Mocking appropriate — fake client for unit tests", "checked": true},
+    {"item": "TE7: Assertions specific — exact error type check via apierrors.IsNotFound, not just err != nil", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Q1: fernetKeysHash does one thing — read Secret, compute hash, return error", "checked": true},
+    {"item": "Q4: Clear naming — error wrapping message includes namespace/name context", "checked": true},
+    {"item": "Q7: No dead code introduced", "checked": true},
+    {"item": "P2: Uses existing apierrors.IsNotFound utility from k8s.io/apimachinery", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "S3: No hardcoded secrets — Secret is read from API server", "checked": true},
+    {"item": "S5: Sensitive data not exposed in error messages — only namespace/name logged, not Secret content", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "C1: Implements exactly what external reviewer requested — propagate not-found error to caller", "checked": true},
+    {"item": "C3: Edge case handled — not-found error tolerated in caller via apierrors.IsNotFound check through error wrapping chain", "checked": true},
+    {"item": "C4: Errors propagated explicitly with wrapping context, not silently swallowed", "checked": true},
+    {"item": "C5: Existing tests (TestReconcileDeployment_DeploymentAndServiceCreated etc.) continue to pass — no regression", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "Minimal change — only error handling flow modified, no unnecessary additions", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Non-not-found errors fail immediately; not-found is explicitly tolerated at the caller level", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "fmt.Errorf with %w preserves error chain for apierrors.IsNotFound detection through errors.As", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "detected_patterns": [],
+  "metadata": {
+    "feature_id": "CC-0015",
+    "title": "G001: Implement Keystone dependency details",
+    "date": "2026-03-17",
+    "verdict": "APPROVED",
+    "verification": {
+      "go_vet": "pass (0 issues)",
+      "golangci_lint": "pass (0 issues)",
+      "unit_tests": "pass (controller package, 0.424s)",
+      "integration_tests": "pass (skipped — KUBEBUILDER_ASSETS not set)"
+    },
+    "pre_review_stub_note": "reconcile_deployment.go:190 TODO(CC-0013) is pre-existing and not part of this diff — intentionally deferred credential key management, not a new stub"
+  }
+}

--- a/.planwerk/reviews/CC-0015-github-review-by-gndrmnn-external-1.json
+++ b/.planwerk/reviews/CC-0015-github-review-by-gndrmnn-external-1.json
@@ -1,0 +1,37 @@
+{
+  "feature_id": "CC-0015",
+  "title": "GitHub Review by gndrmnn",
+  "summary": "The reviewer wants `reconcile_deployment.go:44` to return the not-found error to the caller instead of returning an empty hash with no error, as the current behavior is semantically misleading.",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "gndrmnn",
+  "date": "2026-03-17T10:37:21Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 1,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "Returning an empty string for the hash and indicating no error does not seem to make much sense in this specific case. It is better for this function to return the is-not-found error to the caller.",
+      "path": "operators/keystone/internal/controller/reconcile_deployment.go",
+      "line": 44,
+      "author": "gndrmnn",
+      "created_at": "2026-03-17T10:24:53Z",
+      "id": null,
+      "resolution": "fernetKeysHash no longer swallows the IsNotFound error — the special-case `if apierrors.IsNotFound(err) { return \"\", nil }` branch was removed so the wrapped not-found error is returned to the caller. The caller reconcileDeployment now checks `err != nil && !apierrors.IsNotFound(err)` to tolerate not-found gracefully. The function's doc comment was updated from 'returns an empty string without error' to 'the not-found error is returned to the caller'. The test TestFernetKeysHash_SecretNotFound was updated to assert that a not-found error IS returned (using apierrors.IsNotFound) instead of asserting no error."
+    }
+  ],
+  "resolution_summary": "The review comment requested that fernetKeysHash return the not-found error to the caller instead of swallowing it. The fix removed the IsNotFound early-return inside fernetKeysHash so all errors (including not-found) are now propagated. The caller reconcileDeployment was updated to tolerate not-found errors specifically (continuing with an empty hash) while still failing on unexpected errors. The doc comment on fernetKeysHash was also updated to reflect the new behaviour.",
+  "github_review_id": 3959673840
+}

--- a/docs/reference/keystone-reconciler.md
+++ b/docs/reference/keystone-reconciler.md
@@ -1,7 +1,7 @@
 ---
 title: Keystone Reconciler Architecture
 quadrant: operator
-feature: CC-0013
+feature: CC-0013, CC-0015
 ---
 
 # Keystone Reconciler Architecture
@@ -520,6 +520,29 @@ spec. Sets `status.endpoint` when the Deployment becomes available.
 > **Note:** This sub-reconciler accepts the `configMapName` returned by
 > `reconcileConfig` to reference the correct immutable ConfigMap in volume mounts.
 
+**Fernet Keys Hash Annotation (CC-0015):**
+
+Before building the Deployment, `reconcileDeployment` calls `fernetKeysHash()` to
+compute a SHA-256 digest of the `{name}-fernet-keys` Secret data. This hash is set
+as the pod template annotation `keystone.c5c3.io/fernet-keys-hash`, which triggers a
+rolling restart whenever the Fernet rotation CronJob updates the Secret.
+
+```text
+CronJob rotates keys → Secret data changes → secretToKeystoneMapper watch
+  → Reconcile() → reconcileDeployment() reads Secret → computes hash
+  → annotation value changes → Kubernetes triggers rolling restart
+```
+
+The `fernetKeysHash()` helper:
+
+| Behavior | Detail |
+| --- | --- |
+| Secret name | `{keystone.Name}-fernet-keys` |
+| Algorithm | SHA-256 of `json.Marshal(secret.Data)` |
+| Output | Hex-encoded digest (64 characters) |
+| Secret not found | Returns empty string (no error) — safe because `reconcileFernetKeys` runs before `reconcileDeployment` |
+| Determinism | `json.Marshal` on `map[string][]byte` sorts keys alphabetically |
+
 **Deployment Spec:**
 
 | Field | Value |
@@ -530,6 +553,12 @@ spec. Sets `status.endpoint` when the Deployment becomes available.
 | Container name | `keystone-api` |
 | Image | `{spec.image.repository}:{spec.image.tag}` |
 | Port | 5000 (named `keystone-api`) |
+
+**Pod Template Annotations:**
+
+| Annotation | Value | Purpose |
+| --- | --- | --- |
+| `keystone.c5c3.io/fernet-keys-hash` | SHA-256 hex digest of fernet-keys Secret data | Triggers rolling restart on Fernet key rotation (CC-0015) |
 
 **Probes:**
 
@@ -695,8 +724,9 @@ The reconciler has comprehensive unit tests using `gomega` with `NewGomegaWithT(
 | `reconcile_database_test.go` | Managed/brownfield modes, MariaDB CRs, db_sync lifecycle, stale Job detection |
 | `reconcile_fernet_test.go` | Key generation, Secret idempotency, CronJob schedule, PushSecret, key validity |
 | `reconcile_config_test.go` | INI generation, extraConfig merge, plugin config, policy overrides, ConfigMap hashing |
-| `reconcile_deployment_test.go` | Deployment spec, Service creation, readiness, endpoint, owner references |
+| `reconcile_deployment_test.go` | Deployment spec, Service creation, readiness, endpoint, owner references, fernet-keys hash annotation (CC-0015) |
 | `reconcile_bootstrap_test.go` | Job creation, completion, failure, stale detection, TTL/backoff |
+| `integration_test.go` | Full reconciliation envtest: CronJob spec, bootstrap Job spec, brownfield mode, condition progression (CC-0015) |
 
 ---
 
@@ -724,7 +754,8 @@ operators/keystone/
     │   ├── reconcile_fernet_test.go            Fernet tests
     │   ├── reconcile_config_test.go            Config tests
     │   ├── reconcile_deployment_test.go        Deployment tests
-    │   └── reconcile_bootstrap_test.go         Bootstrap tests
+    │   ├── reconcile_bootstrap_test.go         Bootstrap tests
+    │   └── integration_test.go                 Envtest integration tests (CC-0015)
     └── testutil/
         └── envtest_setup.go                    Keystone-specific envtest helper
 ```

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -694,3 +694,213 @@ func TestIntegration_FullReconcile_Managed(t *testing.T) {
 	g.Expect(c.Get(ctx, userKey, &mariadbv1alpha1.User{})).To(Succeed(), "MariaDB User CR should still exist")
 	g.Expect(c.Get(ctx, grantKey, &mariadbv1alpha1.Grant{})).To(Succeed(), "MariaDB Grant CR should still exist")
 }
+
+// --- Task CC-0015/2.1: CronJob detailed spec test (REQ-006) ---
+
+func TestIntegration_CronJobDetailedSpec(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cronjob-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+	// Fetch the Fernet rotation CronJob (REQ-006).
+	cronJob := &batchv1.CronJob{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-fernet-rotate"}, cronJob)).
+		To(Succeed(), "CronJob test-keystone-fernet-rotate should exist")
+
+	// Verify schedule matches spec.fernet.rotationSchedule.
+	g.Expect(cronJob.Spec.Schedule).To(Equal(ks.Spec.Fernet.RotationSchedule),
+		"CronJob schedule should match spec.fernet.rotationSchedule")
+
+	podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
+	expectedImage := fmt.Sprintf("%s:%s", ks.Spec.Image.Repository, ks.Spec.Image.Tag)
+
+	// Verify ServiceAccountName.
+	g.Expect(podSpec.ServiceAccountName).To(Equal(fmt.Sprintf("%s-fernet-rotate", ks.Name)),
+		"CronJob should use the fernet-rotate ServiceAccount")
+
+	// Verify init container: copy-keys.
+	g.Expect(podSpec.InitContainers).To(HaveLen(1), "CronJob should have exactly one init container")
+	initContainer := podSpec.InitContainers[0]
+	g.Expect(initContainer.Name).To(Equal("copy-keys"))
+	g.Expect(initContainer.Image).To(Equal(expectedImage), "init container image should match spec")
+	g.Expect(initContainer.Command).To(Equal([]string{"sh", "-c", "cp /fernet-keys-src/* /etc/keystone/fernet-keys/"}))
+
+	// Verify init container volume mounts.
+	g.Expect(initContainer.VolumeMounts).To(HaveLen(2))
+	initMounts := map[string]corev1.VolumeMount{}
+	for _, vm := range initContainer.VolumeMounts {
+		initMounts[vm.Name] = vm
+	}
+	g.Expect(initMounts["fernet-keys-src"].MountPath).To(Equal("/fernet-keys-src"))
+	g.Expect(initMounts["fernet-keys-src"].ReadOnly).To(BeTrue(), "fernet-keys-src should be read-only")
+	g.Expect(initMounts["fernet-keys"].MountPath).To(Equal("/etc/keystone/fernet-keys"))
+
+	// Verify main container: fernet-rotate.
+	g.Expect(podSpec.Containers).To(HaveLen(1), "CronJob should have exactly one main container")
+	mainContainer := podSpec.Containers[0]
+	g.Expect(mainContainer.Name).To(Equal("fernet-rotate"))
+	g.Expect(mainContainer.Image).To(Equal(expectedImage), "main container image should match spec")
+	g.Expect(mainContainer.Command).To(Equal([]string{"sh", "-c", fernetRotateScript}))
+
+	// Verify main container env vars.
+	envMap := map[string]corev1.EnvVar{}
+	for _, env := range mainContainer.Env {
+		envMap[env.Name] = env
+	}
+	g.Expect(envMap).To(HaveKey("SECRET_NAME"))
+	g.Expect(envMap["SECRET_NAME"].Value).To(Equal(fmt.Sprintf("%s-fernet-keys", ks.Name)))
+
+	g.Expect(envMap).To(HaveKey("SECRET_NAMESPACE"))
+	g.Expect(envMap["SECRET_NAMESPACE"].ValueFrom).NotTo(BeNil(), "SECRET_NAMESPACE should use ValueFrom")
+	g.Expect(envMap["SECRET_NAMESPACE"].ValueFrom.FieldRef).NotTo(BeNil(), "SECRET_NAMESPACE should use fieldRef")
+	g.Expect(envMap["SECRET_NAMESPACE"].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.namespace"))
+
+	g.Expect(envMap).To(HaveKey("OS_fernet_tokens__max_active_keys"))
+	g.Expect(envMap["OS_fernet_tokens__max_active_keys"].Value).To(Equal("3"),
+		"OS_fernet_tokens__max_active_keys should match spec.fernet.maxActiveKeys")
+
+	// Verify main container volume mounts.
+	g.Expect(mainContainer.VolumeMounts).To(HaveLen(1))
+	g.Expect(mainContainer.VolumeMounts[0].Name).To(Equal("fernet-keys"))
+	g.Expect(mainContainer.VolumeMounts[0].MountPath).To(Equal("/etc/keystone/fernet-keys"))
+
+	// Verify volumes: fernet-keys-src (Secret) and fernet-keys (emptyDir).
+	volMap := map[string]corev1.Volume{}
+	for _, v := range podSpec.Volumes {
+		volMap[v.Name] = v
+	}
+	g.Expect(volMap).To(HaveKey("fernet-keys-src"))
+	g.Expect(volMap["fernet-keys-src"].Secret).NotTo(BeNil(), "fernet-keys-src volume should be a Secret")
+	g.Expect(volMap["fernet-keys-src"].Secret.SecretName).To(Equal(fmt.Sprintf("%s-fernet-keys", ks.Name)))
+
+	g.Expect(volMap).To(HaveKey("fernet-keys"))
+	g.Expect(volMap["fernet-keys"].EmptyDir).NotTo(BeNil(), "fernet-keys volume should be an emptyDir")
+}
+
+// --- Task CC-0015/2.2: Bootstrap Job detailed spec test (REQ-007) ---
+
+// driveReconciliationToBootstrapJob drives external dependencies through
+// reconciliation phases until the bootstrap Job appears, without simulating
+// bootstrap completion (CC-0015, REQ-007).
+func driveReconciliationToBootstrapJob(t testing.TB, ctx context.Context, c client.Client, ksName, ns string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	key := types.NamespacedName{Name: ksName, Namespace: ns}
+
+	waitForCondition(t, ctx, c, key, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+	waitForCondition(t, ctx, c, key, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	dbSyncKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-db-sync", ksName)}
+	g.Eventually(func() error {
+		return c.Get(ctx, dbSyncKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "db-sync Job should appear")
+	g.Expect(simulators.SimulateJobComplete(ctx, c, dbSyncKey)).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "DatabaseReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	deployKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-api", ksName)}
+	deploy := &appsv1.Deployment{}
+	g.Eventually(func() error {
+		return c.Get(ctx, deployKey, deploy)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Expect(simulators.SimulateDeploymentReady(ctx, c, deployKey, ptr.Deref(deploy.Spec.Replicas, 1))).To(Succeed())
+
+	waitForCondition(t, ctx, c, key, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+	bootstrapKey := client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-bootstrap", ksName)}
+	g.Eventually(func() error {
+		return c.Get(ctx, bootstrapKey, &batchv1.Job{})
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "bootstrap Job should appear")
+}
+
+func TestIntegration_BootstrapJobDetailedSpec(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-bootstrap-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationBrownfieldKeystone("test-keystone", ns.Name)
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	// Drive reconciliation until bootstrap Job appears, without completing it (REQ-007).
+	driveReconciliationToBootstrapJob(t, ctx, c, ks.Name, ns.Name)
+
+	// Fetch the bootstrap Job.
+	bootstrapJob := &batchv1.Job{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-bootstrap"}, bootstrapJob)).
+		To(Succeed(), "bootstrap Job should exist")
+
+	// Verify backoffLimit (REQ-007).
+	g.Expect(bootstrapJob.Spec.BackoffLimit).NotTo(BeNil())
+	g.Expect(*bootstrapJob.Spec.BackoffLimit).To(Equal(int32(4)), "backoffLimit should be 4")
+
+	// Verify ttlSecondsAfterFinished (REQ-007).
+	g.Expect(bootstrapJob.Spec.TTLSecondsAfterFinished).NotTo(BeNil())
+	g.Expect(*bootstrapJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(300)), "ttlSecondsAfterFinished should be 300")
+
+	// Verify container spec.
+	podSpec := bootstrapJob.Spec.Template.Spec
+	g.Expect(podSpec.Containers).To(HaveLen(1))
+	container := podSpec.Containers[0]
+	g.Expect(container.Name).To(Equal("bootstrap"))
+
+	// Verify image.
+	expectedImage := fmt.Sprintf("%s:%s", ks.Spec.Image.Repository, ks.Spec.Image.Tag)
+	g.Expect(container.Image).To(Equal(expectedImage))
+
+	// Verify command (REQ-007).
+	g.Expect(container.Command).To(Equal([]string{"keystone-manage", "bootstrap"}))
+
+	// Verify args include all bootstrap parameters.
+	expectedServiceURL := fmt.Sprintf("http://%s-api.%s.svc.cluster.local:5000/v3", ks.Name, ns.Name)
+	g.Expect(container.Args).To(Equal([]string{
+		"--bootstrap-password", "$(BOOTSTRAP_PASSWORD)",
+		"--bootstrap-admin-url", expectedServiceURL,
+		"--bootstrap-internal-url", expectedServiceURL,
+		"--bootstrap-public-url", expectedServiceURL,
+		"--bootstrap-region-id", ks.Spec.Bootstrap.Region,
+	}))
+
+	// Verify BOOTSTRAP_PASSWORD env from SecretKeyRef (REQ-007).
+	g.Expect(container.Env).To(HaveLen(1))
+	pwEnv := container.Env[0]
+	g.Expect(pwEnv.Name).To(Equal("BOOTSTRAP_PASSWORD"))
+	g.Expect(pwEnv.ValueFrom).NotTo(BeNil())
+	g.Expect(pwEnv.ValueFrom.SecretKeyRef).NotTo(BeNil())
+	g.Expect(pwEnv.ValueFrom.SecretKeyRef.Name).To(Equal(ks.Spec.Bootstrap.AdminPasswordSecretRef.Name),
+		"BOOTSTRAP_PASSWORD should reference the admin password Secret")
+	g.Expect(pwEnv.ValueFrom.SecretKeyRef.Key).To(Equal("password"))
+
+	// Verify config volume mount (REQ-007).
+	g.Expect(container.VolumeMounts).To(HaveLen(1))
+	g.Expect(container.VolumeMounts[0].Name).To(Equal("config"))
+	g.Expect(container.VolumeMounts[0].MountPath).To(Equal("/etc/keystone/keystone.conf.d/"))
+	g.Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
+
+	// Verify config volume source is a ConfigMap with the expected name prefix.
+	g.Expect(podSpec.Volumes).To(HaveLen(1))
+	g.Expect(podSpec.Volumes[0].Name).To(Equal("config"))
+	g.Expect(podSpec.Volumes[0].ConfigMap).NotTo(BeNil())
+	g.Expect(podSpec.Volumes[0].ConfigMap.Name).To(HavePrefix(fmt.Sprintf("%s-config-", ks.Name)),
+		"config volume should reference a ConfigMap with the expected name prefix")
+
+	// Verify RestartPolicy.
+	g.Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+}

--- a/operators/keystone/internal/controller/reconcile_config_test.go
+++ b/operators/keystone/internal/controller/reconcile_config_test.go
@@ -452,3 +452,204 @@ func TestReconcileConfig_ImmutableConfigMapWithOwnerReference(t *testing.T) {
 	g.Expect(cm.OwnerReferences[0].Name).To(Equal("test-keystone"))
 	g.Expect(cm.OwnerReferences[0].UID).To(Equal(ks.UID))
 }
+
+func TestResolveDatabaseHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		keystone *keystonev1alpha1.Keystone
+		expected string
+	}{
+		{
+			name: "managed mode with default port",
+			keystone: &keystonev1alpha1.Keystone{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						ClusterRef: &corev1.LocalObjectReference{Name: "mariadb"},
+						Port:       0,
+					},
+				},
+			},
+			expected: "mariadb.default.svc:3306",
+		},
+		{
+			name: "managed mode with explicit port",
+			keystone: &keystonev1alpha1.Keystone{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						ClusterRef: &corev1.LocalObjectReference{Name: "mariadb"},
+						Port:       3307,
+					},
+				},
+			},
+			expected: "mariadb.default.svc:3307",
+		},
+		{
+			name: "brownfield with explicit port",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						Host: "db.example.com",
+						Port: 3306,
+					},
+				},
+			},
+			expected: "db.example.com:3306",
+		},
+		{
+			name: "brownfield with default port",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						Host: "db.example.com",
+						Port: 0,
+					},
+				},
+			},
+			expected: "db.example.com:3306",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := resolveDatabaseHost(tt.keystone)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestDBPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		keystone *keystonev1alpha1.Keystone
+		expected int32
+	}{
+		{
+			name: "explicit port",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						Port: 3307,
+					},
+				},
+			},
+			expected: 3307,
+		},
+		{
+			name: "zero port defaults to 3306",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						Port: 0,
+					},
+				},
+			},
+			expected: 3306,
+		},
+		{
+			name: "negative port defaults to 3306",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Database: commonv1.DatabaseSpec{
+						Port: -1,
+					},
+				},
+			},
+			expected: 3306,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := dbPort(tt.keystone)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestResolveCacheServers(t *testing.T) {
+	tests := []struct {
+		name     string
+		keystone *keystonev1alpha1.Keystone
+		expected string
+	}{
+		{
+			name: "brownfield with multiple servers",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{
+						Servers: []string{"mc-0:11211", "mc-1:11211"},
+					},
+				},
+			},
+			expected: "mc-0:11211,mc-1:11211",
+		},
+		{
+			name: "brownfield with single server",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{
+						Servers: []string{"mc:11211"},
+					},
+				},
+			},
+			expected: "mc:11211",
+		},
+		{
+			name: "managed mode with default replicas",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{
+						ClusterRef: &corev1.LocalObjectReference{Name: "memcached"},
+						Replicas:   0,
+					},
+				},
+			},
+			expected: "memcached-0.memcached:11211,memcached-1.memcached:11211,memcached-2.memcached:11211",
+		},
+		{
+			name: "managed mode with custom replicas",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{
+						ClusterRef: &corev1.LocalObjectReference{Name: "mc"},
+						Replicas:   5,
+					},
+				},
+			},
+			expected: "memcached-0.mc:11211,memcached-1.mc:11211,memcached-2.mc:11211,memcached-3.mc:11211,memcached-4.mc:11211",
+		},
+		{
+			name: "managed mode with single replica",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{
+						ClusterRef: &corev1.LocalObjectReference{Name: "mc"},
+						Replicas:   1,
+					},
+				},
+			},
+			expected: "memcached-0.mc:11211",
+		},
+		{
+			name: "neither ClusterRef nor Servers set",
+			keystone: &keystonev1alpha1.Keystone{
+				Spec: keystonev1alpha1.KeystoneSpec{
+					Cache: commonv1.CacheSpec{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := resolveCacheServers(tt.keystone)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}

--- a/operators/keystone/internal/controller/reconcile_deployment.go
+++ b/operators/keystone/internal/controller/reconcile_deployment.go
@@ -6,12 +6,17 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -24,11 +29,33 @@ import (
 
 // Feature: CC-0013
 
+// fernetKeysHash reads the fernet-keys Secret for the given Keystone instance
+// and returns a deterministic SHA-256 hex digest of its Data map. If the Secret
+// does not exist, the not-found error is returned to the caller (CC-0015).
+func (r *KeystoneReconciler) fernetKeysHash(ctx context.Context, keystone *keystonev1alpha1.Keystone) (string, error) {
+	secretName := fmt.Sprintf("%s-fernet-keys", keystone.Name)
+	var secret corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      secretName,
+		Namespace: keystone.Namespace,
+	}, &secret); err != nil {
+		return "", fmt.Errorf("getting fernet-keys Secret %s/%s: %w", keystone.Namespace, secretName, err)
+	}
+	// json.Marshal sorts map keys, so the hash is deterministic (CC-0015).
+	data, _ := json.Marshal(secret.Data)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
 // reconcileDeployment ensures the Keystone API Deployment and Service exist
 // with the correct spec. It sets the DeploymentReady condition and the
 // status endpoint when the Deployment becomes available (CC-0013, REQ-006, REQ-012).
 func (r *KeystoneReconciler) reconcileDeployment(ctx context.Context, keystone *keystonev1alpha1.Keystone, configMapName string) (ctrl.Result, error) {
-	deploy := buildKeystoneDeployment(keystone, configMapName)
+	hash, err := r.fernetKeysHash(ctx, keystone)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("computing fernet-keys hash: %w", err)
+	}
+	deploy := buildKeystoneDeployment(keystone, configMapName, hash)
 	ready, err := deployment.EnsureDeployment(ctx, r.Client, r.Scheme, keystone, deploy)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring Deployment: %w", err)
@@ -67,7 +94,7 @@ func keystoneAppLabel(keystone *keystonev1alpha1.Keystone) string {
 	return fmt.Sprintf("%s-api", keystone.Name)
 }
 
-func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName string) *appsv1.Deployment {
+func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName string, fernetKeysHash string) *appsv1.Deployment {
 	appLabel := keystoneAppLabel(keystone)
 	labels := map[string]string{"app": appLabel}
 	replicas := int32(keystone.Spec.Replicas)
@@ -86,6 +113,9 @@ func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName 
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"keystone.c5c3.io/fernet-keys-hash": fernetKeysHash,
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -6,6 +6,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,7 +79,7 @@ func newDeployTestReconciler(s *runtime.Scheme, objs ...client.Object) *Keystone
 // readyDeployment returns a Deployment that matches what buildKeystoneDeployment
 // would produce, but with status indicating it is available and ready.
 func readyDeployment(ks *keystonev1alpha1.Keystone, configMapName string) *appsv1.Deployment {
-	deploy := buildKeystoneDeployment(ks, configMapName)
+	deploy := buildKeystoneDeployment(ks, configMapName, "")
 	replicas := int32(ks.Spec.Replicas)
 	deploy.Spec.Replicas = &replicas
 	deploy.Generation = 1
@@ -92,7 +96,7 @@ func readyDeployment(ks *keystonev1alpha1.Keystone, configMapName string) *appsv
 
 // notReadyDeployment returns a Deployment that exists but is not yet available.
 func notReadyDeployment(ks *keystonev1alpha1.Keystone, configMapName string) *appsv1.Deployment {
-	deploy := buildKeystoneDeployment(ks, configMapName)
+	deploy := buildKeystoneDeployment(ks, configMapName, "")
 	deploy.Generation = 1
 	deploy.Status.ObservedGeneration = 1
 	deploy.Status.ReadyReplicas = 0
@@ -354,4 +358,115 @@ func TestReconcileDeployment_ServiceCreatedAlongsideDeployment(t *testing.T) {
 	// Both should have owner references.
 	g.Expect(deploy.OwnerReferences).To(HaveLen(1))
 	g.Expect(svc.OwnerReferences).To(HaveLen(1))
+}
+
+// Feature: CC-0015
+
+func deployTestFernetKeysSecret(ks *keystonev1alpha1.Keystone) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ks.Name + "-fernet-keys",
+			Namespace: ks.Namespace,
+		},
+		Data: map[string][]byte{
+			"0": []byte("fernet-key-0"),
+			"1": []byte("fernet-key-1"),
+		},
+	}
+}
+
+func TestBuildKeystoneDeployment_FernetKeysHashAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := deployTestKeystone()
+	hash := "abc123def456"
+
+	deploy := buildKeystoneDeployment(ks, "keystone-config-abc123", hash)
+
+	g.Expect(deploy.Spec.Template.Annotations).To(HaveKeyWithValue(
+		"keystone.c5c3.io/fernet-keys-hash", hash,
+	))
+}
+
+func TestBuildKeystoneDeployment_FernetKeysHashAnnotation_EmptyHash(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := deployTestKeystone()
+
+	deploy := buildKeystoneDeployment(ks, "keystone-config-abc123", "")
+
+	g.Expect(deploy.Spec.Template.Annotations).To(HaveKeyWithValue(
+		"keystone.c5c3.io/fernet-keys-hash", "",
+	))
+}
+
+func TestFernetKeysHash_Deterministic(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+
+	secret1 := deployTestFernetKeysSecret(ks)
+	secret2 := deployTestFernetKeysSecret(ks)
+
+	// Two identical secrets must produce the same hash.
+	r1 := newDeployTestReconciler(s, ks, secret1)
+	hash1, err := r1.fernetKeysHash(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	r2 := newDeployTestReconciler(s, ks, secret2)
+	hash2, err := r2.fernetKeysHash(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(hash1).To(Equal(hash2))
+
+	// Verify hash is a 64-char hex string (SHA-256 = 32 bytes = 64 hex chars).
+	g.Expect(hash1).To(MatchRegexp("^[0-9a-f]{64}$"))
+
+	// Modify one key and verify different hash.
+	secret3 := deployTestFernetKeysSecret(ks)
+	secret3.Data["0"] = []byte("different-fernet-key")
+	r3 := newDeployTestReconciler(s, ks, secret3)
+	hash3, err := r3.fernetKeysHash(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(hash3).NotTo(Equal(hash1))
+}
+
+func TestFernetKeysHash_SecretNotFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+
+	// No fernet-keys Secret in the fake client — expect not-found error (CC-0015).
+	r := newDeployTestReconciler(s, ks)
+
+	hash, err := r.fernetKeysHash(context.Background(), ks)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected not-found error, got: %v", err)
+	g.Expect(hash).To(Equal(""))
+}
+
+func TestReconcileDeployment_FernetKeysHashFromSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+	secret := deployTestFernetKeysSecret(ks)
+	r := newDeployTestReconciler(s, ks, secret)
+
+	result, err := r.reconcileDeployment(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).NotTo(HaveOccurred())
+	// Deployment just created, not ready yet — should requeue.
+	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+
+	// Verify the created Deployment has the fernet-keys hash annotation.
+	var deploy appsv1.Deployment
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{
+		Name: "test-keystone-api", Namespace: "default",
+	}, &deploy)).To(Succeed())
+
+	// Compute the expected hash from the secret data.
+	data, _ := json.Marshal(secret.Data)
+	sum := sha256.Sum256(data)
+	expectedHash := hex.EncodeToString(sum[:])
+
+	g.Expect(deploy.Spec.Template.Annotations).To(HaveKeyWithValue(
+		"keystone.c5c3.io/fernet-keys-hash", expectedHash,
+	))
 }


### PR DESCRIPTION
**Size:** 🔨 medium
**Category:** backend
**Priority:** high
**Feature ID:** CC-0015 (S015)

## Summary

S015 completes the detailed dependency interactions for the Keystone reconciler. The core logic — DB connection string assembly (managed/brownfield), memcached server list discovery, Fernet rotation CronJob with writable Secret mount and maxActiveKeys enforcement, and bootstrap Job with admin credentials — was implemented in CC-0013. The remaining gaps are: (1) **Deployment rolling restart mechanism after Fernet key rotation** via a hash-based pod template annotation, (2) **standalone table-driven unit tests** for the pure helper functions (`resolveDatabaseHost`, `dbPort`, `resolveCacheServers`), and (3) **envtest integration tests** verifying CronJob and Job detailed specs.

## Scope

**Included:**
- Fernet keys hash annotation on Deployment pod template (`keystone.c5c3.io/fernet-keys-hash`) — computed from the `{name}-fernet-keys` Secret data, set on `spec.template.metadata.annotations` in `buildKeystoneDeployment()` (currently has no annotations at line 87-89 of `reconcile_deployment.go`). The existing `secretToKeystoneMapper` watch already triggers reconcile on fernet-keys Secret changes (via UID ownership check at `keystone_controller.go:160-182`).
- Table-driven unit tests for `resolveDatabaseHost()` — managed mode (`{clusterRef.name}.{ns}.svc:{port}`), brownfield (`{host}:{port}`), port fallback to 3306
- Table-driven unit tests for `dbPort()` — explicit port, zero/default fallback to 3306
- Table-driven unit tests for `resolveCacheServers()` — managed mode pod DNS pattern (`memcached-{i}.{name}:11211`), brownfield explicit list join, replicas=0 fallback to 3, nil ClusterRef + empty Servers returning `""`
- Envtest integration test verifying CronJob detailed spec: schedule, init container `copy-keys`, emptyDir volume, `fernet-keys-src` Secret volume, ServiceAccount `{name}-fernet-rotate`, `OS_fernet_tokens__max_active_keys` env var, image tag
- Envtest integration test verifying bootstrap Job detailed spec: `keystone-manage bootstrap` command/args, admin-credentials env from SecretKeyRef, `backoffLimit: 4`, `ttlSecondsAfterFinished: 300`, config volume mount

**Excluded:**
- Refactoring existing sub-reconcilers (complete from CC-0013, YAGNI)
- Fernet key rotation E2E tests (covered by CC-0016 Chainsaw suite)
- Credential-keys volume mount management (noted as deferred in `reconcile_deployment.go:160`, separate feature)
- MariaDB CR status field resolution (current implementation uses service DNS `{name}.{ns}.svc`, which is the correct K8s pattern)
- ConfigMap hash annotation (already handled by content-hash ConfigMap naming in `reconcileConfig`)

## Visualization

```mermaid
flowchart TD
    subgraph FernetRotation["Fernet Key Rotation Flow"]
        CJ["CronJob: fernet-rotate"]
        IC["Init Container: copy keys to emptyDir"]
        MC["Main Container: keystone-manage fernet_rotate"]
        PY["Python script: PATCH Secret via K8s API"]
        SEC["Secret: fernet-keys"]
        WATCH["secretToKeystoneMapper triggers reconcile"]
        REC["Reconciler: compute fernet-keys hash"]
        ANN["Deployment pod template annotation update"]
        ROLL["Rolling restart of Keystone pods"]
    end

    CJ --> IC
    IC --> MC
    MC --> PY
    PY -->|"PATCH"| SEC
    SEC -->|"ownership UID match"| WATCH
    WATCH --> REC
    REC -->|"hash changed"| ANN
    ANN --> ROLL

    subgraph DBResolution["DB Connection String Assembly"]
        MANAGED_DB["Managed: ClusterRef set"]
        BROWN_DB["Brownfield: Host set"]
        DNS["Service DNS: name.ns.svc:port"]
        EXPLICIT["Explicit: host:port"]
        CONN["mysql+pymysql://user:pass@host:port/db"]
    end

    MANAGED_DB --> DNS --> CONN
    BROWN_DB --> EXPLICIT --> CONN

    subgraph CacheResolution["Memcached Server Discovery"]
        MANAGED_MC["Managed: ClusterRef set"]
        BROWN_MC["Brownfield: Servers list"]
        POD_DNS["Pod DNS: memcached-i.name:11211"]
        EXPLICIT_MC["Explicit server list"]
        SERVERS["Comma-joined server string"]
    end

    MANAGED_MC --> POD_DNS --> SERVERS
    BROWN_MC --> EXPLICIT_MC --> SERVERS
```

```mermaid
sequenceDiagram
    participant CJ as Fernet CronJob
    participant K8S as K8s API
    participant SEC as fernet-keys Secret
    participant REC as Keystone Reconciler
    participant DEP as Keystone Deployment

    CJ->>CJ: Init: copy Secret keys to emptyDir
    CJ->>CJ: keystone-manage fernet_rotate
    CJ->>K8S: PATCH Secret with rotated keys
    K8S->>SEC: Update Secret data
    SEC-->>REC: secretToKeystoneMapper watch fires
    REC->>SEC: Read Secret data, compute SHA-256 hash
    REC->>DEP: Set pod template annotation with new hash
    DEP-->>DEP: Rolling restart with new Fernet keys
```

## Key Components

- **`resolveDatabaseHost()`** (`reconcile_config.go:177`): Pure function resolving DB host — managed mode constructs `{clusterRef.name}.{ns}.svc:{port}`, brownfield uses explicit `{host}:{port}`. Implemented; needs standalone table-driven unit tests.
- **`dbPort()`** (`reconcile_config.go:188`): Pure function returning port with 3306 default fallback. Implemented; needs edge case unit tests (zero value, explicit value).
- **`resolveCacheServers()`** (`reconcile_config.go:155`): Pure function constructing memcached endpoint list — managed mode generates `memcached-{i}.{name}:11211` for `replicas` count (default 3), brownfield joins explicit `Servers` list. Implemented; needs standalone table-driven unit tests.
- **Fernet keys hash annotation** (NEW in `reconcile_deployment.go`): Compute SHA-256 of the `{name}-fernet-keys` Secret data, set as `keystone.c5c3.io/fernet-keys-hash` annotation on `spec.template.metadata.annotations` in `buildKeystoneDeployment()`. Requires `reconcileDeployment()` to read the fernet-keys Secret and pass the hash. This is the missing piece — `buildKeystoneDeployment()` currently sets no pod template annotations (line 87-89).
- **`fernetRotationCronJob()`** (`reconcile_fernet.go:218`): Complete CronJob spec with init container, emptyDir, `OS_fernet_tokens__max_active_keys` env var, ServiceAccount. Implemented; needs envtest test verifying detailed spec fields.
- **`buildBootstrapJob()`** (`reconcile_bootstrap.go:69`): Complete Job spec with `backoffLimit: 4`, `ttlSecondsAfterFinished: 300`, admin-credentials env from SecretKeyRef, config ConfigMap volume mount. Implemented; needs envtest test verifying detailed spec fields.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fernet-keys hash annotation to Keystone pod template in `reconcileDeployment`
> - Adds `fernetKeysHash()` to `KeystoneReconciler` in [`reconcile_deployment.go`](https://github.com/C5C3/forge/pull/69/files#diff-7f62106776671c1ea38fe16a557fb5325c1975b38d9629898f7b3557c06b84c4), which reads the `{name}-fernet-keys` Secret, marshals its data to JSON for deterministic ordering, and returns a SHA-256 hex digest.
> - `reconcileDeployment` now annotates the pod template with `keystone.c5c3.io/fernet-keys-hash`, causing Kubernetes to roll the Deployment when fernet keys rotate.
> - `NotFound` errors from the Secret lookup are tolerated (empty hash proceeds); other API errors short-circuit with a wrapped error.
> - Unit and integration tests cover hash determinism, not-found handling, annotation propagation, and full reconciliation flow including CronJob and bootstrap Job spec validation.
> - Behavioral Change: `buildKeystoneDeployment` signature now requires a `fernetKeysHash string` argument; existing call sites in tests are updated to pass an empty string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00b2dae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->