### PR TITLE
ci: add chainsaw-lint job to schema-validate Chainsaw test definitions

### DIFF
--- a/.github/actions/setup-e2e-infra/action.yaml
+++ b/.github/actions/setup-e2e-infra/action.yaml
@@ -30,22 +30,10 @@ runs:
     - name: Install Flux CLI
       uses: fluxcd/flux2/action@871be9b40d53627786d3a3835a3ddba1e3234bd2 # v2.8.3
 
-    # Cache test tool binaries installed by hack/install-test-deps.sh (chainsaw,
-    # flux, kind, kubectl). The script has skip-if-correct-version logic, so a
-    # cache hit makes install-test-deps a no-op. Key on the script hash so the
-    # cache auto-invalidates when any pinned version changes.
-    - name: Cache test dependency binaries
-      uses: actions/cache@v5
-      with:
-        path: $HOME/.local/bin
-        key: ${{ runner.os }}-testdeps-${{ hashFiles('hack/install-test-deps.sh') }}
-        restore-keys: ${{ runner.os }}-testdeps-
-
-    - name: Install test dependencies
-      shell: bash
-      run: |
-        make install-test-deps
-        echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+    # Cache + `make install-test-deps` is shared with the lightweight
+    # chainsaw-lint job — keeping it in one composite action ensures the cache
+    # key/path stay in lockstep across consumers.
+    - uses: ./.github/actions/setup-test-deps
 
     - name: Deploy infrastructure stack
       shell: bash

--- a/.github/actions/setup-test-deps/action.yaml
+++ b/.github/actions/setup-test-deps/action.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Composite action encapsulating the shared cache + `make install-test-deps`
+# step used by every job that needs the pinned chainsaw/flux/kind/kubectl
+# binaries. Extracted so the cache key, restore-keys, and PATH wiring stay in
+# one place: setup-e2e-infra (cluster-bound jobs) and lightweight jobs like
+# chainsaw-lint both consume this and inherit any future tweaks (key bump,
+# additional pinned tool, etc.) for free.
+
+name: Setup test dependencies
+description: >
+  Restore the shared testdeps cache and run `make install-test-deps` so the
+  pinned chainsaw/flux/kind/kubectl binaries are on PATH. No cluster required.
+
+runs:
+  using: composite
+  steps:
+    # Cache test tool binaries installed by hack/install-test-deps.sh (chainsaw,
+    # flux, kind, kubectl). The script has skip-if-correct-version logic, so a
+    # cache hit makes install-test-deps a no-op. Key on the script hash so the
+    # cache auto-invalidates when any pinned version changes.
+    - name: Cache test dependency binaries
+      uses: actions/cache@v5
+      with:
+        path: $HOME/.local/bin
+        key: ${{ runner.os }}-testdeps-${{ hashFiles('hack/install-test-deps.sh') }}
+        restore-keys: ${{ runner.os }}-testdeps-
+
+    - name: Install test dependencies
+      shell: bash
+      run: |
+        make install-test-deps
+        echo "${HOME}/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,21 @@ jobs:
       - name: Verify CC-0094 invalid-CR fixture drift and structure
         run: make verify-invalid-cr-fixtures
 
+  # Schema-lint every Chainsaw test (tests/**/chainsaw-test.yaml) and config
+  # (tests/{e2e,e2e-chaos}/chainsaw-config.yaml) via `chainsaw lint` so typos,
+  # removed fields, or schema drift after a chainsaw version bump fail fast —
+  # before the cluster-bound e2e-operator/e2e-chaos jobs spin up a kind cluster.
+  # Always-on: no cluster needed; chainsaw is restored from the shared testdeps
+  # cache via the same composite action setup-e2e-infra uses internally.
+  chainsaw-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-test-deps
+      - name: Run chainsaw lint
+        run: make chainsaw-lint
+
   # CC-0018: Matrix over [common, keystone, c5c3] to deduplicate common coverage
   # into a single leg (review comment #7/#8).
   test:
@@ -459,7 +474,7 @@ jobs:
   # as zstd-compressed tarballs.  e2e-operator and tempest download and load
   # the artifact instead of rebuilding, saving ~5-10 min per CI run.
   build-e2e-images:
-    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, verify-invalid-cr-fixtures]
+    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, verify-invalid-cr-fixtures, chainsaw-lint]
     # always(): allow the job to run when upstream Go jobs are skipped
     # (e.g. pure E2E test-definition PRs where go=false). The explicit
     # failure/cancelled guard still blocks if any upstream actually failed.
@@ -686,7 +701,7 @@ jobs:
   # runs to consider making this job blocking and adding it to publish
   # dependencies.
   e2e-chaos:
