### PR TITLE
fix(ci): make untagged-image pruning opt-in to unblock manifest list …

### DIFF
--- a/.github/actions/cleanup-ghcr-package/action.yaml
+++ b/.github/actions/cleanup-ghcr-package/action.yaml
@@ -4,9 +4,10 @@
 ---
 name: Cleanup GHCR package
 description: >
-  Delete untagged and old images for a single GHCR package.
+  Delete old images for a single GHCR package.
   Supports two modes for selecting old tagged images: either a glob
-  pattern (delete-tags) or a keep-list (exclude-tags).
+  pattern (delete-tags) or a keep-list (exclude-tags). Untagged-image
+  pruning is opt-in via delete-untagged (default false).
 
 inputs:
   package:
@@ -32,6 +33,17 @@ inputs:
     description: "Minimum age of images to delete (e.g. '7 days')"
     required: false
     default: "7 days"
+  delete-untagged:
+    description: >
+      Also delete untagged / ghost / partial images. Opt-in because a
+      multi-arch `push-by-digest` flow (build-and-push →
+      merge-operator-images) leaves the per-platform manifests untagged
+      until the manifest list is assembled; pruning untagged images
+      while such a push is in flight removes the digests imagetools
+      needs and breaks the merge step (GH-312). Safe to enable from
+      the nightly cleanup workflow where no parallel push runs.
+    required: false
+    default: "false"
   token:
     description: GitHub token with packages:write scope
     required: true
@@ -40,6 +52,7 @@ runs:
   using: composite
   steps:
     - name: Delete untagged images
+      if: inputs.delete-untagged == 'true'
       uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
       with:
         package: ${{ inputs.package }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1066,6 +1066,12 @@ jobs:
         package: [keystone-operator, keystone, tempest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # GH-312: do NOT pass delete-untagged here. This job runs in
+      # parallel with build-and-push, which uploads per-platform
+      # manifests via push-by-digest=true (i.e. untagged) and relies on
+      # merge-operator-images to assemble them into a tagged manifest
+      # list. Pruning untagged images mid-flight removes those digests
+      # and breaks the merge step.
       - name: Delete run-scoped tags for ${{ matrix.package }}
         uses: ./.github/actions/cleanup-ghcr-package
         with:

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -55,6 +55,7 @@ jobs:
           delete-tags: "*.*.*-p*-*-*"
           keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
           older-than: ${{ inputs.older-than || '7 days' }}
+          delete-untagged: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── 1. Service images (SHA tags) ───────────────────────────────────
@@ -71,6 +72,7 @@ jobs:
           exclude-tags: latest
           keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
           older-than: ${{ inputs.older-than || '7 days' }}
+          delete-untagged: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── 2. venv-builder (after service images) ─────────────────────────
@@ -88,6 +90,7 @@ jobs:
           exclude-tags: latest
           keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
           older-than: ${{ inputs.older-than || '7 days' }}
+          delete-untagged: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── 3. python-base (after venv-builder) ────────────────────────────
@@ -105,6 +108,7 @@ jobs:
           exclude-tags: latest
           keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
           older-than: ${{ inputs.older-than || '7 days' }}
+          delete-untagged: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── 4. Operator images (independent) ───────────────────────────────
@@ -128,6 +132,7 @@ jobs:
           exclude-tags: latest
           keep-n-tagged: ${{ inputs.keep-n-tagged || '10' }}
           older-than: ${{ inputs.older-than || '7 days' }}
+          delete-untagged: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── 5. E2E run-scoped tags (safety net for cancelled CI runs) ──────


### PR DESCRIPTION
…push

The cleanup-ghcr-package composite action unconditionally pruned untagged / ghost / partial images as its first step. The new cleanup-e2e-tags job introduced in #311 invokes that action in parallel with build-and-push, which uploads per-platform manifests via push-by-digest=true (i.e. untagged) and relies on merge-operator-images to assemble them into the final tagged manifest list. The cleanup removed those just-pushed digests mid-flight, so imagetools create failed with `keystone-operator@sha256:…: not found` and broke the merge job (observed on run 25133054106 / commit 951c2e5).

- Add a `delete-untagged` input (default `false`) to cleanup-ghcr-package and gate the untagged-pruning step on it; the why is documented in the input description.
- Set `delete-untagged: "true"` on the five nightly cleanup-images callers (service-images, service-sha-images, venv-builder, python-base, operator-images) so their behavior is unchanged. The cleanup-e2e-stale-tags safety-net keeps the default off because untagged pruning for those packages is already covered by the per-package nightly jobs.
- Leave cleanup-e2e-tags in ci.yaml on the default and add a comment pointing at GH-312 so future readers don't reintroduce the race.

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com