### PR TITLE
fix: suspend keystone-operator HelmRelease in kind overlay

### DIFF
--- a/deploy/kind/base/kustomization.yaml
+++ b/deploy/kind/base/kustomization.yaml
@@ -74,3 +74,24 @@ patches:
         values:
           webhook:
             enabled: false
+
+  # keystone-operator: suspend Flux management in kind so that the e2e CI
+  # job can install it manually with a locally built dev image.
+  # Without this patch Flux installs the published chart from c5c3-charts,
+  # creating the ClusterRole with meta.helm.sh/release-namespace=openstack.
+  # The CI's subsequent `helm install` (no --namespace flag → default) then
+  # fails with an ownership-annotation conflict (fix-001).
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: keystone-operator
+      namespace: openstack
+    patch: |
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: keystone-operator
+        namespace: openstack
+      spec:
+        suspend: true


### PR DESCRIPTION
Flux reconciles the keystone-operator HelmRelease (namespace: openstack) during deploy-infra, creating the ClusterRole with annotation meta.helm.sh/release-namespace=openstack. The e2e CI job then runs `helm install keystone-operator` without --namespace (defaults to default), which fails with an ownership-annotation conflict.

Suspend the HelmRelease in the kind/base overlay so Flux leaves it alone; the CI job manages the operator installation itself using the locally built dev image.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com