### PR TITLE
ci: add linux/arm64 platform to operator image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -507,6 +507,7 @@ jobs:
         with:
           context: .
           file: operators/${{ matrix.operator }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
On-behalf-of: @SAP christian.berendt@sap.com