### PR TITLE
fix(CC-0047): Reflect MariaDB cluster health in DatabaseReady

### DIFF
--- a/docs/reference/backend/keystone-operator-packaging.md
+++ b/docs/reference/backend/keystone-operator-packaging.md
@@ -326,6 +326,7 @@ permissions required for the operator to manage Keystone resources and their dep
 | `""` (core) | `events` | create, patch |
 | `batch` | `jobs`, `cronjobs` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `databases`, `users`, `grants` | get, list, watch, create, update, patch, delete |
+| `k8s.mariadb.com` | `mariadbs` | get, list, watch |
 | `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch |
 | `rbac.authorization.k8s.io` | `roles`, `rolebindings` | get, list, watch, create, update, patch, delete |
 

--- a/docs/reference/keystone-reconciler.md
+++ b/docs/reference/keystone-reconciler.md
@@ -107,6 +107,7 @@ RBAC markers on the reconciler generate the required ClusterRole:
 | `core` | `services`, `configmaps`, `secrets` | get, list, watch, create, update, patch, delete |
 | `batch` | `jobs`, `cronjobs` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `databases`, `users`, `grants` | get, list, watch, create, update, patch, delete |
+| `k8s.mariadb.com` | `mariadbs` | get, list, watch |
 | `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch |
 | `policy` | `poddisruptionbudgets` | get, list, watch, create, update, patch, delete |
 | `autoscaling` | `horizontalpodautoscalers` | get, list, watch, create, update, patch, delete |
@@ -133,7 +134,8 @@ RBAC markers on the reconciler generate the required ClusterRole:
 │           │                                                                  │
 │           ▼                                                                  │
 │  ┌───────────────────┐                                                       │
-│  │ reconcileDatabase │  Ensure MariaDB CRs + run db_sync Job                │
+│  │ reconcileDatabase │  Managed mode: verify MariaDB cluster health first,   │
+│  │                   │  then ensure Database/User/Grant CRs + run db_sync Job│
 │  │                   │  Sets: DatabaseReady                                  │
 │  └────────┬──────────┘  Requeue: 30s                                         │
 │           │                                                                  │

--- a/operators/keystone/helm/keystone-operator/templates/_helpers.tpl
+++ b/operators/keystone/helm/keystone-operator/templates/_helpers.tpl
@@ -159,6 +159,17 @@ Extracted into a named template to prevent drift when rules change.
     - update
     - patch
     - delete
+# k8s.mariadb.com - mariadbs (read-only, CC-0047)
+# Required for the operator to observe the referenced MariaDB cluster's
+# Ready condition and reflect outages in DatabaseReady.
+- apiGroups:
+    - k8s.mariadb.com
+  resources:
+    - mariadbs
+  verbs:
+    - get
+    - list
+    - watch
 # external-secrets.io - externalsecrets, pushsecrets (CC-0017)
 - apiGroups:
     - external-secrets.io

--- a/operators/keystone/helm/keystone-operator/tests/clusterrole_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/clusterrole_test.yaml
@@ -7,7 +7,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 14
+          count: 15
 
   - it: should grant full CRUD on keystones
     asserts:
@@ -143,6 +143,20 @@ tests:
               - update
               - patch
               - delete
+
+  - it: should grant read-only on mariadb cluster CRs
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - k8s.mariadb.com
+            resources:
+              - mariadbs
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: should grant read/write without delete on external-secrets resources
     asserts:

--- a/operators/keystone/helm/keystone-operator/tests/role_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/role_test.yaml
@@ -41,7 +41,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have 14 rules matching ClusterRole
+  - it: should have 15 rules matching ClusterRole
     set:
       rbac:
         namespaceScoped: true
@@ -50,7 +50,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 14
+          count: 15
 
   - it: should grant full CRUD on keystones
     set:
@@ -226,6 +226,25 @@ tests:
               - update
               - patch
               - delete
