### PR TITLE
feat: add OCI base image digest labels to all container images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,6 +5,7 @@
 name: Build Images
 
 "on":
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -44,6 +45,8 @@ jobs:
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     outputs:
       python-base-image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+      python-base-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+      python-base-digest: ${{ steps.build-python-base.outputs.digest }}
       venv-builder-image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
     steps:
       # CC-0007: Fork PRs receive a read-only GITHUB_TOKEN that cannot push
@@ -73,6 +76,18 @@ jobs:
       # CC-0030: Install cosign for image signing
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
+      - name: Resolve ubuntu:noble digest
+        id: ubuntu-base
+        run: |
+          set -euo pipefail
+          digest=$(docker buildx imagetools inspect ubuntu:noble --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [[ -z "${digest}" ]]; then
+            echo "ERROR: failed to resolve ubuntu:noble digest" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ubuntu:noble digest: ${digest}"
+
       # CC-0031: Generate OCI annotations for python-base
       - name: Generate metadata for python-base
         id: meta-python-base
@@ -95,7 +110,10 @@ jobs:
           tags: |
             ghcr.io/${{ steps.meta.outputs.owner }}/python-base:latest
             ghcr.io/${{ steps.meta.outputs.owner }}/python-base:${{ github.sha }}
-          labels: ${{ steps.meta-python-base.outputs.labels }}
+          labels: |
+            ${{ steps.meta-python-base.outputs.labels }}
+            org.opencontainers.image.base.name=ubuntu:noble
+            org.opencontainers.image.base.digest=${{ steps.ubuntu-base.outputs.digest }}
           cache-from: type=gha,scope=python-base
           cache-to: type=gha,mode=max,scope=python-base
 
@@ -182,7 +200,10 @@ jobs:
           tags: |
             ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:latest
             ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:${{ github.sha }}
-          labels: ${{ steps.meta-venv-builder.outputs.labels }}
+          labels: |
+            ${{ steps.meta-venv-builder.outputs.labels }}
+            org.opencontainers.image.base.name=ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+            org.opencontainers.image.base.digest=${{ steps.build-python-base.outputs.digest }}
           cache-from: type=gha,scope=venv-builder
           cache-to: type=gha,mode=max,scope=venv-builder
 
@@ -432,7 +453,10 @@ jobs:
             ${{ steps.tags.outputs.composite }}
             ${{ github.ref_name == 'main' && steps.tags.outputs.version || '' }}
             ${{ steps.tags.outputs.sha }}
-          labels: ${{ steps.meta-service.outputs.labels }}
+          labels: |
+            ${{ steps.meta-service.outputs.labels }}
+            org.opencontainers.image.base.name=${{ needs.build-base-images.outputs.python-base-name }}
+            org.opencontainers.image.base.digest=${{ needs.build-base-images.outputs.python-base-digest }}
           cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}
 

