### PR TITLE
ci: Use blacksmith-4vcpu-ubuntu-2404 runner for Tempest and E2E jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,7 +330,7 @@ jobs:
   e2e-infra:
     needs: [changes]
     if: needs.changes.outputs.e2e-infra == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -372,7 +372,7 @@ jobs:
       needs.changes.outputs.has-e2e-operators == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -449,7 +449,7 @@ jobs:
       needs.changes.outputs.has-e2e-operators == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
Move the e2e-infra, e2e-operator, and tempest jobs to the larger Blacksmith runner to speed up kind cluster bring-up and test execution.

On-behalf-of: @SAP christian.berendt@sap.com