### PR TITLE
ci: refactor platform matrix and extract shared composite actions

### DIFF
--- a/.github/actions/derive-service-tags/action.yaml
+++ b/.github/actions/derive-service-tags/action.yaml
@@ -14,6 +14,10 @@ inputs:
   repository-owner:
     description: GitHub repository owner (github.repository_owner)
     required: true
+  install_yq:
+    description: Install yq before running. Set to 'false' if the caller already provides yq.
+    required: false
+    default: 'true'
 
 outputs:
   image:
@@ -38,6 +42,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install yq
+      if: ${{ inputs.install_yq != 'false' }}
+      uses: mikefarah/yq@b534aa9ee5d38001fba3cd8fe254a037e4847b37 # v4.45.4
+
     - name: Derive tags
       id: run
       shell: bash

--- a/.github/actions/platform-pair/action.yaml
+++ b/.github/actions/platform-pair/action.yaml
@@ -1,0 +1,23 @@
+name: Normalize platform pair
+description: >
+  Convert a platform string (e.g. linux/amd64) to an artifact-safe name
+  (e.g. linux-amd64) by replacing slashes with dashes.
+
+inputs:
+  platform:
+    description: Platform string (e.g. linux/amd64)
+    required: true
+
+outputs:
+  value:
+    description: Artifact-safe platform string (e.g. linux-amd64)
+    value: ${{ steps.run.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: |
+        platform="${{ inputs.platform }}"
+        echo "value=${platform//\//-}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -96,9 +96,9 @@ jobs:
 
       - name: Prepare platform pair
         id: platform-pair
-        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
-        env:
-          PLATFORM: ${{ matrix.platform }}
+        uses: ./.github/actions/platform-pair
+        with:
+          platform: ${{ matrix.platform }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -591,9 +591,9 @@ jobs:
 
       - name: Prepare platform pair
         id: platform-pair
-        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
-        env:
-          PLATFORM: ${{ matrix.platform }}
+        uses: ./.github/actions/platform-pair
+        with:
+          platform: ${{ matrix.platform }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -468,7 +468,7 @@ jobs:
   # Each platform is pushed by digest; merge-operator-images assembles the manifest list.
   # Runs only on push events (main branch or v* tags) after E2E passed.
   build-and-push:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 15
     needs: [changes, e2e-operator]
     if: github.event_name == 'push' && needs.e2e-operator.result == 'success'
@@ -479,20 +479,19 @@ jobs:
       fail-fast: false
       matrix:
         operator: ${{ fromJson(needs.changes.outputs.e2e-operators).operator }}
-        platform: [linux/amd64, linux/arm64]
-        include:
-          - platform: linux/amd64
+        platform:
+          - name: linux/amd64
             runner: ubuntu-latest
-          - platform: linux/arm64
+          - name: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Prepare platform pair
         id: platform-pair
-        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
-        env:
-          PLATFORM: ${{ matrix.platform }}
+        uses: ./.github/actions/platform-pair
+        with:
+          platform: ${{ matrix.platform.name }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
@@ -519,7 +518,7 @@ jobs:
         with:
           context: .
           file: operators/${{ matrix.operator }}/Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform.name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Extract repeated platform-pair normalization into a reusable composite action (.github/actions/platform-pair) to eliminate duplication across build-base-images, build-service-images, and build-and-push jobs
- Bundle yq install inside derive-service-tags composite action so all callers have a consistent dependency without extra setup steps
- Restructure build-and-push matrix to use nested platform objects (name + runner) as a single source of truth, removing the brittle split between top-level platform list and include entries

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com