### PR TITLE
perf: Parallelize Tempest tests and reduce default uWSGI threads

### DIFF
--- a/docs/reference/keystone-crd.md
+++ b/docs/reference/keystone-crd.md
@@ -121,7 +121,7 @@ status:
 | `policyOverrides` | [`*PolicySpec`](#policyspec) | No | `nil` | Custom oslo.policy rules. |
 | `autoscaling` | [`*AutoscalingSpec`](#autoscalingspec) | No | `nil` | Horizontal pod autoscaling configuration. When set, an HPA is created targeting the `{name}-api` Deployment. When removed, the HPA is deleted (CC-0038). |
 | `resources` | [`*corev1.ResourceRequirements`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) | No | See below | CPU and memory requests and limits for the Keystone API container. When unset, the defaulting webhook injects sensible defaults to ensure Burstable QoS class and enable HPA utilization calculations (CC-0042). |
-| `uwsgi` | [`*UWSGISpec`](#uwsgispec) | No | `nil` | uWSGI application server parameters. When set, the operator uses these values for the Deployment container command. When `nil`, hardcoded defaults (processes=2, threads=2, httpKeepAlive=true) are used in the reconciler, preserving backward compatibility for existing CRs (CC-0040). |
+| `uwsgi` | [`*UWSGISpec`](#uwsgispec) | No | `nil` | uWSGI application server parameters. When set, the operator uses these values for the Deployment container command. When `nil`, hardcoded defaults (processes=2, threads=1, httpKeepAlive=true) are used in the reconciler (CC-0040). |
 | `extraConfig` | `map[string]map[string]string` | No | `nil` | Free-form INI sections for additional configuration. |
 
 ### CEL Validation Rules
@@ -209,16 +209,15 @@ spec:
 
 Configures the uWSGI application server parameters for the Keystone API container
 (CC-0040). This is a pointer field (`*UWSGISpec`) on `KeystoneSpec` — when `nil`,
-the reconciler uses hardcoded defaults (processes=2, threads=2, httpKeepAlive=true)
-and the webhook does **not** inject a default `UWSGISpec`. This preserves backward
-compatibility: existing CRs without `spec.uwsgi` continue to produce an identical
-Deployment command. When set (even as `uwsgi: {}`), the webhook defaults zero-valued
-sub-fields and the reconciler reads from the spec.
+the reconciler uses hardcoded defaults (processes=2, threads=1, httpKeepAlive=true)
+and the webhook does **not** inject a default `UWSGISpec`. When set (even as
+`uwsgi: {}`), the webhook defaults zero-valued sub-fields and the reconciler reads
+from the spec.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `processes` | `int32` | No | `2` | Number of uWSGI worker processes. Minimum: 1. Maps to `--processes` in the container command. |
-| `threads` | `int32` | No | `2` | Number of threads per uWSGI worker process. Minimum: 1. Maps to `--threads` in the container command. |
+| `threads` | `int32` | No | `1` | Number of threads per uWSGI worker process. Minimum: 1. Maps to `--threads` in the container command. |
 | `httpKeepAlive` | `bool` | No | `true` | Enables the `--http-keepalive` flag on the uWSGI process. When `false`, the flag is omitted. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat) for the zero-value caveat. |
 
 ### Deployment Command Mapping
@@ -237,7 +236,7 @@ of configuration:
 | `--lazy-apps` | Fixed — loads apps in each worker after fork |
 | `--need-app` | Fixed — exits if no WSGI app is found |
 | `--processes <N>` | `spec.uwsgi.processes` (default: 2) |
-| `--threads <N>` | `spec.uwsgi.threads` (default: 2) |
+| `--threads <N>` | `spec.uwsgi.threads` (default: 1) |
 | `--pyargv=--config-dir=/etc/keystone/keystone.conf.d/` | Fixed — passes config directory to Keystone |
 
 ### HTTPKeepAlive Defaulting Caveat
@@ -249,9 +248,9 @@ and `threads`. The CRD schema default (`+kubebuilder:default=true`) handles
 `httpKeepAlive` in the normal admission path (API server applies the schema
 default before the webhook runs). This means:
 
-- `uwsgi: {}` → processes=2 (webhook), threads=2 (webhook),
+- `uwsgi: {}` → processes=2 (webhook), threads=1 (webhook),
   httpKeepAlive=true (CRD schema default via normal admission)
-- `uwsgi: {processes: 4}` → processes=4, threads=2 (webhook),
+- `uwsgi: {processes: 4}` → processes=4, threads=1 (webhook),
   httpKeepAlive=true (CRD schema default)
 - `uwsgi: {httpKeepAlive: false}` → httpKeepAlive stays `false` (explicit value
   is preserved by the API server)
@@ -430,7 +429,7 @@ Sets spec fields to their documented defaults when they carry zero values. Expli
 | `spec.bootstrap.adminUser` | `== ""` | `"admin"` |
 | `spec.bootstrap.region` | `== ""` | `"RegionOne"` |
 | `spec.uwsgi.processes` | `== 0` (when `spec.uwsgi` is non-nil) | `2` — webhook only; when `spec.uwsgi` is `nil`, the reconciler applies this default internally (CC-0040). |
-| `spec.uwsgi.threads` | `== 0` (when `spec.uwsgi` is non-nil) | `2` — same nil-pointer caveat as processes (CC-0040). |
+| `spec.uwsgi.threads` | `== 0` (when `spec.uwsgi` is non-nil) | `1` — same nil-pointer caveat as processes (CC-0040). |
 | `spec.uwsgi.httpKeepAlive` | Field absent from JSON payload | `true` — defaulted by the CRD schema (`+kubebuilder:default=true`), **not** by the webhook. The webhook cannot distinguish "not set" from "explicitly false" for a bool field. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat) (CC-0040). |
 | `spec.resources` | `== nil` or empty (`requests` and `limits` both unset) | `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` — ensures Burstable QoS class and enables HPA utilization calculations (CC-0042). |
 
@@ -569,9 +568,9 @@ exercise the CRD schema constraints.
 | `TestIntegration_WebhookDefaultsPreservesExplicit` | Explicit values preserved | Creates a CR with `replicas=5` and `region="EU-West"`; verifies these values are not overwritten by the defaulting webhook. |
 | `TestIntegration_ResourcesDefaultedWhenNil` | Resources defaulted | Creates a CR with `spec.resources` unset (`nil`); verifies the defaulting webhook injects `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` (CC-0042). |
 | `TestIntegration_ResourcesPreservedWhenExplicit` | Explicit resources preserved | Creates a CR with explicit `spec.resources` (1Gi/2Gi memory, 200m/1 CPU); verifies the defaulting webhook does not overwrite them (CC-0042). |
-| `TestIntegration_UWSGIDefaultsAppliedWhenEmpty` | uWSGI defaults applied | Creates a CR with `spec.uwsgi: {}` (all zero values); verifies processes=2, threads=2, httpKeepAlive=true after admission (CC-0040). |
+| `TestIntegration_UWSGIDefaultsAppliedWhenEmpty` | uWSGI defaults applied | Creates a CR with `spec.uwsgi: {}` (all zero values); verifies processes=2, threads=1, httpKeepAlive=true after admission (CC-0040). |
 | `TestIntegration_UWSGIExplicitValuesPreserved` | Explicit uWSGI preserved | Creates a CR with `spec.uwsgi.processes=4, threads=4`; verifies these values are not overwritten by the defaulting webhook (CC-0040). |
-| `TestIntegration_UWSGIPartialDefaulting` | Partial uWSGI defaults | Creates a CR with only `spec.uwsgi.processes=4`; verifies threads=2 is defaulted while processes=4 is preserved (CC-0040). |
+| `TestIntegration_UWSGIPartialDefaulting` | Partial uWSGI defaults | Creates a CR with only `spec.uwsgi.processes=4`; verifies threads=1 is defaulted while processes=4 is preserved (CC-0040). |
 | `TestIntegration_UWSGINilPreserved` | uWSGI nil preserved | Creates a CR without `spec.uwsgi`; verifies the field remains `nil` after admission — webhook does not inject a default struct (CC-0040). |
 
 #### Webhook Validation Rejection
@@ -610,7 +609,7 @@ deployed and reconciling.
 | Step | Description | Assertion |
 | --- | --- | --- |
 | Step 1 | Apply Keystone CR without explicit `spec.uwsgi` | CR created |
-| Step 2 (`step-2-assert-default-uwsgi-args`) | Assert Deployment command contains default uWSGI args | Container command includes `--processes 2 --threads 2 --http-keepalive` |
+| Step 2 (`step-2-assert-default-uwsgi-args`) | Assert Deployment command contains default uWSGI args | Container command includes `--processes 2 --threads 1 --http-keepalive` |
 | Step 3 | Patch CR with `spec.uwsgi: {processes: 3, threads: 3, httpKeepAlive: false}` | Patch applied |
 | Step 4 (`step-4-assert-custom-uwsgi-args`) | Assert Deployment command updated with custom values | Container command includes `--processes 3 --threads 3`; `--http-keepalive` is absent |
 

--- a/hack/ci-run-tempest.sh
+++ b/hack/ci-run-tempest.sh
@@ -23,6 +23,8 @@
 #   OUTPUT_DIR    — Test output directory (default: _output/tempest)
 #   TEMPEST_IMAGE    — Tempest container image (default: c5c3/tempest:local)
 #   SERVICE_K8S_NAME — K8s Service name for port-forward (default: ${SERVICE}-tempest-2025-2-api)
+#   TEMPEST_CONCURRENCY — stestr worker count (default: 4). Must not exceed the
+#                   request capacity of the Keystone target (replicas × uwsgi.processes).
 #
 # REQ-004: CI-specific Tempest wrapper script.
 # REQ-007: set -euo pipefail, SPDX Apache-2.0 header, shellcheck-clean.
@@ -42,6 +44,7 @@ NAMESPACE="${NAMESPACE:-openstack}"
 ADMIN_SECRET="${ADMIN_SECRET:-keystone-admin}"
 OUTPUT_DIR="${OUTPUT_DIR:-_output/tempest}"
 TEMPEST_IMAGE="${TEMPEST_IMAGE:-c5c3/tempest:local}"
+TEMPEST_CONCURRENCY="${TEMPEST_CONCURRENCY:-4}"
 
 # Derive the service name used in k8s (e.g. keystone-tempest-2025-2-api).
 # CC-0051: Allow override for release-specific CR names (e.g. keystone-tempest-2026-1-api).
@@ -109,7 +112,7 @@ sed -e "s|${SERVICE_K8S_NAME}\\.${NAMESPACE}\\.svc\\.cluster\\.local:5000|localh
 TEMPEST_CMD="stestr run"
 [[ -f "${OUTPUT_DIR}/config/include-tests.txt" ]] && TEMPEST_CMD+=" --include-list /etc/tempest/include-tests.txt"
 [[ -f "${OUTPUT_DIR}/config/exclude-tests.txt" ]] && TEMPEST_CMD+=" --exclude-list /etc/tempest/exclude-tests.txt"
-TEMPEST_CMD+=" --concurrency 1 --subunit"
+TEMPEST_CMD+=" --concurrency ${TEMPEST_CONCURRENCY} --subunit"
 
 # ---------------------------------------------------------------------------
 # 6. Run Tempest in container

--- a/hack/run-tempest.sh
+++ b/hack/run-tempest.sh
@@ -33,6 +33,7 @@ OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/_output/tempest}"
 TEMPEST_TIMEOUT="${TEMPEST_TIMEOUT:-1800}"
 NAMESPACE="${NAMESPACE:-openstack}"
 ADMIN_SECRET="${ADMIN_SECRET:-keystone-admin}"  # K8s secret holding admin password
+TEMPEST_CONCURRENCY="${TEMPEST_CONCURRENCY:-4}" # stestr worker count; cap at replicas × uwsgi.processes
 
 # ---------------------------------------------------------------------------
 # log — Print a timestamped log message (ISO 8601 UTC).
@@ -62,6 +63,7 @@ Optional:
   TEMPEST_TIMEOUT      Timeout for Tempest run in seconds (default: 1800)
   NAMESPACE            Kubernetes namespace for the service (default: openstack)
   ADMIN_SECRET         Kubernetes secret name holding admin password (default: keystone-admin)
+  TEMPEST_CONCURRENCY  stestr worker count (default: 4); must not exceed replicas × uwsgi.processes
 
 Examples:
   SERVICE=keystone hack/run-tempest.sh
@@ -248,7 +250,7 @@ run_tempest() {
   local tempest_cmd="stestr run"
   [[ -f "${etc_dir}/include-tests.txt" ]] && tempest_cmd+=" --include-list /etc/tempest/include-tests.txt"
   [[ -f "${etc_dir}/exclude-tests.txt" ]] && tempest_cmd+=" --exclude-list /etc/tempest/exclude-tests.txt"
-  tempest_cmd+=" --concurrency 1 --subunit"
+  tempest_cmd+=" --concurrency ${TEMPEST_CONCURRENCY} --subunit"
 
   local rc=0
   timeout "${TEMPEST_TIMEOUT}" \

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -455,7 +455,7 @@ func TestIntegration_UWSGIDefaultsAppliedWhenEmpty(t *testing.T) {
 
 	g.Expect(got.Spec.UWSGI).NotTo(BeNil(), "spec.uwsgi should not be nil")
 	g.Expect(got.Spec.UWSGI.Processes).To(Equal(int32(2)), "processes should be defaulted to 2")
-	g.Expect(got.Spec.UWSGI.Threads).To(Equal(int32(2)), "threads should be defaulted to 2")
+	g.Expect(got.Spec.UWSGI.Threads).To(Equal(int32(1)), "threads should be defaulted to 1")
 	g.Expect(got.Spec.UWSGI.HTTPKeepAlive).To(BeTrue(), "httpKeepAlive should be defaulted to true")
 }
 
@@ -496,7 +496,7 @@ func TestIntegration_UWSGIPartialDefaulting(t *testing.T) {
 	g.Expect(c.Create(ctx, ns)).To(Succeed())
 
 	// Only set processes; threads and httpKeepAlive left at zero values.
-	// The webhook will default threads to 2. httpKeepAlive will NOT be
+	// The webhook will default threads to 1. httpKeepAlive will NOT be
 	// defaulted by the webhook (processes != 0 means struct is not fully
 	// zero-valued), but the CRD schema default (+kubebuilder:default=true)
 	// will set it to true in the admission pipeline.
@@ -512,7 +512,7 @@ func TestIntegration_UWSGIPartialDefaulting(t *testing.T) {
 
 	g.Expect(got.Spec.UWSGI).NotTo(BeNil(), "spec.uwsgi should not be nil")
 	g.Expect(got.Spec.UWSGI.Processes).To(Equal(int32(4)), "explicit processes should be preserved")
-	g.Expect(got.Spec.UWSGI.Threads).To(Equal(int32(2)), "threads should be defaulted to 2")
+	g.Expect(got.Spec.UWSGI.Threads).To(Equal(int32(1)), "threads should be defaulted to 1")
 	// httpKeepAlive is true via the CRD schema +kubebuilder:default=true marker,
 	// which applies during the admission pipeline even though the webhook
 	// defaulter skips it when the struct is not fully zero-valued.

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -106,7 +106,7 @@ type KeystoneSpec struct {
 
 	// UWSGI configures the uWSGI application server parameters (CC-0040).
 	// When set, the operator uses these values for the uWSGI command in the
-	// Deployment. When nil, hardcoded defaults (processes=2, threads=2,
+	// Deployment. When nil, hardcoded defaults (processes=2, threads=1,
 	// httpKeepAlive=true) are used.
 	// +optional
 	UWSGI *UWSGISpec `json:"uwsgi,omitempty"`
@@ -189,7 +189,7 @@ type UWSGISpec struct {
 
 	// Threads is the number of threads per uWSGI worker process.
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:default=2
+	// +kubebuilder:default=1
 	Threads int32 `json:"threads,omitempty"`
 
 	// HTTPKeepAlive enables the --http-keepalive flag on the uWSGI process.

--- a/operators/keystone/api/v1alpha1/keystone_webhook.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook.go
@@ -88,7 +88,7 @@ func (w *KeystoneWebhook) Default(_ context.Context, obj *Keystone) error {
 			obj.Spec.UWSGI.Processes = 2
 		}
 		if obj.Spec.UWSGI.Threads == 0 {
-			obj.Spec.UWSGI.Threads = 2
+			obj.Spec.UWSGI.Threads = 1
 		}
 	}
 	// REQ-004 (CC-0042): Default resource requests and limits for Burstable QoS

--- a/operators/keystone/api/v1alpha1/keystone_webhook_test.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook_test.go
@@ -162,7 +162,7 @@ func TestDefault_UWSGIZeroValuedDefaultsProcessesAndThreads(t *testing.T) {
 
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 	g.Expect(k.Spec.UWSGI.Processes).To(Equal(int32(2)))
-	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(2)))
+	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(1)))
 	// HTTPKeepAlive is NOT defaulted in the webhook — the CRD schema
 	// default (+kubebuilder:default=true) handles it in the normal admission
 	// path. The webhook cannot distinguish "not set" from "explicitly false"
@@ -185,7 +185,7 @@ func TestDefault_UWSGIDefaultsProcessesAndThreadsOnly(t *testing.T) {
 
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 	g.Expect(k.Spec.UWSGI.Processes).To(Equal(int32(2)))
-	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(2)))
+	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(1)))
 	g.Expect(k.Spec.UWSGI.HTTPKeepAlive).To(BeTrue())
 }
 