+
+  - it: should grant read-only on mariadb cluster CRs
+    set:
+      rbac:
+        namespaceScoped: true
+      webhook:
+        enabled: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - k8s.mariadb.com
+            resources:
+              - mariadbs
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: should grant read/write without delete on external-secrets resources
     set:

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -609,6 +609,15 @@ func TestIntegration_FullReconcile_Managed(t *testing.T) {
 	// Create prerequisites (same as brownfield — secrets are still needed).
 	createPrerequisites(t, ctx, c, ns.Name)
 
+	// Create a ready MariaDB cluster CR so the reconciler's cluster health
+	// check passes (CC-0047).
+	mdbCluster := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "mariadb", Namespace: ns.Name},
+	}
+	g.Expect(c.Create(ctx, mdbCluster)).To(Succeed(), "create MariaDB cluster CR")
+	g.Expect(simulators.SimulateMariaDBReady(ctx, c, client.ObjectKey{Namespace: ns.Name, Name: "mariadb"}, 1)).
+		To(Succeed(), "simulate MariaDB cluster ready")
+
 	// Create managed-mode Keystone CR (uses spec.database.clusterRef).
 	ks := integrationManagedKeystone("test-keystone", ns.Name)
 	g.Expect(c.Create(ctx, ks)).To(Succeed())
@@ -636,10 +645,11 @@ func TestIntegration_FullReconcile_Managed(t *testing.T) {
 	// Simulate Database ready — this unblocks User/Grant creation.
 	g.Expect(simulators.SimulateDatabaseReady(ctx, c, dbKey)).To(Succeed(), "simulate Database ready")
 
-	// The controller does not watch MariaDB types, so it relies on
-	// RequeueDatabaseWait to discover readiness changes. The reconciler
-	// creates User only after Database is ready, and Grant only after
-	// User is ready, so we must simulate each sequentially.
+	// The controller watches the MariaDB cluster CR but not the Database,
+	// User, or Grant CRs, so it relies on RequeueDatabaseWait to discover
+	// their readiness changes. The reconciler creates User only after
+	// Database is ready, and Grant only after User is ready, so we must
+	// simulate each sequentially.
 
 	// Wait for User CR to appear, then simulate User ready.
 	userKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name}

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
@@ -57,6 +58,7 @@ type KeystoneReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=batch,resources=jobs;cronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=k8s.mariadb.com,resources=databases;users;grants,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=k8s.mariadb.com,resources=mariadbs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=external-secrets.io,resources=externalsecrets;pushsecrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
@@ -181,6 +183,12 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
 			secretToKeystoneMapper(mgr.GetClient()),
 		)).
+		// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
+		// that the operator reflects upstream database outages in DatabaseReady
+		// without waiting for the next periodic requeue (CC-0047).
+		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
+			mariaDBToKeystoneMapper(mgr.GetClient()),
+		)).
 		Complete(r)
 }
 
@@ -201,6 +209,31 @@ func secretToKeystoneMapper(c client.Reader) handler.MapFunc {
 			if ks.Spec.Database.SecretRef.Name == secretName ||
 				ks.Spec.Bootstrap.AdminPasswordSecretRef.Name == secretName ||
 				isOwnedBy(obj, ks) {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(ks),
+				})
+			}
+		}
+		return requests
+	}
+}
+
+// mariaDBToKeystoneMapper returns a MapFunc that maps MariaDB cluster events
+// to reconcile requests for Keystone CRs whose spec.database.clusterRef
+// targets the MariaDB by name in the same namespace (CC-0047).
+func mariaDBToKeystoneMapper(c client.Reader) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		var keystones keystonev1alpha1.KeystoneList
+		if err := c.List(ctx, &keystones, client.InNamespace(obj.GetNamespace())); err != nil {
+			log.FromContext(ctx).Error(err, "listing Keystone CRs for MariaDB watch")
+			return nil
+		}
+
+		mariadbName := obj.GetName()
+		var requests []reconcile.Request
+		for i := range keystones.Items {
+			ks := &keystones.Items[i]
+			if ks.Spec.Database.ClusterRef != nil && ks.Spec.Database.ClusterRef.Name == mariadbName {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: client.ObjectKeyFromObject(ks),
 				})

