### PR TITLE
ci: add hadolint Dockerfile linting to build-images workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -12,19 +12,23 @@ name: Build Images
       - stable/**
     paths:
       - images/**
+      - operators/keystone/Dockerfile
       - releases/**
       - patches/**
       - scripts/**
       - tests/container-images/**
       - .github/workflows/build-images.yaml
+      - .hadolint.yaml
   pull_request:
     paths:
       - images/**
+      - operators/keystone/Dockerfile
       - releases/**
       - patches/**
       - scripts/**
       - tests/container-images/**
       - .github/workflows/build-images.yaml
+      - .hadolint.yaml
 
 permissions:
   contents: read
@@ -34,7 +38,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  lint-dockerfiles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        dockerfile:
+          - images/python-base/Dockerfile
+          - images/venv-builder/Dockerfile
+          - images/keystone/Dockerfile
+          - operators/keystone/Dockerfile
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Lint ${{ matrix.dockerfile }}
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+          failure-threshold: warning
+          config: .hadolint.yaml
+
   build-base-images:
+    needs: lint-dockerfiles
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# DL3006: local build-context references (python-base, venv-builder) intentionally
+# have no registry tag — they are passed as named build contexts at build time.
+# DL3008: apt package version pinning is impractical for Ubuntu-based images —
+# exact versions (e.g. python3=3.12.3-1) are not stable across mirror snapshots
+# and break whenever a point release is published. Reproducibility is achieved
+# through base image digest pinning instead.
+ignored:
+  - DL3006
+  - DL3008

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # ---------- Stage 1: build ----------
+# hadolint ignore=DL3006
 FROM venv-builder AS build
 
 # Comma-separated Python extras (e.g. "ldap,oauth1").
@@ -34,6 +35,7 @@ application = initialize_public_application()\n' \
     chmod +x /var/lib/openstack/bin/keystone-wsgi-public
 
 # ---------- Stage 2: runtime ----------
+# hadolint ignore=DL3006
 FROM python-base
 
 # DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:
@@ -51,6 +53,7 @@ COPY --from=build --link /var/lib/openstack /var/lib/openstack
 # --build-arg EXTRA_APT_PACKAGES=...), skip the install to avoid
 # "E: No packages specified" from apt-get. CI always provides packages
 # via the workflow's "Resolve extra packages" step.
+# hadolint ignore=DL3008
 RUN if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:noble
+FROM ubuntu:noble@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 ENV PATH=/var/lib/openstack/bin:$PATH
 ENV LANG=C.UTF-8

--- a/images/venv-builder/Dockerfile
+++ b/images/venv-builder/Dockerfile
@@ -5,7 +5,7 @@
 FROM python-base
 
 # Install uv (fast Python package manager, pinned via Renovate)
-COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.2@sha256:c4f5de312ee66d46810635ffc5df34a1973ba753e7241ce3a08ef979ddd7bea5 /uv /bin/
 
 # Build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \

--- a/operators/keystone/Dockerfile
+++ b/operators/keystone/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # ---------- Stage 1: builder ----------
-FROM golang:1.25 AS builder
+FROM golang:1.25@sha256:dfae680962532eeea67ab297f1166c2c4e686edb9a8f05f9d02d96fc9191833e AS builder
 
 WORKDIR /workspace
 
@@ -25,7 +25,7 @@ WORKDIR /workspace/operators/keystone
 RUN CGO_ENABLED=0 GOOS=linux go build -o manager main.go
 
 # ---------- Stage 2: runtime ----------
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 
 WORKDIR /
 


### PR DESCRIPTION
Adds a lint-dockerfiles job using hadolint/hadolint-action@v3.3.0 that lints all four Dockerfiles before the build-base-images job runs. Introduces .hadolint.yaml to suppress DL3006 for intentional untagged local build-context references (python-base, venv-builder).

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com