### PR TITLE
fix(CC-0047): Reflect OpenBao store health in SecretsReady

### DIFF
--- a/docs/reference/keystone-reconciler.md
+++ b/docs/reference/keystone-reconciler.md
@@ -69,10 +69,14 @@ The controller watches the primary Keystone CR and all owned resources:
 | `HorizontalPodAutoscaler` | `Owns()` | Triggers reconciliation when owned HPA changes |
 | `CronJob` | `Owns()` | Triggers reconciliation when owned CronJob changes |
 | `Secret` | `Watches()` | Triggers reconciliation for controller-owned Secrets only |
+| `MariaDB` | `Watches()` | Propagates upstream DB cluster health into `DatabaseReady` (CC-0047) |
+| `ClusterSecretStore` | `Watches()` | Propagates OpenBao-backend health into `SecretsReady` (CC-0047) |
 
 Secrets use `Watches()` with `handler.OnlyControllerOwner()` instead of `Owns()` because
 some Secrets (ESO-provided credentials) are not owned by the Keystone CR but still need
-to trigger reconciliation.
+to trigger reconciliation. The `MariaDB` and `ClusterSecretStore` watches exist so the
+operator reacts immediately to upstream dependency outages without waiting for the next
+periodic requeue (CC-0047).
 
 ---
 
