### PR TITLE
fix: add standard Kubernetes labels to all Keystone-owned resources

### DIFF
--- a/docs/reference/keystone-reconciler.md
+++ b/docs/reference/keystone-reconciler.md
@@ -549,7 +549,8 @@ The `fernetKeysHash()` helper:
 | --- | --- |
 | Name | `keystone-api` |
 | Replicas | `spec.replicas` |
-| Labels / Selector | `app: keystone-api` |
+| Labels | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/managed-by=keystone-operator` |
+| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
 | Container name | `keystone-api` |
 | Image | `{spec.image.repository}:{spec.image.tag}` |
 | Port | 5000 (named `keystone-api`) |
@@ -580,7 +581,7 @@ The `fernetKeysHash()` helper:
 | Field | Value |
 | --- | --- |
 | Name | `keystone-api` |
-| Selector | `app: keystone-api` |
+| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
 | Port | 5000 TCP |
 
 **Status Endpoint:**

--- a/internal/common/deployment/deployment.go
+++ b/internal/common/deployment/deployment.go
@@ -7,6 +7,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,6 +39,17 @@ func EnsureDeployment(ctx context.Context, c client.Client, scheme *runtime.Sche
 	}
 	if err != nil {
 		return false, fmt.Errorf("getting Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+	}
+
+	// If the selector has changed, the Deployment must be deleted and re-created:
+	// Kubernetes rejects .spec.selector mutations as immutable after creation.
+	// Returning (false, nil) causes the reconciler to requeue; on the next pass
+	// the Deployment no longer exists and will be created fresh (CC-0005).
+	if !reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector) {
+		if err := c.Delete(ctx, existing); err != nil {
+			return false, fmt.Errorf("deleting Deployment %s/%s for selector migration: %w", deploy.Namespace, deploy.Name, err)
+		}
+		return false, nil
 	}
 
 	// Always update the spec to the desired state. This avoids maintaining

--- a/internal/common/deployment/deployment_test.go
+++ b/internal/common/deployment/deployment_test.go
@@ -175,6 +175,35 @@ func TestEnsureDeployment_notReadyWhenGenerationLags(t *testing.T) {
 	g.Expect(ready).To(BeFalse(), "should return false when ObservedGeneration lags behind Generation on update path")
 }
 
+func TestEnsureDeployment_deletesAndRequeuesOnSelectorChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	// Pre-create a deployment with the old selector.
+	existing := testDeployment()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, existing).
+		WithStatusSubresource(existing).
+		Build()
+
+	// Desired deployment has a different selector.
+	desired := testDeployment()
+	desired.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/name": "test", "app.kubernetes.io/instance": "test-instance"},
+	}
+
+	ready, err := EnsureDeployment(context.Background(), c, s, owner, desired)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "should not be ready when deleted for selector migration")
+
+	// The old Deployment should have been deleted.
+	list := &appsv1.DeploymentList{}
+	g.Expect(c.List(context.Background(), list, client.InNamespace("default"))).To(Succeed())
+	g.Expect(list.Items).To(BeEmpty(), "Deployment should have been deleted for selector migration")
+}
+
 func TestEnsureDeployment_idempotent(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := newScheme()

--- a/operators/keystone/internal/controller/keystone_controller_test.go
+++ b/operators/keystone/internal/controller/keystone_controller_test.go
@@ -155,17 +155,18 @@ func testCompletedDBSyncJob(configMapName string) runtime.Object {
 func testReadyKeystoneDeployment() runtime.Object {
 	ks := testKeystone()
 	replicas := int32(3)
-	appLabel := keystoneAppLabel(ks)
-	labels := map[string]string{"app": appLabel}
+	sel := selectorLabels(ks)
+	labels := commonLabels(ks)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       fmt.Sprintf("%s-api", ks.Name),
 			Namespace:  "default",
 			Generation: 1,
+			Labels:     labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: sel},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "keystone-api", Image: "ghcr.io/c5c3/keystone:2025.2"}}},
@@ -600,6 +601,83 @@ func TestSecretToKeystoneMapper_ReferencedSecrets(t *testing.T) {
 	}
 	reqs = mapper(context.Background(), unrelated)
 	g.Expect(reqs).To(BeEmpty())
+}
+
+// TestCommonLabels_ExactKeyValues pins the exact key/value pairs produced by
+// commonLabels so that future label refactors are caught immediately.
+func TestCommonLabels_ExactKeyValues(t *testing.T) {
+	ks := testKeystone()
+
+	labels := commonLabels(ks)
+
+	expected := map[string]string{
+		"app.kubernetes.io/name":       "keystone",
+		"app.kubernetes.io/instance":   ks.Name,
+		"app.kubernetes.io/managed-by": "keystone-operator",
+	}
+	if len(labels) != len(expected) {
+		t.Fatalf("commonLabels returned %d labels, expected %d: %#v", len(labels), len(expected), labels)
+	}
+	for k, v := range expected {
+		got, ok := labels[k]
+		if !ok {
+			t.Fatalf("commonLabels missing expected key %q", k)
+		}
+		if got != v {
+			t.Fatalf("commonLabels[%q] = %q, expected %q", k, got, v)
+		}
+	}
+}
+
+// TestSelectorLabels_ExactKeyValues pins the exact key/value pairs produced by
+// selectorLabels so that future label refactors are caught immediately.
+func TestSelectorLabels_ExactKeyValues(t *testing.T) {
+	ks := testKeystone()
+
+	sel := selectorLabels(ks)
+
+	expected := map[string]string{
+		"app.kubernetes.io/name":     "keystone",
+		"app.kubernetes.io/instance": ks.Name,
+	}
+	if len(sel) != len(expected) {
+		t.Fatalf("selectorLabels returned %d labels, expected %d: %#v", len(sel), len(expected), sel)
+	}
+	for k, v := range expected {
+		got, ok := sel[k]
+		if !ok {
+			t.Fatalf("selectorLabels missing expected key %q", k)
+		}
+		if got != v {
+			t.Fatalf("selectorLabels[%q] = %q, expected %q", k, got, v)
+		}
+	}
+}
+
+// TestSelectorLabels_SubsetOfCommonLabels verifies that every selector label
+// key/value is present in commonLabels and that managed-by is excluded from
+// the selector (keeping the Deployment selector stable across operator changes).
+func TestSelectorLabels_SubsetOfCommonLabels(t *testing.T) {
+	ks := testKeystone()
+
+	common := commonLabels(ks)
+	sel := selectorLabels(ks)
+
+	for k, v := range sel {
+		cv, ok := common[k]
+		if !ok {
+			t.Fatalf("selector key %q not present in commonLabels", k)
+		}
+		if cv != v {
+			t.Fatalf("value mismatch for key %q: selector=%q, common=%q", k, v, cv)
+		}
+	}
+	if _, ok := sel["app.kubernetes.io/managed-by"]; ok {
+		t.Fatalf("selectorLabels must not include app.kubernetes.io/managed-by")
+	}
+	if _, ok := common["app.kubernetes.io/managed-by"]; !ok {
+		t.Fatalf("commonLabels should include app.kubernetes.io/managed-by")
+	}
 }
 
 func TestSecretToKeystoneMapper_OwnedSecrets(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_deployment.go
+++ b/operators/keystone/internal/controller/reconcile_deployment.go
@@ -89,14 +89,30 @@ func (r *KeystoneReconciler) reconcileDeployment(ctx context.Context, keystone *
 	return ctrl.Result{}, nil
 }
 
-// keystoneAppLabel returns the label value used to select pods for this Keystone instance.
-func keystoneAppLabel(keystone *keystonev1alpha1.Keystone) string {
-	return fmt.Sprintf("%s-api", keystone.Name)
+// commonLabels returns the standard Kubernetes labels applied to all resources
+// owned by this Keystone instance.
+func commonLabels(keystone *keystonev1alpha1.Keystone) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "keystone",
+		"app.kubernetes.io/instance":   keystone.Name,
+		"app.kubernetes.io/managed-by": "keystone-operator",
+	}
+}
+
+// selectorLabels returns the minimal label set used as the Deployment pod
+// selector. It is a subset of commonLabels and must remain stable for the
+// lifetime of a Deployment (selectors are immutable after creation).
+func selectorLabels(keystone *keystonev1alpha1.Keystone) map[string]string {
+	labels := commonLabels(keystone)
+	return map[string]string{
+		"app.kubernetes.io/name":     labels["app.kubernetes.io/name"],
+		"app.kubernetes.io/instance": labels["app.kubernetes.io/instance"],
+	}
 }
 
 func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName string, fernetKeysHash string) *appsv1.Deployment {
-	appLabel := keystoneAppLabel(keystone)
-	labels := map[string]string{"app": appLabel}
+	selector := selectorLabels(keystone)
+	labels := commonLabels(keystone)
 	replicas := int32(keystone.Spec.Replicas)
 	fernetSecretName := fmt.Sprintf("%s-fernet-keys", keystone.Name)
 	credentialSecretName := fmt.Sprintf("%s-credential-keys", keystone.Name)
@@ -104,11 +120,12 @@ func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", keystone.Name),
 			Namespace: keystone.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selector,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -213,14 +230,14 @@ func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName 
 }
 
 func buildKeystoneService(keystone *keystonev1alpha1.Keystone) *corev1.Service {
-	appLabel := keystoneAppLabel(keystone)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", keystone.Name),
 			Namespace: keystone.Namespace,
+			Labels:    commonLabels(keystone),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{"app": appLabel},
+			Selector: selectorLabels(keystone),
 			Ports: []corev1.ServicePort{{
 				Port:       5000,
 				TargetPort: intstr.FromInt32(5000),

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -276,9 +276,14 @@ func TestReconcileDeployment_DeploymentSpec(t *testing.T) {
 	g.Expect(credentialVol.Secret.Optional).NotTo(BeNil())
 	g.Expect(*credentialVol.Secret.Optional).To(BeTrue(), "credential-keys volume should be optional until credential key management is implemented")
 
-	// Verify labels.
-	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app", "test-keystone-api"))
-	g.Expect(deploy.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "test-keystone-api"))
+	// Verify labels on Deployment ObjectMeta, pod template, and selector.
+	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(deploy.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(deploy.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 
 	// Verify Service spec.
 	var svc corev1.Service
@@ -289,7 +294,11 @@ func TestReconcileDeployment_DeploymentSpec(t *testing.T) {
 	g.Expect(svc.Spec.Ports[0].Port).To(Equal(int32(5000)))
 	g.Expect(svc.Spec.Ports[0].TargetPort.IntValue()).To(Equal(5000))
 	g.Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app", "test-keystone-api"))
+	g.Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 }
 
 func TestReconcileDeployment_NotReady_ConditionMessageAndGeneration(t *testing.T) {
@@ -352,8 +361,10 @@ func TestReconcileDeployment_ServiceCreatedAlongsideDeployment(t *testing.T) {
 	}, &svc)).To(Succeed())
 
 	// Verify the Service targets the Deployment's pods.
-	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app", "test-keystone-api"))
-	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app", "test-keystone-api"))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 
 	// Both should have owner references.
 	g.Expect(deploy.OwnerReferences).To(HaveLen(1))

--- a/operators/keystone/internal/controller/reconcile_fernet.go
+++ b/operators/keystone/internal/controller/reconcile_fernet.go
@@ -184,6 +184,7 @@ func (r *KeystoneReconciler) createFernetKeysSecret(ctx context.Context,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: keystone.Namespace,
+			Labels:    commonLabels(keystone),
 		},
 		Data: data,
 	}
@@ -224,12 +225,16 @@ func fernetRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapName st
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-fernet-rotate", keystone.Name),
 			Namespace: keystone.Namespace,
+			Labels:    commonLabels(keystone),
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: keystone.Spec.Fernet.RotationSchedule,
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: commonLabels(keystone),
+						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: saName,
 							RestartPolicy:      corev1.RestartPolicyOnFailure,

--- a/operators/keystone/internal/controller/reconcile_fernet_test.go
+++ b/operators/keystone/internal/controller/reconcile_fernet_test.go
@@ -103,6 +103,9 @@ func TestReconcileFernetKeys_NoSecret_CreatesSecretAndRequeues(t *testing.T) {
 	g.Expect(secret.Data).To(HaveLen(3))
 	g.Expect(secret.OwnerReferences).To(HaveLen(1))
 	g.Expect(secret.OwnerReferences[0].Name).To(Equal("test-keystone"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
 
 	// CronJob and PushSecret are NOT created on this cycle (early return after secret creation).
 
@@ -161,6 +164,9 @@ func TestReconcileFernetKeys_SecretAlreadyExists(t *testing.T) {
 		Namespace: "default",
 		Name:      "test-keystone-fernet-rotate",
 	}, &cronJob)).To(Succeed())
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
 
 	var ps esov1alpha1.PushSecret
 	g.Expect(c.Get(context.Background(), client.ObjectKey{
@@ -465,7 +471,16 @@ func TestReconcileFernetKeys_CronJobSpec(t *testing.T) {
 		Name:      "test-keystone-fernet-rotate",
 	}, &cronJob)).To(Succeed())
 
-	podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
+	// Verify labels on CronJob ObjectMeta and pod template.
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	podTemplate := cronJob.Spec.JobTemplate.Spec.Template
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+
+	podSpec := podTemplate.Spec
 
 	// Verify ServiceAccount (CC-0013).
 	g.Expect(podSpec.ServiceAccountName).To(Equal("test-keystone-fernet-rotate"))


### PR DESCRIPTION
Replace the custom `app: <name>-api` label with the standard `app.kubernetes.io/{name,instance,managed-by}` label set on the Deployment, Service, Fernet-keys Secret, and Fernet-rotation CronJob.

Selector labels (name + instance) are kept as a stable immutable subset of commonLabels. This makes `kubectl get … -l app.kubernetes.io/instance=<cr-name>` work as documented in the Quick Start Guide.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com