### PR TITLE
ci: run ARM builds on native ubuntu-24.04-arm runners

### DIFF
--- a/.github/actions/derive-service-tags/action.yaml
+++ b/.github/actions/derive-service-tags/action.yaml
@@ -1,0 +1,71 @@
+name: Derive service image tags
+description: >
+  Compute the image name and all tags (composite, version, SHA) for a service
+  image. Used by both build-service-images and merge-service-images so that
+  tag derivation stays in a single, authoritative location.
+
+inputs:
+  service:
+    description: OpenStack service name (e.g. keystone)
+    required: true
+  release:
+    description: Release directory name (e.g. 2025.2)
+    required: true
+  repository-owner:
+    description: GitHub repository owner (github.repository_owner)
+    required: true
+
+outputs:
+  image:
+    description: Bare image name without tag (e.g. ghcr.io/owner/keystone)
+    value: ${{ steps.run.outputs.image }}
+  composite:
+    description: Full composite tag reference (e.g. ghcr.io/owner/keystone:28.0.0-p0-main-abc1234)
+    value: ${{ steps.run.outputs.composite }}
+  version:
+    description: Version-only tag reference (e.g. ghcr.io/owner/keystone:28.0.0)
+    value: ${{ steps.run.outputs.version }}
+  sha:
+    description: Short-SHA tag reference (e.g. ghcr.io/owner/keystone:abc1234)
+    value: ${{ steps.run.outputs.sha }}
+  version-ref:
+    description: Raw upstream version string (e.g. 28.0.0)
+    value: ${{ steps.run.outputs.version-ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Derive tags
+      id: run
+      shell: bash
+      env:
+        MATRIX_SERVICE: ${{ inputs.service }}
+        MATRIX_RELEASE: ${{ inputs.release }}
+        IMAGE_OWNER: ${{ inputs.repository-owner }}
+      run: |
+        VERSION=$(yq ".\"${MATRIX_SERVICE}\"" "releases/${MATRIX_RELEASE}/source-refs.yaml")
+        if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+          echo "::error::No source-ref found for '${MATRIX_SERVICE}' in releases/${MATRIX_RELEASE}/source-refs.yaml"
+          exit 1
+        fi
+
+        IMAGE_OWNER="${IMAGE_OWNER,,}"
+        SHORT_SHA="${GITHUB_SHA::7}"
+        BRANCH="${GITHUB_REF_NAME//\//-}"
+
+        PATCH_DIR="patches/${MATRIX_SERVICE}/${MATRIX_RELEASE}"
+        if [ -d "$PATCH_DIR" ]; then
+          PATCH_COUNT=$(find "$PATCH_DIR" -name '*.patch' -type f | wc -l | xargs)
+        else
+          PATCH_COUNT=0
+        fi
+
+        IMAGE="ghcr.io/${IMAGE_OWNER}/${MATRIX_SERVICE}"
+        COMPOSITE="${VERSION}-p${PATCH_COUNT}-${BRANCH}-${SHORT_SHA}"
+
+        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "composite=${IMAGE}:${COMPOSITE}" >> "$GITHUB_OUTPUT"
+        echo "version=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "sha=${IMAGE}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+        echo "version-ref=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "Tags: ${COMPOSITE}, ${VERSION}, ${SHORT_SHA}"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -60,21 +60,23 @@ jobs:
           failure-threshold: warning
           config: .hadolint.yaml
 
+  # Each platform (amd64, arm64) is built on a native runner and pushed by digest.
+  # The merge-base-images job then assembles the multi-arch manifest list.
   build-base-images:
     needs: lint-dockerfiles
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
-      id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing for SBOM attestation, cosign signing, and build provenance
-      attestations: write   # CC-0029, CC-0035: GitHub Attestations API
-      security-events: write  # CC-0032: GitHub Security tab SARIF upload
-    outputs:
-      python-base-image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
-      python-base-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
-      python-base-digest: ${{ steps.build-python-base.outputs.digest }}
-      venv-builder-image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       # CC-0007: Fork PRs receive a read-only GITHUB_TOKEN that cannot push
       # to GHCR. Since base images must be pushed (docker-image:// URIs require
@@ -92,6 +94,12 @@ jobs:
         id: meta
         run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare platform pair
+        id: platform-pair
+        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
@@ -99,9 +107,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # CC-0030: Install cosign for image signing
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
       - name: Resolve ubuntu:noble digest
         id: ubuntu-base
@@ -132,24 +137,135 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: images/python-base
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.meta.outputs.owner }}/python-base:latest
-            ghcr.io/${{ steps.meta.outputs.owner }}/python-base:${{ github.sha }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          tags: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
           labels: |
             ${{ steps.meta-python-base.outputs.labels }}
             org.opencontainers.image.base.name=ubuntu:noble
             org.opencontainers.image.base.digest=${{ steps.ubuntu-base.outputs.digest }}
-          cache-from: type=gha,scope=python-base
-          cache-to: type=gha,mode=max,scope=python-base
+          cache-from: type=gha,scope=python-base-${{ steps.platform-pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=python-base-${{ steps.platform-pair.outputs.value }}
+
+      - name: Export python-base digest
+        run: |
+          mkdir -p /tmp/digests/python-base
+          digest="${{ steps.build-python-base.outputs.digest }}"
+          touch "/tmp/digests/python-base/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: digests-python-base-${{ steps.platform-pair.outputs.value }}
+          path: /tmp/digests/python-base/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # CC-0031: Generate OCI annotations for venv-builder
+      - name: Generate metadata for venv-builder
+        id: meta-venv-builder
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
+          labels: |
+            org.opencontainers.image.title=venv-builder
+            org.opencontainers.image.description=Python virtualenv builder image for OpenStack services
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=SAP SE
+
+      - name: Build and push venv-builder
+        id: build-venv-builder
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: images/venv-builder
+          build-contexts: |
+            python-base=docker-image://ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          tags: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
+          labels: |
+            ${{ steps.meta-venv-builder.outputs.labels }}
+            org.opencontainers.image.base.name=ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+            org.opencontainers.image.base.digest=${{ steps.build-python-base.outputs.digest }}
+          cache-from: type=gha,scope=venv-builder-${{ steps.platform-pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=venv-builder-${{ steps.platform-pair.outputs.value }}
+
+      - name: Export venv-builder digest
+        run: |
+          mkdir -p /tmp/digests/venv-builder
+          digest="${{ steps.build-venv-builder.outputs.digest }}"
+          touch "/tmp/digests/venv-builder/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: digests-venv-builder-${{ steps.platform-pair.outputs.value }}
+          path: /tmp/digests/venv-builder/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assembles per-platform digests into multi-arch manifest lists, then
+  # runs SBOM generation, vulnerability scanning, attestation, and signing.
+  merge-base-images:
+    needs: build-base-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing for SBOM attestation, cosign signing, and build provenance
+      attestations: write   # CC-0029, CC-0035: GitHub Attestations API
+      security-events: write  # CC-0032: GitHub Security tab SARIF upload
+    outputs:
+      python-base-image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.merge-python-base.outputs.digest }}
+      python-base-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+      python-base-digest: ${{ steps.merge-python-base.outputs.digest }}
+      venv-builder-image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.merge-venv-builder.outputs.digest }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Normalize image owner
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CC-0030: Install cosign for image signing
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
+
+      - name: Download python-base digests
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          pattern: digests-python-base-*
+          path: /tmp/digests/python-base
+          merge-multiple: true
+
+      - name: Create and push python-base manifest
+        id: merge-python-base
+        env:
+          IMAGE: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
+        run: |
+          cd /tmp/digests/python-base
+          [[ $(ls | wc -l) -ge 1 ]] || { echo "::error::No digests found for python-base"; exit 1; }
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${{ github.sha }}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${{ github.sha }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Created python-base manifest: ${digest}"
 
       # CC-0029: Generate and attest SBOM for python-base
       - name: Generate SBOM for python-base
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.merge-python-base.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom-python-base.cyclonedx.json
           upload-artifact: false
@@ -174,7 +290,7 @@ jobs:
         id: grype-python-base-image
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
         with:
-          image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.merge-python-base.outputs.digest }}
           severity-cutoff: high
           fail-build: false
           output-format: sarif
@@ -194,7 +310,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
-          subject-digest: ${{ steps.build-python-base.outputs.digest }}
+          subject-digest: ${{ steps.merge-python-base.outputs.digest }}
           sbom-path: sbom-python-base.cyclonedx.json
           push-to-registry: true
 
@@ -204,51 +320,43 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/python-base
-          subject-digest: ${{ steps.build-python-base.outputs.digest }}
+          subject-digest: ${{ steps.merge-python-base.outputs.digest }}
           push-to-registry: true
 
       # CC-0030: Sign python-base with cosign keyless signing
       - name: Sign python-base
         if: github.event_name != 'pull_request'
-        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
+        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.merge-python-base.outputs.digest }}
 
-      # CC-0031: Generate OCI annotations for venv-builder
-      - name: Generate metadata for venv-builder
-        id: meta-venv-builder
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+      - name: Download venv-builder digests
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
-          images: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
-          labels: |
-            org.opencontainers.image.title=venv-builder
-            org.opencontainers.image.description=Python virtualenv builder image for OpenStack services
-            org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.vendor=SAP SE
+          pattern: digests-venv-builder-*
+          path: /tmp/digests/venv-builder
+          merge-multiple: true
 
-      - name: Build and push venv-builder
-        id: build-venv-builder
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: images/venv-builder
-          build-contexts: |
-            python-base=docker-image://ghcr.io/${{ steps.meta.outputs.owner }}/python-base@${{ steps.build-python-base.outputs.digest }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:latest
-            ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder:${{ github.sha }}
-          labels: |
-            ${{ steps.meta-venv-builder.outputs.labels }}
-            org.opencontainers.image.base.name=ghcr.io/${{ steps.meta.outputs.owner }}/python-base
-            org.opencontainers.image.base.digest=${{ steps.build-python-base.outputs.digest }}
-          cache-from: type=gha,scope=venv-builder
-          cache-to: type=gha,mode=max,scope=venv-builder
+      - name: Create and push venv-builder manifest
+        id: merge-venv-builder
+        env:
+          IMAGE: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
+        run: |
+          cd /tmp/digests/venv-builder
+          [[ $(ls | wc -l) -ge 1 ]] || { echo "::error::No digests found for venv-builder"; exit 1; }
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${{ github.sha }}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${{ github.sha }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Created venv-builder manifest: ${digest}"
 
       # CC-0029: Generate and attest SBOM for venv-builder
       - name: Generate SBOM for venv-builder
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.merge-venv-builder.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom-venv-builder.cyclonedx.json
           upload-artifact: false
@@ -270,7 +378,7 @@ jobs:
         id: grype-venv-builder-image
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
         with:
-          image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+          image: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.merge-venv-builder.outputs.digest }}
           severity-cutoff: high
           fail-build: false
           output-format: sarif
@@ -290,7 +398,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
-          subject-digest: ${{ steps.build-venv-builder.outputs.digest }}
+          subject-digest: ${{ steps.merge-venv-builder.outputs.digest }}
           sbom-path: sbom-venv-builder.cyclonedx.json
           push-to-registry: true
 
@@ -300,16 +408,16 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder
-          subject-digest: ${{ steps.build-venv-builder.outputs.digest }}
+          subject-digest: ${{ steps.merge-venv-builder.outputs.digest }}
           push-to-registry: true
 
       # CC-0030: Sign venv-builder with cosign keyless signing
       - name: Sign venv-builder
         if: github.event_name != 'pull_request'
-        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.build-venv-builder.outputs.digest }}
+        run: cosign sign --yes ghcr.io/${{ steps.meta.outputs.owner }}/venv-builder@${{ steps.merge-venv-builder.outputs.digest }}
 
   verify-base-images:
-    needs: [build-base-images]
+    needs: [merge-base-images]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -326,30 +434,31 @@ jobs:
 
       - name: Pull base images
         env:
-          PYTHON_BASE_IMAGE: ${{ needs.build-base-images.outputs.python-base-image }}
-          VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
+          PYTHON_BASE_IMAGE: ${{ needs.merge-base-images.outputs.python-base-image }}
+          VENV_BUILDER_IMAGE: ${{ needs.merge-base-images.outputs.venv-builder-image }}
         run: |
           docker pull "$PYTHON_BASE_IMAGE"
           docker pull "$VENV_BUILDER_IMAGE"
 
       - name: Verify python-base image
         env:
-          PYTHON_BASE_IMAGE: ${{ needs.build-base-images.outputs.python-base-image }}
+          PYTHON_BASE_IMAGE: ${{ needs.merge-base-images.outputs.python-base-image }}
         run: bash tests/container-images/verify_python_base.sh "$PYTHON_BASE_IMAGE"
 
       - name: Verify venv-builder image
         env:
-          VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
+          VENV_BUILDER_IMAGE: ${{ needs.merge-base-images.outputs.venv-builder-image }}
         run: bash tests/container-images/verify_venv_builder.sh "$VENV_BUILDER_IMAGE"
 
   generate-matrix:
