### PR TITLE
fix(tempest): Split core and plugin suites into sequential stestr phases

### DIFF
--- a/docs/reference/tempest-test-infrastructure.md
+++ b/docs/reference/tempest-test-infrastructure.md
@@ -216,6 +216,51 @@ For Keystone, two patterns include all identity-related tests:
 | `tempest.api.identity` | Core Tempest identity API tests |
 | `keystone_tempest_plugin.tests` | Keystone-specific plugin tests |
 
+#### Scope-split invariant
+
+Both runners (`hack/ci-run-tempest.sh` and `hack/run-tempest.sh`) split this
+include list into two phase files at runtime and run `stestr` twice in the
+same workspace:
+
+1. `phase-1-core.txt` — every non-comment line that starts with `tempest.`
+2. `phase-2-plugin.txt` — every non-comment line that starts with
+   `keystone_tempest_plugin.`
+
+The two phases run **sequentially**; within each phase `stestr` runs at
+`TEMPEST_CONCURRENCY` (default 4).
+
+Each runner enforces that every non-comment, non-empty line in
+`include-tests.txt` lands in exactly one phase. A line with any other prefix
+causes the runner to abort with a clear error — this guards against silent
+drops when new include patterns are added. Both phases must be non-empty.
+
+**Why sequential.** Keystone re-resolves the list of enabled federation
+service providers on every `POST /v3/auth/tokens` and `GET /v3/auth/tokens`
+call and injects it into the response body; the token itself does not cache
+it. `tempest.api.identity.v3.test_tokens.TokensV3Test.test_validate_token`
+issues a token via POST, validates it via GET, and asserts the two response
+bodies are equal. When `keystone_tempest_plugin.tests.api.identity.v3.
+test_service_providers.ServiceProvidersTest` runs concurrently on another
+stestr worker, its per-test `addCleanup` deletes the service provider it
+created — and if that cleanup lands in the ~20 ms window between
+`test_validate_token`'s POST and GET, the two responses diverge on the
+`service_providers` key and the assertion fails.
+
+Upstream's `openstack/keystone` `keystone-tempest` gate job sets
+`tempest_test_regex: "keystone_tempest_plugin"` and therefore only runs
+`keystone_tempest_plugin.*` tests — the core `tempest.api.identity.*` suite
+(which contains `test_validate_token`) never runs in the same Tempest
+invocation as the service-providers tests, so upstream never observes this
+race. We run both suites for fuller coverage and replicate the isolation by
+running them in two separate stestr invocations.
+
+The two phases each emit a subunit stream (`phase-1-core.subunit`,
+`phase-2-plugin.subunit`); the runner concatenates them into
+`tempest.subunit` and converts that to JUnit XML. Subunit v2 is
+stream-concatenation safe by design. The overall exit code is the maximum
+of the two phase exit codes, so both phases always run and any failure in
+either is reported.
+
 ### exclude-tests.txt
 
 **Location:** `tests/tempest/<service>/exclude-tests.txt`
@@ -312,7 +357,7 @@ SERVICE=keystone hack/run-tempest.sh
 | Pre-flight checks | Validates `SERVICE` is set, required tools (`docker`, `kubectl`, `yq`) are installed, Docker is running, service config directory exists, `test-refs.yaml` exists | Exits 1 with descriptive error |
 | Build Tempest image | Resolves versions from `test-refs.yaml`, builds with `docker build` using named build contexts pointing to GHCR base images | Exits on build failure (set -e) |
 | Extract admin password | Reads `keystone-admin` secret from the K8s cluster via `kubectl get secret` | Exits 1 if secret is not found or empty |
-| Run Tempest | Mounts `tempest.conf`, `include-tests.txt`, `exclude-tests.txt` into container; initializes Tempest workspace; runs `stestr run --subunit`; converts to JUnit XML via `subunit2junitxml` | Returns Tempest exit code |
+| Run Tempest | Mounts `tempest.conf`, `phases/phase-1-core.txt`, `phases/phase-2-plugin.txt`, `exclude-tests.txt` into container; initializes Tempest workspace; runs `stestr run --subunit` once per phase; concatenates the subunit streams; converts to JUnit XML via `subunit2junitxml` | Returns max of the two phase exit codes |
 
 **Output files:**
 