--- a/operators/keystone/internal/controller/reconcile_database.go
+++ b/operators/keystone/internal/controller/reconcile_database.go
@@ -11,8 +11,10 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -23,6 +25,28 @@ import (
 
 // Feature: CC-0013
 
+// isMariaDBClusterReady returns whether the MariaDB cluster referenced by
+// spec.database.clusterRef currently reports a Ready=True condition. It
+// returns (false, nil) when the cluster CR does not yet exist or is not
+// ready, and surfaces transient errors so the reconciler can retry. Keeping
+// this check in reconcileDatabase ensures the operator reflects upstream
+// database outages in DatabaseReady rather than caching the last sync result
+// forever (CC-0047).
+func isMariaDBClusterReady(ctx context.Context, c client.Client, keystone *keystonev1alpha1.Keystone) (bool, error) {
+	cluster := &mariadbv1alpha1.MariaDB{}
+	key := client.ObjectKey{
+		Namespace: keystone.Namespace,
+		Name:      keystone.Spec.Database.ClusterRef.Name,
+	}
+	if err := c.Get(ctx, key, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting MariaDB %s: %w", key, err)
+	}
+	return conditions.IsReady(cluster.Status.Conditions), nil
+}
+
 // reconcileDatabase ensures the Keystone database schema is provisioned and
 // migrated. In managed mode (ClusterRef set) it creates MariaDB Database, User,
 // and Grant CRs and waits for them to become Ready before running the db_sync
@@ -31,8 +55,27 @@ import (
 func (r *KeystoneReconciler) reconcileDatabase(ctx context.Context, keystone *keystonev1alpha1.Keystone, configMapName string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Managed mode: create MariaDB CRs and wait for readiness.
+	// Managed mode: verify MariaDB cluster health, create MariaDB CRs and
+	// wait for readiness.
 	if keystone.Spec.Database.ClusterRef != nil {
+		clusterReady, err := isMariaDBClusterReady(ctx, r.Client, keystone)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("checking MariaDB cluster readiness: %w", err)
+		}
+		if !clusterReady {
+			logger.Info("MariaDB cluster not ready, requeuing",
+				"cluster", keystone.Spec.Database.ClusterRef.Name)
+			conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
+				Type:               "DatabaseReady",
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: keystone.Generation,
+				Reason:             "ClusterNotReady",
+				Message: fmt.Sprintf("MariaDB cluster %q is not ready",
+					keystone.Spec.Database.ClusterRef.Name),
+			})
+			return ctrl.Result{RequeueAfter: RequeueDatabaseWait}, nil
+		}
+
 		dbReady, err := database.EnsureDatabase(ctx, r.Client, r.Scheme, keystone, buildDatabase(keystone))
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensuring Database: %w", err)

--- a/operators/keystone/internal/controller/reconcile_database_test.go
+++ b/operators/keystone/internal/controller/reconcile_database_test.go
@@ -138,6 +138,40 @@ func failedDBSyncJob(ks *keystonev1alpha1.Keystone) *batchv1.Job {
 	return j
 }
 
+// readyMariaDBCluster returns a MariaDB cluster CR with Ready=True matching
+// the name referenced by ks.Spec.Database.ClusterRef (CC-0047).
+func readyMariaDBCluster(ks *keystonev1alpha1.Keystone) *mariadbv1alpha1.MariaDB {
+	mdb := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ks.Spec.Database.ClusterRef.Name,
+			Namespace: ks.Namespace,
+		},
+	}
+	meta.SetStatusCondition(&mdb.Status.Conditions, metav1.Condition{
+		Type:   "Ready",
+		Status: metav1.ConditionTrue,
+		Reason: "StatefulSetReady",
+	})
+	return mdb
+}
+
+// notReadyMariaDBCluster returns a MariaDB cluster CR with Ready=False,
+// simulating an upstream database outage (CC-0047).
+func notReadyMariaDBCluster(ks *keystonev1alpha1.Keystone) *mariadbv1alpha1.MariaDB {
+	mdb := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ks.Spec.Database.ClusterRef.Name,
+			Namespace: ks.Namespace,
+		},
+	}
+	meta.SetStatusCondition(&mdb.Status.Conditions, metav1.Condition{
+		Type:   "Ready",
+		Status: metav1.ConditionFalse,
+		Reason: "StatefulSetNotReady",
+	})
+	return mdb
+}
+
 // readyDatabase returns a MariaDB Database CR with Ready=True.
 func readyDatabase(ks *keystonev1alpha1.Keystone) *mariadbv1alpha1.Database {
 	db := buildDatabase(ks)
@@ -179,6 +213,7 @@ func TestReconcileDatabase_Managed_AllReady_DatabaseSynced(t *testing.T) {
 	ks := managedKeystone()
 
 	r := newDBTestReconciler(s, ks,
+		readyMariaDBCluster(ks),
 		readyDatabase(ks),
 		readyUser(ks),
 		readyGrant(ks),
@@ -202,7 +237,7 @@ func TestReconcileDatabase_Managed_DatabaseNotReady_Requeues(t *testing.T) {
 
 	// Database CR exists but is not ready (no Ready condition).
 	db := buildDatabase(ks)
-	r := newDBTestReconciler(s, ks, db)
+	r := newDBTestReconciler(s, ks, readyMariaDBCluster(ks), db)
 
 	result, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -221,6 +256,7 @@ func TestReconcileDatabase_Managed_UserNotReady_Requeues(t *testing.T) {
 
 	// Database is ready, but User is not.
 	r := newDBTestReconciler(s, ks,
+		readyMariaDBCluster(ks),
 		readyDatabase(ks),
 		buildUser(ks), // exists but not ready
 	)
@@ -233,6 +269,63 @@ func TestReconcileDatabase_Managed_UserNotReady_Requeues(t *testing.T) {
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).To(Equal("WaitingForDatabase"))
+}
+
+func TestReconcileDatabase_Managed_ClusterMissing_Requeues(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTestScheme()
+	ks := managedKeystone()
+
+	// No MariaDB cluster CR in the fake client — reconciler should report
+	// DatabaseReady=False rather than proceeding to create the Database CR.
+	r := newDBTestReconciler(s, ks)
+
+	result, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RequeueDatabaseWait))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "DatabaseReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ClusterNotReady"))
+
+	// No Database CR should be created while the cluster is unavailable.
+	dbList := &mariadbv1alpha1.DatabaseList{}
+	g.Expect(r.Client.List(context.Background(), dbList, client.InNamespace("default"))).To(Succeed())
+	g.Expect(dbList.Items).To(BeEmpty())
+}
+
+func TestReconcileDatabase_Managed_ClusterNotReady_FlipsDatabaseReadyFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTestScheme()
+	ks := managedKeystone()
+
+	// Simulate a previously successful reconcile: DatabaseReady=True is set
+	// and the db_sync Job has completed. A downstream MariaDB outage must
+	// flip DatabaseReady back to False on the next reconcile (CC-0047).
+	meta.SetStatusCondition(&ks.Status.Conditions, metav1.Condition{
+		Type:   "DatabaseReady",
+		Status: metav1.ConditionTrue,
+		Reason: "DatabaseSynced",
+	})
+
+	r := newDBTestReconciler(s, ks,
+		notReadyMariaDBCluster(ks),
+		readyDatabase(ks),
+		readyUser(ks),
+		readyGrant(ks),
+		completedDBSyncJob(ks),
+	)
+
+	result, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RequeueDatabaseWait))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "DatabaseReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ClusterNotReady"))
+	g.Expect(cond.Message).To(ContainSubstring("mariadb"))
 }
 
 // --- Brownfield mode tests ---
