### PR TITLE
docs: add observability, day-2, and advanced configuration guides

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,6 +19,14 @@ export default defineConfig({
         ],
       },
       {
+        text: 'Guides',
+        items: [
+          { text: 'Observability & Diagnostics', link: '/guides/observability' },
+          { text: 'Day 2 Operations', link: '/guides/day-2-operations' },
+          { text: 'Advanced Configuration', link: '/guides/advanced-configuration' },
+        ],
+      },
+      {
         text: 'Reference',
         items: [
           { text: 'Keystone CRD', link: '/reference/keystone-crd' },

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -1,0 +1,209 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Advanced Configuration
+
+Beyond the minimal `Keystone` CR from the [Quick Start](../quick-start.md), the operator
+supports a number of configuration options for real cluster deployments. This guide
+walks through the four that cover the most common real-world needs and points to the
+reference for the rest.
+
+**Prerequisites:** A running Keystone CR from the [Quick Start](../quick-start.md).
+Each pattern below is an independent recipe — apply only what you need.
+
+---
+
+## Brownfield database
+
+The Quick Start uses the "managed mode" where the operator creates the `MariaDB`
+Database, User, and Grant CRs for you (`spec.database.clusterRef`). If you already run
+MariaDB/Galera outside the operator's reach — managed by another team, hosted
+externally, or on a different operator — use **brownfield mode** with an explicit host.
+
+```yaml
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone
+  namespace: openstack
+spec:
+  replicas: 1
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    # brownfield: explicit host/port, no clusterRef
+    host: mariadb.db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    # brownfield cache: explicit server list, no clusterRef
+    servers:
+      - "memcached.cache.example.com:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+```
+
+::: warning In brownfield mode you own schema setup
+The operator does **not** create the database, user, or grants. You must provision
+them before the CR reconciles:
+
+```sql
+CREATE DATABASE keystone DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE USER 'keystone'@'%' IDENTIFIED BY '<password-from-secretRef>';
+GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%';
+FLUSH PRIVILEGES;
+```
+
+The secret referenced by `secretRef` must contain a `password` key matching the SQL
+user. Once those exist, `db_sync` will create the Keystone schema on first reconcile.
+:::
+
+The webhook enforces that exactly one of `clusterRef` or `host` is set — never both —
+for both `database` and `cache`.
+
+---
+
+## Autoscaling (HPA)
+
+Replace hand-patching `spec.replicas` with a `HorizontalPodAutoscaler` managed by the
+operator. When `spec.autoscaling` is present, the HPA owns the Deployment's replica
+count.
+
+```yaml
+spec:
+  replicas: 3       # seeds the Deployment; HPA owns the Deployment replica count once created
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilization: 80
+    targetMemoryUtilization: 70
+```
+
+- At least one of `targetCPUUtilization` or `targetMemoryUtilization` is required.
+- `minReplicas` defaults to `spec.replicas` if unset — omitting it will floor the HPA at your current hand-set replica count, not at 1.
+- The generated HPA references `deploy/keystone-api` and uses the Kubernetes standard
+  `metrics-server`. The Quick Start kind cluster does **not** ship one — the HPA will
+  sit at `unknown/80%` until you install it:
+
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+  ```
+
+  On kind (and most development clusters that use self-signed kubelet certs) patch
+  the Deployment to skip TLS verification, otherwise `metrics-server` will fail to
+  scrape the kubelet:
+
+  ```bash
+  kubectl patch -n kube-system deploy/metrics-server --type=json \
+    -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+  ```
+
+Inspect the HPA:
+
+```bash
+kubectl get hpa -n openstack -l app.kubernetes.io/instance=keystone
+kubectl describe hpa keystone-api -n openstack
+```
+
+Removing `spec.autoscaling` deletes the HPA and returns replica control to
+`spec.replicas`. See [HPA Resource Mapping in the CRD reference](../reference/keystone-crd.md#hpa-resource-mapping)
+for the exact field-to-resource mapping.
+
+---
+
+## Network policy
+
+When set, `spec.networkPolicy` creates a Kubernetes `NetworkPolicy` that restricts
+ingress to the Keystone API pods. Egress rules for database, cache, and DNS are
+derived automatically from the rest of the CR — you only declare the ingress sources.
+
+```yaml
+spec:
+  networkPolicy:
+    ingress:
+      # Allow the ingress gateway to reach the Keystone API
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: envoy-gateway-system
+      # Allow the monitoring namespace to scrape metrics
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+```
+
+Each list entry supports `namespaceSelector` and/or `podSelector` (label-selector
+semantics) and an optional `ports` list. When the list is non-empty, all other ingress
+is blocked by default — **including kubelet probes from other namespaces, which is
+normally not an issue because probes originate from the node, but verify in your
+cluster topology.**
+
+Removing `spec.networkPolicy` deletes the NetworkPolicy and restores unrestricted
+traffic. See the [NetworkPolicy reference](../reference/keystone-crd.md#networkpolicyspec)
+for the auto-derived egress rules (Keystone API → MariaDB, Memcached, DNS).
+
+---
+
+## ExtraConfig — free-form INI sections
+
+The typed fields on the CR cover the supported configuration surface. For everything
+else — logging levels, oslo.messaging tuning, experimental Keystone flags —
+`spec.extraConfig` takes a `map[section][key] = value` that is rendered into the
+generated `keystone.conf`.
+
+```yaml
+spec:
+  extraConfig:
+    DEFAULT:
+      debug: "true"
+      log_dir: "/var/log/keystone"
+    token:
+      expiration: "43200"        # 12h instead of default 1h
+      allow_expired_window: "172800"
+    oslo_messaging_rabbit:
+      heartbeat_timeout_threshold: "60"
+```
+
+The operator does not validate the content of these sections. A typo becomes a silent
+no-op at best and a crash loop at worst — test changes in a lab before rolling out.
+A change to `extraConfig` triggers a ConfigMap rehash and a rolling Deployment update.
+
+---
+
+## Feature pointer table
+
+Everything else the CR supports — the flags you did not see above. One-line hints plus
+a link to the full reference.
+
+| Feature | Field | What it does | Reference |
+|---------|-------|--------------|-----------|
+| Credential-key rotation | `spec.credentialKeys` | Separate rotation schedule for the credential encryption key | [CredentialKeysSpec](../reference/keystone-crd.md#credentialkeysspec) |
+| Trust flush | `spec.trustFlush` | CronJob running `keystone-manage trust_flush` on a schedule | [TrustFlushSpec](../reference/keystone-crd.md#trustflushspec) |
+| uWSGI tuning | `spec.uwsgi` | Worker processes, threads, HTTP keep-alive | [UWSGISpec](../reference/keystone-crd.md#uwsgispec) |
+| Topology spread | `spec.topologySpreadConstraints` | Pod spread across zones/hostnames | [TopologySpreadConstraints](../reference/keystone-crd.md#topologyspreadconstraints) |
+| Priority class | `spec.priorityClassName` | Scheduling priority and preemption class | [PriorityClassName](../reference/keystone-crd.md#priorityclassname) |
+| Policy overrides | `spec.policyOverrides` | Custom `oslo.policy` rules (inline or ConfigMap) | [PolicySpec](../reference/keystone-crd.md#policyspec) |
+| Middleware | `spec.middleware` | Custom WSGI filters in the `api-paste.ini` pipeline | [MiddlewareSpec](../reference/keystone-crd.md#middlewarespec) |
+| Plugins | `spec.plugins` | Service-side Keystone plugins/drivers | [PluginSpec](../reference/keystone-crd.md#pluginspec) |
+| Federation | `spec.federation` | Enables Keystone federation (SAML/OIDC, Shibboleth) | [FederationSpec](../reference/keystone-crd.md#federationspec) |
+| Resource requests/limits | `spec.resources` | CPU/memory requests and limits on API pods | [KeystoneSpec](../reference/keystone-crd.md#keystonespec) |
+| Public endpoint | `spec.bootstrap.publicEndpoint` | External URL written to the Keystone service catalogue | [BootstrapSpec](../reference/keystone-crd.md#bootstrapspec) |
+
+---
+
+## Further reading
+
+- [Keystone CRD API Reference](../reference/keystone-crd.md) — complete field-by-field reference with validation rules and examples
+- [Observability & Diagnostics](./observability.md) — how to verify a new configuration took effect
+- [Day 2 Operations](./day-2-operations.md) — scale, upgrade, rotate using the configured CR

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -1,0 +1,157 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Day 2 Operations
+
+Three operational patterns you will use most often on a running Keystone CR: scaling,
+upgrading the OpenStack release, and rotating Fernet keys.
+
+**Prerequisites:** A running Keystone CR from the [Quick Start](../quick-start.md) (Steps 1–9).
+The examples assume the CR is named `keystone` in the `openstack` namespace.
+
+---
+
+## Scale replicas
+
+`spec.replicas` can be patched at any time; the operator updates the Deployment and the
+rollout is handled by Kubernetes.
+
+```bash
+kubectl patch keystone keystone -n openstack \
+  --type merge \
+  -p '{"spec":{"replicas":5}}'
+```
+
+Watch the rollout:
+
+```bash
+kubectl rollout status deploy/keystone-api -n openstack
+```
+
+Scale down the same way. With a `PodDisruptionBudget` in place (created by the operator
+based on `spec.replicas`), Kubernetes will not drain the last healthy pod during a
+voluntary disruption.
+
+::: tip Prefer autoscaling?
+For load-driven scaling use `spec.autoscaling` instead of hand-patching `spec.replicas`
+— see [Advanced Configuration — Autoscaling (HPA)](./advanced-configuration.md#autoscaling-hpa).
+The HPA then owns `spec.replicas` on the Deployment.
+:::
+
+---
+
+## Image upgrade with UpgradePhase
+
+Changing `spec.image.tag` to a newer OpenStack release triggers the operator's
+expand-migrate-contract pipeline. The API stays available throughout — old and new
+schemas coexist while data is migrated.
+
+```bash
+kubectl patch keystone keystone -n openstack \
+  --type merge \
+  -p '{"spec":{"image":{"tag":"2026.1"}}}'
+```
+
+Watch the four phases:
+
+```bash
+kubectl get keystone keystone -n openstack -w \
+  -o custom-columns=NAME:.metadata.name,PHASE:.status.upgradePhase,FROM:.status.installedRelease,TO:.status.targetRelease,READY:.status.conditions[?(@.type=='Ready')].status
+```
+
+Expected timeline:
+
+| Phase | What the operator does |
+|-------|------------------------|
+| `Expanding` | Runs `db_sync --expand` with the new image — adds columns/tables without dropping anything |
+| `Migrating` | Runs `db_sync --migrate` — copies/transforms data into new schema elements |
+| `RollingUpdate` | Updates the Deployment to the new image and waits for rollout |
+| `Contracting` | Runs `db_sync --contract` — drops old columns/tables that are no longer read |
+
+When all four complete successfully:
+
+- `.status.installedRelease` is set to the new tag
+- `.status.targetRelease` and `.status.upgradePhase` are cleared
+- A `UpgradeComplete` event is emitted
+
+::: warning Upgrade constraints
+Only **sequential** upgrades are supported: `2025.1 → 2025.2`, `2025.2 → 2026.1`,
+`2026.1 → 2026.2`. Skip-level jumps (e.g. `2024.2 → 2026.1`) and downgrades are
+rejected with `UpgradePathInvalid` or `DowngradeNotSupported` Warning events. Tags
+that differ only in patch suffix (`2025.2` → `2025.2-p1`) use the plain `db_sync`
+path — no upgrade pipeline.
+
+Full contract in [Keystone Upgrade Flow](../reference/keystone-upgrade-flow.md).
+:::
+
+### Rolling back a bad upgrade
+
+The upgrade pipeline is forward-only. If a new release is broken, the recovery path is
+to restore the database from backup, then patch `spec.image.tag` back. There is no
+`db_sync --downgrade`. Plan cut-overs around a maintenance window and a tested backup.
+
+---
+
+## Rotate Fernet keys manually
+
+The operator ships a `CronJob` that rotates the Fernet Secret on the schedule in
+`spec.fernet.rotationSchedule` (default weekly). You can trigger a rotation immediately
+without waiting for the cron job to fire — useful after a suspected key compromise.
+
+```bash
+# Trigger an on-demand rotation by creating a Job from the CronJob
+kubectl create job keystone-manual-fernet-rotate \
+  --from=cronjob/keystone-fernet-rotate \
+  -n openstack
+
+kubectl wait --for=condition=complete \
+  job/keystone-manual-fernet-rotate -n openstack --timeout=120s
+```
+
+Verify the Secret actually changed:
+
+```bash
+kubectl get secret keystone-fernet-keys -n openstack \
+  -o jsonpath='{.data}' | sha256sum
+```
+
+### What to expect
+
+- The Fernet key Secret now holds a new primary key. Older keys stay in the Secret
+  until `spec.fernet.maxActiveKeys` is exceeded — tokens issued before rotation
+  remain valid through the overlap window.
+- **No Deployment rollout happens.** The API pods pick up the new keys via the
+  Secret remount — their UIDs stay unchanged. Verify with:
+
+  ```bash
+  kubectl get pods -n openstack -l app.kubernetes.io/name=keystone \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\n"}{end}'
+  ```
+- The same pattern works for credential keys — if you have configured
+  `spec.credentialKeys`, use a distinct Job name so both rotation recipes can run
+  side-by-side without colliding:
+
+  ```bash
+  kubectl create job keystone-manual-credential-rotate \
+    --from=cronjob/keystone-credential-rotate \
+    -n openstack
+  ```
+
+::: tip Cleanup
+Manual rotation Jobs accumulate if you run them often — delete after verification:
+
+```bash
+kubectl delete job keystone-manual-fernet-rotate keystone-manual-credential-rotate -n openstack --ignore-not-found
+```
+:::
+
+---
+
+## Further reading
+
+- [Observability & Diagnostics](./observability.md) — reading conditions, events, and status fields while operations run
+- [Keystone Upgrade Flow](../reference/keystone-upgrade-flow.md) — state machine, job names, retry behavior
+- [Keystone Controller Events](../reference/keystone-events.md) — full event catalogue for upgrade, rotation, and scale events
+- [Advanced Configuration](./advanced-configuration.md) — brownfield DB, autoscaling, network policy, and more

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,168 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Observability & Diagnostics
+
+How to read what the Keystone operator is doing — without tailing controller logs.
+
+**Prerequisites:** A running Keystone CR from the [Quick Start](../quick-start.md) (Steps 1–9).
+
+The operator surfaces its state through three complementary channels:
+
+| Channel | Purpose | Primary audience |
+|---------|---------|------------------|
+| **Print columns** | One-line health summary for every Keystone CR | Humans, `kubectl get` |
+| **Status conditions** | Structured, programmatic state | Automation, CI, alerts |
+| **Events** | Timestamped audit trail of transitions | Humans investigating incidents |
+
+---
+
+## Print columns
+
+`kubectl get keystones` exposes a compact summary via four printer columns:
+
+```bash
+kubectl get keystones -A
+```
+
+```
+NAMESPACE   NAME       READY   ENDPOINT                                              RELEASE   AGE
+openstack   keystone   True    http://keystone-api.openstack.svc.cluster.local:5000  2025.2    12m
+```
+
+| Column | Source | Meaning |
+|--------|--------|---------|
+| `READY` | `.status.conditions[?(@.type=='Ready')].status` | Aggregate health |
+| `ENDPOINT` | `.status.endpoint` | In-cluster Keystone API URL |
+| `RELEASE` | `.status.installedRelease` | OpenStack release currently deployed |
+| `AGE` | `.metadata.creationTimestamp` | CR age |
+
+---
+
+## Status conditions
+
+`.status.conditions[]` follows the standard Kubernetes pattern (`type`, `status`, `reason`, `message`, `lastTransitionTime`, `observedGeneration`). Eleven sub-conditions feed into the aggregate `Ready` — some are only reported when the matching optional spec field is set:
+
+| Condition | Means |
+|-----------|-------|
+| `SecretsReady` | Referenced database and admin Secrets are available |
+| `FernetKeysReady` | Fernet key Secret and rotation CronJob exist |
+| `CredentialKeysReady` | Credential key Secret and rotation CronJob exist (if `spec.credentialKeys` is set) |
+| `DatabaseReady` | `db_sync` Job completed successfully (and schema check passed) |
+| `PolicyValidReady` | `spec.policyOverrides` validated against `oslo.policy` |
+| `DeploymentReady` | API Deployment has available replicas |
+| `KeystoneAPIReady` | Keystone API is responding to `/v3` health probes |
+| `HPAReady` | HorizontalPodAutoscaler created (if `spec.autoscaling` is set) |
+| `NetworkPolicyReady` | NetworkPolicy created (if `spec.networkPolicy` is set) |
+| `BootstrapReady` | Bootstrap Job completed (admin user, region, endpoints) |
+| `TrustFlushReady` | Trust-flush CronJob created (if `spec.trustFlush` is set) |
+| `Ready` | All of the above are `True` |
+
+Read them as a tree:
+
+```bash
+kubectl get keystone keystone -n openstack \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' \
+  | column -t -s $'\t'
+```
+
+Or wait for a specific one:
+
+```bash
+kubectl wait keystone/keystone -n openstack \
+  --for=condition=DatabaseReady --timeout=5m
+```
+
+::: tip Diagnosing a stuck CR
+The first `status=False` condition from the top is usually the bottleneck:
+
+- `SecretsReady=False` → check that `keystone-db` and `keystone-admin` Secrets exist in the same namespace
+- `DatabaseReady=False` → look at Events for `DBSyncFailed` or `SchemaDriftDetected`
+- `DeploymentReady=False` → `kubectl describe deploy keystone-api` — usually image pull or probe failures
+:::
+
+---
+
+## Upgrade status fields
+
+During an image-tag change, three additional status fields track progress (see [Day 2 Operations — Image upgrade](./day-2-operations.md#image-upgrade-with-upgradephase)):
+
+| Field | Outside upgrade | During upgrade |
+|-------|-----------------|----------------|
+| `.status.installedRelease` | Currently deployed release | Previous release (not yet changed) |
+| `.status.targetRelease` | `""` | Target release |
+| `.status.upgradePhase` | `""` | `Expanding` → `Migrating` → `RollingUpdate` → `Contracting` |
+
+Watch the upgrade live:
+
+```bash
+kubectl get keystone keystone -n openstack -w \
+  -o custom-columns=NAME:.metadata.name,PHASE:.status.upgradePhase,FROM:.status.installedRelease,TO:.status.targetRelease
+```
+
+---
+
+## Events
+
+Every lifecycle transition emits a Kubernetes Event with a stable, PascalCase `reason`. Events are deduplicated by (object, reason, message) — repeated reconciles do not spam the event stream.
+
+### Show everything for a CR
+
+```bash
+kubectl describe keystone keystone -n openstack
+```
+
+The bottom of the output lists the Events in reverse-chronological order. Alternatively, a timeline view:
+
+```bash
+kubectl get events -n openstack \
+  --field-selector involvedObject.kind=Keystone \
+  --sort-by='.lastTimestamp'
+```
+
+### Common reasons
+
+| Reason | Type | When you see it |
+|--------|------|-----------------|
+| `BootstrapComplete` | Normal | First reconciliation finished |
+| `DatabaseSynced` | Normal | `db_sync` finished, schema matches Alembic head |
+| `FernetKeysGenerated` | Normal | Fernet Secret was created or rotated |
+| `UpgradeInitiated` | Normal | `spec.image.tag` change triggered an upgrade |
+| `ExpandComplete` / `MigrateComplete` | Normal | Upgrade phase boundary reached |
+| `UpgradeComplete` | Normal | Full expand-migrate-contract pipeline finished, `installedRelease` advanced |
+| `ContractFailed` | Warning | Contract phase `db_sync --contract` returned non-zero |
+| `DBSyncFailed` | Warning | `db_sync` Job returned non-zero |
+| `SchemaDriftDetected` | Warning | Schema check found unexpected drift |
+| `DowngradeNotSupported` | Warning | Target tag is older than `installedRelease` |
+| `UpgradePathInvalid` | Warning | Target tag skips a release (non-sequential) |
+
+The full catalogue is in [Keystone Controller Events](../reference/keystone-events.md).
+
+---
+
+## Controller logs (last resort)
+
+If status and events don't explain a failure, read the operator logs directly:
+
+```bash
+kubectl logs -n openstack -l app.kubernetes.io/name=keystone-operator \
+  --tail=200 -f
+```
+
+The operator uses structured `logr` output — every line includes the reconciled object's namespace/name and the sub-reconciler that produced the log. Filter a specific CR:
+
+```bash
+kubectl logs -n openstack -l app.kubernetes.io/name=keystone-operator --tail=500 \
+  | grep '"Keystone":"openstack/keystone"'
+```
+
+---
+
+## Further reading
+
+- [Keystone Controller Events](../reference/keystone-events.md) — full event reason catalogue with example messages and alerting templates
+- [Keystone Reconciler Architecture](../reference/keystone-reconciler.md) — sub-reconciler contracts and watches
+- [Keystone Upgrade Flow](../reference/keystone-upgrade-flow.md) — state machine that drives upgrade conditions
+- [Day 2 Operations](./day-2-operations.md) — putting this observability into practice during scale, upgrade, rotation

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -336,16 +336,23 @@ kubectl apply -f keystone.yaml
 
 ## Step 8 — Wait for Keystone to become Ready
 
-The operator reconciles the CR through five sequential sub-conditions before the aggregate
-`Ready` condition is set:
+The operator reconciles the CR through eleven sub-conditions before the aggregate
+`Ready` condition is set — some are only reported when the matching optional spec
+field is configured:
 
 | Condition | What it waits for |
 |-----------|-------------------|
 | `SecretsReady` | `keystone-db` and `keystone-admin` Secrets are available |
 | `FernetKeysReady` | Fernet key Secret and CronJob created |
+| `CredentialKeysReady` | Credential key Secret and rotation CronJob exist (if `spec.credentialKeys` is set) |
 | `DatabaseReady` | `db_sync` Job completed successfully |
+| `PolicyValidReady` | `spec.policyOverrides` validated against `oslo.policy` |
 | `DeploymentReady` | Keystone API Deployment has available replicas |
+| `KeystoneAPIReady` | Keystone API is responding to `/v3` health probes |
+| `HPAReady` | HorizontalPodAutoscaler created (if `spec.autoscaling` is set) |
+| `NetworkPolicyReady` | NetworkPolicy created (if `spec.networkPolicy` is set) |
 | `BootstrapReady` | Bootstrap Job completed (admin user, region, endpoints) |
+| `TrustFlushReady` | Trust-flush CronJob created (if `spec.trustFlush` is set) |
 
 Watch the conditions with:
 
@@ -455,6 +462,22 @@ A successful `curl` response begins with `{"version": {"id": "v3", ...}}`. A suc
 > that authenticate directly against `OS_AUTH_URL` work via port-forward. Commands that resolve
 > other service endpoints from the catalog (Nova, Neutron, …) require additional port-forwards
 > for each service.
+
+---
+
+## Next steps
+
+Keystone is running, you can reach the API, and you have admin credentials. The three
+follow-up guides below cover everything you will actually do with the CR:
+
+| Guide | When to read it |
+|-------|-----------------|
+| [Observability & Diagnostics](./guides/observability.md) | First stop when something is not `Ready` — how to read conditions, events, and status fields |
+| [Day 2 Operations](./guides/day-2-operations.md) | Scale, upgrade the OpenStack release, rotate Fernet keys manually |
+| [Advanced Configuration](./guides/advanced-configuration.md) | Brownfield database, autoscaling, network policy, free-form INI, and pointers to every other `spec.*` option |
+
+For the full field reference of the Keystone CR, see
+[Keystone CRD API Reference](./reference/keystone-crd.md).
 
 ---
 


### PR DESCRIPTION
Introduce docs/guides/ with three how-to guides that keep the quick-start lean while surfacing the rest of the Keystone CR surface: observability (conditions, events, status fields), day-2 operations (scale, image upgrade, fernet rotation), and advanced configuration (brownfield DB, HPA, NetworkPolicy, ExtraConfig + pointers to every other spec field).

Link the guides from a new Next steps section in quick-start.md and from a Guides sidebar entry in the VitePress config.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com