@@ -321,7 +366,9 @@ SERVICE=keystone hack/run-tempest.sh
 | `_output/tempest/tempest-results.xml` | JUnit XML | Test results for CI artifact upload |
 | `_output/tempest/tempest.subunit` | Subunit v2 | Raw test result stream |
 
-The script exits with the same exit code as `stestr run` — non-zero if any test fails.
+The script exits with the maximum of the two per-phase `stestr` exit codes —
+non-zero if any test fails in either phase. Both phases always run, so a
+failure in phase 1 does not short-circuit phase 2.
 
 ### make tempest-test
 
@@ -487,11 +534,16 @@ releases/<release>/test-refs.yaml ──yq──▶ TEMPEST_VERSION + KEYSTONE_T
                          ▼
          docker run --network host \
            -v tempest.conf:/etc/tempest/tempest.conf \
-           -v include-tests.txt:/etc/tempest/include-tests.txt \
+           -v phases/phase-1-core.txt:/etc/tempest/phases/phase-1-core.txt \
+           -v phases/phase-2-plugin.txt:/etc/tempest/phases/phase-2-plugin.txt \
            -v exclude-tests.txt:/etc/tempest/exclude-tests.txt \
            c5c3/tempest:<release> bash -c "
-             tempest init . && cp tempest.conf etc/ &&
-             stestr run --subunit | tee tempest.subunit &&
+             tempest init . && cp tempest.conf etc/;
+             stestr run --include-list phases/phase-1-core.txt ... --subunit \
+               | tee /output/phase-1-core.subunit;
+             stestr run --include-list phases/phase-2-plugin.txt ... --subunit \
+               | tee /output/phase-2-plugin.subunit;
+             cat phase-1-core.subunit phase-2-plugin.subunit > tempest.subunit;
              subunit2junitxml < tempest.subunit > tempest-results.xml"
                          │
                          ▼

--- a/hack/ci-run-tempest.sh
+++ b/hack/ci-run-tempest.sh
@@ -11,6 +11,13 @@
 # counterpart to hack/run-tempest.sh (which handles local execution
 # including image building and more complex orchestration).
 #
+# Runs Tempest in two sequential stestr phases to isolate core tempest.api.*
+# from keystone_tempest_plugin.* — they share state via Keystone's dynamic
+# service_providers injection, which makes tempest.api.identity.v3.test_tokens.
+# TokensV3Test.test_validate_token race against ServiceProvidersTest cleanup
+# under parallel execution. Inside each phase, tests still run at the default
+# concurrency of 4. See docs/reference/tempest-test-infrastructure.md.
+#
 # Required env vars:
 #   (none — all have sensible defaults for the keystone test scenario)
 #
@@ -103,16 +110,48 @@ sed -e "s|${SERVICE_K8S_NAME}\\.${NAMESPACE}\\.svc\\.cluster\\.local:5000|localh
     -e "s|\${KEYSTONE_ADMIN_PASSWORD}|${ADMIN_PASSWORD_ESCAPED}|" \
     "${CONFIG_DIR}/tempest.conf" > "${OUTPUT_DIR}/config/tempest.conf"
 
-[[ -f "${CONFIG_DIR}/include-tests.txt" ]] && cp "${CONFIG_DIR}/include-tests.txt" "${OUTPUT_DIR}/config/"
 [[ -f "${CONFIG_DIR}/exclude-tests.txt" ]] && cp "${CONFIG_DIR}/exclude-tests.txt" "${OUTPUT_DIR}/config/"
 
 # ---------------------------------------------------------------------------
-# 5. Build tempest run command
+# 5. Scope-split the include list into two phase files.
 # ---------------------------------------------------------------------------
