### PR TITLE
docs: remove CC and REQ feature identifiers from documentation

### DIFF
--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -5,20 +5,19 @@ SPDX-License-Identifier: Apache-2.0
 ---
 title: Enable the Keystone Operator Metrics Endpoint
 quadrant: operator
-feature: CC-0089
+
 ---
 
 # How-to: Enable the Keystone Operator Metrics Endpoint
 
 This guide walks an operator through turning on the Prometheus
-ServiceMonitor shipped with the `keystone-operator` Helm chart
-(CC-0089, REQ-011), importing the reference Grafana dashboard, and
+ServiceMonitor shipped with the `keystone-operator` Helm chart, importing the reference Grafana dashboard, and
 verifying that scrape targets transition to `Up`.
 
 For the authoritative metric catalogue (names, labels, buckets), see
 [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md).
 For the controller-side instrumentation contract, see
-[Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation-cc-0089).
+[Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation).
 
 ---
 
@@ -99,7 +98,7 @@ The repository ships a reference dashboard in
 [`operators/keystone/dashboards/keystone-operator.json`](../../operators/keystone/dashboards/keystone-operator.json)
 covering the four core SLIs: reconcile p95 per sub-reconciler, error
 rate per condition type, rotation age per key, and `db_sync` duration
-p95 with failure count (CC-0089, REQ-010).
+p95 with failure count.
 
 1. In Grafana: **Dashboards → New → Import**.
 2. Upload `keystone-operator.json` or paste its contents.
@@ -174,7 +173,7 @@ Expected: `# TYPE` and `# HELP` lines for every metric in the
 example:
 
 ```
-# HELP keystone_operator_reconcile_duration_seconds Wall-clock duration of a Keystone sub-reconciler invocation, in seconds (CC-0089, REQ-001).
+# HELP keystone_operator_reconcile_duration_seconds Wall-clock duration of a Keystone sub-reconciler invocation, in seconds.
 # TYPE keystone_operator_reconcile_duration_seconds histogram
 ```
 
@@ -245,7 +244,7 @@ ServiceMonitor (and therefore the Prometheus scrape) is removed.
 
 ## See also
 
-- [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md) — authoritative metric catalogue (CC-0089).
-- [Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation-cc-0089) — how sub-reconcilers are instrumented.
+- [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md) — authoritative metric catalogue.
+- [Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation) — how sub-reconcilers are instrumented.
 - [Observability & Diagnostics](../guides/observability.md) — conditions, events, and logs.
 - [`operators/keystone/dashboards/keystone-operator.json`](../../operators/keystone/dashboards/keystone-operator.json) — reference Grafana dashboard.

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -1,20 +1,19 @@
 ---
 title: Enable the Keystone Operator NetworkPolicy
 quadrant: operator
-feature: CC-0090
 ---
 
 # How-to: Enable the Keystone Operator NetworkPolicy
 
 This guide walks an operator through opting in to the chart-level
 NetworkPolicy that restricts the keystone-operator pod's egress and ingress
-to the minimum required for correct reconciliation (CC-0090). For the
+to the minimum required for correct reconciliation. For the
 authoritative rule table, failure modes, and schema contract, see
 [Keystone Operator NetworkPolicy](../reference/keystone/keystone-operator-networkpolicy.md).
 
 > **Scope.** This guide covers the NetworkPolicy that protects the
 > **operator pod itself**. For the per-CR NetworkPolicy that protects
-> Keystone API pods (CC-0039), see the
+> Keystone API pods, see the
 > [reconcileNetworkPolicy sub-reconciler](../reference/keystone/keystone-reconciler.md#sub-reconciler-contracts).
 
 ---
@@ -283,7 +282,7 @@ networkPolicy.kubeApiServer.cidrs must not be empty ...
 ```
 
 **Diagnosis:** you set `networkPolicy.enabled=true` but left `cidrs` or
-`ports` empty. This is the fail-closed guard (CC-0090, REQ-006) — the
+`ports` empty. This is the fail-closed guard — the
 template refuses to render a policy that would break the operator.
 
 **Fix:** populate both lists from step 1 and re-run the upgrade.
@@ -315,8 +314,8 @@ without a pod restart.
 ## See also
 
 - [Keystone Operator NetworkPolicy](../reference/keystone/keystone-operator-networkpolicy.md) —
-  authoritative rule table and schema contract (CC-0090).
+  authoritative rule table and schema contract.
 - [Keystone Reconciler Architecture](../reference/keystone/keystone-reconciler.md) —
-  the CR-scoped `reconcileNetworkPolicy` sub-reconciler (CC-0039) for the
+  the CR-scoped `reconcileNetworkPolicy` sub-reconciler for the
   Keystone API pod NetworkPolicy (different scope from this guide).
 - [Kubernetes NetworkPolicy concepts](https://kubernetes.io/docs/concepts/services-networking/network-policies/).

--- a/docs/guides/keystone-key-rotation.md
+++ b/docs/guides/keystone-key-rotation.md
@@ -1,19 +1,18 @@
 ---
 title: Rotate Keystone Fernet and Credential Keys
 quadrant: operator
-feature: CC-0073, CC-0081
 ---
 
 # Rotate Keystone Fernet and Credential Keys
 
 This guide walks an operator through triggering a manual rotation of a
 Keystone instance's Fernet or credential-encryption keys, verifying each
-stage of the split-compute-write rotation pipeline introduced by CC-0081,
+stage of the split-compute-write rotation pipeline,
 and recovering when the operator rejects a staged rotation.
 
 For the reconciler-side contract (RBAC split, staging-Secret naming,
 validation rules, event reasons), see
-[Key Rotation RBAC Split](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split-cc-0081)
+[Key Rotation RBAC Split](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split)
 under the Fernet and credential sub-reconciler sections in
 [Keystone Reconciler Architecture](../reference/keystone/keystone-reconciler.md).
 
@@ -26,8 +25,8 @@ under the Fernet and credential sub-reconciler sections in
 
 ## Background: Who Writes What
 
-Before CC-0081 the rotation CronJob wrote directly to the production
-`{ks}-fernet-keys` Secret with `patch` RBAC. CC-0081 split that path:
+Earlier the rotation CronJob wrote directly to the production
+`{ks}-fernet-keys` Secret with `patch` RBAC. The current design splits that path:
 
 | Actor | Writes to | Reads from |
 | --- | --- | --- |
@@ -147,7 +146,7 @@ kubectl -n <ns> get secret <ks>-fernet-keys \
   -o jsonpath='{range .data.*}{@}{"\n"}{end}' | sha256sum
 ```
 
-Thanks to the kubelet's in-place Secret projection (CC-0074), running
+Thanks to the kubelet's in-place Secret projection, running
 Keystone pods pick up the new keys on their next projection refresh
 (~60 seconds) without a Deployment rollout. A token minted before the
 rotation remains valid until its native TTL expires, because the old key
@@ -188,7 +187,7 @@ kubectl -n <ns> get secret <ks>-fernet-keys-rotation -o yaml
 ```
 
 Match the event message against the operator's validation contract
-(see [Operator validation rules](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split-cc-0081)):
+(see [Operator validation rules](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split)):
 
 | Event message contains | Likely cause |
 | --- | --- |
@@ -217,8 +216,8 @@ The recovery sequence is always:
 3. Confirm apply by repeating steps 2-4 above.
 
 > **Production safety note.** The production Secret is never modified
-> during a rejected rotation — that is the whole point of the CC-0081
-> split. You can inspect a `RotationRejected` state as long as you like
+> during a rejected rotation — that is the whole point of the
+> staging/production split. You can inspect a `RotationRejected` state as long as you like
 > without impacting running Keystone pods; they continue to serve tokens
 > with the previous key set.
 
@@ -241,20 +240,20 @@ One additional step runs inside the credential CronJob: after
 **before** the staging PATCH. This re-encrypts existing stored credentials
 with the new primary key, so by the time the operator applies the Secret
 swap there is no surviving plaintext encrypted under a key scheduled for
-aging-out (CC-0036).
+aging-out.
 
-> **Key-rollover window (pre-existing, not introduced by CC-0081).** There
+> **Key-rollover window.** There
 > is a ~60s window between `credential_migrate` completion and the kubelet
-> refreshing the in-place Secret projection (CC-0074). During this window,
+> refreshing the in-place Secret projection. During this window,
 > running Keystone pods still have the old keyset mounted and cannot decrypt
-> rows already re-encrypted under the new primary. This is a pre-existing
-> property of the rotation flow, not a regression introduced by CC-0081.
+> rows already re-encrypted under the new primary. This is an inherent
+> property of the rotation flow, not a regression.
 
 ---
 
 ## Related reference
 
-- [Key Rotation RBAC Split](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split-cc-0081) — the authoritative contract for the Fernet sub-reconciler (CC-0081).
-- [Labels and Annotations](../reference/keystone/keystone-reconciler.md#labels-and-annotations) — stable metadata keys observable by consumers (CC-0081).
-- [Rotation Scripts](../reference/backend/rotation-scripts.md) — the embedded `fernet_rotate.sh` / `credential_rotate.sh` contract (CC-0073).
+- [Key Rotation RBAC Split](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split) — the authoritative contract for the Fernet sub-reconciler.
+- [Labels and Annotations](../reference/keystone/keystone-reconciler.md#labels-and-annotations) — stable metadata keys observable by consumers.
+- [Rotation Scripts](../reference/backend/rotation-scripts.md) — the embedded `fernet_rotate.sh` / `credential_rotate.sh` contract.
 - Chainsaw tests: `tests/e2e/keystone/fernet-rotation/chainsaw-test.yaml` and `tests/e2e/keystone/credential-rotation/chainsaw-test.yaml` assert this guide's happy path and the RBAC verb split end-to-end.

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -1,12 +1,11 @@
 ---
 title: Multi-Tenant Deployment
 quadrant: operator
-feature: CC-0043
 ---
 
 # Multi-Tenant Deployment
 
-Guide for deploying the Keystone operator in namespace-scoped mode (CC-0043).
+Guide for deploying the Keystone operator in namespace-scoped mode.
 In this mode the operator uses a `Role` / `RoleBinding` instead of
 `ClusterRole` / `ClusterRoleBinding` and restricts its cache, watches, and
 reconciliation to a single namespace.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -164,7 +164,7 @@ kubectl logs -n openstack -l app.kubernetes.io/name=keystone-operator --tail=500
 
 - [Keystone Controller Events](../reference/keystone/keystone-events.md) — full event reason catalogue with example messages and alerting templates
 - [Keystone Reconciler Architecture](../reference/keystone/keystone-reconciler.md) — sub-reconciler contracts and watches
-- [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md) — metric catalogue, labels, buckets, and sample PromQL (CC-0089)
-- [Enable the Keystone operator metrics endpoint](./enable-keystone-operator-metrics.md) — ServiceMonitor enablement and Grafana import walk-through (CC-0089)
+- [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md) — metric catalogue, labels, buckets, and sample PromQL
+- [Enable the Keystone operator metrics endpoint](./enable-keystone-operator-metrics.md) — ServiceMonitor enablement and Grafana import walk-through
 - [Keystone Upgrade Flow](../reference/keystone/keystone-upgrade-flow.md) — state machine that drives upgrade conditions
 - [Day 2 Operations](./day-2-operations.md) — putting this observability into practice during scale, upgrade, rotation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 layout: home
-
 hero:
   name: CobaltCore Forge
   text: Kubernetes-native OpenStack
@@ -12,7 +11,6 @@ hero:
     - theme: alt
       text: Reference Docs
       link: /reference/keystone/keystone-crd
-
 features:
   - title: Operators
     details: Service operators following a shared sub-reconciler pattern, with Keystone as the reference implementation and c5c3-operator as the ControlPlane orchestration layer.

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -226,7 +226,7 @@ openstack   keystone-db           (database credentials from OpenBao)
 ```
 :::
 
-::: tip Enabling Chaos Mesh (CC-0097)
+::: tip Enabling Chaos Mesh
 Chaos Mesh is **not installed by default** in the kind Quick Start. The default
 `make deploy-infra` flow leaves the `chaos-mesh` namespace absent so first-run
 deployments are faster and do not require the `chaos-daemon` privileged

--- a/docs/reference/backend/helm-values-schema.md
+++ b/docs/reference/backend/helm-values-schema.md
@@ -1,12 +1,11 @@
 ---
 title: Helm Values Schema
 quadrant: backend
-feature: CC-0069
 ---
 
 # Helm Values Schema
 
-Reference documentation for the `values.schema.json` JSON Schema (CC-0069) that validates
+Reference documentation for the `values.schema.json` JSON Schema that validates
 Helm chart values for the keystone-operator chart. Helm enforces this schema automatically
 during `helm install`, `helm upgrade`, `helm lint`, and `helm template`.
 
@@ -66,9 +65,9 @@ the Kubernetes quantity grammar does not allow combining both.
 | --- | --- | --- | --- |
 | `rbac.namespaceScoped` | `boolean` | conditional: requires `webhook.enabled=false` | `false` |
 
-**Conditional constraint (REQ-010):** When `rbac.namespaceScoped` is `true`, the schema
+**Conditional constraint:** When `rbac.namespaceScoped` is `true`, the schema
 requires `webhook.enabled` to be `false`. This is enforced via a top-level `if`/`then`
-rule. Namespace-scoped RBAC (CC-0043) cannot coexist with webhooks because
+rule. Namespace-scoped RBAC cannot coexist with webhooks because
 `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` are cluster-scoped
 resources that require a `ClusterRole` to manage.
 
@@ -142,23 +141,23 @@ Schema validation is tested with helm-unittest in
 
 ### Negative Tests (rejection)
 
-| Category | Example | Requirement |
-| --- | --- | --- |
-| Type violations | `replicas: "abc"` (string instead of integer) | REQ-001, REQ-002 |
-| Enum violations | `image.pullPolicy: "InvalidPolicy"` | REQ-003 |
-| Range violations | `replicas: 0`, `metrics.port: 65536` | REQ-004 |
-| Unknown properties | `image.digest: "sha256:abc"` | REQ-008 |
-| Invalid quantities | `resources.limits.cpu: "not-valid"` | REQ-009 |
-| Exponent+suffix | `cpu: "1e3m"`, `memory: "1e3Ki"` | REQ-009 |
-| Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=true` | REQ-010 |
+| Category | Example |
+| --- | --- |
+| Type violations | `replicas: "abc"` (string instead of integer) |
+| Enum violations | `image.pullPolicy: "InvalidPolicy"` |
+| Range violations | `replicas: 0`, `metrics.port: 65536` |
+| Unknown properties | `image.digest: "sha256:abc"` |
+| Invalid quantities | `resources.limits.cpu: "not-valid"` |
+| Exponent+suffix | `cpu: "1e3m"`, `memory: "1e3Ki"` |
+| Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=true` |
 
 ### Positive Tests (acceptance)
 
-| Category | Example | Requirement |
-| --- | --- | --- |
-| Custom replicas | `replicas: 5` | CC-0069 |
-| Custom metrics port | `metrics.port: 9090` | CC-0069 |
-| String resource quantities | `cpu: "2"`, `memory: "1Gi"` | CC-0069 |
-| Numeric resource quantities | `cpu: 0.5` | CC-0069 |
-| Exponent-only quantities | `cpu: "1e3"` | CC-0069 |
-| Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=false` | CC-0069 |
+| Category | Example |
+| --- | --- |
+| Custom replicas | `replicas: 5` |
+| Custom metrics port | `metrics.port: 9090` |
+| String resource quantities | `cpu: "2"`, `memory: "1Gi"` |
+| Numeric resource quantities | `cpu: 0.5` |
+| Exponent-only quantities | `cpu: "1e3"` |
+| Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=false` |

--- a/docs/reference/backend/keystone-operator-packaging.md
+++ b/docs/reference/backend/keystone-operator-packaging.md
@@ -1,12 +1,11 @@
 ---
 title: Keystone Operator Packaging
 quadrant: backend
-feature: CC-0017
 ---
 
 # Keystone Operator Packaging
 
-Reference documentation for the Keystone operator packaging artifacts (CC-0017). This covers
+Reference documentation for the Keystone operator packaging artifacts. This covers
 the multi-stage Dockerfile, Helm chart configuration, FluxCD HelmRelease integration,
 dependency chain, and CRD installation behavior. These artifacts package the Keystone
 operator for deployment into Kubernetes clusters via the GitOps pipeline.
@@ -20,7 +19,7 @@ operators/keystone/
 │   └── keystone-operator/
 │       ├── Chart.yaml                  Helm chart metadata (v0.1.0)
 │       ├── values.yaml                 Default configuration values
-│       ├── values.schema.json          JSON Schema for values validation (CC-0069)
+│       ├── values.schema.json          JSON Schema for values validation
 │       ├── crds/
 │       │   └── keystone.openstack.c5c3.io_keystones.yaml   CRD (auto-installed by Helm)
 │       └── templates/

--- a/docs/reference/backend/kubernetes-packages.md
+++ b/docs/reference/backend/kubernetes-packages.md
@@ -1,13 +1,12 @@
 ---
 title: Kubernetes-Interacting Packages
 quadrant: shared-library
-feature: CC-0005, CC-0077
 ---
 
 # Kubernetes-Interacting Packages
 
 Reference documentation for the `internal/common/` packages that interact with the
-Kubernetes API server (CC-0005). These packages provide reconciler building blocks for
+Kubernetes API server. These packages provide reconciler building blocks for
 managing external operator CRDs (MariaDB, External Secrets Operator, cert-manager) and
 core Kubernetes resources (Deployments, Services, Jobs, CronJobs, ConfigMaps).
 
@@ -52,8 +51,8 @@ These packages import typed Go structs from external operator modules:
 
 ## Package: `config`
 
-Implements the INI configuration rendering pipeline for CobaltCore operators (CC-0004).
-CC-0005 adds the `CreateImmutableConfigMap` function for Kubernetes-interacting config
+Implements the INI configuration rendering pipeline for CobaltCore operators.
+The `CreateImmutableConfigMap` function provides Kubernetes-interacting config
 management.
 
 ### CreateImmutableConfigMap
@@ -129,7 +128,7 @@ Deletes stale immutable ConfigMaps that were previously created by
 `CreateImmutableConfigMap`, retaining the newest `retain` historical ConfigMaps
 (by `CreationTimestamp`) plus the currently active one identified by `currentName`.
 This prevents unbounded accumulation of immutable ConfigMaps across reconcile
-cycles (CC-0077).
+cycles.
 
 **Parameters:**
 
@@ -187,7 +186,7 @@ cycles (CC-0077).
 | `retain=0` | All historical ConfigMaps deleted, only `currentName` survives |
 | ConfigMap deleted between list and delete | `NotFound` silently ignored |
 | Overlapping prefix (e.g., `test-config-` vs `test-config-extra-`) | Strict `baseName + "-"` prefix prevents false matches |
-| Pre-existing ConfigMaps without `forge.c5c3.io/config-base` label | Not pruned — invisible to server-side selector. Bounded in number and GC'd on CR deletion via owner reference (CC-0077). |
+| Pre-existing ConfigMaps without `forge.c5c3.io/config-base` label | Not pruned — invisible to server-side selector. Bounded in number and GC'd on CR deletion via owner reference. |
 
 **Example:**
 
@@ -461,8 +460,7 @@ indicating the Job has permanently failed (e.g. exceeded its backoffLimit).
 
 ## Package: `policy`
 
-Provides pure functions for OpenStack oslo.policy rule rendering, merging, and validation
-(CC-0004). CC-0005 adds the `LoadPolicyFromConfigMap` function for reading policy from
+Provides pure functions for OpenStack oslo.policy rule rendering, merging, and validation. The `LoadPolicyFromConfigMap` function reads policy from
 Kubernetes ConfigMaps.
 
 ### LoadPolicyFromConfigMap
@@ -686,7 +684,7 @@ database/ ──depends-on──▶ job/
 ```
 
 The `database` package imports `job` to delegate `RunDBSyncJob` to `job.RunJob`. All other
-CC-0005 packages are independent of each other.
+packages are independent of each other.
 
 ## Reconciler Integration Pattern
 

--- a/docs/reference/backend/rotation-scripts.md
+++ b/docs/reference/backend/rotation-scripts.md
@@ -1,7 +1,6 @@
 ---
 title: Rotation Scripts
 quadrant: backend
-feature: CC-0073
 ---
 
 # Rotation Scripts
@@ -30,8 +29,8 @@ see the sub-reconciler sections in
 ```text
 operators/keystone/internal/controller/
 ├── scripts/
-│   ├── fernet_rotate.sh          # Fernet key rotation (CC-0073)
-│   └── credential_rotate.sh      # Credential key rotation (CC-0073)
+│   ├── fernet_rotate.sh          # Fernet key rotation
+│   └── credential_rotate.sh      # Credential key rotation
 ├── reconcile_fernet.go           # go:embed + ConfigMap creation
 └── reconcile_credential.go       # go:embed + ConfigMap creation
 ```

--- a/docs/reference/ci-cd/build-images-workflow.md
+++ b/docs/reference/ci-cd/build-images-workflow.md
@@ -1,30 +1,24 @@
 ---
 title: Build Images Workflow
 quadrant: infrastructure
-feature: CC-0007, CC-0029, CC-0030, CC-0031, CC-0032, CC-0034, CC-0051, CC-0055
 ---
 
 ::: v-pre
 
 # Build Images Workflow
 
-Reference documentation for the GitHub Actions build-images workflow (CC-0007, CC-0029,
-CC-0030, CC-0031, CC-0032, CC-0034, CC-0055) and the verify-container-images workflow
-(CC-0028). The build-images workflow builds, tags, and publishes container images for
+Reference documentation for the GitHub Actions build-images workflow and the verify-container-images workflow. The build-images workflow builds, tags, and publishes container images for
 OpenStack services to GHCR (GitHub Container Registry). Each pushed image receives OCI
-Image Spec annotations (CC-0031), a CycloneDX SBOM, a Sigstore-signed attestation
-(CC-0029), and a Grype vulnerability scan with SARIF upload to the GitHub Security tab
-(CC-0032). The verify-container-images workflow runs static verification tests against
+Image Spec annotations, a CycloneDX SBOM, a Sigstore-signed attestation, and a Grype vulnerability scan with SARIF upload to the GitHub Security tab. The verify-container-images workflow runs static verification tests against
 container infrastructure files (Dockerfiles, workflows, release configs) without requiring
 Docker.
 
-CC-0055 refactored repeated inline step sequences into reusable composite GitHub Actions
+Repeated inline step sequences are extracted into reusable composite GitHub Actions
 (`.github/actions/setup-docker-registry/`, `.github/actions/supply-chain-attest/`,
 `.github/actions/checkout-service-source/`, `.github/actions/export-digest/`) and
 standalone CI scripts (`hack/ci-merge-manifest.sh`, `hack/ci-run-unit-tests.sh`), reducing
-duplication across jobs. This is a purely structural refactoring — all jobs produce
-identical outputs and maintain the same security pipeline. See
-[Reusable Components (CC-0055)](#reusable-components-cc-0055) for details.
+duplication across jobs. All jobs produce identical outputs and maintain the same
+security pipeline. See [Reusable Components](#reusable-components) for details.
 
 ## File Locations
 
@@ -32,20 +26,20 @@ identical outputs and maintain the same security pipeline. See
 | --- | --- |
 | Build Images workflow | `.github/workflows/build-images.yaml` |
 | Verify Container Images workflow | `.github/workflows/verify-container-images.yaml` |
-| Setup Docker Registry action (CC-0055) | `.github/actions/setup-docker-registry/action.yaml` |
-| Supply Chain Attest action (CC-0055) | `.github/actions/supply-chain-attest/action.yaml` |
-| Checkout Service Source action (CC-0055) | `.github/actions/checkout-service-source/action.yaml` |
-| Export Digest action (CC-0055) | `.github/actions/export-digest/action.yaml` |
-| Merge Manifest script (CC-0055) | `hack/ci-merge-manifest.sh` |
-| Run Unit Tests script (CC-0055) | `hack/ci-run-unit-tests.sh` |
+| Setup Docker Registry action | `.github/actions/setup-docker-registry/action.yaml` |
+| Supply Chain Attest action | `.github/actions/supply-chain-attest/action.yaml` |
+| Checkout Service Source action | `.github/actions/checkout-service-source/action.yaml` |
+| Export Digest action | `.github/actions/export-digest/action.yaml` |
+| Merge Manifest script | `hack/ci-merge-manifest.sh` |
+| Run Unit Tests script | `hack/ci-run-unit-tests.sh` |
 
 Both workflow files use the `.yaml` extension and quote the trigger key as `"on"` to
-prevent YAML boolean interpretation (REQ-008). They start with the standard SPDX license
+prevent YAML boolean interpretation. They start with the standard SPDX license
 header (matching `ci.yaml`).
 
 ## Trigger Events
 
-The workflow triggers on two events (REQ-001):
+The workflow triggers on two events:
 
 | Event | Scope | Description |
 | --- | --- | --- |
@@ -58,11 +52,11 @@ single-arch images loaded locally for testing (see [PR vs Push Behavior](#pr-vs-
 > **Fork PRs are not supported.** Base images must be pushed to GHCR on every run
 > (because downstream `docker-image://` URIs require registry availability), but fork
 > PRs receive a read-only `GITHUB_TOKEN` that cannot write packages. The workflow
-> detects fork PRs and fails fast with a clear error message (CC-0007).
+> detects fork PRs and fails fast with a clear error message.
 
 ## Permissions
 
-Top-level permissions grant least privilege (REQ-008). Registry write access and
+Top-level permissions grant least privilege. Registry write access and
 attestation permissions are scoped to merge and build jobs only:
 
 ```yaml
@@ -74,9 +68,9 @@ permissions:
 permissions:
   contents: read
   packages: write
-  id-token: write         # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing for SBOM attestation, cosign signing, and build provenance
-  attestations: write     # CC-0029, CC-0035: GitHub Attestations API
-  security-events: write  # CC-0032: GitHub Security tab SARIF upload
+  id-token: write
+  attestations: write
+  security-events: write
 
 # Verification jobs (verify-base-images, verify-service-images)
 permissions:
@@ -90,21 +84,21 @@ digests) and to `merge-base-images`, `merge-tempest-image`, `merge-service-image
 pushing manifest lists).
 `id-token: write` enables Sigstore keyless OIDC signing — the GitHub Actions runner
 requests a short-lived OIDC token bound to the workflow identity, which Sigstore uses to
-sign the attestation without managing keys (CC-0029). `attestations: write` grants
+sign the attestation without managing keys. `attestations: write` grants
 access to the GitHub Attestations API for storing signed attestations.
 `security-events: write` allows uploading Grype vulnerability scan results in SARIF
-format to the GitHub Security tab (CC-0032). These three permissions are scoped to the
+format to the GitHub Security tab. These three permissions are scoped to the
 merge jobs (`merge-base-images`, `merge-tempest-image`, `merge-service-images`) and to
 `build-service-images` and `build-tempest` (for PR-only Grype scans via
 `supply-chain-attest` with `scan-mode: image`). The verification jobs
 (`verify-base-images`, `verify-service-images`) do **not** receive `id-token`,
 `attestations`, or `security-events` permissions — they only need `contents: read` (for
 checkout and test scripts) and `packages: read` (for pulling images from GHCR), following
-the principle of least privilege (CC-0028).
+the principle of least privilege.
 
 ## Concurrency
 
-The workflow uses a concurrency group scoped per-branch per-workflow (REQ-008):
+The workflow uses a concurrency group scoped per-branch per-workflow:
 
 ```yaml
 concurrency:
@@ -116,13 +110,13 @@ For pull requests, pushing new commits cancels any in-progress build for that sa
 branch. For pushes to `main` or `stable/**`, in-progress runs are **not** cancelled,
 ensuring every merge commit produces a complete set of images.
 
-## Reusable Components (CC-0055)
+## Reusable Components
 
-CC-0055 extracted repeated inline step sequences into six composite GitHub Actions and
+Repeated inline step sequences are extracted into six composite GitHub Actions and
 four standalone CI scripts. These components encapsulate patterns that were previously
 duplicated across multiple jobs, ensuring consistency and reducing the workflow from
-~934 lines to under 600 lines. All components follow the existing CC-0050 conventions
-for CI scripts and the repository's composite action patterns.
+~934 lines to under 600 lines. All components follow the repository's CI script
+and composite action conventions.
 
 ### setup-docker-registry
 
@@ -222,7 +216,7 @@ composite action after building, replacing inline `mkdir`/`touch`/`upload-artifa
 
 Merges per-platform digest files into a multi-arch manifest using
 `docker buildx imagetools create`, then inspects the result to extract and output the
-final manifest digest. Follows CC-0050 conventions: shebang, SPDX header, feature ID,
+final manifest digest. Follows the repo's CI-script conventions: shebang, SPDX header,
 `set -euo pipefail`, env var interface with `::error::` annotations.
 
 | Env var | Required | Default | Description |
@@ -242,7 +236,7 @@ env vars passed through the step's `env:` block.
 
 Runs stestr-based OpenStack service unit tests inside a `venv-builder` container image.
 Handles volume mounts for source code, constraints, test excludes, and result collection.
-Follows CC-0050 conventions.
+Follows the repo's CI-script conventions.
 
 | Env var | Required | Default | Description |
 | --- | --- | --- | --- |
@@ -262,7 +256,7 @@ debugging failed tests.
 
 ## Jobs
 
-The workflow defines eleven jobs with a dependency graph (CC-0028, CC-0034, CC-0055):
+The workflow defines eleven jobs with a dependency graph:
 
 ```text
 lint-dockerfiles ─┐
@@ -285,28 +279,27 @@ prepare ──────────┤
 Each platform (linux/amd64 on `ubuntu-latest`, linux/arm64 on `ubuntu-24.04-arm`) is
 built on a native runner and pushed by digest. `merge-base-images` then assembles the
 multi-arch manifest list and runs the supply chain security pipeline via the
-`supply-chain-attest` composite action (CC-0055). The same pattern applies to service
+`supply-chain-attest` composite action. The same pattern applies to service
 images via `build-service-images` and `merge-service-images`, and to Tempest images via
 `build-tempest` and `merge-tempest-image`.
 
 The `verify-base-images` job validates base image properties (Python version, user
 UID/GID, PATH, uv version) before service image builds begin. This catches base image
 regressions before they cascade into service image failures. The `test-service-images`
-job (CC-0034) runs upstream unit tests for each service via `hack/ci-run-unit-tests.sh`
-(CC-0055), in parallel with `build-service-images`. On push events, the
+job runs upstream unit tests for each service via `hack/ci-run-unit-tests.sh`, in parallel with `build-service-images`. On push events, the
 `verify-service-images` job validates service images pulled from GHCR and gates on
 `merge-service-images` and `test-service-images`. On PRs, the equivalent image
 verification runs as an inline step within `build-service-images` because `--load` makes
 the image available only on the same runner (ARM64 is excluded on PRs).
 
-All jobs use the `setup-docker-registry` composite action (CC-0055) for Docker Buildx
+All jobs use the `setup-docker-registry` composite action for Docker Buildx
 setup, registry authentication, and optional cosign installation, replacing the
 previously duplicated three-step setup sequence.
 
 ### build-base-images
 
 Builds the two base images (`python-base` and `venv-builder`) per platform on native
-runners and pushes each single-arch image by digest (REQ-002). These must always be
+runners and pushes each single-arch image by digest. These must always be
 pushed — even on PRs — because downstream service builds reference them via
 `docker-image://` URIs, which require registry availability. The multi-arch manifest list
 is assembled by the subsequent `merge-base-images` job.
@@ -325,18 +318,18 @@ is assembled by the subsequent `merge-base-images` job.
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork (CC-0007) |
+| 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork |
 | 2 | Checkout | `actions/checkout@v6` | Checks out the repository |
-| 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references (CC-0007) |
+| 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references |
 | 4 | Prepare platform pair | `.github/actions/platform-pair` | Converts `linux/amd64` → `linux-amd64` for use in artifact names and cache scopes |
-| 5 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login (cosign disabled); replaces inline buildx + login steps (CC-0055) |
+| 5 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login (cosign disabled); replaces inline buildx + login steps |
 | 6 | Resolve ubuntu:noble digest | Shell | Resolves the upstream base image digest for OCI base-image annotations |
-| 7 | Generate metadata for python-base | `docker/metadata-action@v6` | Produces OCI labels (title, description, licenses, vendor) for python-base (CC-0031) |
+| 7 | Generate metadata for python-base | `docker/metadata-action@v6` | Produces OCI labels (title, description, licenses, vendor) for python-base |
 | 8 | Build python-base | `docker/build-push-action@v7` | Context: `images/python-base`, single platform, `push-by-digest=true`; digest exported as artifact |
-| 9 | Export python-base digest | `.github/actions/export-digest` | Writes digest to staging dir and uploads as artifact `digests-python-base-<platform-pair>` (CC-0055) |
-| 10 | Generate metadata for venv-builder | `docker/metadata-action@v6` | Produces OCI labels for venv-builder (CC-0031) |
+| 9 | Export python-base digest | `.github/actions/export-digest` | Writes digest to staging dir and uploads as artifact `digests-python-base-<platform-pair>` |
+| 10 | Generate metadata for venv-builder | `docker/metadata-action@v6` | Produces OCI labels for venv-builder |
 | 11 | Build venv-builder | `docker/build-push-action@v7` | Context: `images/venv-builder`, single platform, `push-by-digest=true`; uses python-base from step 8 by digest |
-| 12 | Export venv-builder digest | `.github/actions/export-digest` | Writes digest to staging dir and uploads as artifact `digests-venv-builder-<platform-pair>` (CC-0055) |
+| 12 | Export venv-builder digest | `.github/actions/export-digest` | Writes digest to staging dir and uploads as artifact `digests-venv-builder-<platform-pair>` |
 
 :::
 
@@ -360,14 +353,14 @@ on the final manifests.
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
-| 2 | Normalize image owner | Shell script | Outputs lowercase `owner` value (CC-0007) |
-| 3 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign (CC-0055) |
+| 2 | Normalize image owner | Shell script | Outputs lowercase `owner` value |
+| 3 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign |
 | 4 | Download python-base digests | `actions/download-artifact@v4` | Downloads all `digests-python-base-*` artifacts, merges into `/tmp/digests/python-base/` |
-| 5 | Create python-base manifest | `hack/ci-merge-manifest.sh` | Assembles per-platform digests into multi-arch manifest; tags `:latest` and `:${{ github.sha }}`; outputs merged manifest digest (CC-0055) |
-| 6 | Supply chain attest python-base | `.github/actions/supply-chain-attest` | SBOM + Grype scan + SARIF upload + attestation + provenance + cosign sign. Uses `scan-mode: sbom` on push, `image` on PR (CC-0055) |
+| 5 | Create python-base manifest | `hack/ci-merge-manifest.sh` | Assembles per-platform digests into multi-arch manifest; tags `:latest` and `:${{ github.sha }}`; outputs merged manifest digest |
+| 6 | Supply chain attest python-base | `.github/actions/supply-chain-attest` | SBOM + Grype scan + SARIF upload + attestation + provenance + cosign sign. Uses `scan-mode: sbom` on push, `image` on PR |
 | 7 | Download venv-builder digests | `actions/download-artifact@v4` | Downloads all `digests-venv-builder-*` artifacts |
-| 8 | Create venv-builder manifest | `hack/ci-merge-manifest.sh` | Same pattern as step 5 for venv-builder (CC-0055) |
-| 9 | Supply chain attest venv-builder | `.github/actions/supply-chain-attest` | Same pattern as step 6 for venv-builder (CC-0055) |
+| 8 | Create venv-builder manifest | `hack/ci-merge-manifest.sh` | Same pattern as step 5 for venv-builder |
+| 9 | Supply chain attest venv-builder | `.github/actions/supply-chain-attest` | Same pattern as step 6 for venv-builder |
 
 :::
 
@@ -375,7 +368,7 @@ on the final manifests.
 
 Each base image is tagged with both `:latest` (mutable convenience tag) and
 `:${{ github.sha }}` (immutable commit-pinned tag). The SHA tag provides an auditable
-mapping from any base image in GHCR back to the commit that produced it (CC-0007).
+mapping from any base image in GHCR back to the commit that produced it.
 
 :::
 
@@ -387,12 +380,12 @@ mapping from any base image in GHCR back to the commit that produced it (CC-0007
 | `venv-builder-image` | `ghcr.io/<owner>/venv-builder@sha256:<digest>` | `ghcr.io/c5c3/venv-builder@sha256:def456...` |
 
 These outputs are consumed by `verify-base-images` and `build-service-images` via
-`needs.merge-base-images.outputs` (REQ-003).
+`needs.merge-base-images.outputs`.
 
 ### verify-base-images
 
 Validates that just-assembled base image manifests meet expected properties before
-service image builds begin (CC-0028). Runs after `merge-base-images` and blocks
+service image builds begin. Runs after `merge-base-images` and blocks
 `build-service-images`, forming the dependency chain:
 `build-base-images` → `merge-base-images` → `verify-base-images` → `build-service-images`.
 
@@ -408,7 +401,7 @@ service image builds begin (CC-0028). Runs after `merge-base-images` and blocks
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts) |
-| 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step (CC-0055) |
+| 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step |
 | 3 | Pull base images | Shell | Pulls both `python-base` and `venv-builder` by digest from `merge-base-images` outputs |
 | 4 | Verify python-base | Shell | Runs `verify_python_base.sh` with the digest-tagged image ref |
 | 5 | Verify venv-builder | Shell | Runs `verify_venv_builder.sh` with the digest-tagged image ref |
@@ -426,9 +419,8 @@ ensuring the exact manifests that were just assembled are the ones being tested.
 ### build-service-images
 
 Builds service images per platform on native runners and pushes each single-arch image by
-digest (REQ-004). Depends on `merge-base-images` for image references (REQ-003) and on
-`verify-base-images` to ensure base images are valid before building on top of them
-(CC-0028). The multi-arch manifest list is assembled by `merge-service-images`.
+digest. Depends on `merge-base-images` for image references and on
+`verify-base-images` to ensure base images are valid before building on top of them. The multi-arch manifest list is assembled by `merge-service-images`.
 
 On pull requests, ARM64 is excluded (only `linux/amd64` is built) and the image is loaded
 locally for inline verification instead of being pushed to GHCR.
@@ -447,16 +439,16 @@ locally for inline verification instead of being pushed to GHCR.
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out this repository |
-| 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides (CC-0055) |
-| 3 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards (CC-0027). |
-| 4 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (see [Tag Schema](#tag-schema)) (REQ-005, CC-0029) |
+| 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides |
+| 3 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards. |
+| 4 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (see [Tag Schema](#tag-schema)) |
 | 5 | Prepare platform pair | `.github/actions/platform-pair` | Converts `linux/amd64` → `linux-amd64` for artifact names and cache scopes |
-| 6 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login (cosign disabled) (CC-0055) |
-| 7 | Generate metadata for service image | `docker/metadata-action@v6` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy (CC-0031) |
-| 8 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args. Non-PR: `push-by-digest=true`, digest exported as artifact. PR: `load: true`, composite tag (REQ-006) |
-| 9 | Export service image digest | `.github/actions/export-digest` | Non-PR only. Uploads artifact `digests-service-<service>-<release>-<platform-pair>` (CC-0055) |
-| 10 | Supply chain scan (PR) | `.github/actions/supply-chain-attest` | PR only: scans locally loaded image via Grype (`scan-mode: image`), uploads SARIF (CC-0055) |
-| 11 | Verify service image (PR) | Shell (conditional) | PR only: runs `verify_${{ matrix.service }}.sh` with the locally loaded image ref (CC-0028) |
+| 6 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login (cosign disabled) |
+| 7 | Generate metadata for service image | `docker/metadata-action@v6` | Produces OCI labels and overrides version to the upstream release ref via `type=raw` strategy |
+| 8 | Build service image | `docker/build-push-action@v7` | Builds with four named build contexts and three build args. Non-PR: `push-by-digest=true`, digest exported as artifact. PR: `load: true`, composite tag |
+| 9 | Export service image digest | `.github/actions/export-digest` | Non-PR only. Uploads artifact `digests-service-<service>-<release>-<platform-pair>` |
+| 10 | Supply chain scan (PR) | `.github/actions/supply-chain-attest` | PR only: scans locally loaded image via Grype (`scan-mode: image`), uploads SARIF |
+| 11 | Verify service image (PR) | Shell (conditional) | PR only: runs `verify_${{ matrix.service }}.sh` with the locally loaded image ref |
 
 :::
 
@@ -487,13 +479,13 @@ were computed during the build.
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
 | 2 | Install yq | `mikefarah/yq@v4` | Required by the derive-service-tags composite action |
-| 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value (CC-0007) |
-| 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign (CC-0055) |
-| 5 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (REQ-005) |
+| 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value |
+| 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign |
+| 5 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags |
 | 6 | Download service image digests | `actions/download-artifact@v4` | Downloads all `digests-service-<service>-<release>-*` artifacts |
 | 7 | Build service image tags | Shell | Assembles composite + SHA tags (all branches), version + release tags (main only) |
-| 8 | Create and push service image manifest | `hack/ci-merge-manifest.sh` | Assembles per-platform digests into multi-arch manifest; outputs merged manifest digest (CC-0055) |
-| 9 | Supply chain attest service image | `.github/actions/supply-chain-attest` | SBOM + Grype scan + SARIF upload + attestation + provenance + cosign sign (CC-0055) |
+| 8 | Create and push service image manifest | `hack/ci-merge-manifest.sh` | Assembles per-platform digests into multi-arch manifest; outputs merged manifest digest |
+| 9 | Supply chain attest service image | `.github/actions/supply-chain-attest` | SBOM + Grype scan + SARIF upload + attestation + provenance + cosign sign |
 
 :::
 
@@ -509,7 +501,7 @@ The service image build passes four named build contexts to resolve `FROM` and
 | `<service>` | `src/<service>` | Service source tree (upstream checkout) |
 | `upper-constraints` | `releases/<release>/` | Release directory containing `upper-constraints.txt` |
 
-**Build Arguments (CC-0027):**
+**Build Arguments:**
 
 The service image build passes three build arguments sourced from
 `releases/<release>/extra-packages.yaml` by the "Resolve extra packages" step:
@@ -526,13 +518,13 @@ The service image build passes three build arguments sourced from
 YAML schema.
 
 This job does not declare outputs. The `verify-service-images` job derives its own image
-refs independently via its own matrix strategy (CC-0007).
+refs independently via its own matrix strategy.
 
 ### test-service-images
 
 ::: v-pre
 
-Runs upstream unit tests for each service inside the `venv-builder` container (CC-0034).
+Runs upstream unit tests for each service inside the `venv-builder` container.
 The job checks out the service source at the version specified in `source-refs.yaml`,
 applies any patches and constraint overrides, then executes `stestr run` inside a Docker
 container built from the `venv-builder` image. Test results are exported as subunit
@@ -560,10 +552,10 @@ This job runs in parallel with `build-service-images` — both depend on
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
-| 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides; eliminates "MUST stay in sync" duplication with `build-service-images` (CC-0055) |
+| 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides; eliminates "MUST stay in sync" duplication with `build-service-images` |
 | 3 | Resolve pip extras | Shell | Reads `pip_extras` from `extra-packages.yaml` to construct the install spec (e.g. `.[ldap]` or `.`) |
-| 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); authenticates to pull `venv-builder` image (CC-0055) |
-| 5 | Run tests | `hack/ci-run-unit-tests.sh` | Runs stestr-based unit tests inside the `venv-builder` container via env var interface; replaces ~50-line inline `docker run` block (CC-0055) |
+| 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); authenticates to pull `venv-builder` image |
+| 5 | Run tests | `hack/ci-run-unit-tests.sh` | Runs stestr-based unit tests inside the `venv-builder` container via env var interface; replaces ~50-line inline `docker run` block |
 | 6 | Upload test results | `actions/upload-artifact@v7` | Always runs. Uploads `results/testresults.subunit` with 30-day retention |
 
 :::
@@ -579,7 +571,7 @@ lines are regex patterns matching test IDs to skip. See
 **Test Coverage:**
 
 The `verify_build_images_workflow.sh` script validates test-service-images job structure
-and steps (CC-0034):
+and steps:
 
 | Test | Validates |
 | --- | --- |
@@ -600,13 +592,13 @@ and steps (CC-0034):
 | `test_test_service_images_artifact_name` | Artifact name includes `matrix.service` and `matrix.release` for disambiguation |
 | `test_test_service_images_env_vars` | `run:` blocks use `env:` for matrix values, not direct <code v-pre>${{ matrix.* }}</code> interpolation |
 | `test_test_service_images_docker_run` | Run tests uses `docker run` with `VENV_BUILDER_IMAGE` |
-| `test_test_service_images_feature_comment` | Workflow contains CC-0034 feature comment |
+| `test_test_service_images_feature_comment` | Workflow contains the expected feature comment |
 | `test_verify_service_images_depends_on_service_images` | `verify-service-images` `needs` includes both `build-service-images` and `test-service-images` |
 | `test_timeout_minutes_on_all_jobs` | All jobs including `test-service-images` have `timeout-minutes` set |
 | `test_runs_on_ubuntu_latest` | All jobs including `test-service-images` use `runs-on: ubuntu-latest` |
 | `test_matrix_jobs_fail_fast_false` | All matrix jobs including `test-service-images` have `fail-fast: false` |
 
-The `verify_release_config.sh` script validates test-excludes file structure (CC-0034):
+The `verify_release_config.sh` script validates test-excludes file structure:
 
 | Test | Validates |
 | --- | --- |
@@ -618,8 +610,7 @@ The `verify_release_config.sh` script validates test-excludes file structure (CC
 
 ::: v-pre
 
-Validates that built service images are functional by running `verify_${{ matrix.service }}.sh`
-(CC-0028). This job replaces the former `smoke-test` job and runs only on push events
+Validates that built service images are functional by running `verify_${{ matrix.service }}.sh`. This job replaces the former `smoke-test` job and runs only on push events
 (when images are in GHCR). It uses its own matrix strategy matching
 `build-service-images` to test every service independently.
 
@@ -644,7 +635,7 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts, `source-refs.yaml`, and patch counting) |
-| 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step (CC-0055) |
+| 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step |
 | 3 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Reconstructs tags using the same logic as `build-service-images` and `merge-service-images` |
 | 4 | Pull and verify | Shell | `docker pull <image-ref>` then runs `verify_${{ matrix.service }}.sh` with the pulled image ref |
 
@@ -662,7 +653,7 @@ truth shared by `build-service-images`, `merge-service-images`, and `verify-serv
 
 ## Tag Schema
 
-Each service image build produces two to four tags on push events (REQ-005):
+Each service image build produces two to four tags on push events:
 
 | Tag | Format | Example | Branches |
 | --- | --- | --- | --- |
@@ -673,7 +664,7 @@ Each service image build produces two to four tags on push events (REQ-005):
 
 The version-only and release tags are restricted to the `main` branch to prevent silent
 overwrites when multiple branches build the same upstream version. The composite tag
-already encodes the branch, so `stable/**` builds remain uniquely identifiable (CC-0007).
+already encodes the branch, so `stable/**` builds remain uniquely identifiable.
 
 **Tag components:**
 
@@ -690,7 +681,7 @@ systems.
 
 ## PR vs Push Behavior
 
-The workflow behaves differently depending on the trigger event (REQ-006):
+The workflow behaves differently depending on the trigger event:
 
 | Aspect | Pull Request | Push (main / stable/**) |
 | --- | --- | --- |
@@ -699,11 +690,11 @@ The workflow behaves differently depending on the trigger event (REQ-006):
 | Service image platforms | `linux/amd64` only (ARM64 excluded) | `linux/amd64,linux/arm64` |
 | Service image push | No (`load: true` on amd64 runner) | Yes (by digest, tags assigned by `merge-service-images`) |
 | Service image tags | Computed but not published | Published to GHCR |
-| SBOM generation | Skipped (CC-0029) | CycloneDX JSON for every merged manifest |
-| Vulnerability scanning | Image-based scan on PR (`image:` input in `build-service-images`) (CC-0032) | SBOM-based scan in `merge-service-images` (`sbom:` input) (CC-0032) |
-| SBOM attestation | Skipped (CC-0029) | Sigstore-signed, pushed to GHCR |
-| Cosign signing | Skipped (CC-0030) | Keyless signature for every merged manifest |
-| OIDC token request | None | Requested in merge jobs for Sigstore signing (CC-0029, CC-0030) |
+| SBOM generation | Skipped | CycloneDX JSON for every merged manifest |
+| Vulnerability scanning | Image-based scan on PR (`image:` input in `build-service-images`) | SBOM-based scan in `merge-service-images` (`sbom:` input) |
+| SBOM attestation | Skipped | Sigstore-signed, pushed to GHCR |
+| Cosign signing | Skipped | Keyless signature for every merged manifest |
+| OIDC token request | None | Requested in merge jobs for Sigstore signing |
 | Service image verification | Inline step in `build-service-images` | Separate `verify-service-images` job |
 | Verification image source | Locally loaded image (same amd64 runner) | Pulled from GHCR |
 
@@ -721,8 +712,7 @@ digest), so the native ARM runner is exercised without requiring a locally loade
 
 ## GHA Caching
 
-All `docker/build-push-action` steps use GitHub Actions cache for Docker layers
-(REQ-009):
+All `docker/build-push-action` steps use GitHub Actions cache for Docker layers:
 
 ```yaml
 cache-from: type=gha,scope=<scope>
@@ -741,20 +731,20 @@ The `mode=max` setting caches all intermediate layers, not just the final image 
 
 ## Action Pinning
 
-All actions are pinned to full commit SHAs with version comments (REQ-008), matching the
+All actions are pinned to full commit SHAs with version comments, matching the
 convention in `ci.yaml`:
 
 ```yaml
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
 uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4
-uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5 (CC-0031)
+uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
 uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
-uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0 (CC-0029)
-uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c  # v7 (CC-0032)
-uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4 (CC-0029)
-uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818  # v3 (CC-0032)
-uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4 (CC-0030)
+uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0
+uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c  # v7
+uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
+uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818  # v3
+uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4
 ```
 
 This prevents supply-chain attacks via tag mutation while remaining auditable through
@@ -763,14 +753,13 @@ version comments.
 ## SBOM Generation and Attestation
 
 Every container image pushed to GHCR on non-PR events receives a CycloneDX SBOM and a
-Sigstore-signed attestation (CC-0029). This enables consumers to audit image contents,
+Sigstore-signed attestation. This enables consumers to audit image contents,
 check for known vulnerabilities, and verify that images have not been tampered with since
 build time.
 
-> **CC-0055 consolidation:** SBOM generation, attestation, vulnerability scanning,
-> build provenance, and cosign signing are now handled by a single parameterised
-> composite action (`.github/actions/supply-chain-attest`). The behavior described
-> below is unchanged — only the implementation is consolidated. See
+> **Consolidation note.** SBOM generation, attestation, vulnerability scanning,
+> build provenance, and cosign signing are handled by a single parameterised
+> composite action (`.github/actions/supply-chain-attest`). See
 > [supply-chain-attest](#supply-chain-attest) for the composite action interface.
 
 ### How It Works
@@ -789,7 +778,7 @@ merge job and performs:
    token binds the attestation to the specific workflow run.
 
 This pattern is applied to all four image types via the `supply-chain-attest` composite
-action (CC-0055):
+action:
 
 ::: v-pre
 
@@ -828,7 +817,7 @@ SBOM attestation requires two additional job-level permissions beyond the existi
 
 | Permission | Purpose |
 | --- | --- |
-| `id-token: write` | Allows the GitHub Actions runner to request a short-lived Sigstore OIDC token for keyless signing (CC-0029, CC-0030) |
+| `id-token: write` | Allows the GitHub Actions runner to request a short-lived Sigstore OIDC token for keyless signing |
 | `attestations: write` | Grants access to the GitHub Attestations API for storing signed attestations |
 
 These permissions are granted to `merge-base-images`, `merge-tempest-image`,
@@ -866,8 +855,7 @@ gh attestation verify oci://ghcr.io/<owner>/<service>:<tag> \
 
 ### Test Coverage
 
-The `verify_build_images_workflow.sh` script validates SBOM/attestation configuration
-(CC-0029):
+The `verify_build_images_workflow.sh` script validates SBOM/attestation configuration:
 
 | Test | Validates |
 | --- | --- |
@@ -884,13 +872,13 @@ The `verify_build_images_workflow.sh` script validates SBOM/attestation configur
 ## Cosign Image Signing
 
 Every container image pushed to GHCR on non-PR events is signed with cosign keyless
-signing (CC-0030). This provides an independent signature layer alongside the SBOM
-attestation (CC-0029), enabling consumers to verify image provenance using standard
+signing. This provides an independent signature layer alongside the SBOM
+attestation, enabling consumers to verify image provenance using standard
 Sigstore tooling.
 
 ### How It Works
 
-Cosign is installed by the `setup-docker-registry` composite action (CC-0055) when
+Cosign is installed by the `setup-docker-registry` composite action when
 `install-cosign: 'true'` (the default, used by merge jobs). The `supply-chain-attest`
 composite action then runs `cosign sign --yes` as the final step of the supply chain
 pipeline:
@@ -904,7 +892,7 @@ pipeline:
    specific workflow run.
 
 This pattern is applied to all four image types via the `supply-chain-attest` composite
-action (CC-0055):
+action:
 
 | Image | Job | Digest source |
 | --- | --- | --- |
@@ -925,7 +913,7 @@ pull requests:
 ### Required Permissions
 
 Cosign keyless signing reuses the same `id-token: write` permission required by SBOM
-attestation (CC-0029). No additional permissions are needed.
+attestation. No additional permissions are needed.
 
 ### Verifying Signatures
 
@@ -940,8 +928,7 @@ cosign verify \
 
 ### Test Coverage
 
-The `verify_build_images_workflow.sh` script validates cosign signing configuration
-(CC-0030):
+The `verify_build_images_workflow.sh` script validates cosign signing configuration:
 
 | Test | Validates |
 | --- | --- |
@@ -951,19 +938,19 @@ The `verify_build_images_workflow.sh` script validates cosign signing configurat
 | `test_cosign_sign_steps_pr_guard` | All sign steps have `github.event_name != 'pull_request'` guard |
 | `test_cosign_sign_steps_reference_digest` | Sign steps reference the correct digest output |
 | `test_cosign_sign_uses_yes_flag` | All sign steps use the `--yes` flag |
-| `test_cosign_id_token_permission_comment` | `id-token: write` comment references CC-0030 |
+| `test_cosign_id_token_permission_comment` | `id-token: write` comment references cosign signing |
 
 ## Vulnerability Scanning
 
 Every container image is scanned for known CVEs using Grype (via `anchore/scan-action`)
-on every push and pull request (CC-0032). Unlike SBOM generation, attestation, and cosign
+on every push and pull request. Unlike SBOM generation, attestation, and cosign
 signing (which are skipped on PRs), vulnerability scanning runs on **both** event types
 to provide immediate feedback on high-severity CVEs before merging.
 
-> **CC-0055 consolidation:** Vulnerability scanning is now part of the
+> **Consolidation note.** Vulnerability scanning is part of the
 > `supply-chain-attest` composite action. In `sbom` mode (push), Grype scans the SBOM.
 > In `image` mode (PR), Grype scans the image directly. Both modes upload SARIF to the
-> GitHub Security tab. The behavior is unchanged from the previous inline implementation.
+> GitHub Security tab.
 
 ### How It Works
 
@@ -983,7 +970,7 @@ The `supply-chain-attest` composite action includes two vulnerability scanning s
    scan step crashes without producing output.
 
 This pattern is applied to all four image types via the `supply-chain-attest` composite
-action (CC-0055):
+action:
 
 ::: v-pre
 
@@ -1028,7 +1015,7 @@ All Grype scan steps use `severity-cutoff: high` with `fail-build: false`:
 ### CVE Suppression
 
 A `.grype.yaml` configuration file at the repository root allows suppression of
-known-accepted CVEs (CC-0032). Grype automatically reads this file from the working
+known-accepted CVEs. Grype automatically reads this file from the working
 directory (default behavior — no explicit configuration needed).
 
 ```yaml
@@ -1061,13 +1048,13 @@ Grype scan results are uploaded to the GitHub Security tab via
 
 SARIF upload requires `security-events: write` permission on merge jobs
 (`merge-base-images`, `merge-tempest-image`, `merge-service-images`) and on
-`build-service-images` (for PR-only scans) (CC-0032). Verification jobs (`verify-base-images`,
+`build-service-images` (for PR-only scans). Verification jobs (`verify-base-images`,
 `verify-service-images`) do not receive this permission (least privilege).
 
 ### Test Coverage
 
 The `verify_build_images_workflow.sh` script validates vulnerability scanning
-configuration (CC-0032):
+configuration:
 
 | Test | Validates |
 | --- | --- |
@@ -1088,11 +1075,11 @@ configuration (CC-0032):
 | `test_security_events_permission_build_base_images` | `build-base-images` has `security-events: write` |
 | `test_security_events_permission_build_service_images` | `build-service-images` has `security-events: write` |
 | `test_verify_jobs_no_security_events_permission` | Verify jobs do **not** have `security-events` permission |
-| `test_security_events_permission_comment` | `security-events` permission comment references CC-0032 |
+| `test_security_events_permission_comment` | `security-events` permission comment references SARIF upload |
 
 ## OCI Annotations
 
-Every container image receives OCI Image Spec annotations (CC-0031) via a two-layer
+Every container image receives OCI Image Spec annotations via a two-layer
 approach: static `LABEL` instructions in Dockerfiles provide baseline metadata for local
 builds, while `docker/metadata-action` in CI generates dynamic labels that supplement the
 static ones at push time.
@@ -1170,8 +1157,7 @@ without an upstream software version.
 
 ### Test Coverage
 
-The `verify_build_images_workflow.sh` script validates OCI annotation configuration
-(CC-0031):
+The `verify_build_images_workflow.sh` script validates OCI annotation configuration:
 
 | Test | Validates |
 | --- | --- |
@@ -1200,7 +1186,7 @@ Add a Dockerfile at `images/<service>/Dockerfile` following the two-stage patter
 `images/keystone/Dockerfile`. The Dockerfile must use named build contexts
 (`python-base`, `venv-builder`, `<service>`, `upper-constraints`) — not hardcoded paths.
 Include a `LABEL` instruction in the runtime stage with OCI annotations (title,
-description, licenses, vendor) — see [OCI Annotations](#oci-annotations) (CC-0031).
+description, licenses, vendor) — see [OCI Annotations](#oci-annotations).
 
 ### 2. Add the source ref
 
@@ -1259,7 +1245,7 @@ changes are needed.
 The tag derivation, build context resolution, source checkout (via
 `checkout-service-source`), unit test execution (via `hack/ci-run-unit-tests.sh`), supply
 chain attestation (via `supply-chain-attest`), and verification steps all use matrix
-variables and work automatically for new services (CC-0055). The `verify-service-images`
+variables and work automatically for new services. The `verify-service-images`
 job derives its own image refs independently via its own matrix strategy. Note that adding
 a new service also requires creating a corresponding `verify_<service>.sh` test script in
 `tests/container-images/` and updating the inline PR verification step in
@@ -1275,10 +1261,10 @@ Create the release directory with required files:
 
 ```text
 releases/2026.1/
-├── extra-packages.yaml       # Extra pip/apt packages per service (CC-0027)
+├── extra-packages.yaml       # Extra pip/apt packages per service
 ├── source-refs.yaml          # Service versions for this release
-├── test-refs.yaml            # PyPI version pins for test tooling (CC-0035)
-├── test-excludes/            # (Optional) Per-service stestr exclude-lists (CC-0034)
+├── test-refs.yaml            # PyPI version pins for test tooling
+├── test-excludes/            # (Optional) Per-service stestr exclude-lists
 │   └── <service>.txt
 └── upper-constraints.txt     # From openstack/requirements stable/2026.1
 ```
@@ -1286,7 +1272,7 @@ releases/2026.1/
 `extra-packages.yaml` is required — the workflow reads it to resolve `PIP_EXTRAS`,
 `PIP_PACKAGES`, and `EXTRA_APT_PACKAGES` build arguments. `test-refs.yaml` is required —
 the `build-tempest` job reads it to resolve `TEMPEST_VERSION` and
-`KEYSTONE_TEMPEST_PLUGIN_VERSION` build arguments (CC-0035). See
+`KEYSTONE_TEMPEST_PLUGIN_VERSION` build arguments. See
 [Container Images — extra-packages.yaml](container-images.md#extra-packagesyaml) for the
 YAML schema and `releases/2025.2/extra-packages.yaml` for a working example.
 
@@ -1322,8 +1308,7 @@ add a corresponding matrix entry to the `tempest` job in `ci.yaml` (see
 ## Verify Container Images Workflow
 
 A separate workflow (`.github/workflows/verify-container-images.yaml`) runs static
-verification tests against container infrastructure files without requiring Docker
-(CC-0028). This workflow validates Dockerfiles, workflow structure, SPDX compliance,
+verification tests against container infrastructure files without requiring Docker. This workflow validates Dockerfiles, workflow structure, SPDX compliance,
 release configuration, and constraint override scripts.
 
 ### Trigger Events
@@ -1367,9 +1352,9 @@ non-zero, the job fails.
 
 | Script | Validates |
 | --- | --- |
-| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration (CC-0029), cosign signing configuration (CC-0030), OCI annotation configuration (CC-0031), vulnerability scanning configuration (CC-0032), test-service-images job structure and steps (CC-0034) |
+| `verify_build_images_workflow.sh` | Workflow structure: job names, dependency chain, trigger events, permissions, action pinning, concurrency, matrix strategy, SBOM/attestation configuration, cosign signing configuration, OCI annotation configuration, vulnerability scanning configuration, test-service-images job structure and steps |
 | `verify_deviation_comments.sh` | DEVIATION comments in Dockerfiles cross-reference architecture docs |
-| `verify_release_config.sh` | `source-refs.yaml`, `extra-packages.yaml` structure and content validity, test-excludes file format and directory structure (CC-0034) |
+| `verify_release_config.sh` | `source-refs.yaml`, `extra-packages.yaml` structure and content validity, test-excludes file format and directory structure |
 | `verify_spdx_headers.sh` | SPDX Apache-2.0 license headers present on all infrastructure files |
 | `test_apply_constraint_overrides.sh` | `scripts/apply-constraint-overrides.sh` correctly applies constraint overrides |
 
@@ -1389,7 +1374,7 @@ signals in GitHub's check status UI. The Docker-based image verification tests
 
 ## Verification Coverage Summary
 
-The following table summarizes which test scripts run where (CC-0028, CC-0029, CC-0032):
+The following table summarizes which test scripts run where:
 
 | Test Script | verify-container-images.yaml | build-images.yaml | Requires Docker |
 | --- | --- | --- | --- |
@@ -1404,7 +1389,7 @@ The following table summarizes which test scripts run where (CC-0028, CC-0029, C
 
 ## SPDX Header
 
-The file starts with the standard SPDX license header (REQ-008):
+The file starts with the standard SPDX license header:
 
 ```text
 # SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
@@ -1413,9 +1398,9 @@ The file starts with the standard SPDX license header (REQ-008):
 ---
 ```
 
-## Dependencies on CC-0006
+## Dependencies on Base Images and Release Configs
 
-The build-images workflow depends on artifacts introduced by CC-0006:
+The build-images workflow depends on the following artifacts:
 
 | Artifact | Used by | Purpose |
 | --- | --- | --- |

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -1,16 +1,15 @@
 ---
 title: CI Workflow
 quadrant: infrastructure
-feature: CC-0003, CC-0018, CC-0041, CC-0050, CC-0051, CC-0052, CC-0053, CC-0054, CC-0059, CC-0061
 ---
 
 ::: v-pre
 
 # CI Workflow
 
-Reference documentation for the GitHub Actions CI workflow (CC-0003, CC-0018, CC-0041, CC-0050, CC-0052, CC-0053, CC-0054, CC-0061).
+Reference documentation for the GitHub Actions CI workflow.
 
-CC-0050 refactored repeated E2E logic into reusable shell scripts (`hack/ci-*.sh`) and a
+Repeated E2E logic is factored into reusable shell scripts (`hack/ci-*.sh`) and a
 composite GitHub Action (`.github/actions/setup-e2e-infra/`), reducing duplication across
 the `e2e-infra`, `e2e-operator`, and `tempest` jobs.
 
@@ -26,17 +25,17 @@ triggered the pipeline.
 `.github/workflows/ci.yaml`
 
 The file uses the `.yaml` extension (matching `reuse.yaml` and `deploy-docs.yaml`) and
-quotes the trigger key as `"on"` to prevent YAML boolean interpretation (REQ-001).
+quotes the trigger key as `"on"` to prevent YAML boolean interpretation.
 
 ## Trigger Events
 
-The workflow triggers on three event types (CC-0003 REQ-008, CC-0018 REQ-001):
+The workflow triggers on three event types:
 
 | Event | Scope | Description |
 | --- | --- | --- |
 | `push` | `branches: [main]` | Runs on every push to the main branch |
 | `push` | `tags: ["v*"]` | Runs on every v-prefixed tag push (triggers publish and release jobs) |
-| `pull_request` | `branches: [main]`, `types: [opened, synchronize, reopened, labeled]` | Runs on every pull request targeting main; includes `labeled` type to support on-demand chaos via `run-chaos` label (CC-0049 REQ-007) |
+| `pull_request` | `branches: [main]`, `types: [opened, synchronize, reopened, labeled]` | Runs on every pull request targeting main; includes `labeled` type to support on-demand chaos via `run-chaos` label |
 
 Tag pushes (`v*`) enable the full release pipeline: gate jobs, E2E tests, image/chart
 publishing, and GitHub Release creation. Pull requests and main-branch pushes run only
@@ -45,28 +44,27 @@ gate and E2E jobs (publish jobs are skipped via `if` conditions).
 ## Environment Variables
 
 Top-level environment variables centralise registry configuration and pin tool versions
-for CI reproducibility (CC-0018):
+for CI reproducibility:
 
 ```yaml
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/c5c3
   CONTROLLER_GEN_VERSION: v0.20.1
-  GOFUMPT_VERSION: v0.9.2  # CC-0053
+  GOFUMPT_VERSION: v0.9.2
 ```
 
 `REGISTRY` and `IMAGE_PREFIX` are referenced by the `build-and-push`, `helm-push`,
 `e2e-operator`, and `tempest` jobs to construct image names and registry URLs.
 `CONTROLLER_GEN_VERSION` is used by `verify-codegen` to pin controller-gen to a specific
-version. `GOFUMPT_VERSION` is used by `format-check` to pin gofumpt to a specific version
-(CC-0053); the same version is mirrored in the Makefile (`GOFUMPT_VERSION ?= v0.9.2`) so
+version. `GOFUMPT_VERSION` is used by `format-check` to pin gofumpt to a specific version; the same version is mirrored in the Makefile (`GOFUMPT_VERSION ?= v0.9.2`) so
 that `make fmt` and `make format-check` use a consistent version locally.
 `setup-envtest` is installed via `@release-0.23` because the sub-module does not
 publish its own release tags.
 
 ## Permissions
 
-Top-level permissions are restricted to least privilege (CC-0003 REQ-007):
+Top-level permissions are restricted to least privilege:
 
 ```yaml
 permissions:
@@ -84,8 +82,7 @@ Jobs that need elevated access declare per-job `permissions:` blocks:
 
 ## Job Dependency DAG
 
-The workflow defines 22 jobs organised in a directed acyclic graph (CC-0018, CC-0041,
-CC-0050, CC-0052, CC-0053, CC-0054, CC-0061, CC-0094):
+The workflow defines 22 jobs organised in a directed acyclic graph:
 
 ```
 Gate Jobs (always run):
@@ -124,13 +121,13 @@ Release Job (v* tags only, depends on publish):
 
 The four E2E jobs (`e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest`) share infrastructure
 setup via the `setup-e2e-infra` composite action and diagnostic teardown via
-`hack/ci-dump-diagnostics.sh` (CC-0050).
+`hack/ci-dump-diagnostics.sh`.
 
 ## Jobs
 
 ### lint
 
-Runs golangci-lint using the project's `.golangci.yml` configuration (CC-0003 REQ-002).
+Runs golangci-lint using the project's `.golangci.yml` configuration.
 
 | Step | Action | Details |
 | --- | --- | --- |
@@ -150,25 +147,25 @@ internally.
 
 | Linter | Category | Description |
 | --- | --- | --- |
-| `errcheck` | correctness | Checks for unchecked errors in Go code (CC-0003) |
-| `gocritic` | style | Provides diagnostics for bugs, performance, and style issues (CC-0003) |
-| `govet` | correctness | Reports suspicious constructs, roughly equivalent to `go vet` (CC-0003) |
-| `ineffassign` | correctness | Detects assignments to existing variables that are never used (CC-0003) |
-| `staticcheck` | correctness | Comprehensive static analysis rules from the staticcheck suite (CC-0003) |
-| `unused` | correctness | Checks for unused constants, variables, functions, and types (CC-0003) |
-| `bodyclose` | resource-leak | Checks whether HTTP response bodies are closed successfully (CC-0059) |
-| `errorlint` | correctness | Validates Go 1.13+ error wrapping patterns (`%w`, `errors.Is`, `errors.As`) (CC-0059) |
-| `exhaustive` | correctness | Checks exhaustiveness of enum switch statements (CC-0059) |
-| `gosec` | security | Inspects source code for security problems (hardcoded credentials, weak crypto, unsafe operations) (CC-0059) |
-| `nilerr` | correctness | Finds code that returns nil even after checking that an error is not nil (CC-0059) |
-| `noctx` | correctness | Detects HTTP requests and TLS dials missing `context.Context` propagation (CC-0059) |
+| `errcheck` | correctness | Checks for unchecked errors in Go code |
+| `gocritic` | style | Provides diagnostics for bugs, performance, and style issues |
+| `govet` | correctness | Reports suspicious constructs, roughly equivalent to `go vet` |
+| `ineffassign` | correctness | Detects assignments to existing variables that are never used |
+| `staticcheck` | correctness | Comprehensive static analysis rules from the staticcheck suite |
+| `unused` | correctness | Checks for unused constants, variables, functions, and types |
+| `bodyclose` | resource-leak | Checks whether HTTP response bodies are closed successfully |
+| `errorlint` | correctness | Validates Go 1.13+ error wrapping patterns (`%w`, `errors.Is`, `errors.As`) |
+| `exhaustive` | correctness | Checks exhaustiveness of enum switch statements |
+| `gosec` | security | Inspects source code for security problems (hardcoded credentials, weak crypto, unsafe operations) |
+| `nilerr` | correctness | Finds code that returns nil even after checking that an error is not nil |
+| `noctx` | correctness | Detects HTTP requests and TLS dials missing `context.Context` propagation |
 
 Generated code matching `zz_generated.*.go` is excluded from all lint checks via the
 `exclusions.paths` configuration.
 
 ### format-check
 
-Verifies all Go files conform to gofumpt formatting (CC-0053). gofumpt is a strict superset
+Verifies all Go files conform to gofumpt formatting. gofumpt is a strict superset
 of gofmt — it applies all standard gofmt rules plus additional formatting conventions for
 consistency. Detects non-conforming files and prints a unified diff showing the required
 changes, so developers can identify and fix formatting issues without guessing.
@@ -201,7 +198,7 @@ Timeout: 5 minutes.
 
 ### shellcheck
 
-Validates shell scripts with shellcheck to catch scripting issues early (CC-0010).
+Validates shell scripts with shellcheck to catch scripting issues early.
 The shellcheck binary is pre-installed on `ubuntu-latest` runners.
 
 | Step | Action | Details |
@@ -213,7 +210,7 @@ Timeout: 5 minutes.
 
 ### verify-invalid-cr-fixtures
 
-Enforces the canonical-scaffold contract for the invalid-CR Chainsaw fixtures (CC-0094).
+Enforces the canonical-scaffold contract for the invalid-CR Chainsaw fixtures.
 Runs `_generate.py --check` (drift mode) and the `test_generate.py` unit suite
 (FIXTURES count + `chainsaw-test.yaml` cross-reference) so a hand-edit to any
 `02-…/03-…/…/12-*.yaml` fixture, or a rename or removal that desynchronises FIXTURES
@@ -224,7 +221,7 @@ job runs. Always-on because the check is sub-second and `python3` is preinstalle
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `make verify-invalid-cr-fixtures` | Runs `_generate.py --check` and `test_generate.py` (CC-0094) |
+| 2 | `make verify-invalid-cr-fixtures` | Runs `_generate.py --check` and `test_generate.py` |
 
 Timeout: 5 minutes.
 
@@ -249,9 +246,9 @@ Timeout: 5 minutes.
 
 ### test
 
-Runs unit tests with a matrix strategy over `[common, keystone, c5c3]` (CC-0018 REQ-002).
+Runs unit tests with a matrix strategy over `[common, keystone, c5c3]`.
 Each matrix leg tests a single target — either `internal/common` or one operator — producing
-a single coverage profile uploaded to Codecov under a dedicated flag (REQ-004).
+a single coverage profile uploaded to Codecov under a dedicated flag.
 
 | Step | Action | Details |
 | --- | --- | --- |
@@ -287,7 +284,7 @@ coverage data is not lost.
 ### test-integration
 
 Runs envtest-based integration tests with a matrix strategy over `[common, keystone, c5c3]`
-and coverage uploaded to Codecov (CC-0018 REQ-003, REQ-004). Requires `setup-envtest` to
+and coverage uploaded to Codecov. Requires `setup-envtest` to
 download kubebuilder assets (kube-apiserver, etcd) for the test API server.
 
 | Step | Action | Details |
@@ -318,7 +315,7 @@ Timeout: 15 minutes (longer than unit tests to account for envtest startup).
 ### test-race
 
 Runs all Go unit tests with the race detector enabled to catch data races in concurrent
-operator code — reconcilers, watches, informer caches (CC-0052). Separate from the main
+operator code — reconcilers, watches, informer caches. Separate from the main
 `test` job because the race detector adds 2–5x overhead. Uses `-count=1` to disable test
 caching, since race conditions are non-deterministic and cached results could mask real
 races.
@@ -331,7 +328,7 @@ races.
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `make test-race RACE_FLAGS="-count=1"` | Delegates to the Makefile so the module list stays in sync (CC-0052) |
+| 3 | `make test-race RACE_FLAGS="-count=1"` | Delegates to the Makefile so the module list stays in sync |
 
 CI delegates to `make test-race` so the list of modules under race testing is defined in one
 place (the Makefile's `OPERATORS` variable and `internal/common`). `RACE_FLAGS="-count=1"`
@@ -349,7 +346,7 @@ Timeout: 20 minutes (accommodates 2–5x race detector overhead).
 ### govulncheck
 
 Scans all Go modules for reachable vulnerabilities using govulncheck, the official Go
-vulnerability scanner maintained by the Go team (CC-0061). Unlike dependency-list scanners,
+vulnerability scanner maintained by the Go team. Unlike dependency-list scanners,
 govulncheck analyses call graphs to detect only vulnerabilities in code paths that are
 actually reachable — reducing false positives. Catches supply-chain vulnerabilities at the
 PR stage, before container images are built.
@@ -368,7 +365,7 @@ PR stage, before container images are built.
 govulncheck uses `@latest` intentionally — unlike other pinned tools (controller-gen,
 gofumpt), pinning govulncheck to an old version defeats the purpose of vulnerability
 scanning because the vulnerability database is updated frequently. This is a deliberate
-deviation from the CC-0018 pinning policy, justified by the security tool's nature.
+deviation from the general pinning policy, justified by the security tool's nature.
 
 The CI step delegates to `make govulncheck`, which iterates over `internal/common` and
 each operator in the `$(OPERATORS)` Makefile variable. The Makefile target exits on the
@@ -388,7 +385,7 @@ Timeout: 10 minutes.
 ### verify-codegen
 
 Verifies that generated code (CRD manifests, deepcopy functions) is committed and
-up-to-date (CC-0018 REQ-009). This is a gate job — it blocks merge alongside `lint`,
+up-to-date. This is a gate job — it blocks merge alongside `lint`,
 `test`, and `shellcheck`.
 
 | Step | Action | Details |
@@ -405,7 +402,7 @@ instructions to run `make manifests && make generate` locally and commit the res
 
 ### docs
 
-Builds the VitePress documentation site to catch broken links and build errors (CC-0003).
+Builds the VitePress documentation site to catch broken links and build errors.
 
 **Dependencies:** `needs: [changes]`
 **Condition:** `if: needs.changes.outputs.docs == 'true'`
@@ -421,7 +418,7 @@ Builds the VitePress documentation site to catch broken links and build errors (
 ### helm-validate
 
 Validates Helm chart structure, template rendering, and unit tests without requiring a
-cluster (CC-0041). Runs `helm lint`, `helm template` with five value override scenarios,
+cluster. Runs `helm lint`, `helm template` with five value override scenarios,
 and `helm unittest` to catch chart regressions at PR time.
 
 **Dependencies:** `needs: [changes]`
@@ -445,7 +442,7 @@ and `helm unittest` to catch chart regressions at PR time.
 | 2 — webhook disabled | `webhook.enabled=false` | Validates conditional exclusion of webhook resources |
 | 3 — external service account | `serviceAccount.create=false`, `serviceAccount.name=existing-sa` | Validates ServiceAccount conditional logic |
 | 4 — custom resources | `resources.limits.cpu=100m`, `resources.limits.memory=64Mi` | Validates resource override wiring |
-| 5 — namespace-scoped RBAC | `rbac.namespaceScoped=true`, `webhook.enabled=false` | Validates Role/RoleBinding rendering instead of ClusterRole/ClusterRoleBinding (CC-0043) |
+| 5 — namespace-scoped RBAC | `rbac.namespaceScoped=true`, `webhook.enabled=false` | Validates Role/RoleBinding rendering instead of ClusterRole/ClusterRoleBinding |
 
 **Unit test suites (step 6):**
 
@@ -463,7 +460,7 @@ Timeout: 10 minutes.
 
 ### e2e-infra
 
-End-to-end infrastructure deployment and Chainsaw test (CC-0010, CC-0050). Deploys the full
+End-to-end infrastructure deployment and Chainsaw test. Deploys the full
 infrastructure stack (Flux, cert-manager, MariaDB, ESO, OpenBao) to a kind cluster and
 validates health of all operators, CRs, and ExternalSecrets.
 
@@ -475,9 +472,9 @@ validates health of all operators, CRs, and ExternalSecrets.
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
-| 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack (CC-0050 REQ-005) |
+| 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
 | 5 | `chainsaw test` | Runs E2E tests from `tests/e2e/infrastructure/` |
-| 6 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs (CC-0050 REQ-001) |
+| 6 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
 | 7 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
 
 Timeout: 20 minutes.
@@ -514,7 +511,7 @@ Timeout: 30 minutes.
 
 ### e2e-operator
 
-End-to-end operator test using kind cluster and Chainsaw (CC-0018 REQ-005, CC-0050).
+End-to-end operator test using kind cluster and Chainsaw.
 Loads pre-built images from the `build-e2e-images` artifact via the `load-e2e-images`
 composite action, deploys the infrastructure stack and operator via Helm, and runs
 Chainsaw E2E test suites.
@@ -529,10 +526,10 @@ Chainsaw E2E test suites.
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
 | 4 | `load-e2e-images` composite action | Downloads shared artifact and loads all zstd-compressed images into Docker |
 | 5 | `kind load docker-image` | Loads operator, 2025.2 service, 2025.2-upgraded, and 2026.1 service images into kind |
-| 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack (CC-0050 REQ-005) |
-| 7 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys operator via Helm (CC-0050 REQ-003) |
+| 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
+| 7 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys operator via Helm |
 | 8 | `chainsaw test` | Runs E2E tests from `tests/e2e/<operator>/` |
-| 9 | `hack/ci-dump-diagnostics.sh` (always) | Dumps operator pods, all pods, events, operator logs (CC-0050 REQ-001) |
+| 9 | `hack/ci-dump-diagnostics.sh` (always) | Dumps operator pods, all pods, events, operator logs |
 | 10 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
 
 **Matrix strategy:**
@@ -549,19 +546,18 @@ kind-loaded image is used instead of attempting a registry pull. Timeout: 45 min
 
 ### e2e-chaos
 
-End-to-end chaos tests using kind cluster, Chaos Mesh, and Chainsaw (CC-0054). Builds the
+End-to-end chaos tests using kind cluster, Chaos Mesh, and Chainsaw. Builds the
 keystone operator image, deploys it alongside Chaos Mesh infrastructure, and runs the chaos
 test suites (MariaDB pod kill, Memcached pod kill, OpenBao pod kill, MariaDB network partition, MariaDB network latency). See
 [Chaos E2E Test Suites](../testing/chaos-e2e-tests.md) for test suite details.
 
 **Dependencies:** `needs: [changes, lint, shellcheck, test, test-integration, verify-codegen]`
-**Condition:** Runs only when `e2e-chaos == 'true'` or the PR has a `run-chaos` label (CC-0049 REQ-007), and no dependency failed or was cancelled.
+**Condition:** Runs only when `e2e-chaos == 'true'` or the PR has a `run-chaos` label, and no dependency failed or was cancelled.
 
 The `e2e-chaos` job depends on the standard gate jobs. The `e2e-operator` dependency was
-removed (CC-0049 REQ-006) so chaos tests run in parallel with operator E2E tests, reducing
+removed so chaos tests run in parallel with operator E2E tests, reducing
 overall CI wall time. The job uses `continue-on-error: true` while chaos test stability is
-being proven in CI — failures are visible but do not block merges or the publish pipeline
-(CC-0054 REQ-004). This will be revisited after 2–4 weeks of successful CI runs.
+being proven in CI — failures are visible but do not block merges or the publish pipeline. This will be revisited after 2–4 weeks of successful CI runs.
 
 | Step | Action | Details |
 | --- | --- | --- |
@@ -569,12 +565,12 @@ being proven in CI — failures are visible but do not block merges or the publi
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
 | 4 | `make docker-build` | Builds keystone operator image with tag `<IMAGE_PREFIX>/keystone-operator:dev` |
-| 5 | `hack/ci-build-service-image.sh` | Builds the OpenStack 2025.2 keystone service image (CC-0050 REQ-002) |
+| 5 | `hack/ci-build-service-image.sh` | Builds the OpenStack 2025.2 keystone service image |
 | 6 | `kind load docker-image` | Loads operator and service images into kind |
-| 7 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack (CC-0050 REQ-005) |
-| 8 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys keystone operator via Helm (CC-0050 REQ-003) |
+| 7 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
+| 8 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys keystone operator via Helm |
 | 9 | `chainsaw test` | Runs chaos E2E tests from `tests/e2e-chaos/` with `tests/e2e-chaos/chainsaw-config.yaml` |
-| 10 | `hack/ci-dump-diagnostics.sh` (always) | Dumps operator pods, all pods, events, operator logs with `OPERATOR=keystone` (CC-0050 REQ-001) |
+| 10 | `hack/ci-dump-diagnostics.sh` (always) | Dumps operator pods, all pods, events, operator logs with `OPERATOR=keystone` |
 | 11 | Upload JUnit report | Uploads `_output/reports/` as `e2e-chaos-junit-report` artifact (14-day retention) |
 
 **Key differences from `e2e-operator`:**
@@ -602,16 +598,15 @@ tests validate operator resilience against the current codebase.
 
 ### tempest
 
-Tempest API integration tests (CC-0035, CC-0050, CC-0051). Deploys services into a kind
-cluster and runs the OpenStack Tempest test suite against them. Uses a release matrix
-(CC-0051) to validate each OpenStack release independently, with per-release Tempest
+Tempest API integration tests. Deploys services into a kind
+cluster and runs the OpenStack Tempest test suite against them. Uses a release matrix to validate each OpenStack release independently, with per-release Tempest
 configuration, Keystone CRs, and K8s service names. Loads pre-built images from the
 `build-e2e-images` artifact via the `load-e2e-images` composite action.
 
 **Dependencies:** `needs: [changes, build-e2e-images]`
 **Condition:** Runs only when `has-e2e-operators == 'true'` and `build-e2e-images` succeeded.
 
-**Matrix strategy (CC-0051):**
+**Matrix strategy:**
 
 ```yaml
 strategy:
@@ -640,23 +635,23 @@ these via `matrix.release`, `matrix.config-dir`, `matrix.cr-name`, and
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
 | 4 | `load-e2e-images` composite action | Downloads shared artifact and loads all zstd-compressed images into Docker |
 | 5 | `kind load docker-image` | Loads keystone operator and service images into kind |
-| 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack (CC-0050 REQ-005) |
-| 7 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys operator via Helm (CC-0050 REQ-003) |
+| 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
+| 7 | `hack/ci-deploy-operator.sh` | Installs CRDs and deploys operator via Helm |
 | 8 | Deploy Keystone CR | Applies `matrix.config-dir/00-keystone-cr.yaml` and waits for `matrix.cr-name` Ready |
-| 9 | `hack/ci-run-tempest.sh` | Runs Tempest API tests with `CONFIG_DIR=matrix.config-dir`, `SERVICE_K8S_NAME=matrix.service-k8s-name` (CC-0050 REQ-004) |
+| 9 | `hack/ci-run-tempest.sh` | Runs Tempest API tests with `CONFIG_DIR=matrix.config-dir`, `SERVICE_K8S_NAME=matrix.service-k8s-name` |
 | 10 | Upload Tempest results | Uploads `_output/tempest/` as `tempest-<release>-results` artifact (14-day retention) |
-| 11 | `hack/ci-dump-diagnostics.sh` (always) | Dumps diagnostic info with `OPERATOR=keystone` (CC-0050 REQ-001) |
+| 11 | `hack/ci-dump-diagnostics.sh` (always) | Dumps diagnostic info with `OPERATOR=keystone` |
 
 Timeout: 45 minutes.
 
 ### build-and-push
 
 Builds operator container images per platform on native runners and pushes each
-single-arch image by digest (CC-0018 REQ-006). Runs only on push events (main branch or
+single-arch image by digest. Runs only on push events (main branch or
 v* tags) — skipped on pull requests. The multi-arch manifest list and final tags are
 assembled by the subsequent `merge-operator-images` job.
 
-**Dependencies:** `needs: [changes, e2e-operator]` (renamed from `e2e-keystone` in CC-0050)
+**Dependencies:** `needs: [changes, e2e-operator]`
 **Condition:** `if: github.event_name == 'push' && needs.e2e-operator.result == 'success'`
 **Permissions:** `contents: read`, `packages: write`
 
@@ -693,7 +688,7 @@ platform (`<operator>-operator-linux-amd64` / `<operator>-operator-linux-arm64`)
 ### merge-operator-images
 
 Downloads per-platform digests from `build-and-push`, assembles the multi-arch manifest
-list, and pushes it with the final tags (CC-0018 REQ-006).
+list, and pushes it with the final tags.
 
 **Dependencies:** `needs: [changes, build-and-push]`
 **Condition:** `if: github.event_name == 'push' && needs.build-and-push.result == 'success'`
@@ -721,10 +716,10 @@ Images are published at `ghcr.io/c5c3/<operator>-operator:<tag>`.
 
 ### helm-push
 
-Packages and pushes operator Helm charts to the GHCR OCI registry (CC-0018 REQ-007).
+Packages and pushes operator Helm charts to the GHCR OCI registry.
 Runs only on push events — skipped on pull requests.
 
-**Dependencies:** `needs: [changes, e2e-operator]` (renamed from `e2e-keystone` in CC-0050)
+**Dependencies:** `needs: [changes, e2e-operator]`
 **Condition:** `if: github.event_name == 'push' && needs.e2e-operator.result == 'success'`
 **Permissions:** `contents: read`, `packages: write`
 
@@ -755,8 +750,7 @@ When `CHART_VERSION` is set (for tag pushes), it overrides the version in `Chart
 
 ### github-release
 
-Creates a GitHub Release with auto-generated release notes on v* tag pushes (CC-0018
-REQ-008).
+Creates a GitHub Release with auto-generated release notes on v* tag pushes.
 
 **Dependencies:** `needs: [changes, merge-operator-images, helm-push]`
 **Condition:** `if: startsWith(github.ref, 'refs/tags/v') && needs.merge-operator-images.result == 'success' && needs.helm-push.result == 'success'`
@@ -774,14 +768,14 @@ successfully, ensuring the final multi-arch manifest list and charts are publish
 the release is created. Helm chart tarballs
 are attached as release assets for direct download. Timeout: 5 minutes.
 
-## Reusable CI Scripts (CC-0050)
+## Reusable CI Scripts
 
-CC-0050 extracted repeated inline shell logic from E2E jobs into standalone scripts under
+Repeated inline shell logic from E2E jobs is extracted into standalone scripts under
 `hack/`. Each script uses `set -euo pipefail`, includes an SPDX Apache-2.0 header, and
-passes shellcheck (REQ-007). All scripts are designed to work both in CI and locally
+passes shellcheck. All scripts are designed to work both in CI and locally
 against any kubeconfig.
 
-### hack/ci-dump-diagnostics.sh (REQ-001)
+### hack/ci-dump-diagnostics.sh
 
 Dumps diagnostic information after E2E failures. Shared across `e2e-infra`, `e2e-operator`,
 and `tempest` jobs.
@@ -805,7 +799,7 @@ hack/ci-dump-diagnostics.sh                    # infra-only diagnostics
 OPERATOR=keystone hack/ci-dump-diagnostics.sh   # + operator-specific diagnostics
 ```
 
-### hack/ci-build-service-image.sh (REQ-002)
+### hack/ci-build-service-image.sh
 
 Builds an OpenStack service container image by resolving upstream source refs, cloning the
 project at the pinned ref, applying constraint overrides, and building the full image chain
@@ -827,7 +821,7 @@ Usage:
 OPERATOR=keystone IMAGE_PREFIX=ghcr.io/c5c3 hack/ci-build-service-image.sh
 ```
 
-### hack/ci-deploy-operator.sh (REQ-003)
+### hack/ci-deploy-operator.sh
 
 Deploys an operator into a kind cluster by installing CRDs, waiting for establishment, and
 deploying the operator via Helm with the specified container image.
@@ -847,7 +841,7 @@ Usage:
 OPERATOR=keystone IMAGE_REPO=ghcr.io/c5c3/keystone-operator hack/ci-deploy-operator.sh
 ```
 
-### hack/ci-build-tempest-image.sh (REQ-002)
+### hack/ci-build-tempest-image.sh
 
 Builds the Tempest test container image by resolving Tempest and plugin version refs from
 the release config, then running `docker build` with the pinned versions.
@@ -868,7 +862,7 @@ hack/ci-build-tempest-image.sh
 RELEASE=2025.2 TEMPEST_IMAGE=c5c3/tempest:local hack/ci-build-tempest-image.sh
 ```
 
-### hack/ci-run-tempest.sh (REQ-004)
+### hack/ci-run-tempest.sh
 
 CI-specific Tempest execution wrapper that handles port-forwarding, config generation, and
 Docker-based test execution. This is the CI counterpart to `hack/run-tempest.sh` (which
@@ -882,7 +876,7 @@ handles local execution including image building).
 | `ADMIN_SECRET` | No | `keystone-admin` | Secret name holding admin password |
 | `OUTPUT_DIR` | No | `_output/tempest` | Test output directory |
 | `TEMPEST_IMAGE` | No | `c5c3/tempest:local` | Tempest container image |
-| `SERVICE_K8S_NAME` | No | `<SERVICE>-tempest-api` | K8s Service name for port-forwarding (CC-0051: allows override for release-specific CR names, e.g. `keystone-tempest-2026-1-api`) |
+| `SERVICE_K8S_NAME` | No | `<SERVICE>-tempest-api` | K8s Service name for port-forwarding (allows override for release-specific CR names, e.g. `keystone-tempest-2026-1-api`) |
 
 The script:
 1. Extracts the admin password from the Kubernetes secret
@@ -915,7 +909,7 @@ consume this and inherit any future tweaks (key bump, additional pinned tool) fo
 
 The action takes no inputs.
 
-## Composite Action: setup-e2e-infra (CC-0050 REQ-005)
+## Composite Action: setup-e2e-infra
 
 `.github/actions/setup-e2e-infra/action.yaml`
 
@@ -969,7 +963,7 @@ The action takes no inputs. It assumes the `e2e-images` artifact was uploaded by
 
 ## How the Pieces Fit Together
 
-The E2E jobs follow a common pattern, with shared components extracted by CC-0050:
+The E2E jobs follow a common pattern with shared components:
 
 ```
 1. Checkout + Go setup + kind cluster creation     (workflow steps)
@@ -985,7 +979,7 @@ The E2E jobs follow a common pattern, with shared components extracted by CC-005
 Image building is centralised in `build-e2e-images`, which runs once before the E2E jobs.
 The `e2e-infra` job uses steps 1, 4, 6-8 (no operator or service images needed). The
 `e2e-operator` and `tempest` jobs use all steps, loading images from the shared artifact.
-The `e2e-chaos` job (CC-0054) still builds its own images locally (it does not depend on
+The `e2e-chaos` job still builds its own images locally (it does not depend on
 `build-e2e-images`) and uses a chaos-specific Chainsaw config
 (`tests/e2e-chaos/chainsaw-config.yaml`) and test directory (`tests/e2e-chaos/`). The
 `tempest` job additionally deploys a Keystone CR before running `hack/ci-run-tempest.sh`
@@ -993,7 +987,7 @@ instead of Chainsaw.
 
 ## Go Setup Convention
 
-All Go-based jobs use `actions/setup-go@v6` with (CC-0003 REQ-005):
+All Go-based jobs use `actions/setup-go@v6` with:
 
 ```yaml
 go-version-file: go.work
@@ -1006,7 +1000,7 @@ project uses a Go Workspace with multiple modules (`internal/common`, `operators
 
 ## Concurrency
 
-The workflow uses a concurrency group scoped per-branch per-workflow (CC-0003 REQ-006):
+The workflow uses a concurrency group scoped per-branch per-workflow:
 
 ```yaml
 concurrency:
@@ -1021,8 +1015,7 @@ branches do not cancel each other's runs.
 
 ## Action Pinning
 
-All GitHub Actions are referenced by full SHA hash with a trailing version comment
-(CC-0003 REQ-001):
+All GitHub Actions are referenced by full SHA hash with a trailing version comment:
 
 ```yaml
 - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1033,7 +1026,7 @@ traceability. The version comment preserves human readability.
 
 ## SPDX Header
 
-The file starts with the standard SPDX license header (CC-0003 REQ-001):
+The file starts with the standard SPDX license header:
 
 ```text
 # SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
@@ -1044,8 +1037,7 @@ The file starts with the standard SPDX license header (CC-0003 REQ-001):
 
 ## Codecov Configuration
 
-`.codecov.yml` defines coverage status checks and component-level thresholds (CC-0018
-REQ-012).
+`.codecov.yml` defines coverage status checks and component-level thresholds.
 
 ### Status Checks
 
@@ -1089,9 +1081,9 @@ Each component is tracked independently on the Codecov dashboard:
 
 ## Makefile Targets
 
-The CI workflow depends on several Makefile targets (CC-0018):
+The CI workflow depends on several Makefile targets:
 
-### docker-build (REQ-010)
+### docker-build
 
 Builds the operator Docker image from `operators/<operator>/Dockerfile` with the
 repository root as build context (required by `go.work`).
@@ -1103,7 +1095,7 @@ make docker-build OPERATOR=keystone [IMG=custom:tag]
 The `IMG` variable controls the image tag, defaulting to
 `ghcr.io/c5c3/<operator>-operator:latest`. The `OPERATOR` variable is required.
 
-### helm-package (REQ-011)
+### helm-package
 
 Packages the operator Helm chart from
 `operators/<operator>/helm/<operator>-operator/`.
@@ -1115,7 +1107,7 @@ make helm-package OPERATOR=keystone [CHART_VERSION=1.2.3]
 When `CHART_VERSION` is set, it overrides the version in the chart's `Chart.yaml`. The
 packaged `.tgz` is output to the current directory. The `OPERATOR` variable is required.
 
-### test-common (CC-0018)
+### test-common
 
 Runs unit tests for `internal/common` only, producing a single coverage profile.
 
@@ -1126,7 +1118,7 @@ make test-common
 Produces `cover-unit-common.out`. Used by the `common` matrix leg in the `test` CI job to
 deduplicate common coverage into a single upload.
 
-### test-operator (CC-0018)
+### test-operator
 
 Runs unit tests for a single operator without `internal/common`.
 
@@ -1137,7 +1129,7 @@ make test-operator OPERATOR=keystone
 Produces `cover-unit-<operator>.out`. Used by operator matrix legs in the `test` CI job.
 The `OPERATOR` variable is required.
 
-### test-integration (REQ-003)
+### test-integration
 
 Runs envtest-based integration tests (tagged with `//go:build integration`) for operators.
 Requires `setup-envtest` to be installed.
@@ -1151,7 +1143,7 @@ Sets `KUBEBUILDER_ASSETS` via `setup-envtest use <pinned-k8s-version> -p path`, 
 `cover-integration-<operator>.out` files. Without `OPERATOR`, runs for all operators in
 the `OPERATORS` list.
 
-### test-integration-common (CC-0018)
+### test-integration-common
 
 Runs envtest-based integration tests for `internal/common` only.
 
@@ -1165,7 +1157,7 @@ Used by the `common` matrix leg in CI to meet the 80% codecov target for `intern
 
 ## Dependencies on Prior Features
 
-The CI workflow depends on artifacts introduced by CC-0001, CC-0010, and CC-0050:
+The CI workflow depends on the following artifacts:
 
 | Artifact | Used by | Purpose |
 | --- | --- | --- |
@@ -1180,13 +1172,13 @@ The CI workflow depends on artifacts introduced by CC-0001, CC-0010, and CC-0050
 | `go.work` | All Go-based jobs | Provides the Go version for `actions/setup-go@v6` |
 | `hack/*.sh` | `shellcheck` job | Shell scripts validated by shellcheck |
 | `.codecov.yml` | Codecov integration | Component-level coverage thresholds |
-| `hack/ci-dump-diagnostics.sh` | `e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest` jobs | Shared diagnostic dump (CC-0050) |
-| `hack/ci-build-service-image.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Builds OpenStack service images (CC-0050) |
-| `hack/ci-deploy-operator.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Deploys operator via Helm (CC-0050) |
-| `hack/ci-run-tempest.sh` | `tempest` job | Runs Tempest API tests (CC-0050) |
+| `hack/ci-dump-diagnostics.sh` | `e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest` jobs | Shared diagnostic dump |
+| `hack/ci-build-service-image.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Builds OpenStack service images |
+| `hack/ci-deploy-operator.sh` | `e2e-operator`, `e2e-chaos`, `tempest` jobs | Deploys operator via Helm |
+| `hack/ci-run-tempest.sh` | `tempest` job | Runs Tempest API tests |
 | `.github/actions/setup-test-deps/` | `chainsaw-lint` job, `setup-e2e-infra` composite action | Composite action for testdeps cache + `make install-test-deps` |
-| `.github/actions/setup-e2e-infra/` | `e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest` jobs | Composite action for infra setup (CC-0050) |
+| `.github/actions/setup-e2e-infra/` | `e2e-infra`, `e2e-operator`, `e2e-chaos`, `tempest` jobs | Composite action for infra setup |
 | `.github/actions/load-e2e-images/` | `e2e-operator`, `tempest` jobs | Composite action for artifact download + zstd decompress + docker load |
-| `tests/e2e-chaos/chainsaw-config.yaml` | `e2e-chaos` job | Chaos-specific Chainsaw configuration (CC-0054) |
+| `tests/e2e-chaos/chainsaw-config.yaml` | `e2e-chaos` job | Chaos-specific Chainsaw configuration |
 
 :::

--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -1,12 +1,11 @@
 ---
 title: Container Images
 quadrant: infrastructure
-feature: CC-0006, CC-0031
 ---
 
 # Container Images
 
-Reference documentation for the container image build system (CC-0006). This covers
+Reference documentation for the container image build system. This covers
 the Dockerfile hierarchy, base image contents, release configuration file formats,
 named build context patterns, constraint override tooling, and local build instructions.
 
@@ -64,7 +63,7 @@ The foundational runtime image for all OpenStack service containers.
 rather than creating per-service users. This is a deliberate deviation from the architecture
 document — see [Design Deviations](#design-deviations) for rationale.
 
-**OCI labels (CC-0031):** The Dockerfile includes static `LABEL` instructions for baseline
+**OCI labels:** The Dockerfile includes static `LABEL` instructions for baseline
 OCI Image Spec annotations (`title`, `description`, `licenses`, `vendor`). These are
 always present on locally-built images. In CI, `docker/metadata-action` supplements these
 with dynamic labels (created, revision, source, url, version) — see
@@ -111,7 +110,7 @@ These packages are installed **without** the `--constraint` flag. The `venv-buil
 is release-independent — version constraints are release-specific and applied only in
 service Dockerfiles when installing the actual service.
 
-**OCI labels (CC-0031):** Same static `LABEL` pattern as `python-base` — title, description,
+**OCI labels:** Same static `LABEL` pattern as `python-base` — title, description,
 licenses, and vendor are embedded in the Dockerfile for local build visibility.
 
 ## Service Images
@@ -154,7 +153,7 @@ The Keystone identity service image uses a two-stage build:
 - Virtualenv at `/var/lib/openstack` with all Keystone dependencies
 - `keystone-manage` CLI available via `PATH`
 
-**OCI labels (CC-0031):** The `LABEL` instruction is placed in Stage 2 (runtime) before
+**OCI labels:** The `LABEL` instruction is placed in Stage 2 (runtime) before
 the `USER` instruction. Labels added in Stage 1 (build) are discarded by Docker's
 multi-stage build process — only the runtime stage labels appear on the final image. In
 CI, `docker/metadata-action` overrides `org.opencontainers.image.version` with the

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -1,12 +1,11 @@
 ---
 title: Infrastructure E2E Deployment
 quadrant: infrastructure
-feature: CC-0010
 ---
 
 # Infrastructure E2E Deployment
 
-Reference documentation for the infrastructure E2E deployment automation (CC-0010).
+Reference documentation for the infrastructure E2E deployment automation.
 This feature provides shell-based orchestration to deploy the full infrastructure stack
 (cert-manager, OpenBao, ESO, MariaDB Operator, Memcached Operator, infrastructure CRs,
 ExternalSecrets) into a local kind cluster and validate it with Chainsaw E2E tests.
@@ -58,7 +57,7 @@ ExternalSecrets) into a local kind cluster and validate it with Chainsaw E2E tes
 | Docker | Running Docker daemon (kind uses Docker containers as nodes) |
 | kubectl | Kubernetes CLI for cluster interaction |
 | kind | Kubernetes IN Docker for local cluster creation |
-| flux | **Optional** — the Flux CLI is no longer required by `make deploy-infra`; bootstrap uses flux-operator + FluxInstance (CC-0085). Opt in with `WITH_FLUX_CLI=true make install-test-deps` for ad-hoc `flux logs` debugging. |
+| flux | **Optional** — the Flux CLI is no longer required by `make deploy-infra`; bootstrap uses flux-operator + FluxInstance. Opt in with `WITH_FLUX_CLI=true make install-test-deps` for ad-hoc `flux logs` debugging. |
 | chainsaw | Kyverno Chainsaw for E2E test execution |
 | jq | JSON processor used by deployment scripts |
 
@@ -96,7 +95,7 @@ Produces JUnit XML reports in `_output/reports/`.
 ```text
 Step 1 ── Create kind cluster (hack/kind-config.yaml)
      │
-Step 2 ── Install flux-operator + apply FluxInstance (CC-0085)
+Step 2 ── Install flux-operator + apply FluxInstance
      │         kubectl apply -f flux-operator install.yaml
      │         kubectl apply -f deploy/flux-system/fluxinstance.yaml
      │         wait_for_fluxinstance polls Ready condition
@@ -106,7 +105,7 @@ Step 2 ── Install flux-operator + apply FluxInstance (CC-0085)
      │         Required by the keystone-operator HTTPRoute watch; version
      │         pinned via GATEWAY_API_VERSION, default matches go.mod.
      │
-     ├── Install Envoy Gateway + Gateway/openstack-gw (kind-only) (CC-0088)
+     ├── Install Envoy Gateway + Gateway/openstack-gw (kind-only)
      │         Installed as part of the deploy/kind/base/ overlay applied
      │         in Step 3: the `envoy-gateway` HelmRelease brings up the
      │         control plane, and deploy/kind/base/openstack-gateway.yaml
@@ -117,7 +116,7 @@ Step 2 ── Install flux-operator + apply FluxInstance (CC-0085)
      │         polls Programmed=True after Phase 3.
      │         The production deploy/flux-system/ overlay does NOT ship
      │         these resources — operators pick their own Gateway
-     │         implementation in production (CC-0088, REQ-011/REQ-012).
+     │         implementation in production.
      │
 Step 3 ── Apply base kustomize overlay (deploy/kind/base/)
      │         Namespaces, HelmRepositories, HelmReleases
@@ -201,7 +200,7 @@ The deployment script supports configurable timeouts via environment variables:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `CLUSTER_NAME` | `forge-e2e` | Kind cluster name |
-| `FLUX_OPERATOR_VERSION` | _pinned in script_ | Tag of the flux-operator `install.yaml` release applied in Step 2 (CC-0085); kept in sync by Renovate via a `customManager` on `hack/deploy-infra.sh` |
+| `FLUX_OPERATOR_VERSION` | _pinned in script_ | Tag of the flux-operator `install.yaml` release applied in Step 2; kept in sync by Renovate via a `customManager` on `hack/deploy-infra.sh` |
 | `HELMRELEASE_TIMEOUT` | `600` | Seconds to wait for HelmReleases Ready (also bounds the `wait_for_fluxinstance` poll in Step 2) |
 | `POD_TIMEOUT` | `300` | Seconds to wait for OpenBao pods Ready |
 | `EXTERNALSECRET_TIMEOUT` | `120` | Seconds to wait for ExternalSecrets synced |
@@ -297,8 +296,8 @@ make teardown-infra
 
 ## Related Resources
 
-- [OpenBao Bootstrap Procedure](openbao-bootstrap.md) — OpenBao deployment and bootstrap (CC-0009)
-- `deploy/flux-system/` — Production FluxCD base manifests (CC-0008)
-- `deploy/kind/` — Kind-specific kustomize overlays (CC-0010)
-- `tests/e2e/infrastructure/` — Chainsaw E2E test files (CC-0010)
-- `.github/workflows/ci.yaml` — CI workflow with `e2e-infra` job (CC-0010)
+- [OpenBao Bootstrap Procedure](openbao-bootstrap.md) — OpenBao deployment and bootstrap
+- `deploy/flux-system/` — Production FluxCD base manifests
+- `deploy/kind/` — Kind-specific kustomize overlays
+- `tests/e2e/infrastructure/` — Chainsaw E2E test files
+- `.github/workflows/ci.yaml` — CI workflow with `e2e-infra` job

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -1,12 +1,11 @@
 ---
 title: Infrastructure Manifests
 quadrant: infrastructure
-feature: CC-0008
 ---
 
 # Infrastructure Manifests
 
-Reference documentation for the FluxCD infrastructure manifests (CC-0008). These manifests
+Reference documentation for the FluxCD infrastructure manifests. These manifests
 define HelmRepository sources, HelmRelease operators, and infrastructure custom resources
 that provision the shared platform services required by OpenStack operators. Deployment is
 split into two phases: base resources (namespaces, sources, releases) and CRD-dependent
@@ -19,7 +18,7 @@ deploy/
 └── flux-system/
     ├── kustomization.yaml                Base kustomize overlay (namespaces, FluxInstance, sources, releases)
     ├── namespaces.yaml                   Namespace resources for all components
-    ├── fluxinstance.yaml                 FluxInstance CR driving the flux-operator (CC-0085)
+    ├── fluxinstance.yaml                 FluxInstance CR driving the flux-operator
     ├── sources/                          FluxCD HelmRepository CRs
     │   ├── cert-manager.yaml             Jetstack Helm chart registry
     │   ├── mariadb-operator.yaml         MariaDB Operator Helm chart registry
@@ -60,14 +59,14 @@ created.
 | `cert-manager` | cert-manager operator and its resources |
 | `mariadb-system` | MariaDB Operator |
 | `external-secrets` | External Secrets Operator |
-| `monitoring-system` | Prometheus Operator CRDs (CC-0010) |
+| `monitoring-system` | Prometheus Operator CRDs |
 | `memcached-system` | Memcached Operator |
 | `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster) |
-| `openbao-system` | OpenBao HA Raft cluster (CC-0009) |
+| `openbao-system` | OpenBao HA Raft cluster |
 
 The `chaos-mesh` namespace is **not** part of the production base. It is created
 inline by the kind-only opt-in overlay at `deploy/kind/chaos-mesh/` when
-`WITH_CHAOS_MESH=true make deploy-infra` is used (CC-0097). See
+`WITH_CHAOS_MESH=true make deploy-infra` is used. See
 [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in) below.
 
 **Note:** The `install.createNamespace: true` setting on HelmReleases instructs FluxCD's
@@ -83,7 +82,7 @@ solve this chicken-and-egg problem.
 A single `FluxInstance` CR drives the
 [flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator), which replaces
 the imperative `flux install` / `flux bootstrap` path with a declarative,
-operator-managed Flux lifecycle (CC-0085). The flux-operator reconciles the Flux
+operator-managed Flux lifecycle. The flux-operator reconciles the Flux
 controller Deployments from this spec and publishes a `FluxReport/flux` summarizing the
 installation state.
 
@@ -132,7 +131,7 @@ namespace, and poll at `interval: 1h`.
 | `sources/prometheus-community.yaml` | `prometheus-community` | `oci://ghcr.io/prometheus-community/charts` | OCI |
 
 The `chaos-mesh` HelmRepository ships in the kind-only opt-in overlay at
-`deploy/kind/chaos-mesh/source.yaml` (CC-0097) — it is intentionally absent
+`deploy/kind/chaos-mesh/source.yaml` — it is intentionally absent
 from `deploy/flux-system/{sources,kustomization.yaml}`. See
 [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in).
 
@@ -176,7 +175,7 @@ mariadb-operator-crds     (no dependencies)
 FluxCD resolves this dependency graph and installs operators in the correct order.
 If cert-manager is not ready, dependent operators are held in a pending state.
 
-The kind-only `chaos-mesh` HelmRelease (`deploy/kind/chaos-mesh/`, CC-0097) also
+The kind-only `chaos-mesh` HelmRelease (`deploy/kind/chaos-mesh/`) also
 declares `dependsOn: cert-manager` but is only installed when
 `WITH_CHAOS_MESH=true make deploy-infra` is used. Production overlays do not
 install it. See [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in).
@@ -215,7 +214,7 @@ install it. See [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in).
 
 The Prometheus Operator CRDs chart installs ServiceMonitor, PodMonitor, PrometheusRule,
 and related monitoring.coreos.com CRDs. These are required by the memcached-operator
-controller, which unconditionally watches ServiceMonitor resources via Owns() (CC-0010).
+controller, which unconditionally watches ServiceMonitor resources via Owns().
 
 ### MariaDB Operator CRDs
 
@@ -310,7 +309,7 @@ OCI registry (`oci://ghcr.io/c5c3/charts`), not a dedicated HelmRepository. The
 OpenBao is deployed as a 3-replica HA Raft cluster with TLS enabled. The injector is
 disabled. TLS certificates are sourced from a cert-manager-provisioned Secret
 (`openbao-tls`). See `architecture/docs/09-implementation/09-openbao-deployment.md` for
-design rationale (CC-0009).
+design rationale.
 
 **Helm values:**
 
@@ -365,7 +364,7 @@ Each HelmRelease `sourceRef.name` must match a HelmRepository `metadata.name` in
 | `keystone-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 
 The kind-only `chaos-mesh` HelmRelease ships in the opt-in overlay at
-`deploy/kind/chaos-mesh/release.yaml` (CC-0097), with its own local
+`deploy/kind/chaos-mesh/release.yaml`, with its own local
 `source.yaml`. It is intentionally absent from this always-on table because
 production overlays do not install it.
 
@@ -411,8 +410,7 @@ by the mariadb-operator. MaxScale is enabled with 2 replicas to provide intellig
 routing and read/write splitting across the Galera nodes.
 
 The root password is sourced from a Kubernetes Secret (`mariadb-root-password`, key
-`password`) — secret provisioning is handled by the External Secrets Operator integration
-(CC-0009).
+`password`) — secret provisioning is handled by the External Secrets Operator integration.
 
 **Services:**
 
@@ -467,7 +465,7 @@ These resources do not depend on any custom CRDs.
 | **Total** | **22** | |
 
 The `chaos-mesh` HelmRepository, HelmRelease, and Namespace ship in the
-kind-only opt-in overlay at `deploy/kind/chaos-mesh/` (CC-0097) and are not
+kind-only opt-in overlay at `deploy/kind/chaos-mesh/` and are not
 counted here.
 
 ### Infrastructure Kustomization
@@ -513,10 +511,10 @@ for the operators to finish installing and retry.
 
 > **Expected transient failure:** The MariaDB cluster references a
 > `rootPasswordSecretKeyRef` Secret (`mariadb-root-password`) that is provisioned by
-> the External Secrets Operator integration (CC-0009). Until that Secret exists, the
+> the External Secrets Operator integration. Until that Secret exists, the
 > mariadb-operator will enter a failed reconciliation loop with
 > `Secret "mariadb-root-password" not found` errors. This is expected and resolves
-> automatically once CC-0009 is applied.
+> automatically once OpenBao bootstrap is applied.
 
 ### Validate manifests locally
 
@@ -537,7 +535,7 @@ syntax and resource inclusion before deployment.
 ## Extensibility
 
 The manifest structure is designed for straightforward extension. Adding a new operator
-(e.g., OpenBao for CC-0009) requires four steps:
+(e.g., OpenBao) requires four steps:
 
 1. **Add a source file** in `sources/` (e.g., `sources/openbao.yaml`) — or reuse an
    existing HelmRepository if the chart is in a shared registry
@@ -583,7 +581,7 @@ in FluxCD reconciliation.
 ### No secret configuration
 
 The manifests intentionally contain no password, credential, or secret configuration.
-Secret management is handled by the External Secrets Operator integration (CC-0009),
+Secret management is handled by the External Secrets Operator integration,
 which provisions secrets from an external vault into the cluster.
 
 ### Memcached Operator source
@@ -598,11 +596,11 @@ internally-built charts to `oci://ghcr.io/c5c3/charts` (see
 The kind overlay (`deploy/kind/base/kustomization.yaml`) layers a small set of
 kind-only demo manifests on top of the production base. These files live under
 `deploy/kind/base/` and are **not** referenced from `deploy/flux-system/kustomization.yaml`,
-so they never reach production clusters. The section below catalogues the addons that
-the `CC-0086` tranche introduced; earlier kind-only manifests (Headlamp, OpenBao UI
-patch) are documented in the Quick Start (CC-0086, REQ-008). Chaos Mesh ships as a
+so they never reach production clusters. The section below catalogues these addons;
+earlier kind-only manifests (Headlamp, OpenBao UI patch) are documented in the Quick Start.
+Chaos Mesh ships as a
 separate **opt-in** kind overlay at `deploy/kind/chaos-mesh/` — applied only when
-`WITH_CHAOS_MESH=true` is set on `make deploy-infra` (CC-0097); see
+`WITH_CHAOS_MESH=true` is set on `make deploy-infra`; see
 [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in) below.
 
 ### Flux Web UI ResourceSet
@@ -638,8 +636,7 @@ targets `deploy/kind/base/flux-web.yaml` and pulls release metadata from
 `controlplaneio-fluxcd/flux-operator` GitHub releases. The customManager shares
 the same `packageRules` as `hack/deploy-infra.sh` — major upgrades are
 disabled, minor/patch upgrades auto-merge after a three-day `minimumReleaseAge`
-cooldown. See the Renovate subsection in CC-0086 (REQ-004) for the exact
-matcher regex.
+cooldown.
 
 **Production opt-out.** `deploy/flux-system/kustomization.yaml` deliberately
 does **not** list `deploy/kind/base/flux-web.yaml`. The flux-operator Web UI
@@ -664,7 +661,7 @@ plugin does not know about.
 **File:** `deploy/kind/chaos-mesh/kustomization.yaml`
 
 [Chaos Mesh](https://chaos-mesh.org/) ships as a separate **opt-in** kind
-overlay (CC-0097). The default `make deploy-infra` flow does **not** install
+overlay. The default `make deploy-infra` flow does **not** install
 it — first-run deployments skip the privileged `chaos-daemon` DaemonSet, the
 `chaos-mesh` namespace, and the upstream HelmRepository / HelmRelease pair so
 that developers who never run chaos E2E suites pay zero install cost. The
@@ -686,7 +683,7 @@ overlay bundles them with:
 
 **Kind-tuning patch** (relocated here from
 `deploy/kind/base/kustomization.yaml` because kustomize requires the patch
-target to live in the same overlay — CC-0097, REQ-009):
+target to live in the same overlay):
 
 | Helm value | Override | Purpose |
 | --- | --- | --- |
@@ -709,8 +706,7 @@ the kind-tuning values.
 `LoadRestrictionsRootOnly` security check is therefore satisfied without
 `--load-restrictor=LoadRestrictionsNone`, which matters because kubectl's
 embedded kustomize does not expose that flag (kubernetes/kubectl#948) and
-`hack/deploy-infra.sh` invokes the apply via `kubectl apply -k`
-(CC-0097, REQ-003).
+`hack/deploy-infra.sh` invokes the apply via `kubectl apply -k`.
 
 **Opt-in usage:**
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -1,12 +1,11 @@
 ---
 title: OpenBao Bootstrap Procedure
 quadrant: infrastructure
-feature: CC-0009
 ---
 
 # OpenBao Bootstrap Procedure
 
-Reference documentation for the OpenBao deployment and bootstrap procedure (CC-0009).
+Reference documentation for the OpenBao deployment and bootstrap procedure.
 OpenBao is deployed as a 3-replica HA Raft cluster via FluxCD HelmRelease, then
 initialized and configured through a sequence of idempotent bootstrap scripts. The
 scripts provision secret engines, authentication backends, least-privilege policies, and
@@ -180,7 +179,7 @@ export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n openbao-system \
 > **Note:** For a kind-only walkthrough that uses the same `BAO_TOKEN` extraction to open
 > the OpenBao web UI, see
 > [Quick Start (Extended) — Step 4b: Open the OpenBao UI](../../quick-start-extended.md#step-4b-openbao-ui)
-> (CC-0082). The UI is disabled in the production flux-system overlay.
+>. The UI is disabled in the production flux-system overlay.
 
 ## Script Reference
 
@@ -559,7 +558,7 @@ Common causes:
 
 ## Related Resources
 
-- [Infrastructure Manifests](./infrastructure-manifests.md) — FluxCD base deployment (CC-0008)
+- [Infrastructure Manifests](./infrastructure-manifests.md) — FluxCD base deployment
 - `deploy/flux-system/releases/openbao.yaml` — OpenBao HelmRelease
 - `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` — TLS Certificate
 - `deploy/eso/clustersecretstore.yaml` — ClusterSecretStore configuration

--- a/docs/reference/keystone-operator-metrics.md
+++ b/docs/reference/keystone-operator-metrics.md
@@ -5,17 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 ---
 title: Keystone Operator Prometheus Metrics
 quadrant: operator
-feature: CC-0089
+
 ---
 
 # Keystone Operator Prometheus Metrics
 
 Reference catalogue for every Prometheus collector the Keystone operator
-exposes on the controller-runtime metrics endpoint (CC-0089, REQ-008,
-REQ-009). Every metric name, label set, and histogram bucket list below
+exposes on the controller-runtime metrics endpoint. Every metric name, label set, and histogram bucket list below
 is authoritative — the contract test
 `operators/keystone/internal/metrics/contract_test.go` fails the build if
-this document drifts from the registered collectors (CC-0089, REQ-009).
+this document drifts from the registered collectors.
 
 All metrics are registered via the process-wide `sync.Once` initializer
 `globalCollectors()` in
@@ -40,8 +39,7 @@ for cluster-side wiring.
 
 ## `keystone_operator_reconcile_duration_seconds`
 
-Wall-clock duration of a single sub-reconciler invocation in seconds
-(CC-0089, REQ-001).
+Wall-clock duration of a single sub-reconciler invocation in seconds.
 
 | Attribute | Value |
 | --- | --- |
@@ -54,7 +52,7 @@ Wall-clock duration of a single sub-reconciler invocation in seconds
 set of 14 strings — the keys of `subReconcilerConditionTypes` — so the
 series count is bounded regardless of how many Keystone CRs exist. The
 metric deliberately omits a `keystone`/`namespace` label to keep
-cardinality fleet-independent (CC-0089, REQ-012); per-CR attribution is
+cardinality fleet-independent; per-CR attribution is
 available via logs.
 
 **Example PromQL.** p95 per sub-reconciler over the last 5 minutes:
@@ -73,8 +71,7 @@ histogram_quantile(
 ## `keystone_operator_reconcile_errors_total`
 
 Count of sub-reconciler errors, partitioned by the offending sub-reconciler
-and the `status.conditions[]` type it failed to drive to `True`
-(CC-0089, REQ-002).
+and the `status.conditions[]` type it failed to drive to `True`.
 
 | Attribute | Value |
 | --- | --- |
@@ -107,7 +104,7 @@ sum by (sub_reconciler) (
 
 Age in seconds of the most recent successful key rotation for a given
 Keystone CR and key type, measured as `time.Since(rotation-completed-at)`
-at reconcile time (CC-0089, REQ-003).
+at reconcile time.
 
 | Attribute | Value |
 | --- | --- |
@@ -126,7 +123,7 @@ as `time.Since(completedAt)` on every reconcile) tracks wall-clock age
 correctly even after the staging Secret has been deleted. If the
 production Secret has no annotation yet — i.e. the very-first rotation
 has not been applied — the lookup falls back to the staging Secret to
-cover the post-CronJob-PATCH/pre-apply window (CC-0089, REQ-003).
+cover the post-CronJob-PATCH/pre-apply window.
 
 **When the gauge is NOT set.** Both lookups skip the gauge on absent or
 malformed `forge.c5c3.io/rotation-completed-at` annotations: a missing
@@ -140,7 +137,7 @@ staging payload are tracked via the `RotationRejected` event (see
 **Series lifecycle.** When a Keystone CR is deleted, every rotation-age
 series tagged with that (keystone, namespace) pair is dropped by
 `DeleteForKeystone` in `reconcileDelete`, preventing orphan series
-from accumulating over the CR lifetime (CC-0089, REQ-004).
+from accumulating over the CR lifetime.
 
 **Example PromQL.** Alert if any rotation is older than 14 days:
 
@@ -155,7 +152,7 @@ max by (keystone, namespace, key_type) (
 ## `keystone_operator_db_sync_total`
 
 Count of DB-related Job terminal transitions per Keystone CR, labelled
-by the terminal state (CC-0089, REQ-005).
+by the terminal state.
 
 | Attribute | Value |
 | --- | --- |
@@ -167,12 +164,12 @@ by the terminal state (CC-0089, REQ-005).
 DB-related Job the operator runs against the Keystone CR:
 
 - `<keystone>-db-sync` — non-upgrade schema sync (`reconcileDatabase`).
-- `<keystone>-schema-check` — post-`db_sync` drift detection (CC-0064).
+- `<keystone>-schema-check` — post-`db_sync` drift detection.
 - `<keystone>-db-expand` / `-db-migrate` / `-db-contract` — the three
-  phases of the expand-migrate-contract upgrade flow (CC-0056).
+  phases of the expand-migrate-contract upgrade flow.
 
 This deliberate aggregation keeps the dashboard panel and failure-rate
-alerts populated during upgrades (CC-0089, REQ-005). The counter does
+alerts populated during upgrades. The counter does
 NOT carry a per-phase label; use the matching `DatabaseReady` condition
 reasons (`DBSyncFailed`, `ExpandFailed`, `MigrateFailed`, `ContractFailed`,
 `SchemaDriftDetected`) on the CR to attribute a failure to a specific
@@ -192,8 +189,7 @@ double-count the same Job UID; on patch failure the metric is deferred
 to the next reconcile, an Info-level log line is emitted, and a
 `Warning` event with reason `DBSyncMetricEmissionDeferred` is recorded
 on the Keystone CR so persistent apiserver failures are visible at
-default log verbosity and via `kubectl describe keystone` (CC-0089,
-W-003, review-2 suggestion 1).
+default log verbosity and via `kubectl describe keystone`.
 
 **Series lifecycle.** Deleted alongside the per-CR rotation-age gauge
 in `DeleteForKeystone` when the Keystone CR is removed.
@@ -211,7 +207,7 @@ sum by (keystone, namespace) (
 ## `keystone_operator_db_sync_duration_seconds`
 
 Duration in seconds of terminated DB-related Jobs, measured as
-`condition.LastTransitionTime − Job.CreationTimestamp` (CC-0089, REQ-005).
+`condition.LastTransitionTime − Job.CreationTimestamp`.
 
 | Attribute | Value |
 | --- | --- |
@@ -241,8 +237,7 @@ histogram_quantile(
 
 ## Enabling the ServiceMonitor
 
-The Helm chart ships an opt-in `monitoring.coreos.com/v1` ServiceMonitor
-(CC-0089, REQ-006). Enable it via `values.yaml`:
+The Helm chart ships an opt-in `monitoring.coreos.com/v1` ServiceMonitor. Enable it via `values.yaml`:
 
 ```yaml
 # values.yaml fragment
@@ -264,7 +259,7 @@ see
 
 ## Related
 
-- [Keystone Reconciler Architecture — Metrics Instrumentation](./keystone/keystone-reconciler.md#metrics-instrumentation-cc-0089) — the `instrumentSubReconciler` contract and the rule that every new sub-reconciler must be wrapped.
+- [Keystone Reconciler Architecture — Metrics Instrumentation](./keystone/keystone-reconciler.md#metrics-instrumentation) — the `instrumentSubReconciler` contract and the rule that every new sub-reconciler must be wrapped.
 - [Observability & Diagnostics](../guides/observability.md) — human-facing status, conditions, and events.
 - [How to enable the Keystone operator metrics endpoint](../guides/enable-keystone-operator-metrics.md) — cluster-side Prometheus/Grafana wiring.
 - [`operators/keystone/dashboards/keystone-operator.json`](../../operators/keystone/dashboards/keystone-operator.json) — reference Grafana dashboard consuming the metrics above.

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -1,12 +1,11 @@
 ---
 title: Keystone CRD API Reference
 quadrant: operator
-feature: CC-0011, CC-0012, CC-0013, CC-0016, CC-0036, CC-0038, CC-0039, CC-0040, CC-0042, CC-0056, CC-0057, CC-0065, CC-0075, CC-0084, CC-0094, CC-0095
 ---
 
 # Keystone CRD API Reference
 
-Reference documentation for the Keystone Custom Resource Definition (CC-0011). The
+Reference documentation for the Keystone Custom Resource Definition. The
 Keystone CRD is the reference implementation for all CobaltCore service operators —
 the patterns established here (types, webhooks, generation, scheme registration) will
 be replicated for Nova, Neutron, Glance, and other OpenStack service operators.
@@ -35,7 +34,7 @@ with the manager's scheme.
 
 ---
 
-## Sub-Resource Naming Convention (CC-0095)
+## Sub-Resource Naming Convention
 
 All operator-managed sub-resources for a Keystone CR are named after the CR itself
 with **no `-api` suffix**. For a Keystone CR named `keystone` in namespace `openstack`,
@@ -51,14 +50,14 @@ the operator creates:
 | `HTTPRoute` | `keystone` | — |
 | Container & named port | `keystone` | port 5000 |
 
-This convention replaces the historical `<name>-api` form (where the same CR would <!-- CC-0095 legacy: pre-rename name referenced for traceability. -->
-have produced `keystone-api` Service, Deployment, etc.). <!-- CC-0095 legacy: pre-rename name referenced for traceability. -->
+This convention replaces the historical `<name>-api` form (where the same CR would
+have produced `keystone-api` Service, Deployment, etc.).
 The change aligns the internal Service DNS with the public Gateway hostname posture
-established by CC-0088 and removes the redundant suffix that no longer reflected a
-meaningful split — the Keystone CR has owned only the API role since CC-0011.
+and removes the redundant suffix that no longer reflected a meaningful split — the
+Keystone CR has only ever owned the API role.
 
 For migration semantics (catalog refresh, ownerReference cascade GC of legacy
-sub-resources, and operator workflows for upgrading a pre-CC-0095 cluster), see the
+sub-resources, and operator workflows for upgrading a pre-rename cluster), see the
 [Keystone Upgrade Flow reference](./keystone-upgrade-flow.md).
 
 ---
@@ -168,23 +167,23 @@ status:
 | `database` | [`DatabaseSpec`](#databasespec) | Yes | — | MariaDB connection configuration. |
 | `cache` | [`CacheSpec`](#cachespec) | Yes | — | Memcached cache configuration. |
 | `fernet` | [`FernetSpec`](#fernetspec) | No | See below | Fernet key rotation configuration. |
-| `credentialKeys` | [`CredentialKeysSpec`](#credentialkeysspec) | No | See below | Credential-key rotation configuration. Drives the per-CR CronJob that rotates and `credential_migrate`s the credential keys used for encrypting application credentials (CC-0036). |
-| `trustFlush` | [`*TrustFlushSpec`](#trustflushspec) | No | `nil` | Trust flush CronJob configuration. When set, the operator creates a CronJob running `keystone-manage trust_flush` on the specified schedule. When removed, the CronJob is deleted (CC-0057). |
+| `credentialKeys` | [`CredentialKeysSpec`](#credentialkeysspec) | No | See below | Credential-key rotation configuration. Drives the per-CR CronJob that rotates and `credential_migrate`s the credential keys used for encrypting application credentials. |
+| `trustFlush` | [`*TrustFlushSpec`](#trustflushspec) | No | `nil` | Trust flush CronJob configuration. When set, the operator creates a CronJob running `keystone-manage trust_flush` on the specified schedule. When removed, the CronJob is deleted. |
 | `federation` | [`*FederationSpec`](#federationspec) | No | `nil` | Federation configuration (optional). |
 | `bootstrap` | [`BootstrapSpec`](#bootstrapspec) | Yes | — | Initial Keystone bootstrap parameters. |
 | `middleware` | `[]MiddlewareSpec` | No | `nil` | WSGI middleware filters for api-paste.ini. |
 | `plugins` | `[]PluginSpec` | No | `nil` | Service plugins/drivers to configure. |
 | `policyOverrides` | [`*PolicySpec`](#policyspec) | No | `nil` | Custom oslo.policy rules. |
-| `autoscaling` | [`*AutoscalingSpec`](#autoscalingspec) | No | `nil` | Horizontal pod autoscaling configuration. When set, an HPA is created targeting the `{name}` Deployment. When removed, the HPA is deleted (CC-0038). |
-| `networkPolicy` | [`*NetworkPolicySpec`](#networkpolicyspec) | No | `nil` | Network isolation for Keystone API pods. When set, a NetworkPolicy restricting ingress to TCP 5000 and auto-deriving egress rules for DNS, MariaDB, and Memcached is created. When `nil`, no NetworkPolicy is managed and traffic is unrestricted (CC-0039). |
-| `gateway` | [`*GatewaySpec`](#gatewayspec) | No | `nil` | Gateway API HTTPRoute configuration. When set, an HTTPRoute is created targeting the `{name}` Service on port 5000 and attached to the referenced pre-existing Gateway; `status.endpoint` is updated to `https://{hostname}/v3`. When removed, the HTTPRoute is deleted and `status.endpoint` reverts to the cluster-local Service URL (CC-0065). |
-| `resources` | [`*corev1.ResourceRequirements`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) | No | See below | CPU and memory requests and limits for the Keystone API container. When unset, the defaulting webhook injects sensible defaults to ensure Burstable QoS class and enable HPA utilization calculations (CC-0042). |
-| `uwsgi` | [`*UWSGISpec`](#uwsgispec) | No | `nil` | uWSGI application server parameters. When set, the operator uses these values for the Deployment container command. When `nil`, hardcoded defaults (processes=2, threads=1, httpKeepAlive=true) are used in the reconciler (CC-0040). |
-| `topologySpreadConstraints` | [`[]corev1.TopologySpreadConstraint`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) | No | See [below](#topologyspreadconstraints) | Scheduler hints for spreading pods across zones and nodes. `nil` injects two defaults (zone + hostname, MaxSkew=1, `ScheduleAnyway`); a non-nil value (including `[]`) is used verbatim (CC-0075). |
-| `priorityClassName` | `*string` | No | `nil` | PriorityClass attached to the Keystone API pod spec. When set, the webhook verifies the class exists; when unset, no priority class is configured (CC-0075). |
-| `terminationGracePeriodSeconds` | `*int64` | No | `nil` | Grace period (seconds) granted to Keystone API pods between SIGTERM and SIGKILL during rolling updates. When `nil`, the reconciler applies `30` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `10`. Must be strictly greater than `preStopSleepSeconds`. Drives the PodSpec `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields-cc-0084) and the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md` (CC-0084). |
-| `preStopSleepSeconds` | `*int64` | No | `nil` | Sleep duration (seconds) of the preStop lifecycle hook, covering the window between EndpointSlice removal and kube-proxy/ingress propagation. When `nil`, the reconciler applies `5` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `0`. Must be strictly less than `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields-cc-0084) (CC-0084). |
-| `strategy` | [`*appsv1.DeploymentStrategy`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) | No | `RollingUpdate(maxSurge=1, maxUnavailable=0)` | Overrides the Deployment rollout strategy. When `nil`, the reconciler injects `RollingUpdate` with `maxUnavailable=0` and `maxSurge=1` so available capacity never drops below `spec.replicas` during an image-tag patch. Set to customize surge/unavailable counts or switch to `Recreate` (CC-0084). |
+| `autoscaling` | [`*AutoscalingSpec`](#autoscalingspec) | No | `nil` | Horizontal pod autoscaling configuration. When set, an HPA is created targeting the `{name}` Deployment. When removed, the HPA is deleted. |
+| `networkPolicy` | [`*NetworkPolicySpec`](#networkpolicyspec) | No | `nil` | Network isolation for Keystone API pods. When set, a NetworkPolicy restricting ingress to TCP 5000 and auto-deriving egress rules for DNS, MariaDB, and Memcached is created. When `nil`, no NetworkPolicy is managed and traffic is unrestricted. |
+| `gateway` | [`*GatewaySpec`](#gatewayspec) | No | `nil` | Gateway API HTTPRoute configuration. When set, an HTTPRoute is created targeting the `{name}` Service on port 5000 and attached to the referenced pre-existing Gateway; `status.endpoint` is updated to `https://{hostname}/v3`. When removed, the HTTPRoute is deleted and `status.endpoint` reverts to the cluster-local Service URL. |
+| `resources` | [`*corev1.ResourceRequirements`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) | No | See below | CPU and memory requests and limits for the Keystone API container. When unset, the defaulting webhook injects sensible defaults to ensure Burstable QoS class and enable HPA utilization calculations. |
+| `uwsgi` | [`*UWSGISpec`](#uwsgispec) | No | `nil` | uWSGI application server parameters. When set, the operator uses these values for the Deployment container command. When `nil`, hardcoded defaults (processes=2, threads=1, httpKeepAlive=true) are used in the reconciler. |
+| `topologySpreadConstraints` | [`[]corev1.TopologySpreadConstraint`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) | No | See [below](#topologyspreadconstraints) | Scheduler hints for spreading pods across zones and nodes. `nil` injects two defaults (zone + hostname, MaxSkew=1, `ScheduleAnyway`); a non-nil value (including `[]`) is used verbatim. |
+| `priorityClassName` | `*string` | No | `nil` | PriorityClass attached to the Keystone API pod spec. When set, the webhook verifies the class exists; when unset, no priority class is configured. |
+| `terminationGracePeriodSeconds` | `*int64` | No | `nil` | Grace period (seconds) granted to Keystone API pods between SIGTERM and SIGKILL during rolling updates. When `nil`, the reconciler applies `30` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `10`. Must be strictly greater than `preStopSleepSeconds`. Drives the PodSpec `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields) and the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
+| `preStopSleepSeconds` | `*int64` | No | `nil` | Sleep duration (seconds) of the preStop lifecycle hook, covering the window between EndpointSlice removal and kube-proxy/ingress propagation. When `nil`, the reconciler applies `5` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `0`. Must be strictly less than `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields). |
+| `strategy` | [`*appsv1.DeploymentStrategy`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) | No | `RollingUpdate(maxSurge=1, maxUnavailable=0)` | Overrides the Deployment rollout strategy. When `nil`, the reconciler injects `RollingUpdate` with `maxUnavailable=0` and `maxSurge=1` so available capacity never drops below `spec.replicas` during an image-tag patch. Set to customize surge/unavailable counts or switch to `Recreate`. |
 | `extraConfig` | `map[string]map[string]string` | No | `nil` | Free-form INI sections for additional configuration. |
 
 ### CEL Validation Rules
@@ -209,14 +208,14 @@ webhooks are invoked:
 | `spec.autoscaling.targetMemoryUtilization` | Range: 1–100 | — |
 | `spec.uwsgi.processes` | Minimum: 1 | — |
 | `spec.uwsgi.threads` | Minimum: 1 | — |
-| `spec.uwsgi.harakiri` | Minimum: 1 | — (CC-0084) |
-| `spec.uwsgi.httpKeepAliveTimeout` | Minimum: 1 | — (CC-0084) |
-| `spec.terminationGracePeriodSeconds` | Minimum: 10 | — (CC-0084) |
-| `spec.preStopSleepSeconds` | Minimum: 0 | — (CC-0084) |
+| `spec.uwsgi.harakiri` | Minimum: 1 | — |
+| `spec.uwsgi.httpKeepAliveTimeout` | Minimum: 1 | — |
+| `spec.terminationGracePeriodSeconds` | Minimum: 10 | — |
+| `spec.preStopSleepSeconds` | Minimum: 0 | — |
 | `spec.gateway.hostname` | MinLength: 1 | (empty string rejected by API server) |
 | `spec.gateway.parentRef.name` | MinLength: 1 | (empty string rejected by API server) |
 
-> **Known limitation (CC-0040):** `spec.uwsgi.processes` and `spec.uwsgi.threads`
+> **Known limitation:** `spec.uwsgi.processes` and `spec.uwsgi.threads`
 > have no upper-bound validation. A user could set an extremely high value (e.g.,
 > `processes: 10000`), causing the Deployment to request more workers than the node
 > can sustain. A `+kubebuilder:validation:Maximum` marker should be added once the
@@ -226,7 +225,7 @@ webhooks are invoked:
 
 ## AutoscalingSpec
 
-Configures horizontal pod autoscaling for the Keystone API Deployment (CC-0038).
+Configures horizontal pod autoscaling for the Keystone API Deployment.
 This is a pointer field (`*AutoscalingSpec`) on `KeystoneSpec` — when `nil`,
 no HPA is created and the `HPAReady` condition is set to `True` with reason
 `HPANotRequired`. When set, a `HorizontalPodAutoscaler` (autoscaling/v2) is
@@ -284,8 +283,7 @@ spec:
 
 ## UWSGISpec
 
-Configures the uWSGI application server parameters for the Keystone API container
-(CC-0040). This is a pointer field (`*UWSGISpec`) on `KeystoneSpec` — when `nil`,
+Configures the uWSGI application server parameters for the Keystone API container. This is a pointer field (`*UWSGISpec`) on `KeystoneSpec` — when `nil`,
 the reconciler uses hardcoded defaults (processes=2, threads=1, httpKeepAlive=true)
 and the webhook does **not** inject a default `UWSGISpec`. When set (even as
 `uwsgi: {}`), the webhook defaults zero-valued sub-fields and the reconciler reads
@@ -296,8 +294,8 @@ from the spec.
 | `processes` | `int32` | No | `2` | Number of uWSGI worker processes. Minimum: 1. Maps to `--processes` in the container command. |
 | `threads` | `int32` | No | `1` | Number of threads per uWSGI worker process. Minimum: 1. Maps to `--threads` in the container command. |
 | `httpKeepAlive` | `bool` | No | `true` | Enables the `--http-keepalive` flag on the uWSGI process. When `false`, the flag is omitted. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat) for the zero-value caveat. |
-| `harakiri` | `*int32` | No | `nil` (flag omitted) | Caps the per-request worker lifetime (seconds) via `--harakiri`. Minimum: `1`. The webhook additionally enforces `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` so the worst-case per-request kill fits inside the shutdown drain window. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md` (CC-0084). |
-| `httpKeepAliveTimeout` | `*int32` | No | `nil` (flag omitted) | Idle timeout (seconds) for keep-alive connections via `--http-keepalive-timeout`. Minimum: `1`. Emitted only when `httpKeepAlive=true` (the webhook rejects a non-nil timeout combined with `httpKeepAlive=false`). Recommended to set `≤ preStopSleepSeconds` so idle sockets close before SIGTERM reaches uWSGI. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md` (CC-0084). |
+| `harakiri` | `*int32` | No | `nil` (flag omitted) | Caps the per-request worker lifetime (seconds) via `--harakiri`. Minimum: `1`. The webhook additionally enforces `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` so the worst-case per-request kill fits inside the shutdown drain window. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
+| `httpKeepAliveTimeout` | `*int32` | No | `nil` (flag omitted) | Idle timeout (seconds) for keep-alive connections via `--http-keepalive-timeout`. Minimum: `1`. Emitted only when `httpKeepAlive=true` (the webhook rejects a non-nil timeout combined with `httpKeepAlive=false`). Recommended to set `≤ preStopSleepSeconds` so idle sockets close before SIGTERM reaches uWSGI. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
 
 ### Deployment Command Mapping
 
@@ -363,7 +361,7 @@ spec:
 
 ---
 
-## Graceful-termination fields (CC-0084)
+## Graceful-termination fields
 
 Five CR fields control the shutdown envelope applied during Keystone rolling
 updates — `spec.terminationGracePeriodSeconds`, `spec.preStopSleepSeconds`,
@@ -374,7 +372,7 @@ and defaulting behavior.
 
 For the rollout sequence diagram and tunable-selection guidance, see
 `architecture/docs/04-architecture/04-high-availability.md` (section
-"Keystone Rolling Update (CC-0084)").
+"Keystone Rolling Update").
 
 ### Field Summary
 
@@ -386,18 +384,18 @@ For the rollout sequence diagram and tunable-selection guidance, see
 | `spec.uwsgi.harakiri`                     | `*int32`                          | unset (flag omitted)                         | `1`     | Per-request worker kill bound (`--harakiri <n>`). Prevents a single stuck request from holding a worker past the shutdown envelope. |
 | `spec.uwsgi.httpKeepAliveTimeout`         | `*int32`                          | unset (flag omitted)                         | `1`     | Idle keep-alive socket timeout (`--http-keepalive-timeout <n>`). Only emitted when `httpKeepAlive=true`.                           |
 
-### Interaction Rules Enforced by the Webhook (CC-0084)
+### Interaction Rules Enforced by the Webhook
 
 The validating webhook enforces the following cross-field invariants so that the
 shutdown envelope is always internally consistent. Violations are returned as
 `field.Invalid` errors.
 
-| Rule                                                                                                    | REQ           |
-| ------------------------------------------------------------------------------------------------------- | ------------- |
-| `preStopSleepSeconds < terminationGracePeriodSeconds` (with `nil` pointers resolved to defaults 5 / 30) | REQ-007       |
-| `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` (only when `harakiri` is set)          | REQ-008       |
-| `httpKeepAliveTimeout` requires `httpKeepAlive=true`                                                    | REQ-012       |
-| `strategy.type=Recreate` must not carry a `strategy.rollingUpdate` block                                | REQ-006       |
+| Rule                                                                                                    |
+| ------------------------------------------------------------------------------------------------------- |
+| `preStopSleepSeconds < terminationGracePeriodSeconds` (with `nil` pointers resolved to defaults 5 / 30) |
+| `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` (only when `harakiri` is set)          |
+| `httpKeepAliveTimeout` requires `httpKeepAlive=true`                                                    |
+| `strategy.type=Recreate` must not carry a `strategy.rollingUpdate` block                                |
 
 ### Operator Guidance (not webhook-enforced)
 
@@ -413,7 +411,7 @@ shutdown envelope is always internally consistent. Violations are returned as
 ### Reconciler Fallbacks
 
 The reconciler applies internal defaults when the CR field is `nil` so
-pre-CC-0084 CRs continue to reconcile without the fields set:
+older CRs continue to reconcile without the fields set:
 
 | Field                                | Fallback when `nil`                                         |
 | ------------------------------------ | ----------------------------------------------------------- |
@@ -471,7 +469,7 @@ Configures Fernet token key rotation.
 
 ## CredentialKeysSpec
 
-Configures credential-key rotation (CC-0036). Credential keys encrypt the
+Configures credential-key rotation. Credential keys encrypt the
 application-credential passwords stored in the database. Rotation uses the same
 32-byte base64url format as Fernet but runs `keystone-manage credential_migrate`
 after generating a new primary key so that existing rows stay readable after the
@@ -488,7 +486,7 @@ ServiceAccount. The Secret is also mirrored to OpenBao through a `PushSecret`.
 
 ## TrustFlushSpec
 
-Configures periodic purging of expired trust delegations (CC-0057). This is a
+Configures periodic purging of expired trust delegations. This is a
 pointer field (`*TrustFlushSpec`) on `KeystoneSpec` — when `nil`, no trust-flush
 CronJob is created and the `TrustFlushReady` condition is set to `True` with reason
 `TrustFlushNotRequired`. When set, the operator creates a CronJob named
@@ -552,7 +550,7 @@ spec:
 
 ## NetworkPolicySpec
 
-Configures network isolation for the Keystone API pods (CC-0039). This is a
+Configures network isolation for the Keystone API pods. This is a
 pointer field (`*NetworkPolicySpec`) on `KeystoneSpec` — when `nil`, no
 NetworkPolicy is managed and the `NetworkPolicyReady` condition is set to
 `True` with reason `NetworkPolicyNotRequired`. When set, the operator creates
@@ -619,8 +617,7 @@ spec:
 
 ## GatewaySpec
 
-Configures external exposure of the Keystone API via a Gateway API HTTPRoute
-(CC-0065). This is a pointer field (`*GatewaySpec`) on `KeystoneSpec` — when `nil`,
+Configures external exposure of the Keystone API via a Gateway API HTTPRoute. This is a pointer field (`*GatewaySpec`) on `KeystoneSpec` — when `nil`,
 no HTTPRoute is created and the `HTTPRouteReady` condition is set to `True` with
 reason `HTTPRouteNotRequired`. When set, an `HTTPRoute` (from
 `gateway.networking.k8s.io/v1`) is created in the Keystone CR's namespace, attached
@@ -700,13 +697,13 @@ appended unconditionally because Keystone API v3 is served at that fixed path; t
 `PathPrefix` match on the HTTPRoute routes any prefix under `spec.gateway.path` to
 the backend. `spec.publicEndpoint` (if set) still takes precedence over the
 gateway-derived URL for the `--bootstrap-public-url` argument passed to
-`keystone-manage bootstrap`; the precedence is unchanged from pre-CC-0065 behavior.
+`keystone-manage bootstrap`; the precedence is unchanged from earlier behavior.
 
 ### Interaction with NetworkPolicy
 
 When both `spec.gateway` and `spec.networkPolicy` are configured, the operator
 automatically appends an extra ingress peer to the managed NetworkPolicy so that
-the Gateway's data-plane pods can reach Keystone on TCP 5000 (CC-0065, REQ-008):
+the Gateway's data-plane pods can reach Keystone on TCP 5000:
 
 - **Peer selector:** `namespaceSelector` matching
   `kubernetes.io/metadata.name={gatewayNamespace}`. The gateway data plane's pod
@@ -721,7 +718,7 @@ the Gateway's data-plane pods can reach Keystone on TCP 5000 (CC-0065, REQ-008):
 
 ### Example — Basic Gateway Exposure
 
-> **kind Quick Start note (CC-0088):** a ready-made
+> **kind Quick Start note:** a ready-made
 > `Gateway/openstack-gw` ships in the kind overlay
 > (`deploy/kind/base/openstack-gateway.yaml`) and is reachable on the host
 > at `https://keystone.127-0-0-1.nip.io/v3` — see the
@@ -790,7 +787,7 @@ The operator-managed NetworkPolicy allows ingress from:
 ## TopologySpreadConstraints
 
 `spec.topologySpreadConstraints` attaches scheduler spread hints to the
-Keystone API Deployment's pod template (CC-0075). Uses the upstream
+Keystone API Deployment's pod template. Uses the upstream
 `corev1.TopologySpreadConstraint` type verbatim, except that the webhook
 restricts `labelSelector` to exact `matchLabels` matching the Deployment
 selector (see below).
@@ -828,7 +825,7 @@ spec:
 
 ## PriorityClassName
 
-`spec.priorityClassName` (pointer, CC-0075) passes through to
+`spec.priorityClassName` (pointer) passes through to
 `pod.spec.priorityClassName` on the Keystone API pods. Uses the standard
 `scheduling.k8s.io/v1` `PriorityClass` resource model.
 
@@ -863,7 +860,7 @@ Configures the initial Keystone bootstrap.
 | `adminUser` | `string` | No | `"admin"` | Admin username for the bootstrap. |
 | `adminPasswordSecretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | — | Secret containing the admin password. |
 | `region` | `string` | No | `"RegionOne"` | Keystone region name. |
-| `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS (CC-0013). |
+| `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS. |
 
 ---
 
@@ -873,9 +870,9 @@ Configures the initial Keystone bootstrap.
 | --- | --- | --- |
 | `conditions` | `[]metav1.Condition` | Latest available observations of the Keystone state. |
 | `endpoint` | `string` | Keystone API endpoint URL (set by the controller when ready). Defaults to `http://{name}.{namespace}.svc.cluster.local:5000/v3`. |
-| `installedRelease` | `string` | OpenStack release version currently deployed. Set by the controller after a successful `db_sync`; reflects the value extracted from `spec.image.tag` (CC-0056). |
-| `targetRelease` | `string` | Upgrade target release during an active upgrade. Set while `upgradePhase` is one of `Expanding`/`Migrating`/`RollingUpdate`/`Contracting`; cleared after `Contracting` completes (CC-0056). |
-| `upgradePhase` | [`UpgradePhase`](#upgradephase) | Current phase of an active database upgrade. Empty outside upgrades (CC-0056). |
+| `installedRelease` | `string` | OpenStack release version currently deployed. Set by the controller after a successful `db_sync`; reflects the value extracted from `spec.image.tag`. |
+| `targetRelease` | `string` | Upgrade target release during an active upgrade. Set while `upgradePhase` is one of `Expanding`/`Migrating`/`RollingUpdate`/`Contracting`; cleared after `Contracting` completes. |
+| `upgradePhase` | [`UpgradePhase`](#upgradephase) | Current phase of an active database upgrade. Empty outside upgrades. |
 
 The status subresource is enabled via `+kubebuilder:subresource:status`.
 
@@ -883,7 +880,7 @@ The status subresource is enabled via `+kubebuilder:subresource:status`.
 
 `UpgradePhase` is a string enum (`+kubebuilder:validation:Enum=Expanding;Migrating;RollingUpdate;Contracting`)
 representing the current phase of a sequential release upgrade driven by
-`reconcileDatabase` (CC-0056). Phase transitions follow the expand-migrate-contract
+`reconcileDatabase`. Phase transitions follow the expand-migrate-contract
 pattern:
 
 | Value | Meaning |
@@ -996,14 +993,14 @@ Sets spec fields to their documented defaults when they carry zero values. Expli
 | --- | --- | --- |
 | `spec.replicas` | `== 0` | `3` |
 | `spec.fernet.maxActiveKeys` | `== 0` | `3` |
-| `spec.credentialKeys.maxActiveKeys` | `== 0` | `3` (CC-0036) |
+| `spec.credentialKeys.maxActiveKeys` | `== 0` | `3` |
 | `spec.cache.backend` | `== ""` | `"dogpile.cache.pymemcache"` |
 | `spec.bootstrap.adminUser` | `== ""` | `"admin"` |
 | `spec.bootstrap.region` | `== ""` | `"RegionOne"` |
-| `spec.uwsgi.processes` | `== 0` (when `spec.uwsgi` is non-nil) | `2` — webhook only; when `spec.uwsgi` is `nil`, the reconciler applies this default internally (CC-0040). |
-| `spec.uwsgi.threads` | `== 0` (when `spec.uwsgi` is non-nil) | `1` — same nil-pointer caveat as processes (CC-0040). |
-| `spec.uwsgi.httpKeepAlive` | Field absent from JSON payload | `true` — defaulted by the CRD schema (`+kubebuilder:default=true`), **not** by the webhook. The webhook cannot distinguish "not set" from "explicitly false" for a bool field. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat) (CC-0040). |
-| `spec.resources` | `== nil` or empty (`requests` and `limits` both unset) | `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` — ensures Burstable QoS class and enables HPA utilization calculations (CC-0042). |
+| `spec.uwsgi.processes` | `== 0` (when `spec.uwsgi` is non-nil) | `2` — webhook only; when `spec.uwsgi` is `nil`, the reconciler applies this default internally. |
+| `spec.uwsgi.threads` | `== 0` (when `spec.uwsgi` is non-nil) | `1` — same nil-pointer caveat as processes. |
+| `spec.uwsgi.httpKeepAlive` | Field absent from JSON payload | `true` — defaulted by the CRD schema (`+kubebuilder:default=true`), **not** by the webhook. The webhook cannot distinguish "not set" from "explicitly false" for a bool field. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat). |
+| `spec.resources` | `== nil` or empty (`requests` and `limits` both unset) | `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` — ensures Burstable QoS class and enables HPA utilization calculations. |
 
 **Not defaulted by the webhook:**
 
@@ -1012,11 +1009,11 @@ Sets spec fields to their documented defaults when they carry zero values. Expli
   `spec.priorityClassName` — these rely on CRD schema defaults or reconciler-level
   fallbacks. For `topologySpreadConstraints` the reconciler distinguishes `nil`
   (inject zone+hostname defaults) from `[]` (opt out), so the webhook must not
-  materialise a struct (CC-0075).
+  materialise a struct.
 
 **Design note:** `spec.fernet.rotationSchedule` is NOT defaulted by the webhook — it
-relies solely on the Kubebuilder `+kubebuilder:default="0 0 * * 0"` marker (plan
-decision #3, CC-0011). The webhook uses conditional checks (`== 0` / `== ""`) rather
+relies solely on the Kubebuilder `+kubebuilder:default="0 0 * * 0"` marker.
+The webhook uses conditional checks (`== 0` / `== ""`) rather
 than always-set to cooperate with the remaining Kubebuilder `+default` markers, which
 also provide schema-level defaults. Both layers are intentional — schema defaults apply
 at deserialization time, while webhook defaults catch zero values that bypass schema
@@ -1042,42 +1039,42 @@ single `apierrors.NewInvalid` error. It does **not** short-circuit on the first 
 | Rule | Field Path | Error Type | Condition |
 | --- | --- | --- | --- |
 | Replicas minimum | `spec.replicas` | `field.Invalid` | `replicas < 1`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
-| Cache mutual exclusivity | `spec.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither. Defense-in-depth alongside the CEL XValidation rule (CC-0011). |
-| Database mutual exclusivity | `spec.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither. Defense-in-depth alongside the CEL XValidation rule (CC-0011). |
+| Cache mutual exclusivity | `spec.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither. Defense-in-depth alongside the CEL XValidation rule. |
+| Database mutual exclusivity | `spec.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither. Defense-in-depth alongside the CEL XValidation rule. |
 | Fernet maxActiveKeys minimum | `spec.fernet.maxActiveKeys` | `field.Invalid` | `maxActiveKeys < 3`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=3` marker. |
 | Fernet schedule required | `spec.fernet.rotationSchedule` | `field.Required` | Empty after admission (bypass paths). |
 | Fernet cron expression | `spec.fernet.rotationSchedule` | `field.Invalid` | `cron.ParseStandard()` fails. Error message includes the parse failure details. |
-| CredentialKeys maxActiveKeys minimum | `spec.credentialKeys.maxActiveKeys` | `field.Invalid` | `maxActiveKeys < 3`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=3` marker (CC-0036). |
-| CredentialKeys schedule required | `spec.credentialKeys.rotationSchedule` | `field.Required` | Empty after admission (bypass paths) (CC-0036). |
-| CredentialKeys cron expression | `spec.credentialKeys.rotationSchedule` | `field.Invalid` | `cron.ParseStandard()` fails (CC-0036). |
+| CredentialKeys maxActiveKeys minimum | `spec.credentialKeys.maxActiveKeys` | `field.Invalid` | `maxActiveKeys < 3`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=3` marker. |
+| CredentialKeys schedule required | `spec.credentialKeys.rotationSchedule` | `field.Required` | Empty after admission (bypass paths). |
+| CredentialKeys cron expression | `spec.credentialKeys.rotationSchedule` | `field.Invalid` | `cron.ParseStandard()` fails. |
 | Duplicate plugin sections | `spec.plugins[i].configSection` | `field.Duplicate` | Two or more plugins share the same `configSection` value. |
 | Policy source required | `spec.policyOverrides` | `field.Required` | `policyOverrides` is set but both `rules` and `configMapRef` are nil/empty. |
 | Empty policy rule name | `spec.policyOverrides.rules` | `field.Invalid` | A key in `rules` map is the empty string. |
-| Autoscaling maxReplicas minimum | `spec.autoscaling.maxReplicas` | `field.Invalid` | `maxReplicas < 1`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker (CC-0038). |
-| Autoscaling minReplicas minimum | `spec.autoscaling.minReplicas` | `field.Invalid` | `minReplicas < 1` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker (CC-0038). |
-| Autoscaling min exceeds max | `spec.autoscaling.minReplicas` | `field.Invalid` | `minReplicas > maxReplicas` when set (CC-0038). |
-| Autoscaling maxReplicas vs replicas | `spec.autoscaling.maxReplicas` | `field.Invalid` | `minReplicas` is unset and `spec.replicas > autoscaling.maxReplicas`. Would otherwise produce an HPA the API server rejects, because `minReplicas` defaults to `spec.replicas` (CC-0038). |
-| Autoscaling CPU utilization range | `spec.autoscaling.targetCPUUtilization` | `field.Invalid` | Value outside `1..100` when set (CC-0038). |
-| Autoscaling memory utilization range | `spec.autoscaling.targetMemoryUtilization` | `field.Invalid` | Value outside `1..100` when set (CC-0038). |
-| Autoscaling no metric targets | `spec.autoscaling` | `field.Required` | Neither `targetCPUUtilization` nor `targetMemoryUtilization` is set. Defense-in-depth alongside the CEL XValidation rule (CC-0038). |
-| NetworkPolicy ingress required | `spec.networkPolicy.ingress` | `field.Required` | `networkPolicy` is set but `ingress` is empty. Defense-in-depth alongside the CEL XValidation rule (CC-0039). |
-| uWSGI processes minimum | `spec.uwsgi.processes` | `field.Invalid` | `processes < 1` when `spec.uwsgi` is non-nil. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker (CC-0040). |
-| uWSGI threads minimum | `spec.uwsgi.threads` | `field.Invalid` | `threads < 1` when `spec.uwsgi` is non-nil. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker (CC-0040). |
-| uWSGI harakiri minimum | `spec.uwsgi.harakiri` | `field.Invalid` | `harakiri < 1` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker (CC-0084). |
-| uWSGI keep-alive timeout minimum | `spec.uwsgi.httpKeepAliveTimeout` | `field.Invalid` | `httpKeepAliveTimeout < 1` when set. A zero value is rejected because uWSGI interprets it as unbounded, defeating the graceful-termination contract (CC-0084). |
-| uWSGI keep-alive timeout without keep-alive | `spec.uwsgi.httpKeepAliveTimeout` | `field.Invalid` | `httpKeepAliveTimeout` is set while `httpKeepAlive=false`. The `--http-keepalive-timeout` flag is only emitted when keep-alive is enabled, so the combination is rejected to avoid silently dropping user intent (CC-0084). |
-| TerminationGracePeriodSeconds minimum | `spec.terminationGracePeriodSeconds` | `field.Invalid` | `terminationGracePeriodSeconds < 10` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=10` marker (CC-0084). |
-| PreStopSleepSeconds minimum | `spec.preStopSleepSeconds` | `field.Invalid` | `preStopSleepSeconds < 0` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=0` marker (CC-0084). |
-| PreStopSleep ≥ grace period | `spec.preStopSleepSeconds` | `field.Invalid` | Resolved `preStopSleepSeconds >= terminationGracePeriodSeconds` (nil pointers resolve to defaults 5/30). Guarantees a non-zero drain window between the end of the preStop sleep and SIGKILL (CC-0084). |
-| Harakiri ≥ drain window | `spec.uwsgi.harakiri` | `field.Invalid` | `harakiri >= terminationGracePeriodSeconds − preStopSleepSeconds` (nil pointers resolve to defaults). Guarantees the per-request kill fits inside the shutdown envelope (CC-0084). |
-| Recreate strategy with RollingUpdate | `spec.strategy.rollingUpdate` | `field.Invalid` | `strategy.type = Recreate` combined with a non-nil `strategy.rollingUpdate` block. The Deployment controller would reject the object at apply time; the webhook catches the misconfiguration up-front (CC-0084). |
-| Resource request exceeds limit | `spec.resources.requests.<resource>` | `field.Invalid` | A resource request exceeds its corresponding limit (e.g., CPU request 1000m > limit 500m). Checked per resource type when both requests and limits are set (CC-0042). |
-| Trust flush schedule required | `spec.trustFlush.schedule` | `field.Required` | `trustFlush` is set but `schedule` is empty. Defense-in-depth — the `+kubebuilder:default` marker normally prevents this, but bypass paths (e.g., `kubectl patch`) may produce an empty string (CC-0057). |
-| Trust flush cron expression | `spec.trustFlush.schedule` | `field.Invalid` | `cron.ParseStandard()` fails on `trustFlush.schedule`. Error message includes the parse failure details (CC-0057). |
-| PriorityClass existence | `spec.priorityClassName` | `field.NotFound` / `field.InternalError` | The webhook performs a cluster-scoped `Get` of the referenced `scheduling.k8s.io/v1` `PriorityClass` when the field is non-empty. Missing classes produce `NotFound`; transient API errors produce `InternalError` (CC-0075). |
-| TopologySpread labelSelector required | `spec.topologySpreadConstraints[i].labelSelector` | `field.Required` | Entry has no `labelSelector` (CC-0075). |
-| TopologySpread matchLabels mismatch | `spec.topologySpreadConstraints[i].labelSelector` | `field.Invalid` | `matchLabels` does not exactly equal `{app.kubernetes.io/name: keystone, app.kubernetes.io/instance: {CR name}}` (CC-0075). |
-| TopologySpread matchExpressions forbidden | `spec.topologySpreadConstraints[i].labelSelector.matchExpressions` | `field.Invalid` | `matchExpressions` is non-empty. Only exact `matchLabels` are allowed (CC-0075). |
+| Autoscaling maxReplicas minimum | `spec.autoscaling.maxReplicas` | `field.Invalid` | `maxReplicas < 1`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
+| Autoscaling minReplicas minimum | `spec.autoscaling.minReplicas` | `field.Invalid` | `minReplicas < 1` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
+| Autoscaling min exceeds max | `spec.autoscaling.minReplicas` | `field.Invalid` | `minReplicas > maxReplicas` when set. |
+| Autoscaling maxReplicas vs replicas | `spec.autoscaling.maxReplicas` | `field.Invalid` | `minReplicas` is unset and `spec.replicas > autoscaling.maxReplicas`. Would otherwise produce an HPA the API server rejects, because `minReplicas` defaults to `spec.replicas`. |
+| Autoscaling CPU utilization range | `spec.autoscaling.targetCPUUtilization` | `field.Invalid` | Value outside `1..100` when set. |
+| Autoscaling memory utilization range | `spec.autoscaling.targetMemoryUtilization` | `field.Invalid` | Value outside `1..100` when set. |
+| Autoscaling no metric targets | `spec.autoscaling` | `field.Required` | Neither `targetCPUUtilization` nor `targetMemoryUtilization` is set. Defense-in-depth alongside the CEL XValidation rule. |
+| NetworkPolicy ingress required | `spec.networkPolicy.ingress` | `field.Required` | `networkPolicy` is set but `ingress` is empty. Defense-in-depth alongside the CEL XValidation rule. |
+| uWSGI processes minimum | `spec.uwsgi.processes` | `field.Invalid` | `processes < 1` when `spec.uwsgi` is non-nil. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
+| uWSGI threads minimum | `spec.uwsgi.threads` | `field.Invalid` | `threads < 1` when `spec.uwsgi` is non-nil. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
+| uWSGI harakiri minimum | `spec.uwsgi.harakiri` | `field.Invalid` | `harakiri < 1` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
+| uWSGI keep-alive timeout minimum | `spec.uwsgi.httpKeepAliveTimeout` | `field.Invalid` | `httpKeepAliveTimeout < 1` when set. A zero value is rejected because uWSGI interprets it as unbounded, defeating the graceful-termination contract. |
+| uWSGI keep-alive timeout without keep-alive | `spec.uwsgi.httpKeepAliveTimeout` | `field.Invalid` | `httpKeepAliveTimeout` is set while `httpKeepAlive=false`. The `--http-keepalive-timeout` flag is only emitted when keep-alive is enabled, so the combination is rejected to avoid silently dropping user intent. |
+| TerminationGracePeriodSeconds minimum | `spec.terminationGracePeriodSeconds` | `field.Invalid` | `terminationGracePeriodSeconds < 10` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=10` marker. |
+| PreStopSleepSeconds minimum | `spec.preStopSleepSeconds` | `field.Invalid` | `preStopSleepSeconds < 0` when set. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=0` marker. |
+| PreStopSleep ≥ grace period | `spec.preStopSleepSeconds` | `field.Invalid` | Resolved `preStopSleepSeconds >= terminationGracePeriodSeconds` (nil pointers resolve to defaults 5/30). Guarantees a non-zero drain window between the end of the preStop sleep and SIGKILL. |
+| Harakiri ≥ drain window | `spec.uwsgi.harakiri` | `field.Invalid` | `harakiri >= terminationGracePeriodSeconds − preStopSleepSeconds` (nil pointers resolve to defaults). Guarantees the per-request kill fits inside the shutdown envelope. |
+| Recreate strategy with RollingUpdate | `spec.strategy.rollingUpdate` | `field.Invalid` | `strategy.type = Recreate` combined with a non-nil `strategy.rollingUpdate` block. The Deployment controller would reject the object at apply time; the webhook catches the misconfiguration up-front. |
+| Resource request exceeds limit | `spec.resources.requests.<resource>` | `field.Invalid` | A resource request exceeds its corresponding limit (e.g., CPU request 1000m > limit 500m). Checked per resource type when both requests and limits are set. |
+| Trust flush schedule required | `spec.trustFlush.schedule` | `field.Required` | `trustFlush` is set but `schedule` is empty. Defense-in-depth — the `+kubebuilder:default` marker normally prevents this, but bypass paths (e.g., `kubectl patch`) may produce an empty string. |
+| Trust flush cron expression | `spec.trustFlush.schedule` | `field.Invalid` | `cron.ParseStandard()` fails on `trustFlush.schedule`. Error message includes the parse failure details. |
+| PriorityClass existence | `spec.priorityClassName` | `field.NotFound` / `field.InternalError` | The webhook performs a cluster-scoped `Get` of the referenced `scheduling.k8s.io/v1` `PriorityClass` when the field is non-empty. Missing classes produce `NotFound`; transient API errors produce `InternalError`. |
+| TopologySpread labelSelector required | `spec.topologySpreadConstraints[i].labelSelector` | `field.Required` | Entry has no `labelSelector`. |
+| TopologySpread matchLabels mismatch | `spec.topologySpreadConstraints[i].labelSelector` | `field.Invalid` | `matchLabels` does not exactly equal `{app.kubernetes.io/name: keystone, app.kubernetes.io/instance: {CR name}}`. |
+| TopologySpread matchExpressions forbidden | `spec.topologySpreadConstraints[i].labelSelector.matchExpressions` | `field.Invalid` | `matchExpressions` is non-empty. Only exact `matchLabels` are allowed. |
 
 **Error format:** All validation errors are returned as a structured
 `apierrors.StatusError` with `GroupKind{Group: "keystone.openstack.c5c3.io", Kind: "Keystone"}`,
@@ -1087,9 +1084,9 @@ providing clear, field-specific error messages to the operator.
 
 ## Testing
 
-The Keystone CRD has a three-layer test strategy (CC-0012):
+The Keystone CRD has a three-layer test strategy:
 
-1. **Unit tests** — fast, in-process tests for webhook logic (existing from CC-0011).
+1. **Unit tests** — fast, in-process tests for webhook logic.
 2. **Integration tests** — envtest-based tests that run a real API server + etcd to
    validate CRD schema, CEL rules, and webhooks through the full admission pipeline.
 3. **E2E tests** — Chainsaw tests that deploy the operator to a real cluster and verify
@@ -1116,7 +1113,7 @@ func SetupKeystoneEnvTest(
 ) (client.Client, context.Context, context.CancelFunc)
 ```
 
-**Design decisions (CC-0012):**
+**Design decisions:**
 
 - Uses a **local scheme** — `SharedScheme()` from `internal/common` is not modified.
   Only Keystone tests need Keystone types registered.
@@ -1172,20 +1169,20 @@ exercise the CRD schema constraints.
 | --- | --- | --- |
 | `TestIntegration_WebhookDefaultsSetsZeroValues` | Defaults applied | Creates a CR with zero-valued defaultable fields; verifies `replicas=3`, `cache.backend="dogpile.cache.pymemcache"`, `bootstrap.adminUser="admin"`, `bootstrap.region="RegionOne"`, `fernet.maxActiveKeys=3` after admission. |
 | `TestIntegration_WebhookDefaultsPreservesExplicit` | Explicit values preserved | Creates a CR with `replicas=5` and `region="EU-West"`; verifies these values are not overwritten by the defaulting webhook. |
-| `TestIntegration_ResourcesDefaultedWhenNil` | Resources defaulted | Creates a CR with `spec.resources` unset (`nil`); verifies the defaulting webhook injects `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` (CC-0042). |
-| `TestIntegration_ResourcesPreservedWhenExplicit` | Explicit resources preserved | Creates a CR with explicit `spec.resources` (1Gi/2Gi memory, 200m/1 CPU); verifies the defaulting webhook does not overwrite them (CC-0042). |
-| `TestIntegration_UWSGIDefaultsAppliedWhenEmpty` | uWSGI defaults applied | Creates a CR with `spec.uwsgi: {}` (all zero values); verifies processes=2, threads=1, httpKeepAlive=true after admission (CC-0040). |
-| `TestIntegration_UWSGIExplicitValuesPreserved` | Explicit uWSGI preserved | Creates a CR with `spec.uwsgi.processes=4, threads=4`; verifies these values are not overwritten by the defaulting webhook (CC-0040). |
-| `TestIntegration_UWSGIPartialDefaulting` | Partial uWSGI defaults | Creates a CR with only `spec.uwsgi.processes=4`; verifies threads=1 is defaulted while processes=4 is preserved (CC-0040). |
-| `TestIntegration_UWSGINilPreserved` | uWSGI nil preserved | Creates a CR without `spec.uwsgi`; verifies the field remains `nil` after admission — webhook does not inject a default struct (CC-0040). |
+| `TestIntegration_ResourcesDefaultedWhenNil` | Resources defaulted | Creates a CR with `spec.resources` unset (`nil`); verifies the defaulting webhook injects `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}`. |
+| `TestIntegration_ResourcesPreservedWhenExplicit` | Explicit resources preserved | Creates a CR with explicit `spec.resources` (1Gi/2Gi memory, 200m/1 CPU); verifies the defaulting webhook does not overwrite them. |
+| `TestIntegration_UWSGIDefaultsAppliedWhenEmpty` | uWSGI defaults applied | Creates a CR with `spec.uwsgi: {}` (all zero values); verifies processes=2, threads=1, httpKeepAlive=true after admission. |
+| `TestIntegration_UWSGIExplicitValuesPreserved` | Explicit uWSGI preserved | Creates a CR with `spec.uwsgi.processes=4, threads=4`; verifies these values are not overwritten by the defaulting webhook. |
+| `TestIntegration_UWSGIPartialDefaulting` | Partial uWSGI defaults | Creates a CR with only `spec.uwsgi.processes=4`; verifies threads=1 is defaulted while processes=4 is preserved. |
+| `TestIntegration_UWSGINilPreserved` | uWSGI nil preserved | Creates a CR without `spec.uwsgi`; verifies the field remains `nil` after admission — webhook does not inject a default struct. |
 
 #### Webhook Validation Rejection
 
 | Test | Requirement | Trigger | Expected Error |
 | --- | --- | --- | --- |
-| `TestIntegration_ResourcesRequestExceedsLimitRejected` | Request must not exceed limit | `spec.resources` with CPU request 1000m > limit 500m | Invalid/Forbidden containing "resources" (CC-0042). |
-| `TestIntegration_UWSGIProcessesBelowMinimumRejected` | Processes minimum | `spec.uwsgi.processes` below minimum (bypassing defaulting) | Invalid/Forbidden containing "uwsgi" (CC-0040). |
-| `TestIntegration_UWSGIThreadsBelowMinimumRejected` | Threads minimum | `spec.uwsgi.threads` below minimum (bypassing defaulting) | Invalid/Forbidden containing "uwsgi" (CC-0040). |
+| `TestIntegration_ResourcesRequestExceedsLimitRejected` | Request must not exceed limit | `spec.resources` with CPU request 1000m > limit 500m | Invalid/Forbidden containing "resources". |
+| `TestIntegration_UWSGIProcessesBelowMinimumRejected` | Processes minimum | `spec.uwsgi.processes` below minimum (bypassing defaulting) | Invalid/Forbidden containing "uwsgi". |
+| `TestIntegration_UWSGIThreadsBelowMinimumRejected` | Threads minimum | `spec.uwsgi.threads` below minimum (bypassing defaulting) | Invalid/Forbidden containing "uwsgi". |
 
 ### Chainsaw E2E Tests
 
@@ -1196,29 +1193,29 @@ E2E test suite inventory (basic-deployment, scale, fernet-rotation,
 credential-rotation, network-policy, topology-spread, priority-class,
 release-upgrade, schema-drift-detection, events, healthcheck, graceful-shutdown,
 policy-validation, config-pruning, …), see
-[Keystone E2E Test Suites](../testing/keystone-e2e-tests.md) (CC-0016).
+[Keystone E2E Test Suites](../testing/keystone-e2e-tests.md).
 
 #### invalid-cr Suite
 
-The full webhook + CEL rejection matrix (CC-0094) extends the original
-two-step suite (CC-0012) so that every implemented `XValidation` rule and
+The full webhook + CEL rejection matrix extends the original
+two-step suite so that every implemented `XValidation` rule and
 every `webhook.validate()` branch in `operators/keystone/api/v1alpha1/`
-is pinned by a Chainsaw step. Each row maps 1:1 to a CC-0094 requirement.
+is pinned by a Chainsaw step.
 
 | Step | Manifest | Requirement | Expected Error |
 | --- | --- | --- | --- |
-| `invalid-cron-expression-rejected` | `00-invalid-cron.yaml` | Invalid cron (CC-0012 REQ-008) | Error containing "rotationSchedule" and "invalid cron expression" |
-| `duplicate-plugin-config-section-rejected` | `01-duplicate-plugins.yaml` | Duplicate configSection (CC-0012 REQ-009) | Error containing "configSection" and "Duplicate value" |
-| `database-both-modes-rejected` | `02-database-both-modes.yaml` | DatabaseSpec mutual exclusivity (CC-0094 REQ-001) | Error containing "spec.database" and "exactly one of clusterRef or host must be set" |
-| `cache-both-modes-rejected` | `03-cache-both-modes.yaml` | CacheSpec mutual exclusivity (CC-0094 REQ-002) | Error containing "spec.cache" and "exactly one of clusterRef or servers must be set" |
-| `autoscaling-no-target-rejected` | `04-autoscaling-no-target.yaml` | AutoscalingSpec target required (CC-0094 REQ-003) | Error containing "spec.autoscaling" and "at least one of targetCPUUtilization or targetMemoryUtilization" |
-| `policy-overrides-no-source-rejected` | `05-policy-overrides-no-source.yaml` | PolicyOverrides source required (CC-0094 REQ-004) | Error containing "spec.policyOverrides" and "at least one of rules or configMapRef must be set" |
-| `policy-overrides-empty-rule-key-rejected` | `06-policy-overrides-empty-rule-key.yaml` | Non-empty rule names (CC-0094 REQ-005) | Error containing "spec.policyOverrides" and "policy rule name must not be empty" |
-| `networkpolicy-empty-ingress-rejected` | `07-networkpolicy-empty-ingress.yaml` | NetworkPolicy ingress required (CC-0094 REQ-006) | Error containing "spec.networkPolicy" and "at least one ingress source" |
-| `replicas-negative-rejected` | `09-replicas-negative.yaml` | Replicas Minimum=1 (CC-0094 REQ-008; subsumes the dropped REQ-007 / `08-replicas-zero.yaml` case — see layer-ordering aside) | Error containing "replicas" |
-| `hpa-min-greater-than-max-rejected` | `10-hpa-min-greater-than-max.yaml` | minReplicas ≤ maxReplicas (CC-0094 REQ-009) | Error containing "spec.autoscaling.minReplicas" and "must not exceed maxReplicas" |
-| `fernet-maxactivekeys-below-minimum-rejected` | `11-fernet-maxactivekeys-below-minimum.yaml` | Fernet maxActiveKeys Minimum=3 (CC-0094 REQ-010) | Error containing "maxActiveKeys" |
-| `credentialkeys-maxactivekeys-below-minimum-rejected` | `12-credentialkeys-maxactivekeys-below-minimum.yaml` | CredentialKeys maxActiveKeys Minimum=3 (CC-0094 REQ-011) | Error containing "maxActiveKeys" |
+| `invalid-cron-expression-rejected` | `00-invalid-cron.yaml` | Invalid cron | Error containing "rotationSchedule" and "invalid cron expression" |
+| `duplicate-plugin-config-section-rejected` | `01-duplicate-plugins.yaml` | Duplicate configSection | Error containing "configSection" and "Duplicate value" |
+| `database-both-modes-rejected` | `02-database-both-modes.yaml` | DatabaseSpec mutual exclusivity | Error containing "spec.database" and "exactly one of clusterRef or host must be set" |
+| `cache-both-modes-rejected` | `03-cache-both-modes.yaml` | CacheSpec mutual exclusivity | Error containing "spec.cache" and "exactly one of clusterRef or servers must be set" |
+| `autoscaling-no-target-rejected` | `04-autoscaling-no-target.yaml` | AutoscalingSpec target required | Error containing "spec.autoscaling" and "at least one of targetCPUUtilization or targetMemoryUtilization" |
+| `policy-overrides-no-source-rejected` | `05-policy-overrides-no-source.yaml` | PolicyOverrides source required | Error containing "spec.policyOverrides" and "at least one of rules or configMapRef must be set" |
+| `policy-overrides-empty-rule-key-rejected` | `06-policy-overrides-empty-rule-key.yaml` | Non-empty rule names | Error containing "spec.policyOverrides" and "policy rule name must not be empty" |
+| `networkpolicy-empty-ingress-rejected` | `07-networkpolicy-empty-ingress.yaml` | NetworkPolicy ingress required | Error containing "spec.networkPolicy" and "at least one ingress source" |
+| `replicas-negative-rejected` | `09-replicas-negative.yaml` | Replicas Minimum=1 (subsumes the dropped `08-replicas-zero.yaml` case — see layer-ordering aside) | Error containing "replicas" |
+| `hpa-min-greater-than-max-rejected` | `10-hpa-min-greater-than-max.yaml` | minReplicas ≤ maxReplicas | Error containing "spec.autoscaling.minReplicas" and "must not exceed maxReplicas" |
+| `fernet-maxactivekeys-below-minimum-rejected` | `11-fernet-maxactivekeys-below-minimum.yaml` | Fernet maxActiveKeys Minimum=3 | Error containing "maxActiveKeys" |
+| `credentialkeys-maxactivekeys-below-minimum-rejected` | `12-credentialkeys-maxactivekeys-below-minimum.yaml` | CredentialKeys maxActiveKeys Minimum=3 | Error containing "maxActiveKeys" |
 
 Each step uses `apply` with `expect` to assert that the `$error` variable is non-null
 and contains the expected field-level error message. Kubernetes admission evaluates
@@ -1228,36 +1225,36 @@ that rejects an object is the one whose message Chainsaw sees. The mutating step
 listed first because it can silently rewrite a value out from under a downstream
 rule: `keystone_webhook.go:80-82` coerces `spec.replicas == 0` to `3` BEFORE the
 `+kubebuilder:validation:Minimum=1` marker is evaluated, so a manifest using
-`spec.replicas: 0` would be silently accepted. This is the precise reason REQ-007
-(originally `08-replicas-zero.yaml`) was dropped from the suite during the CC-0094
-review-1 cycle: REQ-008 (`09-replicas-negative.yaml`, `spec.replicas: -1`) uses a
+`spec.replicas: 0` would be silently accepted. This is the precise reason the
+`08-replicas-zero.yaml` case was dropped from the suite: the
+`09-replicas-negative.yaml` fixture (`spec.replicas: -1`) uses a
 value the defaulter does not touch (the defaulter only fires on `== 0`) and exercises
 the same `Minimum=1` and webhook-defense-in-depth path. The same trap applies to
-`maxActiveKeys: 0`, which is why REQ-010 / REQ-011 use `2` rather than `0`.
+`maxActiveKeys: 0`, which is why the `maxActiveKeys` fixtures use `2` rather than `0`.
 
-For most CC-0094 rules the producing layer is unambiguous (CEL emits the exact
+For most rules the producing layer is unambiguous (CEL emits the exact
 "exactly one of …", "at least one of …", "must not exceed maxReplicas" wording),
-so the assertions match the full webhook-equivalent message. REQ-005
-(`06-policy-overrides-empty-rule-key.yaml`) and REQ-006
-(`07-networkpolicy-empty-ingress.yaml`) are the dual-layer exceptions where the
+so the assertions match the full webhook-equivalent message. The
+`06-policy-overrides-empty-rule-key.yaml` and
+`07-networkpolicy-empty-ingress.yaml` fixtures are the dual-layer exceptions where the
 fieldPath emitted by CEL is the parent path (`spec.policyOverrides` /
 `spec.networkPolicy`) — the path where the `XValidation` rule is declared — and
 NOT the deeper path the validating webhook would emit (`…rules` / `…ingress`).
 Because CEL fails first and short-circuits the admission pipeline, the validating
 webhook's deeper-path message never reaches Chainsaw, so the assertions match only
-the parent path. REQ-010 (`11-fernet-maxactivekeys-below-minimum.yaml`) and REQ-011
-(`12-credentialkeys-maxactivekeys-below-minimum.yaml`) are the field-substring
+the parent path. The `11-fernet-maxactivekeys-below-minimum.yaml` and
+`12-credentialkeys-maxactivekeys-below-minimum.yaml` fixtures are the field-substring
 exceptions: they trip the CRD structural schema's `Minimum=N` first, whose generated
 wording ("must be greater than or equal to N") differs from the webhook's
 defense-in-depth wording ("maxActiveKeys must be at least 3"). Both layers carry
 the field name, so the loose-substring assertion (`maxActiveKeys`) keeps the tests
 stable regardless of which layer fires first and across upstream Kubernetes
-admission-pipeline changes (CC-0094).
+admission-pipeline changes.
 
-The 10 CC-0094 fixtures (`02-…` through `12-…`, with the `08-replicas-zero.yaml`
+The 10 generated fixtures (`02-…` through `12-…`, with the `08-replicas-zero.yaml`
 gap explained above) share an otherwise-identical minimal valid Keystone scaffold
 and differ only by the field under test. To prevent that scaffold from drifting
-across files (sourcery-ai review #1, CC-0094), the fixtures are generated from a
+across files, the fixtures are generated from a
 single canonical source in `tests/e2e/keystone/invalid-cr/_generate.py`. After
 editing the scaffold or any per-fixture override, regenerate via
 `python3 tests/e2e/keystone/invalid-cr/_generate.py`. The
@@ -1267,11 +1264,11 @@ in drift mode and the `test_generate.py` unit suite (`len(FIXTURES) == 10` plus
 a cross-reference assertion that every `Fixture.filename` appears as a
 `file:` step in `chainsaw-test.yaml`), so a hand-edit to any generated fixture
 — or a rename/removal that desynchs `FIXTURES` from `chainsaw-test.yaml` —
-fails the build before the cluster-bound `e2e-operator` job runs. The CC-0012
-fixtures (`00-invalid-cron.yaml`, `01-duplicate-plugins.yaml`) predate CC-0094
-and are intentionally NOT regenerated.
+fails the build before the cluster-bound `e2e-operator` job runs. The
+`00-invalid-cron.yaml` and `01-duplicate-plugins.yaml` fixtures predate the
+generator and are intentionally NOT regenerated.
 
-The following CC-0094 follow-up gaps are intentionally **not** covered by this
+The following follow-up gaps are intentionally **not** covered by this
 suite — they require new validation rules that do not exist yet, and each one
 is tracked as its own feature ticket:
 
@@ -1279,7 +1276,7 @@ is tracked as its own feature ticket:
 - `topologySpreadConstraints[*].maxSkew: 0` (no CRD-level minimum on the upstream type, no defense-in-depth in the Keystone webhook).
 - Mutation of immutable fields (`spec.database.clusterRef`, `spec.cache.clusterRef`) on `ValidateUpdate` — old-vs-new comparison is not yet implemented.
 
-#### uwsgi Suite (CC-0040)
+#### uwsgi Suite
 
 The `uwsgi` suite (`tests/e2e/keystone/uwsgi/`) validates that `spec.uwsgi` values
 propagate to the Deployment container command in a real cluster with the operator
@@ -1336,7 +1333,7 @@ operators/keystone/
 │   ├── keystone_webhook.go           Defaulting + validating webhooks
 │   ├── keystone_types_test.go        Type and scheme registration tests
 │   ├── keystone_webhook_test.go      Webhook unit tests (table-driven)
-│   ├── integration_test.go           envtest integration tests (CC-0012)
+│   ├── integration_test.go           envtest integration tests
 │   └── zz_generated.deepcopy.go     Generated DeepCopy methods
 ├── config/crd/bases/
 │   └── keystone.openstack.c5c3.io_keystones.yaml  Generated CRD manifest
@@ -1344,37 +1341,37 @@ operators/keystone/
 │   ├── manifests.yaml                Generated webhook configurations
 │   └── ...
 ├── internal/testutil/
-│   └── envtest_setup.go              Keystone-specific envtest helper (CC-0012)
+│   └── envtest_setup.go              Keystone-specific envtest helper
 └── main.go                           Scheme registration + bootstrap + webhook wiring
 
 tests/e2e/keystone/
-├── basic-deployment/                 Happy-path reconciliation E2E (CC-0016)
-├── missing-secret/                   Secret dependency recovery E2E (CC-0016)
-├── fernet-rotation/                  Fernet key rotation E2E (CC-0016)
-├── scale/                            Replica scaling E2E (CC-0016)
-├── deletion-cleanup/                 Garbage collection E2E (CC-0016)
-├── policy-overrides/                 oslo.policy integration E2E (CC-0016)
-├── middleware-config/                Middleware pipeline E2E (CC-0016)
-├── brownfield-database/              External database mode E2E (CC-0016)
-├── image-upgrade/                    Rolling image upgrade E2E (CC-0016)
-├── uwsgi/                            uWSGI field propagation E2E (CC-0040)
+├── basic-deployment/                 Happy-path reconciliation E2E
+├── missing-secret/                   Secret dependency recovery E2E
+├── fernet-rotation/                  Fernet key rotation E2E
+├── scale/                            Replica scaling E2E
+├── deletion-cleanup/                 Garbage collection E2E
+├── policy-overrides/                 oslo.policy integration E2E
+├── middleware-config/                Middleware pipeline E2E
+├── brownfield-database/              External database mode E2E
+├── image-upgrade/                    Rolling image upgrade E2E
+├── uwsgi/                            uWSGI field propagation E2E
 │   ├── chainsaw-test.yaml            Chainsaw E2E test definition
 │   ├── 00-keystone-cr.yaml           Keystone CR without explicit uWSGI
 │   └── 01-patch-custom-uwsgi.yaml    Patch with custom uWSGI values
 └── invalid-cr/
-    ├── chainsaw-test.yaml                                  Chainsaw E2E test definition (CC-0012, CC-0094)
-    ├── 00-invalid-cron.yaml                                Invalid cron expression CR manifest (CC-0012)
-    ├── 01-duplicate-plugins.yaml                           Duplicate plugin configSection CR manifest (CC-0012)
-    ├── 02-database-both-modes.yaml                         Database clusterRef + host both set (CC-0094)
-    ├── 03-cache-both-modes.yaml                            Cache clusterRef + servers both set (CC-0094)
-    ├── 04-autoscaling-no-target.yaml                       Autoscaling without utilization target (CC-0094)
-    ├── 05-policy-overrides-no-source.yaml                  PolicyOverrides without rules or configMapRef (CC-0094)
-    ├── 06-policy-overrides-empty-rule-key.yaml             PolicyOverrides rule with empty key (CC-0094)
-    ├── 07-networkpolicy-empty-ingress.yaml                 NetworkPolicy with empty ingress array (CC-0094)
-    ├── 09-replicas-negative.yaml                           spec.replicas: -1 (CC-0094; subsumes the dropped 08-replicas-zero case)
-    ├── 10-hpa-min-greater-than-max.yaml                    HPA minReplicas > maxReplicas (CC-0094)
-    ├── 11-fernet-maxactivekeys-below-minimum.yaml          Fernet maxActiveKeys < 3 (CC-0094)
-    └── 12-credentialkeys-maxactivekeys-below-minimum.yaml  CredentialKeys maxActiveKeys < 3 (CC-0094)
+    ├── chainsaw-test.yaml                                  Chainsaw E2E test definition
+    ├── 00-invalid-cron.yaml                                Invalid cron expression CR manifest
+    ├── 01-duplicate-plugins.yaml                           Duplicate plugin configSection CR manifest
+    ├── 02-database-both-modes.yaml                         Database clusterRef + host both set
+    ├── 03-cache-both-modes.yaml                            Cache clusterRef + servers both set
+    ├── 04-autoscaling-no-target.yaml                       Autoscaling without utilization target
+    ├── 05-policy-overrides-no-source.yaml                  PolicyOverrides without rules or configMapRef
+    ├── 06-policy-overrides-empty-rule-key.yaml             PolicyOverrides rule with empty key
+    ├── 07-networkpolicy-empty-ingress.yaml                 NetworkPolicy with empty ingress array
+    ├── 09-replicas-negative.yaml                           spec.replicas: -1 (subsumes the dropped 08-replicas-zero case)
+    ├── 10-hpa-min-greater-than-max.yaml                    HPA minReplicas > maxReplicas
+    ├── 11-fernet-maxactivekeys-below-minimum.yaml          Fernet maxActiveKeys < 3
+    └── 12-credentialkeys-maxactivekeys-below-minimum.yaml  CredentialKeys maxActiveKeys < 3
 ```
 
 This layout is the canonical pattern for all CobaltCore operators. New operators

--- a/docs/reference/keystone/keystone-events.md
+++ b/docs/reference/keystone/keystone-events.md
@@ -1,13 +1,11 @@
 ---
 title: Keystone Controller Events
 quadrant: operator
-feature: CC-0070
 ---
 
 # Keystone Controller Events
 
-Reference documentation for Kubernetes events emitted by the Keystone controller
-(CC-0070). The controller emits events on key lifecycle transitions to provide
+Reference documentation for Kubernetes events emitted by the Keystone controller. The controller emits events on key lifecycle transitions to provide
 observability via `kubectl describe keystone` and `kubectl get events` without
 requiring access to controller logs.
 

--- a/docs/reference/keystone/keystone-operator-networkpolicy.md
+++ b/docs/reference/keystone/keystone-operator-networkpolicy.md
@@ -1,16 +1,14 @@
 ---
 title: Keystone Operator NetworkPolicy
 quadrant: operator
-feature: CC-0090
 ---
 
 # Keystone Operator NetworkPolicy
 
 Reference documentation for the chart-level NetworkPolicy that restricts the
-egress and ingress of the keystone-operator pod itself (CC-0090). This is
+egress and ingress of the keystone-operator pod itself. This is
 distinct from the per-CR NetworkPolicy emitted by
-[`reconcileNetworkPolicy`](./keystone-reconciler.md#sub-reconciler-contracts)
-(CC-0039), which protects Keystone API pods rendered *from* a `Keystone` CR.
+[`reconcileNetworkPolicy`](./keystone-reconciler.md#sub-reconciler-contracts), which protects Keystone API pods rendered *from* a `Keystone` CR.
 
 - **Scope:** the operator Deployment pod selected by
   `keystone-operator.selectorLabels`.
@@ -36,7 +34,7 @@ When `networkPolicy.enabled=true`, the chart renders one `networking.k8s.io/v1`
    ingress on the metrics port from the listed peers (opt-in).
 
 Two failure modes are explicitly refused by the template at render time
-(fail-closed — REQ-006): an empty `kubeApiServer.cidrs` or an empty
+(fail-closed): an empty `kubeApiServer.cidrs` or an empty
 `kubeApiServer.ports` list while `enabled=true`. Either condition triggers
 `{{ fail }}` rather than rendering a NetworkPolicy that would block all
 controller traffic or open every port.
@@ -77,7 +75,7 @@ All rules below are emitted on a single `NetworkPolicy` object named after
 > `egress` entry with all CIDRs under `to:` and all ports under `ports:`. By
 > NetworkPolicy semantics this permits every (cidr, port) combination — one
 > rule with three CIDRs and two ports covers six tuples. Do not expand the
-> list into one rule per tuple (REQ-004).
+> list into one rule per tuple.
 
 ### Ingress
 
@@ -96,7 +94,7 @@ is not subject to `NetworkPolicy` in the standard CNIs
 — see the upstream
 [Kubernetes NetworkPolicy "what you can't do" list](https://kubernetes.io/docs/concepts/services-networking/network-policies/#what-you-can-t-do-with-network-policies-at-least-not-yet).
 Therefore the template renders **no ingress rule for 8081**, and adding one
-is unnecessary (REQ-009). Probes continue to work with the default-deny
+is unnecessary. Probes continue to work with the default-deny
 ingress posture.
 
 ## Values snippet: kind cluster
@@ -117,8 +115,7 @@ networkPolicy:
 ```
 
 This same snippet is the fixture used by the chart-level E2E test at
-`tests/e2e/keystone-operator/network-policy-egress/00-install-operator.yaml`
-(CC-0090, REQ-010) and is the minimum viable configuration on kind.
+`tests/e2e/keystone-operator/network-policy-egress/00-install-operator.yaml` and is the minimum viable configuration on kind.
 
 ### Production example
 
@@ -148,7 +145,7 @@ networkPolicy:
           app.kubernetes.io/name: prometheus
 ```
 
-## Fail-closed guards (REQ-006)
+## Fail-closed guards
 
 The template mirrors the defensive guard convention from the per-CR
 NetworkPolicy sub-reconciler
@@ -160,14 +157,12 @@ or `kubeApiServer.ports` is empty, Helm render aborts with one of:
 Error: execution error at (keystone-operator/templates/networkpolicy.yaml):
 networkPolicy.kubeApiServer.cidrs must not be empty when networkPolicy.enabled=true:
 refusing to render a NetworkPolicy that would block all kube-apiserver egress
-(CC-0090, REQ-006)
 ```
 
 ```
 Error: execution error at (keystone-operator/templates/networkpolicy.yaml):
 networkPolicy.kubeApiServer.ports must not be empty when networkPolicy.enabled=true:
 refusing to render a NetworkPolicy that would open all ports to kube-apiserver
-(CC-0090, REQ-006)
 ```
 
 The JSON schema (`values.schema.json`) also enforces `minItems: 1` on both
@@ -179,9 +174,9 @@ defense-in-depth backstop that catches that case.
 
 | File | Scope |
 | --- | --- |
-| `operators/keystone/helm/keystone-operator/tests/networkpolicy_test.yaml` | helm-unittest suite: default-off, enabled-on, DNS rule, kube-apiserver rule, webhook ingress, metrics ingress, no 8081 rule, fail-closed guards (CC-0090, REQ-001..REQ-009) |
-| `operators/keystone/helm/keystone-operator/tests/schema_validation_test.yaml` | Schema tests for `networkPolicy` (invalid CIDR, out-of-range port, non-boolean `enabled`) (CC-0090, REQ-005) |
-| `tests/e2e/keystone-operator/network-policy-egress/chainsaw-test.yaml` | Chainsaw E2E: operator installed with `networkPolicy.enabled=true` on kind still reconciles a minimal Keystone CR to `Ready=True` (CC-0090, REQ-010) |
+| `operators/keystone/helm/keystone-operator/tests/networkpolicy_test.yaml` | helm-unittest suite: default-off, enabled-on, DNS rule, kube-apiserver rule, webhook ingress, metrics ingress, no 8081 rule, fail-closed guards |
+| `operators/keystone/helm/keystone-operator/tests/schema_validation_test.yaml` | Schema tests for `networkPolicy` (invalid CIDR, out-of-range port, non-boolean `enabled`) |
+| `tests/e2e/keystone-operator/network-policy-egress/chainsaw-test.yaml` | Chainsaw E2E: operator installed with `networkPolicy.enabled=true` on kind still reconciles a minimal Keystone CR to `Ready=True` |
 
 Run the helm-unittest suite locally with:
 
@@ -197,7 +192,7 @@ helm unittest operators/keystone/helm/keystone-operator \
 - [Keystone Reconciler Architecture](./keystone-reconciler.md) —
   including the per-CR
   [`reconcileNetworkPolicy`](./keystone-reconciler.md#sub-reconciler-contracts)
-  sub-reconciler (CC-0039), which protects Keystone API pods (not the
+  sub-reconciler, which protects Keystone API pods (not the
   operator itself).
 - Upstream:
   [Kubernetes NetworkPolicy concepts](https://kubernetes.io/docs/concepts/services-networking/network-policies/).

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -1,13 +1,11 @@
 ---
 title: Keystone Reconciler Architecture
 quadrant: operator
-feature: CC-0013, CC-0015, CC-0038, CC-0057, CC-0058, CC-0064, CC-0065, CC-0067, CC-0068, CC-0071, CC-0072, CC-0073, CC-0074, CC-0077, CC-0078, CC-0079, CC-0080, CC-0081, CC-0087, CC-0095
 ---
 
 # Keystone Reconciler Architecture
 
-Reference documentation for the KeystoneReconciler and its sub-reconciler contracts
-(CC-0013). The KeystoneReconciler implements the control loop that drives a Keystone
+Reference documentation for the KeystoneReconciler and its sub-reconciler contracts. The KeystoneReconciler implements the control loop that drives a Keystone
 CR from desired state to a fully operational Keystone Identity Service deployment.
 
 For CRD type definitions and webhooks, see
@@ -18,7 +16,7 @@ used by sub-reconcilers, see
 For the NetworkPolicy that hardens the **keystone-operator pod itself**
 (distinct from the per-CR NetworkPolicy emitted by
 [`reconcileNetworkPolicy`](#sub-reconciler-contracts) below), see
-[Keystone Operator NetworkPolicy](./keystone-operator-networkpolicy.md) (CC-0090).
+[Keystone Operator NetworkPolicy](./keystone-operator-networkpolicy.md).
 
 ## Controller Registration
 
@@ -74,28 +72,27 @@ The controller watches the primary Keystone CR and all owned resources:
 | `HorizontalPodAutoscaler` | `Owns()` | Triggers reconciliation when owned HPA changes |
 | `CronJob` | `Owns()` | Triggers reconciliation when owned CronJob changes |
 | `HTTPRoute` | `Owns()` (optional) | Registered only when the `gateway.networking.k8s.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. Triggers reconciliation when owned HTTPRoute changes (only created when `spec.gateway` is set). |
-| `Secret` | `Watches()` | Maps Secret events to referencing Keystone CRs via the `KeystoneSecretNameIndexKey` field indexer, with an owner-ref fallback for rotation staging Secrets (CC-0087) |
-| `MariaDB` | `Watches()` | Propagates upstream DB cluster health into `DatabaseReady` (CC-0047) |
-| `ClusterSecretStore` | `Watches()` | Propagates OpenBao-backend health into `SecretsReady` (CC-0047) |
-| `PushSecret` | `Watches()` | Maps backup PushSecret events to the owning Keystone CR via `pushSecretToKeystoneMapper` (name-match against `openBaoBackupPushSecretNames`). A predicate admits only the transitions that affect the [OpenBao Finalizer](#openbao-finalizer) state machine — `esoPushSecretFinalizer` set churn, `DeletionTimestamp` flip, or `Generation` bump — and suppresses ESO's status-only re-emits. Replaces the prior `Owns(PushSecret)` wiring (CC-0092). |
+| `Secret` | `Watches()` | Maps Secret events to referencing Keystone CRs via the `KeystoneSecretNameIndexKey` field indexer, with an owner-ref fallback for rotation staging Secrets |
+| `MariaDB` | `Watches()` | Propagates upstream DB cluster health into `DatabaseReady` |
+| `ClusterSecretStore` | `Watches()` | Propagates OpenBao-backend health into `SecretsReady` |
+| `PushSecret` | `Watches()` | Maps backup PushSecret events to the owning Keystone CR via `pushSecretToKeystoneMapper` (name-match against `openBaoBackupPushSecretNames`). A predicate admits only the transitions that affect the [OpenBao Finalizer](#openbao-finalizer) state machine — `esoPushSecretFinalizer` set churn, `DeletionTimestamp` flip, or `Generation` bump — and suppresses ESO's status-only re-emits. Replaces the prior `Owns(PushSecret)` wiring. |
 
 Secrets use `Watches()` with a `MapFunc` instead of `Owns()` because some Secrets
 (ESO-provided credentials in `spec.database.secretRef` and
 `spec.bootstrap.adminPasswordSecretRef`) are owned by the ExternalSecret controller,
 not by the Keystone CR, so an owner-reference filter would never match them. The
 mapper therefore combines an indexed reverse lookup with an owner-ref fallback for
-rotation staging Secrets — see [Secret Field Indexer](#secret-field-indexer-cc-0087)
+rotation staging Secrets — see [Secret Field Indexer](#secret-field-indexer)
 below. The `MariaDB` and `ClusterSecretStore` watches exist so the operator reacts
 immediately to upstream dependency outages without waiting for the next periodic
-requeue (CC-0047). The `PushSecret` watch plays the same role for the
+requeue. The `PushSecret` watch plays the same role for the
 OpenBao-backup finalizer loop: without it the finalizer would requeue at the
 `RequeueSecretPolling` (15s) cadence between each `esoPushSecretFinalizer`
-adoption check (Pass-0, CC-0091) and each `DeletionTimestamp` check (Pass-1,
-CC-0079); with it, each stage transition wakes on watch delivery instead
-(CC-0092) — see [PushSecret Name-Match Mapper](#pushsecret-name-match-mapper-cc-0092)
+adoption check (Pass-0) and each `DeletionTimestamp` check (Pass-1);
+with it, each stage transition wakes on watch delivery instead — see [PushSecret Name-Match Mapper](#pushsecret-name-match-mapper)
 below.
 
-#### Secret Field Indexer (CC-0087)
+#### Secret Field Indexer
 
 The Keystone controller registers a controller-runtime field indexer on the
 `Keystone` kind so that a Secret event is resolved to the referencing Keystone
@@ -103,15 +100,15 @@ CR(s) via an O(1) cache lookup instead of an unfiltered namespace-scoped List.
 Without the indexer, every Secret create/update/delete event in a namespace
 containing ESO-managed Secrets would force the mapper to List every Keystone CR
 in that namespace — producing API server load that scales linearly with the
-number of Secret events, not with the number of Keystone CRs (CC-0087, REQ-001).
+number of Secret events, not with the number of Keystone CRs.
 
 | Aspect | Value |
 | --- | --- |
 | Index key | `KeystoneSecretNameIndexKey = "spec.secretRefs.name"` (exported package-level constant in `operators/keystone/internal/controller/keystone_controller.go`) |
 | Indexed fields | `spec.database.secretRef.name` **and** `spec.bootstrap.adminPasswordSecretRef.name` — the deduplicated union of both is emitted by the extractor; empty strings are skipped so unset optional fields do not pollute the index. |
-| Registration site | `SetupWithManager` → `registerSecretNameIndex(ctx, mgr.GetFieldIndexer())`, invoked **before** the `Watches(Secret, …)` chain. Any error from `IndexField` is wrapped with the index key and propagated, so manager startup aborts loudly if registration fails (REQ-006). |
+| Registration site | `SetupWithManager` → `registerSecretNameIndex(ctx, mgr.GetFieldIndexer())`, invoked **before** the `Watches(Secret, …)` chain. Any error from `IndexField` is wrapped with the index key and propagated, so manager startup aborts loudly if registration fails. |
 | Lookup site | `secretToKeystoneMapper(mgr.GetClient())` — performs a namespace-scoped `client.List` with `client.MatchingFields{KeystoneSecretNameIndexKey: secret.Name}`. On List error, the error is logged and swallowed (the `handler.MapFunc` contract forbids returning errors) so the owner-ref fallback still runs. |
-| Owner-ref fallback | For each `ownerReference` on the Secret where `Kind == "Keystone"` and the parsed group of `APIVersion` equals `keystonev1alpha1.GroupVersion.Group` (`keystone.openstack.c5c3.io`, any version), the mapper enqueues `{Namespace: secret.Namespace, Name: ownerRef.Name}`. A cached `Get` against the informer cache drops owner-refs whose target Keystone no longer exists (stale or spurious refs); any non-`NotFound` error falls through and enqueues anyway so a transient cache blip cannot swallow a legitimate event. Group-only matching means existing Secrets continue to resolve after a future API version bump (CC-0087 review #1). This preserves the enqueue path for rotation staging Secrets (`{name}-fernet-keys-rotation`, `{name}-credential-keys-rotation`; see [Key Rotation RBAC Split](#key-rotation-rbac-split-cc-0081)) which are owned by the Keystone CR but not referenced by name from the spec (CC-0081). |
+| Owner-ref fallback | For each `ownerReference` on the Secret where `Kind == "Keystone"` and the parsed group of `APIVersion` equals `keystonev1alpha1.GroupVersion.Group` (`keystone.openstack.c5c3.io`, any version), the mapper enqueues `{Namespace: secret.Namespace, Name: ownerRef.Name}`. A cached `Get` against the informer cache drops owner-refs whose target Keystone no longer exists (stale or spurious refs); any non-`NotFound` error falls through and enqueues anyway so a transient cache blip cannot swallow a legitimate event. Group-only matching means existing Secrets continue to resolve after a future API version bump. This preserves the enqueue path for rotation staging Secrets (`{name}-fernet-keys-rotation`, `{name}-credential-keys-rotation`; see [Key Rotation RBAC Split](#key-rotation-rbac-split)) which are owned by the Keystone CR but not referenced by name from the spec. |
 | Deduplication | The indexed-lookup and owner-ref paths are unioned by `types.NamespacedName` before returning, so a Secret that is both name-referenced and owner-referenced to the same Keystone yields exactly one `reconcile.Request`. |
 
 **Adding new Secret references.** When a future change introduces another
@@ -120,13 +117,13 @@ emit that field's name alongside the existing two, and add a corresponding
 unit-test case. The index key itself (`spec.secretRefs.name`) is intentionally
 named as a union key so new indexed fields do not require a new indexer.
 
-#### PushSecret Name-Match Mapper (CC-0092)
+#### PushSecret Name-Match Mapper
 
 The backup PushSecrets that the [OpenBao Finalizer](#openbao-finalizer)
 reconciles (the Fernet and credential key PushSecrets produced by
 `openBaoBackupPushSecretNames(keystone)`) are watched via an explicit
 name-matching mapper rather than `Owns()`. The mapper's contract mirrors the
-[Secret Field Indexer](#secret-field-indexer-cc-0087) mapper above but uses
+[Secret Field Indexer](#secret-field-indexer) mapper above but uses
 direct name matching instead of a field indexer (there are at most two backup
 PushSecret names per Keystone CR, so an indexer would not pay for itself).
 
@@ -157,21 +154,21 @@ feature targets.
 
 The motivating transitions are:
 
-- **Pass-0 adoption gate (CC-0091).** The operator waits for ESO to stamp
+- **Pass-0 adoption gate.** The operator waits for ESO to stamp
   `esoPushSecretFinalizer` (declared in `reconcile_secrets.go`) onto each
   backup PushSecret before allowing `Delete`; otherwise a racing `Delete`
   could remove the object before ESO's cleanup finalizer runs. Under the
   prior `Owns()` wiring this check requeued at `RequeueSecretPolling`
-  (15s); under CC-0092 it wakes on the `esoPushSecretFinalizer`-add update.
-- **Pass-1 delete step (CC-0079).** The operator issues `Delete` against
+  (15s); now it wakes on the `esoPushSecretFinalizer`-add update.
+- **Pass-1 delete step.** The operator issues `Delete` against
   each backup PushSecret and then waits for `DeletionTimestamp` to be
   non-zero and eventually for the object to disappear. Each of those
-  observations was a 15s requeue before CC-0092; they are now watch-driven.
+  observations was a 15s requeue earlier; they are now watch-driven.
 
 See [OpenBao Finalizer](#openbao-finalizer) for the full Pass-0/Pass-1
 state machine the watch feeds, and [RBAC Permissions](#rbac-permissions) for
 the `external-secrets.io/pushsecrets` verb set (`get, list, watch, create,
-update, patch, delete`, CC-0079).
+update, patch, delete`).
 
 ---
 
@@ -191,7 +188,7 @@ type KeystoneReconciler struct {
 | `Client` | `client.Client` | Kubernetes API client for CRUD operations |
 | `Scheme` | `*runtime.Scheme` | Runtime scheme for owner reference resolution |
 | `Recorder` | `record.EventRecorder` | Records Kubernetes events for state transitions |
-| `HTTPClient` | `HTTPDoer` | Injectable HTTP client for health checks; falls back to `http.DefaultClient` when nil (CC-0067) |
+| `HTTPClient` | `HTTPDoer` | Injectable HTTP client for health checks; falls back to `http.DefaultClient` when nil |
 
 ---
 
@@ -209,12 +206,12 @@ RBAC markers on the reconciler generate the required ClusterRole:
 | `batch` | `jobs`, `cronjobs` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `databases`, `users`, `grants` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `mariadbs` | get, list, watch |
-| `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch, delete (CC-0079) |
+| `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch, delete |
 | `external-secrets.io` | `clustersecretstores` | get, list, watch |
 | `policy` | `poddisruptionbudgets` | get, list, watch, create, update, patch, delete |
 | `autoscaling` | `horizontalpodautoscalers` | get, list, watch, create, update, patch, delete |
-| `gateway.networking.k8s.io` | `httproutes` | get, list, watch, create, update, patch, delete (CC-0065) |
-| `gateway.networking.k8s.io` | `httproutes/status` | get (CC-0065) |
+| `gateway.networking.k8s.io` | `httproutes` | get, list, watch, create, update, patch, delete |
+| `gateway.networking.k8s.io` | `httproutes/status` | get |
 
 ---
 
@@ -226,20 +223,20 @@ resource. In addition, the following forge-specific metadata keys carry
 controller-observable semantics and are stable across releases — consumers
 (watch predicates, chainsaw tests, dashboards) may rely on them:
 
-| Key | Kind | Applied to | Value | Feature | Purpose |
-| --- | --- | --- | --- | --- | --- |
-| `forge.c5c3.io/rotation-target` | Label | Staging Secrets (`{name}-fernet-keys-rotation`, `{name}-credential-keys-rotation`) | `fernet-keys`, `credential-keys` | CC-0081 | Distinguishes rotation staging Secrets from production key Secrets so the operator's Secret→Keystone mapper can enqueue the owning Keystone on staging PATCHes. |
-| `forge.c5c3.io/rotation-completed-at` | Annotation | Staging Secrets (written by the rotation CronJob) | RFC3339 UTC timestamp (e.g. `2026-04-18T12:34:56Z`) | CC-0081 | Single-shot commit marker. The operator only applies a staging Secret's data to the production Secret when this annotation is present and parses cleanly; the annotation is removed implicitly when the staging Secret is deleted at the end of a successful apply. |
+| Key | Kind | Applied to | Value | Purpose |
+| --- | --- | --- | --- | --- |
+| `forge.c5c3.io/rotation-target` | Label | Staging Secrets (`{name}-fernet-keys-rotation`, `{name}-credential-keys-rotation`) | `fernet-keys`, `credential-keys` | Distinguishes rotation staging Secrets from production key Secrets so the operator's Secret→Keystone mapper can enqueue the owning Keystone on staging PATCHes. |
+| `forge.c5c3.io/rotation-completed-at` | Annotation | Staging Secrets (written by the rotation CronJob) | RFC3339 UTC timestamp (e.g. `2026-04-18T12:34:56Z`) | Single-shot commit marker. The operator only applies a staging Secret's data to the production Secret when this annotation is present and parses cleanly; the annotation is removed implicitly when the staging Secret is deleted at the end of a successful apply. |
 
 The Go constants backing these keys are exported from
 `operators/keystone/internal/controller/rotation_staging.go`:
 
 ```go
-const StagingSecretLabelKey       = "forge.c5c3.io/rotation-target"        // CC-0081
-const RotationCompletedAnnotation = "forge.c5c3.io/rotation-completed-at"  // CC-0081
+const StagingSecretLabelKey       = "forge.c5c3.io/rotation-target"
+const RotationCompletedAnnotation = "forge.c5c3.io/rotation-completed-at"
 ```
 
-See [Key Rotation RBAC Split](#key-rotation-rbac-split-cc-0081) under the
+See [Key Rotation RBAC Split](#key-rotation-rbac-split) under the
 Fernet and credential sub-reconciler sections for the full contract.
 
 ---
@@ -259,7 +256,7 @@ Fernet and credential sub-reconciler sections for the full contract.
 │         ▼                                    ┌─────────────────────────────┐ │
 │  ┌──────────────────┐                        │         LEGEND              │ │
 │  │ reconcileSecrets │  Check ESO synced      │  ───── Sequential           │ │
-│  │                  │  Sets: SecretsReady    │  ═════ Parallel (CC-0071)   │ │
+│  │                  │  Sets: SecretsReady    │  ═════ Parallel             │ │
 │  └────────┬─────────┘  Requeue: 15s          └─────────────────────────────┘ │
 │           │                                                                  │
 │           ▼                                                                  │
@@ -270,13 +267,13 @@ Fernet and credential sub-reconciler sections for the full contract.
 │           │                                                                  │
 │           ▼                                                                  │
 │  ╔═════════════════════════════════════════════════════════════════════════╗ │
-│  ║  reconcileParallelGroup (CC-0071)                                       ║ │
+│  ║  reconcileParallelGroup                                                 ║ │
 │  ║                                                                         ║ │
 │  ║  errgroup.WithContext — each goroutine receives a DeepCopy of the CR    ║ │
 │  ║                                                                         ║ │
 │  ║  ┌──────────────────────┐  ┌──────────────────────────┐                 ║ │
 │  ║  │ reconcileFernetKeys  │  │ reconcileCredentialKeys  │  (concurrent)   ║ │
-│  ║  │ + script ConfigMap   │  │ + script ConfigMap       │  (CC-0073)      ║ │
+│  ║  │ + script ConfigMap   │  │ + script ConfigMap       │                 ║ │
 │  ║  │ Sets: FernetKeysReady│  │ Sets: CredentialKeysReady│                 ║ │
 │  ║  └──────────────────────┘  └──────────────────────────┘                 ║ │
 │  ║  ┌─────────────────────────┐                                            ║ │
@@ -292,7 +289,7 @@ Fernet and credential sub-reconciler sections for the full contract.
 │  ┌───────────────────┐                                                       │
 │  │ reconcileDatabase │  Managed mode: verify MariaDB cluster health first,   │
 │  │                   │  then ensure Database/User/Grant CRs + run db_sync    │
-│  │                   │  Job + run schema-check Job (CC-0064)                 │
+│  │                   │  Job + run schema-check Job                           │
 │  │                   │  Sets: DatabaseReady                                  │
 │  └────────┬──────────┘  Requeue: 30s                                         │
 │           │                                                                  │
@@ -312,7 +309,7 @@ Fernet and credential sub-reconciler sections for the full contract.
 │           ▼                                                                  │
 │  ┌─────────────────────────┐                                                 │
 │  │ pruneStaleConfigMaps    │  Delete old {name}-config-{hash} ConfigMaps     │
-│  │                         │  Retain 3 historical + current (CC-0077)        │
+│  │                         │  Retain 3 historical + current                  │
 │  └────────┬────────────────┘  No condition, no requeue                       │
 │           │                                                                  │
 │           ▼                                                                  │
@@ -320,13 +317,13 @@ Fernet and credential sub-reconciler sections for the full contract.
 │  │ reconcileHTTPRoute      │  Create/update/delete HTTPRoute based on        │
 │  │                         │  spec.gateway; reflect parent Accepted status   │
 │  │                         │  Sets: HTTPRouteReady                           │
-│  └────────┬────────────────┘  Requeue: 10s while not Accepted (CC-0065)      │
+│  └────────┬────────────────┘  Requeue: 10s while not Accepted                │
 │           │                                                                  │
 │           ▼                                                                  │
 │  ┌────────────────────────┐                                                  │
 │  │ reconcileHealthCheck   │  HTTP GET to Status.Endpoint                     │
 │  │                        │  Sets: KeystoneAPIReady                          │
-│  └────────┬───────────────┘  Requeue: 10s (CC-0067)                          │
+│  └────────┬───────────────┘  Requeue: 10s                                    │
 │           │                                                                  │
 │           ▼                                                                  │
 │  ┌──────────────┐                                                            │
@@ -355,7 +352,7 @@ Fernet and credential sub-reconciler sections for the full contract.
 
 ### Execution Model
 
-Sub-reconcilers execute in a defined order using two execution modes (CC-0071):
+Sub-reconcilers execute in a defined order using two execution modes:
 
 1. **Sequential sub-reconcilers** run one at a time. Each is called only if all
    previous sub-reconcilers succeeded without requesting a requeue.
@@ -389,7 +386,7 @@ sub-reconcilers are merged even on partial failure.
 
 `updateStatus()` persists all condition changes via `r.Status().Update()` and returns
 the provided `(result, error)` pair unchanged. If the status update itself fails, the
-behavior depends on whether a reconcile error is also present (CC-0068):
+behavior depends on whether a reconcile error is also present:
 
 | reconcileErr | Status().Update() | Returned error |
 | --- | --- | --- |
@@ -424,7 +421,7 @@ clients can detect stale status.
 
 Three sub-reconcilers — `reconcileFernetKeys`, `reconcileCredentialKeys`, and
 `reconcileNetworkPolicy` — run concurrently via `reconcileParallelGroup` after
-`reconcileConfig` completes and before `reconcileDatabase` begins (CC-0071). These
+`reconcileConfig` completes and before `reconcileDatabase` begins. These
 sub-reconcilers are eligible for parallelization because they have no data
 dependencies on each other (see [Dependency Graph](#dependency-graph) below).
 
@@ -566,7 +563,7 @@ the group.
 The KeystoneReconciler installs a finalizer on every Keystone CR so that the
 MariaDB `Database`, `User`, and `Grant` CRs owned by the Keystone are
 deterministically torn down **before** the Keystone CR itself is removed from
-etcd (CC-0078). Without a finalizer, the Keystone CR would be deleted
+etcd. Without a finalizer, the Keystone CR would be deleted
 immediately on `kubectl delete keystone <name>` and the controller would have
 no opportunity to clean up the MariaDB resources it orchestrated — leaving them
 orphaned when redeploying or tearing down the service.
@@ -752,7 +749,7 @@ cleanup, captured via `record.EventRecorder`:
 | `FinalizingDatabase` | `Normal` | `"Cleaning up MariaDB Database, User, and Grant before removing Keystone"` | First terminating reconcile pass where at least one MariaDB CR is still live (not emitted for brownfield CRs or when all CRs are already gone) |
 | `DatabaseFinalized` | `Normal` | `"MariaDB Database, User, and Grant removed; releasing finalizer"` | Once per termination, immediately before `RemoveFinalizer` + `Update` |
 
-> **Note (CC-0078):** The two Events are intentionally asymmetric. A
+> **Note:** The two Events are intentionally asymmetric. A
 > brownfield-terminating CR (or a managed CR whose MariaDB resources were
 > already removed externally before deletion) emits only `DatabaseFinalized`,
 > **not** `FinalizingDatabase`, because there is no real cleanup work to
@@ -795,7 +792,7 @@ ordering and observability on top of GC's eventual-consistency guarantee.
 
 In addition to the MariaDB finalizer, every Keystone CR carries a dedicated
 finalizer that drives cleanup of the backup PushSecrets ESO uses to persist
-the Fernet and credential signing keys to OpenBao (CC-0079). Without this
+the Fernet and credential signing keys to OpenBao. Without this
 finalizer, deleting a Keystone CR would garbage-collect the PushSecret CRs
 via owner references **without** triggering the remote delete on the KV-v2
 path — leaving stale cryptographic material in OpenBao after the Keystone
@@ -841,19 +838,19 @@ The finalizer does **not** touch any other Keystone-owned resource
 built-in Kubernetes garbage collector via owner references — see
 [Owned Resources](#owned-resources).
 
-> **Path scoping (CC-0093):** Both KV-v2 paths are per-CR-scoped via
+> **Path scoping:** Both KV-v2 paths are per-CR-scoped via
 > `openstack/keystone/{keystone.Name}/<leaf>` (where `<leaf>` is `fernet-keys`
 > or `credential-keys`), so multiple Keystone CRs in the same namespace write
 > to disjoint paths and cannot collide. See
-> [Migration note: legacy flat paths (CC-0093)](#migration-note-legacy-flat-paths-cc-0093)
-> for upgrade behaviour and recommended cleanup of orphaned pre-CC-0093 paths.
+> [Migration note: legacy flat paths](#migration-note-legacy-flat-paths)
+> for upgrade behaviour and recommended cleanup of orphaned legacy paths.
 
-### Migration note: legacy flat paths (CC-0093)
+### Migration note: legacy flat paths
 
-Before CC-0093, both backup PushSecrets wrote to the cluster-global, flat
+Earlier, both backup PushSecrets wrote to the cluster-global, flat
 KV-v2 paths `kv-v2/openstack/keystone/fernet-keys` and
-`kv-v2/openstack/keystone/credential-keys`. Starting with CC-0093 the
-operator writes to the per-CR-scoped paths
+`kv-v2/openstack/keystone/credential-keys`. The operator now writes to the
+per-CR-scoped paths
 `kv-v2/openstack/keystone/{keystone.Name}/fernet-keys` and
 `kv-v2/openstack/keystone/{keystone.Name}/credential-keys`.
 
@@ -869,7 +866,7 @@ is re-run; for production clusters managed outside the bootstrap flow the
 equivalent is a single `bao policy write push-keystone-keys …` against the
 updated HCL file.
 
-The pre-CC-0093 flat paths are **orphaned but harmless** after upgrade:
+The legacy flat paths are **orphaned but harmless** after upgrade:
 the live Keystone control plane reads its Fernet and credential keys from
 the local Kubernetes `Secret` (`{name}-fernet-keys`, `{name}-credential-keys`),
 not from the OpenBao backup. The OpenBao copy is a disaster-recovery
@@ -894,8 +891,8 @@ operation and the right inverse of the now-superseded write.
 The Keystone operator has no OpenBao credentials and does not talk to the
 OpenBao API directly. Remote purge of the KV-v2 path is delegated to ESO
 via the PushSecret field `Spec.DeletionPolicy`. The `RemoteKey` follows the
-per-CR layout `openstack/keystone/{keystone.Name}/<leaf>` introduced by
-CC-0093, so each Keystone CR writes to its own KV-v2 prefix:
+per-CR layout `openstack/keystone/{keystone.Name}/<leaf>`,
+so each Keystone CR writes to its own KV-v2 prefix:
 
 ```go
 Spec: esov1alpha1.PushSecretSpec{
@@ -970,7 +967,7 @@ func (r *KeystoneReconciler) reconcileDeleteOpenBao(
 The deletion handler proceeds as follows:
 
 1. **No-op guard.** If the Keystone CR does not carry
-   `keystoneOpenBaoFinalizer` (e.g. a CR that pre-dates CC-0079, or whose
+   `keystoneOpenBaoFinalizer` (e.g. a CR that predates the finalizer, or whose
    finalizer was already released on a prior pass), `reconcileDeleteOpenBao`
    returns `(ctrl.Result{}, nil)` immediately — no Delete calls, no Events.
 2. **Cleanup-work announcement.** `hasLiveOpenBaoBackupPushSecrets` probes
@@ -981,8 +978,8 @@ The deletion handler proceeds as follows:
    requeues observe no live PushSecret and suppress the emit, giving
    exactly-once semantics per termination across requeue loops.
 3. **Cleanup.** `finalizeOpenBaoSecrets` runs in **three** sequential
-   passes over the backup PushSecret names (CC-0091 extended the original
-   CC-0079 two-pass design with a Pass-0 adoption wait):
+   passes over the backup PushSecret names (the two-pass design was
+   extended with a Pass-0 adoption wait):
    - **Pass-0 — adoption wait.** For each backup PushSecret that still
      exists and is not already Terminating, verify that ESO's cleanup
      finalizer (`pushsecret.externalsecrets.io/finalizer`)
@@ -1103,7 +1100,7 @@ The three passes execute in strict order:
    and returns `(done=false, nil)`. Release of the openbao-finalizer
    requires **all** PushSecrets to return `NotFound`.
 
-#### Motivating race (CC-0091)
+#### Motivating race
 
 Without Pass-0, a Keystone CR deleted within 1–2 s of creation can outrun
 ESO's first reconcile: the operator calls `Delete` on the PushSecret
@@ -1111,9 +1108,9 @@ before ESO has installed its own cleanup finalizer, the API server
 immediately garbage-collects the PushSecret object, and ESO never observes
 the `DeletionTimestamp` — so `DeletionPolicy=Delete` never runs and the
 referenced kv-v2 path is orphaned in OpenBao. The observed stuck path now
-takes the per-CR form `kv-v2/openstack/keystone/{name}/fernet-keys` (CC-0093);
-this was originally seen in CI run 24842115250, which predated CC-0093 and
-therefore observed the now-legacy flat path
+takes the per-CR form `kv-v2/openstack/keystone/{name}/fernet-keys`;
+this was originally seen in CI run 24842115250 against the
+now-legacy flat path
 `kv-v2/openstack/keystone/fernet-keys`. The race itself is path-shape
 independent — the only difference is the kv-v2 key that would be left
 orphaned without Pass-0. Pass-0 gates the operator's `Delete` on ESO having
@@ -1185,9 +1182,9 @@ The message names the specific PushSecret (first stuck one encountered)
 so `kubectl get keystone -o yaml` surfaces which backup is wedged without
 attaching a debugger. Reusing `SecretsReady` (instead of introducing a new
 condition type) keeps the status surface coherent — any secret-store
-lifecycle concern appears under the same condition type
-(CC-0013 for initial ExternalSecret sync, CC-0047 for ClusterSecretStore
-health, CC-0079 for finalizer teardown). The condition is persisted through
+lifecycle concern (initial ExternalSecret sync, ClusterSecretStore
+health, finalizer teardown) appears under the same condition type.
+The condition is persisted through
 the existing `updateStatus` path so the message stays fresh across
 requeues at the `RequeueSecretPolling` (15s) interval.
 
@@ -1269,7 +1266,7 @@ sub-reconciler is responsible for:
 
 Every `conditions.SetCondition` call **must** include `ObservedGeneration: keystone.Generation`
 so that external tooling (ArgoCD health checks, status controllers) can distinguish whether
-a condition reflects the current spec or a stale generation (CC-0072). This applies to both
+a condition reflects the current spec or a stale generation. This applies to both
 `True` and `False` condition paths — no condition may omit the field.
 
 ```go
@@ -1299,16 +1296,16 @@ after a full reconcile loop, every condition in the status carries the correct
 | --- | --- | --- |
 | `SecretsReady` | `reconcileSecrets` | ESO-provided credentials are synced |
 | `DatabaseReady` | `reconcileDatabase` | MariaDB CRs ready and db_sync complete |
-| `FernetKeysReady` | `reconcileFernetKeys` | Fernet Secret, script ConfigMap, CronJob, and PushSecret ensured (CC-0073) |
-| `CredentialKeysReady` | `reconcileCredentialKeys` | Credential keys Secret, script ConfigMap, CronJob, and PushSecret ensured (CC-0036, CC-0073) |
-| `NetworkPolicyReady` | `reconcileNetworkPolicy` | NetworkPolicy configured or not required (CC-0039) |
-| `PolicyValidReady` | `reconcilePolicyValidation` | Policy override validation passed or not required (CC-0058) |
+| `FernetKeysReady` | `reconcileFernetKeys` | Fernet Secret, script ConfigMap, CronJob, and PushSecret ensured |
+| `CredentialKeysReady` | `reconcileCredentialKeys` | Credential keys Secret, script ConfigMap, CronJob, and PushSecret ensured |
+| `NetworkPolicyReady` | `reconcileNetworkPolicy` | NetworkPolicy configured or not required |
+| `PolicyValidReady` | `reconcilePolicyValidation` | Policy override validation passed or not required |
 | `DeploymentReady` | `reconcileDeployment` | Deployment available and Service created |
-| `KeystoneAPIReady` | `reconcileHealthCheck` | Keystone API responding to HTTP health check (CC-0067) |
+| `KeystoneAPIReady` | `reconcileHealthCheck` | Keystone API responding to HTTP health check |
 | `HTTPRouteReady` | `reconcileHTTPRoute` | HTTPRoute accepted by Gateway, not required (no `spec.gateway`), or Gateway API CRD missing (reason `GatewayAPINotInstalled`) |
 | `HPAReady` | `reconcileHPA` | HPA configured or not required |
 | `BootstrapReady` | `reconcileBootstrap` | Bootstrap Job completed successfully |
-| `TrustFlushReady` | `reconcileTrustFlush` | Trust flush CronJob configured or not required (CC-0057) |
+| `TrustFlushReady` | `reconcileTrustFlush` | Trust flush CronJob configured or not required |
 
 ---
 
@@ -1331,14 +1328,14 @@ ExternalSecrets managed by the External Secrets Operator.
 
 | Step | Resource | Source |
 | --- | --- | --- |
-| 0 | `ClusterSecretStore openbao-cluster-store` | Ready condition (CC-0047) |
+| 0 | `ClusterSecretStore openbao-cluster-store` | Ready condition |
 | 1 | DB credentials `ExternalSecret` | `spec.database.secretRef.name` |
 | 2 | Admin credentials `ExternalSecret` | `spec.bootstrap.adminPasswordSecretRef.name` |
 
 The `ClusterSecretStore` check runs first so upstream OpenBao outages surface
 as `SecretsReady=False` immediately. Per-ExternalSecret `Ready` conditions
 alone would mask outages up to the ESO `refreshInterval` (1h) because the
-cached Secret remains valid (CC-0047).
+cached Secret remains valid.
 
 **Condition Contract:**
 
@@ -1374,9 +1371,9 @@ Supports two modes:
 
 - **Managed mode** (`spec.database.clusterRef` set): Creates MariaDB Database, User,
   and Grant CRs within the referenced cluster, then runs `db_sync`, then runs
-  schema-check (CC-0064).
+  schema-check.
 - **Brownfield mode** (`spec.database.host` set): Skips MariaDB CRs entirely and runs
-  `db_sync` directly against the external database, then runs schema-check (CC-0064).
+  `db_sync` directly against the external database, then runs schema-check.
 
 After `db_sync` completes successfully, a schema-check Job verifies that the database
 schema matches the expected Alembic migration head. See
@@ -1418,7 +1415,7 @@ context and returned. The `DBSyncFailed` condition is set before returning the e
 so that the failure reason is visible in the CR status.
 
 **Shared library calls:** `database.EnsureDatabase()`, `database.EnsureDatabaseUser()`,
-`database.RunDBSyncJob()`, `job.RunJob()` (schema-check, CC-0064)
+`database.RunDBSyncJob()`, `job.RunJob()` (schema-check)
 
 ---
 
@@ -1444,7 +1441,7 @@ and disaster recovery backup to OpenBao.
    RoleBinding (`{name}-fernet-rotate`) for the rotation CronJob.
 3. **Create script ConfigMap** — Create an immutable, versioned ConfigMap
    `{name}-fernet-rotate-script-{hash}` containing the embedded
-   `fernet_rotate.sh` script (CC-0073). Uses `config.CreateImmutableConfigMap()`
+   `fernet_rotate.sh` script. Uses `config.CreateImmutableConfigMap()`
    which appends a content-hash suffix and sets `immutable: true`.
 4. **Ensure rotation CronJob** — Create or update `{name}-fernet-rotate` CronJob
    with the schedule from `spec.fernet.rotationSchedule`.
@@ -1470,12 +1467,12 @@ and disaster recovery backup to OpenBao.
 | Schedule | `spec.fernet.rotationSchedule` |
 | ServiceAccount | `{name}-fernet-rotate` |
 | Init container | Copies keys from `fernet-keys-src` (Secret) to `fernet-keys` (emptyDir) |
-| Command | `/scripts/fernet_rotate.sh` (CC-0073) |
+| Command | `/scripts/fernet_rotate.sh` |
 | Volume `fernet-keys-src` | Secret `{name}-fernet-keys` (read-only source) |
 | Volume `fernet-keys` | emptyDir (writable working copy) |
 | Volume `credential-keys` | Secret `{name}-credential-keys` (read-only, required by config) |
 | Volume `config` | ConfigMap `{configMapName}` |
-| Volume `scripts` | ConfigMap `{name}-fernet-rotate-script-{hash}` (`defaultMode: 0555`) (CC-0073) |
+| Volume `scripts` | ConfigMap `{name}-fernet-rotate-script-{hash}` (`defaultMode: 0555`) |
 
 **PushSecret:**
 
@@ -1494,7 +1491,7 @@ and disaster recovery backup to OpenBao.
 | `True` | `FernetKeysRotated` | "rotation applied; staging secret cleared" | — (transient: apply-success short-circuit at `reconcile_fernet.go:97-103`; operators see this immediately after a rotation apply via `kubectl describe`, before the next reconcile transitions to the steady-state Reason) |
 | `True` | `FernetKeysAvailable` | "Fernet keys Secret exists and rotation CronJob is configured" | — |
 
-**Versioned Script ConfigMap (CC-0073):**
+**Versioned Script ConfigMap:**
 
 The rotation script is embedded in the Go binary via `go:embed` and mounted into the
 CronJob pod through a versioned, immutable ConfigMap. The ConfigMap name includes a
@@ -1516,7 +1513,7 @@ creating a new one.
 **Shared library calls:** `config.CreateImmutableConfigMap()`, `job.EnsureCronJob()`,
 `secrets.EnsurePushSecret()`
 
-#### Key Rotation RBAC Split (CC-0081)
+#### Key Rotation RBAC Split
 
 The Fernet rotation path separates the **compute** of new keys (performed by
 the rotation CronJob) from the **write** onto the production Secret
@@ -1570,7 +1567,7 @@ controller-owned `ResourceVersion`, which guarantees optimistic concurrency
 The Update fully replaces the map — stale key indices absent from the staging
 payload (e.g. those renumbered by `keystone-manage fernet_rotate` or trimmed
 by a reduction in `spec.fernet.maxActiveKeys`) are removed, which is the
-atomic-swap semantic REQ-006 requires. A strategic-merge PATCH on this field
+atomic-swap semantic the rotation flow requires. A strategic-merge PATCH on this field
 would merge by key and allow decommissioned keys to accumulate, so it is
 intentionally avoided.
 
@@ -1603,7 +1600,7 @@ func (r *KeystoneReconciler) reconcileCredentialKeys(ctx context.Context,
 ```
 
 **Purpose:** Manage credential encryption keys — initial generation, rotation schedule
-with credential migration, and disaster recovery backup to OpenBao (CC-0036).
+with credential migration, and disaster recovery backup to OpenBao.
 
 **Steps (in order):**
 
@@ -1613,7 +1610,7 @@ with credential migration, and disaster recovery backup to OpenBao (CC-0036).
    RoleBinding (`{name}-credential-rotate`) for the rotation CronJob.
 3. **Create script ConfigMap** — Create an immutable, versioned ConfigMap
    `{name}-credential-rotate-script-{hash}` containing the embedded
-   `credential_rotate.sh` script (CC-0073). Uses `config.CreateImmutableConfigMap()`
+   `credential_rotate.sh` script. Uses `config.CreateImmutableConfigMap()`
    which appends a content-hash suffix and sets `immutable: true`.
 4. **Ensure rotation CronJob** — Create or update `{name}-credential-rotate` CronJob
    with the schedule from `spec.credentialKeys.rotationSchedule`.
@@ -1639,17 +1636,17 @@ with credential migration, and disaster recovery backup to OpenBao (CC-0036).
 | Schedule | `spec.credentialKeys.rotationSchedule` |
 | ServiceAccount | `{name}-credential-rotate` |
 | Init container | Copies keys from `credential-keys-src` (Secret) to `credential-keys` (emptyDir) |
-| Command | `/scripts/credential_rotate.sh` (CC-0073) |
+| Command | `/scripts/credential_rotate.sh` |
 | Volume `credential-keys-src` | Secret `{name}-credential-keys` (read-only source) |
 | Volume `credential-keys` | emptyDir (writable working copy) |
 | Volume `fernet-keys` | Secret `{name}-fernet-keys` (read-only, required by config) |
 | Volume `config` | ConfigMap `{configMapName}` |
-| Volume `scripts` | ConfigMap `{name}-credential-rotate-script-{hash}` (`defaultMode: 0555`) (CC-0073) |
+| Volume `scripts` | ConfigMap `{name}-credential-rotate-script-{hash}` (`defaultMode: 0555`) |
 
 > **Note:** The `credential_rotate.sh` script runs both `credential_rotate` and
 > `credential_migrate`. The migrate step re-encrypts existing credentials in the
 > database with the new primary key, which is critical to prevent data loss when
-> old keys are eventually purged (CC-0036).
+> old keys are eventually purged.
 
 **PushSecret:**
 
@@ -1668,7 +1665,7 @@ with credential migration, and disaster recovery backup to OpenBao (CC-0036).
 | `True` | `CredentialKeysRotated` | "rotation applied; staging secret cleared" | — (transient: apply-success short-circuit at `reconcile_credential.go:107-113`; operators see this immediately after a rotation apply via `kubectl describe`, before the next reconcile transitions to the steady-state Reason) |
 | `True` | `CredentialKeysAvailable` | "Credential keys Secret exists and rotation CronJob is configured" | — |
 
-**Versioned Script ConfigMap (CC-0073):**
+**Versioned Script ConfigMap:**
 
 Uses the same versioned, immutable ConfigMap pattern as `reconcileFernetKeys`. See the
 description in that section for details on content-hash naming and immutability.
@@ -1683,7 +1680,7 @@ modified. This prevents overwriting keys that have been rotated by the CronJob.
 **Shared library calls:** `config.CreateImmutableConfigMap()`, `job.EnsureCronJob()`,
 `secrets.EnsurePushSecret()`
 
-#### Key Rotation RBAC Split (CC-0081)
+#### Key Rotation RBAC Split
 
 The credential rotation path mirrors the Fernet split exactly: the
 `{name}-credential-rotate` CronJob computes rotated keys, PATCHes them into
@@ -1723,22 +1720,21 @@ verbatim, issues an `Update`, deletes the staging Secret, and emits a
 Normal event `CredentialKeysRotated`. Because the CronJob already ran
 `credential_migrate` before PATCHing staging, every credential row in the
 database is re-encrypted with the new primary by the time the operator
-commits the Secret swap — no data loss when old keys age out (CC-0036).
+commits the Secret swap — no data loss when old keys age out.
 
-> **Key-rollover window (pre-existing, not introduced by CC-0081).** There
+> **Key-rollover window.** There
 > is a ~60s window between `credential_migrate` completion and the kubelet
-> refreshing the in-place Secret projection (CC-0074). During that window,
+> refreshing the in-place Secret projection. During that window,
 > running Keystone pods still have the old credential keyset mounted —
 > database rows are already encrypted under the new primary, but the pods
-> cannot decrypt them yet. This is a pre-existing property of the rotation
-> flow and is not a regression introduced by CC-0081; it is tracked
-> separately under CC-0074 and should be considered when sizing the
-> rotation schedule against request volume.
+> cannot decrypt them yet. This is an inherent property of the rotation
+> flow and is tracked as a known limitation; it should be considered when
+> sizing the rotation schedule against request volume.
 
 **Production `Secret.Data` field ownership.** Same contract as Fernet: the
 operator owns the production `.data` map, writes are `Update`-based under
 the controller-owned `ResourceVersion`, and the Update fully replaces the
-map so stale indices are removed atomically (REQ-006). Strategic-merge PATCH
+map so stale indices are removed atomically. Strategic-merge PATCH
 is intentionally avoided here for the same merge-vs-replace reason
 documented in the Fernet section.
 
@@ -1882,7 +1878,7 @@ func (r *KeystoneReconciler) reconcilePolicyValidation(ctx context.Context,
 ```
 
 **Purpose:** Validate custom oslo.policy overrides via `oslopolicy-validator` before the
-Deployment is updated (CC-0058). This sub-reconciler gates the Deployment rollout:
+Deployment is updated. This sub-reconciler gates the Deployment rollout:
 invalid policy overrides are caught before reaching running pods. Two lifecycle paths:
 
 1. **No policy overrides** (`spec.policyOverrides` is nil): Delete any existing
@@ -1916,7 +1912,7 @@ invalid policy overrides are caught before reaching running pods. Two lifecycle 
 **Error Extraction (`getValidationErrorMessage`):**
 
 When a validation Job fails, the reconciler extracts a descriptive error message from the
-failed Pod's termination message (CC-0058, REQ-006):
+failed Pod's termination message:
 
 1. Lists Pods by `job-name` label selector in the Job's namespace.
 2. Sorts by creation timestamp (most recent first).
@@ -1959,7 +1955,7 @@ spec. Sets `status.endpoint` when the Deployment becomes available.
 > **Note:** This sub-reconciler accepts the `configMapName` returned by
 > `reconcileConfig` to reference the correct immutable ConfigMap in volume mounts.
 
-**In-Place Key Rotation (CC-0074):**
+**In-Place Key Rotation:**
 
 Fernet and credential key rotation is handled in-place via kubelet Secret
 projection. When the rotation CronJob updates a Secret, the kubelet
@@ -1978,13 +1974,13 @@ CronJob rotates keys → Secret data changes → kubelet projects new keys
 
 | Field | Value |
 | --- | --- |
-| Name | `{name}` (bare CR name; since CC-0095) |
+| Name | `{name}` (bare CR name) |
 | Replicas | `spec.replicas` |
 | Labels | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/managed-by=keystone-operator` |
 | Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
-| Container name | `keystone` (since CC-0095) |
+| Container name | `keystone` |
 | Image | `{spec.image.repository}:{spec.image.tag}` |
-| Port | 5000 (named `keystone`; since CC-0095) |
+| Port | 5000 (named `keystone`) |
 
 **Probes:**
 
@@ -1993,7 +1989,7 @@ CronJob rotates keys → Secret data changes → kubelet projects new keys
 | Liveness | TCPSocket | — | 5000 | 15s | 20s |
 | Readiness | HTTPGet | `/v3` | 5000 | 5s | 10s |
 
-The liveness and readiness probes are intentionally separated (CC-0062). The liveness probe uses a TCP socket check that only verifies the uWSGI process is accepting connections, without exercising the database code path. This prevents the kubelet from killing pods during transient database outages (e.g., MariaDB maintenance), avoiding CrashLoopBackOff cascades and thundering-herd restarts. The readiness probe continues to use HTTP GET `/v3`, which exercises the full stack including the database. When the database is unavailable, the readiness probe fails and the pod is removed from Service endpoints, preventing HTTP 500 responses to clients. Once the database recovers, the pod re-enters Service endpoints within one readiness probe period (10s).
+The liveness and readiness probes are intentionally separated. The liveness probe uses a TCP socket check that only verifies the uWSGI process is accepting connections, without exercising the database code path. This prevents the kubelet from killing pods during transient database outages (e.g., MariaDB maintenance), avoiding CrashLoopBackOff cascades and thundering-herd restarts. The readiness probe continues to use HTTP GET `/v3`, which exercises the full stack including the database. When the database is unavailable, the readiness probe fails and the pod is removed from Service endpoints, preventing HTTP 500 responses to clients. Once the database recovers, the pod re-enters Service endpoints within one readiness probe period (10s).
 
 **Volume Mounts:**
 
@@ -2007,15 +2003,14 @@ The liveness and readiness probes are intentionally separated (CC-0062). The liv
 
 | Field | Value |
 | --- | --- |
-| Name | `{name}` (bare CR name; since CC-0095) |
+| Name | `{name}` (bare CR name) |
 | Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
 | Port | 5000 TCP |
 
 **Status Endpoint:**
 
 When the Deployment becomes ready, `status.endpoint` is set via the
-`keystoneStatusEndpoint` helper (defined in `reconcile_httproute.go`, CC-0065,
-REQ-004):
+`keystoneStatusEndpoint` helper (defined in `reconcile_httproute.go`):
 
 | `spec.gateway` | Resulting `status.endpoint` |
 | --- | --- |
@@ -2027,7 +2022,7 @@ The helper is owned by `reconcile_httproute.go` but invoked from
 `reconcileHealthCheck` step reads it. `reconcileHTTPRoute` runs later in the
 sequence and does not mutate `status.endpoint`.
 
-**PodDisruptionBudget (CC-0037):**
+**PodDisruptionBudget:**
 
 After ensuring the Deployment and Service, `reconcileDeployment` creates or updates
 a PodDisruptionBudget via `deployment.EnsurePDB()`. The PDB uses a replica-aware
@@ -2073,7 +2068,7 @@ func (r *KeystoneReconciler) pruneStaleConfigMaps(ctx context.Context,
 
 **Purpose:** Remove historical immutable ConfigMaps that exceed the retain count
 after the Deployment has rolled out successfully. This prevents unbounded accumulation
-of `{name}-config-{hash}` ConfigMaps in the namespace (CC-0077).
+of `{name}-config-{hash}` ConfigMaps in the namespace.
 
 > **Note:** This is not a sub-reconciler — it does not set any status condition and
 > returns only `error`. It is a thin wrapper around `config.PruneImmutableConfigMaps`
@@ -2141,10 +2136,9 @@ func (r *KeystoneReconciler) reconcileHTTPRoute(ctx context.Context,
 ```
 
 **Purpose:** Manage the optional Gateway API `HTTPRoute` that exposes the
-Keystone API outside the cluster via a pre-existing `Gateway` (CC-0065). The
+Keystone API outside the cluster via a pre-existing `Gateway`. The
 Gateway is owned by the platform team; this sub-reconciler only ensures the
-route that attaches the Keystone Service to it. Four lifecycle paths
-(REQ-001, REQ-002, REQ-005):
+route that attaches the Keystone Service to it. Four lifecycle paths:
 
 0. **Gateway API not installed** (`r.gatewayAPIAvailable` is false): The
    CRD presence check in `SetupWithManager` found no mapping for
@@ -2176,7 +2170,7 @@ references it, and before `reconcileHealthCheck` reads `status.endpoint`. The
 route is deliberately not part of `reconcileParallelGroup` because it has a
 transitive dependency on the Service created by `reconcileDeployment`.
 
-**HTTPRoute Construction (`buildKeystoneHTTPRoute`, REQ-001, REQ-003, REQ-006):**
+**HTTPRoute Construction (`buildKeystoneHTTPRoute`):**
 
 | HTTPRoute Field | Source |
 | --- | --- |
@@ -2204,7 +2198,7 @@ re-asserted. `apiequality.Semantic.DeepEqual` guards against no-op writes —
 references actually changed. Empty maps are normalized to nil via
 `hrNormalizeMap` so nil-vs-empty does not trigger a spurious diff.
 
-**Acceptance Detection (`isHTTPRouteAccepted`, REQ-005):** Iterates
+**Acceptance Detection (`isHTTPRouteAccepted`):** Iterates
 `status.parents[*].conditions` and returns `true` as soon as any parent reports
 `Accepted=True`. An empty `Parents` slice (Gateway controller has not yet
 observed the route) is treated as "not yet accepted", yielding a `False`
@@ -2226,7 +2220,7 @@ condition with a short requeue rather than a permanent error.
 | `keystoneAPIPort` | `gatewayv1.PortNumber(5000)` | Backend Service port targeted by the route |
 | `defaultHTTPRoutePath` | `"/"` | Path prefix applied when `spec.gateway.path` is empty |
 
-**`status.endpoint` Derivation (REQ-004):** The gateway-aware helper
+**`status.endpoint` Derivation:** The gateway-aware helper
 `keystoneStatusEndpoint()` is defined alongside this sub-reconciler but called
 from `reconcileDeployment`. When `spec.gateway.hostname` is set, the helper
 returns `https://{hostname}/v3`; otherwise it returns the cluster-local
@@ -2236,7 +2230,7 @@ appended to `status.endpoint`. The `https` scheme is emitted unconditionally
 when a gateway hostname is configured — gateways are the public-ingress hop
 and terminate TLS.
 
-**Interaction with `reconcileNetworkPolicy` (REQ-008):** When `spec.gateway`
+**Interaction with `reconcileNetworkPolicy`:** When `spec.gateway`
 is set, `reconcileNetworkPolicy` appends an extra ingress peer that selects
 the gateway's namespace by the well-known label
 `kubernetes.io/metadata.name={parentRef.namespace or CR namespace}`. This lets
@@ -2271,7 +2265,7 @@ func (r *KeystoneReconciler) reconcileHealthCheck(ctx context.Context,
 ```
 
 **Purpose:** Perform an HTTP GET to the Keystone `/v3` endpoint after the Deployment
-reports ready, verifying that the API is actually responding to requests (CC-0067).
+reports ready, verifying that the API is actually responding to requests.
 This catches cases where pods pass their readiness probe but the API is not
 functionally healthy.
 
@@ -2352,8 +2346,7 @@ func (r *KeystoneReconciler) reconcileHPA(ctx context.Context,
     keystone *keystonev1alpha1.Keystone) (ctrl.Result, error)
 ```
 
-**Purpose:** Manage the HorizontalPodAutoscaler for the Keystone API Deployment
-(CC-0038). Three lifecycle paths:
+**Purpose:** Manage the HorizontalPodAutoscaler for the Keystone API Deployment. Three lifecycle paths:
 
 1. **Autoscaling disabled** (`spec.autoscaling` is nil): Delete any existing HPA
    and set `HPAReady=True` with reason `HPANotRequired`.
@@ -2466,7 +2459,7 @@ func (r *KeystoneReconciler) reconcileTrustFlush(ctx context.Context,
 ```
 
 **Purpose:** Manage the trust flush CronJob that periodically purges expired trust
-delegations from the Keystone database (CC-0057). Three lifecycle paths:
+delegations from the Keystone database. Three lifecycle paths:
 
 1. **Trust flush disabled** (`spec.trustFlush` is nil): Delete any existing
    `{name}-trust-flush` CronJob and set `TrustFlushReady=True` with reason
@@ -2538,9 +2531,9 @@ controller-runtime for exponential backoff.
 | `reconcileConfig` | — | — | Secret read failure, render failure → exponential backoff |
 | `reconcilePolicyValidation` | Job running | 15s | `ErrJobFailed` from validation → descriptive error |
 | `reconcileDeployment` | Deployment not available | 10s | API error → exponential backoff |
-| `pruneStaleConfigMaps` | — | — | List/delete failure → exponential backoff (CC-0077) |
-| `reconcileHTTPRoute` | Gateway has not yet set `Accepted=True` on parent status | 10s | API error on ensure/get/delete → exponential backoff (CC-0065) |
-| `reconcileHealthCheck` | Non-2xx, timeout, DNS, connection refused | 10s | Malformed URL → exponential backoff (CC-0067) |
+| `pruneStaleConfigMaps` | — | — | List/delete failure → exponential backoff |
+| `reconcileHTTPRoute` | Gateway has not yet set `Accepted=True` on parent status | 10s | API error on ensure/get/delete → exponential backoff |
+| `reconcileHealthCheck` | Non-2xx, timeout, DNS, connection refused | 10s | Malformed URL → exponential backoff |
 | `reconcileHPA` | — | — | API error → exponential backoff |
 | `reconcileBootstrap` | Job running | 60s | `ErrJobFailed` from bootstrap |
 | `reconcileTrustFlush` | — | — | API error → exponential backoff |
@@ -2564,40 +2557,40 @@ Keystone CR via `controllerutil.SetControllerReference()`. This enables:
 | Resource | Name | Owner |
 | --- | --- | --- |
 | Secret | `{name}-fernet-keys` | Keystone CR |
-| Secret | `{name}-fernet-keys-rotation` | Keystone CR (rotation staging, CC-0081) |
+| Secret | `{name}-fernet-keys-rotation` | Keystone CR (rotation staging) |
 | CronJob | `{name}-fernet-rotate` | Keystone CR |
 | PushSecret | `{name}-fernet-keys-backup` | Keystone CR |
 | Secret | `{name}-credential-keys` | Keystone CR |
-| Secret | `{name}-credential-keys-rotation` | Keystone CR (rotation staging, CC-0081) |
+| Secret | `{name}-credential-keys-rotation` | Keystone CR (rotation staging) |
 | CronJob | `{name}-credential-rotate` | Keystone CR |
 | PushSecret | `{name}-credential-keys-backup` | Keystone CR |
 | ConfigMap | `{name}-config-{hash}` | Keystone CR |
-| Job | `keystone-db-sync` | Keystone CR | <!-- TODO: align to {name}-* pattern (pre-existing, CC-0073 W-002) -->
-| Job | `keystone-bootstrap` | Keystone CR | <!-- TODO: align to {name}-* pattern (pre-existing, CC-0073 W-002) -->
-| Deployment | `{name}` | Keystone CR (bare CR name since CC-0095) |
-| Service | `{name}` | Keystone CR (bare CR name since CC-0095) |
-| PodDisruptionBudget | `{name}` | Keystone CR (bare CR name since CC-0095) |
-| HorizontalPodAutoscaler | `{name}` | Keystone CR (only when `spec.autoscaling` is set; bare CR name since CC-0095) |
-| HTTPRoute | `{name}` | Keystone CR (only when `spec.gateway` is set, CC-0065; bare CR name since CC-0095) |
+| Job | `keystone-db-sync` | Keystone CR | <!-- TODO: align to {name}-* pattern -->
+| Job | `keystone-bootstrap` | Keystone CR | <!-- TODO: align to {name}-* pattern -->
+| Deployment | `{name}` | Keystone CR (bare CR name) |
+| Service | `{name}` | Keystone CR (bare CR name) |
+| PodDisruptionBudget | `{name}` | Keystone CR (bare CR name) |
+| HorizontalPodAutoscaler | `{name}` | Keystone CR (only when `spec.autoscaling` is set; bare CR name) |
+| HTTPRoute | `{name}` | Keystone CR (only when `spec.gateway` is set; bare CR name) |
 | Job | `{name}-policy-validation` | Keystone CR (only when `spec.policyOverrides` is set) |
 | CronJob | `{name}-trust-flush` | Keystone CR (only when `spec.trustFlush` is set) |
-| ConfigMap | `{name}-fernet-rotate-script-{hash}` | Keystone CR (CC-0073) |
-| ConfigMap | `{name}-credential-rotate-script-{hash}` | Keystone CR (CC-0073) |
-| Database | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer — CC-0078) |
-| User | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer — CC-0078) |
-| Grant | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer — CC-0078) |
+| ConfigMap | `{name}-fernet-rotate-script-{hash}` | Keystone CR |
+| ConfigMap | `{name}-credential-rotate-script-{hash}` | Keystone CR |
+| Database | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer) |
+| User | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer) |
+| Grant | `keystone` | Keystone CR (managed mode only; additionally cleaned up by the finalizer) |
 
 ---
 
-## Database credentials and oslo.config env-var overrides (CC-0080)
+## Database credentials and oslo.config env-var overrides
 
 Keystone's `[database] connection` URL embeds the MySQL username and password.
-Prior to CC-0080, the rendered URL was written directly into `keystone.conf`
+Earlier, the rendered URL was written directly into `keystone.conf`
 inside the operator-managed immutable ConfigMap. ConfigMaps lack encryption at
 rest and are routinely granted broad `get` RBAC for observability workflows,
 which caused production database credentials to be readable by any actor with
-`get configmap` on the Keystone namespace. CC-0080 replaces that design by (1)
-writing a non-secret placeholder into the ConfigMap and (2) materialising the
+`get configmap` on the Keystone namespace. The current design replaces that
+by (1) writing a non-secret placeholder into the ConfigMap and (2) materialising the
 real connection URL into a derived Kubernetes `Secret` which every pod consumes
 through the oslo.config `OS_<GROUP>__<OPTION>` environment-variable override
 mechanism.
@@ -2717,7 +2710,7 @@ readable through the `get configmap` verb.
 
 The reconciler has comprehensive unit tests using `gomega` with `NewGomegaWithT(t)`.
 For end-to-end Chainsaw tests that validate the reconciler in a real cluster, see
-[Keystone E2E Test Suites](../testing/keystone-e2e-tests.md) (CC-0016).
+[Keystone E2E Test Suites](../testing/keystone-e2e-tests.md).
 
 ### Running Tests
 
@@ -2729,7 +2722,7 @@ For end-to-end Chainsaw tests that validate the reconciler in a real cluster, se
 ### ObservedGeneration Test Convention
 
 Every sub-reconciler test file that sets conditions includes a dedicated
-`TestReconcile{SubReconciler}_ConditionObservedGeneration` test function (CC-0072).
+`TestReconcile{SubReconciler}_ConditionObservedGeneration` test function.
 This test exercises at least one `True` and one `False` condition path with distinct,
 non-default generation values to verify that `ObservedGeneration` is propagated on
 every code path. When adding a new sub-reconciler, copy this test pattern from any
@@ -2739,21 +2732,21 @@ existing file (e.g. `reconcile_hpa_test.go`).
 
 | File | Coverage |
 | --- | --- |
-| `keystone_controller_test.go` | Reconcile() orchestration, sequential execution, parallel group (CC-0071), early return, Ready aggregation, idempotency, benchmark, finalizer install/remove and termination branching + Events (CC-0078) |
-| `reconcile_secrets_test.go` | DB/admin credential readiness, error propagation, condition messages, ObservedGeneration (CC-0072) |
-| `reconcile_database_test.go` | Managed/brownfield modes, MariaDB CRs, db_sync lifecycle, stale Job detection, ObservedGeneration (CC-0072), finalizeDatabaseResources cleanup + idempotency (CC-0078) |
-| `reconcile_fernet_test.go` | Key generation, Secret idempotency, script ConfigMap creation, CronJob schedule/volumes, PushSecret, key validity (CC-0073), ObservedGeneration (CC-0072) |
-| `reconcile_credential_test.go` | Key generation, Secret idempotency, script ConfigMap creation, CronJob schedule/volumes, PushSecret, RBAC, key validity (CC-0036, CC-0073), ObservedGeneration (CC-0072) |
-| `reconcile_networkpolicy_test.go` | NetworkPolicy creation, update, deletion, ingress rules, condition contract (CC-0039) |
+| `keystone_controller_test.go` | Reconcile() orchestration, sequential execution, parallel group, early return, Ready aggregation, idempotency, benchmark, finalizer install/remove and termination branching + Events |
+| `reconcile_secrets_test.go` | DB/admin credential readiness, error propagation, condition messages, ObservedGeneration |
+| `reconcile_database_test.go` | Managed/brownfield modes, MariaDB CRs, db_sync lifecycle, stale Job detection, ObservedGeneration, finalizeDatabaseResources cleanup + idempotency |
+| `reconcile_fernet_test.go` | Key generation, Secret idempotency, script ConfigMap creation, CronJob schedule/volumes, PushSecret, key validity, ObservedGeneration |
+| `reconcile_credential_test.go` | Key generation, Secret idempotency, script ConfigMap creation, CronJob schedule/volumes, PushSecret, RBAC, key validity, ObservedGeneration |
+| `reconcile_networkpolicy_test.go` | NetworkPolicy creation, update, deletion, ingress rules, condition contract |
 | `reconcile_config_test.go` | INI generation, extraConfig merge, plugin config, policy overrides, ConfigMap hashing |
-| `reconcile_policyvalidation_test.go` | Policy validation lifecycle, condition contract, error extraction, Job spec (CC-0058), ObservedGeneration |
-| `reconcile_deployment_test.go` | Deployment spec, Service creation, readiness, endpoint, owner references, stable pod template (CC-0074), ObservedGeneration (CC-0072) |
-| `reconcile_healthcheck_test.go` | Health check happy/unhealthy paths, timeout, DNS, connection refused, empty endpoint, response body close, HTTPDoer injection (CC-0067), ObservedGeneration |
-| `reconcile_hpa_test.go` | HPA creation, update, deletion, metrics (CPU/memory), minReplicas defaulting, condition contract, error propagation (CC-0038), ObservedGeneration |
-| `reconcile_httproute_test.go` | HTTPRoute creation, update, deletion, gateway namespace defaulting, PathPrefix match, backend Service port 5000, parent Accepted reflection, status.endpoint derivation, condition contract (CC-0065), ObservedGeneration |
-| `reconcile_trustflush_test.go` | CronJob creation, deletion, schedule/suspend/args, security context, volume mounts, condition contract, error propagation (CC-0057), ObservedGeneration |
-| `reconcile_bootstrap_test.go` | Job creation, completion, failure, stale detection, TTL/backoff, ObservedGeneration (CC-0072) |
-| `integration_test.go` | Full reconciliation envtest: CronJob spec, bootstrap Job spec, brownfield mode, condition progression (CC-0015), ObservedGeneration (CC-0072, pre-existing) |
+| `reconcile_policyvalidation_test.go` | Policy validation lifecycle, condition contract, error extraction, Job spec, ObservedGeneration |
+| `reconcile_deployment_test.go` | Deployment spec, Service creation, readiness, endpoint, owner references, stable pod template, ObservedGeneration |
+| `reconcile_healthcheck_test.go` | Health check happy/unhealthy paths, timeout, DNS, connection refused, empty endpoint, response body close, HTTPDoer injection, ObservedGeneration |
+| `reconcile_hpa_test.go` | HPA creation, update, deletion, metrics (CPU/memory), minReplicas defaulting, condition contract, error propagation, ObservedGeneration |
+| `reconcile_httproute_test.go` | HTTPRoute creation, update, deletion, gateway namespace defaulting, PathPrefix match, backend Service port 5000, parent Accepted reflection, status.endpoint derivation, condition contract, ObservedGeneration |
+| `reconcile_trustflush_test.go` | CronJob creation, deletion, schedule/suspend/args, security context, volume mounts, condition contract, error propagation, ObservedGeneration |
+| `reconcile_bootstrap_test.go` | Job creation, completion, failure, stale detection, TTL/backoff, ObservedGeneration |
+| `integration_test.go` | Full reconciliation envtest: CronJob spec, bootstrap Job spec, brownfield mode, condition progression, ObservedGeneration |
 
 ---
 
@@ -2772,46 +2765,45 @@ operators/keystone/
     │   ├── reconcile_secrets.go                reconcileSecrets sub-reconciler
     │   ├── reconcile_database.go               reconcileDatabase sub-reconciler
     │   ├── reconcile_fernet.go                 reconcileFernetKeys sub-reconciler
-    │   ├── reconcile_credential.go             reconcileCredentialKeys sub-reconciler (CC-0036)
-    │   ├── reconcile_networkpolicy.go          reconcileNetworkPolicy sub-reconciler (CC-0039)
-    │   ├── reconcile_config.go                 reconcileConfig + pruneStaleConfigMaps (CC-0077)
-    │   ├── reconcile_policyvalidation.go        reconcilePolicyValidation sub-reconciler (CC-0058)
+    │   ├── reconcile_credential.go             reconcileCredentialKeys sub-reconciler
+    │   ├── reconcile_networkpolicy.go          reconcileNetworkPolicy sub-reconciler
+    │   ├── reconcile_config.go                 reconcileConfig + pruneStaleConfigMaps
+    │   ├── reconcile_policyvalidation.go        reconcilePolicyValidation sub-reconciler
     │   ├── reconcile_deployment.go             reconcileDeployment sub-reconciler
-    │   ├── reconcile_healthcheck.go           reconcileHealthCheck sub-reconciler (CC-0067)
-    │   ├── reconcile_hpa.go                   reconcileHPA sub-reconciler (CC-0038)
-    │   ├── reconcile_httproute.go             reconcileHTTPRoute sub-reconciler + keystoneStatusEndpoint helper (CC-0065)
-    │   ├── reconcile_trustflush.go            reconcileTrustFlush sub-reconciler (CC-0057)
+    │   ├── reconcile_healthcheck.go           reconcileHealthCheck sub-reconciler
+    │   ├── reconcile_hpa.go                   reconcileHPA sub-reconciler
+    │   ├── reconcile_httproute.go             reconcileHTTPRoute sub-reconciler + keystoneStatusEndpoint helper
+    │   ├── reconcile_trustflush.go            reconcileTrustFlush sub-reconciler
     │   ├── reconcile_bootstrap.go              reconcileBootstrap sub-reconciler
     │   ├── scripts/
-    │   │   ├── fernet_rotate.sh               Fernet key rotation script (CC-0073)
-    │   │   └── credential_rotate.sh           Credential key rotation script (CC-0073)
+    │   │   ├── fernet_rotate.sh               Fernet key rotation script
+    │   │   └── credential_rotate.sh           Credential key rotation script
     │   ├── keystone_controller_test.go         Orchestration tests
     │   ├── reconcile_secrets_test.go           Secrets tests
     │   ├── reconcile_database_test.go          Database tests
-    │   ├── reconcile_fernet_test.go            Fernet tests (CC-0073)
-    │   ├── reconcile_credential_test.go        Credential keys tests (CC-0036, CC-0073)
-    │   ├── reconcile_networkpolicy_test.go     NetworkPolicy tests (CC-0039)
+    │   ├── reconcile_fernet_test.go            Fernet tests
+    │   ├── reconcile_credential_test.go        Credential keys tests
+    │   ├── reconcile_networkpolicy_test.go     NetworkPolicy tests
     │   ├── reconcile_config_test.go            Config tests
-    │   ├── reconcile_policyvalidation_test.go   Policy validation tests (CC-0058)
+    │   ├── reconcile_policyvalidation_test.go   Policy validation tests
     │   ├── reconcile_deployment_test.go        Deployment tests
-    │   ├── reconcile_healthcheck_test.go      Health check tests (CC-0067)
-    │   ├── reconcile_hpa_test.go              HPA tests (CC-0038)
-    │   ├── reconcile_httproute_test.go        HTTPRoute tests (CC-0065)
-    │   ├── reconcile_trustflush_test.go       Trust flush tests (CC-0057)
+    │   ├── reconcile_healthcheck_test.go      Health check tests
+    │   ├── reconcile_hpa_test.go              HPA tests
+    │   ├── reconcile_httproute_test.go        HTTPRoute tests
+    │   ├── reconcile_trustflush_test.go       Trust flush tests
     │   ├── reconcile_bootstrap_test.go         Bootstrap tests
-    │   └── integration_test.go                 Envtest integration tests (CC-0015)
+    │   └── integration_test.go                 Envtest integration tests
     └── testutil/
         └── envtest_setup.go                    Keystone-specific envtest helper
 ```
 
 ---
 
-## Metrics Instrumentation (CC-0089)
+## Metrics Instrumentation
 
 Every sub-reconciler invocation is instrumented for Prometheus via a
 single helper, `instrumentSubReconciler`, defined in
-`operators/keystone/internal/controller/instrumentation.go` (CC-0089,
-REQ-001, REQ-002, REQ-007). The orchestration `Reconcile` wraps every
+`operators/keystone/internal/controller/instrumentation.go`. The orchestration `Reconcile` wraps every
 sub-reconciler call with this helper; direct calls that bypass it are a
 contract violation.
 
@@ -2843,7 +2835,7 @@ Behavioural contract:
   `panic`/error that `fn` produced.
 - Carries no per-CR labels. The `sub_reconciler` label is bounded by
   the number of sub-reconciler names, keeping series count
-  fleet-independent (CC-0089, REQ-012).
+  fleet-independent.
 
 ### Name → `condition_type` lookup
 
@@ -2902,5 +2894,5 @@ Three regression tests guard this contract:
 For CR lifecycle hygiene, `reconcileDelete` calls
 `metrics.DeleteForKeystone(name, namespace)` after the finalizer is
 removed so per-CR series (`key_rotation_age_seconds`, `db_sync_*`) do
-not leak across the lifetime of a cluster (CC-0089, REQ-004).
+not leak across the lifetime of a cluster.
 

--- a/docs/reference/keystone/keystone-schema-drift-detection.md
+++ b/docs/reference/keystone/keystone-schema-drift-detection.md
@@ -1,12 +1,11 @@
 ---
 title: Keystone Schema Drift Detection
 quadrant: operator
-feature: CC-0064
 ---
 
 # Keystone Schema Drift Detection
 
-Reference documentation for the Keystone schema drift detection feature (CC-0064).
+Reference documentation for the Keystone schema drift detection feature.
 After the `db_sync` Job completes successfully, the operator runs a read-only
 schema-check Job that verifies the database schema matches the expected Alembic
 migration head. This detects drift caused by manual DDL changes, partial migration
@@ -55,7 +54,7 @@ reconcileDatabase()
   |     +-- running --> DatabaseReady=False/DBSyncInProgress, requeue 30s
   |     +-- done    --> proceed to schema check
   |
-  +-- schema-check Job (CC-0064)
+  +-- schema-check Job
   |     |
   |     +-- failed  --> DatabaseReady=False/SchemaDriftDetected, return error
   |     +-- running --> DatabaseReady=False/SchemaCheckInProgress, requeue 30s
@@ -184,7 +183,7 @@ All conditions include `ObservedGeneration` set to `keystone.Generation`.
 ## Interaction with Upgrade Flow
 
 The schema-check Job runs only on the **non-upgrade** (simple `db_sync`) path. The
-expand-migrate-contract upgrade flow (CC-0056) has its own validation through Alembic's
+expand-migrate-contract upgrade flow has its own validation through Alembic's
 `_validate_upgrade_order` check, which ensures expand, migrate, and contract steps
 execute in the correct order.
 
@@ -313,7 +312,7 @@ period.
    built-in validation.
 
 3. **No resource limits on schema-check Jobs.** The schema-check Job inherits no
-   resource requests/limits (BestEffort QoS). This is tracked under CC-0042.
+   resource requests/limits (BestEffort QoS).
 
 4. **Transient connectivity failures.** The `backoffLimit: 2` provides limited retry
    for transient database connectivity issues. If the database is temporarily

--- a/docs/reference/keystone/keystone-upgrade-flow.md
+++ b/docs/reference/keystone/keystone-upgrade-flow.md
@@ -1,13 +1,12 @@
 ---
 title: Keystone Upgrade Flow
 quadrant: operator
-feature: CC-0056, CC-0095
 ---
 
 # Keystone Upgrade Flow
 
 Reference documentation for the Keystone expand-migrate-contract database upgrade
-flow (CC-0056). The operator automatically performs phased database migrations when
+flow. The operator automatically performs phased database migrations when
 `spec.image.tag` changes to a new OpenStack release, maintaining API availability
 throughout the upgrade.
 
@@ -492,17 +491,17 @@ recover automatically.
 
 ---
 
-## Sub-Resource Rename (CC-0095)
+## Sub-Resource Rename
 
-CC-0095 dropped the `-api` suffix from operator-managed sub-resources. Clusters
-deployed before this change have sub-resources named `<cr-name>-api`; clusters <!-- CC-0095 legacy: pre-rename name referenced for traceability. -->
-deployed after that change carry sub-resources named `<cr-name>` (bare CR name).
-When the operator is upgraded across this boundary, the rename takes effect on
-the next reconcile that touches each sub-resource.
+A previous change dropped the `-api` suffix from operator-managed sub-resources.
+Clusters deployed before this change have sub-resources named `<cr-name>-api`;
+clusters deployed after that change carry sub-resources named `<cr-name>` (bare CR
+name). When the operator is upgraded across this boundary, the rename takes effect
+on the next reconcile that touches each sub-resource.
 
 ### Affected Sub-Resources
 
-The following sub-resources are renamed from `<cr-name>-api` to `<cr-name>`: <!-- CC-0095 legacy: pre-rename name referenced for traceability. -->
+The following sub-resources are renamed from `<cr-name>-api` to `<cr-name>`:
 
 - `Deployment`
 - `Service` (ClusterIP)
@@ -513,10 +512,10 @@ The following sub-resources are renamed from `<cr-name>-api` to `<cr-name>`: <!-
 - Container name and named container port (`5000`) inside the Deployment Pod template
 
 The cluster-internal Service DNS therefore changes from
-`http://<cr-name>-api.<namespace>.svc.cluster.local:5000/v3` to <!-- CC-0095 legacy: pre-rename DNS form referenced for traceability. -->
+`http://<cr-name>-api.<namespace>.svc.cluster.local:5000/v3` to
 `http://<cr-name>.<namespace>.svc.cluster.local:5000/v3`. This is reflected
 in `status.endpoint` once the controller re-reconciles. See the
-[Keystone CRD Sub-Resource Naming Convention section](./keystone-crd.md#sub-resource-naming-convention-cc-0095).
+[Keystone CRD Sub-Resource Naming Convention section](./keystone-crd.md#sub-resource-naming-convention).
 
 ### Catalog Self-Heal via `keystone-manage bootstrap`
 
@@ -552,22 +551,22 @@ Two paths are supported for the post-upgrade catalog refresh:
    Repeat for the `admin` and `internal` interfaces. The `public` interface
    typically resolves through the Gateway and is unaffected by the rename.
 
-### Manual Cleanup of Legacy `<cr-name>-api` Sub-Resources <!-- CC-0095 legacy: heading names the pre-rename form for traceability. -->
+### Manual Cleanup of Legacy `<cr-name>-api` Sub-Resources
 
 The renamed sub-resources are new objects with new `metadata.uid` values and
-fresh `ownerReferences` to the Keystone CR. The legacy `<cr-name>-api` <!-- CC-0095 legacy: pre-rename name referenced for traceability. -->
-sub-resources from the pre-CC-0095 operator carry their own owner references
-to the same Keystone CR, but the post-CC-0095 reconciler does **not** issue
+fresh `ownerReferences` to the Keystone CR. The legacy `<cr-name>-api`
+sub-resources from earlier operator releases carry their own owner references
+to the same Keystone CR, but the current reconciler does **not** issue
 `Delete` calls for them — it simply stops reconciling those names. As a
 result, on an upgraded cluster the legacy objects persist alongside the new
 bare-name objects until an operator removes them.
 
 ::: danger Cleanup is operator-driven, not automatic
-There is currently no controller-side garbage collection of pre-CC-0095
-sub-resources (CC-0095, REQ-004). Because the legacy objects retain valid
+There is currently no controller-side garbage collection of pre
+sub-resources. Because the legacy objects retain valid
 `ownerReferences` to the still-existing Keystone CR, the Kubernetes garbage
 collector will not delete them on its own. Operators upgrading across the
-CC-0095 boundary must remove them by hand. Skipping this step leaves stale
+rename boundary must remove them by hand. Skipping this step leaves stale
 Deployments/Services/PDBs/HPAs/HTTPRoutes/NetworkPolicies in the namespace,
 which can confuse `kubectl get`, score against `ResourceQuota`, and — in
 the case of the legacy Service — keep an unused ClusterIP routable.
@@ -580,18 +579,18 @@ the deletes idempotent, so re-applying the runbook on a partially cleaned
 namespace is a no-op for already-removed objects.
 
 ```bash
-# Core API sub-resources (always present on a pre-CC-0095 cluster).
-kubectl -n <namespace> delete deployment              <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename Deployment.
-kubectl -n <namespace> delete service                 <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename Service.
-kubectl -n <namespace> delete poddisruptionbudget     <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename PodDisruptionBudget.
+# Core API sub-resources (always present on a pre-rename cluster).
+kubectl -n <namespace> delete deployment              <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename Deployment.
+kubectl -n <namespace> delete service                 <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename Service.
+kubectl -n <namespace> delete poddisruptionbudget     <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename PodDisruptionBudget.
 
 # Optional sub-resources — delete only if the corresponding spec.* field
 # was set on the pre-upgrade CR. Running them unconditionally is safe
 # because of --ignore-not-found.
-kubectl -n <namespace> delete horizontalpodautoscaler <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename HPA.
-kubectl -n <namespace> delete networkpolicy           <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename NetworkPolicy.
+kubectl -n <namespace> delete horizontalpodautoscaler <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename HPA.
+kubectl -n <namespace> delete networkpolicy           <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename NetworkPolicy.
 kubectl -n <namespace> delete httproute.gateway.networking.k8s.io \
-                                                      <cr-name>-api --ignore-not-found  # CC-0095 legacy: targets the pre-rename HTTPRoute.
+                                                      <cr-name>-api --ignore-not-found  # legacy: targets the pre-rename HTTPRoute.
 ```
 
 Deleting the legacy `Deployment` cascades to its `ReplicaSet`s and `Pod`s
@@ -611,10 +610,10 @@ A clean upgrade shows exactly one row per kind, all named `<cr-name>`
 missed delete — re-run the corresponding `kubectl delete` above.
 
 ::: warning Until a cleanup sub-reconciler exists
-A future change may add an automated cleanup step to the operator (tracked
-as a follow-up to CC-0095). Until then, the manual runbook above is the
-only supported path for removing pre-CC-0095 leftovers; observed legacy
-objects on a live cluster will **not** disappear on subsequent reconciles.
+A future change may add an automated cleanup step to the operator. Until then,
+the manual runbook above is the only supported path for removing legacy
+leftovers; observed legacy objects on a live cluster will **not** disappear on
+subsequent reconciles.
 :::
 
 ---
@@ -632,7 +631,7 @@ objects on a live cluster will **not** disappear on subsequent reconciles.
    c5c3-operator.
 
 4. **No resource limits on upgrade Jobs.** Upgrade Jobs inherit no resource
-   requests/limits (BestEffort QoS). This is tracked under CC-0042.
+   requests/limits (BestEffort QoS).
 
 5. **Image compatibility required.** The `db_sync --expand`, `--migrate`, and
    `--contract` flags must be supported by the Keystone container image. If the

--- a/docs/reference/testing/chaos-e2e-tests.md
+++ b/docs/reference/testing/chaos-e2e-tests.md
@@ -1,15 +1,14 @@
 ---
 title: Chaos E2E Test Suites
 quadrant: operator
-feature: CC-0047, CC-0048, CC-0049, CC-0054, CC-0066
 ---
 
 # Chaos E2E Test Suites
 
-Reference documentation for the chaos E2E test suites (CC-0047, CC-0048, CC-0049, CC-0066). These
+Reference documentation for the chaos E2E test suites. These
 tests verify that OpenStack operators correctly detect infrastructure dependency failures
-via status conditions and recover autonomously when dependencies return. Phase 2 (CC-0048)
-extends the suite with operator resilience and workload chaos scenarios. Phase 3 (CC-0066)
+via status conditions and recover autonomously when dependencies return. Phase 2
+extends the suite with operator resilience and workload chaos scenarios. Phase 3
 adds operator pod kill with leader re-election and post-failover reconciliation verification.
 
 For happy-path E2E tests, see [Keystone E2E Test Suites](./keystone-e2e-tests.md).
@@ -17,10 +16,10 @@ For happy-path E2E tests, see [Keystone E2E Test Suites](./keystone-e2e-tests.md
 ## Overview
 
 The 9 chaos test suites validate operator behavior during and after fault injection.
-Phase 1 (CC-0047) covers infrastructure dependency pod kills. Phase 2 (CC-0048) adds
+Phase 1 covers infrastructure dependency pod kills. Phase 2 adds
 operator self-recovery, CronJob workload fault tolerance, and PDB availability guarantee
-scenarios. Phase 3 (CC-0066) adds an all-pod operator kill with leader re-election
-verification. Phase 4 (CC-0049) adds network chaos scenarios (partition and latency).
+scenarios. Phase 3 adds an all-pod operator kill with leader re-election
+verification. Phase 4 adds network chaos scenarios (partition and latency).
 Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 [Chaos Mesh](https://chaos-mesh.org/) `PodChaos` or `NetworkChaos` fault, asserts the expected degradation
 (or stability), removes the fault, and asserts full recovery. Tests use
@@ -30,7 +29,7 @@ Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │  Chainsaw Chaos E2E Runner (parallel: 1)                                     │
 │                                                                              │
-│  Phase 1 (CC-0047): Dependency Pod Kill                                      │
+│  Phase 1: Dependency Pod Kill                                                │
 │  ┌──────────────────────┐  ┌──────────────────────┐  ┌────────────────────┐  │
 │  │ mariadb-pod-kill     │  │ memcached-pod-kill   │  │ openbao-pod-kill   │  │
 │  │ SC-CHAOS-001         │  │ SC-CHAOS-002         │  │ SC-CHAOS-003       │  │
@@ -41,7 +40,7 @@ Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 │  │                      │  │                      │  │ recovery           │  │
 │  └──────────────────────┘  └──────────────────────┘  └────────────────────┘  │
 │                                                                              │
-│  Phase 2 (CC-0048): Operator Resilience and Workload Chaos                   │
+│  Phase 2: Operator Resilience and Workload Chaos                             │
 │  ┌──────────────────────┐  ┌──────────────────────┐  ┌────────────────────┐  │
 │  │ operator-pod-crash   │  │ cronjob-rotation-    │  │ api-pod-kill-pdb   │  │
 │  │ SC-CHAOS-004         │  │ failure              │  │ SC-CHAOS-008       │  │
@@ -53,7 +52,7 @@ Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 │  │                      │  │ fault tolerance      │  │ guarantee          │  │
 │  └──────────────────────┘  └──────────────────────┘  └────────────────────┘  │
 │                                                                              │
-│  Phase 3 (CC-0066): Concurrent Conflicts and Failover                        │
+│  Phase 3: Concurrent Conflicts and Failover                                  │
 │  ┌──────────────────────┐                                                    │
 │  │ operator-pod-kill    │                                                    │
 │  │ SC-CHAOS-009         │                                                    │
@@ -64,7 +63,7 @@ Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 │  │ failover reconcile   │                                                    │
 │  └──────────────────────┘                                                    │
 │                                                                              │
-│  Phase 4 (CC-0049): Network Chaos                                            │
+│  Phase 4: Network Chaos                                                      │
 │  ┌──────────────────────┐  ┌──────────────────────┐                          │
 │  │ mariadb-network-     │  │ mariadb-network-     │                          │
 │  │ partition            │  │ latency              │                          │
@@ -88,7 +87,7 @@ Each suite deploys a Keystone CR, asserts a healthy baseline, injects a
 All 9 test suites require the infrastructure stack and Chaos Mesh to be deployed and
 healthy.
 
-::: warning Run `WITH_CHAOS_MESH=true make deploy-infra` first (CC-0097)
+::: warning Run `WITH_CHAOS_MESH=true make deploy-infra` first
 Chaos Mesh is **opt-in** in the kind Quick Start — the default `make deploy-infra`
 flow leaves the `chaos-mesh` namespace absent. Run
 `WITH_CHAOS_MESH=true make deploy-infra` before `make e2e-chaos`, or `make e2e-chaos`
@@ -99,7 +98,7 @@ for the rationale.
 
 | Prerequisite | Details |
 | --- | --- |
-| Infrastructure stack | Deployed via `WITH_CHAOS_MESH=true make deploy-infra` (CC-0097 — opt-in path; see [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md)) |
+| Infrastructure stack | Deployed via `WITH_CHAOS_MESH=true make deploy-infra` (opt-in path; see [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md)) |
 | Chaos Mesh | Installed in `chaos-mesh` namespace by the kind-only opt-in overlay at `deploy/kind/chaos-mesh/` (or by `chaos-mesh/chaos-mesh-action` in CI) |
 | Keystone operator | Deployed to the cluster with CRDs installed |
 | ESO ExternalSecrets | `keystone-admin`, `keystone-db` synced in `openstack` namespace |
@@ -137,7 +136,7 @@ Individual test suites override the assert timeout to 5 minutes (`5m`) at the sp
 
 ## CI Trigger Policy
 
-Chaos tests run as a separate `e2e-chaos` GitHub Actions job in the CI workflow (CC-0054).
+Chaos tests run as a separate `e2e-chaos` GitHub Actions job in the CI workflow.
 The job is path-filtered and non-blocking while stability is being proven. See
 [CI Workflow — e2e-chaos](../ci-cd/ci-workflow.md#e2e-chaos) for full job documentation.
 
@@ -153,14 +152,14 @@ active regardless of which files were touched.
 | Event | Runs when |
 | --- | --- |
 | Push to `main` | Path filter matches or Go code changed (always on `v*` tags) |
-| Pull request | Path filter matches, Go code changed, **or `run-chaos` label present** (CC-0049 REQ-007) |
+| Pull request | Path filter matches, Go code changed, **or `run-chaos` label present** |
 
 **Dependencies:** The job depends on all gate jobs (`lint`, `shellcheck`, `test`,
 `test-integration`, `verify-codegen`). It only runs if no dependency failed or was
 cancelled.
 
 **Non-blocking (`continue-on-error: true`):** Chaos test failures are visible in the CI
-status but do not block merges or the publish pipeline (CC-0054 REQ-004). This is
+status but do not block merges or the publish pipeline. This is
 intentional while chaos test stability is being proven in CI. The setting will be revisited
 after 2–4 weeks of successful CI runs to consider making the job blocking.
 
@@ -169,17 +168,17 @@ assertion windows.
 
 ## Test Suite Inventory
 
-| Suite | Scenario ID | CR Name | Test Pattern | Condition Assertions | Requirements |
-| --- | --- | --- | --- | --- | --- |
-| [mariadb-pod-kill](#mariadb-pod-kill) | SC-CHAOS-001 | `keystone-chaos-db` | Degradation and recovery | `DatabaseReady=False` → `DatabaseReady=True`, `Ready=True` | REQ-003, REQ-004, REQ-008, REQ-009 |
-| [memcached-pod-kill](#memcached-pod-kill) | SC-CHAOS-002 | `keystone-chaos-mc` | No-regression | All 6 conditions remain `True` during outage | REQ-005, REQ-008, REQ-009 |
-| [openbao-pod-kill](#openbao-pod-kill) | SC-CHAOS-003 | `keystone-chaos-bao` | Degradation and recovery | `SecretsReady=False` → `SecretsReady=True`, `Ready=True` | REQ-006, REQ-007, REQ-008, REQ-009 |
-| [operator-pod-crash](#operator-pod-crash) | SC-CHAOS-004 | `keystone-chaos-op` | Operator self-recovery (no-regression) | Operator pod `Ready=false` → `Ready=true`, CR `Ready=True` maintained | REQ-001, REQ-005, REQ-006, REQ-008 (CC-0048) |
-| [cronjob-rotation-failure](#cronjob-rotation-failure) | SC-CHAOS-005 | `keystone-chaos-cron` | Workload fault tolerance | `FernetKeysReady=True` maintained, `Ready=True` maintained | REQ-002, REQ-006, REQ-008 (CC-0048) |
-| [mariadb-network-partition](#mariadb-network-partition) | SC-CHAOS-006 | `keystone-chaos-net-part` | Degradation and recovery (NetworkChaos) | `DatabaseReady=False` → `DatabaseReady=True`, `Ready=True` | REQ-001, REQ-002, REQ-008 (CC-0049) |
-| [mariadb-network-latency](#mariadb-network-latency) | SC-CHAOS-007 | `keystone-chaos-net-lat` | Latency tolerance (no-regression) | `Ready=True` maintained, operator `restartCount=0` | REQ-003, REQ-004, REQ-008 (CC-0049) |
-| [api-pod-kill-pdb](#api-pod-kill-pdb) | SC-CHAOS-008 | `keystone-chaos-api` | PDB availability guarantee | PDB `minAvailable: 1`, `DeploymentReady=True` maintained, `Ready=True` maintained | REQ-003, REQ-004, REQ-006, REQ-008 (CC-0048) |
-| [operator-pod-kill](#operator-pod-kill) | SC-CHAOS-009 | `keystone-chaos-opk` | Operator pod kill (all) with failover reconciliation | All 6 conditions `True` maintained, replica patch reconciled by new leader | REQ-005, REQ-006, REQ-007, REQ-008 (CC-0066) |
+| Suite | Scenario ID | CR Name | Test Pattern | Condition Assertions |
+| --- | --- | --- | --- | --- |
+| [mariadb-pod-kill](#mariadb-pod-kill) | SC-CHAOS-001 | `keystone-chaos-db` | Degradation and recovery | `DatabaseReady=False` → `DatabaseReady=True`, `Ready=True` |
+| [memcached-pod-kill](#memcached-pod-kill) | SC-CHAOS-002 | `keystone-chaos-mc` | No-regression | All 6 conditions remain `True` during outage |
+| [openbao-pod-kill](#openbao-pod-kill) | SC-CHAOS-003 | `keystone-chaos-bao` | Degradation and recovery | `SecretsReady=False` → `SecretsReady=True`, `Ready=True` |
+| [operator-pod-crash](#operator-pod-crash) | SC-CHAOS-004 | `keystone-chaos-op` | Operator self-recovery (no-regression) | Operator pod `Ready=false` → `Ready=true`, CR `Ready=True` maintained |
+| [cronjob-rotation-failure](#cronjob-rotation-failure) | SC-CHAOS-005 | `keystone-chaos-cron` | Workload fault tolerance | `FernetKeysReady=True` maintained, `Ready=True` maintained |
+| [mariadb-network-partition](#mariadb-network-partition) | SC-CHAOS-006 | `keystone-chaos-net-part` | Degradation and recovery (NetworkChaos) | `DatabaseReady=False` → `DatabaseReady=True`, `Ready=True` |
+| [mariadb-network-latency](#mariadb-network-latency) | SC-CHAOS-007 | `keystone-chaos-net-lat` | Latency tolerance (no-regression) | `Ready=True` maintained, operator `restartCount=0` |
+| [api-pod-kill-pdb](#api-pod-kill-pdb) | SC-CHAOS-008 | `keystone-chaos-api` | PDB availability guarantee | PDB `minAvailable: 1`, `DeploymentReady=True` maintained, `Ready=True` maintained |
+| [operator-pod-kill](#operator-pod-kill) | SC-CHAOS-009 | `keystone-chaos-opk` | Operator pod kill (all) with failover reconciliation | All 6 conditions `True` maintained, replica patch reconciled by new leader |
 
 ---
 
@@ -248,7 +247,7 @@ namespace events.
 `kubectl wait` with label selectors. The original `kubectl wait` approach raced with pod
 deletion — when Chaos Mesh deletes a pod, the watch errors with `NotFound` because it
 resolves the label selector once and watches the specific pod object rather than
-re-resolving onto the replacement pod (CC-0076, issue #214). Deployment-level polling
+re-resolving onto the replacement pod. Deployment-level polling
 watches the persistent Deployment object and is resilient to pod replacements, matching
 the pattern used by `operator-pod-crash` and `api-pod-kill-pdb`.
 
@@ -292,7 +291,7 @@ and namespace events.
 
 **File:** `tests/e2e-chaos/operator-pod-crash/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-004 (CC-0048)
+**Scenario:** SC-CHAOS-004
 
 **Purpose:** Validates that the Keystone operator self-recovers after its own pod is killed
 mid-reconcile. The Deployment controller restarts the operator pod, controller-runtime
@@ -329,7 +328,7 @@ for mitigation guidance if CI flakiness occurs.
 
 **File:** `tests/e2e-chaos/cronjob-rotation-failure/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-005 (CC-0048)
+**Scenario:** SC-CHAOS-005
 
 **Purpose:** Validates that the Keystone operator maintains `FernetKeysReady=True` and
 `Ready=True` when a manually triggered fernet rotation Job's pods are killed by PodChaos.
@@ -370,7 +369,7 @@ ensures every pod spawned by the targeted Job is affected.
 
 **File:** `tests/e2e-chaos/mariadb-network-partition/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-006 (CC-0049)
+**Scenario:** SC-CHAOS-006
 
 **Purpose:** Validates that the Keystone operator detects a MariaDB network partition
 (unidirectional traffic block from keystone to mariadb), transitions `DatabaseReady` to
@@ -412,7 +411,7 @@ mode (`baseline`/`chaos`) and `--dep-label=app.kubernetes.io/name=mariadb`.
 
 **File:** `tests/e2e-chaos/mariadb-network-latency/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-007 (CC-0049)
+**Scenario:** SC-CHAOS-007
 
 **Purpose:** Validates that the Keystone operator tolerates slow MariaDB responses (10s
 latency, 2s jitter) without crash-looping or losing Ready status, confirming adequate
@@ -442,7 +441,7 @@ appropriate mode (`baseline`/`chaos`) and `--dep-label=app.kubernetes.io/name=ma
   because latency should be tolerated by the operator's database client timeouts.
 - `duration: 180s` acts as a safety net for auto-expiry.
 - Step 4 uses `kubectl wait --for=condition=AllInjected` to confirm injection is active
-  before checking operator stability, replacing a fixed sleep for determinism (CC-0049).
+  before checking operator stability, replacing a fixed sleep for determinism.
 - Restart count is checked by container name (`manager`) rather than by array index to
   avoid false negatives if container ordering changes.
 
@@ -452,7 +451,7 @@ appropriate mode (`baseline`/`chaos`) and `--dep-label=app.kubernetes.io/name=ma
 
 **File:** `tests/e2e-chaos/api-pod-kill-pdb/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-008 (CC-0048)
+**Scenario:** SC-CHAOS-008
 
 **Purpose:** Validates that the Keystone operator creates a PodDisruptionBudget with
 `minAvailable: 1` for Keystone API pods when `replicas > 1`, and that at least one API
@@ -471,9 +470,9 @@ PDB assertion step and a script-based availability check.
 | 1 | Apply Keystone CR (replicas: 3) | `apply` | Applies `00-keystone-cr.yaml` — Keystone CR `keystone-chaos-api` with database `keystone_chaos_api`, replicas: 3 |
 | 2 | Assert baseline Ready=True | `assert` (5m) | Ready=True with reason AllReady |
 | 3 | Assert PDB exists | `assert` (5m) | PDB `keystone-chaos-api` with `spec.minAvailable: 1` (apiVersion: `policy/v1`) |
-| 4 | Inject PodChaos | `apply` | Applies `01-podchaos.yaml` — PodChaos `kill-keystone-api` targeting `app.kubernetes.io/name: keystone` AND `app.kubernetes.io/instance: keystone-chaos-api` in `openstack` (the PodChaos resource name retains its historical `kill-keystone-api` label as a chaos-test identifier; the chaos still targets the bare-name `keystone-chaos-api` Pods, since CC-0095) | <!-- CC-0095 legacy: chaos-test fixture identifier intentionally retained -->
+| 4 | Inject PodChaos | `apply` | Applies `01-podchaos.yaml` — PodChaos `kill-keystone-api` targeting `app.kubernetes.io/name: keystone` AND `app.kubernetes.io/instance: keystone-chaos-api` in `openstack` (the PodChaos resource name retains its historical `kill-keystone-api` label as a chaos-test identifier; the chaos still targets the bare-name `keystone-chaos-api` Pods) |
 | 5 | Verify PDB enforcement and assert conditions | `script` (120s) + `assert` (5m) | Script polls until `readyReplicas < 3` (kill took effect), then asserts `availableReplicas >= 1`; Chainsaw asserts `DeploymentReady=True` and `Ready=True` with reason AllReady |
-| 6 | Delete PodChaos | `delete` | Removes PodChaos `kill-keystone-api` to clean up | <!-- CC-0095 legacy: chaos-test fixture identifier intentionally retained -->
+| 6 | Delete PodChaos | `delete` | Removes PodChaos `kill-keystone-api` to clean up |
 | 7 | Assert Ready=True after recovery | `assert` (5m) | Ready=True with reason AllReady — full replica count restored |
 
 **Fixtures:** `00-keystone-cr.yaml`, `01-podchaos.yaml`
@@ -486,7 +485,7 @@ Steps 5 and 7 catch with `diagnostics.sh chaos` using
 `wait` with a label selector waits for ALL matching pods, which does not work when the goal
 is to verify that NOT ALL pods are down. The script polls `readyReplicas < 3` (confirming
 the kill took effect) then asserts `availableReplicas >= 1`. The PDB name follows the
-naming convention `subResourceName(keystone)` = `{cr-name}` (bare CR name since CC-0095),
+naming convention `subResourceName(keystone)` = `{cr-name}` (bare CR name),
 so for CR `keystone-chaos-api`, the PDB is `keystone-chaos-api`.
 
 ---
@@ -495,7 +494,7 @@ so for CR `keystone-chaos-api`, the PDB is `keystone-chaos-api`.
 
 **File:** `tests/e2e-chaos/operator-pod-kill/chainsaw-test.yaml`
 
-**Scenario:** SC-CHAOS-009 (CC-0066)
+**Scenario:** SC-CHAOS-009
 
 **Purpose:** Validates that the Keystone operator recovers after ALL operator pods are killed
 simultaneously (`mode: all`), forcing the Deployment controller to restart every pod and
@@ -809,7 +808,7 @@ SC-CHAOS-005 additionally collects CronJob/Job-specific diagnostics in Steps 4 a
 
 ```text
 tests/e2e-chaos/
-├── chainsaw-config.yaml              Chaos-specific Chainsaw configuration (CC-0047)
+├── chainsaw-config.yaml              Chaos-specific Chainsaw configuration
 ├── diagnostics.sh                    Shared diagnostic collection script
 ├── README.md                         Quick-start documentation
 ├── mariadb-pod-kill/                 SC-CHAOS-001: MariaDB pod kill
@@ -824,27 +823,27 @@ tests/e2e-chaos/
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-bao)
 │   ├── 01-podchaos.yaml              PodChaos targeting openbao in openbao-system
 │   └── chainsaw-test.yaml            Test: SecretsReady=False → recovery
-├── operator-pod-crash/               SC-CHAOS-004: Operator self-recovery (CC-0048)
+├── operator-pod-crash/               SC-CHAOS-004: Operator self-recovery
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-op)
 │   ├── 01-podchaos.yaml              PodChaos targeting keystone-operator in openstack
 │   └── chainsaw-test.yaml            Test: Ready=True maintained after operator restart
-├── cronjob-rotation-failure/         SC-CHAOS-005: CronJob fault tolerance (CC-0048)
+├── cronjob-rotation-failure/         SC-CHAOS-005: CronJob fault tolerance
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-cron)
 │   ├── 01-podchaos.yaml              PodChaos pod-failure targeting job pods
 │   └── chainsaw-test.yaml            Test: FernetKeysReady=True maintained
-├── mariadb-network-partition/        SC-CHAOS-006: MariaDB network partition (CC-0049)
+├── mariadb-network-partition/        SC-CHAOS-006: MariaDB network partition
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-net-part)
 │   ├── 01-networkchaos.yaml          NetworkChaos partitioning keystone→mariadb traffic
 │   └── chainsaw-test.yaml            Test: DatabaseReady=False → recovery
-├── mariadb-network-latency/          SC-CHAOS-007: MariaDB network latency (CC-0049)
+├── mariadb-network-latency/          SC-CHAOS-007: MariaDB network latency
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-net-lat)
 │   ├── 01-networkchaos.yaml          NetworkChaos injecting 10s latency on keystone→mariadb
 │   └── chainsaw-test.yaml            Test: Ready=True maintained, no crash-loop
-├── api-pod-kill-pdb/                 SC-CHAOS-008: PDB availability guarantee (CC-0048)
+├── api-pod-kill-pdb/                 SC-CHAOS-008: PDB availability guarantee
 │   ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-api, replicas: 3)
 │   ├── 01-podchaos.yaml              PodChaos targeting keystone API pods (multi-label)
 │   └── chainsaw-test.yaml            Test: PDB minAvailable=1, availability maintained
-└── operator-pod-kill/                SC-CHAOS-009: Operator pod kill all + failover (CC-0066)
+└── operator-pod-kill/                SC-CHAOS-009: Operator pod kill all + failover
     ├── 00-keystone-cr.yaml           Keystone CR fixture (keystone-chaos-opk)
     ├── 01-podchaos.yaml              PodChaos targeting keystone-operator (mode: all)
     ├── 02-patch-replicas.yaml        Patch replicas 1→2 for post-failover reconciliation
@@ -861,8 +860,8 @@ tests/e2e-chaos/
 6. All files must include the `SPDX-License-Identifier: Apache-2.0` header
 
 ## Related Resources
-- [Keystone E2E Test Suites](./keystone-e2e-tests.md) — Happy-path E2E tests (CC-0016)
-- [Keystone Reconciler Architecture](../keystone/keystone-reconciler.md) — Sub-reconciler contracts and condition semantics (CC-0013, CC-0015)
-- [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md) — Infrastructure stack deployment (CC-0010)
+- [Keystone E2E Test Suites](./keystone-e2e-tests.md) — Happy-path E2E tests
+- [Keystone Reconciler Architecture](../keystone/keystone-reconciler.md) — Sub-reconciler contracts and condition semantics
+- [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md) — Infrastructure stack deployment
 - `tests/e2e-chaos/chainsaw-config.yaml` — Chaos-specific Chainsaw configuration
 - `tests/e2e-chaos/README.md` — Quick-start guide

--- a/docs/reference/testing/keystone-e2e-tests.md
+++ b/docs/reference/testing/keystone-e2e-tests.md
@@ -1,12 +1,11 @@
 ---
 title: Keystone E2E Test Suites
 quadrant: operator
-feature: CC-0016
 ---
 
 # Keystone E2E Test Suites
 
-Reference documentation for the Keystone Chainsaw E2E test suites (CC-0016). These
+Reference documentation for the Keystone Chainsaw E2E test suites. These
 tests validate the KeystoneReconciler's end-to-end behavior in a real Kubernetes cluster
 with all infrastructure dependencies deployed (MariaDB, Memcached, ESO, OpenBao).
 
@@ -123,27 +122,27 @@ Deployment rollout, bootstrap Job).
 
 ## Test Suite Inventory
 
-| Suite | CR Name | Reconciler Behavior Validated | Requirements |
-| --- | --- | --- | --- |
-| [basic-deployment](#basic-deployment) | `keystone-basic` | Full happy-path reconciliation, all conditions, owned resources, API accessibility | REQ-001, REQ-002, REQ-003, REQ-012, REQ-013 |
-| [missing-secret](#missing-secret) | `keystone-missing-secret` | SecretsReady requeue on missing ESO Secrets, recovery on creation | REQ-004, REQ-012, REQ-013 |
-| [fernet-rotation](#fernet-rotation) | `keystone-fernet` | CronJob schedule, manual rotation trigger, Secret data change, pod UID stability (no rollout), token validation (CC-0074) | REQ-005, REQ-012, REQ-013 |
-| [scale](#scale) | `keystone-scale` | Replica scaling up (3→5) and down (5→2) | REQ-006, REQ-012, REQ-013 |
-| [deletion-cleanup](#deletion-cleanup) | `keystone-cleanup` | Owner reference cascading deletion of all owned resources | REQ-007, REQ-012, REQ-013 |
-| [policy-overrides](#policy-overrides) | `keystone-policy` | oslo.policy integration via ConfigMap reference | REQ-008, REQ-012, REQ-013 |
-| [middleware-config](#middleware-config) | `keystone-middleware` | WSGI middleware pipeline customization in api-paste.ini | REQ-009, REQ-012, REQ-013 |
-| [brownfield-database](#brownfield-database) | `keystone-brownfield` | Explicit database host (no MariaDB CRs created) | REQ-010, REQ-012, REQ-013 |
-| [image-upgrade](#image-upgrade) | `keystone-upgrade` | Rolling image update without losing Ready status | REQ-011, REQ-012, REQ-013 |
-| [release-upgrade](#release-upgrade) | `keystone-release-upgrade` | Cross-release upgrade from 2025.2 to 2026.1 via expand-migrate-contract, API accessibility before/after | REQ-001–REQ-009 (CC-0060) |
-| [concurrent-cr-conflicts](#concurrent-cr-conflicts) | `keystone-concurrent-a`, `keystone-concurrent-b` | Concurrent CR reconciliation with shared secrets, sub-resource isolation, deletion without cross-CR impact | REQ-001, REQ-002, REQ-003, REQ-004, REQ-008 (CC-0066) |
-| [config-pruning](#config-pruning) | `keystone-pruning` | Immutable ConfigMap pruning — stale ConfigMaps removed after multiple config changes, retain+1 cap, Ready=True preserved | REQ-007 (CC-0077) |
-| [events](#events) | `keystone-events` | Kubernetes event emission for BootstrapComplete, DatabaseSynced, FernetKeysGenerated, CredentialKeysGenerated | REQ-001, REQ-002 (CC-0070) |
-| [graceful-shutdown](#graceful-shutdown) | `keystone-graceful-shutdown` | Deployment configured with `terminationGracePeriodSeconds=30`, preStop sleep hook, startup probe | REQ-001, REQ-002, REQ-003 (CC-0063) |
-| [healthcheck](#healthcheck) | `keystone-healthcheck` | Post-Deployment HTTP health check gates `KeystoneAPIReady=True` with reason `APIHealthy` before aggregate `Ready` flips | REQ-001, REQ-005 (CC-0067) |
-| [policy-validation](#policy-validation) | `keystone-policy-validation` | `PolicyValidReady` gates the Deployment; validation Job lifecycle on `policyOverrides` add/remove | REQ-001, REQ-002, REQ-003, REQ-005 (CC-0058) |
-| [priority-class](#priority-class) | `keystone-pc` | `spec.priorityClassName` propagation: unset → empty, set → applied, patched empty → removed | REQ-004 (CC-0075) |
-| [schema-drift-detection](#schema-drift-detection) | `keystone-schema-drift` | `DatabaseReady=True` with message "revision verified"; schema-check Job runs and completes | REQ-003, REQ-004 (CC-0064) |
-| [topology-spread](#topology-spread) | `keystone-tsc` | `spec.topologySpreadConstraints`: `nil` injects 2 defaults; non-empty slice passes through verbatim; `[]` disables all constraints | REQ-005 (CC-0075) |
+| Suite | CR Name | Reconciler Behavior Validated |
+| --- | --- | --- |
+| [basic-deployment](#basic-deployment) | `keystone-basic` | Full happy-path reconciliation, all conditions, owned resources, API accessibility |
+| [missing-secret](#missing-secret) | `keystone-missing-secret` | SecretsReady requeue on missing ESO Secrets, recovery on creation |
+| [fernet-rotation](#fernet-rotation) | `keystone-fernet` | CronJob schedule, manual rotation trigger, Secret data change, pod UID stability (no rollout), token validation |
+| [scale](#scale) | `keystone-scale` | Replica scaling up (3→5) and down (5→2) |
+| [deletion-cleanup](#deletion-cleanup) | `keystone-cleanup` | Owner reference cascading deletion of all owned resources |
+| [policy-overrides](#policy-overrides) | `keystone-policy` | oslo.policy integration via ConfigMap reference |
+| [middleware-config](#middleware-config) | `keystone-middleware` | WSGI middleware pipeline customization in api-paste.ini |
+| [brownfield-database](#brownfield-database) | `keystone-brownfield` | Explicit database host (no MariaDB CRs created) |
+| [image-upgrade](#image-upgrade) | `keystone-upgrade` | Rolling image update without losing Ready status |
+| [release-upgrade](#release-upgrade) | `keystone-release-upgrade` | Cross-release upgrade from 2025.2 to 2026.1 via expand-migrate-contract, API accessibility before/after |
+| [concurrent-cr-conflicts](#concurrent-cr-conflicts) | `keystone-concurrent-a`, `keystone-concurrent-b` | Concurrent CR reconciliation with shared secrets, sub-resource isolation, deletion without cross-CR impact |
+| [config-pruning](#config-pruning) | `keystone-pruning` | Immutable ConfigMap pruning — stale ConfigMaps removed after multiple config changes, retain+1 cap, Ready=True preserved |
+| [events](#events) | `keystone-events` | Kubernetes event emission for BootstrapComplete, DatabaseSynced, FernetKeysGenerated, CredentialKeysGenerated |
+| [graceful-shutdown](#graceful-shutdown) | `keystone-graceful-shutdown` | Deployment configured with `terminationGracePeriodSeconds=30`, preStop sleep hook, startup probe |
+| [healthcheck](#healthcheck) | `keystone-healthcheck` | Post-Deployment HTTP health check gates `KeystoneAPIReady=True` with reason `APIHealthy` before aggregate `Ready` flips |
+| [policy-validation](#policy-validation) | `keystone-policy-validation` | `PolicyValidReady` gates the Deployment; validation Job lifecycle on `policyOverrides` add/remove |
+| [priority-class](#priority-class) | `keystone-pc` | `spec.priorityClassName` propagation: unset → empty, set → applied, patched empty → removed |
+| [schema-drift-detection](#schema-drift-detection) | `keystone-schema-drift` | `DatabaseReady=True` with message "revision verified"; schema-check Job runs and completes |
+| [topology-spread](#topology-spread) | `keystone-tsc` | `spec.topologySpreadConstraints`: `nil` injects 2 defaults; non-empty slice passes through verbatim; `[]` disables all constraints |
 
 ---
 
@@ -208,7 +207,7 @@ resource. The ESO controller then syncs the actual Secret.
 Deploys a Keystone CR, verifies the CronJob schedule matches `spec.fernet.rotationSchedule`,
 triggers a manual rotation via `kubectl create job --from=cronjob`, and verifies
 that Secret data changes, pod UIDs remain stable (no Deployment rollout), and a
-fernet token obtained before rotation still validates after rotation (CC-0074).
+fernet token obtained before rotation still validates after rotation.
 
 **Steps:**
 
@@ -217,13 +216,13 @@ fernet token obtained before rotation still validates after rotation (CC-0074).
 | 1 | Apply Keystone CR | `apply` | Applies `00-keystone-cr.yaml` — Keystone CR `keystone-fernet` |
 | 2 | Wait for Ready=True | `assert` (5m) | Ready=True with reason AllReady |
 | 3 | Assert CronJob schedule matches spec | `assert` (5m) | CronJob `keystone-fernet-fernet-rotate` schedule is `"0 0 * * 0"` |
-| 4 | Trigger rotation, verify no rollout, validate token | `script` (180s) | Records pod UIDs and Secret hash before rotation, obtains a fernet token, creates manual Job from CronJob, verifies Secret data hash changed, asserts pod UIDs are unchanged (no rollout), validates the pre-rotation token still works (CC-0074) |
+| 4 | Trigger rotation, verify no rollout, validate token | `script` (180s) | Records pod UIDs and Secret hash before rotation, obtains a fernet token, creates manual Job from CronJob, verifies Secret data hash changed, asserts pod UIDs are unchanged (no rollout), validates the pre-rotation token still works |
 | 5 | Assert Ready=True maintained | `assert` (5m) | Ready=True with reason AllReady after rotation |
 
 **Fixtures:** `00-keystone-cr.yaml`
 
 **Rotation verification approach:** The script step verifies in-place key delivery
-by asserting that pod UIDs remain unchanged after rotation (CC-0074). The Secret
+by asserting that pod UIDs remain unchanged after rotation. The Secret
 data hash comparison confirms the rotation actually occurred, while the token
 validation confirms that Keystone can still decrypt tokens issued with the
 previous key set.
@@ -374,8 +373,8 @@ Keystone CR with tag 2025.2, verifies the Keystone API at `/v3` is accessible, p
 the Deployment image updates to 2026.1, the rollout completes, `installedRelease` reaches
 2026.1, and the Keystone API remains accessible post-upgrade.
 
-This differs from `image-upgrade` (CC-0016), which tests same-release tag swaps
-(2025.2→2025.2-upgraded) without database migration, and from `upgrade-flow` (CC-0056),
+This differs from `image-upgrade`, which tests same-release tag swaps
+(2025.2→2025.2-upgraded) without database migration, and from `upgrade-flow`,
 which focuses on internal state machine mechanics (skip-level rejection).
 
 **Steps:**
@@ -403,7 +402,7 @@ debugging failures.
   avoid conflicts during parallel execution.
 - The 5-minute assert timeout accommodates the full expand→migrate→rolling-update→contract
   cycle.
-- This test complements `upgrade-flow` (CC-0056): `upgrade-flow` validates internal state
+- This test complements `upgrade-flow`: `upgrade-flow` validates internal state
   machine behavior (skip-level rejection, phase transitions), while `release-upgrade`
   validates the user-facing lifecycle (API accessibility before/after, Deployment rollout).
 
@@ -451,7 +450,7 @@ Service status, CronJob status, ConfigMap list, pod logs, and namespace events.
 
 **File:** `tests/e2e/keystone/config-pruning/chainsaw-test.yaml`
 
-**Purpose:** Validates that the immutable ConfigMap pruning logic (CC-0077) caps
+**Purpose:** Validates that the immutable ConfigMap pruning logic caps
 the number of historical config ConfigMaps at `retain + 1` (current + 3
 historical = 4 max) across multiple config changes, while keeping
 `Ready=True` throughout the churn.
@@ -474,7 +473,7 @@ historical = 4 max) across multiple config changes, while keeping
 **File:** `tests/e2e/keystone/events/chainsaw-test.yaml`
 
 **Purpose:** Verifies that the reconciler emits Kubernetes Events for key
-lifecycle transitions (CC-0070) that unit tests with `FakeRecorder` cannot
+lifecycle transitions that unit tests with `FakeRecorder` cannot
 observe: `BootstrapComplete`, `DatabaseSynced`, `FernetKeysGenerated`,
 `CredentialKeysGenerated`.
 
@@ -495,7 +494,7 @@ observe: `BootstrapComplete`, `DatabaseSynced`, `FernetKeysGenerated`,
 **File:** `tests/e2e/keystone/graceful-shutdown/chainsaw-test.yaml`
 
 **Purpose:** Ensures the reconciler configures the Keystone API Deployment with
-the graceful-shutdown shape required by CC-0063:
+the graceful-shutdown shape:
 `terminationGracePeriodSeconds=30`, a `preStop` exec hook (`sleep 5`), and a
 startup probe (`HTTP GET /v3:5000`, `failureThreshold=30`).
 
@@ -515,8 +514,7 @@ startup probe (`HTTP GET /v3:5000`, `failureThreshold=30`).
 
 **File:** `tests/e2e/keystone/healthcheck/chainsaw-test.yaml`
 
-**Purpose:** Validates the post-Deployment HTTP health check sub-reconciler
-(CC-0067). The aggregate `Ready` condition must not flip to `True` until the
+**Purpose:** Validates the post-Deployment HTTP health check sub-reconciler. The aggregate `Ready` condition must not flip to `True` until the
 separate `KeystoneAPIReady` condition is `True` with reason `APIHealthy`,
 meaning the API genuinely responds after `DeploymentReady`.
 
@@ -537,7 +535,7 @@ meaning the API genuinely responds after `DeploymentReady`.
 
 **File:** `tests/e2e/keystone/policy-validation/chainsaw-test.yaml`
 
-**Purpose:** Exercises the policy-validation gating sub-reconciler (CC-0058).
+**Purpose:** Exercises the policy-validation gating sub-reconciler.
 When `policyOverrides` is set, a validation Job runs before the Deployment is
 reconciled; `PolicyValidReady` transitions `False/PolicyValidationInProgress →
 True/PolicyValidationPassed`. Removing `policyOverrides` flips the condition
@@ -562,7 +560,7 @@ to `True/PolicyValidationNotRequired` and cleans up the Job.
 
 **File:** `tests/e2e/keystone/priority-class/chainsaw-test.yaml`
 
-**Purpose:** Validates `spec.priorityClassName` propagation (CC-0075):
+**Purpose:** Validates `spec.priorityClassName` propagation:
 a CR without the field yields an empty `priorityClassName` on the Deployment;
 patching with a valid class sets it; patching with empty string removes it.
 
@@ -587,8 +585,7 @@ patching with a valid class sets it; patching with empty string removes it.
 
 **File:** `tests/e2e/keystone/schema-drift-detection/chainsaw-test.yaml`
 
-**Purpose:** Validates schema-drift detection after successful deployment
-(CC-0064). The reconciler runs a schema-check Job whose completion produces
+**Purpose:** Validates schema-drift detection after successful deployment. The reconciler runs a schema-check Job whose completion produces
 `DatabaseReady=True` with the message
 `"Database schema is up to date (revision verified)"`.
 
@@ -608,7 +605,7 @@ patching with a valid class sets it; patching with empty string removes it.
 
 **File:** `tests/e2e/keystone/topology-spread/chainsaw-test.yaml`
 
-**Purpose:** Validates `spec.topologySpreadConstraints` behavior (CC-0075):
+**Purpose:** Validates `spec.topologySpreadConstraints` behavior:
 `nil` (unset) injects the two default constraints (zone + hostname,
 `MaxSkew=1`, `ScheduleAnyway`); a non-empty slice passes through verbatim;
 an empty slice explicitly disables all constraints.
@@ -728,136 +725,136 @@ single assert step, validating the full progression.
 ```text
 tests/e2e/keystone/
 ├── autoscaling/
-│   ├── chainsaw-test.yaml              HPA reconciliation (CC-0038)
+│   ├── chainsaw-test.yaml              HPA reconciliation
 │   ├── 00-keystone-cr.yaml             Keystone CR with CPU autoscaling
 │   ├── 01-patch-add-memory-metric.yaml Patch to add memory metric
 │   └── 02-patch-disable-autoscaling.yaml Patch to disable autoscaling
 ├── basic-deployment/
-│   ├── chainsaw-test.yaml              Happy-path reconciliation (CC-0016)
+│   ├── chainsaw-test.yaml              Happy-path reconciliation
 │   └── 00-keystone-cr.yaml             Keystone CR in managed mode
 ├── basic-deployment-2026-1/
-│   ├── chainsaw-test.yaml              Happy-path reconciliation 2026.1 (CC-0051)
+│   ├── chainsaw-test.yaml              Happy-path reconciliation 2026.1
 │   └── 00-keystone-cr.yaml             Keystone CR with 2026.1 image
 ├── brownfield-database/
-│   ├── chainsaw-test.yaml              External database mode (CC-0016)
+│   ├── chainsaw-test.yaml              External database mode
 │   ├── 00-brownfield-db-setup.yaml     External database setup
 │   └── 00-keystone-cr.yaml             Keystone CR with database.host
 ├── concurrent-cr-conflicts/
-│   ├── chainsaw-test.yaml              Concurrent CR conflict handling (CC-0066)
+│   ├── chainsaw-test.yaml              Concurrent CR conflict handling
 │   ├── 00-keystone-cr-a.yaml           Keystone CR fixture A (keystone-concurrent-a)
 │   └── 01-keystone-cr-b.yaml           Keystone CR fixture B (keystone-concurrent-b)
 ├── config-pruning/
-│   ├── chainsaw-test.yaml              Immutable ConfigMap pruning (CC-0077)
+│   ├── chainsaw-test.yaml              Immutable ConfigMap pruning
 │   └── 00-keystone-cr.yaml             Keystone CR for pruning test
 ├── credential-rotation/
-│   ├── chainsaw-test.yaml              Credential key rotation (CC-0036, CC-0074)
+│   ├── chainsaw-test.yaml              Credential key rotation
 │   └── 00-keystone-cr.yaml             Keystone CR with rotation schedule
 ├── deletion-cleanup/
-│   ├── chainsaw-test.yaml              Garbage collection (CC-0016)
+│   ├── chainsaw-test.yaml              Garbage collection
 │   └── 00-keystone-cr.yaml             Keystone CR for cleanup test
 ├── events/
-│   ├── chainsaw-test.yaml              Kubernetes event emission (CC-0070)
+│   ├── chainsaw-test.yaml              Kubernetes event emission
 │   └── 00-keystone-cr.yaml             Keystone CR for event test
 ├── fernet-rotation/
-│   ├── chainsaw-test.yaml              Fernet key rotation (CC-0016, CC-0074)
+│   ├── chainsaw-test.yaml              Fernet key rotation
 │   └── 00-keystone-cr.yaml             Keystone CR with rotation schedule
 ├── graceful-shutdown/
-│   ├── chainsaw-test.yaml              Graceful shutdown (CC-0063)
+│   ├── chainsaw-test.yaml              Graceful shutdown
 │   └── 00-keystone-cr.yaml             Keystone CR for graceful shutdown
 ├── healthcheck/
-│   ├── chainsaw-test.yaml              Post-Deployment API health check (CC-0067)
+│   ├── chainsaw-test.yaml              Post-Deployment API health check
 │   └── 00-keystone-cr.yaml             Keystone CR for healthcheck test
 ├── image-upgrade/
-│   ├── chainsaw-test.yaml              Rolling image upgrade (CC-0016)
+│   ├── chainsaw-test.yaml              Rolling image upgrade
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial image tag
 │   └── 01-patch-image.yaml             Patch spec.image.tag
 ├── invalid-cr/
-│   ├── chainsaw-test.yaml                                  CRD webhook + CEL validation (CC-0012, CC-0094)
-│   ├── _generate.py                                        Canonical scaffold + generator for CC-0094 fixtures (sourcery-ai review #1)
-│   ├── test_generate.py                                    Fast unit tests for the generator: drift check, FIXTURES count, chainsaw-test.yaml cross-reference (CC-0094, run by `make verify-invalid-cr-fixtures`)
-│   ├── 00-invalid-cron.yaml                                Invalid cron expression CR (CC-0012)
-│   ├── 01-duplicate-plugins.yaml                           Duplicate plugin configSection CR (CC-0012)
-│   ├── 02-database-both-modes.yaml                         Database both modes set (CC-0094, generated)
-│   ├── 03-cache-both-modes.yaml                            Cache both modes set (CC-0094, generated)
-│   ├── 04-autoscaling-no-target.yaml                       Autoscaling without target (CC-0094, generated)
-│   ├── 05-policy-overrides-no-source.yaml                  PolicyOverrides without source (CC-0094, generated)
-│   ├── 06-policy-overrides-empty-rule-key.yaml             PolicyOverrides empty rule key (CC-0094, generated)
-│   ├── 07-networkpolicy-empty-ingress.yaml                 NetworkPolicy empty ingress (CC-0094, generated)
-│   ├── 09-replicas-negative.yaml                           replicas: -1 (CC-0094, generated; subsumes dropped 08-replicas-zero case)
-│   ├── 10-hpa-min-greater-than-max.yaml                    HPA minReplicas > maxReplicas (CC-0094, generated)
-│   ├── 11-fernet-maxactivekeys-below-minimum.yaml          Fernet maxActiveKeys < 3 (CC-0094, generated)
-│   └── 12-credentialkeys-maxactivekeys-below-minimum.yaml  CredentialKeys maxActiveKeys < 3 (CC-0094, generated)
+│   ├── chainsaw-test.yaml                                  CRD webhook + CEL validation
+│   ├── _generate.py                                        Canonical scaffold + generator for invalid-cr fixtures
+│   ├── test_generate.py                                    Fast unit tests for the generator: drift check, FIXTURES count, chainsaw-test.yaml cross-reference (run by `make verify-invalid-cr-fixtures`)
+│   ├── 00-invalid-cron.yaml                                Invalid cron expression CR
+│   ├── 01-duplicate-plugins.yaml                           Duplicate plugin configSection CR
+│   ├── 02-database-both-modes.yaml                         Database both modes set (generated)
+│   ├── 03-cache-both-modes.yaml                            Cache both modes set (generated)
+│   ├── 04-autoscaling-no-target.yaml                       Autoscaling without target (generated)
+│   ├── 05-policy-overrides-no-source.yaml                  PolicyOverrides without source (generated)
+│   ├── 06-policy-overrides-empty-rule-key.yaml             PolicyOverrides empty rule key (generated)
+│   ├── 07-networkpolicy-empty-ingress.yaml                 NetworkPolicy empty ingress (generated)
+│   ├── 09-replicas-negative.yaml                           replicas: -1 (generated; subsumes dropped 08-replicas-zero case)
+│   ├── 10-hpa-min-greater-than-max.yaml                    HPA minReplicas > maxReplicas (generated)
+│   ├── 11-fernet-maxactivekeys-below-minimum.yaml          Fernet maxActiveKeys < 3 (generated)
+│   └── 12-credentialkeys-maxactivekeys-below-minimum.yaml  CredentialKeys maxActiveKeys < 3 (generated)
 ├── middleware-config/
-│   ├── chainsaw-test.yaml              Middleware pipeline (CC-0016)
+│   ├── chainsaw-test.yaml              Middleware pipeline
 │   └── 00-keystone-cr.yaml             Keystone CR with custom middleware
 ├── missing-secret/
-│   ├── chainsaw-test.yaml              Secret dependency recovery (CC-0016)
+│   ├── chainsaw-test.yaml              Secret dependency recovery
 │   ├── 00-keystone-cr.yaml             Keystone CR with non-existent secretRefs
 │   └── 01-late-secrets.yaml            ExternalSecrets created after CR
 ├── namespace-scoped-rbac/
-│   ├── chainsaw-test.yaml              Namespace-scoped RBAC (CC-0043)
+│   ├── chainsaw-test.yaml              Namespace-scoped RBAC
 │   └── 00-keystone-cr.yaml             Keystone CR for RBAC test
 ├── network-policy/
-│   ├── chainsaw-test.yaml              NetworkPolicy reconciliation (CC-0039)
+│   ├── chainsaw-test.yaml              NetworkPolicy reconciliation
 │   ├── 00-keystone-cr.yaml             Keystone CR with ingress policy
 │   ├── 01-patch-update-ingress.yaml    Patch ingress rule
 │   └── 02-patch-disable-networkpolicy.yaml Patch to disable NetworkPolicy
 ├── policy-overrides/
-│   ├── chainsaw-test.yaml              oslo.policy integration (CC-0016)
+│   ├── chainsaw-test.yaml              oslo.policy integration
 │   ├── 00-policy-cm.yaml               Policy source ConfigMap
 │   └── 01-keystone-cr.yaml             Keystone CR with policyOverrides
 ├── policy-validation/
-│   ├── chainsaw-test.yaml              Policy validation gating (CC-0058)
+│   ├── chainsaw-test.yaml              Policy validation gating
 │   ├── 00-policy-cm.yaml               Policy source ConfigMap
 │   ├── 01-keystone-cr.yaml             Keystone CR with policyOverrides
 │   └── 02-patch-disable-policy.yaml    Patch to remove policyOverrides
 ├── priority-class/
-│   ├── chainsaw-test.yaml              spec.priorityClassName propagation (CC-0075)
+│   ├── chainsaw-test.yaml              spec.priorityClassName propagation
 │   ├── 00-priority-class.yaml          Cluster-scoped PriorityClass fixture
 │   ├── 01-keystone-cr.yaml             Keystone CR without priorityClassName
 │   ├── 02-patch-priority-class.yaml    Patch to set priorityClassName
 │   └── 03-patch-empty-priority-class.yaml Patch to clear priorityClassName
 ├── release-upgrade/
-│   ├── chainsaw-test.yaml              Cross-release upgrade 2025.2→2026.1 (CC-0060)
+│   ├── chainsaw-test.yaml              Cross-release upgrade 2025.2→2026.1
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial tag 2025.2
 │   └── 01-patch-upgrade.yaml           Patch spec.image.tag to 2026.1
 ├── resources/
-│   ├── chainsaw-test.yaml              Resource defaults and propagation (CC-0042)
+│   ├── chainsaw-test.yaml              Resource defaults and propagation
 │   ├── 00-keystone-cr.yaml             Keystone CR without explicit resources
 │   └── 01-patch-custom-resources.yaml  Patch with custom resource limits
 ├── scale/
-│   ├── chainsaw-test.yaml              Replica scaling and PDB (CC-0016, CC-0037)
+│   ├── chainsaw-test.yaml              Replica scaling and PDB
 │   ├── 00-keystone-cr.yaml             Keystone CR with replicas: 3
 │   ├── 01-patch-scale-up.yaml          Patch replicas to 5
 │   ├── 02-patch-scale-down.yaml        Patch replicas to 2
 │   └── 03-patch-scale-to-one.yaml      Patch replicas to 1
 ├── schema-drift-detection/
-│   ├── chainsaw-test.yaml              Schema drift detection (CC-0064)
+│   ├── chainsaw-test.yaml              Schema drift detection
 │   └── 00-keystone-cr.yaml             Keystone CR for schema drift test
 ├── topology-spread/
-│   ├── chainsaw-test.yaml              spec.topologySpreadConstraints (CC-0075)
+│   ├── chainsaw-test.yaml              spec.topologySpreadConstraints
 │   ├── 00-keystone-cr.yaml             Keystone CR without explicit TSC
 │   ├── 01-patch-custom-tsc.yaml        Patch with custom TSC
 │   └── 02-patch-empty-tsc.yaml         Patch with empty TSC (disable)
 ├── trust-flush/
-│   ├── chainsaw-test.yaml              Trust flush CronJob (CC-0057)
+│   ├── chainsaw-test.yaml              Trust flush CronJob
 │   ├── 00-keystone-cr.yaml             Keystone CR with trustFlush config
 │   └── 01-patch-disable-trust-flush.yaml Patch to disable trust flush
 ├── upgrade-flow/
-│   ├── chainsaw-test.yaml              Expand-migrate-contract upgrade (CC-0056)
+│   ├── chainsaw-test.yaml              Expand-migrate-contract upgrade
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial release
 │   ├── 01-patch-upgrade.yaml           Patch for sequential upgrade
 │   └── 02-patch-skip-level.yaml        Patch for skip-level upgrade
 └── uwsgi/
-    ├── chainsaw-test.yaml              uWSGI command propagation (CC-0040)
+    ├── chainsaw-test.yaml              uWSGI command propagation
     ├── 00-keystone-cr.yaml             Keystone CR without explicit uWSGI
     └── 01-patch-custom-uwsgi.yaml      Patch with custom uWSGI settings
 ```
 
 ## Related Resources
 
-- [Keystone CRD API Reference](../keystone/keystone-crd.md) — CRD types, webhooks, and `invalid-cr` E2E tests (CC-0011, CC-0012, CC-0094)
-- [Keystone Reconciler Architecture](../keystone/keystone-reconciler.md) — Sub-reconciler contracts and unit tests (CC-0013, CC-0015)
-- [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md) — Infrastructure stack deployment and `infra-stack-health` test (CC-0010)
+- [Keystone CRD API Reference](../keystone/keystone-crd.md) — CRD types, webhooks, and `invalid-cr` E2E tests
+- [Keystone Reconciler Architecture](../keystone/keystone-reconciler.md) — Sub-reconciler contracts and unit tests
+- [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md) — Infrastructure stack deployment and `infra-stack-health` test
 - `tests/e2e/chainsaw-config.yaml` — Shared Chainsaw configuration
 - `.github/workflows/ci.yaml` — CI workflow with E2E job

--- a/docs/reference/testing/tempest-test-infrastructure.md
+++ b/docs/reference/testing/tempest-test-infrastructure.md
@@ -1,19 +1,18 @@
 ---
 title: Tempest Test Infrastructure
 quadrant: infrastructure
-feature: CC-0035, CC-0051
 ---
 
 ::: v-pre
 
 # Tempest Test Infrastructure
 
-Reference documentation for the Tempest API test infrastructure (CC-0035, CC-0051). This
+Reference documentation for the Tempest API test infrastructure. This
 covers the Tempest container image, version management, per-service test configuration,
 the image verification script, local execution via `hack/run-tempest.sh`, the `make
 tempest-test` target, and CI integration in both `ci.yaml` and `build-images.yaml`.
-CC-0051 extended the infrastructure with multi-release support: the `tempest` job in
-`ci.yaml` now uses a release matrix to validate each OpenStack release independently,
+The infrastructure supports multiple releases: the `tempest` job in
+`ci.yaml` uses a release matrix to validate each OpenStack release independently,
 and `build-images.yaml` dynamically discovers releases for the Tempest image pipeline.
 
 ## File Locations
@@ -23,15 +22,15 @@ and `build-images.yaml` dynamically discovers releases for the Tempest image pip
 | `images/tempest/Dockerfile` | Two-stage Tempest container image (venv-builder → python-base) |
 | `releases/<release>/test-refs.yaml` | PyPI version pins for test tooling (single source of truth), per release |
 | `tests/tempest/keystone-2025-2/` | Keystone 2025.2 Tempest configuration (`tempest.conf`, `include-tests.txt`, `exclude-tests.txt`) |
-| `tests/tempest/keystone-2026-1/` | Keystone 2026.1 Tempest configuration (CC-0051) |
+| `tests/tempest/keystone-2026-1/` | Keystone 2026.1 Tempest configuration |
 | `tests/container-images/verify_tempest.sh` | Image verification script (PASS/FAIL counters) |
 | `hack/run-tempest.sh` | Local orchestration script for running Tempest against a kind cluster |
-| `hack/ci-run-tempest.sh` | CI-specific Tempest wrapper with port-forwarding and config generation (CC-0050) |
+| `hack/ci-run-tempest.sh` | CI-specific Tempest wrapper with port-forwarding and config generation |
 | `hack/tempest/extract-failed.py` | Print anchored regex patterns for failed testcases in a JUnit report (used to build the retry include-list) |
 | `hack/tempest/merge-retry-junit.py` | Merge a retry subunit stream into a JUnit report, rewriting resolved failures as flakes |
 | `hack/tempest/run-tests.sh` | Shared in-container runner invoked by both runners; holds the phase + retry + exit-code logic so it stays identical between CI and local runs |
 | `Makefile` | `tempest-test` target delegates to `hack/run-tempest.sh` |
-| `.github/workflows/ci.yaml` | `tempest` job with release matrix (CC-0051) |
+| `.github/workflows/ci.yaml` | `tempest` job with release matrix |
 | `.github/workflows/build-images.yaml` | `build-tempest` and `merge-tempest-image` jobs (release-parameterized via `generate-matrix`) |
 
 ## Architecture
@@ -118,7 +117,7 @@ in three ways: (1) it installs from PyPI instead of mounting a git source tree,
 
 - Copies `/var/lib/openstack` virtualenv from the build stage via `COPY --from=build --link`
 - Sets static OCI labels (title, description, licenses, vendor) following the
-  two-layer annotation pattern (CC-0031)
+  two-layer annotation pattern
 - Runs as `openstack` user (UID 42424, GID 42424)
 
 **Final image properties:**
@@ -423,12 +422,12 @@ Omitting `SERVICE` produces an error message:
 
 ### ci.yaml — tempest Job
 
-The `tempest` job (CC-0050, CC-0051) is a dedicated job that deploys services into a kind
-cluster and runs the OpenStack Tempest test suite. CC-0051 added a release matrix so each
-OpenStack release is validated independently with its own Tempest configuration, Keystone
+The `tempest` job is a dedicated job that deploys services into a kind
+cluster and runs the OpenStack Tempest test suite. A release matrix lets each
+OpenStack release be validated independently with its own Tempest configuration, Keystone
 CR, and K8s service name.
 
-**Release matrix (CC-0051):**
+**Release matrix:**
 
 | Release | Config directory | CR name | K8s service name |
 | --- | --- | --- | --- |
@@ -461,7 +460,7 @@ CR, and K8s service name.
 ### build-images.yaml — build-tempest Job
 
 Builds the Tempest container image per release and per platform, runs verification on PRs,
-and pushes by digest on push events. CC-0051 parameterized this job by release via the
+and pushes by digest on push events. The job is parameterized by release via the
 `generate-matrix` job, which discovers all releases from `releases/*/` directories.
 
 **Dependencies:** `needs: [lint-dockerfiles, merge-base-images, verify-base-images, generate-matrix]`
@@ -473,11 +472,11 @@ and pushes by digest on push events. CC-0051 parameterized this job by release v
 | Step | Condition | Description |
 | --- | --- | --- |
 | Resolve Tempest versions | Always | Reads `releases/<release>/test-refs.yaml` via `yq` |
-| Generate metadata | Always | OCI labels via `docker/metadata-action` (CC-0031) |
+| Generate metadata | Always | OCI labels via `docker/metadata-action` |
 | Build Tempest image | PR: amd64 only; push: both platforms | `docker/build-push-action` with named build contexts, `upper-constraints` from `releases/<release>/` |
 | Export digest | Push only | Writes digest to `/tmp/digests/` for merge job |
 | Upload digest artifact | Push only | `digests-tempest-<release>-<platform-pair>`, 1-day retention |
-| Scan for vulnerabilities | PR, amd64 only | Grype scan against loaded image (CC-0032) |
+| Scan for vulnerabilities | PR, amd64 only | Grype scan against loaded image |
 | Upload SARIF | PR, if scan produced output | GitHub Security tab under `grype-tempest-<release>-<platform>` |
 | Verify Tempest image | PR, amd64 only | Runs `verify_tempest.sh` against the built image |
 
@@ -493,7 +492,7 @@ and pushes by digest on push events. CC-0051 parameterized this job by release v
 ### build-images.yaml — merge-tempest-image Job
 
 Assembles per-platform digests into a multi-arch manifest list with full supply chain
-security. CC-0051 parameterized this job by release via the `generate-matrix` job.
+security. The job is parameterized by release via the `generate-matrix` job.
 
 **Dependencies:** `needs: [build-tempest, generate-matrix]`
 **Condition:** `if: github.event_name != 'pull_request'`
@@ -505,9 +504,9 @@ security. CC-0051 parameterized this job by release via the `generate-matrix` jo
 | --- | --- |
 | `contents: read` | Repository checkout |
 | `packages: write` | Push manifest list to GHCR |
-| `id-token: write` | Sigstore OIDC signing for cosign and build provenance (CC-0030) |
-| `attestations: write` | GitHub Attestations API (CC-0029) |
-| `security-events: write` | SARIF upload to GitHub Security tab (CC-0032) |
+| `id-token: write` | Sigstore OIDC signing for cosign and build provenance |
+| `attestations: write` | GitHub Attestations API |
+| `security-events: write` | SARIF upload to GitHub Security tab |
 
 **Image tags applied:**
 
@@ -538,8 +537,7 @@ strategy:
       - images/python-base/Dockerfile
       - images/venv-builder/Dockerfile
       - images/keystone/Dockerfile
-      - images/tempest/Dockerfile      # CC-0035
-      - operators/keystone/Dockerfile
+      - images/tempest/Dockerfile
 ```
 
 Hadolint runs with `failure-threshold: warning` and the project's `.hadolint.yaml`
@@ -596,14 +594,14 @@ releases/<release>/test-refs.yaml ──yq──▶ TEMPEST_VERSION + KEYSTONE_T
 
 ## Dependencies on Prior Features
 
-| Feature | Artifact | Used by Tempest infrastructure |
-| --- | --- | --- |
-| CC-0006 | `images/python-base/Dockerfile`, `images/venv-builder/Dockerfile` | Base images for the Tempest Dockerfile build chain |
-| CC-0006 | `releases/<release>/upper-constraints.txt` | Dependency constraints for PyPI installs |
-| CC-0028 | `tests/lib/assertions.sh` | Assertion helpers sourced by `verify_tempest.sh` |
-| CC-0029 | SBOM attestation pattern in `build-images.yaml` | Reused by `merge-tempest-image` for Tempest SBOM |
-| CC-0030 | Cosign signing pattern in `build-images.yaml` | Reused by `merge-tempest-image` for Tempest signing |
-| CC-0031 | Two-layer OCI annotation pattern | Static Dockerfile labels + CI metadata-action |
-| CC-0032 | Grype scanning pattern in `build-images.yaml` | Reused by `build-tempest` and `merge-tempest-image` |
+| Artifact | Used by Tempest infrastructure |
+| --- | --- |
+| `images/python-base/Dockerfile`, `images/venv-builder/Dockerfile` | Base images for the Tempest Dockerfile build chain |
+| `releases/<release>/upper-constraints.txt` | Dependency constraints for PyPI installs |
+| `tests/lib/assertions.sh` | Assertion helpers sourced by `verify_tempest.sh` |
+| SBOM attestation pattern in `build-images.yaml` | Reused by `merge-tempest-image` for Tempest SBOM |
+| Cosign signing pattern in `build-images.yaml` | Reused by `merge-tempest-image` for Tempest signing |
+| Two-layer OCI annotation pattern | Static Dockerfile labels + CI metadata-action |
+| Grype scanning pattern in `build-images.yaml` | Reused by `build-tempest` and `merge-tempest-image` |
 
 :::


### PR DESCRIPTION
Strip all CC-XXXX and REQ-XXX feature ticket references from user-facing documentation under docs/ — including frontmatter feature: fields, parenthetical references in prose, dedicated requirement columns in tables, code-block comments, and HTML comments. Rephrase prose that referenced tickets directly (e.g. "before CC-0081", "since CC-0095", "tracked under CC-0042"). Update cross-document anchor links that had been suffixed with -cc-XXXX so they continue to resolve after the matching headings were renamed.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com