### PR TITLE
feat(kind): Add Headlamp UI with Flux plugin for live demos

### DIFF
--- a/deploy/kind/base/headlamp.yaml
+++ b/deploy/kind/base/headlamp.yaml
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Headlamp Kubernetes UI (kind-only demo addon).
+#
+# Bundled with the official Flux plugin (headlamp-k8s/plugins) via an
+# init-container that copies the plugin bundle into an emptyDir mounted
+# at /build/plugins. The main container discovers plugins through
+# config.pluginsDir.
+#
+# This manifest is deployed only from the kind overlay
+# (deploy/kind/base/kustomization.yaml) and NEVER reaches
+# deploy/flux-system/ — an unauthenticated web UI has no place in
+# production clusters.
+#
+# Access in the quick-start guide is via kubectl port-forward + a
+# short-lived ServiceAccount token bound to read-only RBAC (view
+# ClusterRole plus the headlamp-flux-viewer ClusterRole defined below,
+# which covers the Flux toolkit API groups and forge-stack CRs).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlamp-system
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/headlamp/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: headlamp-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: headlamp
+      version: ">=0.41.0 <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp
+        namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 1
+    serviceAccount:
+      create: true
+      name: headlamp
+    service:
+      type: ClusterIP
+      port: 80
+    config:
+      pluginsDir: /build/plugins
+    initContainers:
+      - name: headlamp-plugins
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+          - cp -r /plugins/. /build/plugins/
+        volumeMounts:
+          - name: headlamp-plugins
+            mountPath: /build/plugins
+    volumes:
+      - name: headlamp-plugins
+        emptyDir: {}
+    volumeMounts:
+      - name: headlamp-plugins
+        mountPath: /build/plugins
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+---
+# Read-only ClusterRole covering the Flux toolkit API groups and the
+# forge-stack CRDs. The built-in `view` role (bound below) does not
+# know about these groups, so the UI would otherwise show empty panes.
+#
+# Resources are enumerated explicitly rather than using ["*"] so the
+# demo RBAC stays close to least-privilege: the role only grants read
+# access to the kinds the Headlamp Flux plugin actually renders and the
+# forge-stack CRs that the quick-start walks through.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: headlamp-flux-viewer
+rules:
+  # Flux source-controller — the plugin's "Sources" pane.
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - buckets
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs: ["get", "list", "watch"]
+  # Flux helm-controller — the plugin's "Helm Releases" pane.
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  # Flux kustomize-controller — the plugin's "Kustomizations" pane.
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch"]
+  # Flux notification-controller — the plugin's "Notifications" pane.
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources: ["alerts", "providers", "receivers"]
+    verbs: ["get", "list", "watch"]
+  # Flux image-automation — the plugin's "Image Automation" pane.
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources:
+      - imagepolicies
+      - imagerepositories
+      - imageupdateautomations
+    verbs: ["get", "list", "watch"]
+  # CRDs — needed so the plugin can discover which groups are served.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  # forge-stack CRs the quick-start walkthrough reconciles.
+  - apiGroups: ["keystone.openstack.c5c3.io"]
+    resources: ["keystones"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["memcached.c5c3.io"]
+    resources: ["memcacheds"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["k8s.mariadb.com"]
+    resources: ["mariadbs", "databases", "users", "grants"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - clustersecretstores
+      - externalsecrets
+      - secretstores
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificaterequests
+      - certificates
+      - clusterissuers
+      - issuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: headlamp
+    namespace: headlamp-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-flux-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: headlamp-flux-viewer
+subjects:
+  - kind: ServiceAccount
+    name: headlamp
+    namespace: headlamp-system

--- a/deploy/kind/base/kustomization.yaml
+++ b/deploy/kind/base/kustomization.yaml
@@ -14,6 +14,8 @@ kind: Kustomization
 
 resources:
   - ../../flux-system
+  # Headlamp UI — kind-only demo addon (see headlamp.yaml header).
+  - headlamp.yaml
 
 patches:
   - target:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -130,7 +130,12 @@ external-secrets      external-secrets-*     Ready
 openbao-system        openbao-0              Ready (unsealed)
 openstack             openstack-db-*         Ready (MariaDB cluster)
 openstack             openstack-memcached-*  Ready (Memcached cluster)
+headlamp-system       headlamp-*             Starting (kind-only demo UI, not waited on)
 ```
+
+Headlamp is deployed asynchronously and is **not** part of the `deploy-infra` wait list — a
+broken upstream chart release must never block E2E runs. Step 4 below waits for it explicitly
+at the point you actually need the UI.
 
 The `openstack` namespace also holds the synced secrets:
 
@@ -142,7 +147,29 @@ openstack   keystone-db           (database credentials from OpenBao)
 
 ---
 
-## Step 4 — Deploy the Keystone operator
+## Step 4 — Open the Headlamp UI
+
+The kind overlay ships [Headlamp](https://headlamp.dev/) with the Flux plugin preloaded, so
+you can watch Steps 5–9 reconcile live. Wait for the HelmRelease to become Ready, then
+get a token, port-forward, and open the UI:
+
+```bash
+kubectl wait helmrelease/headlamp \
+  -n headlamp-system \
+  --for=condition=Ready \
+  --timeout=300s
+
+kubectl create token headlamp -n headlamp-system --duration=8h
+kubectl port-forward svc/headlamp -n headlamp-system 8080:80
+```
+
+Open `http://localhost:8080`, paste the token. The sidebar shows **Flux → Helm Releases /
+Kustomizations / Sources** alongside the standard resources. The `headlamp` ServiceAccount is
+bound to a read-only ClusterRole covering Flux toolkit API groups and forge-stack CRDs.
+
+---
+
+## Step 5 — Deploy the Keystone operator
 
 The Keystone operator is distributed as a Helm chart. There are two ways to deploy it depending on
 your goal.
@@ -211,7 +238,7 @@ keystone-operator-6d7f9f4d5b-xyz99   1/1     Running   0          30s
 
 ---
 
-## Step 5 — Build and load the Keystone service image
+## Step 6 — Build and load the Keystone service image
 
 The `Keystone` CR references a service image that runs the actual OpenStack Keystone API. Either
 pull the pre-built image from GHCR or build it locally.
@@ -263,11 +290,11 @@ kind load docker-image "ghcr.io/c5c3/keystone:${RELEASE}" --name forge-e2e
 
 ---
 
-## Step 6 — Create a Keystone CR
+## Step 7 — Create a Keystone CR
 
 Apply the following manifest to deploy a Keystone instance in **managed mode**. In this mode the
 operator creates and manages the MariaDB database (via `clusterRef`) and configures Memcached
-for session caching. Replace `<RELEASE>` with the same value used in Step 5 (e.g. `2025.2`):
+for session caching. Replace `<RELEASE>` with the same value used in Step 6 (e.g. `2025.2`):
 
 ```yaml
 # keystone.yaml
@@ -280,7 +307,7 @@ spec:
   replicas: 3
   image:
     repository: ghcr.io/c5c3/keystone
-    tag: "<RELEASE>"   # e.g. 2025.2 — must match the image loaded in Step 5
+    tag: "<RELEASE>"   # e.g. 2025.2 — must match the image loaded in Step 6
   database:
     clusterRef:
       name: openstack-db
@@ -307,7 +334,7 @@ kubectl apply -f keystone.yaml
 
 ---
 
-## Step 7 — Wait for Keystone to become Ready
+## Step 8 — Wait for Keystone to become Ready
 
 The operator reconciles the CR through five sequential sub-conditions before the aggregate
 `Ready` condition is set:
@@ -343,7 +370,7 @@ keystone.keystone.openstack.c5c3.io/keystone condition met
 
 ---
 
-## Step 8 — Verify the deployment
+## Step 9 — Verify the deployment
 
 ### Check all owned resources
 
@@ -467,7 +494,7 @@ JUnit XML reports are written to `_output/reports/` after each run.
 
 ## Running Tempest API tests
 
-With the Keystone CR Ready from Step 7, validate the identity API with the OpenStack Tempest
+With the Keystone CR Ready from Step 8, validate the identity API with the OpenStack Tempest
 test suite:
 
 ```bash


### PR DESCRIPTION
Deploys Headlamp as a kind-only demo addon so operators can watch HelmReleases, Kustomizations, Pods and forge-stack CRDs reconcile live in a browser during the quick-start walkthrough. Never reaches deploy/flux-system/ — an unauthenticated web UI has no place in production.

- deploy/kind/base/headlamp.yaml: Namespace, HelmRepository (pinned to headlamp >=0.41.0 <1.0.0), HelmRelease with the Flux plugin preloaded via init-container (pinned to headlamp-plugin-flux:0.6.0), and read-only RBAC (view ClusterRole plus a custom headlamp-flux- viewer covering the Flux toolkit API groups and forge-stack CRDs).
- deploy/kind/base/kustomization.yaml: wire headlamp.yaml into the overlay. Headlamp is intentionally NOT added to the deploy-infra.sh wait list so it cannot block E2E runs.
- docs/quick-start.md: new optional Step 4 that brings up the UI immediately after 'make deploy-infra', with port-forward + short- lived token flow. Existing Steps 4-8 renumbered to 5-9; internal cross-references updated accordingly.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com