-TEMPEST_CMD="stestr run"
-[[ -f "${OUTPUT_DIR}/config/include-tests.txt" ]] && TEMPEST_CMD+=" --include-list /etc/tempest/include-tests.txt"
-[[ -f "${OUTPUT_DIR}/config/exclude-tests.txt" ]] && TEMPEST_CMD+=" --exclude-list /etc/tempest/exclude-tests.txt"
-TEMPEST_CMD+=" --concurrency ${TEMPEST_CONCURRENCY} --subunit"
+# Run core tempest.api.* and keystone_tempest_plugin.* in two sequential stestr
+# invocations so they never share workers. Keystone injects the current list of
+# federation service providers into every token issue/validate response, so
+# ServiceProvidersTest cleanups racing against TokensV3Test.test_validate_token
+# make the latter flaky under parallel execution. Upstream's keystone-tempest
+# gate avoids this by only running keystone_tempest_plugin.* in its job; we run
+# both suites and therefore isolate them by time.
+PHASES_DIR="${OUTPUT_DIR}/config/phases"
+mkdir -p "${PHASES_DIR}"
+
+if [[ ! -f "${CONFIG_DIR}/include-tests.txt" ]]; then
+  echo "::error::${CONFIG_DIR}/include-tests.txt is required for scope-split execution"
+  exit 1
+fi
+
+grep -E '^tempest\.' "${CONFIG_DIR}/include-tests.txt" \
+  > "${PHASES_DIR}/phase-1-core.txt" || true
+grep -E '^keystone_tempest_plugin\.' "${CONFIG_DIR}/include-tests.txt" \
+  > "${PHASES_DIR}/phase-2-plugin.txt" || true
+
+# Invariant: every non-comment, non-empty line in include-tests.txt must land
+# in exactly one phase file. Unknown prefixes would otherwise be silently
+# dropped and leave tests unrun.
+TOTAL_PATTERNS=$(grep -cE '^[^#[:space:]]' \
+  "${CONFIG_DIR}/include-tests.txt" || true)
+PHASE1_COUNT=$(wc -l < "${PHASES_DIR}/phase-1-core.txt" | tr -d ' ')
+PHASE2_COUNT=$(wc -l < "${PHASES_DIR}/phase-2-plugin.txt" | tr -d ' ')
+COVERED=$((PHASE1_COUNT + PHASE2_COUNT))
+
+if [[ "${COVERED}" -ne "${TOTAL_PATTERNS}" ]]; then
+  echo "::error::Scope-split does not cover include-tests.txt: ${TOTAL_PATTERNS} patterns, ${COVERED} covered (phase1=${PHASE1_COUNT}, phase2=${PHASE2_COUNT}). Every non-comment line must start with 'tempest.' or 'keystone_tempest_plugin.'."
+  exit 1
+fi
+if [[ "${PHASE1_COUNT}" -eq 0 || "${PHASE2_COUNT}" -eq 0 ]]; then
+  echo "::error::Scope-split produced an empty phase (phase1=${PHASE1_COUNT}, phase2=${PHASE2_COUNT}). Both phases must have at least one pattern."
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # 6. Run Tempest in container
@@ -135,20 +174,45 @@ docker run --rm \
     cd /tmp/tempest-workspace
     tempest init .
     cp /etc/tempest/tempest.conf etc/tempest.conf
-    set +e
-    ${TEMPEST_CMD} | tee /output/tempest.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
-    rc=\${PIPESTATUS[0]}
-    set -e
-    if [[ -f /output/tempest.subunit ]]; then
-      subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
+
+    exclude_args=''
+    if [[ -f /etc/tempest/exclude-tests.txt ]]; then
+      exclude_args='--exclude-list /etc/tempest/exclude-tests.txt'
     fi
+
+    run_phase() {
+      local phase=\$1
+      echo
+      echo \"::group::Tempest phase: \${phase}\"
+      set +e
+      # shellcheck disable=SC2086  # intentional word-splitting on exclude_args
+      stestr run --include-list /etc/tempest/phases/\${phase}.txt \${exclude_args} --concurrency ${TEMPEST_CONCURRENCY} --subunit | tee /output/\${phase}.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
+      local phase_rc=\${PIPESTATUS[0]}
+      set -e
+      echo '::endgroup::'
+      return \${phase_rc}
+    }
+
+    overall_rc=0
+    run_phase phase-1-core || overall_rc=\$?
+    phase2_rc=0
+    run_phase phase-2-plugin || phase2_rc=\$?
+    if [[ \${phase2_rc} -gt \${overall_rc} ]]; then
+      overall_rc=\${phase2_rc}
+    fi
+
+    # Merge the two subunit streams into the single artifact the CI upload
+    # step expects. Subunit v2 is stream-concatenation safe by design.
+    cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit > /output/tempest.subunit
+    subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
+
     # Guard against stestr run --subunit exiting 0 on test failures:
     # check the JUnit XML for reported failures or errors.
