### PR TITLE
fix: make operator-pod-crash chaos test race-free with UID tracking

### DIFF
--- a/tests/e2e-chaos/operator-pod-crash/chainsaw-test.yaml
+++ b/tests/e2e-chaos/operator-pod-crash/chainsaw-test.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Chainsaw chaos E2E test for operator pod crash recovery (CC-0048).
-# Verifies the Keystone operator self-recovers after its own pod is killed
+# Verifies the Keystone operator self-recovers after one of its pods is killed
 # and maintains Ready=True throughout — the operator crash should be
 # invisible to the Keystone CR conditions since the Deployment controller
 # restarts the operator pod and reconciliation resumes.
@@ -85,8 +85,14 @@ spec:
 
           # Phase 1: wait until at least one pre-chaos UID is gone, proving
           # mode: one replaced a pod. 60 iterations × 2s = 120s max.
+          # Empty CURRENT_UIDS (transient kubectl failure) would spuriously
+          # match "no UIDs present" — skip those iterations instead.
           for i in $(seq 1 60); do
             CURRENT_UIDS=$(kubectl get pods -n default -l app.kubernetes.io/name=keystone-operator -o jsonpath='{.items[*].metadata.uid}')
+            if [ -z "$CURRENT_UIDS" ]; then
+              sleep 2
+              continue
+            fi
             REPLACED=0
             for uid in $OLD_UIDS; do
               case " $CURRENT_UIDS " in


### PR DESCRIPTION
Polling readyReplicas for a transient drop below 2 is racy: with gracePeriod: 0 the kill+reschedule+ready cycle can complete before the first 2s poll, so the loop never observes the dip and fails with "pod kill did not take effect" even though PodChaos succeeded. Snapshot pre-chaos pod UIDs and wait for one to disappear instead — proves the replacement happened regardless of timing. Mirrors the fix already applied to operator-pod-kill (CC-0066).

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com