-    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, build-e2e-images]
+    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
     # always(): allow the job to run when upstream Go jobs are skipped
     # (e.g. pure E2E test-definition PRs where go=false). The explicit
     # failure/cancelled guard still blocks if any upstream actually failed.

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,25 @@ shellcheck:
 	@echo "Linting operator rotation scripts..."
 	@shellcheck --severity=warning operators/*/internal/controller/scripts/*.sh
 
+.PHONY: chainsaw-lint
+# chainsaw-lint validates every Chainsaw test (tests/**/chainsaw-test.yaml) and
+# Chainsaw configuration (tests/**/chainsaw-config.yaml) against the Chainsaw
+# schema. Catches structural issues (typos, removed fields, schema drift after
+# a chainsaw version bump) before the heavy cluster-bound e2e-operator and
+# e2e-chaos jobs run. No cluster required — chainsaw must be on PATH (install
+# via `make install-test-deps`). xargs propagates any per-file failure as a
+# non-zero exit (123) so make fails the target as a whole; -print0/-0 keeps
+# paths with spaces safe; -r/--no-run-if-empty turns an empty find result
+# into a clean no-op instead of a `flag needs an argument` error if the
+# tests/ tree is ever restructured (GNU xargs only, matches the Linux-only
+# CI runner).
+chainsaw-lint:
+	@command -v chainsaw >/dev/null 2>&1 || { echo 'chainsaw is not installed; run `make install-test-deps` first' >&2; exit 1; }
+	@echo "Linting Chainsaw test definitions..."
+	@find tests -type f -name 'chainsaw-test.yaml' -print0 | xargs -0 -r -n1 chainsaw lint test -f
+	@echo "Linting Chainsaw configurations..."
+	@find tests -type f -name 'chainsaw-config.yaml' -print0 | xargs -0 -r -n1 chainsaw lint configuration -f
+
 .PHONY: test-shell
 # test-shell runs every shell-script unit test under tests/unit/ (CC-0085, REQ-003/REQ-005/REQ-007).
 # Each test is a self-contained bash script that uses tests/lib/assertions.sh.

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -84,17 +84,19 @@ Jobs that need elevated access declare per-job `permissions:` blocks:
 
 ## Job Dependency DAG
 
-The workflow defines 18 jobs organised in a directed acyclic graph (CC-0018, CC-0041,
-CC-0050, CC-0052, CC-0053, CC-0054, CC-0061):
+The workflow defines 22 jobs organised in a directed acyclic graph (CC-0018, CC-0041,
+CC-0050, CC-0052, CC-0053, CC-0054, CC-0061, CC-0094):
 
 ```
 Gate Jobs (always run):
-  lint ─────────────┐
-  format-check ─────┤
-  shellcheck ───────┤
-  verify-codegen ───┤
-  test (matrix) ────┼──> build-e2e-images ──> E2E Jobs
-  test-integration ─┘
+  lint ────────────────────────┐
+  format-check ────────────────┤
+  shellcheck ──────────────────┤
+  verify-codegen ──────────────┤
+  verify-invalid-cr-fixtures ──┤
+  chainsaw-lint ───────────────┤
+  test (matrix) ───────────────┼──> build-e2e-images ──> E2E Jobs
+  test-integration ────────────┘
 
 Conditional Jobs (path-filtered via changes job):
   test-race ────> needs: [changes], if: needs.changes.outputs.go == 'true'
@@ -103,12 +105,12 @@ Conditional Jobs (path-filtered via changes job):
   docs ──────────> needs: [changes], if: needs.changes.outputs.docs == 'true'
 
 Image Build (depends on gates):
-  build-e2e-images ──> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen]
+  build-e2e-images ──> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, verify-invalid-cr-fixtures, chainsaw-lint]
 
 E2E Jobs (depends on build-e2e-images):
   e2e-infra ──────> needs: [changes], if: needs.changes.outputs.e2e-infra == 'true'
   e2e-operator ───> needs: [changes, build-e2e-images]
-  e2e-chaos ──────> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen]
+  e2e-chaos ──────> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
   tempest ────────> needs: [changes, build-e2e-images]
 
 Publish Jobs (main/tags only, depends on E2E):
@@ -206,6 +208,42 @@ The shellcheck binary is pre-installed on `ubuntu-latest` runners.
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `shellcheck --severity=warning hack/*.sh` | Lints all shell scripts in `hack/` |
+
+Timeout: 5 minutes.
+
+### verify-invalid-cr-fixtures
+
+Enforces the canonical-scaffold contract for the invalid-CR Chainsaw fixtures (CC-0094).
+Runs `_generate.py --check` (drift mode) and the `test_generate.py` unit suite
+(FIXTURES count + `chainsaw-test.yaml` cross-reference) so a hand-edit to any
+`02-…/03-…/…/12-*.yaml` fixture, or a rename or removal that desynchronises FIXTURES
+from `chainsaw-test.yaml`, fails the build before the heavy cluster-bound `e2e-operator`
+job runs. Always-on because the check is sub-second and `python3` is preinstalled on
+`ubuntu-latest` runners.
+
+| Step | Action | Details |
+| --- | --- | --- |
+| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 2 | `make verify-invalid-cr-fixtures` | Runs `_generate.py --check` and `test_generate.py` (CC-0094) |
+
+Timeout: 5 minutes.
+
+### chainsaw-lint
+
+Schema-lints every Chainsaw test (`tests/**/chainsaw-test.yaml`) and configuration
+(`tests/{e2e,e2e-chaos}/chainsaw-config.yaml`) via `chainsaw lint` so typos, removed
+fields, or schema drift after a chainsaw version bump fail fast — before the
+cluster-bound `e2e-operator` and `e2e-chaos` jobs spin up a kind cluster. Always-on
+because no cluster is needed: chainsaw is restored from the shared testdeps cache via
+the `setup-test-deps` composite action, the same one consumed internally by
+`setup-e2e-infra`. A schema break therefore surfaces in `needs.*.result` for both
+`build-e2e-images` and `e2e-chaos`.
+
+| Step | Action | Details |
+| --- | --- | --- |
+| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 2 | `./.github/actions/setup-test-deps` | Restores the testdeps cache and runs `make install-test-deps` (puts `chainsaw` on `PATH`) |
+| 3 | `make chainsaw-lint` | Runs `chainsaw lint test -f` and `chainsaw lint configuration -f` over every matching file under `tests/` |
 
 Timeout: 5 minutes.
 
@@ -860,6 +898,23 @@ hack/ci-run-tempest.sh
 SERVICE=keystone OUTPUT_DIR=_output/tempest hack/ci-run-tempest.sh
 ```
 