-    if [[ \${rc} -eq 0 && -f /output/tempest-results.xml ]]; then
+    if [[ \${overall_rc} -eq 0 && -f /output/tempest-results.xml ]]; then
       if grep -qE 'failures=\"[1-9]|errors=\"[1-9]' /output/tempest-results.xml; then
         echo '::error::Tempest reported test failures.'
-        rc=1
+        overall_rc=1
       fi
     fi
-    exit \${rc}
+    exit \${overall_rc}
   "

--- a/hack/run-tempest.sh
+++ b/hack/run-tempest.sh
@@ -11,6 +11,10 @@
 #   2. Build the Tempest container image using the service Dockerfile
 #   3. Extract the admin password from the Kubernetes secret
 #   4. Run Tempest inside the container with the service-specific configuration
+#      in two sequential stestr phases (core tempest.api.* vs
+#      keystone_tempest_plugin.*) to isolate suites that share Keystone's
+#      dynamic service_providers state — see docs/reference/tempest-test-
+#      infrastructure.md
 #   5. Convert subunit results to JUnit XML for CI artifact upload
 #
 # REQ-006: Local Tempest execution orchestration script.
@@ -239,18 +243,47 @@ run_tempest() {
     -e "s|http://[^/]*:5000|http://${container_host}:5000|" \
     -e "s|\${KEYSTONE_ADMIN_PASSWORD}|${admin_password}|" \
     "${config_dir}/tempest.conf" > "${etc_dir}/tempest.conf"
-  [[ -f "${config_dir}/include-tests.txt" ]] && cp "${config_dir}/include-tests.txt" "${etc_dir}/"
   [[ -f "${config_dir}/exclude-tests.txt" ]] && cp "${config_dir}/exclude-tests.txt" "${etc_dir}/"
+
+  # Scope-split the include list into two phase files so core tempest.api.*
+  # and keystone_tempest_plugin.* run in separate sequential stestr passes.
+  # Keystone injects the current list of federation service providers into
+  # every token issue/validate response, so ServiceProvidersTest cleanups
+  # race against tempest.api.identity.v3.test_tokens.TokensV3Test.
+  # test_validate_token when both suites share workers. Upstream's
+  # keystone-tempest gate only runs keystone_tempest_plugin.* and therefore
+  # never sees this race; we run both suites and isolate them by time.
+  if [[ ! -f "${config_dir}/include-tests.txt" ]]; then
+    log "ERROR: ${config_dir}/include-tests.txt is required for scope-split execution."
+    return 1
+  fi
+  local phases_dir="${etc_dir}/phases"
+  mkdir -p "${phases_dir}"
+  grep -E '^tempest\.' "${config_dir}/include-tests.txt" \
+    > "${phases_dir}/phase-1-core.txt" || true
+  grep -E '^keystone_tempest_plugin\.' "${config_dir}/include-tests.txt" \
+    > "${phases_dir}/phase-2-plugin.txt" || true
+
+  local total_patterns phase1_count phase2_count
+  total_patterns=$(grep -cE '^[^#[:space:]]' \
+    "${config_dir}/include-tests.txt" || true)
+  phase1_count=$(wc -l < "${phases_dir}/phase-1-core.txt" | tr -d ' ')
+  phase2_count=$(wc -l < "${phases_dir}/phase-2-plugin.txt" | tr -d ' ')
+  if [[ $((phase1_count + phase2_count)) -ne "${total_patterns}" ]]; then
+    log "ERROR: scope-split does not cover include-tests.txt: ${total_patterns} patterns, $((phase1_count + phase2_count)) covered (phase1=${phase1_count}, phase2=${phase2_count})."
+    log "ERROR: every non-comment line must start with 'tempest.' or 'keystone_tempest_plugin.'."
+    return 1
+  fi
+  if [[ "${phase1_count}" -eq 0 || "${phase2_count}" -eq 0 ]]; then
+    log "ERROR: scope-split produced an empty phase (phase1=${phase1_count}, phase2=${phase2_count}); both phases must have at least one pattern."
+    return 1
+  fi
 
   log "Running Tempest tests for service '${SERVICE}'..."
   log "  Endpoint: http://${container_host}:5000"
   log "  Output:   ${OUTPUT_DIR}"
   log "  Timeout:  ${TEMPEST_TIMEOUT}s"
-
-  local tempest_cmd="stestr run"
-  [[ -f "${etc_dir}/include-tests.txt" ]] && tempest_cmd+=" --include-list /etc/tempest/include-tests.txt"
-  [[ -f "${etc_dir}/exclude-tests.txt" ]] && tempest_cmd+=" --exclude-list /etc/tempest/exclude-tests.txt"
-  tempest_cmd+=" --concurrency ${TEMPEST_CONCURRENCY} --subunit"
+  log "  Phases:   phase-1-core (${phase1_count}), phase-2-plugin (${phase2_count})"
 
   local rc=0
   timeout "${TEMPEST_TIMEOUT}" \
@@ -271,14 +304,46 @@ run_tempest() {
         cd /tmp/tempest-workspace
         tempest init .
         cp /etc/tempest/tempest.conf etc/tempest.conf
-        set +e
-        ${tempest_cmd} | tee /output/tempest.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
-        rc=\${PIPESTATUS[0]}
-        set -e
-        if [[ -f /output/tempest.subunit ]]; then
-          subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
+
+        exclude_args=''
+        if [[ -f /etc/tempest/exclude-tests.txt ]]; then
+          exclude_args='--exclude-list /etc/tempest/exclude-tests.txt'
         fi
-        exit \${rc}
+
+        run_phase() {
+          local phase=\$1
+          echo
+          echo \"--- Tempest phase: \${phase} ---\"
+          set +e
+          # shellcheck disable=SC2086  # intentional word-splitting on exclude_args
+          stestr run --include-list /etc/tempest/phases/\${phase}.txt \${exclude_args} --concurrency ${TEMPEST_CONCURRENCY} --subunit | tee /output/\${phase}.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
+          local phase_rc=\${PIPESTATUS[0]}
+          set -e
+          return \${phase_rc}
+        }
+
+        overall_rc=0
+        run_phase phase-1-core || overall_rc=\$?
+        phase2_rc=0
+        run_phase phase-2-plugin || phase2_rc=\$?
+        if [[ \${phase2_rc} -gt \${overall_rc} ]]; then
+          overall_rc=\${phase2_rc}
+        fi
+
+        # Subunit v2 is stream-concatenation safe, so cat'ing the two phase
+        # streams produces a single valid subunit stream.
+        cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit > /output/tempest.subunit
+        subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
+
+        # Guard against stestr run --subunit exiting 0 on test failures:
+        # check the JUnit XML for reported failures or errors.
+        if [[ \${overall_rc} -eq 0 && -f /output/tempest-results.xml ]]; then
+          if grep -qE 'failures=\"[1-9]|errors=\"[1-9]' /output/tempest-results.xml; then
+            echo 'ERROR: Tempest reported test failures.'
+            overall_rc=1
+          fi
+        fi
+        exit \${overall_rc}
       " || rc=$?
 
   if [[ "${rc}" -eq 124 ]]; then


### PR DESCRIPTION
tempest.api.identity.v3.test_tokens.TokensV3Test.test_validate_token races against keystone_tempest_plugin ServiceProvidersTest under parallel execution. The test POSTs a token then GETs it and asserts the two response bodies are equal. Keystone re-resolves the list of enabled federation service providers on every token issue/validate and injects it into the response body -- the token itself does not cache it -- so an SP cleanup landing in the ~20 ms window between POST and GET causes the two responses to diverge on service_providers and the assertion fails.

Upstream's keystone-tempest gate sets tempest_test_regex to "keystone_tempest_plugin" and therefore never runs the core identity suite in the same invocation as the plugin, so the race is invisible upstream. We run both suites for fuller coverage.

Split include-tests.txt into two phase files at runtime (tempest.* and keystone_tempest_plugin.*) and invoke stestr twice in the same workspace. Each phase still runs at TEMPEST_CONCURRENCY internally. Subunit v2 stream-concatenation produces a single tempest.subunit that yields the same JUnit XML the CI upload step already expects. Both runners enforce the invariant that every non-comment line lands in exactly one phase. Overall exit code is max of the two phases so both always run.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com