@@ -109,6 +113,7 @@ RBAC markers on the reconciler generate the required ClusterRole:
 | `k8s.mariadb.com` | `databases`, `users`, `grants` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `mariadbs` | get, list, watch |
 | `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch |
+| `external-secrets.io` | `clustersecretstores` | get, list, watch |
 | `policy` | `poddisruptionbudgets` | get, list, watch, create, update, patch, delete |
 | `autoscaling` | `horizontalpodautoscalers` | get, list, watch, create, update, patch, delete |
 
@@ -267,23 +272,32 @@ ExternalSecrets managed by the External Secrets Operator.
 
 **Checks (in order):**
 
-| Step | ExternalSecret | Source Field |
+| Step | Resource | Source |
 | --- | --- | --- |
-| 1 | DB credentials | `spec.database.secretRef.name` |
-| 2 | Admin credentials | `spec.bootstrap.adminPasswordSecretRef.name` |
+| 0 | `ClusterSecretStore openbao-cluster-store` | Ready condition (CC-0047) |
+| 1 | DB credentials `ExternalSecret` | `spec.database.secretRef.name` |
+| 2 | Admin credentials `ExternalSecret` | `spec.bootstrap.adminPasswordSecretRef.name` |
+
+The `ClusterSecretStore` check runs first so upstream OpenBao outages surface
+as `SecretsReady=False` immediately. Per-ExternalSecret `Ready` conditions
+alone would mask outages up to the ESO `refreshInterval` (1h) because the
+cached Secret remains valid (CC-0047).
 
 **Condition Contract:**
 
 | Status | Reason | Message | RequeueAfter |
 | --- | --- | --- | --- |
+| `False` | `SecretStoreNotReady` | `"ClusterSecretStore \"openbao-cluster-store\" is not ready; upstream secret backend unreachable"` | 15s |
 | `False` | `WaitingForDBCredentials` | "Waiting for ESO to sync database credentials from OpenBao" | 15s |
 | `False` | `WaitingForAdminCredentials` | "Waiting for ESO to sync admin credentials from OpenBao" | 15s |
 | `True` | `SecretsAvailable` | — | — |
 
-**Error handling:** API errors from `secrets.WaitForExternalSecret()` are returned
-directly (no condition set), causing controller-runtime exponential backoff.
+**Error handling:** API errors from `secrets.IsClusterSecretStoreReady()` and
+`secrets.WaitForExternalSecret()` are returned directly (no condition set),
+causing controller-runtime exponential backoff.
 
-**Shared library calls:** `secrets.WaitForExternalSecret()`
+**Shared library calls:** `secrets.IsClusterSecretStoreReady()`,
+`secrets.WaitForExternalSecret()`
 
 ---
 

--- a/internal/common/secrets/secrets.go
+++ b/internal/common/secrets/secrets.go
@@ -41,6 +41,30 @@ func WaitForExternalSecret(ctx context.Context, c client.Client, key client.Obje
 	return false, nil
 }
 
+// IsClusterSecretStoreReady checks whether the ClusterSecretStore identified
+// by name currently reports a Ready condition with status True. It returns
+// (false, nil) when the store does not exist or is not ready, and (false,
+// error) on unexpected client failures. Consumers use this to flip their own
+// *Ready conditions when the upstream secret backend is unreachable — ESO
+// only re-syncs ExternalSecrets at their refreshInterval (default 1h), so
+// relying on ExternalSecret Ready alone would miss short-lived outages.
+func IsClusterSecretStoreReady(ctx context.Context, c client.Client, name string) (bool, error) {
+	store := &esov1.ClusterSecretStore{}
+	if err := c.Get(ctx, client.ObjectKey{Name: name}, store); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting ClusterSecretStore %s: %w", name, err)
+	}
+
+	for _, cond := range store.Status.Conditions {
+		if cond.Type == esov1.SecretStoreReady && cond.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // IsSecretReady checks whether a Kubernetes Secret exists at the given key and
 // contains all expectedKeys in its Data field. When no expectedKeys are
 // provided, it only checks for Secret existence. It returns (true, nil) when

--- a/internal/common/secrets/secrets_test.go
+++ b/internal/common/secrets/secrets_test.go
@@ -106,6 +106,71 @@ func TestWaitForExternalSecret_notFound(t *testing.T) {
 	g.Expect(ready).To(BeFalse())
 }
 
+// --- IsClusterSecretStoreReady ---
+
+func TestIsClusterSecretStoreReady_ready(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "openbao-cluster-store"},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(store).
+		WithStatusSubresource(store).
+		Build()
+
+	ready, err := IsClusterSecretStoreReady(context.Background(), c, "openbao-cluster-store")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue())
+}
+
+func TestIsClusterSecretStoreReady_notReady(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "openbao-cluster-store"},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(store).
+		WithStatusSubresource(store).
+		Build()
+
+	ready, err := IsClusterSecretStoreReady(context.Background(), c, "openbao-cluster-store")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+}
+
+func TestIsClusterSecretStoreReady_notFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	// NotFound is treated as not-ready so the caller can reflect upstream
+	// outages without special-casing a missing store (CC-0047).
+	ready, err := IsClusterSecretStoreReady(context.Background(), c, "missing")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+}
+
 // --- IsSecretReady ---
 
 func TestIsSecretReady_exists(t *testing.T) {

--- a/operators/keystone/helm/keystone-operator/templates/_helpers.tpl
+++ b/operators/keystone/helm/keystone-operator/templates/_helpers.tpl
@@ -183,6 +183,19 @@ Extracted into a named template to prevent drift when rules change.
     - create
     - update
     - patch
+# external-secrets.io - clustersecretstores (read-only, CC-0047)
+# Required so the operator can observe the ClusterSecretStore's Ready
+# condition and reflect upstream secret-backend (OpenBao) outages in
+# SecretsReady. ClusterSecretStore is cluster-scoped; the rule is only
+# effective when rendered into the ClusterRole.
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - clustersecretstores
+  verbs:
+    - get
+    - list
+    - watch
 # rbac.authorization.k8s.io - roles, rolebindings (CC-0017)
 - apiGroups:
     - rbac.authorization.k8s.io

--- a/operators/keystone/helm/keystone-operator/tests/clusterrole_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/clusterrole_test.yaml
@@ -7,7 +7,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 15
+          count: 16
 
   - it: should grant full CRUD on keystones
     asserts:
@@ -175,6 +175,20 @@ tests:
               - create
               - update
               - patch
+
+  - it: should grant read-only on clustersecretstores
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - external-secrets.io
+            resources:
+              - clustersecretstores
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: should grant full CRUD on rbac resources
     asserts:

--- a/operators/keystone/helm/keystone-operator/tests/role_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/role_test.yaml
@@ -41,7 +41,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have 15 rules matching ClusterRole
+  - it: should have 16 rules matching ClusterRole
     set:
       rbac:
         namespaceScoped: true
@@ -50,7 +50,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 15
+          count: 16
 
   - it: should grant full CRUD on keystones
     set:
@@ -268,6 +268,25 @@ tests:
               - create
               - update
               - patch
+
+  - it: should grant read-only on clustersecretstores
+    set:
+      rbac:
+        namespaceScoped: true
+      webhook:
+        enabled: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - external-secrets.io
+            resources:
+              - clustersecretstores
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: should grant full CRUD on rbac resources
     set:

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -157,6 +158,33 @@ func integrationManagedKeystone(name, namespace string) *keystonev1alpha1.Keysto
 	}
 }
 
+// ensureReadyClusterSecretStore creates or refreshes the OpenBao-backed
+// ClusterSecretStore with a Ready=True condition. reconcileSecrets now gates
+// on this status (CC-0047); without it every integration test would flip to
+// SecretsReady=False with reason SecretStoreNotReady. Safe to call multiple
+// times across namespaces since ClusterSecretStore is cluster-scoped.
+func ensureReadyClusterSecretStore(t testing.TB, ctx context.Context, c client.Client) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "openbao-cluster-store"},
+	}
+	err := c.Get(ctx, client.ObjectKeyFromObject(store), store)
+	if apierrors.IsNotFound(err) {
+		g.Expect(c.Create(ctx, store)).To(Succeed(), "create ClusterSecretStore")
+	} else {
+		g.Expect(err).NotTo(HaveOccurred(), "get ClusterSecretStore")
+	}
+
+	store.Status = esov1.SecretStoreStatus{
+		Conditions: []esov1.SecretStoreStatusCondition{
+			{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+		},
+	}
+	g.Expect(c.Status().Update(ctx, store)).To(Succeed(), "update ClusterSecretStore status")
+}
+
 // createPrerequisites creates the ExternalSecret and Secret resources that the
 // Keystone reconciler expects to find. It creates the DB credentials ExternalSecret
 // and Secret (username+password), the admin credentials ExternalSecret and Secret
@@ -164,6 +192,10 @@ func integrationManagedKeystone(name, namespace string) *keystonev1alpha1.Keysto
 func createPrerequisites(t testing.TB, ctx context.Context, c client.Client, ns string) {
 	t.Helper()
 	g := NewGomegaWithT(t)
+
+	// Ensure the OpenBao-backed ClusterSecretStore reports Ready=True so
+	// reconcileSecrets proceeds past the store gate (CC-0047).
+	ensureReadyClusterSecretStore(t, ctx, c)
 
 	// Create DB credentials ExternalSecret and Secret.
 	dbES := &esov1.ExternalSecret{
@@ -347,6 +379,11 @@ func TestIntegration_ConditionProgression(t *testing.T) {
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-progression-"}}
 	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	// Ensure the ClusterSecretStore gate is open so this test still exercises
+	// the per-ExternalSecret Ready progression rather than short-circuiting on
+	// SecretStoreNotReady (CC-0047).
+	ensureReadyClusterSecretStore(t, ctx, c)
 
 	// Phase 0: Create ExternalSecrets and Secrets but do NOT simulate sync yet.
 	// The reconciler should see SecretsReady=False because ESO hasn't set the

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -61,6 +62,7 @@ type KeystoneReconciler struct {
 // +kubebuilder:rbac:groups=k8s.mariadb.com,resources=databases;users;grants,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=k8s.mariadb.com,resources=mariadbs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=external-secrets.io,resources=externalsecrets;pushsecrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=external-secrets.io,resources=clustersecretstores,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -194,6 +196,13 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
 			mariaDBToKeystoneMapper(mgr.GetClient()),
 		)).
+		// Watch the OpenBao-backed ClusterSecretStore so the operator reflects
+		// upstream secret-backend outages in SecretsReady as soon as ESO flips
+		// the store's Ready condition, rather than waiting for the next periodic
+		// requeue (CC-0047).
+		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
+			clusterSecretStoreToKeystoneMapper(mgr.GetClient()),
+		)).
 		Complete(r)
 }
 
@@ -243,6 +252,33 @@ func mariaDBToKeystoneMapper(c client.Reader) handler.MapFunc {
 					NamespacedName: client.ObjectKeyFromObject(ks),
 				})
 			}
+		}
+		return requests
+	}
+}
+
+// clusterSecretStoreToKeystoneMapper returns a MapFunc that enqueues every
+// Keystone CR in the cluster when the OpenBao-backed ClusterSecretStore
+// changes. The store is cluster-scoped and shared across namespaces, so any
+// status transition (e.g. ESO losing the backend connection) must retrigger
+// reconcile on all Keystones that route secrets through it (CC-0047).
+func clusterSecretStoreToKeystoneMapper(c client.Reader) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetName() != openBaoClusterStoreName {
+			return nil
+		}
+
+		var keystones keystonev1alpha1.KeystoneList
+		if err := c.List(ctx, &keystones); err != nil {
+			log.FromContext(ctx).Error(err, "listing Keystone CRs for ClusterSecretStore watch")
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(keystones.Items))
+		for i := range keystones.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&keystones.Items[i]),
+			})
 		}
 		return requests
 	}

--- a/operators/keystone/internal/controller/keystone_controller_test.go
+++ b/operators/keystone/internal/controller/keystone_controller_test.go
@@ -77,7 +77,9 @@ func testKeystone() *keystonev1alpha1.Keystone {
 }
 
 // testReadyExternalSecrets returns ready ExternalSecret objects for the DB and
-// admin credentials referenced by testKeystone.
+// admin credentials referenced by testKeystone, plus the OpenBao-backed
+// ClusterSecretStore with a Ready=True condition that reconcileSecrets now
+// gates on (CC-0047).
 func testReadyExternalSecrets() []runtime.Object {
 	dbES := &esov1.ExternalSecret{
 		ObjectMeta: metav1.ObjectMeta{Name: "keystone-db", Namespace: "default"},
@@ -95,7 +97,15 @@ func testReadyExternalSecrets() []runtime.Object {
 			},
 		},
 	}
-	return []runtime.Object{dbES, adminES}
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "openbao-cluster-store"},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	return []runtime.Object{dbES, adminES, store}
 }
 
 // testDBCredentialsSecret returns a Secret containing the DB credentials

--- a/operators/keystone/internal/controller/reconcile_secrets.go
+++ b/operators/keystone/internal/controller/reconcile_secrets.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,12 +17,39 @@ import (
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
+// openBaoClusterStoreName is the ClusterSecretStore that fronts the OpenBao
+// backend used by deploy/eso/externalsecrets/*.yaml. The operator checks this
+// store's Ready condition on every reconcile so SecretsReady reflects upstream
+// backend outages within the ESO store-reconcile interval — ExternalSecrets
+// themselves use a 1h refreshInterval and would otherwise mask short outages
+// (CC-0047).
+const openBaoClusterStoreName = "openbao-cluster-store"
+
 // reconcileSecrets checks that ESO-provided Kubernetes Secrets exist before
 // proceeding. It verifies the DB credentials and admin credentials
 // ExternalSecrets are ready (CC-0013).
 func (r *KeystoneReconciler) reconcileSecrets(ctx context.Context,
 	keystone *keystonev1alpha1.Keystone,
 ) (ctrl.Result, error) {
+	// Check the ClusterSecretStore first so upstream backend outages surface
+	// as SecretsReady=False even while per-ExternalSecret caches still report
+	// Ready=True from their last successful sync (CC-0047).
+	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !storeReady {
+		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
+			Type:               "SecretsReady",
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: keystone.Generation,
+			Reason:             "SecretStoreNotReady",
+			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
+				openBaoClusterStoreName),
+		})
+		return ctrl.Result{RequeueAfter: RequeueSecretPolling}, nil
+	}
+
 	dbSecretKey := client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Database.SecretRef.Name}
 	adminSecretKey := client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Bootstrap.AdminPasswordSecretRef.Name}
 

--- a/operators/keystone/internal/controller/reconcile_secrets_test.go
+++ b/operators/keystone/internal/controller/reconcile_secrets_test.go
@@ -92,6 +92,33 @@ func notReadyExternalSecret(name, namespace string) *esov1.ExternalSecret {
 	}
 }
 
+// readyClusterSecretStore returns a ClusterSecretStore with a Ready=True
+// status condition so reconcileSecrets proceeds past the store gate (CC-0047).
+func readyClusterSecretStore(name string) *esov1.ClusterSecretStore {
+	return &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// notReadyClusterSecretStore returns a ClusterSecretStore whose Ready
+// condition is explicitly False so reconcileSecrets flips SecretsReady to
+// False with reason SecretStoreNotReady (CC-0047).
+func notReadyClusterSecretStore(name string) *esov1.ClusterSecretStore {
+	return &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+}
+
 func TestReconcileSecrets_BothReady(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := secretsTestScheme()
@@ -109,10 +136,11 @@ func TestReconcileSecrets_BothReady(t *testing.T) {
 		Data:       map[string][]byte{"password": []byte("admin-password")},
 	}
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES, dbSecret, adminSecret).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES, dbSecret, adminSecret).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -141,10 +169,11 @@ func TestReconcileSecrets_DBCredentialsNotReady(t *testing.T) {
 	dbES := notReadyExternalSecret("keystone-db", "default")
 	adminES := readyExternalSecret("keystone-admin", "default")
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -178,10 +207,11 @@ func TestReconcileSecrets_AdminCredentialsNotReady(t *testing.T) {
 		Data:       map[string][]byte{"username": []byte("keystone"), "password": []byte("secret")},
 	}
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES, dbSecret).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES, dbSecret).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -207,9 +237,14 @@ func TestReconcileSecrets_ErrorFetchingExternalSecret(t *testing.T) {
 	s := secretsTestScheme()
 	ks := secretsTestKeystone()
 
+	// A ready ClusterSecretStore lets reconcileSecrets past the store gate so
+	// the interceptor exercises the ExternalSecret Get path (CC-0047).
+	store := readyClusterSecretStore("openbao-cluster-store")
 	// Use an interceptor to inject an error on Get for ExternalSecrets.
 	c := fake.NewClientBuilder().
 		WithScheme(s).
+		WithObjects(store).
+		WithStatusSubresource(store).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				if _, ok := obj.(*esov1.ExternalSecret); ok {
@@ -240,10 +275,11 @@ func TestReconcileSecrets_DBNotReady_ConditionMessage(t *testing.T) {
 	dbES := notReadyExternalSecret("keystone-db", "default")
 	adminES := readyExternalSecret("keystone-admin", "default")
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -274,10 +310,11 @@ func TestReconcileSecrets_AdminNotReady_ConditionMessage(t *testing.T) {
 		Data:       map[string][]byte{"username": []byte("keystone"), "password": []byte("secret")},
 	}
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES, dbSecret).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES, dbSecret).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -308,10 +345,11 @@ func TestReconcileSecrets_DBSecretMissingKeys(t *testing.T) {
 		Data:       map[string][]byte{"wrong-key": []byte("val")},
 	}
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES, dbSecret).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES, dbSecret).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -349,10 +387,11 @@ func TestReconcileSecrets_AdminSecretMissingKeys(t *testing.T) {
 		Data:       map[string][]byte{"wrong-key": []byte("val")},
 	}
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES, dbSecret, adminSecret).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES, dbSecret, adminSecret).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -382,10 +421,11 @@ func TestReconcileSecrets_BothNotReady_DBCheckFirst(t *testing.T) {
 	dbES := notReadyExternalSecret("keystone-db", "default")
 	adminES := notReadyExternalSecret("keystone-admin", "default")
 
+	store := readyClusterSecretStore("openbao-cluster-store")
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dbES, adminES).
-		WithStatusSubresource(dbES, adminES).
+		WithObjects(store, dbES, adminES).
+		WithStatusSubresource(dbES, adminES, store).
 		Build()
 
 	r := &KeystoneReconciler{
@@ -405,4 +445,137 @@ func TestReconcileSecrets_BothNotReady_DBCheckFirst(t *testing.T) {
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).To(Equal("WaitingForDBCredentials"))
 	g.Expect(cond.Message).To(Equal("Waiting for ESO to sync database credentials from OpenBao"))
+}
+
+func TestReconcileSecrets_StoreNotReady(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+
+	// ExternalSecrets look healthy — the store condition should still drive
+	// SecretsReady to False so chaos in OpenBao surfaces within the ESO store
+	// reconcile interval rather than the per-ES refreshInterval (CC-0047).
+	dbES := readyExternalSecret("keystone-db", "default")
+	adminES := readyExternalSecret("keystone-admin", "default")
+	store := notReadyClusterSecretStore("openbao-cluster-store")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(store, dbES, adminES).
+		WithStatusSubresource(dbES, adminES, store).
+		Build()
+
+	r := &KeystoneReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := r.reconcileSecrets(context.Background(), ks)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RequeueSecretPolling))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "SecretsReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
+	g.Expect(cond.Message).To(ContainSubstring("openbao-cluster-store"))
+	g.Expect(cond.ObservedGeneration).To(Equal(ks.Generation))
+}
+
+func TestReconcileSecrets_StoreMissing(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+
+	// No ClusterSecretStore object exists. IsClusterSecretStoreReady treats
+	// NotFound as not-ready so the operator still reports the upstream
+	// backend as unreachable (CC-0047).
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	r := &KeystoneReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := r.reconcileSecrets(context.Background(), ks)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RequeueSecretPolling))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "SecretsReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
+}
+
+func TestReconcileSecrets_StoreGetErrorSurfaces(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+
+	// Transient API-server errors on the ClusterSecretStore Get must be
+	// returned to the caller so controller-runtime requeues the reconcile —
+	// silently setting SecretsReady=False on a flaky API would mask real
+	// outages from everything downstream (CC-0047).
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*esov1.ClusterSecretStore); ok {
+					return fmt.Errorf("simulated API server error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &KeystoneReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.reconcileSecrets(context.Background(), ks)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("simulated API server error"))
+}
+
+func TestReconcileSecrets_StoreCheckedBeforeExternalSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+
+	// Store not ready AND DB ExternalSecret not ready. The reason must be
+	// SecretStoreNotReady — store outage is the root cause and must win the
+	// ordering so operators do not chase the wrong symptom (CC-0047).
+	store := notReadyClusterSecretStore("openbao-cluster-store")
+	dbES := notReadyExternalSecret("keystone-db", "default")
+	adminES := notReadyExternalSecret("keystone-admin", "default")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(store, dbES, adminES).
+		WithStatusSubresource(store, dbES, adminES).
+		Build()
+
+	r := &KeystoneReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.reconcileSecrets(context.Background(), ks)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "SecretsReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
 }

--- a/tests/e2e-chaos/openbao-pod-kill/chainsaw-test.yaml
+++ b/tests/e2e-chaos/openbao-pod-kill/chainsaw-test.yaml
@@ -10,6 +10,18 @@
 # NOTE: OpenBao runs in the openbao-system namespace, not openstack.
 # The PodChaos CR targets openbao-system via selector.namespaces.
 #
+# NOTE: The kind/E2E topology runs OpenBao single-replica with file/raft
+# storage and Shamir-key sealing (init keys live in Secret
+# openbao-system/openbao-init-keys, applied at bootstrap by
+# hack/deploy-infra.sh::openbao_init_unseal). After PodChaos pod-kill the
+# new openbao-0 starts sealed and stays 0/1 Running indefinitely — there is
+# no auto-unseal in this topology. Production runs 3-replica HA Raft, where
+# the surviving quorum keeps the cluster unsealed; that recovery path does
+# not exist with one replica. Step 6 below explicitly re-unseals openbao-0
+# via tests/e2e-chaos/unseal-openbao.sh so the test validates the operator-
+# side recovery (SecretsReady False -> True) without depending on automatic
+# OpenBao recovery the kind topology cannot provide.
+#
 # SC-CHAOS-003, REQ-006, REQ-007, REQ-008, REQ-009 (CC-0047)
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
@@ -74,7 +86,18 @@ spec:
           apiVersion: chaos-mesh.org/v1alpha1
           kind: PodChaos
           name: kill-openbao
-  # ── Step 6: Assert full recovery to SecretsReady=True and Ready=True ───
+  # ── Step 6: Re-unseal openbao-0 (kind single-replica recovery) ─────────
+  # See header comment for why this step exists. The helper is idempotent:
+  # if openbao-0 happens to come back unsealed (it will not, in this
+  # topology, but the script handles the case), it exits 0 without acting.
+  - try:
+    - script:
+        timeout: 180s
+        content: ../unseal-openbao.sh
+    catch:
+    - script:
+        content: ../diagnostics.sh chaos keystone-chaos-bao --dep-label=app.kubernetes.io/name=openbao --dep-ns=openbao-system --log-label=app.kubernetes.io/name=keystone-operator --eso
+  # ── Step 7: Assert full recovery to SecretsReady=True and Ready=True ───
   # REVIEWER-DISAGREEMENT: [Reviewer requested adding inline `kubectl get
   # keystone keystone-chaos-bao -n $NAMESPACE -o yaml` here] — see Step 4
   # comment: diagnostics.sh already collects Keystone CR status uniformly.

