### PR TITLE
ci: cache E2E images on Blacksmith Sticky Disk to avoid GH timeouts

### DIFF
--- a/.github/actions/load-e2e-images/action.yaml
+++ b/.github/actions/load-e2e-images/action.yaml
@@ -2,19 +2,60 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Composite action to download and load pre-built E2E images.
-# Shared between e2e-operator and tempest jobs to avoid duplicating the
-# artifact download + zstd decompress + docker load sequence.
+# Composite action to fetch and load pre-built E2E images.
+# Shared between e2e-operator, tempest, e2e-chaos, and e2e-prometheus jobs to
+# avoid duplicating the artifact/sticky-disk + zstd decompress + docker load
+# sequence.
+#
+# Prefer Blacksmith Sticky Disk to dodge the slow Blacksmith <-> GitHub
+# artifact-storage round trip that has been driving the "Load E2E images"
+# timeouts; fall back to actions/download-artifact when the consumer runs on
+# a non-Blacksmith runner (Sticky Disks are Blacksmith-only) or when the
+# disk is cold.
 
 name: Load E2E images
 description: >
-  Download pre-built E2E images from the shared artifact, verify zstd
-  is available, and load all images into the local Docker daemon.
+  Mount the Blacksmith sticky disk holding the pre-built E2E image tarballs
+  (or download them from the GitHub artifact as a fallback), verify zstd is
+  available, and load every tarball into the local Docker daemon.
+
+inputs:
+  use-sticky-disk:
+    description: >
+      Mount the Blacksmith sticky disk and reuse the tarballs from there.
+      Must be "false" on GitHub-hosted runners (Sticky Disks are
+      Blacksmith-only). A cold sticky disk on a Blacksmith runner still
+      falls back to the GitHub artifact.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
-    - name: Download E2E images
+    - name: Mount E2E images sticky disk
+      if: inputs.use-sticky-disk == 'true'
+      uses: useblacksmith/stickydisk@41873b1513bb679f9c115504cbd13d3660432504 # v1
+      with:
+        key: ${{ github.repository }}-e2e-images-${{ github.run_id }}
+        path: _output/e2e-images
+
+    - name: Check sticky disk for pre-built images
+      if: inputs.use-sticky-disk == 'true'
+      id: check
+      shell: bash
+      run: |
+        shopt -s nullglob
+        files=(_output/e2e-images/*.tar.zst)
+        if (( ${#files[@]} > 0 )); then
+          echo "Sticky disk hit: ${#files[@]} tarballs"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::Sticky disk empty - falling back to GitHub artifact"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Download E2E images from artifact
+      if: inputs.use-sticky-disk != 'true' || steps.check.outputs.found != 'true'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: e2e-images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -572,6 +572,20 @@ jobs:
             echo "::endgroup::"
           done
 
+      # Mount a Blacksmith sticky disk at _output/e2e-images so the consumer
+      # jobs (e2e-operator, tempest, e2e-chaos pod) can pick up the tarballs
+      # directly off Blacksmith-local storage instead of round-tripping
+      # through GitHub artifact storage. The matching mount in
+      # .github/actions/load-e2e-images keys off ${github.run_id} so each run
+      # gets a fresh disk; Blacksmith GCs them after 7 days of inactivity.
+      # The artifact upload below stays as the fallback for the e2e-chaos
+      # network suite, which runs on a GitHub-hosted ubuntu-24.04 runner.
+      - name: Mount E2E images sticky disk
+        uses: useblacksmith/stickydisk@41873b1513bb679f9c115504cbd13d3660432504 # v1
+        with:
+          key: ${{ github.repository }}-e2e-images-${{ github.run_id }}
+          path: _output/e2e-images
+
       # Save each image as an individually zstd-compressed tarball.
       # zstd -T0 uses all available cores; -3 is the default level (fast).
       - name: Save images
@@ -760,8 +774,13 @@ jobs:
           cluster_name: forge-e2e
       # Load pre-built images from shared artifact instead of rebuilding.
       # build-e2e-images is in needs, so the artifact is guaranteed to exist.
+      # Blacksmith Sticky Disk on the pod-suite runner; the network suite
+      # runs on GitHub-hosted ubuntu-24.04 where Sticky Disks are unavailable
+      # and must use the artifact path.
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
+        with:
+          use-sticky-disk: ${{ startsWith(matrix.runner, 'blacksmith') }}
       - name: Load images into kind
         run: |
           kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e


### PR DESCRIPTION
The "Load E2E images" step has been timing out because the zstd-compressed image tarballs are shipped through GitHub artifact storage, forcing every Blacksmith consumer job to round-trip across the Blacksmith <-> GitHub network boundary on download. Mount a Blacksmith sticky disk at _output/e2e-images in build-e2e-images and again in the shared load-e2e-images composite action so the tarballs stay on Blacksmith-local storage. The disk is keyed off ${github.run_id} to keep each run on its own snapshot; Blacksmith GCs them after 7 days of inactivity.

actions/upload-artifact in build-e2e-images stays put because the e2e-chaos network suite still has to run on a GitHub-hosted ubuntu-24.04 runner (Blacksmith Firecracker microVM lacks the netem/ip_set kernel modules). That suite passes use-sticky-disk: false to the composite action and follows the artifact path. A cold sticky disk on a Blacksmith runner also falls back to the artifact, so an isolated sticky-disk hiccup does not break the pipeline.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com