### PR TITLE
perf(images): speed up APT downloads with cache mounts, retries, and …

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -123,6 +123,8 @@ jobs:
           context: images/python-base
           platform: ${{ matrix.platform }}
           platform-pair: ${{ steps.platform-pair.outputs.value }}
+          build-args: |
+            APT_MIRROR=http://azure.archive.ubuntu.com
           labels-title: python-base
           labels-description: Python runtime base image for OpenStack services
           extra-labels: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,7 +446,9 @@ jobs:
       # reuse them via the skip-if-exists guard in ci-build-service-image.sh.
       - name: Build base images
         run: |
-          docker build -t python-base images/python-base/
+          docker build -t python-base \
+            --build-arg APT_MIRROR=http://azure.archive.ubuntu.com \
+            images/python-base/
           docker build -t venv-builder images/venv-builder/
 
       # Build operator images for all resolved operators (changed + keystone).

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -11,3 +11,4 @@
 ignored:
   - DL3006
   - DL3008
+  - DL3009  # apt lists are in --mount=type=cache, not in the image layer

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -54,7 +54,9 @@ COPY --from=build --link /var/lib/openstack /var/lib/openstack
 # "E: No packages specified" from apt-get. CI always provides packages
 # via the workflow's "Resolve extra packages" step.
 # hadolint ignore=DL3008
-RUN if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \
     rm -rf /var/lib/apt/lists/*; \

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -7,8 +7,24 @@ FROM ubuntu:noble@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e8769
 ENV PATH=/var/lib/openstack/bin:$PATH
 ENV LANG=C.UTF-8
 
+# Optional APT mirror override (e.g. https://azure.archive.ubuntu.com for
+# GitHub Actions runners).  When empty the default Ubuntu mirrors are kept.
+# On arm64 ports.ubuntu.com has no Azure equivalent so the sed is a no-op.
+ARG APT_MIRROR=""
+RUN if [ -n "$APT_MIRROR" ]; then \
+        sed -i \
+            -e "s|http://archive.ubuntu.com|${APT_MIRROR}|g" \
+            -e "s|http://security.ubuntu.com|${APT_MIRROR}|g" \
+            /etc/apt/sources.list.d/ubuntu.sources; \
+    fi && \
+    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
 # Runtime dependencies shared by all services
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+# Cache mounts speed up rebuilds under BuildKit; the trailing rm is a no-op
+# when the mount is active but keeps the layer clean on non-BuildKit engines.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     netbase \
     python3 \

--- a/images/venv-builder/Dockerfile
+++ b/images/venv-builder/Dockerfile
@@ -8,7 +8,9 @@ FROM python-base
 COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /bin/
 
 # Build dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     libffi-dev \


### PR DESCRIPTION
…Azure mirror

APT downloads during container image builds were slow and unreliable due to cold layer caches and transient mirror failures. This adds three complementary mitigations:

- BuildKit cache mounts for /var/cache/apt and /var/lib/apt/lists so downloaded .deb files persist across layer invalidations
- Acquire::Retries "3" in python-base to survive transient mirror errors
- Azure-hosted mirror replacement on amd64 runners (no-op on arm64)

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com