### PR TITLE
fix(test-shell): align flux-web pins with FLUX_OPERATOR_VERSION v0.50.0

### DIFF
--- a/deploy/kind/base/flux-web.yaml
+++ b/deploy/kind/base/flux-web.yaml
@@ -46,7 +46,7 @@
 #
 # Version pin: `spec.inputs[0].version` is a SemVer range locked to the
 # minor track of `FLUX_OPERATOR_VERSION` in hack/deploy-infra.sh (today
-# v0.49.0 → 0.49.x). Bump both together when upgrading the operator.
+# v0.50.0 → 0.50.x). Bump both together when upgrading the operator.
 #
 # Feature: CC-0086, REQ-001
 ---
@@ -64,7 +64,7 @@ spec:
   # This keeps the kind-only addon self-contained — no extra
   # ResourceSetInputProvider CR to maintain. Feature: CC-0086, REQ-001
   inputs:
-    - version: "0.49.x"
+    - version: "0.50.x"
   resources:
     - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository

--- a/tests/unit/deploy/kind_base_flux_web_test.sh
+++ b/tests/unit/deploy/kind_base_flux_web_test.sh
@@ -138,7 +138,7 @@ test_kustomize_build_emits_resourceset() {
 # --- Test 3: chart version pin is a SemVer range locked to the minor
 #             track shipped by hack/deploy-infra.sh (CC-0086, REQ-001) ---
 test_chart_version_pin_is_semver_range() {
-  echo "Test: ResourceSet spec.inputs[0].version is 0.49.x and matches FLUX_OPERATOR_VERSION minor track (CC-0086, REQ-001)"
+  echo "Test: ResourceSet spec.inputs[0].version is 0.50.x and matches FLUX_OPERATOR_VERSION minor track (CC-0086, REQ-001)"
 
   if [[ ! -f "$FLUX_WEB_FILE" ]]; then
     echo "  FAIL: $FLUX_WEB_FILE does not exist"
@@ -152,12 +152,12 @@ test_chart_version_pin_is_semver_range() {
   else
     local version
     version="$(yq -r '.spec.inputs[0].version' "$FLUX_WEB_FILE" 2>/dev/null | head -n1)"
-    assert_eq "spec.inputs[0].version pins the 0.49.x SemVer range" "0.49.x" "$version"
+    assert_eq "spec.inputs[0].version pins the 0.50.x SemVer range" "0.50.x" "$version"
   fi
 
-  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.49.0\"" \
+  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.50.0\"" \
     "$DEPLOY_INFRA_SH" \
-    'FLUX_OPERATOR_VERSION="v0.49.0"'
+    'FLUX_OPERATOR_VERSION="v0.50.0"'
 }
 
 # --- Test 4: kind kustomization lists flux-web.yaml after headlamp.yaml (CC-0086, REQ-002) ---


### PR DESCRIPTION
## Summary
- Renovate bump c2da42a0 raised `FLUX_OPERATOR_VERSION` to `v0.50.0` in `hack/deploy-infra.sh` but left the related chart-range pin in `deploy/kind/base/flux-web.yaml` (`0.49.x`) and the regression test in `tests/unit/deploy/kind_base_flux_web_test.sh` unchanged, so `make test-shell` on `main` has been red since.
- Bumps the chart pin and its in-file comment to `0.50.x`, and updates the test's `version` / `FLUX_OPERATOR_VERSION` assertions to match.
- No production-overlay changes; `deploy/flux-system/` is unaffected (the test still verifies zero diff vs. `origin/main`).

## Why renovate missed it
The custom regex manager for `deploy/kind/base/flux-web.yaml` targets `- version: "..."`, but the `0.49.x` (range) value is not a SemVer release that the `github-releases` datasource can resolve, so renovate does not produce a follow-up PR. The two files have to be bumped manually in lockstep with each minor cycle.

## Test plan
- [x] `bash tests/unit/deploy/kind_base_flux_web_test.sh` — 19 passed, 0 failed
- [ ] CI `test-shell` job goes green on this branch
- [ ] CI `e2e-infra` still installs the flux-operator (sanity-check that `0.50.x` resolves a real chart version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)