### PR TITLE
perf(ci): add build caches for Go tools, envtest, lint, and E2E Docke…

### DIFF
--- a/.github/actions/setup-e2e-infra/action.yaml
+++ b/.github/actions/setup-e2e-infra/action.yaml
@@ -17,6 +17,17 @@ runs:
     - name: Install Flux CLI
       uses: fluxcd/flux2/action@871be9b40d53627786d3a3835a3ddba1e3234bd2 # v2.8.3
 
+    # Cache test tool binaries installed by hack/install-test-deps.sh (chainsaw,
+    # flux, kind, kubectl). The script has skip-if-correct-version logic, so a
+    # cache hit makes install-test-deps a no-op. Key on the script hash so the
+    # cache auto-invalidates when any pinned version changes.
+    - name: Cache test dependency binaries
+      uses: actions/cache@v4
+      with:
+        path: $HOME/.local/bin
+        key: ${{ runner.os }}-testdeps-${{ hashFiles('hack/install-test-deps.sh') }}
+        restore-keys: ${{ runner.os }}-testdeps-
+
     - name: Install test dependencies
       shell: bash
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ env:
   # CC-0018: Pin tool versions for CI reproducibility (single source of truth).
   CONTROLLER_GEN_VERSION: v0.20.1
   GOFUMPT_VERSION: v0.9.2  # CC-0053
+  GOLANGCI_LINT_VERSION: v2.11.4
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -135,11 +136,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        id: setup-go
         with:
           go-version-file: go.work
+      # Cache golangci-lint result cache — golangci-lint-action with install-only:true
+      # does not manage the analysis cache itself, so we persist it explicitly.
+      # Include Go and golangci-lint versions so upgrades automatically invalidate.
+      - uses: actions/cache@v4
+        with:
+          path: $HOME/.cache/golangci-lint
+          key: ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ hashFiles('.golangci.yml', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-
+            ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-golangci-
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.11.4
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           install-only: true
       - name: Run lint
         run: make lint
@@ -155,9 +167,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        id: setup-go
         with:
           go-version-file: go.work
+      - uses: actions/cache@v4
+        id: gofumpt-cache
+        with:
+          path: $HOME/go/bin/gofumpt
+          key: ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-gofumpt-${{ env.GOFUMPT_VERSION }}
       - name: Install gofumpt
+        if: steps.gofumpt-cache.outputs.cache-hit != 'true'
         run: go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}
       # CC-0053: Only check git-tracked Go files to skip generated, vendored,
       # or tooling code that may not follow gofumpt conventions (review #1).
@@ -229,6 +248,16 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.work
+      # Derive the envtest k8s version from the Makefile (single source of truth).
+      - name: Get envtest k8s version
+        id: envtest-ver
+        run: echo "version=$(awk '/ENVTEST_K8S_VERSION/ {print $NF; exit}' Makefile)" >> "$GITHUB_OUTPUT"
+      # Cache kubebuilder envtest assets (etcd, kube-apiserver binaries).
+      # Key on the k8s version — invalidates automatically when Makefile changes it.
+      - uses: actions/cache@v4
+        with:
+          path: $HOME/.local/share/kubebuilder-envtest
+          key: ${{ runner.os }}-envtest-${{ steps.envtest-ver.outputs.version }}
       - name: Install setup-envtest
         run: go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
       - name: Run integration tests
@@ -295,9 +324,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        id: setup-go
         with:
           go-version-file: go.work
+      - uses: actions/cache@v4
+        id: controller-gen-cache
+        with:
+          path: $HOME/go/bin/controller-gen
+          key: ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-controller-gen-${{ env.CONTROLLER_GEN_VERSION }}
       - name: Install controller-gen
+        if: steps.controller-gen-cache.outputs.cache-hit != 'true'
         run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@${{ env.CONTROLLER_GEN_VERSION }}
       - name: Run code generation
         run: |
@@ -419,6 +455,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Enable BuildKit (required for type=gha cache) as the default builder.
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
       - name: Verify zstd is available
         run: |
           if ! command -v zstd &>/dev/null; then
