### PR TITLE
ci: generate service×release matrix dynamically from releases/ directory

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -342,8 +342,41 @@ jobs:
           VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
         run: bash tests/container-images/verify_venv_builder.sh "$VENV_BUILDER_IMAGE"
 
-  build-service-images:
+  generate-matrix:
     needs: [build-base-images, verify-base-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: mikefarah/yq@b534aa9ee5d38001fba3cd8fe254a037e4847b37 # v4.45.4
+
+      - name: Generate service×release matrix
+        id: matrix
+        run: |
+          matrix=$(
+            shopt -s nullglob
+            dirs=(releases/*/)
+            if [[ ${#dirs[@]} -eq 0 ]]; then
+              echo '{"include":[]}'
+            else
+              for release_dir in "${dirs[@]}"; do
+                release="${release_dir%/}"
+                release="${release#releases/}"
+                while IFS= read -r service; do
+                  echo "{\"service\":\"${service}\",\"release\":\"${release}\"}"
+                done < <(yq 'keys | .[]' "releases/${release}/source-refs.yaml")
+              done | jq -sc '{"include": .}'
+            fi
+          )
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  build-service-images:
+    needs: [build-base-images, verify-base-images, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -354,9 +387,7 @@ jobs:
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     strategy:
       fail-fast: false
-      matrix:
-        service: [keystone]
-        release: ["2025.2"]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -578,7 +609,7 @@ jobs:
 
   # CC-0034: Run upstream unit tests for each service inside the venv-builder container
   test-service-images:
-    needs: [build-base-images, verify-base-images]
+    needs: [build-base-images, verify-base-images, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -612,9 +643,7 @@ jobs:
           --health-retries=5
     strategy:
       fail-fast: false
-      matrix:
-        service: [keystone]
-        release: ["2025.2"]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -754,7 +783,7 @@ jobs:
 
   verify-service-images:
     if: github.event_name != 'pull_request'
-    needs: [build-service-images, test-service-images]
+    needs: [build-service-images, test-service-images, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -762,9 +791,7 @@ jobs:
       packages: read
     strategy:
       fail-fast: false
-      matrix:
-        service: [keystone]
-        release: ["2025.2"]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -201,18 +201,23 @@ test_service_images_depend_on_base() {
 
   assert_contains "build-service-images needs build-base-images" "$needs" "build-base-images"
   assert_contains "build-service-images needs verify-base-images" "$needs" "verify-base-images"
+  assert_contains "build-service-images needs generate-matrix" "$needs" "generate-matrix"
 }
 
-# --- REQ-004: Matrix includes service and release ---
+# --- REQ-004: Matrix is dynamic via fromJson ---
 test_matrix_includes_service_and_release() {
-  echo "Test: matrix includes service and release (REQ-004)"
+  echo "Test: matrix is dynamic via fromJson(needs.generate-matrix.outputs.matrix) (REQ-004)"
 
-  local services releases
-  services=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" || true)
-  releases=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]["release"][]' "$WORKFLOW" || true)
+  local matrix_expr
+  matrix_expr=$(yq_raw '.jobs["build-service-images"]["strategy"]["matrix"]' "$WORKFLOW" || true)
 
-  assert_contains "matrix includes keystone service" "$services" "keystone"
-  assert_contains "matrix includes 2025.2 release" "$releases" "2025.2"
+  assert_contains "build-service-images matrix uses fromJson" "$matrix_expr" "fromJson"
+  assert_contains "build-service-images matrix reads generate-matrix output" "$matrix_expr" "generate-matrix"
+
+  local gen_matrix_output
+  gen_matrix_output=$(yq_raw '.jobs["generate-matrix"]["outputs"]["matrix"]' "$WORKFLOW" || true)
+
+  assert_contains "generate-matrix job exposes matrix output" "$gen_matrix_output" "matrix"
 }
 
 # --- REQ-004: Source ref resolution step exists ---
@@ -328,16 +333,18 @@ test_verify_service_images_depends_on_service_images() {
 
   assert_contains "verify-service-images needs build-service-images" "$needs" "build-service-images"
   assert_contains "verify-service-images needs test-service-images" "$needs" "test-service-images"
+  assert_contains "verify-service-images needs generate-matrix" "$needs" "generate-matrix"
 }
 
-# --- REQ-007: verify-service-images has its own matrix strategy for multi-service support ---
+# --- REQ-007: verify-service-images uses dynamic matrix via fromJson ---
 test_verify_service_images_has_matrix() {
-  echo "Test: verify-service-images has its own matrix strategy (REQ-007)"
+  echo "Test: verify-service-images uses dynamic matrix via fromJson (REQ-007)"
 
-  local services
-  services=$(yq_raw '.jobs["verify-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" || true)
+  local matrix_expr
+  matrix_expr=$(yq_raw '.jobs["verify-service-images"]["strategy"]["matrix"]' "$WORKFLOW" || true)
 
-  assert_contains "verify-service-images matrix includes keystone" "$services" "keystone"
+  assert_contains "verify-service-images matrix uses fromJson" "$matrix_expr" "fromJson"
+  assert_contains "verify-service-images matrix reads generate-matrix output" "$matrix_expr" "generate-matrix"
 }
 
 # --- REQ-007: verify-service-images derives image ref independently ---
@@ -640,13 +647,12 @@ test_test_service_images_depends_on_base() {
 test_test_service_images_has_matrix() {
   echo "Test: test-service-images has matrix strategy (CC-0034 REQ-001)"
 
-  local services releases fail_fast
-  services=$(yq_raw '.jobs["test-service-images"]["strategy"]["matrix"]["service"][]' "$WORKFLOW" || true)
-  releases=$(yq_raw '.jobs["test-service-images"]["strategy"]["matrix"]["release"][]' "$WORKFLOW" || true)
+  local matrix_expr fail_fast
+  matrix_expr=$(yq_raw '.jobs["test-service-images"]["strategy"]["matrix"]' "$WORKFLOW" || true)
   fail_fast=$(yq_raw '.jobs["test-service-images"]["strategy"]["fail-fast"]' "$WORKFLOW" || echo "null")
 
-  assert_contains "test-service-images matrix includes keystone" "$services" "keystone"
-  assert_contains "test-service-images matrix includes release 2025.2" "$releases" "2025.2"
+  assert_contains "test-service-images matrix uses fromJson" "$matrix_expr" "fromJson"
+  assert_contains "test-service-images matrix reads generate-matrix output" "$matrix_expr" "generate-matrix"
   assert_eq "test-service-images has fail-fast: false" "false" "$fail_fast"
 }
 


### PR DESCRIPTION
Replace hardcoded matrix (service: [keystone], release: ["2025.2"]) with a generate-matrix job that enumerates releases/*/source-refs.yaml at runtime and emits a fromJson include array. New releases and services are picked up automatically without touching the workflow.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com