### PR TITLE
perf(ci): migrate test-integration and e2e-chaos to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,7 @@ jobs:
   test-integration:
     needs: [changes]
     if: needs.changes.outputs.go == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -609,7 +609,7 @@ jobs:
       needs.changes.outputs.e2e-chaos == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     continue-on-error: true
     steps:


### PR DESCRIPTION
Use faster Blacksmith runners for CI jobs that were still on ubuntu-latest: test-integration → blacksmith-2vcpu-ubuntu-2404, e2e-chaos → blacksmith-4vcpu-ubuntu-2404.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com