### PR TITLE
perf(ci): cache kind node image and parallelise kind load

### DIFF
--- a/.github/actions/create-kind-cluster/action.yaml
+++ b/.github/actions/create-kind-cluster/action.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Composite action for kind cluster creation with node image caching.
+# Caches the kindest/node image tar between CI runs to avoid re-downloading
+# ~700 MB from Docker Hub on every E2E job.  On cache hit the image is
+# pre-loaded into Docker before kind create, so kind skips the pull entirely.
+# All four E2E jobs (e2e-infra, e2e-operator, e2e-chaos, tempest) use this
+# action so the cache is shared and only populated once per image version.
+
+name: Create kind cluster
+description: >
+  Creates a kind cluster with node image caching. Restores the kindest/node
+  image from cache before cluster creation and saves it after a cache miss.
+  Assumes the caller has already checked out the repository.
+
+inputs:
+  cluster-name:
+    description: Name of the kind cluster
+    required: false
+    default: forge-e2e
+  node-image:
+    description: >
+      Pinned kind node image (e.g. kindest/node:v1.32.2). Must match the
+      KIND_NODE_IMAGE workflow env var so the cache key is stable across jobs.
+    required: true
+  config:
+    description: Path to kind cluster config file
+    required: false
+    default: hack/kind-config.yaml
+
+runs:
+  using: composite
+  steps:
+    # Restore the kindest/node tar from the GHA cache.  On a hit the image is
+    # already in Docker's store before kind create runs, so kind skips the pull
+    # and saves the ~700 MB download.
+    - name: Restore kind node image cache
+      id: kind-image-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/kind-node.tar
+        key: kind-node-${{ inputs.node-image }}
+
+    - name: Load kind node image from cache
+      if: steps.kind-image-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load < /tmp/kind-node.tar
+
+    - name: Create kind cluster
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+      with:
+        config: ${{ inputs.config }}
+        cluster_name: ${{ inputs.cluster-name }}
+        node_image: ${{ inputs.node-image }}
+
+    # Persist the image for subsequent runs.  Runs only on a cache miss so we
+    # do not re-write an unchanged tar on every run.
+    - name: Save kind node image to cache
+      if: steps.kind-image-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: docker save ${{ inputs.node-image }} > /tmp/kind-node.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ env:
   CONTROLLER_GEN_VERSION: v0.20.1
   GOFUMPT_VERSION: v0.9.2  # CC-0053
   GOLANGCI_LINT_VERSION: v2.11.4
+  # Pinned kind node image — shared cache key for all E2E jobs.
+  # To update: change tag + digest and run one E2E job to repopulate the cache.
+  KIND_NODE_IMAGE: kindest/node:v1.35.1@sha256:b08d1f9b5244fb2aae7bea9861c1d372a9535f259efed62a9e92e6b5ab500529
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -413,10 +416,9 @@ jobs:
         with:
           go-version-file: go.work
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        uses: ./.github/actions/create-kind-cluster
         with:
-          config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          node-image: ${{ env.KIND_NODE_IMAGE }}
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra
@@ -596,10 +598,9 @@ jobs:
         with:
           go-version-file: go.work
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        uses: ./.github/actions/create-kind-cluster
         with:
-          config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          node-image: ${{ env.KIND_NODE_IMAGE }}
       # Load pre-built images from shared artifact instead of building.
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
@@ -608,10 +609,15 @@ jobs:
           # Tag the service image with the upgrade tag used by the image-upgrade E2E test.
           docker tag ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2 \
             ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2-upgraded
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2 --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2-upgraded --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2026.1 --name forge-e2e
+          # Load images in parallel; track each PID so any failure is surfaced.
+          pids=()
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}-operator:dev --name forge-e2e & pids+=($!)
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2 --name forge-e2e & pids+=($!)
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2025.2-upgraded --name forge-e2e & pids+=($!)
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/${{ matrix.operator }}:2026.1 --name forge-e2e & pids+=($!)
+          failed=0
+          for pid in "${pids[@]}"; do wait "$pid" || failed=1; done
+          exit "$failed"
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra
@@ -666,18 +672,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        uses: ./.github/actions/create-kind-cluster
         with:
-          config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          node-image: ${{ env.KIND_NODE_IMAGE }}
       # Load pre-built images from shared artifact instead of rebuilding
       # (e2e-operator already waited on build-e2e-images, so the artifact is available).
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
       - name: Load images into kind
         run: |
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name forge-e2e
+          # Load images in parallel; track each PID so any failure is surfaced.
+          pids=()
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e & pids+=($!)
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name forge-e2e & pids+=($!)
+          failed=0
+          for pid in "${pids[@]}"; do wait "$pid" || failed=1; done
+          exit "$failed"
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra
@@ -729,18 +739,22 @@ jobs:
         with:
           go-version-file: go.work
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        uses: ./.github/actions/create-kind-cluster
         with:
-          config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          node-image: ${{ env.KIND_NODE_IMAGE }}
       # -- Keystone --------------------------------------------------------
       # Load pre-built images from shared artifact instead of building.
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
       - name: Load images into kind
         run: |
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:${{ matrix.release }} --name forge-e2e
+          # Load images in parallel; track each PID so any failure is surfaced.
+          pids=()
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e & pids+=($!)
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:${{ matrix.release }} --name forge-e2e & pids+=($!)
+          failed=0
+          for pid in "${pids[@]}"; do wait "$pid" || failed=1; done
+          exit "$failed"
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -11,3 +11,15 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    # Disable leader election for scheduler and controller-manager.
+    # In a single-node CI cluster there is only one instance of each component,
+    # so leader election adds ~5 s of startup delay with no benefit.
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        scheduler:
+          extraArgs:
+            leader-elect: "false"
+        controllerManager:
+          extraArgs:
+            leader-elect: "false"


### PR DESCRIPTION
Adds a create-kind-cluster composite action that caches the kindest/node image (~700 MB) between CI runs via actions/cache, so all four E2E jobs skip the Docker Hub pull on cache hit.  kind load calls are parallelised with & + wait to remove sequential transfer overhead.  leader-elect is disabled for scheduler and controller-manager in kind-config.yaml, saving ~5 s of control-plane startup in single-node CI clusters.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com