### PR TITLE
fix(ci): prevent push-to-main runs from cancelling each other

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ env:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Detect which areas of code changed to avoid running expensive jobs on


### PR DESCRIPTION
The previous expression `${{ github.event_name == 'pull_request' }}` evaluates to the string "false" for push events, which GitHub Actions treats as truthy — causing cancel-in-progress to be always active. This caused every push to main to cancel the previous commit's CI run, preventing build-and-push from ever completing.

Replace with `${{ github.ref != 'refs/heads/main' }}` which correctly evaluates to a boolean false for main-branch pushes.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com