@@ -207,7 +207,7 @@ func TestDefault_UWSGIDoesNotOverwriteHTTPKeepAlive(t *testing.T) {
 
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 	g.Expect(k.Spec.UWSGI.Processes).To(Equal(int32(4)))
-	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(2)))
+	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(1)))
 	g.Expect(k.Spec.UWSGI.HTTPKeepAlive).To(BeFalse())
 }
 
@@ -227,7 +227,7 @@ func TestDefault_UWSGIZeroProcessesAndThreadsDoNotOverrideExplicitFalse(t *testi
 
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 	g.Expect(k.Spec.UWSGI.Processes).To(Equal(int32(2)))
-	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(2)))
+	g.Expect(k.Spec.UWSGI.Threads).To(Equal(int32(1)))
 	g.Expect(k.Spec.UWSGI.HTTPKeepAlive).To(BeFalse())
 }
 

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -676,7 +676,7 @@ spec:
                 description: |-
                   UWSGI configures the uWSGI application server parameters (CC-0040).
                   When set, the operator uses these values for the uWSGI command in the
-                  Deployment. When nil, hardcoded defaults (processes=2, threads=2,
+                  Deployment. When nil, hardcoded defaults (processes=2, threads=1,
                   httpKeepAlive=true) are used.
                 properties:
                   httpKeepAlive:
@@ -692,7 +692,7 @@ spec:
                     minimum: 1
                     type: integer
                   threads:
-                    default: 2
+                    default: 1
                     description: Threads is the number of threads per uWSGI worker
                       process.
                     format: int32

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -679,7 +679,7 @@ spec:
                 description: |-
                   UWSGI configures the uWSGI application server parameters (CC-0040).
                   When set, the operator uses these values for the uWSGI command in the
-                  Deployment. When nil, hardcoded defaults (processes=2, threads=2,
+                  Deployment. When nil, hardcoded defaults (processes=2, threads=1,
                   httpKeepAlive=true) are used.
                 properties:
                   httpKeepAlive:
@@ -695,7 +695,7 @@ spec:
                     minimum: 1
                     type: integer
                   threads:
-                    default: 2
+                    default: 1
                     description: Threads is the number of threads per uWSGI worker
                       process.
                     format: int32

--- a/operators/keystone/internal/controller/reconcile_deployment.go
+++ b/operators/keystone/internal/controller/reconcile_deployment.go
@@ -289,13 +289,13 @@ func buildPodDisruptionBudget(keystone *keystonev1alpha1.Keystone) *policyv1.Pod
 }
 
 // uwsgiCommand constructs the uWSGI container command from the given spec.
-// When uwsgi is nil (existing CRs without spec.uwsgi), hardcoded defaults
-// (processes=2, threads=2, httpKeepAlive=true) are used to preserve backward
-// compatibility. Fixed flags (--http :5000, --wsgi-file, --master, --lazy-apps,
-// --need-app, --pyargv) are always included regardless of configuration (CC-0040, REQ-004).
+// When uwsgi is nil, hardcoded defaults (processes=2, threads=1,
+// httpKeepAlive=true) are used. Fixed flags (--http :5000, --wsgi-file,
+// --master, --lazy-apps, --need-app, --pyargv) are always included regardless
+// of configuration (CC-0040, REQ-004).
 func uwsgiCommand(uwsgi *keystonev1alpha1.UWSGISpec) []string {
 	processes := int32(2)
-	threads := int32(2)
+	threads := int32(1)
 	httpKeepAlive := true
 
 	if uwsgi != nil {

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -869,7 +869,7 @@ func TestReconcileDeployment_PDBEnsureError(t *testing.T) {
 // Feature: CC-0040
 
 // TestUWSGICommand_NilUWSGI verifies that uwsgiCommand(nil) returns the command
-// with hardcoded defaults: --processes 2 --threads 2 --http-keepalive (CC-0040, REQ-004).
+// with hardcoded defaults: --processes 2 --threads 1 --http-keepalive (CC-0040, REQ-004).
 func TestUWSGICommand_NilUWSGI(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -880,14 +880,14 @@ func TestUWSGICommand_NilUWSGI(t *testing.T) {
 	g.Expect(cmd).To(ContainElement("--threads"))
 	g.Expect(cmd).To(ContainElement("--http-keepalive"))
 
-	// Verify processes=2, threads=2 by checking positional pairs.
+	// Verify processes=2, threads=1 by checking positional pairs.
 	processesIdx := indexOf(cmd, "--processes")
 	g.Expect(processesIdx).NotTo(Equal(-1))
 	g.Expect(cmd[processesIdx+1]).To(Equal("2"))
 
 	threadsIdx := indexOf(cmd, "--threads")
 	g.Expect(threadsIdx).NotTo(Equal(-1))
-	g.Expect(cmd[threadsIdx+1]).To(Equal("2"))
+	g.Expect(cmd[threadsIdx+1]).To(Equal("1"))
 }
 
 // TestUWSGICommand_CustomValues verifies that uwsgiCommand with processes=4,

--- a/tests/e2e/keystone/uwsgi/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/uwsgi/00-keystone-cr.yaml
@@ -4,7 +4,7 @@
 
 # Keystone CR fixture for the uwsgi E2E test (CC-0040).
 # No explicit spec.uwsgi — the reconciler uses hardcoded defaults
-# (processes=2, threads=2, httpKeepAlive=true).
+# (processes=2, threads=1, httpKeepAlive=true).
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: Keystone
 metadata:

--- a/tests/e2e/keystone/uwsgi/chainsaw-test.yaml
+++ b/tests/e2e/keystone/uwsgi/chainsaw-test.yaml
@@ -5,7 +5,7 @@
 # Chainsaw E2E test for spec.uwsgi propagation to Deployment command (CC-0040).
 # Validates that:
 #   - A Keystone CR without explicit spec.uwsgi gets default uWSGI command
-#     (processes=2, threads=2, --http-keepalive) propagated to the Deployment
+#     (processes=2, threads=1, --http-keepalive) propagated to the Deployment
 #   - Patching spec.uwsgi updates the Deployment container command
 #
 # REQ-007 (CC-0040)
@@ -60,7 +60,7 @@ spec:
                   - "--processes"
                   - "2"
                   - "--threads"
-                  - "2"
+                  - "1"
                   - "--pyargv=--config-dir=/etc/keystone/keystone.conf.d/"
     catch:
     - script:


### PR DESCRIPTION
Raise Tempest --concurrency from 1 to 4 to run the API test suite in parallel, and drop the default uWSGI threads from 2 to 1 so Keystone workers scale out via processes rather than per-worker threading.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com