--- a/tests/e2e-chaos/unseal-openbao.sh
+++ b/tests/e2e-chaos/unseal-openbao.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# tests/e2e-chaos/unseal-openbao.sh — Re-unseal openbao-0 after a chaos pod-kill.
+#
+# The kind/E2E environment runs OpenBao single-replica with file/raft storage
+# and Shamir-key sealing (init keys live in Secret openbao-system/openbao-init-keys,
+# applied at bootstrap by hack/deploy-infra.sh::openbao_init_unseal). When a
+# chaos PodChaos action=pod-kill restarts the pod, the new instance starts
+# sealed and stays 0/1 Running indefinitely — there is no auto-unseal.
+#
+# Production runs 3-replica HA Raft, where the surviving quorum keeps the
+# cluster unsealed; that recovery path does not exist with one replica. This
+# helper bridges the gap so the openbao-pod-kill chaos test can validate
+# operator-side recovery (SecretsReady False -> True) without depending on
+# OpenBao auto-recovery that the kind topology cannot provide (CC-0047).
+#
+# Idempotent: if the pod is already unsealed, the script exits 0 without
+# touching anything.
+
+set -euo pipefail
+
+# Note: use BAO_NAMESPACE (not NAMESPACE) because chainsaw injects $NAMESPACE
+# into script env from the test's spec.namespace (openstack), which would
+# silently override a NAMESPACE default and make us look for openbao-0 in the
+# wrong namespace.
+BAO_NAMESPACE="${BAO_NAMESPACE:-openbao-system}"
+POD="${POD:-openbao-0}"
+SECRET_NAME="${SECRET_NAME:-openbao-init-keys}"
+BAO_ADDR="${BAO_ADDR:-https://127.0.0.1:8200}"
+VAULT_CACERT="${VAULT_CACERT:-/openbao/tls/ca.crt}"
+KEY_THRESHOLD="${KEY_THRESHOLD:-3}"
+POD_RUNNING_TIMEOUT="${POD_RUNNING_TIMEOUT:-120}"
+BAO_REACHABLE_RETRIES="${BAO_REACHABLE_RETRIES:-30}"
+BAO_REACHABLE_INTERVAL="${BAO_REACHABLE_INTERVAL:-5}"
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] unseal-openbao: $*"
+}
+
+bao_exec() {
+  kubectl exec -n "${BAO_NAMESPACE}" "${POD}" -- \
+    env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" "$@"
+}
+
+# Polls .status.phase directly so a missing pod (StatefulSet still recreating
+# after pod-kill) is treated as "not yet Running" instead of a hard failure
+# the way `kubectl wait --for=jsonpath` would handle it.
+wait_for_pod_running() {
+  local deadline=$(( $(date +%s) + POD_RUNNING_TIMEOUT ))
+  log "Waiting up to ${POD_RUNNING_TIMEOUT}s for pod ${BAO_NAMESPACE}/${POD} to reach phase=Running..."
+  while true; do
+    local phase=""
+    phase=$(kubectl get pod "${POD}" -n "${BAO_NAMESPACE}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null) || phase=""
+    if [[ "${phase}" == "Running" ]]; then
+      log "  pod ${BAO_NAMESPACE}/${POD} is Running"
+      return 0
+    fi
+    if [[ $(date +%s) -ge ${deadline} ]]; then
+      log "ERROR: pod ${BAO_NAMESPACE}/${POD} did not reach Running within ${POD_RUNNING_TIMEOUT}s (last phase: ${phase:-<not found>})"
+      kubectl get pod "${POD}" -n "${BAO_NAMESPACE}" -o wide 2>&1 || true
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+unseal() {
+  log "Reading unseal keys from Secret ${BAO_NAMESPACE}/${SECRET_NAME}..."
+  local init_output
+  if ! init_output=$(kubectl get secret "${SECRET_NAME}" -n "${BAO_NAMESPACE}" \
+      -o jsonpath='{.data.init-output}' | base64 -d); then
+    log "ERROR: could not read Secret ${BAO_NAMESPACE}/${SECRET_NAME} (was openbao bootstrap run?)"
+    exit 1
+  fi
+
+  local i key
+  for i in $(seq 0 $(( KEY_THRESHOLD - 1 ))); do
+    key=$(printf '%s' "${init_output}" | jq -r ".unseal_keys_b64[${i}]")
+    if [[ -z "${key}" || "${key}" == "null" ]]; then
+      log "ERROR: unseal key index ${i} missing from Secret"
+      exit 1
+    fi
+    bao_exec bao operator unseal "${key}" > /dev/null
+    log "  applied unseal key $((i + 1))/${KEY_THRESHOLD}"
+  done
+}
+
+# OpenBao's upstream readiness probe is GET /v1/sys/health, which only returns
+# 200 when the pod is initialized AND unsealed AND active. The kubelet's Ready
+# condition therefore tracks unseal state directly, and is far more reliable
+# than re-running `bao status` post-unseal: the bao client occasionally returns
+# empty stdout while the listener re-initialises, while the readiness probe
+# uses an in-process HTTP path that doesn't depend on TLS or the bao CLI.
+pod_is_ready() {
+  local ready
+  ready=$(kubectl get pod "${POD}" -n "${BAO_NAMESPACE}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null) \
+    || ready=""
+  [[ "${ready}" == "True" ]]
+}
+
+wait_for_pod_ready() {
+  local deadline=$(( $(date +%s) + BAO_REACHABLE_RETRIES * BAO_REACHABLE_INTERVAL ))
+  while true; do
+    if pod_is_ready; then
+      log "${POD} is Ready (unsealed)"
+      return 0
+    fi
+    if [[ $(date +%s) -ge ${deadline} ]]; then
+      log "ERROR: ${POD} did not become Ready within $(( BAO_REACHABLE_RETRIES * BAO_REACHABLE_INTERVAL ))s after unseal"
+      kubectl get pod "${POD}" -n "${BAO_NAMESPACE}" -o wide 2>&1 || true
+      exit 1
+    fi
+    log "  waiting for ${POD} Ready=True after unseal..."
+    sleep "${BAO_REACHABLE_INTERVAL}"
+  done
+}
+
+main() {
+  wait_for_pod_running
+
+  # Fast-path: if the pod is already Ready, OpenBao is already unsealed
+  # (the readiness probe enforces it). Skip the bao client entirely.
+  if pod_is_ready; then
+    log "${POD} already Ready — nothing to do"
+    return 0
+  fi
+
+  log "${POD} is not Ready, applying unseal keys..."
+  unseal
+
+  wait_for_pod_ready
+  log "${POD} unsealed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
The chaos E2E test for openbao pod-kill expects the Keystone operator to flip SecretsReady=False while OpenBao is down. reconcileSecrets was only checking the per-ExternalSecret Ready condition, which ESO keeps True for the full refreshInterval (1h) after the last successful sync, so short outages stayed invisible.

Check the openbao-cluster-store ClusterSecretStore's Ready condition before the per-ExternalSecret checks and propagate it into SecretsReady with reason SecretStoreNotReady. Watch the ClusterSecretStore so ESO's status flip triggers reconcile immediately instead of waiting for the next periodic requeue.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com