@@ -744,7 +837,7 @@ func TestReconcileDatabase_Managed_ConditionMessages(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ks := managedKeystone()
 		db := buildDatabase(ks)
-		r := newDBTestReconciler(s, ks, db)
+		r := newDBTestReconciler(s, ks, readyMariaDBCluster(ks), db)
 
 		_, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
 		g.Expect(err).NotTo(HaveOccurred())
@@ -759,6 +852,7 @@ func TestReconcileDatabase_Managed_ConditionMessages(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ks := managedKeystone()
 		r := newDBTestReconciler(s, ks,
+			readyMariaDBCluster(ks),
 			readyDatabase(ks),
 			buildUser(ks), // exists but not ready
 		)
@@ -795,6 +889,7 @@ func TestReconcileDatabase_Managed_ConditionMessages(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ks := managedKeystone()
 		r := newDBTestReconciler(s, ks,
+			readyMariaDBCluster(ks),
 			readyDatabase(ks),
 			readyUser(ks),
 			readyGrant(ks),


### PR DESCRIPTION
The chaos E2E test for mariadb pod-kill expects the Keystone operator to flip DatabaseReady=False while the database is down. The operator was caching the first successful db_sync result and never re-checked the underlying cluster, so the condition stayed True throughout the outage.

Fetch the referenced mariadbv1alpha1.MariaDB CR on each reconcile and propagate its Ready condition into DatabaseReady, and watch the CR so status changes trigger a reconcile immediately.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com