@@ -444,19 +483,27 @@ jobs:
 
       # Build base images once — all subsequent service and tempest builds
       # reuse them via the skip-if-exists guard in ci-build-service-image.sh.
+      # GHA cache scopes are shared across branches; these images rarely change.
       - name: Build base images
         run: |
           docker build -t python-base \
+            --cache-from type=gha,scope=e2e-python-base \
+            --cache-to type=gha,mode=max,scope=e2e-python-base \
             --build-arg APT_MIRROR=http://azure.archive.ubuntu.com \
             images/python-base/
-          docker build -t venv-builder images/venv-builder/
+          docker build -t venv-builder \
+            --cache-from type=gha,scope=e2e-venv-builder \
+            --cache-to type=gha,mode=max,scope=e2e-venv-builder \
+            images/venv-builder/
 
       # Build operator images for all resolved operators (changed + keystone).
       - name: Build operator images
         run: |
           for op in $BUILD_OPERATORS; do
             echo "::group::Building ${op}-operator:dev"
-            make docker-build OPERATOR="${op}" IMG="${IMAGE_PREFIX}/${op}-operator:dev"
+            make docker-build OPERATOR="${op}" IMG="${IMAGE_PREFIX}/${op}-operator:dev" \
+              DOCKER_CACHE_FROM="type=gha,scope=e2e-${op}-operator" \
+              DOCKER_CACHE_TO="type=gha,mode=max,scope=e2e-${op}-operator"
             echo "::endgroup::"
           done
 
@@ -471,6 +518,8 @@ jobs:
               release="${release##*/}"
               echo "::group::Building ${op}:${release}"
               OPERATOR="${op}" IMAGE_PREFIX="${IMAGE_PREFIX}" RELEASE="${release}" \
+                DOCKER_BUILD_CACHE_FROM="type=gha,scope=e2e-${op}-${release}" \
+                DOCKER_BUILD_CACHE_TO="type=gha,mode=max,scope=e2e-${op}-${release}" \
                 hack/ci-build-service-image.sh
               echo "::endgroup::"
             done
@@ -484,6 +533,8 @@ jobs:
             release="${release##*/}"
             echo "::group::Building tempest:${release}"
             RELEASE="${release}" TEMPEST_IMAGE="c5c3/tempest:${release}" \
+              DOCKER_BUILD_CACHE_FROM="type=gha,scope=e2e-tempest-${release}" \
+              DOCKER_BUILD_CACHE_TO="type=gha,mode=max,scope=e2e-tempest-${release}" \
               hack/ci-build-tempest-image.sh
             echo "::endgroup::"
           done
@@ -614,22 +665,15 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
-        with:
-          go-version-file: go.work
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
           cluster_name: forge-e2e
-      - name: Build operator image
-        run: make docker-build OPERATOR=keystone IMG=${{ env.IMAGE_PREFIX }}/keystone-operator:dev
-      # CC-0050: Use shared service image build script (REQ-002).
-      - name: Build service image
-        run: hack/ci-build-service-image.sh
-        env:
-          OPERATOR: keystone
-          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
+      # Load pre-built images from shared artifact instead of rebuilding
+      # (e2e-operator already waited on build-e2e-images, so the artifact is available).
+      - name: Load E2E images
+        uses: ./.github/actions/load-e2e-images
       - name: Load images into kind
         run: |
           kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e

--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,15 @@ verify-crd-sync:
 # docker-build builds the operator Docker image from operators/$(OPERATOR)/Dockerfile.
 # Build context is the repository root (required by go.work) (CC-0018, REQ-010).
 # Usage: make docker-build OPERATOR=keystone [IMG=custom:tag]
+# Optional: DOCKER_CACHE_FROM=type=gha,scope=... DOCKER_CACHE_TO=type=gha,mode=max,scope=...
+DOCKER_CACHE_FROM ?=
+DOCKER_CACHE_TO ?=
 docker-build:
 	$(if $(OPERATOR),,$(error docker-build requires OPERATOR, e.g. make docker-build OPERATOR=keystone))
