### PR TITLE
ci: retry container registry login to absorb transient ghcr.io flakes

### DIFF
--- a/.github/actions/load-e2e-images/action.yaml
+++ b/.github/actions/load-e2e-images/action.yaml
@@ -53,7 +53,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+    - uses: ./.github/actions/registry-login
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}

--- a/.github/actions/registry-login/action.yaml
+++ b/.github/actions/registry-login/action.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Container registry login with retry/backoff. docker/login-action has no
+# built-in retry, so a transient ghcr.io timeout ("context deadline exceeded")
+# fails the whole job. This wraps `docker login` in a bounded retry loop so
+# registry/DNS/TLS flakes no longer break CI.
+
+name: Registry login
+description: >
+  Authenticate to a container registry via `docker login` with bounded
+  retry and linear backoff to absorb transient network failures.
+
+inputs:
+  registry:
+    description: Container registry URL
+    required: false
+    default: ghcr.io
+  username:
+    description: Registry username
+    required: true
+  password:
+    description: Registry password/token
+    required: true
+  attempts:
+    description: Maximum number of login attempts
+    required: false
+    default: '5'
+  base-delay:
+    description: >
+      Base delay in seconds for the linear backoff between attempts; the
+      Nth retry waits N * base-delay seconds.
+    required: false
+    default: '5'
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to ${{ inputs.registry }}
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_USERNAME: ${{ inputs.username }}
+        REGISTRY_PASSWORD: ${{ inputs.password }}
+        MAX_ATTEMPTS: ${{ inputs.attempts }}
+        BASE_DELAY: ${{ inputs.base-delay }}
+      run: |
+        set -euo pipefail
+        for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+          if echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY" \
+               --username "$REGISTRY_USERNAME" --password-stdin; then
+            exit 0
+          fi
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            delay=$((attempt * BASE_DELAY))
+            echo "::warning::docker login to $REGISTRY failed (attempt $attempt/$MAX_ATTEMPTS); retrying in ${delay}s"
+            sleep "$delay"
+          fi
+        done
+        echo "::error::docker login to $REGISTRY failed after $MAX_ATTEMPTS attempts"
+        exit 1

--- a/.github/actions/setup-docker-registry/action.yaml
+++ b/.github/actions/setup-docker-registry/action.yaml
@@ -33,7 +33,7 @@ runs:
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
     - name: Log in to container registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      uses: ./.github/actions/registry-login
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}

--- a/.github/workflows/check-base-image-updates.yaml
+++ b/.github/workflows/check-base-image-updates.yaml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Normalize image owner
         id: meta
         run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      - uses: ./.github/actions/registry-login
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -648,6 +648,28 @@ jobs:
       # cancelled workflows in cleanup-images.yaml.
       - name: Push E2E images to GHCR
         run: |
+          # docker push has no built-in retry, so a transient ghcr.io timeout
+          # ("Client.Timeout exceeded while awaiting headers") fails the whole
+          # job even though login already succeeded. Mirror the bounded
+          # retry/backoff of the registry-login action so push flakes no
+          # longer break CI.
+          MAX_ATTEMPTS=5
+          BASE_DELAY=5
+          push_with_retry() {
+            local run_ref="$1"
+            for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+              if docker push "${run_ref}"; then
+                return 0
+              fi
+              if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                local delay=$((attempt * BASE_DELAY))
+                echo "::warning::docker push ${run_ref} failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delay}s"
+                sleep "$delay"
+              fi
+            done
+            echo "::error::docker push ${run_ref} failed after ${MAX_ATTEMPTS} attempts"
+            return 1
+          }
           push_image() {
             local local_ref="$1"     # e.g. ghcr.io/c5c3/keystone:2025.2
             local repo="${local_ref%:*}"
@@ -655,7 +677,7 @@ jobs:
             local run_ref="${repo}:${RUN_TAG}-${tag}"
             echo "::group::Push ${run_ref}"
             docker tag "${local_ref}" "${run_ref}"
-            docker push "${run_ref}"
+            push_with_retry "${run_ref}"
             echo "::endgroup::"
           }
           for op in $BUILD_OPERATORS; do

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -561,7 +561,7 @@ jobs:
       # Enable BuildKit (required for type=gha cache) as the default builder.
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      - uses: ./.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -1111,7 +1111,7 @@ jobs:
           platform: ${{ matrix.platform.name }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      - uses: ./.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -1171,7 +1171,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      - uses: ./.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Problem

In [run 26095599689](https://github.com/C5C3/forge/actions/runs/26095599689/job/76736733851) the `verify-base-images` job failed not on a code/config bug but on a transient registry flake:

```
Logging into ghcr.io...
##[error]Error response from daemon: Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

`docker/login-action` has **no built-in retry**, so any single ghcr.io DNS/TLS/network hiccup kills the whole job.

## Change

- New shared composite action `.github/actions/registry-login`: `docker login --password-stdin` with 5 attempts and linear backoff (5/10/15/20 s).
- Wired into all **6** login sites:
  - `.github/actions/setup-docker-registry/action.yaml`
  - `.github/actions/load-e2e-images/action.yaml`
  - `.github/workflows/ci.yaml` (3×)
  - `.github/workflows/check-base-image-updates.yaml` (also gains an `actions/checkout`, required to reference a local action)

## Design notes

- Plain bash retry loop instead of a third-party retry action, to avoid a new SHA-pinned, Renovate-tracked supply-chain dependency.
- Bounded retry by design: a real, sustained ghcr.io outage still fails fast rather than retrying forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)