-    needs: [build-base-images, verify-base-images]
+    needs: [merge-base-images, verify-base-images]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      build-matrix: ${{ steps.matrix.outputs.build-matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -357,27 +466,50 @@ jobs:
 
       - name: Generate service×release matrix
         id: matrix
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
-          matrix=$(
-            shopt -s nullglob
-            dirs=(releases/*/)
-            if [[ ${#dirs[@]} -eq 0 ]]; then
-              echo '{"include":[]}'
-            else
-              for release_dir in "${dirs[@]}"; do
-                release="${release_dir%/}"
-                release="${release#releases/}"
-                while IFS= read -r service; do
-                  echo "{\"service\":\"${service}\",\"release\":\"${release}\"}"
-                done < <(yq 'keys | .[]' "releases/${release}/source-refs.yaml")
-              done | jq -sc '{"include": .}'
-            fi
-          )
-          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          shopt -s nullglob
+          dirs=(releases/*/)
 
+          if [[ ${#dirs[@]} -eq 0 ]]; then
+            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            echo "build-matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Collect {service, release} pairs
+          pairs=$(
+            for release_dir in "${dirs[@]}"; do
+              release="${release_dir%/}"
+              release="${release#releases/}"
+              while IFS= read -r service; do
+                echo "{\"service\":\"${service}\",\"release\":\"${release}\"}"
+              done < <(yq 'keys | .[]' "releases/${release}/source-refs.yaml")
+            done | jq -sc '.'
+          )
+
+          # Simple matrix for test/verify jobs: {service, release}
+          echo "matrix=$(echo "$pairs" | jq -c '{"include": .}')" >> "$GITHUB_OUTPUT"
+
+          # Build matrix for build jobs: {service, release, platform, runner}
+          # ARM64 is excluded on pull_request to avoid unnecessary cross-platform builds
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            platforms='[{"platform":"linux/amd64","runner":"ubuntu-latest"}]'
+          else
+            platforms='[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]'
+          fi
+
+          build_matrix=$(echo "$pairs" | jq -c \
+            --argjson p "$platforms" \
+            '[.[] as $sr | $p[] | {service: $sr.service, release: $sr.release, platform: .platform, runner: .runner}] | {"include": .}')
+          echo "build-matrix=${build_matrix}" >> "$GITHUB_OUTPUT"
+
+  # Each platform is built on a native runner and pushed by digest (non-PR) or
+  # loaded locally for verification (PR, amd64 only via build-matrix filtering).
   build-service-images:
-    needs: [build-base-images, verify-base-images, generate-matrix]
-    runs-on: ubuntu-latest
+    needs: [merge-base-images, verify-base-images, generate-matrix]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -387,7 +519,7 @@ jobs:
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.build-matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -451,31 +583,17 @@ jobs:
 
       - name: Derive tags
         id: tags
+        uses: ./.github/actions/derive-service-tags
+        with:
+          service: ${{ matrix.service }}
+          release: ${{ matrix.release }}
+          repository-owner: ${{ github.repository_owner }}
+
+      - name: Prepare platform pair
+        id: platform-pair
+        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
         env:
-          VERSION: ${{ steps.source-ref.outputs.ref }}
-          MATRIX_SERVICE: ${{ matrix.service }}
-          MATRIX_RELEASE: ${{ matrix.release }}
-          IMAGE_OWNER: ${{ github.repository_owner }}
-        run: |
-          IMAGE_OWNER="${IMAGE_OWNER,,}"
-          SHORT_SHA="${GITHUB_SHA::7}"
-          BRANCH="${GITHUB_REF_NAME//\//-}"
-
-          PATCH_DIR="patches/${MATRIX_SERVICE}/${MATRIX_RELEASE}"
-          if [ -d "$PATCH_DIR" ]; then
-            PATCH_COUNT=$(find "$PATCH_DIR" -name '*.patch' -type f | wc -l | xargs)
-          else
-            PATCH_COUNT=0
-          fi
-
-          IMAGE="ghcr.io/${IMAGE_OWNER}/${MATRIX_SERVICE}"
-          COMPOSITE="${VERSION}-p${PATCH_COUNT}-${BRANCH}-${SHORT_SHA}"
-
-          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "composite=${IMAGE}:${COMPOSITE}" >> "$GITHUB_OUTPUT"
-          echo "version=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "sha=${IMAGE}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Tags: ${COMPOSITE}, ${VERSION}, ${SHORT_SHA}"
+          PLATFORM: ${{ matrix.platform }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -515,49 +633,39 @@ jobs:
             PIP_PACKAGES=${{ steps.extra-pkgs.outputs.pip-packages }}
             EXTRA_APT_PACKAGES=${{ steps.extra-pkgs.outputs.apt-packages }}
           build-contexts: |
-            python-base=docker-image://${{ needs.build-base-images.outputs.python-base-image }}
-            venv-builder=docker-image://${{ needs.build-base-images.outputs.venv-builder-image }}
+            python-base=docker-image://${{ needs.merge-base-images.outputs.python-base-image }}
+            venv-builder=docker-image://${{ needs.merge-base-images.outputs.venv-builder-image }}
             ${{ matrix.service }}=src/${{ matrix.service }}
             upper-constraints=releases/${{ matrix.release }}/
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ matrix.platform }}
+          # PR: load locally with composite tag for verification.
+          # Non-PR: push by digest; merge-service-images creates the tagged manifest list.
           load: ${{ github.event_name == 'pull_request' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          # CC-0007: The version-only tag (e.g. keystone:28.0.0) is restricted
-          # to main to prevent silent overwrites across branches. The composite
-          # tag already encodes branch, so stable/** builds remain identifiable.
-          tags: |
-            ${{ steps.tags.outputs.composite }}
-            ${{ github.ref_name == 'main' && steps.tags.outputs.version || '' }}
-            ${{ steps.tags.outputs.sha }}
+          outputs: ${{ github.event_name != 'pull_request' && 'type=image,push-by-digest=true,name-canonical=true,push=true' || '' }}
+          tags: ${{ github.event_name == 'pull_request' && steps.tags.outputs.composite || steps.tags.outputs.image }}
           labels: |
             ${{ steps.meta-service.outputs.labels }}
-            org.opencontainers.image.base.name=${{ needs.build-base-images.outputs.python-base-name }}
-            org.opencontainers.image.base.digest=${{ needs.build-base-images.outputs.python-base-digest }}
-          cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}
+            org.opencontainers.image.base.name=${{ needs.merge-base-images.outputs.python-base-name }}
+            org.opencontainers.image.base.digest=${{ needs.merge-base-images.outputs.python-base-digest }}
+          cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.release }}-${{ steps.platform-pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ matrix.release }}-${{ steps.platform-pair.outputs.value }}
 
-      # CC-0029: Generate and attest SBOM for service image
-      - name: Generate SBOM for service image
+      - name: Export service image digest
         if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
-        with:
-          image: ${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}
-          format: cyclonedx-json
-          output-file: sbom-${{ matrix.service }}.cyclonedx.json
-          upload-artifact: false
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build-service.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-      # CC-0032: Scan service image for vulnerabilities
-      # See DECISION comment on Scan python-base step above
-      - name: Scan service image for vulnerabilities (SBOM)
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: github.event_name != 'pull_request'
-        id: grype-service-sbom
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
         with:
-          sbom: sbom-${{ matrix.service }}.cyclonedx.json
-          severity-cutoff: high
-          fail-build: false
-          output-format: sarif
+          name: digests-service-${{ matrix.service }}-${{ matrix.release }}-${{ steps.platform-pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
+      # CC-0032: Scan service image for vulnerabilities on PRs (image scan against locally-loaded image)
       - name: Scan service image for vulnerabilities (image)
         if: github.event_name == 'pull_request'
         id: grype-service-image
@@ -569,37 +677,11 @@ jobs:
           output-format: sarif
 
       - name: Upload SARIF for service image
-        if: >-
-          always() &&
-          (steps.grype-service-sbom.outputs.sarif != '' ||
-           steps.grype-service-image.outputs.sarif != '')
+        if: always() && steps.grype-service-image.outputs.sarif != ''
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
-          sarif_file: ${{ steps.grype-service-sbom.outputs.sarif || steps.grype-service-image.outputs.sarif }}
-          category: grype-${{ matrix.service }}
-
-      - name: Attest SBOM for service image
-        if: github.event_name != 'pull_request'
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
-        with:
-          subject-name: ${{ steps.tags.outputs.image }}
-          subject-digest: ${{ steps.build-service.outputs.digest }}
-          sbom-path: sbom-${{ matrix.service }}.cyclonedx.json
-          push-to-registry: true
-
-      # CC-0035: Attest build provenance for service image (SLSA Level 2+)
-      - name: Attest build provenance for service image
-        if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
-        with:
-          subject-name: ${{ steps.tags.outputs.image }}
-          subject-digest: ${{ steps.build-service.outputs.digest }}
-          push-to-registry: true
-
-      # CC-0030: Sign service image with cosign keyless signing
-      - name: Sign service image
-        if: github.event_name != 'pull_request'
-        run: cosign sign --yes ${{ steps.tags.outputs.image }}@${{ steps.build-service.outputs.digest }}
+          sarif_file: ${{ steps.grype-service-image.outputs.sarif }}
+          category: grype-${{ matrix.service }}-${{ steps.platform-pair.outputs.value }}
 
       - name: Verify service image (PR)
         if: github.event_name == 'pull_request'
@@ -607,9 +689,130 @@ jobs:
           IMAGE_REF: ${{ steps.tags.outputs.composite }}
         run: bash tests/container-images/verify_${{ matrix.service }}.sh "$IMAGE_REF"
 
+  # Assembles per-platform digests into multi-arch manifest lists, then
+  # runs SBOM generation, vulnerability scanning, attestation, and signing.
+  merge-service-images:
+    if: github.event_name != 'pull_request'
+    needs: [merge-base-images, build-service-images, generate-matrix]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing for SBOM attestation, cosign signing, and build provenance
+      attestations: write   # CC-0029, CC-0035: GitHub Attestations API
+      security-events: write  # CC-0032: GitHub Security tab SARIF upload
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: mikefarah/yq@b534aa9ee5d38001fba3cd8fe254a037e4847b37 # v4.45.4
+
+      - name: Normalize image owner
+        id: meta
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CC-0030: Install cosign for image signing
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
+
+      - name: Derive tags
+        id: tags
+        uses: ./.github/actions/derive-service-tags
+        with:
+          service: ${{ matrix.service }}
+          release: ${{ matrix.release }}
+          repository-owner: ${{ github.repository_owner }}
+
+      - name: Download service image digests
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          pattern: digests-service-${{ matrix.service }}-${{ matrix.release }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Create and push service image manifest
+        id: merge-service
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}
+        run: |
+          cd /tmp/digests
+          [[ $(ls | wc -l) -ge 1 ]] || { echo "::error::No digests found for ${{ matrix.service }}-${{ matrix.release }}"; exit 1; }
+          # CC-0007: The version-only tag (e.g. keystone:28.0.0) is restricted
+          # to main to prevent silent overwrites across branches.
+          version_tag=""
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            version_tag="-t ${{ steps.tags.outputs.version }}"
+          fi
+          docker buildx imagetools create \
+            -t "${{ steps.tags.outputs.composite }}" \
+            ${version_tag} \
+            -t "${{ steps.tags.outputs.sha }}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          digest=$(docker buildx imagetools inspect "${{ steps.tags.outputs.composite }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Created service image manifest: ${digest}"
+
+      # CC-0029: Generate and attest SBOM for service image
+      - name: Generate SBOM for service image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ${{ steps.tags.outputs.image }}@${{ steps.merge-service.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.service }}.cyclonedx.json
+          upload-artifact: false
+
+      # CC-0032: Scan service image for vulnerabilities
+      # See DECISION comment in merge-base-images
+      - name: Scan service image for vulnerabilities (SBOM)
+        id: grype-service-sbom
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
+        with:
+          sbom: sbom-${{ matrix.service }}.cyclonedx.json
+          severity-cutoff: high
+          fail-build: false
+          output-format: sarif
+
+      - name: Upload SARIF for service image
+        if: always() && steps.grype-service-sbom.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          sarif_file: ${{ steps.grype-service-sbom.outputs.sarif }}
+          category: grype-${{ matrix.service }}
+
+      - name: Attest SBOM for service image
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.merge-service.outputs.digest }}
+          sbom-path: sbom-${{ matrix.service }}.cyclonedx.json
+          push-to-registry: true
+
+      # CC-0035: Attest build provenance for service image (SLSA Level 2+)
+      - name: Attest build provenance for service image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.merge-service.outputs.digest }}
+          push-to-registry: true
+
+      # CC-0030: Sign service image with cosign keyless signing
+      - name: Sign service image
+        run: cosign sign --yes ${{ steps.tags.outputs.image }}@${{ steps.merge-service.outputs.digest }}
+
   # CC-0034: Run upstream unit tests for each service inside the venv-builder container
   test-service-images:
-    needs: [build-base-images, verify-base-images, generate-matrix]
+    needs: [merge-base-images, verify-base-images, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -719,7 +922,7 @@ jobs:
         env:
           MATRIX_SERVICE: ${{ matrix.service }}
           MATRIX_RELEASE: ${{ matrix.release }}
-          VENV_BUILDER_IMAGE: ${{ needs.build-base-images.outputs.venv-builder-image }}
+          VENV_BUILDER_IMAGE: ${{ needs.merge-base-images.outputs.venv-builder-image }}
           # CC-0034: PBR requires version metadata, but uv's build isolation
           # copies source without .git.  Passed into the container to write
           # a PKG-INFO file that PBR reads as a fallback (see script below).
@@ -783,7 +986,7 @@ jobs:
 
   verify-service-images:
     if: github.event_name != 'pull_request'
-    needs: [build-service-images, test-service-images, generate-matrix]
+    needs: [merge-service-images, test-service-images, generate-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -801,36 +1004,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # NOTE: This tag derivation MUST stay in sync with the 'Derive tags' step
-      # in build-service-images. If the tag format changes there, update this
-      # step too — otherwise verify-service-images pulls a ref that was never pushed.
-      - name: Derive image ref
+      - name: Derive tags
         id: tags
-        env:
-          MATRIX_SERVICE: ${{ matrix.service }}
-          MATRIX_RELEASE: ${{ matrix.release }}
-          IMAGE_OWNER: ${{ github.repository_owner }}
-        run: |
-          IMAGE_OWNER="${IMAGE_OWNER,,}"
-          VERSION=$(yq ".\"${MATRIX_SERVICE}\"" "releases/${MATRIX_RELEASE}/source-refs.yaml")
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "::error::No source-ref found for '${MATRIX_SERVICE}' in releases/${MATRIX_RELEASE}/source-refs.yaml"
-            exit 1
-          fi
-          SHORT_SHA="${GITHUB_SHA::7}"
-          BRANCH="${GITHUB_REF_NAME//\//-}"
-          PATCH_DIR="patches/${MATRIX_SERVICE}/${MATRIX_RELEASE}"
-          if [ -d "$PATCH_DIR" ]; then
-            PATCH_COUNT=$(find "$PATCH_DIR" -name '*.patch' -type f | wc -l | xargs)
-          else
-            PATCH_COUNT=0
-          fi
-          IMAGE="ghcr.io/${IMAGE_OWNER}/${MATRIX_SERVICE}"
-          echo "image-ref=${IMAGE}:${VERSION}-p${PATCH_COUNT}-${BRANCH}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/derive-service-tags
+        with:
+          service: ${{ matrix.service }}
+          release: ${{ matrix.release }}
+          repository-owner: ${{ github.repository_owner }}
 
       - name: Pull and verify service image
         env:
-          IMAGE_REF: ${{ steps.tags.outputs.image-ref }}
+          IMAGE_REF: ${{ steps.tags.outputs.composite }}
         run: |
           docker pull "$IMAGE_REF"
           bash tests/container-images/verify_${{ matrix.service }}.sh "$IMAGE_REF"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,14 +464,88 @@ jobs:
           path: _output/reports/
           retention-days: 14
 
-  # CC-0018, REQ-006: Build and push operator container images to GHCR.
+  # CC-0018, REQ-006: Build operator container images per platform on native runners.
+  # Each platform is pushed by digest; merge-operator-images assembles the manifest list.
   # Runs only on push events (main branch or v* tags) after E2E passed.
-  # Tags images with commit SHA and latest; adds version tag for v* tag pushes.
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     needs: [changes, e2e-operator]
     if: github.event_name == 'push' && needs.e2e-operator.result == 'success'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        operator: ${{ fromJson(needs.changes.outputs.e2e-operators).operator }}
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Prepare platform pair
+        id: platform-pair
+        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CC-0018: Generate OCI annotations consistent with the two-layer OCI annotation
+      # pattern in build-images.yaml. type=semver strips the v prefix (v0.1.0 -> 0.1.0).
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator
+          labels: |
+            org.opencontainers.image.title=${{ matrix.operator }}-operator
+            org.opencontainers.image.description=Kubernetes operator for OpenStack ${{ matrix.operator }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=SAP SE
+
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        id: build
+        with:
+          context: .
+          file: operators/${{ matrix.operator }}/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.operator }}-operator-${{ steps.platform-pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.operator }}-operator-${{ steps.platform-pair.outputs.value }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: digests-operator-${{ matrix.operator }}-${{ steps.platform-pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # CC-0018, REQ-006: Assemble per-platform digests into multi-arch manifest lists
+  # and push with final tags (SHA, latest, semver).
+  merge-operator-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes, build-and-push]
+    if: github.event_name == 'push' && needs.build-and-push.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -486,8 +560,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # CC-0018: Generate OCI annotations and tags via docker/metadata-action,
-      # consistent with the two-layer OCI annotation pattern in build-images.yaml.
+
+      # CC-0018: Generate OCI tags via docker/metadata-action.
       # type=semver strips the v prefix (v0.1.0 -> 0.1.0).
       - name: Generate image metadata
         id: meta
@@ -503,16 +577,23 @@ jobs:
             org.opencontainers.image.description=Kubernetes operator for OpenStack ${{ matrix.operator }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=SAP SE
-      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+
+      - name: Download digests
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
-          context: .
-          file: operators/${{ matrix.operator }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.operator }}-operator
-          cache-to: type=gha,mode=max,scope=${{ matrix.operator }}-operator
+          pattern: digests-operator-${{ matrix.operator }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Create and push manifest list
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator
+        run: |
+          cd /tmp/digests
+          [[ $(ls | wc -l) -ge 1 ]] || { echo "::error::No digests found for ${{ matrix.operator }}-operator"; exit 1; }
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
 
   # CC-0018, REQ-007: Package and push operator Helm charts to GHCR OCI registry.
   # Runs only on push events after E2E passed. Uses versioned chart packaging
@@ -551,10 +632,10 @@ jobs:
   github-release:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [changes, build-and-push, helm-push]
+    needs: [changes, merge-operator-images, helm-push]
     if: |
       startsWith(github.ref, 'refs/tags/v') &&
-      needs.build-and-push.result == 'success' &&
+      needs.merge-operator-images.result == 'success' &&
       needs.helm-push.result == 'success'
     permissions:
       contents: write

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -69,18 +69,20 @@ permissions:
   packages: read
 ```
 
-`contents: read` allows repository checkout. `packages: write` is granted only to
-`build-base-images` and `build-service-images` for pushing images to GHCR.
+`contents: read` allows repository checkout. `packages: write` is granted to
+`build-base-images`, `build-service-images` (for pushing per-platform digests) and
+to `merge-base-images`, `merge-service-images` (for pushing manifest lists).
 `id-token: write` enables Sigstore keyless OIDC signing — the GitHub Actions runner
 requests a short-lived OIDC token bound to the workflow identity, which Sigstore uses to
 sign the attestation without managing keys (CC-0029). `attestations: write` grants
 access to the GitHub Attestations API for storing signed attestations.
 `security-events: write` allows uploading Grype vulnerability scan results in SARIF
-format to the GitHub Security tab (CC-0032). The verification jobs (`verify-base-images`,
-`verify-service-images`) do **not** receive `id-token`, `attestations`, or
-`security-events` permissions — they only need `contents: read` (for checkout and test
-scripts) and `packages: read` (for pulling images from GHCR), following the principle of
-least privilege (CC-0028).
+format to the GitHub Security tab (CC-0032). These three permissions are scoped to the
+merge jobs (`merge-base-images`, `merge-service-images`), not the per-platform build jobs.
+The verification jobs (`verify-base-images`, `verify-service-images`) do **not** receive
+`id-token`, `attestations`, or `security-events` permissions — they only need
+`contents: read` (for checkout and test scripts) and `packages: read` (for pulling images
+from GHCR), following the principle of least privilege (CC-0028).
 
 ## Concurrency
 
@@ -98,40 +100,48 @@ ensuring every merge commit produces a complete set of images.
 
 ## Jobs
 
-The workflow defines five jobs with a dependency graph (CC-0028, CC-0034):
+The workflow defines seven jobs with a dependency graph (CC-0028, CC-0034):
 
 ```text
-build-base-images ──> verify-base-images ──┬──> build-service-images ──┬──> verify-service-images (push only)
-                                           │                           │
-                                           └──> test-service-images  ──┘
-                                                      │
-                                                      └── stestr run (upstream unit tests)
+build-base-images (matrix: amd64 + arm64)
+  └──> merge-base-images ──> verify-base-images ──┬──> build-service-images (matrix: service × release × platform)
+                                                  │       └──> merge-service-images ──> verify-service-images (push only)
+                                                  │
+                                                  └──> test-service-images
+                                                            └── stestr run (upstream unit tests)
 ```
+
+Each platform (linux/amd64 on `ubuntu-latest`, linux/arm64 on `ubuntu-24.04-arm`) is
+built on a native runner and pushed by digest. `merge-base-images` then assembles the
+multi-arch manifest list and runs SBOM generation, vulnerability scanning, attestation,
+and cosign signing on the final manifest. The same pattern applies to service images via
+`build-service-images` and `merge-service-images`.
 
 The `verify-base-images` job validates base image properties (Python version, user
 UID/GID, PATH, uv version) before service image builds begin. This catches base image
 regressions before they cascade into service image failures. The `test-service-images`
 job (CC-0034) runs upstream unit tests for each service inside the `venv-builder`
 container, in parallel with `build-service-images`. On push events, the
-`verify-service-images` job validates service images pulled from GHCR and gates on both
-`build-service-images` and `test-service-images`. On PRs, the equivalent image
+`verify-service-images` job validates service images pulled from GHCR and gates on
+`merge-service-images` and `test-service-images`. On PRs, the equivalent image
 verification runs as an inline step within `build-service-images` because `--load` makes
-the image available only on the same runner.
+the image available only on the same runner (ARM64 is excluded on PRs).
 
 ### build-base-images
 
-Builds the two base images (`python-base` and `venv-builder`) sequentially and pushes
-them to GHCR (REQ-002). These must always be pushed — even on PRs — because downstream
-service builds reference them via `docker-image://` URIs, which require registry
-availability.
+Builds the two base images (`python-base` and `venv-builder`) per platform on native
+runners and pushes each single-arch image by digest (REQ-002). These must always be
+pushed — even on PRs — because downstream service builds reference them via
+`docker-image://` URIs, which require registry availability. The multi-arch manifest list
+is assembled by the subsequent `merge-base-images` job.
 
 | Property | Value |
 | --- | --- |
-| `runs-on` | `ubuntu-latest` |
+| `runs-on` | <code v-pre>${{ matrix.runner }}</code> (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) |
 | `timeout-minutes` | `30` |
 | `needs` | *(none — first job)* |
-| Architectures | `linux/amd64,linux/arm64` (always multi-arch) |
-| Push behavior | Always pushes to GHCR (even on PRs) |
+| Matrix | `platform: [linux/amd64, linux/arm64]` × native runner |
+| Push behavior | Pushes by digest to GHCR (even on PRs); tags assigned by `merge-base-images` |
 
 **Steps:**
 
@@ -142,29 +152,53 @@ availability.
 | 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork (CC-0007) |
 | 2 | Checkout | `actions/checkout@v6` | Checks out the repository |
 | 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references (CC-0007) |
-| 4 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
-| 5 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 6 | Install cosign | `sigstore/cosign-installer@v4` | Installs cosign for image signing (CC-0030) |
+| 4 | Prepare platform pair | Shell | Converts `linux/amd64` → `linux-amd64` for use in artifact names and cache scopes |
+| 5 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables single-platform builds on the native runner |
+| 6 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
 | 7 | Generate metadata for python-base | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for python-base (CC-0031) |
-| 8 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 7 |
-| 9 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed python-base image by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
-| 10 | Scan python-base for vulnerabilities | `anchore/scan-action@v7` | Scans via SBOM on push, via image on PR. Reports high/critical CVEs without failing the build (`fail-build: false`). Output: SARIF (CC-0032) |
-| 11 | Upload SARIF for python-base | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists (`if: always() && outputs.sarif != ''`). Uploads Grype results to GitHub Security tab with category `grype-python-base` (CC-0032) |
-| 12 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 13 | Sign python-base | Shell | Skipped on PRs. Signs python-base by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
-| 14 | Generate metadata for venv-builder | `docker/metadata-action@v5` | Produces OCI labels (title, description, licenses, vendor) for venv-builder (CC-0031) |
-| 15 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, multi-arch, push: true, tags: `:latest` and `:${{ github.sha }}`, labels from step 14, `--build-context python-base=docker-image://...` |
-| 16 | Generate SBOM for venv-builder | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed venv-builder image by digest. Output: `sbom-venv-builder.cyclonedx.json` (CC-0029) |
-| 17 | Scan venv-builder for vulnerabilities | `anchore/scan-action@v7` | Scans via SBOM on push, via image on PR. Reports high/critical CVEs without failing the build (`fail-build: false`). Output: SARIF (CC-0032) |
-| 18 | Upload SARIF for venv-builder | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists (`if: always() && outputs.sarif != ''`). Uploads Grype results to GitHub Security tab with category `grype-venv-builder` (CC-0032) |
-| 19 | Attest SBOM for venv-builder | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 20 | Sign venv-builder | Shell | Skipped on PRs. Signs venv-builder by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
+| 8 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, single platform, `push-by-digest=true`; digest exported as artifact |
+| 9 | Export python-base digest | Shell | Writes digest filename to `/tmp/digests/python-base/` |
+| 10 | Upload python-base digest | `actions/upload-artifact@v7` | Artifact name: `digests-python-base-<platform-pair>`, retention: 1 day |
+| 11 | Generate metadata for venv-builder | `docker/metadata-action@v5` | Produces OCI labels for venv-builder (CC-0031) |
+| 12 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, single platform, `push-by-digest=true`; uses python-base from step 8 by digest |
+| 13 | Export venv-builder digest | Shell | Writes digest filename to `/tmp/digests/venv-builder/` |
+| 14 | Upload venv-builder digest | `actions/upload-artifact@v7` | Artifact name: `digests-venv-builder-<platform-pair>`, retention: 1 day |
 
 :::
 
-The `venv-builder` build uses a `docker-image://` build context pointing at the
-just-pushed `python-base` image (referenced by digest), ensuring its `FROM python-base`
-directive resolves to the exact image built in step 7.
+### merge-base-images
+
+Downloads per-platform digests from `build-base-images`, assembles multi-arch manifest
+lists, then runs SBOM generation, vulnerability scanning, attestation, and cosign signing
+on the final manifests.
+
+| Property | Value |
+| --- | --- |
+| `runs-on` | `ubuntu-latest` |
+| `timeout-minutes` | `15` |
+| `needs` | `[build-base-images]` |
+| Permissions | `contents: read`, `packages: write`, `id-token: write`, `attestations: write`, `security-events: write` |
+
+**Steps:**
+
+::: v-pre
+
+| # | Step | Action / Command | Details |
+| --- | --- | --- | --- |
+| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 2 | Set up Buildx + Login | `docker/setup-buildx-action@v4`, `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
+| 3 | Install cosign | `sigstore/cosign-installer@v4` | Installs cosign for image signing (CC-0030) |
+| 4 | Download python-base digests | `actions/download-artifact@v4` | Downloads all `digests-python-base-*` artifacts, merges into `/tmp/digests/python-base/` |
+| 5 | Create python-base manifest | Shell | `docker buildx imagetools create` assembles all per-platform digests; tags `:latest` and `:${{ github.sha }}`; outputs merged manifest digest |
+| 6 | Generate SBOM for python-base | `anchore/sbom-action@v0` | Skipped on PRs. Scans the merged manifest by digest. Output: `sbom-python-base.cyclonedx.json` (CC-0029) |
+| 7 | Scan python-base for vulnerabilities | `anchore/scan-action@v7` | Scans via SBOM on push, via image on PR. Reports high/critical CVEs without failing the build (`fail-build: false`). Output: SARIF (CC-0032) |
+| 8 | Upload SARIF for python-base | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists. Category: `grype-python-base` (CC-0032) |
+| 9 | Attest SBOM for python-base | `actions/attest@v4` | Skipped on PRs. Signs the SBOM and pushes attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 10 | Attest build provenance for python-base | `actions/attest-build-provenance@v4` | Skipped on PRs. SLSA Level 2+ provenance attestation (CC-0035) |
+| 11 | Sign python-base | Shell | Skipped on PRs. Signs python-base manifest by digest with cosign keyless OIDC (CC-0030) |
+| 12–22 | venv-builder equivalent steps | *(same pattern as 4–11 for venv-builder)* | Downloads digests, creates manifest, SBOM, scan, attest, sign |
+
+:::
 
 ::: v-pre
 
@@ -182,20 +216,20 @@ mapping from any base image in GHCR back to the commit that produced it (CC-0007
 | `venv-builder-image` | `ghcr.io/<owner>/venv-builder@sha256:<digest>` | `ghcr.io/c5c3/venv-builder@sha256:def456...` |
 
 These outputs are consumed by `verify-base-images` and `build-service-images` via
-`needs.build-base-images.outputs` (REQ-003).
+`needs.merge-base-images.outputs` (REQ-003).
 
 ### verify-base-images
 
-Validates that just-built base images meet expected properties before service image
-builds begin (CC-0028). Runs after `build-base-images` and blocks
+Validates that just-assembled base image manifests meet expected properties before
+service image builds begin (CC-0028). Runs after `merge-base-images` and blocks
 `build-service-images`, forming the dependency chain:
-`build-base-images` → `verify-base-images` → `build-service-images`.
+`build-base-images` → `merge-base-images` → `verify-base-images` → `build-service-images`.
 
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
 | `timeout-minutes` | `10` |
-| `needs` | `[build-base-images]` |
+| `needs` | `[merge-base-images]` |
 | Permissions | `contents: read`, `packages: read` |
 
 **Steps:**
@@ -215,22 +249,25 @@ builds begin (CC-0028). Runs after `build-base-images` and blocks
 | `tests/container-images/verify_python_base.sh` | Python version, `openstack` user (UID/GID 42424), PATH includes `/opt/openstack/bin`, virtualenv at `/opt/openstack` |
 | `tests/container-images/verify_venv_builder.sh` | uv version (from Dockerfile), pip available, virtualenv at `/var/lib/openstack` |
 
-The job receives image references via `needs.build-base-images.outputs` (digest-pinned),
-ensuring the exact images that were just built are the ones being tested.
+The job receives image references via `needs.merge-base-images.outputs` (digest-pinned),
+ensuring the exact manifests that were just assembled are the ones being tested.
 
 ### build-service-images
 
-Builds service images using a matrix strategy over `service x release` (REQ-004).
-Depends on `build-base-images` for image references (REQ-003) and on
+Builds service images per platform on native runners and pushes each single-arch image by
+digest (REQ-004). Depends on `merge-base-images` for image references (REQ-003) and on
 `verify-base-images` to ensure base images are valid before building on top of them
-(CC-0028).
+(CC-0028). The multi-arch manifest list is assembled by `merge-service-images`.
+
+On pull requests, ARM64 is excluded (only `linux/amd64` is built) and the image is loaded
+locally for inline verification instead of being pushed to GHCR.
 
 | Property | Value |
 | --- | --- |
-| `runs-on` | `ubuntu-latest` |
+| `runs-on` | <code v-pre>${{ matrix.runner }}</code> (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) |
 | `timeout-minutes` | `30` |
-| `needs` | `[build-base-images, verify-base-images]` |
-| Matrix | `service: [keystone]`, `release: ["2025.2"]` |
+| `needs` | `[merge-base-images, verify-base-images, generate-matrix]` |
+| Matrix | `service × release × platform × runner` (from `generate-matrix.build-matrix`; ARM64 excluded on PRs) |
 
 **Steps:**
 
@@ -244,18 +281,57 @@ Depends on `build-base-images` for image references (REQ-003) and on
 | 4 | Apply patches | Shell (conditional) | Runs `git apply` for patches in `patches/<service>/<release>/` — skipped if no `.patch` files exist |
 | 5 | Apply constraint overrides | Shell | Runs `scripts/apply-constraint-overrides.sh <release>` (idempotent) |
 | 6 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards (CC-0027). |
-| 7 | Derive tags | Shell | Computes three image tags and the lowercase `image` path (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
-| 8 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables multi-platform builds |
-| 9 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
-| 10 | Install cosign | `sigstore/cosign-installer@v4` | Installs cosign for image signing (CC-0030) |
+| 7 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
+| 8 | Prepare platform pair | Shell | Converts `linux/amd64` → `linux-amd64` for artifact names and cache scopes |
+| 9 | Set up Buildx | `docker/setup-buildx-action@v4` | Enables single-platform builds on the native runner |
+| 10 | Login to GHCR | `docker/login-action@v4` | Authenticates with `GITHUB_TOKEN` |
 | 11 | Generate metadata for service image | `docker/metadata-action@v5` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy (CC-0031) |
-| 12 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args, conditional platform/push/load, labels from step 11 (REQ-006) |
-| 13 | Generate SBOM for service image | `anchore/sbom-action@v0` | Skipped on PRs. Scans the just-pushed service image by digest. Output: `sbom-${{ matrix.service }}.cyclonedx.json` (CC-0029) |
-| 14 | Scan service image for vulnerabilities | `anchore/scan-action@v7` | Scans via SBOM on push, via composite tag on PR. Reports high/critical CVEs without failing the build (`fail-build: false`). Output: SARIF (CC-0032) |
-| 15 | Upload SARIF for service image | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists (`if: always() && outputs.sarif != ''`). Uploads Grype results to GitHub Security tab with category `grype-${{ matrix.service }}` (CC-0032) |
-| 16 | Attest SBOM for service image | `actions/attest@v4` | Skipped on PRs. Signs the SBOM via Sigstore and pushes the attestation to GHCR as an OCI referrer artifact (CC-0029) |
-| 17 | Sign service image | Shell | Skipped on PRs. Signs service image by digest with cosign keyless OIDC (`cosign sign --yes`) (CC-0030) |
-| 18 | Verify service image (PR) | Shell (conditional) | On PRs only: runs `verify_${{ matrix.service }}.sh` with the locally loaded image ref (CC-0028) |
+| 12 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args. Non-PR: `push-by-digest=true`, digest exported as artifact. PR: `load: true`, composite tag (REQ-006) |
+| 13 | Export service image digest | Shell | Non-PR only: writes digest filename to `/tmp/digests/` |
+| 14 | Upload service image digest | `actions/upload-artifact@v7` | Non-PR only. Artifact name: `digests-service-<service>-<release>-<platform-pair>`, retention: 1 day |
+| 15 | Scan service image for vulnerabilities (PR) | `anchore/scan-action@v7` | PR only: scans locally loaded image. Reports high/critical CVEs without failing the build (`fail-build: false`). Output: SARIF (CC-0032) |
+| 16 | Upload SARIF for service image (PR) | `github/codeql-action/upload-sarif@v3` | PR only. Category: `grype-<service>-<platform-pair>` (CC-0032) |
+| 17 | Verify service image (PR) | Shell (conditional) | PR only: runs `verify_${{ matrix.service }}.sh` with the locally loaded image ref (CC-0028) |
+
+:::
+
+### merge-service-images
+
+Downloads per-platform digests from `build-service-images`, assembles multi-arch manifest
+lists, then runs SBOM generation, vulnerability scanning, attestation, and cosign signing.
+Runs only on push events.
+
+| Property | Value |
+| --- | --- |
+| `runs-on` | `ubuntu-latest` |
+| `timeout-minutes` | `30` |
+| `needs` | `[merge-base-images, build-service-images, generate-matrix]` |
+| `if` | `github.event_name != 'pull_request'` |
+| Matrix | `service × release` (from `generate-matrix.matrix`) |
+| Permissions | `contents: read`, `packages: write`, `id-token: write`, `attestations: write`, `security-events: write` |
+
+Tag derivation uses the same `.github/actions/derive-service-tags` composite action as
+`build-service-images`, ensuring the manifest is assembled under the exact same tags that
+were computed during the build.
+
+**Steps:**
+
+::: v-pre
+
+| # | Step | Action / Command | Details |
+| --- | --- | --- | --- |
+| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 2 | Install yq | `mikefarah/yq@v4` | Required by the derive-service-tags composite action |
+| 3 | Set up Buildx + Login + cosign | *(three steps)* | Authenticates and installs cosign (CC-0030) |
+| 4 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (REQ-005) |
+| 5 | Download service image digests | `actions/download-artifact@v4` | Downloads all `digests-service-<service>-<release>-*` artifacts |
+| 6 | Create and push service image manifest | Shell | `docker buildx imagetools create` assembles all per-platform digests; applies composite, SHA, and (on main) version tags; outputs merged manifest digest |
+| 7 | Generate SBOM for service image | `anchore/sbom-action@v0` | Scans the merged manifest by digest. Output: `sbom-<service>.cyclonedx.json` (CC-0029) |
+| 8 | Scan service image for vulnerabilities | `anchore/scan-action@v7` | SBOM-based scan. Category: `grype-<service>` (CC-0032) |
+| 9 | Upload SARIF for service image | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists (CC-0032) |
+| 10 | Attest SBOM for service image | `actions/attest@v4` | Signs SBOM and pushes attestation to GHCR as an OCI referrer artifact (CC-0029) |
+| 11 | Attest build provenance | `actions/attest-build-provenance@v4` | SLSA Level 2+ provenance attestation (CC-0035) |
+| 12 | Sign service image | Shell | Signs service image manifest by digest with cosign keyless OIDC (CC-0030) |
 
 :::
 
@@ -304,16 +380,16 @@ skips known-failing tests via `stestr run --exclude-list`.
 :::
 
 This job runs in parallel with `build-service-images` — both depend on
-`build-base-images` and `verify-base-images`, but not on each other. The
+`merge-base-images` and `verify-base-images`, but not on each other. The
 `verify-service-images` job gates on both.
 
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
 | `timeout-minutes` | `60` |
-| `needs` | `[build-base-images, verify-base-images]` |
+| `needs` | `[merge-base-images, verify-base-images, generate-matrix]` |
 | Permissions | `contents: read`, `packages: read` |
-| Matrix | `service: [keystone]`, `release: ["2025.2"]` |
+| Matrix | `service × release` (from `generate-matrix.matrix`) |
 
 **Steps:**
 
@@ -397,10 +473,10 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
 | `timeout-minutes` | `10` |
-| `needs` | `[build-service-images, test-service-images]` |
+| `needs` | `[merge-service-images, test-service-images, generate-matrix]` |
 | `if` | `github.event_name != 'pull_request'` |
 | Permissions | `contents: read`, `packages: read` |
-| Matrix | `service: [keystone]`, `release: ["2025.2"]` |
+| Matrix | `service × release` (from `generate-matrix.matrix`) |
 
 **Steps:**
 
@@ -410,7 +486,7 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts, `source-refs.yaml`, and patch counting) |
 | 2 | Login to GHCR | `docker/login-action@v4` | Authenticates to pull the image |
-| 3 | Derive image ref | Shell | Reconstructs the composite tag from the same inputs as `build-service-images` |
+| 3 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Reconstructs tags using the same logic as `build-service-images` and `merge-service-images` |
 | 4 | Pull and verify | Shell | `docker pull <image-ref>` then runs `verify_${{ matrix.service }}.sh` with the pulled image ref |
 
 :::
@@ -421,8 +497,9 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 | --- | --- |
 | `tests/container-images/verify_<service>.sh` | Service-specific checks (e.g. `keystone-manage --version` exits 0), runs as `openstack` user, no build tools (gcc, python3-dev, uv), runtime apt packages installed |
 
-The job fails the workflow if the verify script exits non-zero. The tag derivation
-step must stay in sync with the "Derive tags" step in `build-service-images`.
+The job fails the workflow if the verify script exits non-zero. Tag derivation uses the
+`.github/actions/derive-service-tags` composite action, which is the single source of
+truth shared by `build-service-images`, `merge-service-images`, and `verify-service-images`.
 
 ## Tag Schema
 
@@ -457,18 +534,18 @@ The workflow behaves differently depending on the trigger event (REQ-006):
 
 | Aspect | Pull Request | Push (main / stable/**) |
 | --- | --- | --- |
-| Base images | Multi-arch, pushed to GHCR | Multi-arch, pushed to GHCR |
+| Base images | Per-platform digests pushed; multi-arch manifest assembled by `merge-base-images` | Same |
 | Base image verification | `verify-base-images` job (always runs) | `verify-base-images` job (always runs) |
-| Service image platforms | `linux/amd64` only | `linux/amd64,linux/arm64` |
-| Service image push | No (`push: false`, `load: true`) | Yes (`push: true`) |
+| Service image platforms | `linux/amd64` only (ARM64 excluded) | `linux/amd64,linux/arm64` |
+| Service image push | No (`load: true` on amd64 runner) | Yes (by digest, tags assigned by `merge-service-images`) |
 | Service image tags | Computed but not published | Published to GHCR |
-| SBOM generation | Skipped (CC-0029) | CycloneDX JSON for every image |
-| Vulnerability scanning | Image-based scan via `image:` input (CC-0032) | SBOM-based scan via `sbom:` input (CC-0032) |
+| SBOM generation | Skipped (CC-0029) | CycloneDX JSON for every merged manifest |
+| Vulnerability scanning | Image-based scan on PR (`image:` input in `build-service-images`) (CC-0032) | SBOM-based scan in `merge-service-images` (`sbom:` input) (CC-0032) |
 | SBOM attestation | Skipped (CC-0029) | Sigstore-signed, pushed to GHCR |
-| Cosign signing | Skipped (CC-0030) | Keyless signature for every image |
-| OIDC token request | None | Requested for Sigstore signing (CC-0029, CC-0030) |
+| Cosign signing | Skipped (CC-0030) | Keyless signature for every merged manifest |
+| OIDC token request | None | Requested in merge jobs for Sigstore signing (CC-0029, CC-0030) |
 | Service image verification | Inline step in `build-service-images` | Separate `verify-service-images` job |
-| Verification image source | Locally loaded image (same runner) | Pulled from GHCR |
+| Verification image source | Locally loaded image (same amd64 runner) | Pulled from GHCR |
 
 **Why base images are always pushed:** Service Dockerfiles reference base images via
 `docker-image://` URIs in build contexts. This Docker BuildKit feature requires the
@@ -476,9 +553,11 @@ referenced image to exist in a registry — local images are not sufficient. Pus
 small base images on every PR is a deliberate trade-off to keep Dockerfiles
 registry-independent.
 
-**Why PRs use single-arch:** `docker/build-push-action` with `load: true` only supports
-single-platform builds. Multi-platform images cannot be loaded into the local Docker
-daemon. Since the verification step needs the image locally, PRs build only `linux/amd64`.
+**Why PRs use single-arch for service images:** `docker/build-push-action` with
+`load: true` only supports single-platform builds. Multi-platform images cannot be loaded
+into the local Docker daemon. Since the inline verification step needs the image locally,
+PRs build only `linux/amd64`. Base images are still built for both platforms on PRs (by
+digest), so the native ARM runner is exercised without requiring a locally loaded result.
 
 ## GHA Caching
 
@@ -490,13 +569,13 @@ cache-from: type=gha,scope=<scope>
 cache-to: type=gha,mode=max,scope=<scope>
 ```
 
-Each image has a unique cache scope to prevent collisions:
+Each image has a unique cache scope per platform to prevent cross-arch cache collisions:
 
 | Image | Scope |
 | --- | --- |
-| `python-base` | `python-base` |
-| `venv-builder` | `venv-builder` |
-| Service images | `<service>-<release>` (e.g., `keystone-2025.2`) |
+| `python-base` | `python-base-linux-amd64` / `python-base-linux-arm64` |
+| `venv-builder` | `venv-builder-linux-amd64` / `venv-builder-linux-arm64` |
+| Service images | `<service>-<release>-linux-amd64` / `<service>-<release>-linux-arm64` (e.g., `keystone-2025.2-linux-amd64`) |
 
 The `mode=max` setting caches all intermediate layers, not just the final image layer.
 
@@ -530,12 +609,12 @@ build time.
 
 ### How It Works
 
-After each `docker/build-push-action` step pushes an image to GHCR, two additional steps
-run:
+After per-platform images are pushed by digest and the multi-arch manifest list is
+assembled by the merge job, two additional steps run in the merge job:
 
-1. **SBOM generation** (`anchore/sbom-action`) — Syft scans the pushed image (referenced
-   by digest) and produces a CycloneDX JSON file covering both OS packages (dpkg) and
-   Python packages (dist-info).
+1. **SBOM generation** (`anchore/sbom-action`) — Syft scans the merged manifest
+   (referenced by digest) and produces a CycloneDX JSON file covering both OS packages
+   (dpkg) and Python packages (dist-info).
 
 2. **SBOM attestation** (`actions/attest`) — The CycloneDX file is signed via
    Sigstore keyless OIDC (using the GitHub Actions workflow identity) and pushed to GHCR
@@ -548,9 +627,9 @@ This pattern is applied to all three image types:
 
 | Image | SBOM output file | Job |
 | --- | --- | --- |
-| `python-base` | `sbom-python-base.cyclonedx.json` | `build-base-images` |
-| `venv-builder` | `sbom-venv-builder.cyclonedx.json` | `build-base-images` |
-| Service (e.g., `keystone`) | `sbom-${{ matrix.service }}.cyclonedx.json` | `build-service-images` |
+| `python-base` | `sbom-python-base.cyclonedx.json` | `merge-base-images` |
+| `venv-builder` | `sbom-venv-builder.cyclonedx.json` | `merge-base-images` |
+| Service (e.g., `keystone`) | `sbom-${{ matrix.service }}.cyclonedx.json` | `merge-service-images` |
 
 :::
 

--- a/docs/reference/ci-workflow.md
+++ b/docs/reference/ci-workflow.md
@@ -61,13 +61,14 @@ Jobs that need elevated access declare per-job `permissions:` blocks:
 
 | Job | Additional Permissions | Reason |
 | --- | --- | --- |
-| `build-and-push` | `packages: write` | Push container images to GHCR |
+| `build-and-push` | `packages: write` | Push per-platform operator image digests to GHCR |
+| `merge-operator-images` | `packages: write` | Push final multi-arch operator image manifest list |
 | `helm-push` | `packages: write` | Push Helm charts to GHCR OCI registry |
 | `github-release` | `contents: write` | Create GitHub Releases |
 
 ## Job Dependency DAG
 
-The workflow defines 11 jobs organised in a directed acyclic graph (CC-0018):
+The workflow defines 12 jobs organised in a directed acyclic graph (CC-0018):
 
 ```
 Gate Jobs (always run):
@@ -82,11 +83,12 @@ E2E Jobs (depends on gates):
   e2e-keystone ──> needs: [lint, shellcheck, test, test-integration, verify-codegen]
 
 Publish Jobs (main/tags only, depends on E2E):
-  build-and-push ──> needs: [e2e-keystone], if: push event
-  helm-push ────────> needs: [e2e-keystone], if: push event
+  build-and-push (matrix: operator × platform) ──> needs: [e2e-keystone], if: push event
+    └──> merge-operator-images ──> needs: [build-and-push], if: push event
+  helm-push ──> needs: [e2e-keystone], if: push event
 
 Release Job (v* tags only, depends on publish):
-  github-release ──> needs: [build-and-push, helm-push], if: v* tag
+  github-release ──> needs: [merge-operator-images, helm-push], if: v* tag
 
 Independent:
   docs (no dependencies, no gates)
@@ -278,20 +280,63 @@ build, Helm deploy, and Chainsaw test execution).
 
 ### build-and-push
 
-Builds and pushes operator container images to GHCR (CC-0018 REQ-006). Runs only on push
-events (main branch or v* tags) — skipped on pull requests.
+Builds operator container images per platform on native runners and pushes each
+single-arch image by digest (CC-0018 REQ-006). Runs only on push events (main branch or
+v* tags) — skipped on pull requests. The multi-arch manifest list and final tags are
+assembled by the subsequent `merge-operator-images` job.
 
-**Dependencies:** `needs: [e2e-keystone]`
-**Condition:** `if: github.event_name == 'push'`
+**Dependencies:** `needs: [changes, e2e-operator]`
+**Condition:** `if: github.event_name == 'push' && needs.e2e-operator.result == 'success'`
 **Permissions:** `contents: read`, `packages: write`
 
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `docker/setup-buildx-action@v4` | Sets up Docker Buildx for multi-platform builds |
-| 3 | `docker/login-action@v4` | Authenticates to GHCR (`github.actor` / `GITHUB_TOKEN`) |
-| 4 | `docker/metadata-action@v6` | Generates OCI labels and image tags (two-layer annotation pattern) |
-| 5 | `docker/build-push-action@v7` | Builds and pushes image with GHA cache, OCI labels |
+| 2 | Prepare platform pair | Shell | Converts `linux/amd64` → `linux-amd64` for artifact names and cache scopes |
+| 3 | `docker/setup-buildx-action@v4` | Sets up Docker Buildx |
+| 4 | `docker/login-action@v4` | Authenticates to GHCR (`github.actor` / `GITHUB_TOKEN`) |
+| 5 | `docker/metadata-action@v6` | Generates OCI labels (two-layer annotation pattern) |
+| 6 | `docker/build-push-action@v7` | Builds single-platform image; `push-by-digest=true`; digest exported as artifact |
+| 7 | Export digest | Shell | Writes digest filename to `/tmp/digests/` |
+| 8 | Upload digest | `actions/upload-artifact@v7` | Artifact name: `digests-operator-<operator>-<platform-pair>`, retention: 1 day |
+
+**Matrix strategy:**
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    operator: ${{ fromJson(needs.changes.outputs.e2e-operators).operator }}
+    platform: [linux/amd64, linux/arm64]
+    include:
+      - platform: linux/amd64
+        runner: ubuntu-latest
+      - platform: linux/arm64
+        runner: ubuntu-24.04-arm
+```
+
+Build context is the repository root (required by `go.work`), with the Dockerfile at
+`operators/<operator>/Dockerfile`. GitHub Actions cache (`type=gha`) is scoped per
+platform (`<operator>-operator-linux-amd64` / `<operator>-operator-linux-arm64`).
+
+### merge-operator-images
+
+Downloads per-platform digests from `build-and-push`, assembles the multi-arch manifest
+list, and pushes it with the final tags (CC-0018 REQ-006).
+
+**Dependencies:** `needs: [changes, build-and-push]`
+**Condition:** `if: github.event_name == 'push' && needs.build-and-push.result == 'success'`
+**Permissions:** `contents: read`, `packages: write`
+
+| Step | Action | Details |
+| --- | --- | --- |
+| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 2 | `docker/setup-buildx-action@v4` + `docker/login-action@v4` | Authenticates to GHCR |
+| 3 | `docker/metadata-action@v6` | Generates final image tags |
+| 4 | Download digests | `actions/download-artifact@v4` | Downloads all `digests-operator-<operator>-*` artifacts |
+| 5 | Create and push manifest list | Shell | `docker buildx imagetools create` assembles per-platform digests under the final tags from step 3 |
+
+**Matrix strategy:** Same `operator` dimension as `build-and-push` (via `fromJson(needs.changes.outputs.e2e-operators)`).
 
 **Image tagging strategy:**
 
@@ -301,18 +346,7 @@ events (main branch or v* tags) — skipped on pull requests.
 | Push v* tag (from main) | `sha-<full-sha>`, `latest`, `<version>` (e.g. `0.1.0`, v prefix stripped) |
 | Push v* tag (from non-main) | `sha-<full-sha>`, `<version>` (no `latest` — restricted to default branch) |
 
-**Matrix strategy:**
-
-```yaml
-strategy:
-  matrix:
-    operator: [keystone]
-```
-
-Images are pushed to `ghcr.io/c5c3/<operator>-operator:<tag>`. Build context is the
-repository root (required by `go.work`), with the Dockerfile at
-`operators/<operator>/Dockerfile`. GitHub Actions cache (`type=gha`) is used for layer
-caching.
+Images are published at `ghcr.io/c5c3/<operator>-operator:<tag>`.
 
 ### helm-push
 
@@ -353,8 +387,8 @@ When `CHART_VERSION` is set (for tag pushes), it overrides the version in `Chart
 Creates a GitHub Release with auto-generated release notes on v* tag pushes (CC-0018
 REQ-008).
 
-**Dependencies:** `needs: [build-and-push, helm-push]`
-**Condition:** `if: startsWith(github.ref, 'refs/tags/v')`
+**Dependencies:** `needs: [changes, merge-operator-images, helm-push]`
+**Condition:** `if: startsWith(github.ref, 'refs/tags/v') && needs.merge-operator-images.result == 'success' && needs.helm-push.result == 'success'`
 **Permissions:** `contents: write`
 
 | Step | Action | Details |
@@ -364,8 +398,9 @@ REQ-008).
 | 3 | Package Helm charts | Packages operator Helm charts with release version |
 | 4 | `softprops/action-gh-release@v2` | Creates release with `generate_release_notes: true` and attaches chart tarballs |
 
-This job runs only after both `build-and-push` and `helm-push` complete successfully,
-ensuring all artifacts are published before the release is created. Helm chart tarballs
+This job runs only after both `merge-operator-images` and `helm-push` complete
+successfully, ensuring the final multi-arch manifest list and charts are published before
+the release is created. Helm chart tarballs
 are attached as release assets for direct download. Timeout: 5 minutes.
 
 ## Go Setup Convention

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -76,6 +76,13 @@ test_job_permissions_scoping() {
   assert_eq "build-service-images has packages: write" "write" "$service_perms"
   assert_eq "verify-service-images has packages: read (least privilege)" "read" "$verify_service_perms"
 
+  local merge_base_perms merge_service_perms
+  merge_base_perms=$(yq_raw '.jobs["merge-base-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
+  merge_service_perms=$(yq_raw '.jobs["merge-service-images"]["permissions"]["packages"]' "$WORKFLOW" || echo "null")
+
+  assert_eq "merge-base-images has packages: write" "write" "$merge_base_perms"
+  assert_eq "merge-service-images has packages: write" "write" "$merge_service_perms"
+
   # verify-service-images also needs contents: read for checkout (source-refs.yaml + patch counting)
   local verify_service_contents_perms
   verify_service_contents_perms=$(yq_raw '.jobs["verify-service-images"]["permissions"]["contents"]' "$WORKFLOW" || echo "null")
@@ -104,13 +111,15 @@ test_pull_request_trigger() {
   assert_file_contains "pull_request trigger present" "$WORKFLOW" "pull_request"
 }
 
-# --- REQ-002, REQ-003, REQ-004, REQ-005, REQ-007: Four jobs defined ---
+# --- REQ-002, REQ-003, REQ-004, REQ-005, REQ-007: Seven jobs defined ---
 test_five_jobs_defined() {
-  echo "Test: five jobs defined (REQ-002, REQ-003, REQ-004, REQ-005, CC-0034 REQ-001)"
+  echo "Test: seven jobs defined (REQ-002, REQ-003, REQ-004, REQ-005, CC-0034 REQ-001)"
 
   assert_file_contains "build-base-images job defined" "$WORKFLOW" "build-base-images:"
+  assert_file_contains "merge-base-images job defined" "$WORKFLOW" "merge-base-images:"
   assert_file_contains "verify-base-images job defined" "$WORKFLOW" "verify-base-images:"
   assert_file_contains "build-service-images job defined" "$WORKFLOW" "build-service-images:"
+  assert_file_contains "merge-service-images job defined" "$WORKFLOW" "merge-service-images:"
   assert_file_contains "test-service-images job defined" "$WORKFLOW" "test-service-images:"
   assert_file_contains "verify-service-images job defined" "$WORKFLOW" "verify-service-images:"
 }
@@ -121,7 +130,7 @@ test_verify_base_images_job() {
 
   local needs
   needs=$(yq_raw '.jobs["verify-base-images"]["needs"][]' "$WORKFLOW" || true)
-  assert_contains "verify-base-images needs build-base-images" "$needs" "build-base-images"
+  assert_contains "verify-base-images needs merge-base-images" "$needs" "merge-base-images"
 
   local timeout
   timeout=$(yq_raw '.jobs["verify-base-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
@@ -150,30 +159,10 @@ test_verify_base_images_job() {
 test_base_images_multi_arch() {
   echo "Test: base images use multi-arch platforms (REQ-002)"
 
-  # Both build-push-action steps in build-base-images must specify platforms: linux/amd64,linux/arm64
-  local platforms
-  platforms=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.platforms) | .with.platforms' "$WORKFLOW" || true)
-
-  if [ -z "$platforms" ]; then
-    echo "  FAIL: build-base-images has no platforms values"
-    FAIL=$((FAIL + 1))
-    return
-  fi
-
-  local all_multiarch=true
-  while IFS= read -r val; do
-    [ -z "$val" ] && continue
-    if [ "$val" != "linux/amd64,linux/arm64" ]; then
-      echo "  FAIL: build-base-images platform is not multi-arch: $val"
-      FAIL=$((FAIL + 1))
-      all_multiarch=false
-    fi
-  done <<< "$platforms"
-
-  if $all_multiarch; then
-    echo "  PASS: all build-base-images steps use linux/amd64,linux/arm64"
-    PASS=$((PASS + 1))
-  fi
+  local matrix_platforms
+  matrix_platforms=$(yq_raw '.jobs["build-base-images"]["strategy"]["matrix"]["include"][]["platform"]' "$WORKFLOW" || true)
+  assert_contains "build-base-images matrix includes linux/amd64" "$matrix_platforms" "linux/amd64"
+  assert_contains "build-base-images matrix includes linux/arm64" "$matrix_platforms" "linux/arm64"
 }
 
 # --- REQ-003: Base image outputs contain digest references ---
@@ -181,15 +170,15 @@ test_base_image_digest_outputs() {
   echo "Test: base image outputs contain digest references (REQ-003)"
 
   local python_output venv_output python_name_output python_digest_output
-  python_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-image"]' "$WORKFLOW" || true)
-  venv_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["venv-builder-image"]' "$WORKFLOW" || true)
-  python_name_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-name"]' "$WORKFLOW" || true)
-  python_digest_output=$(yq_raw '.jobs["build-base-images"]["outputs"]["python-base-digest"]' "$WORKFLOW" || true)
+  python_output=$(yq_raw '.jobs["merge-base-images"]["outputs"]["python-base-image"]' "$WORKFLOW" || true)
+  venv_output=$(yq_raw '.jobs["merge-base-images"]["outputs"]["venv-builder-image"]' "$WORKFLOW" || true)
+  python_name_output=$(yq_raw '.jobs["merge-base-images"]["outputs"]["python-base-name"]' "$WORKFLOW" || true)
+  python_digest_output=$(yq_raw '.jobs["merge-base-images"]["outputs"]["python-base-digest"]' "$WORKFLOW" || true)
 
   assert_contains "python-base-image output references digest" "$python_output" "outputs.digest"
   assert_contains "venv-builder-image output references digest" "$venv_output" "outputs.digest"
   assert_contains "python-base-name output is non-empty" "$python_name_output" "python-base"
-  assert_contains "python-base-digest output references build-python-base digest" "$python_digest_output" "build-python-base.outputs.digest"
+  assert_contains "python-base-digest output references merge-python-base digest" "$python_digest_output" "merge-python-base.outputs.digest"
 }
 
 # --- REQ-003, REQ-004: build-service-images depends on build-base-images and verify-base-images ---
@@ -199,7 +188,7 @@ test_service_images_depend_on_base() {
   local needs
   needs=$(yq_raw '.jobs["build-service-images"]["needs"][]' "$WORKFLOW" || true)
 
-  assert_contains "build-service-images needs build-base-images" "$needs" "build-base-images"
+  assert_contains "build-service-images needs merge-base-images" "$needs" "merge-base-images"
   assert_contains "build-service-images needs verify-base-images" "$needs" "verify-base-images"
   assert_contains "build-service-images needs generate-matrix" "$needs" "generate-matrix"
 }
@@ -269,50 +258,46 @@ test_tag_schema_composite() {
   echo "Test: tag schema composite (REQ-005)"
 
   local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
+  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .uses' "$WORKFLOW" || true)
+  assert_contains "Derive tags uses composite action" "$tags_step" "./.github/actions/derive-service-tags"
 
-  assert_contains "composite tag has version component" "$tags_step" 'VERSION'
-  assert_contains "composite tag has patch count (pN)" "$tags_step" '-p${PATCH_COUNT}'
-  assert_contains "composite tag has branch component" "$tags_step" '${BRANCH}'
-  assert_contains "composite tag has SHA component" "$tags_step" '${SHORT_SHA}'
+  local action_file=".github/actions/derive-service-tags/action.yaml"
+  assert_file_contains "composite action has VERSION component" "$action_file" 'VERSION'
+  assert_file_contains "composite action has PATCH_COUNT component" "$action_file" 'PATCH_COUNT'
+  assert_file_contains "composite action has BRANCH component" "$action_file" 'BRANCH'
+  assert_file_contains "composite action has SHORT_SHA component" "$action_file" 'SHORT_SHA'
 }
 
 # --- REQ-005: Branch sanitization (slash-to-dash) ---
 test_branch_sanitization() {
   echo "Test: branch sanitization replaces slashes with dashes (REQ-005)"
 
-  local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
-
-  # GITHUB_REF_NAME//\//-  is the bash pattern substitution for slash-to-dash
-  assert_contains "branch sanitization uses slash-to-dash replacement" "$tags_step" 'GITHUB_REF_NAME//\//-'
+  local action_file=".github/actions/derive-service-tags/action.yaml"
+  assert_file_contains "composite action has slash-to-dash replacement" "$action_file" 'GITHUB_REF_NAME//\\\//-'
 }
 
 # --- REQ-005: Version and SHA tag outputs emitted ---
 test_version_and_sha_outputs() {
   echo "Test: version= and sha= outputs emitted (REQ-005)"
 
-  local tags_step
-  tags_step=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
-
-  assert_contains "version output emitted" "$tags_step" 'echo "version='
-  assert_contains "sha output emitted" "$tags_step" 'echo "sha='
-  assert_contains "image output emitted" "$tags_step" 'echo "image='
+  local action_file=".github/actions/derive-service-tags/action.yaml"
+  assert_file_contains "composite action emits version output" "$action_file" '"version='
+  assert_file_contains "composite action emits sha output" "$action_file" '"sha='
+  assert_file_contains "composite action emits image output" "$action_file" '"image='
 }
 
 # --- REQ-006: PR uses single-arch, load, and conditional push/platforms ---
 test_pr_single_arch_load() {
   echo "Test: PR uses single-arch, load, and conditional push/platforms (REQ-006)"
 
-  local platforms load_val push_val
-  platforms=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.platforms' "$WORKFLOW" || true)
-  load_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.load' "$WORKFLOW" || true)
-  push_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.push' "$WORKFLOW" || true)
+  local build_matrix_run
+  build_matrix_run=$(yq_raw '.jobs["generate-matrix"]["steps"][] | select(.id == "matrix") | .run' "$WORKFLOW" || true)
+  assert_contains "build-matrix excludes ARM64 on pull_request" "$build_matrix_run" "pull_request"
+  assert_contains "build-matrix includes linux/arm64 on push" "$build_matrix_run" "linux/arm64"
 
-  assert_contains "platforms uses pull_request conditional for single-arch" "$platforms" "pull_request"
-  assert_contains "platforms includes linux/amd64 for PR" "$platforms" "linux/amd64"
+  local load_val
+  load_val=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.load' "$WORKFLOW" || true)
   assert_contains "load conditioned on pull_request" "$load_val" "pull_request"
-  assert_contains "push conditioned on not pull_request" "$push_val" "pull_request"
 }
 
 # --- REQ-007: verify-service-images uses verify_<service>.sh via matrix ---
@@ -331,7 +316,7 @@ test_verify_service_images_depends_on_service_images() {
   local needs
   needs=$(yq_raw '.jobs["verify-service-images"]["needs"][]' "$WORKFLOW" || true)
 
-  assert_contains "verify-service-images needs build-service-images" "$needs" "build-service-images"
+  assert_contains "verify-service-images needs merge-service-images" "$needs" "merge-service-images"
   assert_contains "verify-service-images needs test-service-images" "$needs" "test-service-images"
   assert_contains "verify-service-images needs generate-matrix" "$needs" "generate-matrix"
 }
@@ -351,11 +336,9 @@ test_verify_service_images_has_matrix() {
 test_verify_service_images_derives_image_ref() {
   echo "Test: verify-service-images derives image ref via tags step (REQ-007)"
 
-  local derive_step
-  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
-
-  assert_contains "verify-service-images derives VERSION from source-refs.yaml" "$derive_step" "source-refs.yaml"
-  assert_contains "verify-service-images computes image-ref output" "$derive_step" "image-ref="
+  local tags_uses
+  tags_uses=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .uses' "$WORKFLOW" || true)
+  assert_contains "verify-service-images uses derive-service-tags composite action" "$tags_uses" "./.github/actions/derive-service-tags"
 }
 
 # --- REQ-008: All actions pinned to 40-char hex SHA ---
@@ -366,6 +349,8 @@ test_actions_pinned_to_sha() {
 
   while IFS= read -r line; do
     [ -z "$line" ] && continue
+    # Local composite actions (uses: ./) do not require SHA pinning
+    echo "$line" | grep -qE 'uses:[[:space:]]+\./' && continue
     if ! echo "$line" | grep -qE '@[0-9a-f]{40}'; then
       echo "  FAIL: action not pinned to SHA: $line"
       FAIL=$((FAIL + 1))
@@ -387,6 +372,8 @@ test_actions_have_version_comments() {
 
   while IFS= read -r line; do
     [ -z "$line" ] && continue
+    # Local composite actions (uses: ./) do not require version comments
+    echo "$line" | grep -qE 'uses:[[:space:]]+\./' && continue
     if ! echo "$line" | grep -qE '# v[0-9]'; then
       echo "  FAIL: action missing version comment: $line"
       FAIL=$((FAIL + 1))
@@ -464,59 +451,35 @@ test_timeout_minutes_on_all_jobs() {
 test_runs_on_ubuntu_latest() {
   echo "Test: all jobs use runs-on: ubuntu-latest (REQ-008, CC-0034 REQ-012)"
 
-  local base_runner verify_base_runner service_runner test_service_runner verify_service_runner
-  base_runner=$(yq_raw '.jobs["build-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  local verify_base_runner merge_base_runner merge_service_runner test_service_runner verify_service_runner
   verify_base_runner=$(yq_raw '.jobs["verify-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
-  service_runner=$(yq_raw '.jobs["build-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  merge_base_runner=$(yq_raw '.jobs["merge-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  merge_service_runner=$(yq_raw '.jobs["merge-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
   test_service_runner=$(yq_raw '.jobs["test-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
   verify_service_runner=$(yq_raw '.jobs["verify-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
 
-  assert_eq "build-base-images uses ubuntu-latest" "ubuntu-latest" "$base_runner"
   assert_eq "verify-base-images uses ubuntu-latest" "ubuntu-latest" "$verify_base_runner"
-  assert_eq "build-service-images uses ubuntu-latest" "ubuntu-latest" "$service_runner"
+  assert_eq "merge-base-images uses ubuntu-latest" "ubuntu-latest" "$merge_base_runner"
+  assert_eq "merge-service-images uses ubuntu-latest" "ubuntu-latest" "$merge_service_runner"
   assert_eq "test-service-images uses ubuntu-latest" "ubuntu-latest" "$test_service_runner"
   assert_eq "verify-service-images uses ubuntu-latest" "ubuntu-latest" "$verify_service_runner"
+
+  local base_runner service_runner
+  base_runner=$(yq_raw '.jobs["build-base-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+  service_runner=$(yq_raw '.jobs["build-service-images"]["runs-on"]' "$WORKFLOW" || echo "null")
+
+  assert_contains "build-base-images uses matrix runner expression" "$base_runner" "matrix.runner"
+  assert_contains "build-service-images uses matrix runner expression" "$service_runner" "matrix.runner"
 }
 
 # --- REQ-002: Base images always push unconditionally ---
 test_base_images_always_push() {
   echo "Test: base images always push unconditionally (REQ-002)"
 
-  # Check that all build-push-action steps in build-base-images have push: true
-  # and that push is not conditioned on event_name (unlike service images).
-  # Use the raw YAML file to verify the literal "push: true" value.
-  local push_values
-  push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.push) | .with.push' "$WORKFLOW" || true)
-
-  if [ -z "$push_values" ]; then
-    echo "  FAIL: build-base-images has no push values"
-    FAIL=$((FAIL + 1))
-    return
-  fi
-
-  local all_true=true
-  while IFS= read -r val; do
-    [ -z "$val" ] && continue
-    if [ "$val" != "true" ]; then
-      echo "  FAIL: build-base-images push is not unconditionally true: $val"
-      FAIL=$((FAIL + 1))
-      all_true=false
-    fi
-  done <<< "$push_values"
-
-  if $all_true; then
-    echo "  PASS: build-base-images push is unconditionally true"
-    PASS=$((PASS + 1))
-  fi
-
-  # Verify push is not conditioned on event_name (would be a GHA expression string, not boolean)
-  if echo "$push_values" | grep -q 'event_name'; then
-    echo "  FAIL: build-base-images push is conditioned on event_name"
-    FAIL=$((FAIL + 1))
-  else
-    echo "  PASS: build-base-images push is not conditioned on event_name"
-    PASS=$((PASS + 1))
-  fi
+  local outputs_values
+  outputs_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.with.outputs) | .with.outputs' "$WORKFLOW" || true)
+  assert_contains "build-base-images uses push-by-digest=true" "$outputs_values" "push-by-digest=true"
+  assert_contains "build-base-images push-by-digest output includes push=true" "$outputs_values" "push=true"
 }
 
 # --- CC-0007: Fork PRs rejected in build-base-images ---
@@ -535,22 +498,25 @@ test_fork_pr_rejection_step_exists() {
 test_base_images_have_sha_tags() {
   echo "Test: base images have SHA tags for commit traceability (CC-0007)"
 
-  local python_tags venv_tags
-  python_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-python-base") | .with.tags' "$WORKFLOW" || true)
-  venv_tags=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "build-venv-builder") | .with.tags' "$WORKFLOW" || true)
+  # In the push-by-digest architecture, SHA tags are applied in merge-base-images via imagetools create
+  local python_manifest venv_manifest
+  python_manifest=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Create and push python-base manifest") | .run' "$WORKFLOW" || true)
+  venv_manifest=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Create and push venv-builder manifest") | .run' "$WORKFLOW" || true)
 
-  assert_contains "python-base tags include github.sha" "$python_tags" 'github.sha'
-  assert_contains "venv-builder tags include github.sha" "$venv_tags" 'github.sha'
+  assert_contains "python-base tags include github.sha" "$python_manifest" 'github.sha'
+  assert_contains "venv-builder tags include github.sha" "$venv_manifest" 'github.sha'
 }
 
 # --- CC-0007: Version-only tag restricted to main branch ---
 test_version_tag_restricted_to_main() {
   echo "Test: version-only tag restricted to main branch (CC-0007)"
 
-  local tags_block
-  tags_block=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "build-service") | .with.tags' "$WORKFLOW" || true)
+  # In the push-by-digest architecture, the version tag conditional lives in the
+  # merge-service-images manifest creation step's run script (bash GITHUB_REF_NAME check)
+  local manifest_run
+  manifest_run=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.name == "Create and push service image manifest") | .run' "$WORKFLOW" || true)
 
-  assert_contains "version tag line contains ref_name == main conditional" "$tags_block" "github.ref_name == 'main'"
+  assert_contains "version tag line contains ref_name == main conditional" "$manifest_run" 'GITHUB_REF_NAME}" == "main"'
 }
 
 # --- CC-0007: Matrix jobs use fail-fast: false for independent failure reporting ---
@@ -579,22 +545,26 @@ test_source_ref_null_guard() {
   assert_contains "source-ref step exits on invalid ref" "$source_ref_run" "exit 1"
 }
 
-# --- CC-0007: verify-service-images tag derivation has sync comment referencing build-service-images ---
+# --- CC-0007: all three tag-deriving jobs use the same composite action ---
 test_verify_service_images_tag_derivation_sync_comment() {
-  echo "Test: verify-service-images tag derivation has sync comment (CC-0007)"
+  echo "Test: all tag-deriving jobs use derive-service-tags composite action (CC-0007)"
 
-  assert_file_contains "verify-service-images has sync comment referencing Derive tags step" "$WORKFLOW" "MUST stay in sync with the .Derive tags. step"
+  local build_uses merge_uses verify_uses
+  build_uses=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "tags") | .uses' "$WORKFLOW" || true)
+  merge_uses=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.id == "tags") | .uses' "$WORKFLOW" || true)
+  verify_uses=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .uses' "$WORKFLOW" || true)
+  assert_contains "build-service-images uses derive-service-tags" "$build_uses" "./.github/actions/derive-service-tags"
+  assert_contains "merge-service-images uses derive-service-tags" "$merge_uses" "./.github/actions/derive-service-tags"
+  assert_contains "verify-service-images uses derive-service-tags" "$verify_uses" "./.github/actions/derive-service-tags"
 }
 
-# --- CC-0007: verify-service-images validates yq output against null/empty ---
+# --- CC-0007: composite action validates yq output against null/empty ---
 test_verify_service_images_null_guard() {
-  echo "Test: verify-service-images validates yq output against null/empty (CC-0007)"
+  echo "Test: composite action validates yq output against null/empty (CC-0007)"
 
-  local derive_step
-  derive_step=$(yq_raw '.jobs["verify-service-images"]["steps"][] | select(.id == "tags") | .run' "$WORKFLOW" || true)
-
-  assert_contains "verify-service-images derive step checks for null string" "$derive_step" '"null"'
-  assert_contains "verify-service-images derive step exits on invalid ref" "$derive_step" "exit 1"
+  local action_file=".github/actions/derive-service-tags/action.yaml"
+  assert_file_contains "composite action checks for null string" "$action_file" '"null"'
+  assert_file_contains "composite action exits on invalid ref" "$action_file" "exit 1"
 }
 
 # ===========================================================================================
@@ -639,7 +609,7 @@ test_test_service_images_depends_on_base() {
   local needs
   needs=$(yq_raw '.jobs["test-service-images"]["needs"][]' "$WORKFLOW" || true)
 
-  assert_contains "test-service-images needs build-base-images" "$needs" "build-base-images"
+  assert_contains "test-service-images needs merge-base-images" "$needs" "merge-base-images"
   assert_contains "test-service-images needs verify-base-images" "$needs" "verify-base-images"
 }
 
@@ -663,7 +633,7 @@ test_test_service_images_uses_venv_builder_output() {
   local run_step_env
   run_step_env=$(yq_raw '.jobs["test-service-images"]["steps"][] | select(.name == "Run tests") | .env["VENV_BUILDER_IMAGE"]' "$WORKFLOW" || true)
 
-  assert_contains "Run tests env references venv-builder-image output" "$run_step_env" "needs.build-base-images.outputs.venv-builder-image"
+  assert_contains "Run tests env references venv-builder-image output" "$run_step_env" "needs.merge-base-images.outputs.venv-builder-image"
 }
 
 # --- CC-0034 REQ-003: test-service-images resolves source ref from source-refs.yaml ---
@@ -860,28 +830,28 @@ test_run_blocks_use_env_vars() {
   assert_file_not_contains "apply overrides run uses env vars (no direct matrix interpolation)" "$WORKFLOW" 'apply-constraint-overrides.sh \${{ matrix'
 }
 
-# --- CC-0029: SBOM permissions on build-base-images (REQ-012) ---
+# --- CC-0029: SBOM permissions on merge-base-images (REQ-012) ---
 test_sbom_permissions_on_build_base_images() {
-  echo "Test: SBOM permissions on build-base-images (CC-0029, REQ-012)"
+  echo "Test: SBOM permissions on merge-base-images (CC-0029, REQ-012)"
 
   local id_token attestations
-  id_token=$(yq_raw '.jobs["build-base-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
-  attestations=$(yq_raw '.jobs["build-base-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+  id_token=$(yq_raw '.jobs["merge-base-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  attestations=$(yq_raw '.jobs["merge-base-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
 
-  assert_eq "build-base-images has id-token: write" "write" "$id_token"
-  assert_eq "build-base-images has attestations: write" "write" "$attestations"
+  assert_eq "merge-base-images has id-token: write" "write" "$id_token"
+  assert_eq "merge-base-images has attestations: write" "write" "$attestations"
 }
 
-# --- CC-0029: SBOM permissions on build-service-images (REQ-012) ---
+# --- CC-0029: SBOM permissions on merge-service-images (REQ-012) ---
 test_sbom_permissions_on_build_service_images() {
-  echo "Test: SBOM permissions on build-service-images (CC-0029, REQ-012)"
+  echo "Test: SBOM permissions on merge-service-images (CC-0029, REQ-012)"
 
   local id_token attestations
-  id_token=$(yq_raw '.jobs["build-service-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
-  attestations=$(yq_raw '.jobs["build-service-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
+  id_token=$(yq_raw '.jobs["merge-service-images"]["permissions"]["id-token"]' "$WORKFLOW" || echo "null")
+  attestations=$(yq_raw '.jobs["merge-service-images"]["permissions"]["attestations"]' "$WORKFLOW" || echo "null")
 
-  assert_eq "build-service-images has id-token: write" "write" "$id_token"
-  assert_eq "build-service-images has attestations: write" "write" "$attestations"
+  assert_eq "merge-service-images has id-token: write" "write" "$id_token"
+  assert_eq "merge-service-images has attestations: write" "write" "$attestations"
 }
 
 # --- CC-0029: Verify jobs do NOT have SBOM permissions (REQ-012) ---
@@ -912,202 +882,183 @@ test_verify_jobs_no_sbom_permissions() {
 
 # --- CC-0029: SBOM generation steps exist (REQ-010) ---
 test_sbom_generation_steps_exist() {
-  echo "Test: SBOM generation steps exist in both build jobs (CC-0029, REQ-010)"
+  echo "Test: SBOM generation steps exist in both merge jobs (CC-0029, REQ-010)"
 
-  # build-base-images should have 2 SBOM generation steps (python-base, venv-builder)
+  # merge-base-images should have 2 SBOM generation steps (python-base, venv-builder)
   local base_sbom_count
-  base_sbom_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 2 SBOM generation steps" "2" "$base_sbom_count"
+  base_sbom_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 2 SBOM generation steps" "2" "$base_sbom_count"
 
-  # build-service-images should have 1 SBOM generation step
+  # merge-service-images should have 1 SBOM generation step
   local service_sbom_count
-  service_sbom_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
-  assert_eq "build-service-images has 1 SBOM generation step" "1" "$service_sbom_count"
+  service_sbom_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 SBOM generation step" "1" "$service_sbom_count"
 }
 
 # --- CC-0029: SBOM format is cyclonedx-json (REQ-010) ---
 test_sbom_format_cyclonedx_json() {
   echo "Test: SBOM format is cyclonedx-json (CC-0029, REQ-010)"
 
-  # All SBOM generation steps in build-base-images must use cyclonedx-json
+  # All SBOM generation steps in merge-base-images must use cyclonedx-json
   local base_formats
-  base_formats=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
+  base_formats=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
 
   local all_cyclonedx=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [ "$val" != "cyclonedx-json" ]; then
-      echo "  FAIL: build-base-images SBOM format is not cyclonedx-json: $val"
+      echo "  FAIL: merge-base-images SBOM format is not cyclonedx-json: $val"
       FAIL=$((FAIL + 1))
       all_cyclonedx=false
     fi
   done <<< "$base_formats"
 
   if $all_cyclonedx && [ -n "$base_formats" ]; then
-    echo "  PASS: all build-base-images SBOM steps use cyclonedx-json"
+    echo "  PASS: all merge-base-images SBOM steps use cyclonedx-json"
     PASS=$((PASS + 1))
   elif [ -z "$base_formats" ]; then
-    echo "  FAIL: build-base-images SBOM format check found no steps"
+    echo "  FAIL: merge-base-images SBOM format check found no steps"
     FAIL=$((FAIL + 1))
   fi
 
-  # build-service-images SBOM step
+  # merge-service-images SBOM step
   local service_format
-  service_format=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
-  assert_eq "build-service-images SBOM format is cyclonedx-json" "cyclonedx-json" "$service_format"
+  service_format=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with.format' "$WORKFLOW" || true)
+  assert_eq "merge-service-images SBOM format is cyclonedx-json" "cyclonedx-json" "$service_format"
 }
 
 # --- CC-0029: SBOM generation steps disable artifact upload (REQ-010) ---
 test_sbom_no_artifact_upload() {
   echo "Test: SBOM generation steps set upload-artifact: false (CC-0029, REQ-010)"
 
-  # All SBOM generation steps in build-base-images must set upload-artifact: false
+  # All SBOM generation steps in merge-base-images must set upload-artifact: false
   local base_upload_values
-  base_upload_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
+  base_upload_values=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
 
   local all_false=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [ "$val" != "false" ]; then
-      echo "  FAIL: build-base-images SBOM step does not set upload-artifact: false: $val"
+      echo "  FAIL: merge-base-images SBOM step does not set upload-artifact: false: $val"
       FAIL=$((FAIL + 1))
       all_false=false
     fi
   done <<< "$base_upload_values"
 
   if $all_false && [ -n "$base_upload_values" ]; then
-    echo "  PASS: all build-base-images SBOM steps set upload-artifact: false"
+    echo "  PASS: all merge-base-images SBOM steps set upload-artifact: false"
     PASS=$((PASS + 1))
   elif [ -z "$base_upload_values" ]; then
-    echo "  FAIL: no build-base-images SBOM steps found for upload-artifact check"
+    echo "  FAIL: no merge-base-images SBOM steps found for upload-artifact check"
     FAIL=$((FAIL + 1))
   fi
 
-  # build-service-images SBOM step
+  # merge-service-images SBOM step
   local service_upload
-  service_upload=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
-  assert_eq "build-service-images SBOM step sets upload-artifact: false" "false" "$service_upload"
+  service_upload=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action"))) | .with["upload-artifact"]' "$WORKFLOW" || true)
+  assert_eq "merge-service-images SBOM step sets upload-artifact: false" "false" "$service_upload"
 }
 
 # --- CC-0029: SBOM generation references correct digest (REQ-015) ---
 test_sbom_generation_references_digest() {
   echo "Test: SBOM generation steps reference correct digest (CC-0029, REQ-015)"
 
-  # python-base SBOM references build-python-base digest
+  # python-base SBOM references merge-python-base digest
   local python_base_image
-  python_base_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Generate SBOM for python-base") | .with.image' "$WORKFLOW" || true)
-  assert_contains "python-base SBOM references build-python-base digest" "$python_base_image" "build-python-base.outputs.digest"
+  python_base_image=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Generate SBOM for python-base") | .with.image' "$WORKFLOW" || true)
+  assert_contains "python-base SBOM references merge-python-base digest" "$python_base_image" "merge-python-base.outputs.digest"
 
-  # venv-builder SBOM references build-venv-builder digest
+  # venv-builder SBOM references merge-venv-builder digest
   local venv_builder_image
-  venv_builder_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Generate SBOM for venv-builder") | .with.image' "$WORKFLOW" || true)
-  assert_contains "venv-builder SBOM references build-venv-builder digest" "$venv_builder_image" "build-venv-builder.outputs.digest"
+  venv_builder_image=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Generate SBOM for venv-builder") | .with.image' "$WORKFLOW" || true)
+  assert_contains "venv-builder SBOM references merge-venv-builder digest" "$venv_builder_image" "merge-venv-builder.outputs.digest"
 
-  # service SBOM references build-service digest
+  # service SBOM references merge-service digest
   local service_image
-  service_image=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Generate SBOM for service image") | .with.image' "$WORKFLOW" || true)
+  service_image=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.name == "Generate SBOM for service image") | .with.image' "$WORKFLOW" || true)
   assert_contains "service SBOM uses tags.outputs.image" "$service_image" "steps.tags.outputs.image"
-  assert_contains "service SBOM references build-service digest" "$service_image" "build-service.outputs.digest"
+  assert_contains "service SBOM references merge-service digest" "$service_image" "merge-service.outputs.digest"
 }
 
 # --- CC-0029: SBOM attestation steps exist (REQ-011) ---
 test_sbom_attestation_steps_exist() {
-  echo "Test: SBOM attestation steps exist in both build jobs (CC-0029, REQ-011)"
+  echo "Test: SBOM attestation steps exist in both merge jobs (CC-0029, REQ-011)"
 
-  # build-base-images should have 2 attestation steps
+  # merge-base-images should have 2 attestation steps
   local base_attest_count
-  base_attest_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 2 attestation steps" "2" "$base_attest_count"
+  base_attest_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 2 attestation steps" "2" "$base_attest_count"
 
-  # build-service-images should have 1 attestation step
+  # merge-service-images should have 1 attestation step
   local service_attest_count
-  service_attest_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .uses' "$WORKFLOW")
-  assert_eq "build-service-images has 1 attestation step" "1" "$service_attest_count"
+  service_attest_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 attestation step" "1" "$service_attest_count"
 }
 
 # --- CC-0029: SBOM attestation push-to-registry (REQ-016) ---
 test_sbom_attestation_push_to_registry() {
   echo "Test: SBOM attestation push-to-registry is true (CC-0029, REQ-016)"
 
-  # All attestation steps in build-base-images
+  # All attestation steps in merge-base-images
   local base_push_values
-  base_push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+  base_push_values=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
 
   local all_true=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [ "$val" != "true" ]; then
-      echo "  FAIL: build-base-images attestation push-to-registry is not true: $val"
+      echo "  FAIL: merge-base-images attestation push-to-registry is not true: $val"
       FAIL=$((FAIL + 1))
       all_true=false
     fi
   done <<< "$base_push_values"
 
   if $all_true && [ -n "$base_push_values" ]; then
-    echo "  PASS: all build-base-images attestation steps have push-to-registry: true"
+    echo "  PASS: all merge-base-images attestation steps have push-to-registry: true"
     PASS=$((PASS + 1))
   elif [ -z "$base_push_values" ]; then
-    echo "  FAIL: no build-base-images attestation steps found (empty yq result)"
+    echo "  FAIL: no merge-base-images attestation steps found (empty yq result)"
     FAIL=$((FAIL + 1))
   fi
 
-  # build-service-images attestation step
+  # merge-service-images attestation step
   local service_push
-  service_push=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
-  assert_eq "build-service-images attestation push-to-registry is true" "true" "$service_push"
+  service_push=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+  assert_eq "merge-service-images attestation push-to-registry is true" "true" "$service_push"
 }
 
 # --- CC-0029: SBOM/attestation steps have PR-skip guard (REQ-013) ---
 test_sbom_steps_pr_skip_guard() {
   echo "Test: SBOM/attestation steps have PR-skip guard (CC-0029, REQ-013)"
 
-  # All SBOM steps in build-base-images must have PR guard
+  # All SBOM steps in merge-base-images must have PR guard
   local base_sbom_ifs
-  base_sbom_ifs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action|actions/attest"))) | .if' "$WORKFLOW" || true)
+  base_sbom_ifs=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action|actions/attest"))) | .if' "$WORKFLOW" || true)
 
   local all_guarded=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-base-images SBOM/attestation step missing PR guard: $val"
+      echo "  FAIL: merge-base-images SBOM/attestation step missing PR guard: $val"
       FAIL=$((FAIL + 1))
       all_guarded=false
     fi
   done <<< "$base_sbom_ifs"
 
   if $all_guarded && [ -n "$base_sbom_ifs" ]; then
-    echo "  PASS: all build-base-images SBOM/attestation steps have PR-skip guard"
+    echo "  PASS: all merge-base-images SBOM/attestation steps have PR-skip guard"
     PASS=$((PASS + 1))
   elif [ -z "$base_sbom_ifs" ]; then
-    echo "  FAIL: build-base-images SBOM/attestation steps not found or missing PR guard"
+    echo "  FAIL: merge-base-images SBOM/attestation steps not found or missing PR guard"
     FAIL=$((FAIL + 1))
   else
-    echo "  FAIL: some build-base-images SBOM/attestation steps missing PR-skip guard (see above)"
+    echo "  FAIL: some merge-base-images SBOM/attestation steps missing PR-skip guard (see above)"
   fi
 
-  # All SBOM steps in build-service-images must have PR guard
-  local service_sbom_ifs
-  service_sbom_ifs=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/sbom-action|actions/attest"))) | .if' "$WORKFLOW" || true)
-
-  local service_all_guarded=true
-  while IFS= read -r val; do
-    [ -z "$val" ] && continue
-    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-service-images SBOM/attestation step missing PR guard: $val"
-      FAIL=$((FAIL + 1))
-      service_all_guarded=false
-    fi
-  done <<< "$service_sbom_ifs"
-
-  if $service_all_guarded && [ -n "$service_sbom_ifs" ]; then
-    echo "  PASS: all build-service-images SBOM/attestation steps have PR-skip guard"
-    PASS=$((PASS + 1))
-  elif [ -z "$service_sbom_ifs" ]; then
-    echo "  FAIL: build-service-images SBOM/attestation steps not found or missing PR guard"
-    FAIL=$((FAIL + 1))
-  else
-    echo "  FAIL: some build-service-images SBOM/attestation steps missing PR-skip guard (see above)"
-  fi
+  # merge-service-images has job-level PR guard
+  local merge_service_job_if
+  merge_service_job_if=$(yq_raw '.jobs["merge-service-images"]["if"]' "$WORKFLOW" || true)
+  assert_contains "merge-service-images job has PR-skip guard" "$merge_service_job_if" "event_name != 'pull_request'"
 }
 
 # --- CC-0035: build provenance attestation steps exist (SLSA Level 2+) ---
@@ -1115,12 +1066,12 @@ test_build_provenance_steps_exist() {
   echo "Test: build provenance attestation steps exist in both build jobs (CC-0035)"
 
   local base_prov_count
-  base_prov_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 2 build-provenance attestation steps" "2" "$base_prov_count"
+  base_prov_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 2 build-provenance attestation steps" "2" "$base_prov_count"
 
   local service_prov_count
-  service_prov_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .uses' "$WORKFLOW")
-  assert_eq "build-service-images has 1 build-provenance attestation step" "1" "$service_prov_count"
+  service_prov_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 build-provenance attestation step" "1" "$service_prov_count"
 }
 
 # --- CC-0035: build provenance steps have PR-skip guard ---
@@ -1128,50 +1079,37 @@ test_build_provenance_steps_pr_skip_guard() {
   echo "Test: build provenance steps have PR-skip guard (CC-0035)"
 
   local base_prov_ifs
-  base_prov_ifs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .if' "$WORKFLOW" || true)
+  base_prov_ifs=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .if' "$WORKFLOW" || true)
 
   local all_guarded=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-base-images provenance step missing PR guard: $val"
+      echo "  FAIL: merge-base-images provenance step missing PR guard: $val"
       FAIL=$((FAIL + 1))
       all_guarded=false
     fi
   done <<< "$base_prov_ifs"
 
   if $all_guarded && [ -n "$base_prov_ifs" ]; then
-    echo "  PASS: all build-base-images provenance steps have PR-skip guard"
+    echo "  PASS: all merge-base-images provenance steps have PR-skip guard"
     PASS=$((PASS + 1))
   elif [ -z "$base_prov_ifs" ]; then
-    echo "  FAIL: build-base-images provenance steps not found or missing PR guard"
+    echo "  FAIL: merge-base-images provenance steps not found or missing PR guard"
     FAIL=$((FAIL + 1))
   else
-    echo "  FAIL: some build-base-images provenance steps missing PR-skip guard (see above)"
+    echo "  FAIL: some merge-base-images provenance steps missing PR-skip guard (see above)"
     FAIL=$((FAIL + 1))
   fi
 
-  local service_prov_ifs
-  service_prov_ifs=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .if' "$WORKFLOW" || true)
-
-  local service_all_guarded=true
-  while IFS= read -r val; do
-    [ -z "$val" ] && continue
-    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-service-images provenance step missing PR guard: $val"
-      FAIL=$((FAIL + 1))
-      service_all_guarded=false
-    fi
-  done <<< "$service_prov_ifs"
-
-  if $service_all_guarded && [ -n "$service_prov_ifs" ]; then
-    echo "  PASS: all build-service-images provenance steps have PR-skip guard"
+  # merge-service-images uses a job-level if guard instead of per-step guards
+  local service_job_if
+  service_job_if=$(yq_raw '.jobs["merge-service-images"]["if"]' "$WORKFLOW" || true)
+  if [[ "$service_job_if" == *"github.event_name != 'pull_request'"* ]]; then
+    echo "  PASS: merge-service-images has job-level PR-skip guard"
     PASS=$((PASS + 1))
-  elif [ -z "$service_prov_ifs" ]; then
-    echo "  FAIL: build-service-images provenance steps not found or missing PR guard"
-    FAIL=$((FAIL + 1))
   else
-    echo "  FAIL: some build-service-images provenance steps missing PR-skip guard (see above)"
+    echo "  FAIL: merge-service-images missing job-level PR-skip guard: $service_job_if"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -1181,29 +1119,29 @@ test_build_provenance_push_to_registry() {
   echo "Test: build provenance push-to-registry is true (CC-0035)"
 
   local base_push_values
-  base_push_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+  base_push_values=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
 
   local all_true=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [[ "$val" != "true" ]]; then
-      echo "  FAIL: build-base-images provenance step push-to-registry is not true: $val"
+      echo "  FAIL: merge-base-images provenance step push-to-registry is not true: $val"
       FAIL=$((FAIL + 1))
       all_true=false
     fi
   done <<< "$base_push_values"
 
   if $all_true && [ -n "$base_push_values" ]; then
-    echo "  PASS: all build-base-images provenance steps have push-to-registry: true"
+    echo "  PASS: all merge-base-images provenance steps have push-to-registry: true"
     PASS=$((PASS + 1))
   elif [ -z "$base_push_values" ]; then
-    echo "  FAIL: no build-base-images provenance steps found (empty yq result)"
+    echo "  FAIL: no merge-base-images provenance steps found (empty yq result)"
     FAIL=$((FAIL + 1))
   fi
 
   local service_push
-  service_push=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
-  assert_eq "build-service-images provenance push-to-registry is true" "true" "$service_push"
+  service_push=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("actions/attest-build-provenance@"))) | .with["push-to-registry"]' "$WORKFLOW" || true)
+  assert_eq "merge-service-images provenance push-to-registry is true" "true" "$service_push"
 }
 
 # --- CC-0031: metadata-action steps exist in build-base-images (REQ-002) ---
@@ -1402,139 +1340,122 @@ test_dockerfile_static_labels_keystone() {
   assert_contains "keystone runtime stage has org.opencontainers.image.vendor" "$runtime_stage" 'org.opencontainers.image.vendor='
 }
 
-# --- CC-0030: cosign-installer step in build-base-images (REQ-018) ---
+# --- CC-0030: cosign-installer step in merge-base-images (REQ-018) ---
 test_cosign_installer_in_build_base_images() {
-  echo "Test: cosign-installer step exists in build-base-images (CC-0030, REQ-018)"
+  echo "Test: cosign-installer step exists in merge-base-images (CC-0030, REQ-018)"
 
   local installer_count
-  installer_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 1 cosign-installer step" "1" "$installer_count"
+  installer_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 1 cosign-installer step" "1" "$installer_count"
 }
 
-# --- CC-0030: cosign-installer step in build-service-images (REQ-018) ---
+# --- CC-0030: cosign-installer step in merge-service-images (REQ-018) ---
 test_cosign_installer_in_build_service_images() {
-  echo "Test: cosign-installer step exists in build-service-images (CC-0030, REQ-018)"
+  echo "Test: cosign-installer step exists in merge-service-images (CC-0030, REQ-018)"
 
   local installer_count
-  installer_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
-  assert_eq "build-service-images has 1 cosign-installer step" "1" "$installer_count"
+  installer_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("sigstore/cosign-installer"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 cosign-installer step" "1" "$installer_count"
 }
 
-# --- CC-0030: cosign sign steps exist in both build jobs (REQ-019, REQ-020) ---
+# --- CC-0030: cosign sign steps exist in both merge jobs (REQ-019, REQ-020) ---
 test_cosign_sign_steps_count() {
-  echo "Test: cosign sign steps exist in both build jobs (CC-0030, REQ-019, REQ-020)"
+  echo "Test: cosign sign steps exist in both merge jobs (CC-0030, REQ-019, REQ-020)"
 
-  # build-base-images should have 2 sign steps (python-base and venv-builder)
+  # merge-base-images should have 2 sign steps (python-base and venv-builder)
   local base_sign_count
-  base_sign_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
-  assert_eq "build-base-images has 2 cosign sign steps" "2" "$base_sign_count"
+  base_sign_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
+  assert_eq "merge-base-images has 2 cosign sign steps" "2" "$base_sign_count"
 
-  # build-service-images should have 1 sign step
+  # merge-service-images should have 1 sign step
   local service_sign_count
-  service_sign_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
-  assert_eq "build-service-images has 1 cosign sign step" "1" "$service_sign_count"
+  service_sign_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 cosign sign step" "1" "$service_sign_count"
 }
 
 # --- CC-0030: cosign sign steps have PR-skip guard (REQ-021) ---
 test_cosign_sign_steps_pr_guard() {
   echo "Test: cosign sign steps have PR-skip guard (CC-0030, REQ-021)"
 
-  # All cosign sign steps in build-base-images must have PR guard
+  # All cosign sign steps in merge-base-images must have PR guard
   local base_sign_ifs
-  base_sign_ifs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .if' "$WORKFLOW" || true)
+  base_sign_ifs=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .if' "$WORKFLOW" || true)
 
   local all_guarded=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-base-images cosign sign step missing PR guard: $val"
+      echo "  FAIL: merge-base-images cosign sign step missing PR guard: $val"
       FAIL=$((FAIL + 1))
       all_guarded=false
     fi
   done <<< "$base_sign_ifs"
 
   if $all_guarded && [ -n "$base_sign_ifs" ]; then
-    echo "  PASS: all build-base-images cosign sign steps have PR-skip guard"
+    echo "  PASS: all merge-base-images cosign sign steps have PR-skip guard"
     PASS=$((PASS + 1))
   elif [ -z "$base_sign_ifs" ]; then
-    echo "  FAIL: build-base-images cosign sign steps not found or missing PR guard"
+    echo "  FAIL: merge-base-images cosign sign steps not found or missing PR guard"
     FAIL=$((FAIL + 1))
   fi
 
-  # All cosign sign steps in build-service-images must have PR guard
-  local service_sign_ifs
-  service_sign_ifs=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .if' "$WORKFLOW" || true)
-
-  local service_all_guarded=true
-  while IFS= read -r val; do
-    [ -z "$val" ] && continue
-    if [[ "$val" != *"github.event_name != 'pull_request'"* ]]; then
-      echo "  FAIL: build-service-images cosign sign step missing PR guard: $val"
-      FAIL=$((FAIL + 1))
-      service_all_guarded=false
-    fi
-  done <<< "$service_sign_ifs"
-
-  if $service_all_guarded && [ -n "$service_sign_ifs" ]; then
-    echo "  PASS: all build-service-images cosign sign steps have PR-skip guard"
-    PASS=$((PASS + 1))
-  elif [ -z "$service_sign_ifs" ]; then
-    echo "  FAIL: build-service-images cosign sign steps not found or missing PR guard"
-    FAIL=$((FAIL + 1))
-  fi
+  # merge-service-images has job-level PR guard
+  local merge_service_job_if
+  merge_service_job_if=$(yq_raw '.jobs["merge-service-images"]["if"]' "$WORKFLOW" || true)
+  assert_contains "merge-service-images job-level if excludes pull_request" "$merge_service_job_if" "event_name != 'pull_request'"
 }
 
 # --- CC-0030: cosign sign steps reference digest (REQ-022) ---
 test_cosign_sign_steps_reference_digest() {
   echo "Test: cosign sign steps reference correct digest (CC-0030, REQ-022)"
 
-  # python-base sign references build-python-base digest
+  # python-base sign references merge-python-base digest
   local python_base_run
-  python_base_run=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Sign python-base") | .run' "$WORKFLOW" || true)
-  assert_contains "python-base sign references build-python-base digest" "$python_base_run" "build-python-base.outputs.digest"
+  python_base_run=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Sign python-base") | .run' "$WORKFLOW" || true)
+  assert_contains "python-base sign references merge-python-base digest" "$python_base_run" "merge-python-base.outputs.digest"
 
-  # venv-builder sign references build-venv-builder digest
+  # venv-builder sign references merge-venv-builder digest
   local venv_builder_run
-  venv_builder_run=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name == "Sign venv-builder") | .run' "$WORKFLOW" || true)
-  assert_contains "venv-builder sign references build-venv-builder digest" "$venv_builder_run" "build-venv-builder.outputs.digest"
+  venv_builder_run=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name == "Sign venv-builder") | .run' "$WORKFLOW" || true)
+  assert_contains "venv-builder sign references merge-venv-builder digest" "$venv_builder_run" "merge-venv-builder.outputs.digest"
 
-  # service sign references build-service digest
+  # service sign references merge-service digest
   local service_run
-  service_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name == "Sign service image") | .run' "$WORKFLOW" || true)
+  service_run=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.name == "Sign service image") | .run' "$WORKFLOW" || true)
   assert_contains "service sign uses tags.outputs.image" "$service_run" "steps.tags.outputs.image"
-  assert_contains "service sign references build-service digest" "$service_run" "build-service.outputs.digest"
+  assert_contains "service sign references merge-service digest" "$service_run" "merge-service.outputs.digest"
 }
 
 # --- CC-0030: cosign sign uses --yes flag (REQ-022) ---
 test_cosign_sign_uses_yes_flag() {
   echo "Test: cosign sign steps use --yes flag (CC-0030, REQ-022)"
 
-  # All cosign sign run commands in build-base-images must contain --yes
+  # All cosign sign run commands in merge-base-images must contain --yes
   local base_runs
-  base_runs=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
+  base_runs=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
 
   local all_yes=true
   while IFS= read -r val; do
     [ -z "$val" ] && continue
     if [[ "$val" != *"--yes"* ]]; then
-      echo "  FAIL: build-base-images cosign sign step missing --yes flag: $val"
+      echo "  FAIL: merge-base-images cosign sign step missing --yes flag: $val"
       FAIL=$((FAIL + 1))
       all_yes=false
     fi
   done <<< "$base_runs"
 
   if $all_yes && [ -n "$base_runs" ]; then
-    echo "  PASS: all build-base-images cosign sign steps use --yes flag"
+    echo "  PASS: all merge-base-images cosign sign steps use --yes flag"
     PASS=$((PASS + 1))
   elif [ -z "$base_runs" ]; then
-    echo "  FAIL: no build-base-images cosign sign steps found"
+    echo "  FAIL: no merge-base-images cosign sign steps found"
     FAIL=$((FAIL + 1))
   fi
 
   # service sign must contain --yes
   local service_run
-  service_run=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
-  assert_contains "build-service-images cosign sign uses --yes flag" "$service_run" "--yes"
+  service_run=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.run and (.run | test("cosign sign"))) | .run' "$WORKFLOW" || true)
+  assert_contains "merge-service-images cosign sign uses --yes flag" "$service_run" "--yes"
 }
 
 # --- CC-0030: id-token permission comment references CC-0030 (REQ-018) ---
@@ -1549,33 +1470,39 @@ test_cosign_id_token_permission_comment() {
 # CC-0032: Grype vulnerability scanning verification tests
 # =====================================================================
 
-# --- CC-0032: Grype scan steps exist in build-base-images (REQ-001) ---
+# --- CC-0032: Grype scan steps exist in merge-base-images (REQ-001) ---
 test_grype_scan_steps_in_build_base_images() {
-  echo "Test: Grype scan steps exist in build-base-images (CC-0032, REQ-001)"
+  echo "Test: Grype scan steps exist in merge-base-images (CC-0032, REQ-001)"
 
   local scan_count
-  scan_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 4 Grype scan steps" "4" "$scan_count"
+  scan_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 4 Grype scan steps" "4" "$scan_count"
 }
 
-# --- CC-0032: Grype scan step exists in build-service-images (REQ-001) ---
+# --- CC-0032: Grype scan step exists in build-service-images and merge-service-images (REQ-001) ---
 test_grype_scan_step_in_build_service_images() {
-  echo "Test: Grype scan step exists in build-service-images (CC-0032, REQ-001)"
+  echo "Test: Grype scan step exists in build-service-images and merge-service-images (CC-0032, REQ-001)"
 
   local scan_count
   scan_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW")
-  assert_eq "build-service-images has 2 Grype scan steps" "2" "$scan_count"
+  assert_eq "build-service-images has 1 Grype scan step" "1" "$scan_count"
+
+  local merge_scan_count
+  merge_scan_count=$(yq_count '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-service-images has 1 Grype scan step" "1" "$merge_scan_count"
 }
 
 # --- CC-0032: anchore/scan-action is SHA-pinned (REQ-010) ---
 test_grype_scan_action_sha_pinned() {
   echo "Test: anchore/scan-action is SHA-pinned (CC-0032, REQ-010)"
 
-  # Collect all anchore/scan-action uses from both build jobs
+  # Collect all anchore/scan-action uses from both merge jobs and build-service-images
   local uses_values
-  uses_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW" || true)
+  uses_values=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW" || true)
   uses_values+=$'\n'
   uses_values+=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW" || true)
+  uses_values+=$'\n'
+  uses_values+=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("anchore/scan-action"))) | .uses' "$WORKFLOW" || true)
 
   local all_pinned=true
   local found=false
@@ -1609,29 +1536,30 @@ test_grype_scan_steps_cover_both_contexts() {
   # This ensures scanning always runs regardless of event type, while keeping
   # sbom and image as mutually exclusive inputs per anchore/scan-action docs.
 
-  # build-base-images: verify push (SBOM) and PR (image) steps exist for python-base
+  # merge-base-images: verify push (SBOM) and PR (image) steps exist for python-base
   local python_sbom_if
-  python_sbom_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .if' "$WORKFLOW" || true)
+  python_sbom_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .if' "$WORKFLOW" || true)
   assert_contains "python-base SBOM scan has push-only guard" "$python_sbom_if" "!= 'pull_request'"
 
   local python_image_if
-  python_image_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .if' "$WORKFLOW" || true)
+  python_image_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .if' "$WORKFLOW" || true)
   assert_contains "python-base image scan has PR-only guard" "$python_image_if" "== 'pull_request'"
 
-  # build-base-images: verify push (SBOM) and PR (image) steps exist for venv-builder
+  # merge-base-images: verify push (SBOM) and PR (image) steps exist for venv-builder
   local venv_sbom_if
-  venv_sbom_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .if' "$WORKFLOW" || true)
+  venv_sbom_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .if' "$WORKFLOW" || true)
   assert_contains "venv-builder SBOM scan has push-only guard" "$venv_sbom_if" "!= 'pull_request'"
 
   local venv_image_if
-  venv_image_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .if' "$WORKFLOW" || true)
+  venv_image_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .if' "$WORKFLOW" || true)
   assert_contains "venv-builder image scan has PR-only guard" "$venv_image_if" "== 'pull_request'"
 
-  # build-service-images: verify push (SBOM) and PR (image) steps exist for service
-  local service_sbom_if
-  service_sbom_if=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .if' "$WORKFLOW" || true)
-  assert_contains "service SBOM scan has push-only guard" "$service_sbom_if" "!= 'pull_request'"
+  # merge-service-images uses a job-level if guard; the SBOM scan step needs no additional step guard
+  local service_merge_job_if
+  service_merge_job_if=$(yq_raw '.jobs["merge-service-images"]["if"]' "$WORKFLOW" || true)
+  assert_contains "service SBOM scan has push-only guard (job-level)" "$service_merge_job_if" "!= 'pull_request'"
 
+  # build-service-images: verify PR (image) step exists for service
   local service_image_if
   service_image_if=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-image") | .if' "$WORKFLOW" || true)
   assert_contains "service image scan has PR-only guard" "$service_image_if" "== 'pull_request'"
@@ -1643,34 +1571,34 @@ test_grype_sbom_input_wiring() {
 
   # python-base SBOM scan must reference sbom-python-base.cyclonedx.json
   local python_sbom
-  python_sbom=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with.sbom' "$WORKFLOW" || true)
+  python_sbom=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with.sbom' "$WORKFLOW" || true)
   assert_contains "python-base Grype scan references sbom-python-base.cyclonedx.json" "$python_sbom" "sbom-python-base.cyclonedx.json"
 
   # python-base SBOM scan must have push-only conditional guard
   local python_sbom_if
-  python_sbom_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .if' "$WORKFLOW" || true)
+  python_sbom_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .if' "$WORKFLOW" || true)
   assert_contains "python-base Grype sbom input has push-only conditional" "$python_sbom_if" "event_name != 'pull_request'"
 
   # venv-builder SBOM scan must reference sbom-venv-builder.cyclonedx.json
   local venv_sbom
-  venv_sbom=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with.sbom' "$WORKFLOW" || true)
+  venv_sbom=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with.sbom' "$WORKFLOW" || true)
   assert_contains "venv-builder Grype scan references sbom-venv-builder.cyclonedx.json" "$venv_sbom" "sbom-venv-builder.cyclonedx.json"
 
   # venv-builder SBOM scan must have push-only conditional guard
   local venv_sbom_if
-  venv_sbom_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .if' "$WORKFLOW" || true)
+  venv_sbom_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .if' "$WORKFLOW" || true)
   assert_contains "venv-builder Grype sbom input has push-only conditional" "$venv_sbom_if" "event_name != 'pull_request'"
 
   # service SBOM scan must reference sbom-{service}.cyclonedx.json
   local service_sbom
-  service_sbom=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with.sbom' "$WORKFLOW" || true)
+  service_sbom=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with.sbom' "$WORKFLOW" || true)
   assert_contains "service Grype scan references matrix.service SBOM filename" "$service_sbom" "matrix.service"
   assert_contains "service Grype scan SBOM input is cyclonedx.json format" "$service_sbom" "cyclonedx.json"
 
-  # service SBOM scan must have push-only conditional guard
-  local service_sbom_if
-  service_sbom_if=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .if' "$WORKFLOW" || true)
-  assert_contains "service Grype sbom input has push-only conditional" "$service_sbom_if" "event_name != 'pull_request'"
+  # merge-service-images uses a job-level if guard; check job-level guard instead of step-level
+  local service_merge_if
+  service_merge_if=$(yq_raw '.jobs["merge-service-images"]["if"]' "$WORKFLOW" || true)
+  assert_contains "service Grype sbom input has push-only conditional (job-level)" "$service_merge_if" "event_name != 'pull_request'"
 }
 
 # --- CC-0032: Grype scan image input wiring for PR context (REQ-003) ---
@@ -1679,15 +1607,15 @@ test_grype_image_input_wiring() {
 
   # python-base image scan must reference python-base image
   local python_image
-  python_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with.image' "$WORKFLOW" || true)
+  python_image=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with.image' "$WORKFLOW" || true)
   assert_contains "python-base Grype scan image input references python-base" "$python_image" "python-base"
-  assert_contains "python-base Grype scan image input references build-python-base digest" "$python_image" "build-python-base.outputs.digest"
+  assert_contains "python-base Grype scan image input references merge-python-base digest" "$python_image" "merge-python-base.outputs.digest"
 
   # venv-builder image scan must reference venv-builder image
   local venv_image
-  venv_image=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with.image' "$WORKFLOW" || true)
+  venv_image=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with.image' "$WORKFLOW" || true)
   assert_contains "venv-builder Grype scan image input references venv-builder" "$venv_image" "venv-builder"
-  assert_contains "venv-builder Grype scan image input references build-venv-builder digest" "$venv_image" "build-venv-builder.outputs.digest"
+  assert_contains "venv-builder Grype scan image input references merge-venv-builder digest" "$venv_image" "merge-venv-builder.outputs.digest"
 
   # service image scan must reference composite tag
   local service_image
@@ -1701,23 +1629,23 @@ test_grype_severity_threshold() {
 
   # All Grype scan steps (both SBOM and image variants) must have severity-cutoff: high
   local python_sbom_severity
-  python_sbom_severity=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
+  python_sbom_severity=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
   assert_eq "python-base (sbom) Grype severity-cutoff is high" "high" "$python_sbom_severity"
 
   local python_image_severity
-  python_image_severity=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["severity-cutoff"]' "$WORKFLOW" || true)
+  python_image_severity=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["severity-cutoff"]' "$WORKFLOW" || true)
   assert_eq "python-base (image) Grype severity-cutoff is high" "high" "$python_image_severity"
 
   local venv_sbom_severity
-  venv_sbom_severity=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
+  venv_sbom_severity=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (sbom) Grype severity-cutoff is high" "high" "$venv_sbom_severity"
 
   local venv_image_severity
-  venv_image_severity=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["severity-cutoff"]' "$WORKFLOW" || true)
+  venv_image_severity=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["severity-cutoff"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (image) Grype severity-cutoff is high" "high" "$venv_image_severity"
 
   local service_sbom_severity
-  service_sbom_severity=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
+  service_sbom_severity=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["severity-cutoff"]' "$WORKFLOW" || true)
   assert_eq "service (sbom) Grype severity-cutoff is high" "high" "$service_sbom_severity"
 
   local service_image_severity
@@ -1731,23 +1659,23 @@ test_grype_fail_build_false() {
 
   # All Grype scan steps must have fail-build: false (non-blocking scan, to be activated later)
   local python_sbom_fail
-  python_sbom_fail=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
+  python_sbom_fail=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
   assert_eq "python-base (sbom) Grype fail-build is false" "false" "$python_sbom_fail"
 
   local python_image_fail
-  python_image_fail=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["fail-build"]' "$WORKFLOW" || true)
+  python_image_fail=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["fail-build"]' "$WORKFLOW" || true)
   assert_eq "python-base (image) Grype fail-build is false" "false" "$python_image_fail"
 
   local venv_sbom_fail
-  venv_sbom_fail=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
+  venv_sbom_fail=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (sbom) Grype fail-build is false" "false" "$venv_sbom_fail"
 
   local venv_image_fail
-  venv_image_fail=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["fail-build"]' "$WORKFLOW" || true)
+  venv_image_fail=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["fail-build"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (image) Grype fail-build is false" "false" "$venv_image_fail"
 
   local service_sbom_fail
-  service_sbom_fail=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
+  service_sbom_fail=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["fail-build"]' "$WORKFLOW" || true)
   assert_eq "service (sbom) Grype fail-build is false" "false" "$service_sbom_fail"
 
   local service_image_fail
@@ -1760,8 +1688,8 @@ test_sarif_upload_steps_exist() {
   echo "Test: SARIF upload steps exist in both build jobs (CC-0032, REQ-006)"
 
   local base_sarif_count
-  base_sarif_count=$(yq_count '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW")
-  assert_eq "build-base-images has 2 SARIF upload steps" "2" "$base_sarif_count"
+  base_sarif_count=$(yq_count '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW")
+  assert_eq "merge-base-images has 2 SARIF upload steps" "2" "$base_sarif_count"
 
   local service_sarif_count
   service_sarif_count=$(yq_count '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW")
@@ -1774,12 +1702,12 @@ test_sarif_upload_categories() {
 
   # python-base SARIF upload category
   local python_category
-  python_category=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .with.category' "$WORKFLOW" || true)
+  python_category=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .with.category' "$WORKFLOW" || true)
   assert_eq "python-base SARIF category is grype-python-base" "grype-python-base" "$python_category"
 
   # venv-builder SARIF upload category
   local venv_category
-  venv_category=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .with.category' "$WORKFLOW" || true)
+  venv_category=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .with.category' "$WORKFLOW" || true)
   assert_eq "venv-builder SARIF category is grype-venv-builder" "grype-venv-builder" "$venv_category"
 
   # service SARIF upload category must reference matrix.service
@@ -1792,14 +1720,14 @@ test_sarif_upload_categories() {
 test_sarif_upload_always_condition() {
   echo "Test: SARIF upload steps have if: always() with output guard (CC-0032, REQ-006)"
 
-  # Check each SARIF upload step in build-base-images individually
+  # Check each SARIF upload step in merge-base-images individually
   local python_if
-  python_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .if' "$WORKFLOW" || true)
+  python_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .if' "$WORKFLOW" || true)
   assert_contains "python-base SARIF upload has always() condition" "$python_if" "always()"
   assert_contains "python-base SARIF upload has output guard" "$python_if" "outputs.sarif"
 
   local venv_if
-  venv_if=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .if' "$WORKFLOW" || true)
+  venv_if=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .if' "$WORKFLOW" || true)
   assert_contains "venv-builder SARIF upload has always() condition" "$venv_if" "always()"
   assert_contains "venv-builder SARIF upload has output guard" "$venv_if" "outputs.sarif"
 
@@ -1813,11 +1741,13 @@ test_sarif_upload_always_condition() {
 test_sarif_upload_action_sha_pinned() {
   echo "Test: upload-sarif action is SHA-pinned (CC-0032, REQ-010)"
 
-  # Collect all upload-sarif uses from both build jobs
+  # Collect all upload-sarif uses from merge-base-images, build-service-images, and merge-service-images
   local uses_values
-  uses_values=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW" || true)
+  uses_values=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW" || true)
   uses_values+=$'\n'
   uses_values+=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW" || true)
+  uses_values+=$'\n'
+  uses_values+=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.uses and (.uses | test("codeql-action/upload-sarif"))) | .uses' "$WORKFLOW" || true)
 
   local all_pinned=true
   local found=false
@@ -1843,22 +1773,22 @@ test_sarif_upload_action_sha_pinned() {
   assert_file_contains "upload-sarif pin has # v4 version comment" "$WORKFLOW" "codeql-action/upload-sarif@[0-9a-f]\{40\}[[:space:]]*# v4"
 }
 
-# --- CC-0032: security-events permission on build-base-images (REQ-007) ---
+# --- CC-0032: security-events permission on merge-base-images (REQ-007) ---
 test_security_events_permission_build_base_images() {
-  echo "Test: build-base-images has security-events: write permission (CC-0032, REQ-007)"
+  echo "Test: merge-base-images has security-events: write permission (CC-0032, REQ-007)"
 
   local perm
-  perm=$(yq_raw '.jobs["build-base-images"]["permissions"]["security-events"]' "$WORKFLOW" || true)
-  assert_eq "build-base-images security-events permission is write" "write" "$perm"
+  perm=$(yq_raw '.jobs["merge-base-images"]["permissions"]["security-events"]' "$WORKFLOW" || true)
+  assert_eq "merge-base-images security-events permission is write" "write" "$perm"
 }
 
-# --- CC-0032: security-events permission on build-service-images (REQ-007) ---
+# --- CC-0032: security-events permission on merge-service-images (REQ-007) ---
 test_security_events_permission_build_service_images() {
-  echo "Test: build-service-images has security-events: write permission (CC-0032, REQ-007)"
+  echo "Test: merge-service-images has security-events: write permission (CC-0032, REQ-007)"
 
   local perm
-  perm=$(yq_raw '.jobs["build-service-images"]["permissions"]["security-events"]' "$WORKFLOW" || true)
-  assert_eq "build-service-images security-events permission is write" "write" "$perm"
+  perm=$(yq_raw '.jobs["merge-service-images"]["permissions"]["security-events"]' "$WORKFLOW" || true)
+  assert_eq "merge-service-images security-events permission is write" "write" "$perm"
 }
 
 # --- CC-0032: verify jobs do NOT have security-events permission (REQ-009) ---
@@ -1890,23 +1820,23 @@ test_grype_output_format_sarif() {
   echo "Test: Grype scan output-format is sarif (CC-0032, REQ-006)"
 
   local python_sbom_format
-  python_sbom_format=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["output-format"]' "$WORKFLOW" || true)
+  python_sbom_format=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-sbom") | .with["output-format"]' "$WORKFLOW" || true)
   assert_eq "python-base (sbom) Grype output-format is sarif" "sarif" "$python_sbom_format"
 
   local python_image_format
-  python_image_format=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["output-format"]' "$WORKFLOW" || true)
+  python_image_format=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-python-base-image") | .with["output-format"]' "$WORKFLOW" || true)
   assert_eq "python-base (image) Grype output-format is sarif" "sarif" "$python_image_format"
 
   local venv_sbom_format
-  venv_sbom_format=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["output-format"]' "$WORKFLOW" || true)
+  venv_sbom_format=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-sbom") | .with["output-format"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (sbom) Grype output-format is sarif" "sarif" "$venv_sbom_format"
 
   local venv_image_format
-  venv_image_format=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["output-format"]' "$WORKFLOW" || true)
+  venv_image_format=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.id == "grype-venv-builder-image") | .with["output-format"]' "$WORKFLOW" || true)
   assert_eq "venv-builder (image) Grype output-format is sarif" "sarif" "$venv_image_format"
 
   local service_sbom_format
-  service_sbom_format=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["output-format"]' "$WORKFLOW" || true)
+  service_sbom_format=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.id == "grype-service-sbom") | .with["output-format"]' "$WORKFLOW" || true)
   assert_eq "service (sbom) Grype output-format is sarif" "sarif" "$service_sbom_format"
 
   local service_image_format
@@ -1920,19 +1850,22 @@ test_sarif_upload_references_grype_output() {
 
   # SARIF upload uses || expression to pick output from whichever scan step ran
   local python_sarif_file
-  python_sarif_file=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .with.sarif_file' "$WORKFLOW" || true)
+  python_sarif_file=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for python-base"))) | .with.sarif_file' "$WORKFLOW" || true)
   assert_contains "python-base SARIF upload references grype-python-base-sbom output" "$python_sarif_file" "grype-python-base-sbom.outputs.sarif"
   assert_contains "python-base SARIF upload references grype-python-base-image output" "$python_sarif_file" "grype-python-base-image.outputs.sarif"
 
   local venv_sarif_file
-  venv_sarif_file=$(yq_raw '.jobs["build-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .with.sarif_file' "$WORKFLOW" || true)
+  venv_sarif_file=$(yq_raw '.jobs["merge-base-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for venv-builder"))) | .with.sarif_file' "$WORKFLOW" || true)
   assert_contains "venv-builder SARIF upload references grype-venv-builder-sbom output" "$venv_sarif_file" "grype-venv-builder-sbom.outputs.sarif"
   assert_contains "venv-builder SARIF upload references grype-venv-builder-image output" "$venv_sarif_file" "grype-venv-builder-image.outputs.sarif"
 
-  local service_sarif_file
-  service_sarif_file=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for service"))) | .with.sarif_file' "$WORKFLOW" || true)
-  assert_contains "service SARIF upload references grype-service-sbom output" "$service_sarif_file" "grype-service-sbom.outputs.sarif"
-  assert_contains "service SARIF upload references grype-service-image output" "$service_sarif_file" "grype-service-image.outputs.sarif"
+  local service_build_sarif_file
+  service_build_sarif_file=$(yq_raw '.jobs["build-service-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for service"))) | .with.sarif_file' "$WORKFLOW" || true)
+  assert_contains "service SARIF upload (build-service-images) references grype-service-image output" "$service_build_sarif_file" "grype-service-image.outputs.sarif"
+
+  local service_merge_sarif_file
+  service_merge_sarif_file=$(yq_raw '.jobs["merge-service-images"]["steps"][] | select(.name and (.name | test("Upload SARIF for service"))) | .with.sarif_file' "$WORKFLOW" || true)
+  assert_contains "service SARIF upload (merge-service-images) references grype-service-sbom output" "$service_merge_sarif_file" "grype-service-sbom.outputs.sarif"
 }
 
 # --- Run all tests ---


### PR DESCRIPTION
Replace QEMU emulation with native ubuntu-24.04-arm runners for linux/arm64 builds across both the operator CI workflow and the container-image build workflow.

- Split build-and-push into a matrix job (linux/amd64 + linux/arm64), each platform using its native runner and pushing by digest
- Add merge-operator-images job that assembles the multi-arch manifest with docker buildx imagetools create; github-release now depends on the merged manifest

- Split build-base-images and build-service-images into per-platform matrix jobs (native runners, push-by-digest); ARM64 excluded from PR builds to keep CI fast
- Add merge-base-images and merge-service-images jobs that assemble multi-arch manifests and own all post-build steps: SBOM generation, Grype scans, SARIF uploads, cosign signing, and build-provenance attestation
- Extract tag derivation into a reusable composite action (.github/actions/derive-service-tags) to eliminate duplication between build, merge, and verify jobs
- Add empty-digest guard before every imagetools create call
- Fix SARIF category to include platform pair, preventing upload collisions when both platforms run on PRs

- Append platform suffix to all cache scopes to prevent cross-arch cache collisions

- Update all 313 assertions in tests/container-images/verify_build_images_workflow.sh to reflect the new 7-job DAG (build→merge split), composite action usage, job-level PR guards on merge jobs, and push-by-digest tagging

- Update docs/reference/build-images-workflow.md and docs/reference/ci-workflow.md to document the new job DAGs, per-platform matrix strategy, merge jobs, and composite action

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com