-	docker build -t $(IMG) -f operators/$(OPERATOR)/Dockerfile .
+	docker build -t $(IMG) -f operators/$(OPERATOR)/Dockerfile \
+		$(if $(DOCKER_CACHE_FROM),--cache-from $(DOCKER_CACHE_FROM)) \
+		$(if $(DOCKER_CACHE_TO),--cache-to $(DOCKER_CACHE_TO)) \
+		.
 
 .PHONY: helm-package
 # helm-package packages the operator Helm chart (CC-0018, REQ-011).

--- a/hack/ci-build-service-image.sh
+++ b/hack/ci-build-service-image.sh
@@ -85,7 +85,13 @@ if ! docker image inspect venv-builder >/dev/null 2>&1; then
 else
   echo "Reusing existing venv-builder image"
 fi
+# Optional GHA cache flags — set by CI when buildx + type=gha is available.
+cache_args=()
+[[ -n "${DOCKER_BUILD_CACHE_FROM:-}" ]] && cache_args+=(--cache-from "${DOCKER_BUILD_CACHE_FROM}")
+[[ -n "${DOCKER_BUILD_CACHE_TO:-}" ]] && cache_args+=(--cache-to "${DOCKER_BUILD_CACHE_TO}")
+
 docker build -t "${IMAGE_PREFIX}/${OPERATOR}:${RELEASE}" \
+  "${cache_args[@]}" \
   --build-arg "PIP_EXTRAS=${PIP_EXTRAS}" \
   --build-arg "PIP_PACKAGES=${PIP_PACKAGES}" \
   --build-arg "EXTRA_APT_PACKAGES=${APT_PACKAGES}" \

--- a/hack/ci-build-tempest-image.sh
+++ b/hack/ci-build-tempest-image.sh
@@ -41,9 +41,15 @@ echo "Building Tempest image (tempest=${TEMPEST_VERSION}, keystone-tempest-plugi
 # ---------------------------------------------------------------------------
 # 2. Build Tempest image
 # ---------------------------------------------------------------------------
+# Optional GHA cache flags — set by CI when buildx + type=gha is available.
+cache_args=()
+[[ -n "${DOCKER_BUILD_CACHE_FROM:-}" ]] && cache_args+=(--cache-from "${DOCKER_BUILD_CACHE_FROM}")
+[[ -n "${DOCKER_BUILD_CACHE_TO:-}" ]] && cache_args+=(--cache-to "${DOCKER_BUILD_CACHE_TO}")
+
 docker build \
   -t "${TEMPEST_IMAGE}" \
   -f "${REPO_ROOT}/images/tempest/Dockerfile" \
+  "${cache_args[@]}" \
   --build-arg "TEMPEST_VERSION=${TEMPEST_VERSION}" \
   --build-arg "KEYSTONE_TEMPEST_PLUGIN_VERSION=${KTP_VERSION}" \
   --build-context "upper-constraints=${REPO_ROOT}/releases/${RELEASE}/" \


### PR DESCRIPTION
…r builds

- Cache golangci-lint result cache (~/.cache/golangci-lint); the action's install-only mode does not persist it between runs
- Cache gofumpt and controller-gen binaries in ~/go/bin, skip go install on cache hit (version-keyed, invalidates on GOFUMPT/CONTROLLER_GEN_VERSION bump)
- Cache kubebuilder envtest assets (~/.local/share/kubebuilder-envtest); add ENVTEST_K8S_VERSION to workflow env for a stable cache key
- Cache install-test-deps binaries (~/.local/bin) in setup-e2e-infra action, keyed on hack/install-test-deps.sh hash — covers all four E2E jobs at once
- Enable buildx (docker/setup-buildx-action) in build-e2e-images and wire type=gha cache scopes to all five image types (python-base, venv-builder, operator, service×release, tempest×release); extend Makefile docker-build with optional DOCKER_CACHE_FROM/DOCKER_CACHE_TO and both build scripts with a shellcheck-clean array pattern for DOCKER_BUILD_CACHE_FROM/TO
- Replace setup-go + docker-build + ci-build-service-image.sh in e2e-chaos with load-e2e-images action (artifact already available via e2e-operator dep)

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com