### PR TITLE
ci: add OpenStack release tag (e.g. 2025.2) to service image builds

### DIFF
--- a/.github/actions/derive-service-tags/action.yaml
+++ b/.github/actions/derive-service-tags/action.yaml
@@ -28,6 +28,9 @@ outputs:
   sha:
     description: Short-SHA tag reference (e.g. ghcr.io/owner/keystone:abc1234)
     value: ${{ steps.run.outputs.sha }}
+  release:
+    description: Release tag reference (e.g. ghcr.io/owner/keystone:2025.2)
+    value: ${{ steps.run.outputs.release }}
   version-ref:
     description: Raw upstream version string (e.g. 28.0.0)
     value: ${{ steps.run.outputs.version-ref }}
@@ -67,5 +70,6 @@ runs:
         echo "composite=${IMAGE}:${COMPOSITE}" >> "$GITHUB_OUTPUT"
         echo "version=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
         echo "sha=${IMAGE}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+        echo "release=${IMAGE}:${MATRIX_RELEASE}" >> "$GITHUB_OUTPUT"
         echo "version-ref=${VERSION}" >> "$GITHUB_OUTPUT"
-        echo "Tags: ${COMPOSITE}, ${VERSION}, ${SHORT_SHA}"
+        echo "Tags: ${IMAGE}:${COMPOSITE}, ${IMAGE}:${VERSION}, ${IMAGE}:${SHORT_SHA}, ${IMAGE}:${MATRIX_RELEASE}"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -747,15 +747,19 @@ jobs:
         run: |
           cd /tmp/digests
           [[ $(ls | wc -l) -ge 1 ]] || { echo "::error::No digests found for ${{ matrix.service }}-${{ matrix.release }}"; exit 1; }
-          # CC-0007: The version-only tag (e.g. keystone:28.0.0) is restricted
-          # to main to prevent silent overwrites across branches.
+          # CC-0007: The version-only and release tags (e.g. keystone:28.0.0,
+          # keystone:2025.2) are restricted to main to prevent silent overwrites
+          # across branches.
           version_tag=""
+          release_tag=""
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             version_tag="-t ${{ steps.tags.outputs.version }}"
+            release_tag="-t ${{ steps.tags.outputs.release }}"
           fi
           docker buildx imagetools create \
             -t "${{ steps.tags.outputs.composite }}" \
             ${version_tag} \
+            ${release_tag} \
             -t "${{ steps.tags.outputs.sha }}" \
             $(printf "${IMAGE}@sha256:%s " *)
           digest=$(docker buildx imagetools inspect "${{ steps.tags.outputs.composite }}" \

--- a/docs/reference/build-images-workflow.md
+++ b/docs/reference/build-images-workflow.md
@@ -325,7 +325,7 @@ were computed during the build.
 | 3 | Set up Buildx + Login + cosign | *(three steps)* | Authenticates and installs cosign (CC-0030) |
 | 4 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (REQ-005) |
 | 5 | Download service image digests | `actions/download-artifact@v4` | Downloads all `digests-service-<service>-<release>-*` artifacts |
-| 6 | Create and push service image manifest | Shell | `docker buildx imagetools create` assembles all per-platform digests; applies composite, SHA, and (on main) version tags; outputs merged manifest digest |
+| 6 | Create and push service image manifest | Shell | `docker buildx imagetools create` assembles all per-platform digests; applies composite and SHA tags (all branches), and version and release tags (main only); outputs merged manifest digest |
 | 7 | Generate SBOM for service image | `anchore/sbom-action@v0` | Scans the merged manifest by digest. Output: `sbom-<service>.cyclonedx.json` (CC-0029) |
 | 8 | Scan service image for vulnerabilities | `anchore/scan-action@v7` | SBOM-based scan. Category: `grype-<service>` (CC-0032) |
 | 9 | Upload SARIF for service image | `github/codeql-action/upload-sarif@v3` | Runs always when SARIF output exists (CC-0032) |
@@ -503,17 +503,18 @@ truth shared by `build-service-images`, `merge-service-images`, and `verify-serv
 
 ## Tag Schema
 
-Each service image build produces two or three tags on push events (REQ-005):
+Each service image build produces two to four tags on push events (REQ-005):
 
 | Tag | Format | Example | Branches |
 | --- | --- | --- | --- |
 | Composite | `<version>-p<N>-<branch>-<sha>` | `keystone:28.0.0-p0-main-a1b2c3d` | all |
 | Version | `<version>` | `keystone:28.0.0` | `main` only |
+| Release | `<release>` | `keystone:2025.2` | `main` only |
 | SHA | `<sha>` | `keystone:a1b2c3d` | all |
 
-The version-only tag is restricted to the `main` branch to prevent silent overwrites when
-multiple branches build the same upstream version. The composite tag already encodes the
-branch, so `stable/**` builds remain uniquely identifiable (CC-0007).
+The version-only and release tags are restricted to the `main` branch to prevent silent
+overwrites when multiple branches build the same upstream version. The composite tag
+already encodes the branch, so `stable/**` builds remain uniquely identifiable (CC-0007).
 
 **Tag components:**
 


### PR DESCRIPTION
Extend derive-service-tags action with a release output and push it alongside the version and SHA tags in merge-service-images, restricted to main to prevent cross-branch overwrites.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com