+## Composite Action: setup-test-deps
+
+`.github/actions/setup-test-deps/action.yaml`
+
+A composite GitHub Action that encapsulates the shared cache + `make install-test-deps`
+step used by every job that needs the pinned `chainsaw`/`flux`/`kind`/`kubectl` binaries.
+Extracted so the cache key, `restore-keys:`, and `PATH` wiring live in one place:
+`setup-e2e-infra` (cluster-bound jobs) and the lightweight `chainsaw-lint` job both
+consume this and inherit any future tweaks (key bump, additional pinned tool) for free.
+
+| Step | Description |
+| --- | --- |
+| 1 | Restores `$HOME/.local/bin` from cache, keyed on the hash of `hack/install-test-deps.sh` (auto-invalidates when any pinned tool version changes) |
+| 2 | Runs `make install-test-deps` (no-op on cache hit thanks to the script's skip-if-correct-version logic) and appends `~/.local/bin` to `GITHUB_PATH` |
+
+The action takes no inputs.
+
 ## Composite Action: setup-e2e-infra (CC-0050 REQ-005)
 
 `.github/actions/setup-e2e-infra/action.yaml`
@@ -874,7 +929,7 @@ internally).
 | Step | Description |
 | --- | --- |
 | 1 | Installs Flux CLI via `fluxcd/flux2/action@v2.8.3` (SHA-pinned) |
-| 2 | Runs `make install-test-deps` and adds `~/.local/bin` to `GITHUB_PATH` |
+| 2 | Delegates to the `setup-test-deps` composite action (cache restore + `make install-test-deps` + `PATH` wiring) |
 | 3 | Runs `make deploy-infra` with `SKIP_KIND_CREATE=true` |
 
 Usage in a workflow job:
@@ -1129,6 +1184,7 @@ The CI workflow depends on artifacts introduced by CC-0001, CC-0010, and CC-0050
 | `hack/ci-build-service-image.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Builds OpenStack service images (CC-0050) |
 | `hack/ci-deploy-operator.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Deploys operator via Helm (CC-0050) |
 | `hack/ci-run-tempest.sh` | `tempest` job | Runs Tempest API tests (CC-0050) |
+| `.github/actions/setup-test-deps/` | `chainsaw-lint` job, `setup-e2e-infra` composite action | Composite action for testdeps cache + `make install-test-deps` |
 | `.github/actions/setup-e2e-infra/` | `e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest` jobs | Composite action for infra setup (CC-0050) |
 | `.github/actions/load-e2e-images/` | `e2e-operator`, `tempest` jobs | Composite action for artifact download + zstd decompress + docker load |
 | `tests/e2e-chaos/chainsaw-config.yaml` | `e2e-chaos` job | Chaos-specific Chainsaw configuration (CC-0054) |


### PR DESCRIPTION
Lints every tests/**/chainsaw-test.yaml plus both chainsaw-config.yaml files via `chainsaw lint` so typos, removed fields, or schema drift after a chainsaw version bump fail fast — before the cluster-bound e2e-operator and e2e-chaos jobs spin up a kind cluster.

Adds the `chainsaw-lint` Make target (uses the already-pinned chainsaw from install-test-deps, prints output only on failure) and an always-on CI job that reuses the shared testdeps cache. Wired into the `needs:` list of build-e2e-images and e2e-chaos so a schema break blocks the heavy jobs early.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com