--- a/.github/workflows/check-base-image-updates.yaml
+++ b/.github/workflows/check-base-image-updates.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Check Base Image Updates
+
+"on":
+  schedule:
+    # Daily at 05:00 UTC
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  actions: write
+
+jobs:
+  check-base-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Normalize image owner
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve current ubuntu:noble digest
+        id: upstream
+        run: |
+          set -euo pipefail
+          # NOTE: docker buildx imagetools inspect returns the manifest list digest for
+          # multi-arch images when no --platform flag is given. This is intentional — we
+          # compare manifest list digests end-to-end, not platform-specific digests.
+          digest=$(docker buildx imagetools inspect ubuntu:noble --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [[ -z "${digest}" ]]; then
+            echo "ERROR: failed to resolve ubuntu:noble digest" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Current ubuntu:noble digest: ${digest}"
+
+      - name: Read published python-base base digest
+        id: published
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 --quiet ghcr.io/${{ steps.meta.outputs.owner }}/python-base:latest
+          digest=$(docker inspect ghcr.io/${{ steps.meta.outputs.owner }}/python-base:latest \
+            --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}')
+          if [[ -z "${digest}" ]]; then
+            echo "ERROR: failed to read base digest label from python-base:latest" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Published python-base base digest: ${digest}"
+
+      - name: Trigger rebuild if base image changed
+        if: steps.upstream.outputs.digest != steps.published.outputs.digest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Base image changed: ${{ steps.published.outputs.digest }} → ${{ steps.upstream.outputs.digest }}"
+          # NOTE: This always dispatches on main. Images on stable/** branches will not
+          # receive automatic stale-base rebuilds. This is a known limitation.
+          gh workflow run build-images.yaml --repo "$GITHUB_REPOSITORY" --ref main

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -179,12 +179,16 @@ test_base_images_multi_arch() {
 test_base_image_digest_outputs() {
   echo "Test: base image outputs contain digest references (REQ-003)"
 
-  local python_output venv_output
+  local python_output venv_output python_name_output python_digest_output
   python_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-image"]' "$WORKFLOW" || true)
   venv_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["venv-builder-image"]' "$WORKFLOW" || true)
+  python_name_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-name"]' "$WORKFLOW" || true)
+  python_digest_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-digest"]' "$WORKFLOW" || true)
 
   assert_contains "python-base-image output references digest" "$python_output" "outputs.digest"
   assert_contains "venv-builder-image output references digest" "$venv_output" "outputs.digest"
+  assert_contains "python-base-name output is non-empty" "$python_name_output" "python-base"
+  assert_contains "python-base-digest output references build-python-base digest" "$python_digest_output" "build-python-base.outputs.digest"
 }
 
 # --- REQ-003, REQ-004: build-service-images depends on build-base-images and verify-base-images ---
@@ -903,6 +907,23 @@ test_service_build_push_has_labels_input() {
   labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.labels' "$WORKFLOW" || true)
 
   assert_contains "build-service labels references meta-service" "$labels" "steps.meta-service.outputs.labels"
+}
+
+# --- CC-0034: OCI base image labels present in build steps (REQ-002) ---
+test_oci_base_labels_in_build_steps() {
+  echo "Test: OCI base image labels present in all three build steps (CC-0034)"
+
+  local python_labels venv_labels service_labels
+  python_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-python-base") | .with.labels' "$WORKFLOW" || true)
+  venv_labels=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-venv-builder") | .with.labels' "$WORKFLOW" || true)
+  service_labels=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.labels' "$WORKFLOW" || true)
+
+  assert_contains "build-python-base labels include org.opencontainers.image.base.name" "$python_labels" "org.opencontainers.image.base.name"
+  assert_contains "build-python-base labels include org.opencontainers.image.base.digest" "$python_labels" "org.opencontainers.image.base.digest"
+  assert_contains "build-venv-builder labels include org.opencontainers.image.base.name" "$venv_labels" "org.opencontainers.image.base.name"
+  assert_contains "build-venv-builder labels include org.opencontainers.image.base.digest" "$venv_labels" "org.opencontainers.image.base.digest"
+  assert_contains "build-service labels include org.opencontainers.image.base.name" "$service_labels" "org.opencontainers.image.base.name"
+  assert_contains "build-service labels include org.opencontainers.image.base.digest" "$service_labels" "org.opencontainers.image.base.digest"
 }
 
 # --- CC-0031: metadata-action labels include OCI title (REQ-005) ---
@@ -1645,6 +1666,8 @@ echo ""
 test_venv_builder_build_push_has_labels_input
 echo ""
 test_service_build_push_has_labels_input
+echo ""
+test_oci_base_labels_in_build_steps
 echo ""
 test_metadata_action_labels_include_oci_title
 echo ""


### PR DESCRIPTION
Resolves ubuntu:noble digest at CI time and propagates org.opencontainers.image.base.name/digest labels through the full image chain (python-base → venv-builder → service images), making base image updates visible to tooling without a forge commit.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com