### PR TITLE
fix(ci): grant artifact-metadata:write to suppress attest storage-rec…

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -165,6 +165,7 @@ jobs:
       packages: write
       id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing
       attestations: write   # CC-0029, CC-0035: GitHub Attestations API
+      artifact-metadata: write  # gh#108: actions/attest v4.1.0 storage record
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     outputs:
       python-base-image: ghcr.io/${{ needs.prepare.outputs.image-owner }}/python-base@${{ steps.merge-python-base.outputs.digest }}
@@ -326,6 +327,7 @@ jobs:
       packages: write
       id-token: write          # CC-0030, CC-0035: Sigstore OIDC signing
       attestations: write      # CC-0029, CC-0035: GitHub Attestations API
+      artifact-metadata: write # gh#108: actions/attest v4.1.0 storage record
       security-events: write   # CC-0032: GitHub Security tab SARIF upload
     strategy:
       fail-fast: false
@@ -373,6 +375,7 @@ jobs:
       packages: write
       id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing
       attestations: write   # CC-0029, CC-0035: GitHub Attestations API
+      artifact-metadata: write  # gh#108: actions/attest v4.1.0 storage record
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     strategy:
       fail-fast: false
@@ -458,6 +461,7 @@ jobs:
       packages: write
       id-token: write       # CC-0029, CC-0030, CC-0035: Sigstore OIDC signing
       attestations: write   # CC-0029, CC-0035: GitHub Attestations API
+      artifact-metadata: write  # gh#108: actions/attest v4.1.0 storage record
       security-events: write  # CC-0032: GitHub Security tab SARIF upload
     strategy:
       fail-fast: false


### PR DESCRIPTION
…ord warning

actions/attest v4.1.0 (commit 59d8942, pinned via the supply-chain-attest composite) calls POST /orgs/{owner}/artifacts/metadata/storage-record after the OCI push. With only attestations:write set, the API responds "no artifacts found" and the action emits a warning twice per merge job (SBOM
+ build-provenance) across merge-base-images, merge-tempest-image, build-service-images, and merge-service-images. The action wraps the call in try/catch so workflows stay green, but every run on main has eight warnings asking for artifact-metadata:write — the README explicitly lists that permission for the storage-record feature.

Add artifact-metadata:write to the four jobs that invoke the composite action, ordered between attestations:write and security-events:write with a gh#108 marker comment so the rationale is searchable. If the API still returns "no artifacts found" with the permission granted (i.e. GHCR containers are not yet wired to the org artifact index), the fallback is to set create-storage-record:false on both attest steps.

Closes #108

AI-assisted: Claude Code
On-behalf-of: @SAP christian.berendt@sap.com