### PR TITLE
fix(tempest): Retry failed tests once serially to absorb race flakes

### DIFF
--- a/.github/workflows/verify-container-images.yaml
+++ b/.github/workflows/verify-container-images.yaml
@@ -14,8 +14,10 @@ name: Verify Container Images
       - releases/**
       - patches/**
       - scripts/**
+      - hack/tempest/**
       - tests/container-images/**
       - tests/scripts/**
+      - tests/tempest/test_retry_helpers.py
       - .github/workflows/build-images.yaml
       - .github/workflows/verify-container-images.yaml
   pull_request:
@@ -24,8 +26,10 @@ name: Verify Container Images
       - releases/**
       - patches/**
       - scripts/**
+      - hack/tempest/**
       - tests/container-images/**
       - tests/scripts/**
+      - tests/tempest/test_retry_helpers.py
       - .github/workflows/build-images.yaml
       - .github/workflows/verify-container-images.yaml
 
@@ -67,3 +71,11 @@ jobs:
 
       - name: Test apply-constraint-overrides
         run: bash tests/scripts/test_apply_constraint_overrides.sh
+
+      - name: Install tempest retry helper test dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq python3-defusedxml
+
+      - name: Test tempest retry helpers
+        run: python3 tests/tempest/test_retry_helpers.py

--- a/docs/reference/tempest-test-infrastructure.md
+++ b/docs/reference/tempest-test-infrastructure.md
@@ -27,6 +27,9 @@ and `build-images.yaml` dynamically discovers releases for the Tempest image pip
 | `tests/container-images/verify_tempest.sh` | Image verification script (PASS/FAIL counters) |
 | `hack/run-tempest.sh` | Local orchestration script for running Tempest against a kind cluster |
 | `hack/ci-run-tempest.sh` | CI-specific Tempest wrapper with port-forwarding and config generation (CC-0050) |
+| `hack/tempest/extract-failed.py` | Print anchored regex patterns for failed testcases in a JUnit report (used to build the retry include-list) |
+| `hack/tempest/merge-retry-junit.py` | Merge a retry subunit stream into a JUnit report, rewriting resolved failures as flakes |
+| `hack/tempest/run-tests.sh` | Shared in-container runner invoked by both runners; holds the phase + retry + exit-code logic so it stays identical between CI and local runs |
 | `Makefile` | `tempest-test` target delegates to `hack/run-tempest.sh` |
 | `.github/workflows/ci.yaml` | `tempest` job with release matrix (CC-0051) |
 | `.github/workflows/build-images.yaml` | `build-tempest` and `merge-tempest-image` jobs (release-parameterized via `generate-matrix`) |
@@ -257,9 +260,35 @@ running them in two separate stestr invocations.
 The two phases each emit a subunit stream (`phase-1-core.subunit`,
 `phase-2-plugin.subunit`); the runner concatenates them into
 `tempest.subunit` and converts that to JUnit XML. Subunit v2 is
-stream-concatenation safe by design. The overall exit code is the maximum
-of the two phase exit codes, so both phases always run and any failure in
-either is reported.
+stream-concatenation safe by design.
+
+#### Serial retry of failing tests
+
+After both phases, the runner inspects the JUnit report: if any test is
+marked failed or errored, those test IDs are extracted and rerun once in a
+third `stestr run` invocation with `--concurrency 1`. The retry output is
+written to `retry.subunit`, appended to the combined subunit stream, and
+merged into the JUnit report: tests that pass on retry have their
+`<failure>`/`<error>` children removed, the enclosing `<testsuite>` counters
+are decremented, and a `<system-out>` note records `flaky: failed on first
+run, passed on retry`. Tests that still fail after retry stay as failures.
+
+The two helpers live at `hack/tempest/extract-failed.py` (reads the JUnit
+report, prints anchored regex patterns for each failed `classname.method`)
+and `hack/tempest/merge-retry-junit.py` (rewrites the JUnit report from the
+retry subunit stream). The phase + retry + exit-code sequence itself lives
+in `hack/tempest/run-tests.sh`, which is invoked inside the container by
+both `hack/ci-run-tempest.sh` and `hack/run-tempest.sh`. All three files
+are staged next to `tempest.conf` so they are available at `/etc/tempest/`
+inside the container. A failure inside either Python helper (missing
+dependency, parse error) is caught by the runner and falls back to the
+original stestr exit code rather than aborting the whole Tempest run.
+
+The final exit code is derived from the (possibly retry-adjusted) JUnit
+report: any remaining failures or errors fail the job. If the retry
+resolved every failure the runner exits 0. If the initial `stestr` process
+crashed hard enough that no JUnit report was produced, the runner still
+exits non-zero via the captured phase exit code.
 
 ### exclude-tests.txt
 
@@ -357,18 +386,22 @@ SERVICE=keystone hack/run-tempest.sh
 | Pre-flight checks | Validates `SERVICE` is set, required tools (`docker`, `kubectl`, `yq`) are installed, Docker is running, service config directory exists, `test-refs.yaml` exists | Exits 1 with descriptive error |
 | Build Tempest image | Resolves versions from `test-refs.yaml`, builds with `docker build` using named build contexts pointing to GHCR base images | Exits on build failure (set -e) |
 | Extract admin password | Reads `keystone-admin` secret from the K8s cluster via `kubectl get secret` | Exits 1 if secret is not found or empty |
-| Run Tempest | Mounts `tempest.conf`, `phases/phase-1-core.txt`, `phases/phase-2-plugin.txt`, `exclude-tests.txt` into container; initializes Tempest workspace; runs `stestr run --subunit` once per phase; concatenates the subunit streams; converts to JUnit XML via `subunit2junitxml` | Returns max of the two phase exit codes |
+| Run Tempest | Mounts `tempest.conf`, `phases/phase-1-core.txt`, `phases/phase-2-plugin.txt`, `exclude-tests.txt`, `extract-failed.py`, `merge-retry-junit.py` into container; initializes Tempest workspace; runs `stestr run --subunit` once per phase; concatenates the subunit streams; converts to JUnit XML; reruns any failed tests serially; merges the retry outcome into the JUnit report | Non-zero if any failure remains after retry, or on hard `stestr` crash |
 
 **Output files:**
 
 | File | Format | Description |
 | --- | --- | --- |
-| `_output/tempest/tempest-results.xml` | JUnit XML | Test results for CI artifact upload |
-| `_output/tempest/tempest.subunit` | Subunit v2 | Raw test result stream |
+| `_output/tempest/tempest-results.xml` | JUnit XML | Test results for CI artifact upload (retry-adjusted) |
+| `_output/tempest/tempest.subunit` | Subunit v2 | Raw test result stream (phase 1 + phase 2 + retry) |
+| `_output/tempest/retry.subunit` | Subunit v2 | Retry stream (only present if any tests failed on first run) |
 
-The script exits with the maximum of the two per-phase `stestr` exit codes —
-non-zero if any test fails in either phase. Both phases always run, so a
-failure in phase 1 does not short-circuit phase 2.
+The script exits non-zero if the retry-adjusted JUnit report still lists
+failures or errors, and otherwise exits zero. Both phases always run, so a
+failure in phase 1 does not short-circuit phase 2. If the initial `stestr`
+invocations crashed hard enough that no JUnit report was produced, the
+captured phase exit code is used as a fallback so infra failures are still
+reported.
 
 ### make tempest-test
 
@@ -537,14 +570,25 @@ releases/<release>/test-refs.yaml ──yq──▶ TEMPEST_VERSION + KEYSTONE_T
            -v phases/phase-1-core.txt:/etc/tempest/phases/phase-1-core.txt \
            -v phases/phase-2-plugin.txt:/etc/tempest/phases/phase-2-plugin.txt \
            -v exclude-tests.txt:/etc/tempest/exclude-tests.txt \
-           c5c3/tempest:<release> bash -c "
-             tempest init . && cp tempest.conf etc/;
-             stestr run --include-list phases/phase-1-core.txt ... --subunit \
-               | tee /output/phase-1-core.subunit;
-             stestr run --include-list phases/phase-2-plugin.txt ... --subunit \
-               | tee /output/phase-2-plugin.subunit;
-             cat phase-1-core.subunit phase-2-plugin.subunit > tempest.subunit;
-             subunit2junitxml < tempest.subunit > tempest-results.xml"
+           -v extract-failed.py:/etc/tempest/extract-failed.py \
+           -v merge-retry-junit.py:/etc/tempest/merge-retry-junit.py \
+           -v run-tests.sh:/etc/tempest/run-tests.sh \
+           c5c3/tempest:<release> bash /etc/tempest/run-tests.sh
+         #
+         # Internal logic of run-tests.sh (kept here for reference; the runner
+         # scripts never invoke these steps inline — they always `bash
+         # /etc/tempest/run-tests.sh` so CI and local runs share one code path):
+         #
+         #   tempest init . && cp tempest.conf etc/
+         #   stestr run --include-list phases/phase-1-core.txt   --subunit → /output/phase-1-core.subunit
+         #   stestr run --include-list phases/phase-2-plugin.txt --subunit → /output/phase-2-plugin.subunit
+         #   cat phase-1-core.subunit phase-2-plugin.subunit > tempest.subunit
+         #   subunit2junitxml < tempest.subunit > tempest-results.xml
+         #   # retry any failed tests once serially, then rewrite the JUnit:
+         #   python3 /etc/tempest/extract-failed.py tempest-results.xml > retry-list.txt
+         #   stestr run --include-list retry-list.txt --concurrency 1 --subunit → /output/retry.subunit
+         #   cat phase-1-core.subunit phase-2-plugin.subunit retry.subunit > tempest.subunit
+         #   python3 /etc/tempest/merge-retry-junit.py tempest-results.xml retry.subunit
                          │
                          ▼
          actions/upload-artifact ──▶ tempest-<release>-results (14-day retention)

--- a/hack/ci-run-tempest.sh
+++ b/hack/ci-run-tempest.sh
@@ -18,6 +18,11 @@
 # under parallel execution. Inside each phase, tests still run at the default
 # concurrency of 4. See docs/reference/tempest-test-infrastructure.md.
 #
+# After both phases, any test that failed on the first run is re-run once
+# serially (stestr --concurrency 1) to absorb cross-suite race flakes. Tests
+# that pass on retry are rewritten in the JUnit report as flakes rather than
+# failures. Tests that still fail are left as failures and the job exits 1.
+#
 # Required env vars:
 #   (none — all have sensible defaults for the keystone test scenario)
 #
@@ -112,6 +117,15 @@ sed -e "s|${SERVICE_K8S_NAME}\\.${NAMESPACE}\\.svc\\.cluster\\.local:5000|localh
 
 [[ -f "${CONFIG_DIR}/exclude-tests.txt" ]] && cp "${CONFIG_DIR}/exclude-tests.txt" "${OUTPUT_DIR}/config/"
 
+# Stage the retry helpers and shared in-container runner next to tempest.conf
+# so they are available under /etc/tempest/ inside the container.
+install -m 0755 "${SCRIPT_DIR}/tempest/extract-failed.py" \
+  "${OUTPUT_DIR}/config/extract-failed.py"
+install -m 0755 "${SCRIPT_DIR}/tempest/merge-retry-junit.py" \
+  "${OUTPUT_DIR}/config/merge-retry-junit.py"
+install -m 0755 "${SCRIPT_DIR}/tempest/run-tests.sh" \
+  "${OUTPUT_DIR}/config/run-tests.sh"
+
 # ---------------------------------------------------------------------------
 # 5. Scope-split the include list into two phase files.
 # ---------------------------------------------------------------------------
@@ -166,53 +180,9 @@ docker run --rm \
   --add-host "${SERVICE_K8S_NAME}.${NAMESPACE}.svc:127.0.0.1" \
   -v "${WORKSPACE_ROOT}/${OUTPUT_DIR}/config:/etc/tempest:ro" \
   -v "${WORKSPACE_ROOT}/${OUTPUT_DIR}:/output" \
+  -e "TEMPEST_CONCURRENCY=${TEMPEST_CONCURRENCY}" \
+  -e "TEMPEST_GROUP_START=::group::" \
+  -e "TEMPEST_GROUP_END=::endgroup::" \
+  -e "TEMPEST_ERROR_PREFIX=::error::" \
   "${TEMPEST_IMAGE}" \
-  bash -c "
-    set -euo pipefail
-    export HOME=/tmp
-    mkdir -p /tmp/tempest-workspace /tmp/tempest-logs
-    cd /tmp/tempest-workspace
-    tempest init .
-    cp /etc/tempest/tempest.conf etc/tempest.conf
-
-    exclude_args=''
-    if [[ -f /etc/tempest/exclude-tests.txt ]]; then
-      exclude_args='--exclude-list /etc/tempest/exclude-tests.txt'
-    fi
-
-    run_phase() {
-      local phase=\$1
-      echo
-      echo \"::group::Tempest phase: \${phase}\"
-      set +e
-      # shellcheck disable=SC2086  # intentional word-splitting on exclude_args
-      stestr run --include-list /etc/tempest/phases/\${phase}.txt \${exclude_args} --concurrency ${TEMPEST_CONCURRENCY} --subunit | tee /output/\${phase}.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
-      local phase_rc=\${PIPESTATUS[0]}
-      set -e
-      echo '::endgroup::'
-      return \${phase_rc}
-    }
-
-    overall_rc=0
-    run_phase phase-1-core || overall_rc=\$?
-    phase2_rc=0
-    run_phase phase-2-plugin || phase2_rc=\$?
-    if [[ \${phase2_rc} -gt \${overall_rc} ]]; then
-      overall_rc=\${phase2_rc}
-    fi
-
-    # Merge the two subunit streams into the single artifact the CI upload
-    # step expects. Subunit v2 is stream-concatenation safe by design.
-    cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit > /output/tempest.subunit
-    subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
-
-    # Guard against stestr run --subunit exiting 0 on test failures:
-    # check the JUnit XML for reported failures or errors.
-    if [[ \${overall_rc} -eq 0 && -f /output/tempest-results.xml ]]; then
-      if grep -qE 'failures=\"[1-9]|errors=\"[1-9]' /output/tempest-results.xml; then
-        echo '::error::Tempest reported test failures.'
-        overall_rc=1
-      fi
-    fi
-    exit \${overall_rc}
-  "
+  bash /etc/tempest/run-tests.sh

--- a/hack/run-tempest.sh
+++ b/hack/run-tempest.sh
@@ -15,7 +15,10 @@
 #      keystone_tempest_plugin.*) to isolate suites that share Keystone's
 #      dynamic service_providers state — see docs/reference/tempest-test-
 #      infrastructure.md
-#   5. Convert subunit results to JUnit XML for CI artifact upload
+#   5. Retry any failed tests once serially (concurrency 1) to absorb cross-
+#      suite race flakes; tests that pass on retry are rewritten as flakes
+#      rather than failures
+#   6. Convert subunit results to JUnit XML for CI artifact upload
 #
 # REQ-006: Local Tempest execution orchestration script.
 # REQ-011: set -euo pipefail, SPDX Apache-2.0 header, CC-0035 reference.
@@ -245,6 +248,16 @@ run_tempest() {
     "${config_dir}/tempest.conf" > "${etc_dir}/tempest.conf"
   [[ -f "${config_dir}/exclude-tests.txt" ]] && cp "${config_dir}/exclude-tests.txt" "${etc_dir}/"
 
+  # Stage the retry helpers and shared in-container runner alongside
+  # tempest.conf so they are available under /etc/tempest/ inside the
+  # container.
+  install -m 0755 "${SCRIPT_DIR}/tempest/extract-failed.py" \
+    "${etc_dir}/extract-failed.py"
+  install -m 0755 "${SCRIPT_DIR}/tempest/merge-retry-junit.py" \
+    "${etc_dir}/merge-retry-junit.py"
+  install -m 0755 "${SCRIPT_DIR}/tempest/run-tests.sh" \
+    "${etc_dir}/run-tests.sh"
+
   # Scope-split the include list into two phase files so core tempest.api.*
   # and keystone_tempest_plugin.* run in separate sequential stestr passes.
   # Keystone injects the current list of federation service providers into
@@ -294,57 +307,9 @@ run_tempest() {
       --add-host "${svc_name}.${NAMESPACE}.svc:${catalog_ip}" \
       -v "${etc_dir}:/etc/tempest:ro" \
       -v "${OUTPUT_DIR}:/output" \
+      -e "TEMPEST_CONCURRENCY=${TEMPEST_CONCURRENCY}" \
       "${TEMPEST_IMAGE}" \
-      bash -c "
-        set -euo pipefail
-        # HOME=/tmp: the openstack user's real home (/var/lib/openstack) is owned
-        # by root, so tempest cannot create ~/.tempest there. Redirect to /tmp.
-        export HOME=/tmp
-        mkdir -p /tmp/tempest-workspace /tmp/tempest-logs
-        cd /tmp/tempest-workspace
-        tempest init .
-        cp /etc/tempest/tempest.conf etc/tempest.conf
-
-        exclude_args=''
-        if [[ -f /etc/tempest/exclude-tests.txt ]]; then
-          exclude_args='--exclude-list /etc/tempest/exclude-tests.txt'
-        fi
-
-        run_phase() {
-          local phase=\$1
-          echo
-          echo \"--- Tempest phase: \${phase} ---\"
-          set +e
-          # shellcheck disable=SC2086  # intentional word-splitting on exclude_args
-          stestr run --include-list /etc/tempest/phases/\${phase}.txt \${exclude_args} --concurrency ${TEMPEST_CONCURRENCY} --subunit | tee /output/\${phase}.subunit | subunit2pyunit 2>&1 | grep --line-buffered -E '\.\.\. '
-          local phase_rc=\${PIPESTATUS[0]}
-          set -e
-          return \${phase_rc}
-        }
-
-        overall_rc=0
-        run_phase phase-1-core || overall_rc=\$?
-        phase2_rc=0
-        run_phase phase-2-plugin || phase2_rc=\$?
-        if [[ \${phase2_rc} -gt \${overall_rc} ]]; then
-          overall_rc=\${phase2_rc}
-        fi
-
-        # Subunit v2 is stream-concatenation safe, so cat'ing the two phase
-        # streams produces a single valid subunit stream.
-        cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit > /output/tempest.subunit
-        subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
-
-        # Guard against stestr run --subunit exiting 0 on test failures:
-        # check the JUnit XML for reported failures or errors.
-        if [[ \${overall_rc} -eq 0 && -f /output/tempest-results.xml ]]; then
-          if grep -qE 'failures=\"[1-9]|errors=\"[1-9]' /output/tempest-results.xml; then
-            echo 'ERROR: Tempest reported test failures.'
-            overall_rc=1
-          fi
-        fi
-        exit \${overall_rc}
-      " || rc=$?
+      bash /etc/tempest/run-tests.sh || rc=$?
 
   if [[ "${rc}" -eq 124 ]]; then
     log "ERROR: Tempest timed out after ${TEMPEST_TIMEOUT}s. Stopping container..."

--- a/hack/tempest/extract-failed.py
+++ b/hack/tempest/extract-failed.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print dotted IDs of failed/errored testcases from a JUnit XML file.
+
+Used by the Tempest runners to build an `--include-list` for a serial retry
+pass over flaky tests. Each line printed is a `classname.name` pair with regex
+metacharacters escaped and anchored so that stestr's regex matcher rematches
+the same test (and all of its parametrized id-tag variants) on retry.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+from defusedxml.ElementTree import parse as _safe_parse
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: extract-failed.py JUNIT_XML", file=sys.stderr)
+        return 2
+    try:
+        root = _safe_parse(sys.argv[1]).getroot()
+    except (OSError, ET.ParseError) as exc:
+        print(f"error reading {sys.argv[1]}: {exc}", file=sys.stderr)
+        return 1
+
+    seen: set[str] = set()
+    for tc in root.iter("testcase"):
+        classname = tc.attrib.get("classname", "")
+        name = tc.attrib.get("name", "")
+        if not classname or not name:
+            continue
+        if not any(child.tag in ("failure", "error") for child in tc):
+            continue
+        # Strip any trailing "[id-...]" tag from the method name so we retry
+        # the test method itself, not a single parametrized variant.
+        bare_name = re.sub(r"\[[^\]]*\]$", "", name)
+        key = f"{classname}.{bare_name}"
+        if key in seen:
+            continue
+        seen.add(key)
+        # Anchor to the full classname.method prefix and allow an optional
+        # id-tag suffix so stestr matches all variants of the method.
+        pattern = "^" + re.escape(key) + r"(\[|$)"
+        print(pattern)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/tempest/merge-retry-junit.py
+++ b/hack/tempest/merge-retry-junit.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge retry subunit results into a Tempest JUnit XML report.
+
+Reads the final outcome per test_id from a subunit v2 stream produced by a
+retry `stestr run` and, for each testcase in the JUnit XML that failed on
+the initial run but succeeded on retry, removes the failure/error children,
+decrements the failures/errors counters on the enclosing `<testsuite>` (and
+`<testsuites>` root if present), and appends a `<system-out>` note marking
+the test as a resolved flake. Tests that still fail after retry are left
+untouched.
+
+The JUnit file is updated in place. A one-line summary is printed to stderr
+with the count of resolved flakes and still-failing tests.
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+
+from defusedxml.ElementTree import parse as _safe_parse
+
+
+def _load_retry_outcomes(path: str) -> dict[str, str]:
+    # Imported lazily so unit tests for rewrite_junit() can run without the
+    # subunit/testtools packages installed on the host.
+    from subunit.v2 import ByteStreamToStreamResult
+    from testtools import StreamResult
+
+    class _OutcomeCollector(StreamResult):
+        """Collect the final terminal outcome per full test_id."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.outcomes: dict[str, str] = {}
+
+        def status(self, test_id=None, test_status=None, **_: object) -> None:
+            if not test_id or not test_status:
+                return
+            if test_status in {"success", "fail", "skip", "xfail", "uxsuccess"}:
+                # Key by the full test_id (including any parametrization tag)
+                # so variants of the same method are tracked independently
+                # and cannot clobber each other last-wins.
+                self.outcomes[test_id] = test_status
+
+    collector = _OutcomeCollector()
+    with open(path, "rb") as fh:
+        stream = ByteStreamToStreamResult(fh, non_subunit_name="retry")
+        stream.run(collector)
+    return collector.outcomes
+
+
+def _dec(elem: ET.Element, attr: str) -> None:
+    try:
+        value = int(elem.attrib.get(attr, "0"))
+    except ValueError:
+        return
+    if value > 0:
+        elem.attrib[attr] = str(value - 1)
+
+
+def rewrite_junit(junit_path: str, passed_on_retry: set[str]) -> tuple[int, int]:
+    """Rewrite resolved failures as flakes, in place. Returns (fixed, still_failing)."""
+    tree = _safe_parse(junit_path)
+    root = tree.getroot()
+
+    fixed = 0
+    still_failing = 0
+    # Iterate direct-child testcases only: using ts.iter("testcase") would
+    # re-visit nested testcases once per ancestor testsuite, which would
+    # double-remove children and over-adjust counters.
+    for ts in root.iter("testsuite"):
+        for tc in list(ts.findall("testcase")):
+            classname = tc.attrib.get("classname", "")
+            name = tc.attrib.get("name", "")
+            if not classname or not name:
+                continue
+            # Match JUnit testcases by their full classname.name (including
+            # any "[id-...]" parametrization tag) so parametrized variants
+            # are rewritten independently — see W-001.
+            test_id = f"{classname}.{name}"
+            fail_children = [c for c in tc if c.tag in ("failure", "error")]
+            if not fail_children:
+                continue
+            if test_id in passed_on_retry:
+                kinds = {c.tag for c in fail_children}
+                for child in fail_children:
+                    tc.remove(child)
+                note = ET.SubElement(tc, "system-out")
+                note.text = "flaky: failed on first run, passed on retry"
+                for kind in kinds:
+                    attr = "failures" if kind == "failure" else "errors"
+                    _dec(ts, attr)
+                    if root.tag == "testsuites":
+                        _dec(root, attr)
+                fixed += 1
+            else:
+                still_failing += 1
+
+    tree.write(junit_path, xml_declaration=True, encoding="utf-8")
+    return fixed, still_failing
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: merge-retry-junit.py JUNIT_XML RETRY_SUBUNIT",
+            file=sys.stderr,
+        )
+        return 2
+
+    junit_path, retry_path = sys.argv[1], sys.argv[2]
+
+    outcomes = _load_retry_outcomes(retry_path)
+    # xfail (expected failure) still represents a failing test by design, so
+    # only real passes count as "passed on retry". uxsuccess is an unexpected
+    # pass for a test marked xfail — the test code did not raise, so treat it
+    # as a pass for flake-rewrite purposes.
+    passed_on_retry = {
+        tid for tid, status in outcomes.items()
+        if status in {"success", "uxsuccess"}
+    }
+
+    fixed, still_failing = rewrite_junit(junit_path, passed_on_retry)
+    print(
+        f"Retry merge: {fixed} flaky test(s) passed on retry, "
+        f"{still_failing} still failing.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/tempest/run-tests.sh
+++ b/hack/tempest/run-tests.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# hack/tempest/run-tests.sh — In-container Tempest execution helper.
+# Feature: CC-0035, CC-0050
+#
+# Runs Tempest in two sequential stestr phases (core tempest.api.* then
+# keystone_tempest_plugin.*) and retries any failed tests once serially to
+# absorb cross-suite race flakes. Sourced into the Tempest container by both
+# hack/ci-run-tempest.sh and hack/run-tempest.sh so the retry/exit-code logic
+# lives in one place and cannot drift between CI and local runs.
+#
+# Expected layout inside the container:
+#   /etc/tempest/tempest.conf
+#   /etc/tempest/phases/phase-1-core.txt
+#   /etc/tempest/phases/phase-2-plugin.txt
+#   /etc/tempest/extract-failed.py
+#   /etc/tempest/merge-retry-junit.py
+#   /etc/tempest/exclude-tests.txt       (optional)
+#   /output/                              (mounted, writable)
+#
+# Required env vars:
+#   TEMPEST_CONCURRENCY — stestr worker count for the parallel phases
+#
+# Optional env vars:
+#   TEMPEST_GROUP_START  — log group-start marker (default: "--- ")
+#   TEMPEST_GROUP_END    — log group-end marker   (default: empty; CI sets it)
+#   TEMPEST_ERROR_PREFIX — error line prefix      (default: "ERROR: ")
+
+set -euo pipefail
+
+: "${TEMPEST_CONCURRENCY:?TEMPEST_CONCURRENCY must be set}"
+GROUP_START="${TEMPEST_GROUP_START:---- }"
+GROUP_END="${TEMPEST_GROUP_END:-}"
+ERROR_PREFIX="${TEMPEST_ERROR_PREFIX:-ERROR: }"
+
+# HOME=/tmp: the openstack user's real home (/var/lib/openstack) is owned by
+# root, so tempest cannot create ~/.tempest there. Redirect to /tmp.
+export HOME=/tmp
+mkdir -p /tmp/tempest-workspace /tmp/tempest-logs
+cd /tmp/tempest-workspace
+tempest init .
+cp /etc/tempest/tempest.conf etc/tempest.conf
+
+exclude_args=''
+if [[ -f /etc/tempest/exclude-tests.txt ]]; then
+  exclude_args='--exclude-list /etc/tempest/exclude-tests.txt'
+fi
+
+group_end() {
+  if [[ -n "${GROUP_END}" ]]; then
+    echo "${GROUP_END}"
+  fi
+}
+
+run_phase() {
+  local phase=$1 concurrency=$2 include_list=$3 subunit_out=$4
+  echo
+  echo "${GROUP_START}Tempest ${phase} (concurrency=${concurrency})"
+  set +e
+  # shellcheck disable=SC2086  # intentional word-splitting on exclude_args
+  stestr run --include-list ${include_list} ${exclude_args} --concurrency ${concurrency} --subunit \
+    | tee ${subunit_out} \
+    | subunit2pyunit 2>&1 \
+    | grep --line-buffered -E '\.\.\. '
+  local phase_rc=${PIPESTATUS[0]}
+  set -e
+  group_end
+  return ${phase_rc}
+}
+
+overall_rc=0
+run_phase phase-1-core "${TEMPEST_CONCURRENCY}" \
+  /etc/tempest/phases/phase-1-core.txt /output/phase-1-core.subunit || overall_rc=$?
+phase2_rc=0
+run_phase phase-2-plugin "${TEMPEST_CONCURRENCY}" \
+  /etc/tempest/phases/phase-2-plugin.txt /output/phase-2-plugin.subunit || phase2_rc=$?
+if [[ ${phase2_rc} -gt ${overall_rc} ]]; then
+  overall_rc=${phase2_rc}
+fi
+
+# Subunit v2 is stream-concatenation safe, so cat'ing the two phase streams
+# produces a single valid subunit stream.
+cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit > /output/tempest.subunit
+subunit2junitxml < /output/tempest.subunit > /output/tempest-results.xml 2>/dev/null || true
+
+# Retry: if the JUnit report lists any failed or errored tests, re-run just
+# those tests once serially (concurrency 1) to absorb cross-suite race flakes.
+# Tests that pass on retry are rewritten as flakes, not failures, in the JUnit
+# report. Tests that still fail stay as failures. If either helper (extract or
+# merge) crashes we skip retry and fall through to the original exit code
+# instead of aborting the whole run.
+retried=0
+if [[ -f /output/tempest-results.xml ]] \
+   && grep -qE 'failures="[1-9]|errors="[1-9]' /output/tempest-results.xml; then
+  : > /tmp/retry-list.txt
+  if ! python3 /etc/tempest/extract-failed.py /output/tempest-results.xml \
+       > /tmp/retry-list.txt; then
+    echo "${ERROR_PREFIX}extract-failed.py failed; skipping retry."
+    : > /tmp/retry-list.txt
+  fi
+  retry_count=$(wc -l < /tmp/retry-list.txt | tr -d ' ')
+  if [[ ${retry_count} -gt 0 ]]; then
+    retried=1
+    echo
+    echo "${GROUP_START}Tempest retry: ${retry_count} failed test(s), rerunning serially"
+    cat /tmp/retry-list.txt
+    run_phase retry 1 /tmp/retry-list.txt /output/retry.subunit || true
+
+    cat /output/phase-1-core.subunit /output/phase-2-plugin.subunit /output/retry.subunit \
+      > /output/tempest.subunit
+    if ! python3 /etc/tempest/merge-retry-junit.py \
+         /output/tempest-results.xml /output/retry.subunit; then
+      echo "${ERROR_PREFIX}merge-retry-junit.py failed; retry results not merged."
+      # The JUnit report is stale; let the exit-code logic below re-read it
+      # and fail on any remaining failures rather than claiming success.
+      retried=0
+    fi
+  fi
+fi
+
+# Decide exit code:
+#   - If the JUnit report still lists failures/errors, fail.
+#   - Else if we retried and the rewritten report is clean, succeed (the
+#     original non-zero stestr exit was due to resolved flakes).
+#   - Else fall through to the original phase exit code so an infra-level
+#     stestr crash that left the JUnit incomplete still fails.
+if [[ -f /output/tempest-results.xml ]] \
+   && grep -qE 'failures="[1-9]|errors="[1-9]' /output/tempest-results.xml; then
+  echo "${ERROR_PREFIX}Tempest reported test failures (including after retry)."
+  overall_rc=1
+elif [[ ${retried} -eq 1 ]]; then
+  overall_rc=0
+fi
+exit ${overall_rc}

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -22,7 +22,8 @@ RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target
         tempest==${TEMPEST_VERSION} \
         keystone-tempest-plugin==${KEYSTONE_TEMPEST_PLUGIN_VERSION} \
         python-subunit \
-        junitxml
+        junitxml \
+        defusedxml
 
 # ---------- Stage 2: runtime ----------
 # hadolint ignore=DL3006

--- a/tests/tempest/test_retry_helpers.py
+++ b/tests/tempest/test_retry_helpers.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Tempest retry helpers (CC-0035).
+
+Covers hack/tempest/extract-failed.py end-to-end and
+hack/tempest/merge-retry-junit.py via its importable rewrite_junit() entry
+point. The subunit stream loader is not exercised here so the tests can run
+on any host with only defusedxml installed.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_HACK_TEMPEST = _PROJECT_ROOT / "hack" / "tempest"
+
+
+def _load(mod_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+extract_failed = _load("extract_failed", _HACK_TEMPEST / "extract-failed.py")
+merge_retry_junit = _load(
+    "merge_retry_junit", _HACK_TEMPEST / "merge-retry-junit.py"
+)
+
+
+class _JunitFixtureMixin:
+    def _write_junit(self, xml_body: str) -> str:
+        fh = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".xml", delete=False, encoding="utf-8"
+        )
+        fh.write(xml_body)
+        fh.close()
+        self.addCleanup(os.unlink, fh.name)
+        return fh.name
+
+
+class ExtractFailedTests(_JunitFixtureMixin, unittest.TestCase):
+    def _run(self, junit_path: str) -> tuple[int, str, str]:
+        stdout, stderr = io.StringIO(), io.StringIO()
+        saved_argv = sys.argv
+        try:
+            sys.argv = ["extract-failed.py", junit_path]
+            with (
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                rc = extract_failed.main()
+        finally:
+            sys.argv = saved_argv
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_happy_path_single_failure(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuite name="tempest" tests="2" failures="1" errors="0">'
+            '  <testcase classname="tempest.api.foo.Bar" name="test_ok"/>'
+            '  <testcase classname="tempest.api.foo.Bar" name="test_bad">'
+            "    <failure>boom</failure>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        rc, out, _ = self._run(junit)
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            out.strip().splitlines(),
+            [r"^tempest\.api\.foo\.Bar\.test_bad(\[|$)"],
+        )
+
+    def test_parametrized_variants_dedup_to_one_pattern(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuite name="tempest">'
+            '  <testcase classname="tempest.api.foo.Bar"'
+            '            name="test_bad[id-abc]">'
+            "    <failure>boom</failure>"
+            "  </testcase>"
+            '  <testcase classname="tempest.api.foo.Bar"'
+            '            name="test_bad[id-xyz]">'
+            "    <error>crash</error>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        rc, out, _ = self._run(junit)
+        self.assertEqual(rc, 0)
+        lines = out.strip().splitlines()
+        self.assertEqual(
+            lines, [r"^tempest\.api\.foo\.Bar\.test_bad(\[|$)"]
+        )
+
+    def test_regex_metacharacters_escaped(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            "<testsuite>"
+            '  <testcase classname="tempest.api.v3.Foo+Bar"'
+            '            name="test_q[id-x]">'
+            "    <failure/>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        rc, out, _ = self._run(junit)
+        self.assertEqual(rc, 0)
+        line = out.strip()
+        # classname dots escaped
+        self.assertIn(r"tempest\.api\.v3", line)
+        # + character escaped (regex metachar)
+        self.assertIn(r"\+", line)
+        # still the anchored form
+        self.assertTrue(line.startswith("^"))
+        self.assertTrue(line.endswith(r"(\[|$)"))
+
+    def test_no_failures_produces_no_output(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            "<testsuite>"
+            '  <testcase classname="pkg.C" name="test_ok"/>'
+            "</testsuite>"
+        )
+        rc, out, _ = self._run(junit)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.strip(), "")
+
+    def test_mixed_failure_and_error_both_listed(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            "<testsuite>"
+            '  <testcase classname="pkg.C" name="f_method">'
+            "    <failure/>"
+            "  </testcase>"
+            '  <testcase classname="pkg.C" name="e_method">'
+            "    <error/>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        rc, out, _ = self._run(junit)
+        self.assertEqual(rc, 0)
+        lines = sorted(out.strip().splitlines())
+        self.assertEqual(
+            lines,
+            [
+                r"^pkg\.C\.e_method(\[|$)",
+                r"^pkg\.C\.f_method(\[|$)",
+            ],
+        )
+
+    def test_missing_file_returns_error(self) -> None:
+        rc, _, err = self._run("/nonexistent/path/junit.xml")
+        self.assertEqual(rc, 1)
+        self.assertIn("error reading", err)
+
+    def test_malformed_xml_returns_error(self) -> None:
+        junit = self._write_junit("this is not xml")
+        rc, _, err = self._run(junit)
+        self.assertEqual(rc, 1)
+        self.assertIn("error reading", err)
+
+
+class RewriteJunitTests(_JunitFixtureMixin, unittest.TestCase):
+    def test_resolved_failure_rewritten_as_flake(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuites errors="0" failures="1">'
+            '  <testsuite name="tempest" tests="1" failures="1" errors="0">'
+            '    <testcase classname="pkg.C" name="test_bad">'
+            "      <failure>boom</failure>"
+            "    </testcase>"
+            "  </testsuite>"
+            "</testsuites>"
+        )
+        fixed, still = merge_retry_junit.rewrite_junit(
+            junit, {"pkg.C.test_bad"}
+        )
+        self.assertEqual((fixed, still), (1, 0))
+
+        root = ET.parse(junit).getroot()
+        self.assertEqual(root.attrib["failures"], "0")
+        ts = root.find("testsuite")
+        assert ts is not None
+        self.assertEqual(ts.attrib["failures"], "0")
+        tc = ts.find("testcase")
+        assert tc is not None
+        self.assertIsNone(tc.find("failure"))
+        sysout = tc.find("system-out")
+        assert sysout is not None
+        self.assertIn("flaky", sysout.text or "")
+
+    def test_still_failing_left_untouched(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuite name="tempest" tests="1" failures="1" errors="0">'
+            '  <testcase classname="pkg.C" name="test_bad">'
+            "    <failure>boom</failure>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        fixed, still = merge_retry_junit.rewrite_junit(junit, set())
+        self.assertEqual((fixed, still), (0, 1))
+
+        root = ET.parse(junit).getroot()
+        self.assertEqual(root.attrib["failures"], "1")
+        tc = root.find("testcase")
+        assert tc is not None
+        self.assertIsNotNone(tc.find("failure"))
+
+    def test_mixed_failure_and_error_decrements_both_counters(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuites errors="1" failures="1">'
+            '  <testsuite name="tempest" tests="1" failures="1" errors="1">'
+            '    <testcase classname="pkg.C" name="test_bad">'
+            "      <failure>boom</failure>"
+            "      <error>also boom</error>"
+            "    </testcase>"
+            "  </testsuite>"
+            "</testsuites>"
+        )
+        fixed, _ = merge_retry_junit.rewrite_junit(
+            junit, {"pkg.C.test_bad"}
+        )
+        self.assertEqual(fixed, 1)
+
+        root = ET.parse(junit).getroot()
+        self.assertEqual(root.attrib["failures"], "0")
+        self.assertEqual(root.attrib["errors"], "0")
+        ts = root.find("testsuite")
+        assert ts is not None
+        self.assertEqual(ts.attrib["failures"], "0")
+        self.assertEqual(ts.attrib["errors"], "0")
+
+    def test_parametrized_variants_handled_independently(self) -> None:
+        # Regression test for W-001: one variant passes on retry, another
+        # still fails. Only the passing variant must be rewritten.
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuites errors="0" failures="2">'
+            '  <testsuite name="tempest" tests="2" failures="2" errors="0">'
+            '    <testcase classname="pkg.C" name="test_bad[id-ok]">'
+            "      <failure>boom</failure>"
+            "    </testcase>"
+            '    <testcase classname="pkg.C" name="test_bad[id-still-bad]">'
+            "      <failure>boom</failure>"
+            "    </testcase>"
+            "  </testsuite>"
+            "</testsuites>"
+        )
+        fixed, still = merge_retry_junit.rewrite_junit(
+            junit, {"pkg.C.test_bad[id-ok]"}
+        )
+        self.assertEqual((fixed, still), (1, 1))
+
+        root = ET.parse(junit).getroot()
+        self.assertEqual(root.attrib["failures"], "1")
+        ts = root.find("testsuite")
+        assert ts is not None
+        self.assertEqual(ts.attrib["failures"], "1")
+
+        cases = {
+            tc.attrib["name"]: tc for tc in ts.findall("testcase")
+        }
+        self.assertIsNone(cases["test_bad[id-ok]"].find("failure"))
+        self.assertIsNotNone(
+            cases["test_bad[id-still-bad]"].find("failure")
+        )
+
+    def test_empty_passed_on_retry_is_noop(self) -> None:
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuite name="tempest">'
+            '  <testcase classname="pkg.C" name="test_ok"/>'
+            "</testsuite>"
+        )
+        fixed, still = merge_retry_junit.rewrite_junit(junit, set())
+        self.assertEqual((fixed, still), (0, 0))
+
+    def test_non_numeric_counter_does_not_crash(self) -> None:
+        # Regression test for I-001: a malformed counter attribute must not
+        # take down the whole merge.
+        junit = self._write_junit(
+            '<?xml version="1.0"?>'
+            '<testsuite name="tempest" failures="NaN" errors="0">'
+            '  <testcase classname="pkg.C" name="test_bad">'
+            "    <failure>boom</failure>"
+            "  </testcase>"
+            "</testsuite>"
+        )
+        fixed, _ = merge_retry_junit.rewrite_junit(
+            junit, {"pkg.C.test_bad"}
+        )
+        self.assertEqual(fixed, 1)
+
+        root = ET.parse(junit).getroot()
+        # Counter left as-is (unparseable) but the testcase was still
+        # rewritten without an exception.
+        self.assertEqual(root.attrib["failures"], "NaN")
+        tc = root.find("testcase")
+        assert tc is not None
+        self.assertIsNone(tc.find("failure"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
After both phase-1-core and phase-2-plugin finish, the runners now extract any failed or errored testcases from the initial JUnit report and rerun them once with stestr --concurrency 1. Tests that pass on retry are rewritten in the JUnit report as flakes (failure/error children removed, suite counters decremented, system-out note added) so only tests that still fail after retry count against the job exit code. Resolves the intermittent SystemMemberTests.test_identity_list_role_assignments failure in the 2025.2 matrix row without serializing the whole plugin suite.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com