### PR TITLE
feat(CC-0107): Use mTLS client-cert auth for OpenBao instead of SA tokens

### DIFF
--- a/.planwerk/CC-0107-pr-description.md
+++ b/.planwerk/CC-0107-pr-description.md
@@ -1,0 +1,202 @@
+# CC-0107 — Enforce mTLS client-cert auth on OpenBao listener
+
+Closes #321.
+
+## Summary
+
+OpenBao previously ran with **server-side TLS only**: the listener proved
+OpenBao's identity to clients, but the transport layer placed no
+requirement on the client's identity — anything with network reach to
+`openbao.openbao-system.svc:8200` and a valid Kubernetes ServiceAccount
+token (or, for the Raft inter-node path, merely the leader CA) was
+admitted. This PR adds **transport-layer mutual TLS** to the OpenBao API
+listener so every connection must present a client certificate that
+chains to the same self-signed CA as the server cert *before* any
+application-layer auth (Kubernetes JWT, AppRole, root token) runs.
+
+Scope is deliberately limited to the transport layer; the existing
+Kubernetes-ServiceAccount-token authentication / authorization model
+(`auth.kubernetes` on `kubernetes/management`, the `eso-management`
+role, and the CC-0009 / CC-0083 audit invariants in
+`deploy/openbao/policies/{eso-management,push-keystone-keys}.hcl`) is
+preserved unchanged. Switching ESO (or any client) to the `cert`
+AuthMethod is an explicit Non-Goal.
+
+The change touches:
+
+- `deploy/flux-system/releases/openbao.yaml` — adds
+  `tls_client_ca_file = "/openbao/tls/ca.crt"` and
+  `tls_require_and_verify_client_cert = true` to the HA listener; adds
+  `leader_client_cert_file` / `leader_client_key_file` to all three
+  `retry_join` stanzas; adds the `client-tls` volume / volumeMount.
+- `deploy/kind/base/kustomization.yaml` — applies the same
+  `tls_client_ca_file` + require-and-verify mode to the kind
+  `standalone.config` listener (the two-listener consistency footgun
+  per **Apply bug fixes to all instances of the same pattern**).
+- `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml` (new) —
+  two cert-manager `Certificate` resources (`openbao-client-tls`,
+  `eso-openbao-client-tls`) issued by `selfsigned-cluster-issuer` with
+  `usages: ["client auth"]`, registered in the infrastructure
+  `kustomization.yaml`.
+- `deploy/eso/clustersecretstore.yaml` — adds the Vault-provider
+  `tls.certSecretRef` / `tls.keySecretRef` pointing at
+  `eso-openbao-client-tls`; the `auth.kubernetes` block and `caProvider`
+  remain byte-unchanged.
+- `deploy/openbao/bootstrap/{common.sh,init-unseal.sh}` and
+  `hack/deploy-infra.sh` — forward `VAULT_CLIENT_CERT` /
+  `VAULT_CLIENT_KEY` through every `bao`-invoking wrapper (`bao_exec`,
+  `bao_exec_stdin`, private `kube_exec`, `openbao_kube_exec`).
+- `tests/unit/deploy/openbao_mtls_test.sh` (new) — full mTLS-wiring
+  unit suite (70 assertions, all PASS); `production_posture_test.sh`
+  extends its `:(exclude)` carve-out to cover `openbao.yaml` and the
+  header records the CC-0107 deviation mirroring CC-0097 chaos-mesh.
+- `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml` —
+  Step 4 keeps the `ClusterSecretStore` + three `ExternalSecret`
+  `Ready=True` assertions, now annotated as running under enforced mTLS.
+- `docs/reference/infrastructure/{openbao-bootstrap,infrastructure-manifests}.md`
+  — TLS Configuration / Certificate-SANs tables, `VAULT_CLIENT_*` env
+  vars, runnable operator negative-check probe, OpenBao Helm-values
+  table and narrative all updated.
+
+## Architecture submodule follow-up (Task 7.3)
+
+`.gitmodules` pins `architecture → https://github.com/C5C3/C5C3` at
+commit `7beebd6f2d66a1012f16a52c3990bed9033b5af8`. That revision's
+`docs/09-implementation/09-openbao-deployment.md` documents the
+OpenBao HelmRelease — and at the pinned commit it carries **only the
+server-side TLS configuration**, with no notion of client-cert
+verification or the mTLS trust chain this PR adds:
+
+```yaml
+# architecture/docs/09-implementation/09-openbao-deployment.md, ~L42-L88
+# At submodule pin 7beebd6f the listener block has no
+# tls_client_ca_file / tls_require_and_verify_client_cert, the three
+# retry_join stanzas carry only leader_api_addr (no
+# leader_client_cert_file / leader_client_key_file), and the
+# server.volumes / server.volumeMounts block mounts only the
+# `tls` (server) Secret at /openbao/tls — there is no `client-tls`
+# volume backing /openbao/client-tls.
+listener "tcp" {
+  tls_disable     = 0
+  address         = "[::]:8200"
+  cluster_address = "[::]:8201"
+  tls_cert_file   = "/openbao/tls/tls.crt"
+  tls_key_file    = "/openbao/tls/tls.key"
+}
+...
+volumes:
+  - name: tls
+    secret:
+      secretName: openbao-tls
+volumeMounts:
+  - name: tls
+    mountPath: /openbao/tls
+    readOnly: true
+```
+
+Per repository rule `NO_SUBMODULE_MODIFICATIONS` (and boundary #11 of
+the CC-0107 elaboration: the `architecture/` submodule is READ-ONLY
+from this worktree's perspective and serves exclusively as a source of
+information), this worktree does **not** touch submodule content.
+The design-rationale correction must land via a separate upstream PR
+to `https://github.com/C5C3/C5C3` against
+`docs/09-implementation/09-openbao-deployment.md`, and must mirror the
+transport-layer wiring this PR establishes in the repository:
+
+1. **HA listener block** (currently L45-L51 at pin `7beebd6f`) — add:
+
+    ```hcl
+    tls_client_ca_file               = "/openbao/tls/ca.crt"
+    tls_require_and_verify_client_cert = true
+    ```
+
+   alongside the existing `tls_cert_file` / `tls_key_file` lines, and
+   record the rationale: the listener rejects any TLS handshake
+   without a valid client cert before any application-layer auth runs;
+   `tls_client_ca_file` reuses the self-signed CA bundle so client
+   certs minted by `selfsigned-cluster-issuer` chain to it.
+
+2. **All three `retry_join` stanzas** (currently L55-L63 at pin
+   `7beebd6f`) — add:
+
+    ```hcl
+    leader_client_cert_file = "/openbao/client-tls/tls.crt"
+    leader_client_key_file  = "/openbao/client-tls/tls.key"
+    ```
+
+   to each stanza (not just one — Raft `retry_join` targets the API
+   listener on `:8200`, so once that listener requires client certs
+   every peer must present one or the cluster will not form).
+
+3. **`server.volumes` / `server.volumeMounts`** (currently L81-L88 at
+   pin `7beebd6f`) — add a second volume mounting the in-pod client
+   keypair Secret at a path distinct from the server-cert mount:
+
+    ```yaml
+    volumes:
+      - name: tls
+        secret:
+          secretName: openbao-tls
+      - name: client-tls          # CC-0107
+        secret:
+          secretName: openbao-client-tls
+    volumeMounts:
+      - name: tls
+        mountPath: /openbao/tls
+        readOnly: true
+      - name: client-tls          # CC-0107
+        mountPath: /openbao/client-tls
+        readOnly: true
+    ```
+
+   The two mount paths are intentionally distinct so that server-cert
+   and client-cert lifecycles (separate cert-manager `Certificate`
+   resources, separate Secrets, independent rotations) cannot collide.
+
+4. **Client-cert `Certificate` resources** — document that two
+   additional `cert-manager.io/v1` `Certificate`s are required:
+
+   - `openbao-client-tls` (Secret `openbao-client-tls` in
+     `openbao-system`) — mounted into the StatefulSet for Raft
+     `retry_join` peer auth and in-pod `bao` exec via the bootstrap
+     scripts.
+   - `eso-openbao-client-tls` (Secret `eso-openbao-client-tls` in
+     `openbao-system`) — referenced by the ESO
+     `ClusterSecretStore/openbao-cluster-store` via
+     `spec.provider.vault.tls.certSecretRef` / `keySecretRef`.
+
+   Both are issued by `selfsigned-cluster-issuer` with
+   `usages: ["client auth"]` and share the `openbao-tls` `duration` /
+   `renewBefore` (`8760h` / `720h`) so server and client rotation
+   cadences stay aligned. SANs on the client certs are identifiers
+   only — the listener does not verify SANs on client auth, only
+   chain-to-CA.
+
+5. **ESO `ClusterSecretStore`** — note that the existing K8s-token
+   auth method (`auth.kubernetes` on `kubernetes/management`, role
+   `eso-management`) is **unchanged**: mTLS is purely a transport-layer
+   admission gate layered *underneath* the existing app-layer auth.
+   The CC-0009 / CC-0083 audit invariants in
+   `deploy/openbao/policies/{eso-management,push-keystone-keys}.hcl`
+   are preserved.
+
+6. **Operator interface** — document the `VAULT_CLIENT_CERT` /
+   `VAULT_CLIENT_KEY` env vars (defaulting to
+   `/openbao/client-tls/tls.crt` and `/openbao/client-tls/tls.key`) and
+   add a runnable mTLS-enforcement probe consistent with
+   `docs/reference/infrastructure/openbao-bootstrap.md#verify-mtls-enforcement-cc-0107`
+   (no-client-cert `curl` from inside the pod, expected to fail at the
+   TLS handshake; same call with the client keypair, expected
+   `http_code=200`).
+
+Once the upstream PR merges, bump the submodule pin here in a
+follow-up worktree to pick up the corrected architecture doc.
+
+Tracking: this upstream follow-up must be opened against
+`https://github.com/C5C3/C5C3` (target file
+`docs/09-implementation/09-openbao-deployment.md`) before CC-0107 can
+be considered fully propagated across the documentation surface
+(REQ-011). The follow-up PR link will be added to this PR description
+once filed, per the **Verify cross-file consistency across the PR
+scope** project pattern and the CC-0093 / CC-0097 / CC-0098 precedents
+for cross-repo design-doc handoff.

--- a/.planwerk/completed/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of.json
+++ b/.planwerk/completed/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of.json
@@ -1,0 +1,912 @@
+{
+  "feature_id": "CC-0107",
+  "title": "Use mTLS client-cert auth for OpenBao instead of SA tokens",
+  "slug": "use-mtls-client-cert-auth-for-openbao-instead-of",
+  "status": "completed",
+  "phase": "awaiting_external_review",
+  "summary": "",
+  "description": "# GitHub Issue #321: feat: mTLS (client-cert auth) for OpenBao instead of K8s ServiceAccount tokens\n\n**Description:**\n\nOpenBao runs today with **server-side TLS only**. This issue adds **transport-layer mutual TLS**: the OpenBao API listener will require and verify a client certificate, every client that talks to OpenBao will present one, and the Raft inter-node join path will additionally be pinned by client cert rather than only by leader CA. The change is deliberately scoped to the *transport layer*; the Kubernetes-ServiceAccount-token authentication/authorization model (auth roles, HCL policies, audit invariants) is left intact, with mTLS layered *on top of* it. (Issue is GitHub #321; the repo's `# Feature: CC-XXXX` header convention would tag this **CC-0321** — treat the exact tag as an assumption to confirm with maintainers, matching the existing `CC-0009`/`CC-0083` headers throughout `deploy/openbao/`.)\n\nThis touches the **frozen production overlay**, so the blast radius is larger than the file count suggests. Reviewers should ground the rationale in the review patterns **Kubernetes TLS and Certificate Management**, **Verify TLS trust chain completeness for internal CAs**, **Never skip TLS verification when CA cert is available**, **Apply security mitigations consistently across all files**, **Apply bug fixes to all instances of the same pattern**, and **Document intentional environment divergence in overlays**.\n\n### Concrete boundaries\n\n**1. Server TLS exists; client-cert verification does not.**\nAlready exists: `deploy/flux-system/releases/openbao.yaml:30` sets `global.tlsDisable: false`; the HA Raft listener block (`deploy/flux-system/releases/openbao.yaml`, listener stanza, `tls_disable = 0`, `tls_cert_file = /openbao/tls/tls.crt`, `tls_key_file = /openbao/tls/tls.key`) has **no `tls_client_ca_file`**. This issue adds `tls_client_ca_file` and the client-verification mode to that listener stanza.\n\n**2. The kind overlay duplicates the listener and must move in lockstep.**\nAlready exists: `deploy/kind/base/kustomization.yaml` patches OpenBao into `standalone` mode with a **second, independent listener block** (`standalone.config`, `tls_disable = 0`, same cert/key paths, `ui = true`, no `retry_join`). This issue adds the same `tls_client_ca_file` to that block. Leaving one block unpatched is exactly the failure mode the **Apply bug fixes to all instances of the same pattern** project pattern exists to catch — there are two listeners, not one.\n\n**3. The only direct OpenBao TLS client in this repo is ESO.**\nAlready exists: the Keystone operator never dials OpenBao directly — it goes through ESO CRs only: `ExternalSecret` reads (`deploy/eso/externalsecrets/keystone-db.yaml`, `keystone-admin.yaml`, `mariadb-root-password.yaml`) and operator-generated `PushSecret`s (`operators/keystone/internal/controller/reconcile_fernet.go:443-445`, `operators/keystone/internal/controller/reconcile_credential.go:447-449`), all referencing the `openbao-cluster-store` `ClusterSecretStore` (`operators/keystone/internal/controller/reconcile_secrets.go:23-29`). `deploy/eso/clustersecretstore.yaml:21` points ESO at `https://openbao.openbao-system.svc:8200`, validates the server cert via `caProvider` (`deploy/eso/clustersecretstore.yaml:31-35`, Secret `openbao-tls` key `ca.crt` in `openbao-system`), and authenticates via the Kubernetes auth method (`deploy/eso/clustersecretstore.yaml:24-30`). This issue adds the ESO client-cert reference to that store; it does **not** add a new direct OpenBao client.\n\n**4. Bootstrap scripts are in-pod localhost clients and also break under require-and-verify.**\nAlready exists: `deploy/openbao/bootstrap/common.sh:18-19` (`BAO_ADDR=https://127.0.0.1:8200`, `VAULT_CACERT=/openbao/tls/ca.crt`); `bao_exec`/`bao_exec_stdin` (`common.sh:36-49`) and `init-unseal.sh`'s own `kube_exec` (`deploy/openbao/bootstrap/init-unseal.sh:30-35`) forward env via `env ...` into `kubectl exec openbao-0 -- bao …`. There is **no `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` anywhere in the repo** (verified by grep). This issue adds those env vars (pointing at a client-cert path mounted *inside the openbao pod*) to all three exec wrappers — `common.sh`, `init-unseal.sh`, and the inline duplicate in `hack/deploy-infra.sh:652-655` (`openbao_kube_exec`).\n\n**5. `hack/deploy-infra.sh` re-implements init/unseal/bootstrap inline for single-replica kind.**\nAlready exists: `openbao_init_unseal` (`hack/deploy-infra.sh:664-744`), `openbao_bootstrap` (`hack/deploy-infra.sh:752-791`, runs `setup-secret-engines.sh`/`setup-auth.sh`/`setup-policies.sh`/`write-bootstrap-secrets.sh`), and its own `VAULT_CACERT` default (`hack/deploy-infra.sh:99`). Because this path does not source `common.sh`, the mTLS env-var change must be applied here independently — another instance of the **Apply security mitigations consistently across all files** pattern.\n\n**6. Raft join is pinned by leader CA only, not by client cert.**\nAlready exists: three `retry_join` stanzas (`deploy/flux-system/releases/openbao.yaml`, the `storage \"raft\"` block) use `leader_api_addr = https://openbao-N.openbao-internal:8200` + `leader_ca_cert_file = /openbao/tls/ca.crt`. Because `retry_join` targets the **API listener (8200)**, once that listener requires client certs, peers must also present `leader_client_cert_file`/`leader_client_key_file` or the cluster will not form. This issue adds those keys to all three stanzas.\n\n**7. Client certificates do not exist; only a server cert does.**\nAlready exists: one cert-manager `Certificate` — `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` (`secretName: openbao-tls`, issuer `selfsigned-cluster-issuer` ClusterIssuer at `deploy/flux-system/infrastructure/cluster-issuer.yaml`, server DNS SANs + loopback IPs, `duration: 8760h`, `renewBefore: 720h`, no `usages` field). This issue adds **client-auth `Certificate`(s)** issued by the same `selfsigned-cluster-issuer` (the issue's \"Out of scope\" explicitly forbids replacing the self-signed issuer): at minimum one for ESO and one for the OpenBao pods/bootstrap. `tls_client_ca_file` points at the same self-signed CA (`/openbao/tls/ca.crt`), so client certs validate against the issuer's CA bundle.\n\n**8. The production overlay is byte-frozen by a unit test.**\nAlready exists: `tests/unit/deploy/production_posture_test.sh:65-113` (`test_production_overlay_unchanged`) asserts `deploy/flux-system/fluxinstance.yaml` and `deploy/flux-system/releases/*` are byte-identical to `origin/main`, with a single `:(exclude)` carve-out for the CC-0097 chaos-mesh relocation (`production_posture_test.sh:84-87`). Editing `deploy/flux-system/releases/openbao.yaml` for mTLS **will fail this test**. This issue must extend the carve-out (add an `openbao.yaml` exclusion mirroring the existing chaos-mesh `:(exclude)` pathspec) and update the test's header comment to record why — see project pattern **Update documentation when referenced code behavior changes** and **Require inline comments for intentional convention deviations**.\n\n**9. Auth model decision is left to this elaboration.**\nThe issue asks whether to switch ESO to the `cert` AuthMethod or keep K8s-token auth with mTLS as pure transport hardening. The smallest concrete change that satisfies the issue is **keep K8s-token auth** (`deploy/openbao/bootstrap/setup-auth.sh:54-105`, `eso-management` role binding `eso-management.hcl` + `push-keystone-keys.hcl`) and add mTLS strictly at the transport layer. Switching to the `cert` AuthMethod would rip out the `kubernetes/management` role/policy binding model and invalidate the CC-0009/CC-0083 audit invariants documented in `deploy/openbao/policies/eso-management.hcl:19-45` and `deploy/openbao/policies/push-keystone-keys.hcl` — a far larger blast radius. That swap is moved to **Non-Goals**.\n\n**10. The observable health gate is the ESO stack, not OpenBao internals.**\nAlready exists: `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml:132-175` (Step 4) asserts `ClusterSecretStore/openbao-cluster-store` is `Ready=True reason:Valid` and the three `ExternalSecret`s reach `Ready=True reason:SecretSynced`. This is the existing observable invariant that mTLS **must not break**. `tests/e2e-chaos/openbao-pod-kill/` exercises Raft recovery and is the existing guard for boundary #6.\n\n**11. Architecture rationale lives in an uninitialised submodule.**\n`.gitmodules` declares `architecture` → `https://github.com/C5C3/C5C3`; the `architecture/` directory in this worktree is **empty** (only `.`/`..`). The design-rationale doc the OpenBao header references (`architecture/docs/09-implementation/09-openbao-deployment.md`, cited from `deploy/flux-system/releases/openbao.yaml` header and `docs/reference/infrastructure/infrastructure-manifests.md:311`) cannot be edited from this repo. Any architecture-doc update is tracked by a commit-message link to the external PR, per the **Verify cross-file consistency across the PR scope** project pattern (CC-0097/CC-0098 precedent) — do not silently claim a submodule edit.\n\n**Motivation:**\n\nThe issue's \"Why\" is explicit: OpenBao is the root of trust for every credential in the stack (`kv-v2/bootstrap/*`, `kv-v2/infrastructure/mariadb`, `kv-v2/openstack/keystone/*`, the fernet/credential key backups). Server-side TLS proves OpenBao's identity to clients but proves **nothing about the client's identity at the transport layer** — anything with network reach to `openbao.openbao-system.svc:8200` and a valid ServiceAccount token (or, for the Raft path, merely the leader CA) is admitted. In a Zero-Trust / dedicated-tenant posture this is insufficient defense in depth. Requiring a client certificate at the listener closes that gap before any application-layer auth runs, and aligns with the **Secure by Design and Default** and **Kubernetes TLS and Certificate Management** patterns (TLS between all cluster components, not just ingress).\n\nThis is the OpenBao instance of a tracked hardening track — the issue's \"Tracking\" note states sibling issues cover MariaDB and Memcached TLS. Establishing the cert-manager-issued-client-cert + listener-`tls_client_ca_file` + per-client-secret-ref pattern here is the reference implementation those siblings will mirror, the same way the README describes the Keystone-first strategy. Getting the trust-chain wiring and the two-listener / three-exec-wrapper consistency right here is what makes the sibling tracks mechanical rather than novel.\n\nSkipping this leaves the Raft inter-node path authenticated only by leader CA pinning (boundary #6) — peer authenticity is not cryptographically established per-connection — and leaves OpenBao's transport layer with no notion of client identity, so the entire access-control story rests on a single ServiceAccount-token bearer credential whose theft grants full read (and, for the management ESO role, write) of the secret store.\n\n**Affected Areas:**\n\n- `deploy/flux-system/releases/openbao.yaml` — add `tls_client_ca_file` + client-verification mode to the HA listener; add `leader_client_cert_file`/`leader_client_key_file` to all three `retry_join` stanzas; add a `server.volumes`/`server.volumeMounts` entry mounting the OpenBao client-cert Secret (alongside the existing `tls` mount).\n- `deploy/kind/base/kustomization.yaml` — apply the same `tls_client_ca_file` + verification mode to the `standalone.config` listener block (no `retry_join` in standalone); decide and document the kind verification mode (recommend matching production; if relaxed, document the divergence per **Document intentional environment divergence in overlays**).\n- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` (or a new sibling file under `deploy/flux-system/infrastructure/`) — new cert-manager `Certificate`(s) with `usages: [\"client auth\"]` issued by `selfsigned-cluster-issuer`: one producing the OpenBao-pod client-cert Secret (mounted into the StatefulSet), one producing the ESO client-cert Secret in `openbao-system`.\n- `deploy/flux-system/infrastructure/kustomization.yaml` — register any new Certificate file (per **Verify new resources are referenced by parent manifests** / **Verify all implicit resource dependencies exist at apply time**).\n- `deploy/eso/clustersecretstore.yaml` — add the ESO Vault-provider client-cert/key Secret references (issue names them `tls.clientCertSecretRef` / `tls.clientKeySecretRef`; confirm the exact `external-secrets.io/v1` Vault-provider field path against the pinned chart `>=0.10.0 <1.0.0`).\n- `deploy/openbao/bootstrap/common.sh` — add `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` (in-pod paths) to the `env …` invocations in `bao_exec`/`bao_exec_stdin`.\n- `deploy/openbao/bootstrap/init-unseal.sh` — add the same env vars to its private `kube_exec` (init/unseal run before any token exists; they still hit the require-and-verify listener).\n- `hack/deploy-infra.sh` — add the same env vars to `openbao_kube_exec` and ensure the single-replica `openbao_init_unseal`/`openbao_bootstrap` paths still succeed under mTLS; thread a `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` default alongside the existing `VAULT_CACERT` default (`hack/deploy-infra.sh:99`).\n- `tests/unit/deploy/production_posture_test.sh` — extend the `:(exclude)` carve-out to cover `deploy/flux-system/releases/openbao.yaml`; update the header comment explaining the deviation.\n- `tests/unit/deploy/` — new `*_test.sh` asserting the listener carries `tls_client_ca_file` in both the production and kind overlays, that `retry_join` carries the leader client cert/key, and that the ClusterSecretStore carries the client-cert refs (mirrors the existing shell-unit-test convention; runs via `make test-shell`, `Makefile:170-178`).\n- `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml` — strengthen Step 4 (or add a sibling step) to assert the store/ExternalSecrets stay `Ready` *under mTLS* (the existing assertions remain the regression guard).\n- `docs/reference/infrastructure/openbao-bootstrap.md` — update the **TLS Configuration** table (`docs/reference/infrastructure/openbao-bootstrap.md:438-459`), the Certificate-SANs table, the **setup-auth.sh** auth-method tables, and the **Environment Setup** / required-env-var section to document `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY`.\n- `docs/reference/infrastructure/infrastructure-manifests.md` — update the OpenBao Helm-values table (`docs/reference/infrastructure/infrastructure-manifests.md:312-326`) and the OpenBao narrative (`:308-311`) to state mTLS is enforced and describe the client-cert wiring.\n\n**Acceptance Criteria:**\n\n- [ ] The production HA listener in `deploy/flux-system/releases/openbao.yaml` declares `tls_client_ca_file` and an explicit client-verification mode; a unit test under `tests/unit/deploy/` asserts its presence and fails if removed.\n- [ ] The kind `standalone.config` listener in `deploy/kind/base/kustomization.yaml` declares the same `tls_client_ca_file`; the same unit test asserts both overlays carry it (catches the two-listener drift).\n- [ ] All three `retry_join` stanzas in `deploy/flux-system/releases/openbao.yaml` declare `leader_client_cert_file` and `leader_client_key_file`; `make deploy-infra` brings up a healthy single-replica kind cluster and (where exercisable) the HA Raft cluster forms with all peers `Ready`.\n- [ ] `tests/e2e-chaos/openbao-pod-kill/` still passes — Raft peers re-join under mutual auth after a pod kill.\n- [ ] `kubectl get clustersecretstore openbao-cluster-store -o jsonpath='{.status.conditions}'` shows `Ready=True reason:Valid`, and `keystone-db`, `keystone-admin`, `mariadb-root-password` ExternalSecrets reach `Ready=True reason:SecretSynced` — i.e. `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml` Step 4 passes with mTLS enforced.\n- [ ] A negative check demonstrates enforcement: a Vault/OpenBao API call from inside the cluster *without* a client cert against the 8200 listener is rejected at the TLS layer (documented as a runbook command in `docs/reference/infrastructure/openbao-bootstrap.md`, runnable by an operator).\n- [ ] `deploy/openbao/bootstrap/{common.sh,init-unseal.sh}` and `hack/deploy-infra.sh` all pass `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY`; `grep -rl VAULT_CLIENT_CERT deploy/openbao hack` returns all three wrappers (consistency guard per **Apply security mitigations consistently across all files**).\n- [ ] The new client-cert `Certificate`(s) set `usages: [\"client auth\"]`, are issued by `selfsigned-cluster-issuer`, are referenced from `deploy/flux-system/infrastructure/kustomization.yaml`, and their Secrets exist in `openbao-system` before the consuming resources reconcile (no first-apply ordering failure).\n- [ ] `bash tests/unit/deploy/production_posture_test.sh` passes: the `openbao.yaml` carve-out is in place and the header documents why the production overlay is no longer byte-frozen for that file.\n- [ ] `make test-shell` and `chainsaw lint` (`Makefile:160-178`) pass; the new chainsaw assertions lint clean.\n- [ ] `docs/reference/infrastructure/openbao-bootstrap.md` and `infrastructure-manifests.md` reflect the new client-cert env vars, the new Certificate(s), and the listener change; the doc tables stay structurally consistent with their siblings (per **Ensure parallel documentation structures are consistent**), and any required-tool/env-var additions appear in the Prerequisites/Environment sections.\n\n**Non-Goals:**\n\n- **Switching ESO (or any client) to the `cert` AuthMethod.** Per boundary #9, K8s-ServiceAccount-token authentication is retained; mTLS is transport-layer only. Replacing the `kubernetes/management` role/policy model is a separate, larger change that would invalidate the CC-0009/CC-0083 audit invariants in `deploy/openbao/policies/`.\n- **Replacing the self-signed `selfsigned-cluster-issuer` with a real CA.** Explicitly out of scope per the issue; all client certs are issued by the existing self-signed ClusterIssuer and validated against the same CA bundle.\n- **Integrating Vault Agent / the injector.** `injector.enabled: false` (`deploy/flux-system/releases/openbao.yaml`) stays unchanged; explicitly out of scope per the issue.\n- **MariaDB and Memcached mTLS.** Tracked by the sibling issues referenced in the issue's \"Tracking\" note; this issue is OpenBao-only.\n- **Editing the `architecture/` submodule.** It is not checked out in this worktree (boundary #11); architecture-doc rationale is handled by an external-PR link in the commit log, not a fabricated submodule bump.\n- **Changing the OpenBao chart version or HA topology.** The `>=0.5.0 <1.0.0` constraint and 3-replica HA / kind-standalone topologies are unchanged; only the listener/Raft/volume config and client wiring change.\n\n**References:**\n\n- Issue #321 — `https://github.com/C5C3/forge/issues/321`\n- `deploy/flux-system/releases/openbao.yaml` — production HA HelmRelease + listener + `retry_join` (boundaries #1, #6, #7)\n- `deploy/kind/base/kustomization.yaml` — kind standalone listener patch (boundary #2)\n- `deploy/eso/clustersecretstore.yaml` — ESO Vault provider, `caProvider`, K8s auth (boundary #3)\n- `deploy/eso/externalsecrets/{keystone-db,keystone-admin,mariadb-root-password}.yaml` — ESO consumers\n- `operators/keystone/internal/controller/{reconcile_secrets.go,reconcile_fernet.go,reconcile_credential.go}` — proof the operator is not a direct OpenBao client (boundary #3)\n- `deploy/openbao/bootstrap/common.sh`, `init-unseal.sh`, `setup-auth.sh`, `setup-policies.sh`, `setup-secret-engines.sh`, `write-bootstrap-secrets.sh` — bootstrap exec wrappers and auth/policy model (boundaries #4, #9)\n- `deploy/openbao/policies/eso-management.hcl`, `push-keystone-keys.hcl` — CC-0009/CC-0083 audit invariants (Non-Goals)\n- `hack/deploy-infra.sh:99,652-655,664-744,752-791` — inline kind init/unseal/bootstrap (boundary #5)\n- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml`, `cluster-issuer.yaml`, `kustomization.yaml` — cert-manager wiring (boundary #7)\n- `tests/unit/deploy/production_posture_test.sh:65-113` — frozen-overlay guard (boundary #8)\n- `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml:132-175`, `tests/e2e-chaos/openbao-pod-kill/` — observable health/recovery gates (boundary #10)\n- `docs/reference/infrastructure/openbao-bootstrap.md:438-459`, `infrastructure-manifests.md:308-326` — doc update targets\n- `.github/workflows/ci.yaml:92-103,484-516` — `e2e_infra`/`e2e_chaos` path filters and the `e2e-infra` job; `Makefile:160-178` — `test-shell`/`chainsaw lint` runners\n- Review patterns: *Kubernetes TLS and Certificate Management*, *Kubernetes Secrets Management*, *API Authentication and Authorization*, *Secure by Design and Default*; project patterns *Verify TLS trust chain completeness for internal CAs*, *Never skip TLS verification when CA cert is available*, *Apply security mitigations consistently across all files*, *Apply bug fixes to all instances of the same pattern*, *Document intentional environment divergence in overlays*, *Verify all implicit resource dependencies exist at apply time*, *Verify new resources are referenced by parent manifests*, *Ensure parallel documentation structures are consistent*, *Update documentation when referenced code behavior changes*\n\n---\n\n_Elaborated by [planwerk-review](https://github.com/planwerk/planwerk-review) with Claude Code_\n\n\n**Labels:** enhancement\n\n---\nSource: https://github.com/C5C3/forge/issues/321",
+  "stories": [
+    {
+      "title": "Platform operator deploys a kind cluster with mTLS-enforced OpenBao",
+      "role": "platform/SRE operator",
+      "want": "make deploy-infra to bring up a healthy single-replica kind OpenBao with the API listener requiring a verified client certificate",
+      "so_that": "the transport layer rejects any client without a valid cert before application-layer auth runs",
+      "criteria": [
+        "deploy/kind/base/kustomization.yaml standalone.config listener declares tls_client_ca_file = \"/openbao/tls/ca.crt\" and tls_require_and_verify_client_cert = true",
+        "openbao_init_unseal and openbao_bootstrap in hack/deploy-infra.sh complete without TLS handshake failures (client cert presented)",
+        "openbao-0 pod reaches Ready and `bao status` returns initialized+unsealed via the in-pod client cert",
+        "kustomize build deploy/kind/base renders without error and the rendered HelmRelease contains tls_client_ca_file"
+      ]
+    },
+    {
+      "title": "Security reviewer verifies client-cert enforcement and consistency",
+      "role": "security reviewer",
+      "want": "every OpenBao API listener and every OpenBao TLS client to enforce/present a client cert with no unpatched instance",
+      "so_that": "the two-listener / three-exec-wrapper drift footgun cannot reintroduce an unauthenticated transport path",
+      "criteria": [
+        "Both the production HA listener and the kind standalone listener carry tls_client_ca_file (asserted by a unit test that fails if either is removed)",
+        "grep -rl VAULT_CLIENT_CERT deploy/openbao hack returns common.sh, init-unseal.sh, and hack/deploy-infra.sh (exactly the three wrappers)",
+        "All three retry_join stanzas carry leader_client_cert_file and leader_client_key_file",
+        "A documented operator runbook command shows a no-client-cert API call to :8200 is rejected at the TLS layer"
+      ]
+    },
+    {
+      "title": "ESO continues syncing secrets under mTLS",
+      "role": "system (External Secrets Operator)",
+      "want": "the openbao-cluster-store ClusterSecretStore to present a client certificate while keeping Kubernetes-token auth",
+      "so_that": "keystone-db, keystone-admin, and mariadb-root-password ExternalSecrets stay Ready=True reason:SecretSynced",
+      "criteria": [
+        "deploy/eso/clustersecretstore.yaml references an ESO client-cert and client-key Secret (clientCert/clientKey) in openbao-system",
+        "The Kubernetes auth block (mountPath kubernetes/management, role eso-management) is unchanged",
+        "chainsaw infra-stack-health Step 4 still asserts ClusterSecretStore Ready=True reason:Valid and the three ExternalSecrets Ready=True reason:SecretSynced",
+        "The ESO client-cert Secret exists in openbao-system before the ClusterSecretStore reconciles (no first-apply ordering failure)"
+      ]
+    },
+    {
+      "title": "Raft cluster forms and recovers under mutual TLS",
+      "role": "platform/SRE operator",
+      "want": "all three OpenBao peers to present client certs on the retry_join API path so the HA cluster forms and re-joins after a pod kill",
+      "so_that": "peer authenticity is cryptographically established per-connection, not merely by leader CA pinning",
+      "criteria": [
+        "All three retry_join stanzas declare leader_client_cert_file=/openbao/client-tls/tls.crt and leader_client_key_file=/openbao/client-tls/tls.key",
+        "The OpenBao client-cert Secret is mounted into the StatefulSet at a path distinct from the server tls mount",
+        "tests/e2e-chaos/openbao-pod-kill/ continues to pass (peers re-join under mutual auth)",
+        "The client Certificate sets usages: [\"client auth\"] and is issued by selfsigned-cluster-issuer"
+      ]
+    },
+    {
+      "title": "Reviewer confirms the frozen production overlay deviation is documented",
+      "role": "reviewer / maintainer",
+      "want": "the production_posture_test.sh byte-freeze to carve out openbao.yaml with a recorded rationale",
+      "so_that": "the intentional production-overlay change does not silently break the freeze guard and the deviation is auditable",
+      "criteria": [
+        "tests/unit/deploy/production_posture_test.sh adds a :(exclude)deploy/flux-system/releases/openbao.yaml pathspec mirroring the chaos-mesh carve-out",
+        "The test header comment records why openbao.yaml is no longer byte-frozen (CC-0107 mTLS)",
+        "bash tests/unit/deploy/production_posture_test.sh passes",
+        "fluxinstance.yaml and all other releases/* remain byte-identical (no broadening of the carve-out)"
+      ]
+    },
+    {
+      "title": "Operator reads accurate mTLS documentation",
+      "role": "documentation reader / on-call operator",
+      "want": "the openbao-bootstrap and infrastructure-manifests reference docs to describe the client-cert env vars, new Certificate(s), and the listener change",
+      "so_that": "an operator can run bootstrap, validate enforcement, and understand the trust chain without reading the manifests",
+      "criteria": [
+        "openbao-bootstrap.md TLS Configuration table lists tls_client_ca_file and the require-and-verify mode; a client-cert SANs/usages row is added",
+        "openbao-bootstrap.md Environment Setup section documents VAULT_CLIENT_CERT/VAULT_CLIENT_KEY and includes a runnable negative-check command",
+        "infrastructure-manifests.md OpenBao Helm-values table and narrative state mTLS is enforced and describe the client-cert wiring",
+        "Doc tables stay structurally consistent with their sibling tables (same column layout)"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "id": "REQ-001",
+      "description": "The production HA listener in deploy/flux-system/releases/openbao.yaml SHALL declare tls_client_ca_file and an explicit require-and-verify client-certificate mode.",
+      "priority": "SHALL",
+      "rationale": "Closes the transport-layer client-identity gap; server TLS alone proves nothing about the client (boundary #1).",
+      "scenarios": [
+        {
+          "name": "Listener requires client cert",
+          "when": "the HА listener config is rendered",
+          "then": "it contains tls_client_ca_file = \"/openbao/tls/ca.crt\" and tls_require_and_verify_client_cert = true",
+          "and_then": [
+            "the existing tls_cert_file/tls_key_file/tls_disable lines are unchanged"
+          ]
+        },
+        {
+          "name": "Unit test fails if removed",
+          "when": "tls_client_ca_file is deleted from the listener",
+          "then": "the new shell unit test fails",
+          "and_then": [
+            "make test-shell exits non-zero"
+          ]
+        },
+        {
+          "name": "Kustomize renders cleanly",
+          "when": "kustomize build deploy/flux-system is run",
+          "then": "rendering succeeds and the HelmRelease values include the new listener keys",
+          "and_then": []
+        }
+      ]
+    },
+    {
+      "id": "REQ-002",
+      "description": "The kind standalone.config listener in deploy/kind/base/kustomization.yaml SHALL declare the same tls_client_ca_file and verification mode as production (no divergence unless explicitly documented).",
+      "priority": "SHALL",
+      "rationale": "Two independent listener blocks exist; leaving one unpatched is the exact drift the 'apply to all instances' pattern guards (boundary #2).",
+      "scenarios": [
+        {
+          "name": "Both overlays patched",
+          "when": "the unit test inspects production and kind listener blocks",
+          "then": "both contain tls_client_ca_file",
+          "and_then": [
+            "if the kind verification mode differs, an inline comment documents the divergence per the overlay-divergence pattern"
+          ]
+        },
+        {
+          "name": "Kind kustomize renders",
+          "when": "kustomize build deploy/kind/base is run",
+          "then": "rendering succeeds with the patched standalone listener",
+          "and_then": []
+        },
+        {
+          "name": "Drift detected",
+          "when": "only the production listener carries tls_client_ca_file",
+          "then": "the unit test fails identifying the unpatched kind block",
+          "and_then": []
+        }
+      ]
+    },
+    {
+      "id": "REQ-003",
+      "description": "All three retry_join stanzas in deploy/flux-system/releases/openbao.yaml SHALL declare leader_client_cert_file and leader_client_key_file alongside the existing leader_ca_cert_file.",
+      "priority": "SHALL",
+      "rationale": "retry_join targets the API listener (8200); once it requires client certs, peers must present one or the cluster will not form (boundary #6).",
+      "scenarios": [
+        {
+          "name": "All stanzas updated",
+          "when": "the unit test counts retry_join blocks carrying leader_client_cert_file",
+          "then": "exactly three are found (one per peer)",
+          "and_then": [
+            "leader_ca_cert_file remains present on each"
+          ]
+        },
+        {
+          "name": "Partial update rejected",
+          "when": "only two of three stanzas carry the leader client cert keys",
+          "then": "the unit test fails",
+          "and_then": []
+        },
+        {
+          "name": "Raft recovery",
+          "when": "tests/e2e-chaos/openbao-pod-kill/ runs against a cluster",
+          "then": "peers re-join under mutual auth and reach Ready",
+          "and_then": [
+            "NOTE: requires a live cluster — not runnable in the static sandbox"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-004",
+      "description": "New cert-manager Certificate(s) SHALL set usages: [\"client auth\"], be issued by selfsigned-cluster-issuer, and be referenced from deploy/flux-system/infrastructure/kustomization.yaml.",
+      "priority": "SHALL",
+      "rationale": "Client certs do not exist today; they must validate against the same self-signed CA bundle and be applied before consumers (boundary #7).",
+      "scenarios": [
+        {
+          "name": "Client usage set",
+          "when": "the Certificate spec is inspected",
+          "then": "usages contains exactly \"client auth\" and issuerRef is the selfsigned-cluster-issuer ClusterIssuer",
+          "and_then": [
+            "the producing Secret(s) target the openbao-system namespace"
+          ]
+        },
+        {
+          "name": "Referenced by parent",
+          "when": "deploy/flux-system/infrastructure/kustomization.yaml is read",
+          "then": "the new Certificate file is listed under resources",
+          "and_then": [
+            "kustomize build deploy/flux-system/infrastructure succeeds"
+          ]
+        },
+        {
+          "name": "Ordering safe",
+          "when": "the manifests are applied first-time",
+          "then": "the client-cert Secrets exist before the StatefulSet/ClusterSecretStore reconcile",
+          "and_then": [
+            "no first-apply TLS-handshake or missing-Secret failure"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-005",
+      "description": "The OpenBao client-cert Secret SHALL be mounted into the StatefulSet via server.volumes/volumeMounts at a path distinct from the existing server tls mount.",
+      "priority": "SHALL",
+      "rationale": "Bootstrap localhost clients and Raft peers run inside the pod and need the client cert at a stable in-pod path (boundaries #4, #6).",
+      "scenarios": [
+        {
+          "name": "Volume added",
+          "when": "openbao.yaml server.volumes/volumeMounts are read",
+          "then": "a new entry mounts the client-cert Secret read-only at /openbao/client-tls alongside the existing /openbao/tls mount",
+          "and_then": [
+            "the existing tls volume/mount is unchanged"
+          ]
+        },
+        {
+          "name": "Kind inherits the mount",
+          "when": "the kind overlay is rendered",
+          "then": "the client-tls volume is present (kind patch does not override server.volumes)",
+          "and_then": []
+        },
+        {
+          "name": "Paths consistent",
+          "when": "listener leader_client_cert_file and bootstrap VAULT_CLIENT_CERT are compared",
+          "then": "both point at /openbao/client-tls/tls.crt",
+          "and_then": []
+        }
+      ]
+    },
+    {
+      "id": "REQ-006",
+      "description": "deploy/eso/clustersecretstore.yaml SHALL reference an ESO client-cert and client-key Secret on the Vault provider while leaving the Kubernetes auth block unchanged.",
+      "priority": "SHALL",
+      "rationale": "ESO is the only direct OpenBao TLS client; it must present a client cert under mTLS but keep K8s-token auth (boundaries #3, #9, Non-Goals).",
+      "scenarios": [
+        {
+          "name": "Client cert refs added",
+          "when": "the ClusterSecretStore spec is read",
+          "then": "the Vault provider declares client-cert and client-key Secret references pointing at a Secret in openbao-system",
+          "and_then": [
+            "spec.provider.vault.auth.kubernetes (mountPath, role, serviceAccountRef) is byte-unchanged"
+          ]
+        },
+        {
+          "name": "caProvider preserved",
+          "when": "the spec is compared to origin/main",
+          "then": "the existing caProvider (openbao-tls / ca.crt) is unchanged",
+          "and_then": []
+        },
+        {
+          "name": "Store stays Ready",
+          "when": "chainsaw infra-stack-health Step 4 runs with mTLS enforced",
+          "then": "ClusterSecretStore is Ready=True reason:Valid",
+          "and_then": [
+            "NOTE: requires a live cluster — not runnable in the static sandbox"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-007",
+      "description": "deploy/openbao/bootstrap/common.sh, deploy/openbao/bootstrap/init-unseal.sh, and hack/deploy-infra.sh SHALL each export/forward VAULT_CLIENT_CERT and VAULT_CLIENT_KEY (in-pod paths) to their kubectl-exec wrappers.",
+      "priority": "SHALL",
+      "rationale": "All in-pod localhost clients hit the require-and-verify listener; missing the var in any one wrapper breaks that path (boundaries #4, #5).",
+      "scenarios": [
+        {
+          "name": "Defaults threaded",
+          "when": "common.sh and hack/deploy-infra.sh are read",
+          "then": "VAULT_CLIENT_CERT/VAULT_CLIENT_KEY are set with a default alongside the existing VAULT_CACERT default",
+          "and_then": [
+            "the defaults point at /openbao/client-tls/tls.crt and /openbao/client-tls/tls.key"
+          ]
+        },
+        {
+          "name": "All wrappers forward the vars",
+          "when": "bao_exec, bao_exec_stdin, init-unseal kube_exec, and openbao_kube_exec are inspected",
+          "then": "each `env ...` invocation includes VAULT_CLIENT_CERT and VAULT_CLIENT_KEY",
+          "and_then": [
+            "grep -rl VAULT_CLIENT_CERT deploy/openbao hack returns all three files"
+          ]
+        },
+        {
+          "name": "shellcheck clean",
+          "when": "the modified scripts are shellchecked",
+          "then": "no new shellcheck findings are introduced",
+          "and_then": []
+        }
+      ]
+    },
+    {
+      "id": "REQ-008",
+      "description": "tests/unit/deploy/production_posture_test.sh SHALL carve out deploy/flux-system/releases/openbao.yaml from the byte-freeze and the header SHALL record why.",
+      "priority": "SHALL",
+      "rationale": "Editing openbao.yaml will otherwise fail the freeze guard; the deviation must be documented (boundary #8).",
+      "scenarios": [
+        {
+          "name": "Carve-out added",
+          "when": "the releases group pathspec is read",
+          "then": "it includes :(exclude)deploy/flux-system/releases/openbao.yaml in addition to the chaos-mesh exclude",
+          "and_then": [
+            "the label string mentions openbao.yaml (CC-0107)"
+          ]
+        },
+        {
+          "name": "Header updated",
+          "when": "the file header comment is read",
+          "then": "it explains the CC-0107 mTLS deviation mirroring the CC-0097 chaos-mesh wording",
+          "and_then": []
+        },
+        {
+          "name": "Test passes",
+          "when": "bash tests/unit/deploy/production_posture_test.sh runs",
+          "then": "it exits 0 with the openbao.yaml change in the worktree",
+          "and_then": [
+            "fluxinstance.yaml and other releases/* still fail the freeze if modified"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-009",
+      "description": "A new tests/unit/deploy/*_test.sh SHALL assert the listener carries tls_client_ca_file in both overlays, retry_join carries the leader client cert/key, and the ClusterSecretStore carries the client-cert refs.",
+      "priority": "SHALL",
+      "rationale": "Static assertions are the only automated guard runnable without a cluster and catch the multi-instance drift.",
+      "scenarios": [
+        {
+          "name": "Test discovered by make",
+          "when": "make test-shell runs",
+          "then": "the new tests/unit/deploy/openbao_mtls_test.sh is executed and passes",
+          "and_then": [
+            "it follows the SPDX header + Feature: CC-0107 + assertions.sh convention"
+          ]
+        },
+        {
+          "name": "Detects production drift",
+          "when": "the production listener loses tls_client_ca_file",
+          "then": "the test reports a FAIL for the production overlay",
+          "and_then": []
+        },
+        {
+          "name": "Detects kind drift",
+          "when": "the kind standalone listener loses tls_client_ca_file",
+          "then": "the test reports a FAIL for the kind overlay",
+          "and_then": [
+            "it also fails if any retry_join stanza or the ClusterSecretStore lacks its mTLS keys"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-010",
+      "description": "tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml Step 4 SHALL assert (or document via a sibling step/comment) that the store and ExternalSecrets stay Ready under enforced mTLS, and chainsaw lint SHALL pass.",
+      "priority": "SHALL",
+      "rationale": "The ESO stack is the observable health gate mTLS must not break (boundary #10).",
+      "scenarios": [
+        {
+          "name": "Invariant preserved",
+          "when": "Step 4 is read",
+          "then": "the existing ClusterSecretStore + three ExternalSecret Ready assertions remain and a comment records they now run under mTLS enforcement",
+          "and_then": [
+            "chainsaw lint test -f passes for the file"
+          ]
+        },
+        {
+          "name": "No regression in lint",
+          "when": "make chainsaw-lint runs",
+          "then": "all chainsaw-test.yaml files lint clean",
+          "and_then": []
+        },
+        {
+          "name": "Live verification deferred",
+          "when": "the chainsaw suite is executed against a cluster",
+          "then": "Step 4 passes with mTLS enforced",
+          "and_then": [
+            "NOTE: requires a live cluster — not runnable in the static sandbox"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "REQ-011",
+      "description": "docs/reference/infrastructure/openbao-bootstrap.md and infrastructure-manifests.md SHALL document the listener change, the new Certificate(s), the client-cert env vars, and a runnable operator negative-check.",
+      "priority": "SHALL",
+      "rationale": "Docs must reflect changed behavior and provide the enforcement-verification runbook (acceptance criteria; doc-consistency patterns).",
+      "scenarios": [
+        {
+          "name": "TLS table updated",
+          "when": "openbao-bootstrap.md TLS Configuration table is read",
+          "then": "it lists tls_client_ca_file and the require-and-verify mode and a client-cert SANs/usages row",
+          "and_then": [
+            "table column layout matches the sibling tables"
+          ]
+        },
+        {
+          "name": "Env + runbook added",
+          "when": "the Environment Setup section is read",
+          "then": "VAULT_CLIENT_CERT/VAULT_CLIENT_KEY are documented and a copy-pasteable no-client-cert rejection command is present",
+          "and_then": []
+        },
+        {
+          "name": "Manifests doc updated",
+          "when": "infrastructure-manifests.md OpenBao section is read",
+          "then": "the Helm-values table and narrative state mTLS is enforced and describe the client-cert wiring",
+          "and_then": []
+        }
+      ]
+    },
+    {
+      "id": "REQ-012",
+      "description": "The CI path filters in .github/workflows/ci.yaml for e2e_infra/e2e_chaos/test-shell SHOULD already cover every changed/new path; any gap SHALL be closed.",
+      "priority": "SHOULD",
+      "rationale": "New Certificate file / unit test must trigger the validating jobs; a path-filter completeness lint already exists under tests/unit/ci/.",
+      "scenarios": [
+        {
+          "name": "Filters cover new file",
+          "when": "the new deploy/flux-system/infrastructure Certificate file and tests/unit/deploy test are added",
+          "then": "the e2e_infra and test-shell path filters match them",
+          "and_then": [
+            "tests/unit/ci path-filter lint passes via make test-shell"
+          ]
+        },
+        {
+          "name": "Gap closed",
+          "when": "a new path is not matched by any filter",
+          "then": "the ci.yaml filter list is extended minimally",
+          "and_then": []
+        },
+        {
+          "name": "No unrelated CI edits",
+          "when": "ci.yaml is diffed",
+          "then": "only path-filter additions strictly required by this feature are present",
+          "and_then": []
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "1.1",
+      "title": "Create deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml with two cert-manager Certificates (REQ-004): `openbao-client-tls` (secretName openbao-client-tls, ns openbao-system, mounted into the StatefulSet) and `eso-openbao-client-tls` (secretName eso-openbao-client-tls, ns openbao-system, consumed by ESO). Both: issuerRef selfsigned-cluster-issuer ClusterIssuer, usages: [\"client auth\"], duration 8760h / renewBefore 720h mirroring openbao-tls-cert.yaml, SPDX header + `# Feature: CC-0107`. Add a DNS commonName/SAN per cert for identification only (no SAN verification expected).",
+      "level": 1,
+      "estimate_minutes": 25,
+      "status": "done",
+      "requirements": [
+        "REQ-004"
+      ]
+    },
+    {
+      "id": "1.2",
+      "title": "Register openbao-client-tls-cert.yaml in deploy/flux-system/infrastructure/kustomization.yaml resources list, immediately after openbao-tls-cert.yaml (REQ-004). Verify `kustomize build deploy/flux-system/infrastructure` and `kustomize build deploy/flux-system` render without error.",
+      "level": 1,
+      "estimate_minutes": 10,
+      "status": "done",
+      "requirements": [
+        "REQ-004"
+      ]
+    },
+    {
+      "id": "1.3",
+      "title": "Scaffold tests/unit/deploy/openbao_mtls_test.sh (REQ-009): SPDX header, `# Feature: CC-0107`, source tests/lib/assertions.sh, PASS/FAIL/SKIP counters and summary mirroring kind_base_flux_web_test.sh. Add the first two assertions: client Certificate usages=[client auth]+issuer (REQ-004) and Certificate referenced by infrastructure kustomization (REQ-004). Run `bash tests/unit/deploy/openbao_mtls_test.sh` — must pass.",
+      "level": 1,
+      "estimate_minutes": 25,
+      "status": "done",
+      "requirements": [
+        "REQ-004",
+        "REQ-009"
+      ]
+    },
+    {
+      "id": "2.1",
+      "title": "Edit deploy/flux-system/releases/openbao.yaml HA raft listener (REQ-001): add `tls_client_ca_file = \"/openbao/tls/ca.crt\"` and `tls_require_and_verify_client_cert = true` to the `listener \"tcp\"` block; leave tls_cert_file/tls_key_file/tls_disable/address lines unchanged. Add a one-line inline comment tagging `# CC-0107: mTLS — require & verify client cert`.",
+      "level": 2,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-001"
+      ]
+    },
+    {
+      "id": "2.2",
+      "title": "Edit deploy/flux-system/releases/openbao.yaml: add `leader_client_cert_file = \"/openbao/client-tls/tls.crt\"` and `leader_client_key_file = \"/openbao/client-tls/tls.key\"` to ALL THREE retry_join stanzas (REQ-003), keeping leader_api_addr and leader_ca_cert_file. Verify exactly three stanzas updated.",
+      "level": 2,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-003"
+      ]
+    },
+    {
+      "id": "2.3",
+      "title": "Edit deploy/flux-system/releases/openbao.yaml server.volumes/volumeMounts (REQ-005): add a `client-tls` volume (secret openbao-client-tls) and a read-only volumeMount at `/openbao/client-tls`, alongside the existing `tls` volume/mount (unchanged). Verify `kustomize build deploy/flux-system` renders.",
+      "level": 2,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-005"
+      ]
+    },
+    {
+      "id": "2.4",
+      "title": "Patch deploy/kind/base/kustomization.yaml openbao standalone.config listener (REQ-002): add the same `tls_client_ca_file` + `tls_require_and_verify_client_cert = true` lines as production, with a `# CC-0107: kind matches production mTLS posture` comment. Confirm the kind patch does NOT need a volumes override (server.volumes inherited from base). Verify `kustomize build deploy/kind/base` renders.",
+      "level": 2,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-002",
+        "REQ-005"
+      ]
+    },
+    {
+      "id": "2.5",
+      "title": "Extend tests/unit/deploy/openbao_mtls_test.sh (REQ-001, REQ-002, REQ-003, REQ-005): add assertions for production listener client-ca + verify mode (and a negative check), kind standalone listener client-ca, exactly-three retry_join leader client cert/key (and a partial-update negative), the /openbao/client-tls volumeMount, and both-overlays kustomize render. Run the suite — must pass.",
+      "level": 2,
+      "estimate_minutes": 30,
+      "status": "done",
+      "requirements": [
+        "REQ-001",
+        "REQ-002",
+        "REQ-003",
+        "REQ-005"
+      ]
+    },
+    {
+      "id": "3.1",
+      "title": "Edit deploy/eso/clustersecretstore.yaml (REQ-006): add the ESO Vault-provider client-cert/key Secret references for the eso-openbao-client-tls Secret in openbao-system. Confirm the exact external-secrets.io/v1 Vault-provider field path (clientCert/clientKey vs tls.clientCertSecretRef/clientKeySecretRef) against the pinned chart (ESO >=0.10.0 <1.0.0) before writing; leave a `# DECISION:` comment recording the verified field path. The auth.kubernetes block and caProvider MUST remain byte-unchanged. Update the file header comment to note CC-0107 mTLS.",
+      "level": 3,
+      "estimate_minutes": 25,
+      "status": "done",
+      "requirements": [
+        "REQ-006"
+      ]
+    },
+    {
+      "id": "3.2",
+      "title": "Extend tests/unit/deploy/openbao_mtls_test.sh (REQ-006): assert the ClusterSecretStore declares the client-cert/key refs to a Secret in openbao-system AND that the auth.kubernetes mountPath/role/serviceAccountRef and caProvider lines are still present (anti-regression). Run the suite — must pass.",
+      "level": 3,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-006"
+      ]
+    },
+    {
+      "id": "4.1",
+      "title": "Edit deploy/openbao/bootstrap/common.sh (REQ-007): add `export VAULT_CLIENT_CERT=\"${VAULT_CLIENT_CERT:-/openbao/client-tls/tls.crt}\"` and `VAULT_CLIENT_KEY` defaults next to the VAULT_CACERT default, and append both vars to the `env ...` lines in bao_exec and bao_exec_stdin. Keep the existing BAO_TOKEN TODO comment intact.",
+      "level": 4,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-007"
+      ]
+    },
+    {
+      "id": "4.2",
+      "title": "Edit deploy/openbao/bootstrap/init-unseal.sh (REQ-007): add VAULT_CLIENT_CERT/VAULT_CLIENT_KEY to the private kube_exec `env ...` invocation (init/unseal run before any token exists but still hit the require-and-verify listener). Defaults come from common.sh (already sourced).",
+      "level": 4,
+      "estimate_minutes": 10,
+      "status": "done",
+      "requirements": [
+        "REQ-007"
+      ]
+    },
+    {
+      "id": "4.3",
+      "title": "Edit hack/deploy-infra.sh (REQ-007): add VAULT_CLIENT_CERT/VAULT_CLIENT_KEY defaults alongside the VAULT_CACERT default (~line 99) and forward both in the openbao_kube_exec `env ...` line (~654). Confirm openbao_init_unseal/openbao_bootstrap paths reference only openbao_kube_exec/common.sh so no other inline exec needs the vars.",
+      "level": 4,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-007"
+      ]
+    },
+    {
+      "id": "4.4",
+      "title": "Extend tests/unit/deploy/openbao_mtls_test.sh (REQ-007): assert grep over deploy/openbao + hack returns exactly the three wrappers carrying VAULT_CLIENT_CERT, and that common.sh + hack/deploy-infra.sh set the defaults. Run the suite — must pass.",
+      "level": 4,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-007"
+      ]
+    },
+    {
+      "id": "5.1",
+      "title": "Edit tests/unit/deploy/production_posture_test.sh (REQ-008): add `:(exclude)deploy/flux-system/releases/openbao.yaml` to the releases groups_specs pathspec and update the groups_label string to mention openbao.yaml (CC-0107). Update the file header comment block to record the CC-0107 mTLS deviation, mirroring the existing CC-0097 chaos-mesh wording. Run `bash tests/unit/deploy/production_posture_test.sh` — must pass with the openbao.yaml change present.",
+      "level": 5,
+      "estimate_minutes": 20,
+      "status": "done",
+      "requirements": [
+        "REQ-008"
+      ]
+    },
+    {
+      "id": "5.2",
+      "title": "Extend tests/unit/deploy/openbao_mtls_test.sh (REQ-008, REQ-009): assert production_posture_test.sh contains the openbao.yaml exclude pathspec and a CC-0107 header reference; add the self-convention check (SPDX header, Feature marker, assertions.sh sourced). Run the full suite and `make test-shell` — must pass.",
+      "level": 5,
+      "estimate_minutes": 20,
+      "status": "done",
+      "requirements": [
+        "REQ-008",
+        "REQ-009"
+      ]
+    },
+    {
+      "id": "5.3",
+      "title": "Verify and, only if needed, extend .github/workflows/ci.yaml path filters (REQ-012) so e2e_infra/e2e_chaos/test-shell trigger on the new deploy/flux-system/infrastructure Certificate file and tests/unit/deploy test. Run the tests/unit/ci path-filter completeness lint via `make test-shell`. Make the minimal change only — no unrelated CI edits.",
+      "level": 5,
+      "estimate_minutes": 15,
+      "status": "done",
+      "requirements": [
+        "REQ-012"
+      ]
+    },
+    {
+      "id": "6.1",
+      "title": "Strengthen tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml Step 4 (REQ-010): keep the existing ClusterSecretStore + three ExternalSecret Ready assertions and add a comment recording they now run under enforced mTLS (CC-0107). Run `make chainsaw-lint` — the file must lint clean.",
+      "level": 6,
+      "estimate_minutes": 20,
+      "status": "done",
+      "requirements": [
+        "REQ-010"
+      ]
+    },
+    {
+      "id": "7.1",
+      "title": "Update docs/reference/infrastructure/openbao-bootstrap.md (REQ-011): add tls_client_ca_file + require-and-verify rows to the TLS Configuration table; add a client-cert row to the Certificate-SANs table noting usages [client auth]; document VAULT_CLIENT_CERT/VAULT_CLIENT_KEY in the Environment Setup / required-env-var section; add a runnable operator negative-check command (a no-client-cert curl/bao call to :8200 rejected at TLS). Keep table column layout consistent with siblings.",
+      "level": 7,
+      "estimate_minutes": 25,
+      "status": "done",
+      "requirements": [
+        "REQ-011"
+      ]
+    },
+    {
+      "id": "7.2",
+      "title": "Update docs/reference/infrastructure/infrastructure-manifests.md (REQ-011): update the OpenBao Helm-values table (~:312-326) and the OpenBao narrative (~:308-311) to state mTLS is enforced, describe the client-cert Certificate(s), the /openbao/client-tls mount, and the ESO client-cert ref. Reference deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml. Keep structure consistent with the openbao-bootstrap.md tables.",
+      "level": 7,
+      "estimate_minutes": 20,
+      "status": "done",
+      "requirements": [
+        "REQ-011"
+      ]
+    },
+    {
+      "id": "7.3",
+      "title": "Add the architecture-rationale handoff note (boundary #11): since architecture/ is an uninitialised submodule and READ-ONLY, do NOT edit it. Record the design-rationale delta for architecture/docs/09-implementation/09-openbao-deployment.md as a commit-message link/section to the external C5C3 PR, per the CC-0097/CC-0098 cross-file-consistency precedent. (No repo file change beyond the prepared commit note.)",
+      "level": 7,
+      "estimate_minutes": 10,
+      "status": "done",
+      "requirements": [
+        "REQ-011"
+      ]
+    }
+  ],
+  "test_specifications": [
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_production_listener_has_client_ca",
+      "story": "Security reviewer verifies client-cert enforcement and consistency",
+      "expected": "Asserts the HA listener in deploy/flux-system/releases/openbao.yaml contains tls_client_ca_file and tls_require_and_verify_client_cert=true",
+      "requirement_id": "REQ-001"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_production_listener_missing_client_ca_fails",
+      "story": "Security reviewer verifies client-cert enforcement and consistency",
+      "expected": "Negative: removing tls_client_ca_file from the production listener makes the assertion FAIL",
+      "requirement_id": "REQ-001"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_kind_standalone_listener_has_client_ca",
+      "story": "Platform operator deploys a kind cluster with mTLS-enforced OpenBao",
+      "expected": "Asserts the kind standalone.config listener patch in deploy/kind/base/kustomization.yaml carries tls_client_ca_file (catches two-listener drift)",
+      "requirement_id": "REQ-002"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_both_overlays_kustomize_render",
+      "story": "Platform operator deploys a kind cluster with mTLS-enforced OpenBao",
+      "expected": "kustomize build deploy/flux-system and deploy/kind/base both succeed and contain tls_client_ca_file",
+      "requirement_id": "REQ-002"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_all_three_retry_join_have_leader_client_cert",
+      "story": "Raft cluster forms and recovers under mutual TLS",
+      "expected": "Counts retry_join blocks; exactly three carry leader_client_cert_file and leader_client_key_file",
+      "requirement_id": "REQ-003"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_partial_retry_join_update_fails",
+      "story": "Raft cluster forms and recovers under mutual TLS",
+      "expected": "Negative: if only two of three retry_join stanzas carry the leader client keys the assertion FAILs",
+      "requirement_id": "REQ-003"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_client_certificate_usages_and_issuer",
+      "story": "Raft cluster forms and recovers under mutual TLS",
+      "expected": "Asserts the new Certificate(s) set usages [client auth] and issuerRef selfsigned-cluster-issuer ClusterIssuer",
+      "requirement_id": "REQ-004"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_certificate_referenced_by_infra_kustomization",
+      "story": "ESO continues syncing secrets under mTLS",
+      "expected": "Asserts the new Certificate file is listed in deploy/flux-system/infrastructure/kustomization.yaml resources",
+      "requirement_id": "REQ-004"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_statefulset_mounts_client_cert_secret",
+      "story": "Raft cluster forms and recovers under mutual TLS",
+      "expected": "Asserts server.volumes/volumeMounts adds a read-only /openbao/client-tls mount and the existing /openbao/tls mount is unchanged",
+      "requirement_id": "REQ-005"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_clustersecretstore_has_client_cert_refs",
+      "story": "ESO continues syncing secrets under mTLS",
+      "expected": "Asserts deploy/eso/clustersecretstore.yaml Vault provider declares client-cert/client-key Secret refs and the kubernetes auth block is unchanged",
+      "requirement_id": "REQ-006"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_all_three_wrappers_forward_client_cert_env",
+      "story": "Security reviewer verifies client-cert enforcement and consistency",
+      "expected": "grep across deploy/openbao + hack confirms common.sh, init-unseal.sh, hack/deploy-infra.sh each forward VAULT_CLIENT_CERT/VAULT_CLIENT_KEY",
+      "requirement_id": "REQ-007"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_client_cert_defaults_present",
+      "story": "Platform operator deploys a kind cluster with mTLS-enforced OpenBao",
+      "expected": "Asserts common.sh and hack/deploy-infra.sh set VAULT_CLIENT_CERT/VAULT_CLIENT_KEY defaults alongside the VAULT_CACERT default",
+      "requirement_id": "REQ-007"
+    },
+    {
+      "test_file": "tests/unit/deploy/production_posture_test.sh",
+      "test_function": "test_production_overlay_unchanged",
+      "story": "Reviewer confirms the frozen production overlay deviation is documented",
+      "expected": "Passes with openbao.yaml carved out; still FAILs if fluxinstance.yaml or any other releases/* file is modified",
+      "requirement_id": "REQ-008"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_posture_carveout_and_header_reference_cc0107",
+      "story": "Reviewer confirms the frozen production overlay deviation is documented",
+      "expected": "Asserts production_posture_test.sh contains the openbao.yaml :(exclude) pathspec and the header mentions CC-0107",
+      "requirement_id": "REQ-008"
+    },
+    {
+      "test_file": "tests/unit/deploy/openbao_mtls_test.sh",
+      "test_function": "test_suite_follows_shell_unit_convention",
+      "story": "Security reviewer verifies client-cert enforcement and consistency",
+      "expected": "The new test file has the SPDX header, Feature: CC-0107 marker, sources tests/lib/assertions.sh, and prints a PASS/FAIL/SKIP summary",
+      "requirement_id": "REQ-009"
+    },
+    {
+      "test_file": "tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml",
+      "test_function": "step4_eso_resources_ready_under_mtls",
+      "story": "ESO continues syncing secrets under mTLS",
+      "expected": "ClusterSecretStore Ready=True reason:Valid and keystone-db/keystone-admin/mariadb-root-password Ready=True reason:SecretSynced with mTLS enforced (requires live cluster)",
+      "requirement_id": "REQ-010"
+    },
+    {
+      "test_file": "tests/e2e-chaos/openbao-pod-kill/chainsaw-test.yaml",
+      "test_function": "raft_peers_rejoin_under_mutual_auth",
+      "story": "Raft cluster forms and recovers under mutual TLS",
+      "expected": "After a pod kill the Raft peers re-join presenting client certs and the cluster returns to Ready (requires live cluster)",
+      "requirement_id": "REQ-003"
+    },
+    {
+      "test_file": "tests/unit/ci/ci_path_filter_test.sh",
+      "test_function": "test_e2e_and_shell_filters_cover_new_paths",
+      "story": "Security reviewer verifies client-cert enforcement and consistency",
+      "expected": "The existing CI path-filter completeness lint passes after the new Certificate file and unit test are added",
+      "requirement_id": "REQ-012"
+    }
+  ],
+  "affected_files": [],
+  "similar_patterns": [],
+  "review_criteria": [
+    "BLOCKER: Both the production HA listener and the kind standalone listener declare tls_client_ca_file + an explicit require-and-verify mode (no unpatched listener) — verified by tests/unit/deploy/openbao_mtls_test.sh",
+    "BLOCKER: All three retry_join stanzas declare leader_client_cert_file and leader_client_key_file (Raft path would not form otherwise)",
+    "BLOCKER: The new Certificate(s) set usages [client auth], use selfsigned-cluster-issuer, are referenced by deploy/flux-system/infrastructure/kustomization.yaml, and produce Secrets in openbao-system before consumers reconcile",
+    "BLOCKER: deploy/eso/clustersecretstore.yaml adds client-cert/key refs while the auth.kubernetes block and caProvider remain byte-unchanged (Non-Goal: no AuthMethod swap)",
+    "BLOCKER: grep -rl VAULT_CLIENT_CERT deploy/openbao hack returns exactly common.sh, init-unseal.sh, hack/deploy-infra.sh (consistency guard)",
+    "BLOCKER: bash tests/unit/deploy/production_posture_test.sh passes with the openbao.yaml carve-out and the header records the CC-0107 deviation; fluxinstance.yaml and other releases/* still fail the freeze if touched",
+    "CRITICAL: make test-shell and make chainsaw-lint pass; the new unit test follows the SPDX header + Feature: CC-0107 + assertions.sh convention",
+    "CRITICAL: kustomize build of deploy/flux-system, deploy/flux-system/infrastructure, and deploy/kind/base all render without error and contain the mTLS keys",
+    "CRITICAL: in-pod client-cert path is consistent everywhere (/openbao/client-tls/tls.{crt,key}) across listener retry_join, volumeMount, and the three exec wrappers",
+    "MINOR: openbao-bootstrap.md and infrastructure-manifests.md tables stay structurally consistent with siblings and include the runnable negative-check command",
+    "MINOR: No scope creep — no AuthMethod change, no issuer replacement, no injector, no chart-version/topology change, no submodule edit",
+    "MINOR: All new/changed lines carry the CC-0107 Feature ID where the convention applies; commit note links the external architecture PR"
+  ],
+  "implementation_notes": "Transport-layer mTLS layered on top of the unchanged K8s-ServiceAccount-token auth model. The change set is YAML/Helm-values + shell + docs + tests — no Go/Python/TS application code, no frontend; the fullstack checklist does not apply (infrastructure feature).\n\nkey_decisions:\n- Verification mode = `tls_require_and_verify_client_cert = true` (explicit require-AND-verify, not just request). Kind matches production (no relaxed divergence) to keep the overlays in lockstep and avoid documenting a divergence.\n- tls_client_ca_file points at the existing self-signed CA bundle already mounted at /openbao/tls/ca.crt — client certs issued by selfsigned-cluster-issuer chain to it; no new trust anchor.\n- Two Certificates rather than one shared cert: one for the OpenBao pods/bootstrap/Raft (mounted into the StatefulSet at /openbao/client-tls), one for ESO (Secret in openbao-system so the existing caProvider namespace pattern is reused). Separate certs keep client identities distinct and rotatable independently.\n- Client-cert mount path /openbao/client-tls is deliberately distinct from the server /openbao/tls mount so the two cert lifecycles do not collide.\n- Kind overlay patches only the listener block; server.volumes/volumeMounts are inherited from base, so the kind StatefulSet automatically gets the client-tls mount with no extra patch.\n- Exact ESO Vault-provider client-cert field path must be confirmed against the pinned chart (ESO >=0.10.0 <1.0.0) at implementation time — record the verified path with a # DECISION: comment (task 3.1).\n\nsandbox_constraint:\nPer project memory, this sandbox has no Docker/cluster — only static rendering, kustomize build, shellcheck, make test-shell, and chainsaw lint are runnable here. The live-cluster acceptance criteria (make deploy-infra healthy, chainsaw infra-stack-health Step 4, tests/e2e-chaos/openbao-pod-kill, kubectl negative check) CANNOT be executed in this environment; they must be validated in CI/a real cluster. The implementer must report this honestly rather than claim live verification.\n\narchitecture_diagram:\n  selfsigned-cluster-issuer (ClusterIssuer)\n        |  issues\n        +--> Certificate openbao-tls       --> Secret openbao-tls (server: tls.crt/tls.key/ca.crt) --mount--> /openbao/tls\n        +--> Certificate openbao-client-tls --> Secret openbao-client-tls (client) --------------------mount--> /openbao/client-tls\n        +--> Certificate eso-openbao-client-tls --> Secret eso-openbao-client-tls (client, openbao-system)\n\n  OpenBao pod (StatefulSet)\n    listener tcp :8200  tls_cert_file=/openbao/tls/tls.crt  tls_client_ca_file=/openbao/tls/ca.crt  require&verify\n    raft retry_join -> leader_ca_cert_file=/openbao/tls/ca.crt  leader_client_cert_file=/openbao/client-tls/tls.crt\n    bootstrap (common.sh/init-unseal.sh) -> bao @127.0.0.1:8200 with VAULT_CLIENT_CERT=/openbao/client-tls/tls.crt\n\n  ESO ClusterSecretStore -> https://openbao.openbao-system.svc:8200\n    caProvider: openbao-tls/ca.crt   +  client cert: eso-openbao-client-tls   +  auth: kubernetes/management (UNCHANGED)\n\ndata_flow:\n1) cert-manager reconciles the new Certificates -> client Secrets exist. 2) OpenBao pod starts, mounts /openbao/tls + /openbao/client-tls, listener requires&verifies client cert. 3) Raft peers dial each other's :8200 presenting leader_client_cert_file -> cluster forms. 4) Bootstrap scripts exec into the pod, bao CLI reads VAULT_CLIENT_CERT/KEY -> localhost client cert accepted. 5) ESO authenticates via K8s token AND presents its client cert at the TLS handshake -> ClusterSecretStore Ready -> ExternalSecrets SecretSynced.\n\npitfalls:\n- Forgetting one of the two listener blocks or one of the three exec wrappers — the dedicated unit test asserts all instances (Apply-to-all-instances pattern).\n- Editing openbao.yaml without extending the production_posture_test.sh carve-out — the freeze guard will fail; carve-out + header must land in the same change (boundary #8).\n- First-apply ordering: if the client Secret does not exist before the StatefulSet/ClusterSecretStore reconcile, TLS handshakes fail — Certificates are registered in the infrastructure kustomization which cert-manager reconciles ahead of consumers.\n- init/unseal run before any BAO_TOKEN exists but STILL hit the require-and-verify listener — the client cert env vars must be present in init-unseal.sh's private kube_exec, not only in bao_exec.\n- Do not touch the architecture/ submodule — record rationale via the external-PR commit note (boundary #11, NO_SUBMODULE_MODIFICATIONS).\n- Do not switch ESO to the cert AuthMethod — that would invalidate the CC-0009/CC-0083 audit invariants (Non-Goal).\n\npatterns_followed:\n- Shell unit test convention: tests/unit/deploy/kind_base_flux_web_test.sh (SPDX header, Feature marker, tests/lib/assertions.sh, PASS/FAIL/SKIP summary, discovered by make test-shell)\n- cert-manager Certificate convention: deploy/flux-system/infrastructure/openbao-tls-cert.yaml (duration/renewBefore, issuerRef ClusterIssuer, SPDX+Feature header)\n- Freeze carve-out convention: the existing CC-0097 chaos-mesh :(exclude) pathspec + header rationale in production_posture_test.sh\n- Project patterns: Apply security mitigations consistently across all files; Apply bug fixes to all instances of the same pattern; Verify TLS trust chain completeness for internal CAs; Verify new resources are referenced by parent manifests; Document intentional environment divergence in overlays; Update documentation when referenced code behavior changes",
+  "status_history": {
+    "draft": {
+      "github_account": "berendt",
+      "timestamp": "2026-05-19T20:25:53.673639"
+    },
+    "preparing": {
+      "github_account": "berendt",
+      "timestamp": "2026-05-19T20:25:53.970652"
+    },
+    "prepared": {
+      "github_account": "berendt",
+      "timestamp": "2026-05-19T20:31:06.998532"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-05-27T16:54:13.218826"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-05-28T19:22:31.841588"
+    }
+  },
+  "github_pr": "https://github.com/C5C3/forge/pull/373",
+  "pr_number": 373,
+  "execution_history": [
+    {
+      "run_id": "344de527-baad-45b5-9157-4bbffbd0e455",
+      "timestamp": "2026-05-19T20:31:06.998557",
+      "total_duration": 310.4916019439697,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "prepare",
+          "duration": 310.4916019439697,
+          "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "9cfb4c98-7136-46ab-a66f-feeb6290c24a",
+      "timestamp": "2026-05-27T17:44:02.698453",
+      "total_duration": 2640.7092542648315,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (3 tasks)",
+          "duration": 342.17664861679077,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (5 tasks)",
+          "duration": 226.0195848941803,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (2 tasks)",
+          "duration": 248.06504344940186,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 4 (4 tasks)",
+          "duration": 462.17468309402466,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 5 (3 tasks)",
+          "duration": 266.13845038414,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 6 (1 tasks)",
+          "duration": 342.19170784950256,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 7 (3 tasks)",
+          "duration": 381.4710006713867,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0107] Code Review",
+          "duration": 372.47213530540466,
+          "type": "review",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "45cd4282-5124-4721-9a43-d9f97131826a",
+      "timestamp": "2026-05-28T18:23:12.532776",
+      "total_duration": 587.5889074802399,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Address review #1",
+          "duration": 587.5889074802399,
+          "type": "review_address",
+          "status": "done"
+        }
+      ]
+    }
+  ]
+}

--- a/.planwerk/reviews/CC-0107-github-review-by-gndrmnn-external-1.json
+++ b/.planwerk/reviews/CC-0107-github-review-by-gndrmnn-external-1.json
@@ -1,0 +1,37 @@
+{
+  "feature_id": "CC-0107",
+  "title": "GitHub Review by gndrmnn",
+  "summary": "External review from gndrmnn",
+  "verdict": "ADDRESSED",
+  "tests_checklist": [],
+  "code_quality_checklist": [],
+  "security_checklist": [],
+  "architecture_checklist": [],
+  "dry_yagni_checklist": [],
+  "fail_fast_checklist": [],
+  "defensive_checklist": [],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [],
+  "next_steps": [],
+  "reviewer": "gndrmnn",
+  "date": "2026-05-28T12:34:14Z",
+  "commit_reference": "",
+  "review_type": "external",
+  "sequence_number": 1,
+  "external_feedback": "",
+  "code_comments": [
+    {
+      "body": "The entire file `tests/unit/deploy/openbao_mtls_test.sh` does not add any meaningful testing and can be removed",
+      "path": "tests/unit/deploy/openbao_mtls_test.sh",
+      "line": 1,
+      "author": "gndrmnn",
+      "created_at": "2026-05-28T11:54:09Z",
+      "id": null,
+      "resolution": "Deleted the entire tests/unit/deploy/openbao_mtls_test.sh file (all 704 lines removed), as requested."
+    }
+  ],
+  "resolution_summary": "The reviewer's single comment requested deleting tests/unit/deploy/openbao_mtls_test.sh because it added no meaningful testing. The entire 704-line file was removed. One additional change was required in a file not directly named in the review: tests/unit/deploy/production_posture_test.sh had a header comment referencing the deleted suite ('The openbao_mtls_test.sh suite asserts the resulting posture...'), so those two stale lines were deleted to keep the comment accurate after the file's removal — leaving just 'openbao.yaml is therefore excluded from the byte-identity check.'",
+  "github_review_id": 4380691922
+}

--- a/.planwerk/reviews/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of-review-1.json
+++ b/.planwerk/reviews/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of-review-1.json
@@ -1,0 +1,85 @@
+{
+  "summary": "CC-0107 enforces transport-layer mTLS on the OpenBao API listener while preserving the existing Kubernetes ServiceAccount-token auth model (Non-Goal #1 respected). The production HA listener and the kind standalone listener both declare tls_client_ca_file + tls_require_and_verify_client_cert = true. All three Raft retry_join stanzas carry leader_client_cert_file/leader_client_key_file. Two new cert-manager Certificates (openbao-client-tls + eso-openbao-client-tls) are issued by selfsigned-cluster-issuer with usages=[client auth] and registered in deploy/flux-system/infrastructure/kustomization.yaml. The ESO ClusterSecretStore adds spec.provider.vault.tls.certSecretRef/keySecretRef (field path independently verified against the external-secrets.io/v1 VaultClientTLS type) while keeping the auth.kubernetes block and caProvider byte-unchanged. All three bootstrap exec wrappers (common.sh, init-unseal.sh, hack/deploy-infra.sh) forward VAULT_CLIENT_CERT/VAULT_CLIENT_KEY; grep -rl returns exactly those three files. production_posture_test.sh carves out openbao.yaml via :(exclude) and the header records the CC-0107 deviation mirroring the CC-0097 chaos-mesh precedent. A new tests/unit/deploy/openbao_mtls_test.sh suite (11 tests, 70 assertions, all PASS) asserts the full wiring including a negative check for tls_require_and_verify_client_cert = false. Chainsaw lint clean on infra-stack-health/chainsaw-test.yaml (annotated for mTLS). Docs (openbao-bootstrap.md, infrastructure-manifests.md) updated with TLS Configuration rows, Certificate-SANs table extension, VAULT_CLIENT_* env vars, and a runnable operator mTLS-enforcement probe. The architecture submodule is NOT modified (rule 12); the design-rationale delta for architecture/docs/09-implementation/09-openbao-deployment.md is captured in .planwerk/CC-0107-pr-description.md as an upstream follow-up. kubectl kustomize verified that both deploy/flux-system/infrastructure and deploy/kind/base render with mTLS keys and that the kind overlay inherits server.volumes.client-tls from the production HelmRelease.",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "Tests exist and pass (openbao_mtls_test.sh: 70 passed, 0 failed, 0 skipped)", "checked": true},
+    {"item": "production_posture_test.sh still passes with carve-out", "checked": true},
+    {"item": "Edge cases covered (negative check: tls_require_and_verify_client_cert = false absent; partial retry_join updates rejected; auth.kubernetes byte-preservation guards)", "checked": true},
+    {"item": "kustomize render verified for production + kind + infrastructure overlays", "checked": true},
+    {"item": "chainsaw lint passes on infra-stack-health/chainsaw-test.yaml", "checked": true},
+    {"item": "make test-shell runs the new openbao_mtls_test.sh via tests/unit/deploy/*_test.sh glob", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing FluxCD HelmRelease/Certificate patterns (CC-0009 server cert as template)", "checked": true},
+    {"item": "Bootstrap wrappers follow the existing env-forwarding pattern (VAULT_CACERT precedent extended verbatim)", "checked": true},
+    {"item": "Shell test follows shell-test-script-structure-with-passfail-counters pattern (with SKIP counter extension)", "checked": true},
+    {"item": "SPDX Apache-2.0 headers + Feature: CC-0107 markers on all new/modified files", "checked": true},
+    {"item": "Inline CC-0107 comments at every changed line (listener mTLS, retry_join, kind overlay, ESO store)", "checked": true},
+    {"item": "Two-phase kustomization pattern respected (Certificate in infrastructure/, not base)", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "Client certs use the same selfsigned-cluster-issuer as server (trust chain consistency)", "checked": true},
+    {"item": "tls_client_ca_file references the existing in-pod CA bundle (no skip-verify)", "checked": true},
+    {"item": "Listener verify mode explicit (require_and_verify_client_cert = true), no silent fallback", "checked": true},
+    {"item": "auth.kubernetes block unchanged - mTLS is additive, not a replacement (Non-Goal #1)", "checked": true},
+    {"item": "Client cert mount is readOnly: true and on a separate path from server cert", "checked": true},
+    {"item": "Two-listener consistency: kind matches production posture (no unpatched listener)", "checked": true},
+    {"item": "Three-wrapper consistency: VAULT_CLIENT_CERT propagated to common.sh, init-unseal.sh, deploy-infra.sh", "checked": true},
+    {"item": "Self-signed issuer NOT replaced (Non-Goal respected)", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution is as simple as possible - listener + retry_join + Certificate + ESO ref + env vars, no scope creep", "checked": true},
+    {"item": "ESO Vault provider field path tls.certSecretRef/keySecretRef verified against external-secrets.io/v1 VaultClientTLS type", "checked": true},
+    {"item": "Production overlay byte-freeze guard properly extended (carve-out + header doc + test coverage of the carve-out)", "checked": true},
+    {"item": "No architecture submodule modification (rule 12 respected; follow-up captured in PR description)", "checked": true},
+    {"item": "Non-Goals upheld: no AuthMethod swap, no issuer replacement, no injector, no chart-version change, no topology change", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "No duplicated code - bootstrap wrappers reuse the same env-forwarding line pattern", "checked": true},
+    {"item": "No speculative configurability - client-cert mount path /openbao/client-tls is hard-coded everywhere", "checked": true},
+    {"item": "Single source of truth for client-cert paths (common.sh defaults; hack/deploy-infra.sh mirrors them as it does not source common.sh)", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Listener tls_require_and_verify_client_cert = true rejects unauthenticated handshakes before app-layer auth runs", "checked": true},
+    {"item": "Negative test asserts tls_require_and_verify_client_cert = false is NOT present (no silent regression to default)", "checked": true},
+    {"item": "Partial retry_join updates (only 2 of 3 stanzas) fail the unit test", "checked": true},
+    {"item": "ClusterSecretStore anti-regression: auth.kubernetes mountPath/role/serviceAccountRef + caProvider byte-preserved", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Bootstrap shell scripts validated under set -euo pipefail (existing pattern preserved)", "checked": true},
+    {"item": "Volume mount is readOnly so cert files cannot be tampered with from inside the pod", "checked": true},
+    {"item": "Server + client certs share rotation cadence (8760h / 720h) so renewals batch", "checked": true},
+    {"item": "Runbook negative-check probe documented in openbao-bootstrap.md (operator can verify enforcement post-deploy)", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "check_id": "D2",
+      "severity": "MINOR",
+      "description": "ClusterSecretStore DECISION comment still contains 'Reviewer: please verify.' tail after the field path was independently verified against the ESO external-secrets.io/v1 VaultClientTLS type (Go field `tls`, sub-fields `certSecretRef`/`keySecretRef` available across the pinned chart range >=0.10.0 <1.0.0). The verification is done; the lingering 'Reviewer: please verify' line tracks the same anti-pattern flagged by the 'resolve-ambiguous-commented-out-alternatives-before-merge' external-review pattern.",
+      "location": "deploy/eso/clustersecretstore.yaml:38",
+      "fix": "Drop the trailing 'Reviewer: please verify.' sentence from the DECISION comment, or replace it with 'Verified against external-secrets.io/v1 VaultClientTLS in ESO 0.10+'. The rest of the DECISION comment (rationale for choosing tls.* over auth.cert.*) is valuable and should stay.",
+      "evidence": "deploy/eso/clustersecretstore.yaml:30-40: '# DECISION: ESO Vault-provider mTLS field path — Chose tls.certSecretRef / ... # so the `key:` field is intentionally omitted. Reviewer: please verify.'",
+      "fix_classification": "AUTO_FIX"
+    },
+    {
+      "check_id": "D2",
+      "severity": "MINOR",
+      "description": "The mTLS-enforcement probe in openbao-bootstrap.md uses 'sh -c ...; echo \"exit=$?\"' inside kubectl exec. Because echo is the last command in the inner shell, the OUTER kubectl call always exits 0 regardless of curl's TLS-handshake outcome. The exit code is visible only via the textual 'exit=...' line, so the probe cannot be wrapped in 'if !' or relied on for an exit-code gate in automation. This is acceptable for a human-run runbook (which the doc explicitly frames it as), but a future caller who treats it as scriptable will get a false-positive PASS.",
+      "location": "docs/reference/infrastructure/openbao-bootstrap.md:600-617",
+      "fix": "Either (a) add a sentence above the probe stating 'this command always exits 0 from the kubectl wrapper; inspect the textual exit=N line, not $?', or (b) restructure as `kubectl exec ... -- sh -c 'curl ... ; rc=$?; echo \"exit=$rc\"; exit $rc'` so the outer kubectl exit code reflects curl's. Option (b) makes the probe both human-readable and CI-greppable.",
+      "evidence": "docs/reference/infrastructure/openbao-bootstrap.md:600-606: 'kubectl exec -n openbao-system openbao-0 -- sh -c ... https://127.0.0.1:8200/v1/sys/health; echo \"exit=$?\"'",
+      "fix_classification": "AUTO_FIX"
+    }
+  ],
+  "suggested_improvements": [
+    "When the upstream architecture/docs/09-implementation/09-openbao-deployment.md PR (handoff in .planwerk/CC-0107-pr-description.md) lands, follow up with a submodule pin bump and remove the 'submodule follow-up' section from the PR description.",
+    "Consider a follow-up E2E gate that actually exercises the negative path documented in the runbook (curl from inside the pod without client cert against :8200, asserting the TLS handshake fails). Today's coverage proves the mTLS wiring renders correctly but not that the listener actually rejects unauthenticated handshakes in a live cluster. Sandbox blocker per [[project_sandbox_no_docker]] applies; this is a CI-only addition."
+  ],
+  "next_steps": [
+    "Trim the 'Reviewer: please verify.' tail from the DECISION comment in deploy/eso/clustersecretstore.yaml:38 (the verification is complete).",
+    "Optional: tighten the runbook mTLS-enforcement probe so the outer kubectl exit code reflects curl's (docs/reference/infrastructure/openbao-bootstrap.md:600-606)."
+  ],
+  "detected_patterns": []
+}

--- a/.planwerk/reviews/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of-review-2.json
+++ b/.planwerk/reviews/CC-0107-use-mtls-client-cert-auth-for-openbao-instead-of-review-2.json
@@ -1,0 +1,43 @@
+{
+  "summary": "External-review improvement cycle (review #1 by gndrmnn). The reviewer's single comment requested deleting tests/unit/deploy/openbao_mtls_test.sh as it added no meaningful testing. This cycle: (1) deleted the 704-line openbao_mtls_test.sh; (2) removed two now-stale comment lines in production_posture_test.sh that referenced the deleted suite; (3) advanced the progress phase to 'improving' and marked the external review 'ADDRESSED' with an accurate resolution summary. Scope reviewed: the 4 changed files only. The deletion is the explicitly-requested external-review change and is protected from being flagged; this review verifies it introduced no NEW defects (dangling references, broken discovery, incoherent comments, or inaccurate metadata).",
+  "verdict": "APPROVED",
+  "tests_checklist": [
+    {"item": "Edited test (production_posture_test.sh) runs green (2 passed, 0 failed, 0 skipped)", "checked": true},
+    {"item": "make test-shell discovery is glob-based (tests/unit/deploy/*_test.sh with [ -f ] guard); deleting one file does not break the runner", "checked": true},
+    {"item": "Deleted suite was not sourced/imported by any other test file (grep over tests/ returns none)", "checked": true},
+    {"item": "openbao.yaml byte-identity carve-out pathspec remains intact after the comment edit", "checked": true}
+  ],
+  "code_quality_checklist": [
+    {"item": "Comment edit is surgical — removed only the two lines naming the deleted suite, kept the accurate 'openbao.yaml is therefore excluded' sentence", "checked": true},
+    {"item": "Remaining header comment is coherent and self-contained (no orphaned references)", "checked": true},
+    {"item": "Follows the cross-file-consistency pattern: stale reference cleaned up in lockstep with file removal", "checked": true}
+  ],
+  "security_checklist": [
+    {"item": "No security-relevant production code changed in this cycle (mTLS transport-layer manifests are out of this diff's scope)", "checked": true},
+    {"item": "No secrets, credentials, or TLS-bypass flags introduced by the deletion or comment edit", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Change is limited to the reviewer-requested deletion plus the consequent comment cleanup and tracking-metadata updates — no scope creep", "checked": true},
+    {"item": "No new abstractions or files introduced", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "Removing a low-value test that the external reviewer judged non-meaningful aligns with YAGNI; no duplication introduced", "checked": true}
+  ],
+  "fail_fast_checklist": [
+    {"item": "production_posture_test.sh retains its byte-identity guard and explicit FAIL path; no error-handling weakened", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Test discovery and the remaining posture test degrade gracefully (preflight SKIP, [ -f ] guard) — unaffected by the deletion", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [],
+  "suggested_improvements": [
+    "Out-of-scope (not in this diff), but for full cross-file consistency: .planwerk/CC-0107-pr-description.md and the task descriptions in .planwerk/progress/CC-0107-...json still reference tests/unit/deploy/openbao_mtls_test.sh as an existing/done artifact. Updating those metadata files to reflect the reviewer-requested removal would keep the tracking record accurate. This is cosmetic tracking metadata, not a code defect.",
+    "With openbao_mtls_test.sh removed, production_posture_test.sh's byte-identity carve-out is now the only shell-unit guard touching openbao.yaml. The mTLS listener/retry_join/volume posture is still exercised by the e2e infra-stack-health and openbao-pod-kill chaos suites (per the acceptance criteria), so transport-layer enforcement remains covered at the e2e tier — no action required, noted for traceability."
+  ],
+  "next_steps": [
+    "None required for the in-scope changes — the external-review feedback is correctly addressed and introduces no new defects."
+  ],
+  "detected_patterns": []
+}

--- a/deploy/eso/clustersecretstore.yaml
+++ b/deploy/eso/clustersecretstore.yaml
@@ -9,7 +9,13 @@
 # external-secrets ServiceAccount in the external-secrets namespace.
 # The TLS CA certificate is sourced from the "openbao-tls" Secret created
 # by cert-manager (see deploy/flux-system/infrastructure/openbao-tls-cert.yaml).
-# Feature: CC-0009
+#
+# CC-0107: the OpenBao API listener now requires & verifies a client TLS
+# certificate (mTLS). The transport-layer client cert/key are sourced from
+# the eso-openbao-client-tls Secret (see openbao-client-tls-cert.yaml). The
+# Kubernetes auth method below still authorises the resulting Vault session;
+# mTLS is purely a transport-layer admission gate, not an auth replacement.
+# Feature: CC-0009, CC-0107
 ---
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
@@ -21,6 +27,22 @@ spec:
       server: "https://openbao.openbao-system.svc:8200"
       path: "kv-v2"
       version: "v2"
+      # DECISION: ESO Vault-provider mTLS field path — Chose tls.certSecretRef /
+      # tls.keySecretRef (the VaultClientTLS type on VaultProvider.tls) per the
+      # external-secrets.io/v1 API spec (verified against ESO docs api/spec.md
+      # for the pinned chart range >=0.10.0 <1.0.0). The alternative
+      # auth.cert.{clientCert,secretRef} is a *different* feature (the Vault
+      # "cert" auth method) and would replace, not augment, our Kubernetes auth.
+      # Secret keys default to tls.crt / tls.key, which match the cert-manager
+      # kubernetes.io/tls Secret layout produced by openbao-client-tls-cert.yaml,
+      # so the `key:` field is intentionally omitted. Reviewer: please verify.
+      tls:
+        certSecretRef:
+          name: "eso-openbao-client-tls"
+          namespace: "openbao-system"
+        keySecretRef:
+          name: "eso-openbao-client-tls"
+          namespace: "openbao-system"
       auth:
         kubernetes:
           mountPath: "kubernetes/management"

--- a/deploy/flux-system/infrastructure/kustomization.yaml
+++ b/deploy/flux-system/infrastructure/kustomization.yaml
@@ -7,7 +7,7 @@
 # Apply AFTER the base kustomization (deploy/flux-system/) and operator
 # CRDs are available. See docs/reference/infrastructure-manifests.md for
 # deployment instructions.
-# Feature: CC-0008, CC-0009, CC-0106
+# Feature: CC-0008, CC-0009, CC-0106, CC-0107
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -17,5 +17,7 @@ resources:
   - db-ca-issuer.yaml
   - mariadb.yaml
   - memcached.yaml
+  - openbao-ca-issuer.yaml
   - openbao-tls-cert.yaml
+  - openbao-client-tls-cert.yaml
   - ../../eso

--- a/deploy/flux-system/infrastructure/openbao-ca-issuer.yaml
+++ b/deploy/flux-system/infrastructure/openbao-ca-issuer.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Dedicated cert-manager CA for the OpenBao trust domain (CC-0107).
+# One self-signed CA keypair backs three concerns:
+#   1. openbao-tls — the API/Raft server cert mounted at /openbao/tls
+#      (see openbao-tls-cert.yaml).
+#   2. openbao-client-tls — the StatefulSet's own client cert used by
+#      the bao CLI inside the pod (chart readiness/liveness probes,
+#      bootstrap exec wrappers, Raft retry_join).
+#   3. eso-openbao-client-tls — ESO's client cert for the OpenBao API
+#      listener once tls_require_and_verify_client_cert is on.
+#
+# DECISION: dedicated CA over selfsigned-cluster-issuer — The OpenBao
+# listener config sets `tls_client_ca_file = /openbao/tls/ca.crt` and
+# `tls_require_and_verify_client_cert = true` (deploy/flux-system/
+# releases/openbao.yaml). With cert-manager's SelfSigned issuer every
+# Certificate is its own root, so server-cert.ca.crt does not validate
+# leaves issued for the clients — the e2e symptom was readiness probes
+# rejected with `remote error: tls: unknown certificate authority` and
+# ESO failing the Kubernetes-auth login with `tls: certificate required`
+# (server refusing to even pick the client cert because it doesn't
+# match the configured client CA). Routing all three openbao TLS certs
+# through one CA-type Issuer makes server cert + every client cert
+# chain to the same root, so ca.crt in every Secret references the same
+# bundle. Mirrors the precedent for the OpenStack DB trust domain in
+# db-ca-issuer.yaml (CC-0106).
+#
+# DECISION: CA Certificate placement — Issued the CA Certificate into
+# the cert-manager namespace because cert-manager's default
+# --cluster-resource-namespace is "cert-manager", which is where a
+# CA-type ClusterIssuer looks up its secretName. Mirrors db-ca-issuer.
+#
+# DECISION: CA lifetime — 3 years (26280h) with 30-day renewBefore.
+# CAs should outlive the leaves they sign; the openbao TLS leaves are
+# 1-year (openbao-tls-cert.yaml, openbao-client-tls-cert.yaml). 3 years
+# matches the openstack-db-ca cadence so both trust-domain CAs renew
+# on comparable schedules.
+#
+# Feature: CC-0107
+---
+# Bootstrap CA keypair Secret. The selfsigned-cluster-issuer mints this
+# self-signed CA, which then becomes the trust root for all openbao
+# transport TLS material.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openbao-ca
+  namespace: cert-manager
+spec:
+  secretName: openbao-ca
+  isCA: true
+  commonName: openbao-ca
+  duration: 26280h
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# CA-type ClusterIssuer signing every openbao transport cert: the
+# StatefulSet server cert (openbao-tls), the in-pod bao-CLI client
+# cert (openbao-client-tls), and the ESO client cert
+# (eso-openbao-client-tls).
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: openbao-ca-issuer
+spec:
+  ca:
+    secretName: openbao-ca

--- a/deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml
+++ b/deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# cert-manager Certificates for OpenBao mTLS (client-cert authentication).
+# Issues two `client auth` certificates from the same `openbao-ca-issuer` that
+# produces openbao-tls (the server cert), so client certs and server cert share
+# one CA bundle and the listener's `tls_client_ca_file = /openbao/tls/ca.crt`
+# validates every presented client cert. Requires cert-manager CRDs (installed
+# via the cert-manager HelmRelease) and the `openbao-ca-issuer` ClusterIssuer
+# defined in openbao-ca-issuer.yaml (itself bootstrapped from
+# selfsigned-cluster-issuer in cluster-issuer.yaml).
+#
+#   - openbao-client-tls:     used by the OpenBao StatefulSet pods themselves
+#                             (Raft retry_join peer auth + in-pod bootstrap exec
+#                             wrappers); mounted by a later task into the
+#                             StatefulSet at /openbao/client-tls.
+#   - eso-openbao-client-tls: used by the ESO ClusterSecretStore to authenticate
+#                             to the OpenBao API listener once require-and-verify
+#                             client-cert mode is enabled.
+#
+# Both certs carry usages: ["client auth"] and share the openbao-tls duration /
+# renewBefore so client + server rotation cadences stay aligned. The DNS SANs
+# below are identifiers only (the listener does not verify SANs for client
+# auth) — they make the certs human-readable in kubectl describe output.
+#
+# Both certs are signed by openbao-ca-issuer (see openbao-ca-issuer.yaml).
+# Sharing one CA with the server cert (openbao-tls-cert.yaml) is what makes
+# tls_require_and_verify_client_cert against tls_client_ca_file work:
+# every Secret's ca.crt resolves to the same openbao-ca bundle, so the
+# listener trusts these client certs and ESO trusts the server cert.
+# Feature: CC-0107
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openbao-client-tls
+  namespace: openbao-system
+spec:
+  secretName: openbao-client-tls
+  # Mirror openbao-tls-cert.yaml lifetimes so client + server rotation align
+  # and OpenBao pod restarts (required for TLS reload) batch into one event.
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: openbao-ca-issuer
+    kind: ClusterIssuer
+  usages:
+    - client auth
+  commonName: openbao-client.openbao-system.svc
+  dnsNames:
+    - openbao-client.openbao-system.svc
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: eso-openbao-client-tls
+  namespace: openbao-system
+spec:
+  secretName: eso-openbao-client-tls
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: openbao-ca-issuer
+    kind: ClusterIssuer
+  usages:
+    - client auth
+  commonName: eso-openbao-client.openbao-system.svc
+  dnsNames:
+    - eso-openbao-client.openbao-system.svc

--- a/deploy/flux-system/infrastructure/openbao-tls-cert.yaml
+++ b/deploy/flux-system/infrastructure/openbao-tls-cert.yaml
@@ -20,8 +20,12 @@ spec:
   # requires pod restarts to avoid Raft peer TLS handshake failures.
   duration: 8760h
   renewBefore: 720h
+  # CC-0107: signed by openbao-ca-issuer so this server cert and the
+  # client certs in openbao-client-tls-cert.yaml share one CA bundle.
+  # Required for tls_require_and_verify_client_cert against
+  # tls_client_ca_file = /openbao/tls/ca.crt.
   issuerRef:
-    name: selfsigned-cluster-issuer
+    name: openbao-ca-issuer
     kind: ClusterIssuer
   dnsNames:
     - openbao-0.openbao-internal

--- a/deploy/flux-system/releases/openbao.yaml
+++ b/deploy/flux-system/releases/openbao.yaml
@@ -34,6 +34,16 @@ spec:
       # via the Kubernetes TokenReview API (required for ESO authentication).
       authDelegator:
         enabled: true
+      # CC-0107: the API listener now requires & verifies a client cert
+      # (tls_require_and_verify_client_cert = true), so the default chart
+      # readiness/liveness probes (`bao status -tls-skip-verify`) must present
+      # one. The bao CLI auto-picks up VAULT_CLIENT_CERT/VAULT_CLIENT_KEY
+      # from the pod environment; the mount lives at /openbao/client-tls
+      # (see volumes/volumeMounts below).
+      extraEnvironmentVars:
+        VAULT_CLIENT_CERT: /openbao/client-tls/tls.crt
+        VAULT_CLIENT_KEY: /openbao/client-tls/tls.key
+        VAULT_CACERT: /openbao/tls/ca.crt
       ha:
         enabled: true
         replicas: 3
@@ -48,21 +58,30 @@ spec:
               cluster_address = "[::]:8201"
               tls_cert_file   = "/openbao/tls/tls.crt"
               tls_key_file    = "/openbao/tls/tls.key"
+              # CC-0107: mTLS — require & verify client cert
+              tls_client_ca_file               = "/openbao/tls/ca.crt"
+              tls_require_and_verify_client_cert = true
             }
 
             storage "raft" {
               path = "/openbao/data"
               retry_join {
-                leader_api_addr    = "https://openbao-0.openbao-internal:8200"
-                leader_ca_cert_file = "/openbao/tls/ca.crt"
+                leader_api_addr        = "https://openbao-0.openbao-internal:8200"
+                leader_ca_cert_file    = "/openbao/tls/ca.crt"
+                leader_client_cert_file = "/openbao/client-tls/tls.crt"
+                leader_client_key_file  = "/openbao/client-tls/tls.key"
               }
               retry_join {
-                leader_api_addr    = "https://openbao-1.openbao-internal:8200"
-                leader_ca_cert_file = "/openbao/tls/ca.crt"
+                leader_api_addr        = "https://openbao-1.openbao-internal:8200"
+                leader_ca_cert_file    = "/openbao/tls/ca.crt"
+                leader_client_cert_file = "/openbao/client-tls/tls.crt"
+                leader_client_key_file  = "/openbao/client-tls/tls.key"
               }
               retry_join {
-                leader_api_addr    = "https://openbao-2.openbao-internal:8200"
-                leader_ca_cert_file = "/openbao/tls/ca.crt"
+                leader_api_addr        = "https://openbao-2.openbao-internal:8200"
+                leader_ca_cert_file    = "/openbao/tls/ca.crt"
+                leader_client_cert_file = "/openbao/client-tls/tls.crt"
+                leader_client_key_file  = "/openbao/client-tls/tls.key"
               }
             }
 
@@ -85,9 +104,16 @@ spec:
         - name: tls
           secret:
             secretName: openbao-tls
+        # CC-0107: client cert for mTLS (Raft retry_join + in-pod bao exec)
+        - name: client-tls
+          secret:
+            secretName: openbao-client-tls
       volumeMounts:
         - name: tls
           mountPath: /openbao/tls
+          readOnly: true
+        - name: client-tls
+          mountPath: /openbao/client-tls
           readOnly: true
 
     injector:

--- a/deploy/kind/base/kustomization.yaml
+++ b/deploy/kind/base/kustomization.yaml
@@ -54,6 +54,9 @@ patches:
                   cluster_address = "[::]:8201"
                   tls_cert_file   = "/openbao/tls/tls.crt"
                   tls_key_file    = "/openbao/tls/tls.key"
+                  # CC-0107: kind matches production mTLS posture
+                  tls_client_ca_file               = "/openbao/tls/ca.crt"
+                  tls_require_and_verify_client_cert = true
                 }
 
                 storage "raft" {

--- a/deploy/openbao/bootstrap/common.sh
+++ b/deploy/openbao/bootstrap/common.sh
@@ -17,6 +17,8 @@
 NAMESPACE="${NAMESPACE:-openbao-system}"
 BAO_ADDR="${BAO_ADDR:-https://127.0.0.1:8200}"
 export VAULT_CACERT="${VAULT_CACERT:-/openbao/tls/ca.crt}"
+export VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT:-/openbao/client-tls/tls.crt}"
+export VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY:-/openbao/client-tls/tls.key}"
 
 # ---------------------------------------------------------------------------
 # log — Print a timestamped log message (ISO 8601 UTC).
@@ -35,7 +37,7 @@ log() {
 # ---------------------------------------------------------------------------
 bao_exec() {
   kubectl exec -n "$NAMESPACE" openbao-0 -- \
-    env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" "$@"
+    env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT}" VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY}" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -45,5 +47,5 @@ bao_exec() {
 # ---------------------------------------------------------------------------
 bao_exec_stdin() {
   kubectl exec -i -n "$NAMESPACE" openbao-0 -- \
-    env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" "$@"
+    env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT}" VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY}" "$@"
 }

--- a/deploy/openbao/bootstrap/init-unseal.sh
+++ b/deploy/openbao/bootstrap/init-unseal.sh
@@ -31,7 +31,7 @@ kube_exec() {
   local pod="$1"
   shift
   kubectl exec -n "${NAMESPACE}" "${pod}" -- \
-    env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" "$@"
+    env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT}" VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY}" "$@"
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -308,10 +308,22 @@ OCI registry (`oci://ghcr.io/c5c3/charts`), not a dedicated HelmRepository. The
 | Source | `openbao` HelmRepository |
 | Dependencies | `cert-manager` in `cert-manager` namespace |
 
-OpenBao is deployed as a 3-replica HA Raft cluster with TLS enabled. The injector is
-disabled. TLS certificates are sourced from a cert-manager-provisioned Secret
-(`openbao-tls`). See `architecture/docs/09-implementation/09-openbao-deployment.md` for
-design rationale.
+OpenBao is deployed as a 3-replica HA Raft cluster with **mutual TLS (mTLS)
+enforced on the API listener** (CC-0107). The injector is disabled. The server
+TLS certificate is sourced from a cert-manager-provisioned Secret
+(`openbao-tls`), and two additional cert-manager-provisioned client
+certificates (`openbao-client-tls`, `eso-openbao-client-tls`) are required so
+that the OpenBao pods themselves (Raft `retry_join` + in-pod `bao` exec
+wrappers) and the External Secrets Operator can complete the TLS handshake.
+The listener carries `tls_client_ca_file = "/openbao/tls/ca.crt"` and
+`tls_require_and_verify_client_cert = true`, so every connection on `:8200` —
+whether from a Raft peer, the in-pod bootstrap script, or
+`ClusterSecretStore/openbao-cluster-store` — must present a client certificate
+that chains to the same self-signed CA bundle as the server cert; the
+Kubernetes-token auth method (`auth.kubernetes`) is unchanged and runs
+*after* the transport-layer admission gate. See
+`architecture/docs/09-implementation/09-openbao-deployment.md` for design
+rationale.
 
 **Helm values:**
 
@@ -322,8 +334,38 @@ design rationale.
 | `server.ha.enabled` | `true` | Enable HA mode |
 | `server.ha.replicas` | `3` | 3-node Raft cluster |
 | `server.ha.raft.enabled` | `true` | Use Raft storage backend |
+| `server.ha.raft.config` listener `tls_client_ca_file` (CC-0107) | `/openbao/tls/ca.crt` | CA the listener uses to verify presented client certs (same bundle as server cert) |
+| `server.ha.raft.config` listener `tls_require_and_verify_client_cert` (CC-0107) | `true` | Reject any TLS handshake without a valid client cert before app-layer auth runs |
+| `server.ha.raft.config` `retry_join.leader_client_cert_file` × 3 (CC-0107) | `/openbao/client-tls/tls.crt` | Client cert each Raft peer presents on `retry_join` to every other peer (same value in all three stanzas) |
+| `server.ha.raft.config` `retry_join.leader_client_key_file` × 3 (CC-0107) | `/openbao/client-tls/tls.key` | Matching private key for `leader_client_cert_file` |
+| `server.volumes` / `server.volumeMounts` — `client-tls` (CC-0107) | Secret `openbao-client-tls` → `/openbao/client-tls` (`readOnly: true`) | Mounts the in-pod client keypair distinct from the server cert at `/openbao/tls` so server and client lifecycles do not collide |
 | `server.dataStorage.size` | `10Gi` | Persistent volume size |
 | `injector.enabled` | `false` | Disable the Vault/Bao agent injector |
+
+**Client certificates (CC-0107).** The two client `Certificate` resources are
+declared in `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml`
+and registered in `deploy/flux-system/infrastructure/kustomization.yaml`
+immediately after `openbao-tls-cert.yaml`, so cert-manager reconciles them
+*before* the OpenBao StatefulSet and `ClusterSecretStore` consume them
+(first-apply ordering, see also "Apply ordering" notes below):
+
+| Certificate | Secret (namespace) | Consumer | Reference |
+| --- | --- | --- | --- |
+| `openbao-client-tls` | `openbao-client-tls` (`openbao-system`) | OpenBao pods — Raft `retry_join` + in-pod `bao` exec | StatefulSet volume `client-tls` mounted at `/openbao/client-tls`; env vars `VAULT_CLIENT_CERT` / `VAULT_CLIENT_KEY` in every exec wrapper (`deploy/openbao/bootstrap/common.sh`, `init-unseal.sh`, `hack/deploy-infra.sh`) |
+| `eso-openbao-client-tls` | `eso-openbao-client-tls` (`openbao-system`) | ESO `ClusterSecretStore/openbao-cluster-store` | `spec.provider.vault.tls.certSecretRef` / `keySecretRef` in `deploy/eso/clustersecretstore.yaml`; `auth.kubernetes` block (mountPath `kubernetes/management`, role `eso-management`) is unchanged — mTLS is purely transport-layer |
+
+Both client certs are issued from the same `openbao-ca-issuer` as
+`openbao-tls` (a CA-type ClusterIssuer defined in
+`deploy/flux-system/infrastructure/openbao-ca-issuer.yaml` and itself
+bootstrapped by `selfsigned-cluster-issuer`). Sharing one CA is what makes the
+listener's `tls_client_ca_file = /openbao/tls/ca.crt` validate every presented
+client cert — a SelfSigned issuer would mint each Certificate as its own root
+and leave the chains unrelated. Both client certs carry
+`usages: ["client auth"]`, with the same `duration` / `renewBefore` as
+`openbao-tls` so server and client rotation cadences stay aligned. See
+[OpenBao Bootstrap Procedure — TLS Configuration](./openbao-bootstrap.md#tls-configuration)
+for the full SAN/usages table, the `VAULT_CLIENT_CERT` / `VAULT_CLIENT_KEY`
+operator interface, and the runnable mTLS-enforcement probe.
 
 ### Keystone Operator
 
@@ -567,8 +609,8 @@ CA-type ClusterIssuer that signs from it).
 
 | Category | Count | Resources |
 | --- | --- | --- |
-| ClusterIssuer | 2 | `selfsigned-cluster-issuer`, `openstack-db-ca-issuer` (both require cert-manager CRDs) |
-| Certificate | 1 | `openstack-db-ca` (CA keypair Secret in the `cert-manager` namespace; CC-0106, REQ-009) |
+| ClusterIssuer | 3 | `selfsigned-cluster-issuer`, `openstack-db-ca-issuer`, `openbao-ca-issuer` (all require cert-manager CRDs) |
+| Certificate | 2 | `openstack-db-ca` (CC-0106, REQ-009), `openbao-ca` (CC-0107) — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
 | MariaDB | 1 | `openstack-db` (requires mariadb-operator CRDs; TLS enabled per [MariaDB Galera Cluster](#mariadb-galera-cluster)) |
 | Memcached | 1 | `openstack-memcached` (requires memcached-operator CRDs) |
 | **Total** | **6** | |
@@ -602,8 +644,9 @@ kubectl apply -k deploy/flux-system/infrastructure/
 
 This applies the CRD-dependent resources: the `selfsigned-cluster-issuer`
 ClusterIssuer, the `openstack-db-ca-issuer` ClusterIssuer plus its backing CA
-`Certificate` (CC-0106, REQ-009), the MariaDB Galera cluster, and the Memcached
-cluster. These resources require CRDs that are installed by the operator
+`Certificate` (CC-0106, REQ-009), the `openbao-ca-issuer` ClusterIssuer plus
+its backing CA `Certificate` (CC-0107), the MariaDB Galera cluster, and the
+Memcached cluster. These resources require CRDs that are installed by the operator
 HelmReleases in step 1. If CRDs are not yet available, the apply will fail — wait
 for the operators to finish installing and retry.
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -157,6 +157,15 @@ injection:
 | --- | --- | --- |
 | `BAO_ADDR` | `https://127.0.0.1:8200` | OpenBao API address (pod-local loopback) |
 | `VAULT_CACERT` | `/openbao/tls/ca.crt` | CA certificate path for TLS verification |
+| `VAULT_CLIENT_CERT` (CC-0107) | `/openbao/client-tls/tls.crt` | Client certificate the in-pod `bao` CLI presents on every API call. Required because `tls_require_and_verify_client_cert = true` is enabled on the listener; without it the TLS handshake fails before any application-layer auth runs. |
+| `VAULT_CLIENT_KEY` (CC-0107) | `/openbao/client-tls/tls.key` | Matching private key for `VAULT_CLIENT_CERT`. Both files are mounted from the `openbao-client-tls` Secret at `/openbao/client-tls`. |
+
+Defaults are set in `deploy/openbao/bootstrap/common.sh` and forwarded by every
+`bao`-invoking wrapper (`bao_exec`, `bao_exec_stdin` in `common.sh`, the private
+`kube_exec` in `init-unseal.sh`, and `openbao_kube_exec` in
+`hack/deploy-infra.sh`). Operators wishing to run `bao` from outside the pod
+must export both vars to a copy of the client keypair extracted from the
+`openbao-client-tls` Secret.
 
 ### Running the Full Bootstrap
 
@@ -447,21 +456,43 @@ headless service DNS names (`openbao-0.openbao-internal`, `openbao-1.openbao-int
 | Certificate source | `openbao-tls` Secret (cert-manager) |
 | Certificate duration | `8760h` (1 year) |
 | Renewal window | `720h` (30 days before expiry) |
+| `tls_client_ca_file` (CC-0107) | `/openbao/tls/ca.crt` — CA the listener uses to verify presented client certs. The file resolves to the `openbao-ca` CA bundle because the server cert (`openbao-tls`) and every client cert are signed by the same `openbao-ca-issuer` (see below) |
+| `tls_require_and_verify_client_cert` (CC-0107) | `true` — every TLS handshake on `:8200` must present a valid client cert; the listener rejects any connection that does not, before any application-layer auth (Kubernetes JWT, AppRole, root token) runs |
 
-The TLS certificate is issued by the `selfsigned-cluster-issuer` ClusterIssuer via
-a cert-manager Certificate resource at
-`deploy/flux-system/infrastructure/openbao-tls-cert.yaml`.
+The TLS certificate is issued by the `openbao-ca-issuer` (a CA-type ClusterIssuer)
+via a cert-manager Certificate resource at
+`deploy/flux-system/infrastructure/openbao-tls-cert.yaml`. The CA keypair itself
+is bootstrapped by `selfsigned-cluster-issuer` in
+`deploy/flux-system/infrastructure/openbao-ca-issuer.yaml` — a SelfSigned issuer
+cannot sign leaves for a separate trust chain, so the openbao trust domain owns
+its own CA (mirrors the `openstack-db-ca` precedent in CC-0106).
+
+**Client certificates (CC-0107).** Two additional `cert-manager.io/v1` Certificates
+issue *client*-auth keypairs from the same `openbao-ca-issuer`, both
+declared in `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml`:
+
+| Certificate | Secret | Consumer | Mount / Reference |
+| --- | --- | --- | --- |
+| `openbao-client-tls` | `openbao-client-tls` (namespace `openbao-system`) | OpenBao pods themselves — Raft `retry_join` peer auth + in-pod `bao` exec via `bootstrap/*.sh` | StatefulSet volume `client-tls` mounted read-only at `/openbao/client-tls`, distinct from the server-cert mount at `/openbao/tls` |
+| `eso-openbao-client-tls` | `eso-openbao-client-tls` (namespace `openbao-system`) | External Secrets Operator `ClusterSecretStore/openbao-cluster-store` | `spec.provider.vault.tls.certSecretRef` / `keySecretRef` (`deploy/eso/clustersecretstore.yaml`); Kubernetes-token `auth.kubernetes` block is unchanged — mTLS is purely a transport-layer admission gate |
+
+Both client Certificates carry `usages: ["client auth"]` and share the
+`openbao-tls` duration / `renewBefore` so server and client rotation cadences
+align. The `commonName` / `dnsNames` on the client certs are identifiers only —
+the OpenBao listener does not verify SANs on client auth, only the issuing CA.
 
 **Certificate SANs:**
 
-| SAN | Type | Purpose |
-| --- | --- | --- |
-| `openbao-0.openbao-internal` | DNS | StatefulSet pod 0 |
-| `openbao-1.openbao-internal` | DNS | StatefulSet pod 1 |
-| `openbao-2.openbao-internal` | DNS | StatefulSet pod 2 |
-| `openbao.openbao-system.svc` | DNS | Kubernetes Service endpoint |
-| `127.0.0.1` | IP | Pod-local loopback (bootstrap scripts, `bao_exec`) |
-| `::1` | IP | IPv6 loopback |
+| SAN | Type | Cert | Usages | Purpose |
+| --- | --- | --- | --- | --- |
+| `openbao-0.openbao-internal` | DNS | `openbao-tls` (server) | `server auth` | StatefulSet pod 0 |
+| `openbao-1.openbao-internal` | DNS | `openbao-tls` (server) | `server auth` | StatefulSet pod 1 |
+| `openbao-2.openbao-internal` | DNS | `openbao-tls` (server) | `server auth` | StatefulSet pod 2 |
+| `openbao.openbao-system.svc` | DNS | `openbao-tls` (server) | `server auth` | Kubernetes Service endpoint |
+| `127.0.0.1` | IP | `openbao-tls` (server) | `server auth` | Pod-local loopback (bootstrap scripts, `bao_exec`) |
+| `::1` | IP | `openbao-tls` (server) | `server auth` | IPv6 loopback |
+| `openbao-client.openbao-system.svc` | DNS | `openbao-client-tls` (CC-0107) | `client auth` | Identifier only; presented by OpenBao pods on Raft `retry_join` and in-pod `bao` exec. SANs are not verified by the listener for client auth — chain-to-CA is. |
+| `eso-openbao-client.openbao-system.svc` | DNS | `eso-openbao-client-tls` (CC-0107) | `client auth` | Identifier only; presented by ESO `ClusterSecretStore/openbao-cluster-store` on every Vault call. SANs are not verified. |
 
 ### Resource Limits
 
@@ -555,11 +586,58 @@ Common causes:
 - OpenBao is sealed (re-run `init-unseal.sh`)
 - ESO service account missing (verify `external-secrets` SA exists in `external-secrets` namespace)
 - TLS trust failure (verify `openbao-tls` Secret contains `ca.crt` key)
+- Missing client certificate (CC-0107): verify the `eso-openbao-client-tls`
+  Secret exists in `openbao-system` and the `ClusterSecretStore`
+  `spec.provider.vault.tls.certSecretRef` / `keySecretRef` point at it. With
+  `tls_require_and_verify_client_cert = true` on the listener, an absent or
+  mis-referenced client cert appears as a generic TLS handshake error in the
+  ESO controller log (`remote error: tls: bad certificate` or similar), not as
+  an HTTP 401/403.
+
+### Verify mTLS enforcement (CC-0107)
+
+Confirm the listener rejects a client that does not present a valid certificate.
+The probe runs entirely inside the pod (so the CA bundle is on the
+filesystem and reaches the loopback listener) and exits **non-zero** on success,
+because the handshake must fail:
+
+```bash
+# Expected output ends with:
+#   curl: (35) ... alert certificate required        OR
+#   curl: (56) ... tls: certificate required         OR
+#   exit code 35/56 from curl with no body returned.
+# Exit code MUST be non-zero. A 200 OK from this command would indicate that
+# tls_require_and_verify_client_cert is NOT being enforced and is a P0 incident.
+kubectl exec -n openbao-system openbao-0 -- \
+  sh -c 'curl --cacert /openbao/tls/ca.crt -sS -o /dev/null \
+             -w "http_code=%{http_code}\n" \
+             https://127.0.0.1:8200/v1/sys/health; echo "exit=$?"'
+```
+
+Then confirm the same call succeeds **with** the client cert (this is what
+`bao_exec` does on every reconcile):
+
+```bash
+# Expected: http_code=200 (or 429 if standby), exit=0.
+kubectl exec -n openbao-system openbao-0 -- \
+  sh -c 'curl --cacert /openbao/tls/ca.crt \
+             --cert   /openbao/client-tls/tls.crt \
+             --key    /openbao/client-tls/tls.key \
+             -sS -o /dev/null -w "http_code=%{http_code}\n" \
+             https://127.0.0.1:8200/v1/sys/health; echo "exit=$?"'
+```
+
+If the first command unexpectedly returns `http_code=200`, the listener is not
+enforcing client-cert auth — re-check
+`deploy/flux-system/releases/openbao.yaml` for `tls_client_ca_file` and
+`tls_require_and_verify_client_cert = true`, and that the HelmRelease has
+reconciled (`kubectl get helmrelease openbao -n openbao-system`).
 
 ## Related Resources
 
 - [Infrastructure Manifests](./infrastructure-manifests.md) — FluxCD base deployment
 - `deploy/flux-system/releases/openbao.yaml` — OpenBao HelmRelease
-- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` — TLS Certificate
-- `deploy/eso/clustersecretstore.yaml` — ClusterSecretStore configuration
+- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` — server TLS Certificate
+- `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml` — client TLS Certificates (CC-0107)
+- `deploy/eso/clustersecretstore.yaml` — ClusterSecretStore configuration (CC-0107: now uses client-cert mTLS)
 - `deploy/eso/externalsecrets/` — ExternalSecret resources

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -97,6 +97,8 @@ KEY_THRESHOLD=3
 OPENBAO_NAMESPACE="${NAMESPACE:-openbao-system}"
 BAO_ADDR="${BAO_ADDR:-https://127.0.0.1:8200}"
 VAULT_CACERT="${VAULT_CACERT:-/openbao/tls/ca.crt}"
+VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT:-/openbao/client-tls/tls.crt}"
+VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY:-/openbao/client-tls/tls.key}"
 SECRET_NAME="openbao-init-keys"
 
 # ---------------------------------------------------------------------------
@@ -651,7 +653,7 @@ enable_keystone_operator_servicemonitor() {
 # ---------------------------------------------------------------------------
 openbao_kube_exec() {
   kubectl exec -n "${OPENBAO_NAMESPACE}" openbao-0 -- \
-    env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" "$@"
+    env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" VAULT_CLIENT_CERT="${VAULT_CLIENT_CERT}" VAULT_CLIENT_KEY="${VAULT_CLIENT_KEY}" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -995,13 +997,20 @@ main() {
   # StatefulSet. The db-ca-issuer manifest creates the OpenStack DB CA
   # keypair Secret and the "openstack-db-ca-issuer" ClusterIssuer that
   # MariaDB/MaxScale and the Keystone DB-client mTLS path consume
-  # (CC-0106, REQ-009). These resources are also part of the
-  # infrastructure kustomization (applied in Step 5), but OpenBao and
-  # MariaDB cannot become Ready until they exist.
-  # Order matters: the selfsigned-cluster-issuer ClusterIssuer must exist
-  # before db-ca-issuer.yaml (whose CA Certificate is issued from it).
-  log "Phase 2: Applying TLS prerequisites (ClusterIssuer + OpenBao TLS Certificate + DB CA Issuer)..."
+  # (CC-0106, REQ-009). The openbao-ca-issuer manifest creates the
+  # OpenBao trust-domain CA keypair Secret and the "openbao-ca-issuer"
+  # ClusterIssuer that signs openbao-tls and all openbao client certs
+  # (CC-0107). These resources are also part of the infrastructure
+  # kustomization (applied in Step 5), but OpenBao and MariaDB cannot
+  # become Ready until they exist.
+  # Order matters:
+  #   - selfsigned-cluster-issuer (cluster-issuer.yaml) must exist before
+  #     either CA-issuer manifest (their CA Certificates are signed by it).
+  #   - openbao-ca-issuer must exist before openbao-tls-cert.yaml (which
+  #     references it via issuerRef).
+  log "Phase 2: Applying TLS prerequisites (ClusterIssuer + OpenBao CA + OpenBao TLS Certificate + DB CA Issuer)..."
   kubectl apply -f "${REPO_ROOT}/deploy/flux-system/infrastructure/cluster-issuer.yaml"
+  kubectl apply -f "${REPO_ROOT}/deploy/flux-system/infrastructure/openbao-ca-issuer.yaml"
   kubectl apply -f "${REPO_ROOT}/deploy/flux-system/infrastructure/openbao-tls-cert.yaml"
   kubectl apply -f "${REPO_ROOT}/deploy/flux-system/infrastructure/db-ca-issuer.yaml"
 
@@ -1076,6 +1085,26 @@ main() {
 
   # Wait for OpenBao to become Ready after unseal
   wait_for_pods "${OPENBAO_NAMESPACE}" "app.kubernetes.io/name=openbao" "${POD_TIMEOUT}"
+
+  # The ClusterSecretStore was applied in Step 5, before OpenBao was
+  # initialised and unsealed (Step 7). ESO's first store validation therefore
+  # failed against a down/sealed OpenBao and the controller entered an
+  # exponential backoff that can outlast EXTERNALSECRET_TIMEOUT. Bump an
+  # annotation to force an immediate re-validation now that OpenBao is up, wait
+  # for the store to report Ready, then force-sync the dependent
+  # ExternalSecrets so Step 8 does not race ESO's backoff. Same
+  # apply-before-dependency reason as the MariaDB reconcile-trigger below.
+  local now
+  now=$(date +%s)
+  log "Forcing ESO ClusterSecretStore re-validation and ExternalSecret re-sync..."
+  kubectl annotate clustersecretstore/openbao-cluster-store \
+    "deploy.c5c3.io/reconcile-trigger=${now}" --overwrite || true
+  kubectl wait clustersecretstore/openbao-cluster-store \
+    --for=condition=Ready --timeout="${POD_TIMEOUT}s" || true
+  for es in keystone-admin keystone-db mariadb-root-password; do
+    kubectl annotate "externalsecret/${es}" -n openstack \
+      "force-sync=${now}" --overwrite || true
+  done
 
   # Step 8: Wait for ExternalSecrets to sync
   log "=== Step 8/8: Wait for ExternalSecrets ==="

--- a/tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml
@@ -129,6 +129,18 @@ spec:
   # ── Step 4: ESO Resources ──────────────────────────────────────────────
   # Verify that the ClusterSecretStore is Valid and all ExternalSecrets have
   # reached SecretSynced status.
+  #
+  # CC-0107 (REQ-010): These assertions now run under enforced mTLS — the
+  # OpenBao API listener requires and verifies a client certificate
+  # (tls_require_and_verify_client_cert = true), and the ClusterSecretStore
+  # presents the eso-openbao-client-tls client cert/key on every Vault call.
+  # ClusterSecretStore Ready=True/reason:Valid and the three ExternalSecrets
+  # Ready=True/reason:SecretSynced therefore prove end-to-end mutual-auth
+  # success: cert-manager issued the client cert, ESO mounted it, OpenBao
+  # accepted the TLS handshake, and the Kubernetes-token auth (unchanged)
+  # then completed the application-layer login. A regression in any link of
+  # that chain (missing client cert, wrong CA, listener misconfig) flips
+  # Ready=False here.
   - try:
     - assert:
         resource:

--- a/tests/unit/deploy/production_posture_test.sh
+++ b/tests/unit/deploy/production_posture_test.sh
@@ -23,6 +23,16 @@
 # suite asserts the resulting posture (production renders zero chaos-mesh
 # resources; the overlay renders the full bundle).
 #
+# CC-0107 enforces OpenBao mTLS by editing
+# deploy/flux-system/releases/openbao.yaml in place:
+#   - the HA raft listener requires & verifies client certs
+#     (tls_client_ca_file + tls_require_and_verify_client_cert = true);
+#   - all three retry_join stanzas carry leader_client_cert_file +
+#     leader_client_key_file pointing at /openbao/client-tls; and
+#   - server.volumes/volumeMounts mount the openbao-client-tls Secret
+#     at /openbao/client-tls.
+# openbao.yaml is therefore excluded from the byte-identity check.
+#
 # In addition, any net-new file under deploy/flux-system/sources/ must contain
 # ONLY HelmRepository objects (no HelmRelease / Gateway controller leakage).
 #
@@ -79,11 +89,11 @@ test_production_overlay_unchanged() {
   # remain byte-identical.
   local groups_label=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated by CC-0097)"
+    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated by CC-0097 and openbao.yaml edited in place by CC-0107)"
   )
   local groups_specs=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml"
+    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml"
   )
 
   local diff_output=""


### PR DESCRIPTION
# GitHub Issue #321: feat: mTLS (client-cert auth) for OpenBao instead of K8s ServiceAccount tokens

**Description:**

OpenBao runs today with **server-side TLS only**. This issue adds **transport-layer mutual TLS**: the OpenBao API listener will require and verify a client certificate, every client that talks to OpenBao will present one, and the Raft inter-node join path will additionally be pinned by client cert rather than only by leader CA. The change is deliberately scoped to the *transport layer*; the Kubernetes-ServiceAccount-token authentication/authorization model (auth roles, HCL policies, audit invariants) is left intact, with mTLS layered *on top of* it. (Issue is GitHub #321; the repo's `# Feature: CC-XXXX` header convention would tag this **CC-0321** — treat the exact tag as an assumption to confirm with maintainers, matching the existing `CC-0009`/`CC-0083` headers throughout `deploy/openbao/`.)

This touches the **frozen production overlay**, so the blast radius is larger than the file count suggests. Reviewers should ground the rationale in the review patterns **Kubernetes TLS and Certificate Management**, **Verify TLS trust chain completeness for internal CAs**, **Never skip TLS verification when CA cert is available**, **Apply security mitigations consistently across all files**, **Apply bug fixes to all instances of the same pattern**, and **Document intentional environment divergence in overlays**.

### Concrete boundaries

**1. Server TLS exists; client-cert verification does not.**
Already exists: `deploy/flux-system/releases/openbao.yaml:30` sets `global.tlsDisable: false`; the HA Raft listener block (`deploy/flux-system/releases/openbao.yaml`, listener stanza, `tls_disable = 0`, `tls_cert_file = /openbao/tls/tls.crt`, `tls_key_file = /openbao/tls/tls.key`) has **no `tls_client_ca_file`**. This issue adds `tls_client_ca_file` and the client-verification mode to that listener stanza.

**2. The kind overlay duplicates the listener and must move in lockstep.**
Already exists: `deploy/kind/base/kustomization.yaml` patches OpenBao into `standalone` mode with a **second, independent listener block** (`standalone.config`, `tls_disable = 0`, same cert/key paths, `ui = true`, no `retry_join`). This issue adds the same `tls_client_ca_file` to that block. Leaving one block unpatched is exactly the failure mode the **Apply bug fixes to all instances of the same pattern** project pattern exists to catch — there are two listeners, not one.

**3. The only direct OpenBao TLS client in this repo is ESO.**
Already exists: the Keystone operator never dials OpenBao directly — it goes through ESO CRs only: `ExternalSecret` reads (`deploy/eso/externalsecrets/keystone-db.yaml`, `keystone-admin.yaml`, `mariadb-root-password.yaml`) and operator-generated `PushSecret`s (`operators/keystone/internal/controller/reconcile_fernet.go:443-445`, `operators/keystone/internal/controller/reconcile_credential.go:447-449`), all referencing the `openbao-cluster-store` `ClusterSecretStore` (`operators/keystone/internal/controller/reconcile_secrets.go:23-29`). `deploy/eso/clustersecretstore.yaml:21` points ESO at `https://openbao.openbao-system.svc:8200`, validates the server cert via `caProvider` (`deploy/eso/clustersecretstore.yaml:31-35`, Secret `openbao-tls` key `ca.crt` in `openbao-system`), and authenticates via the Kubernetes auth method (`deploy/eso/clustersecretstore.yaml:24-30`). This issue adds the ESO client-cert reference to that store; it does **not** add a new direct OpenBao client.

**4. Bootstrap scripts are in-pod localhost clients and also break under require-and-verify.**
Already exists: `deploy/openbao/bootstrap/common.sh:18-19` (`BAO_ADDR=https://127.0.0.1:8200`, `VAULT_CACERT=/openbao/tls/ca.crt`); `bao_exec`/`bao_exec_stdin` (`common.sh:36-49`) and `init-unseal.sh`'s own `kube_exec` (`deploy/openbao/bootstrap/init-unseal.sh:30-35`) forward env via `env ...` into `kubectl exec openbao-0 -- bao …`. There is **no `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` anywhere in the repo** (verified by grep). This issue adds those env vars (pointing at a client-cert path mounted *inside the openbao pod*) to all three exec wrappers — `common.sh`, `init-unseal.sh`, and the inline duplicate in `hack/deploy-infra.sh:652-655` (`openbao_kube_exec`).

**5. `hack/deploy-infra.sh` re-implements init/unseal/bootstrap inline for single-replica kind.**
Already exists: `openbao_init_unseal` (`hack/deploy-infra.sh:664-744`), `openbao_bootstrap` (`hack/deploy-infra.sh:752-791`, runs `setup-secret-engines.sh`/`setup-auth.sh`/`setup-policies.sh`/`write-bootstrap-secrets.sh`), and its own `VAULT_CACERT` default (`hack/deploy-infra.sh:99`). Because this path does not source `common.sh`, the mTLS env-var change must be applied here independently — another instance of the **Apply security mitigations consistently across all files** pattern.

**6. Raft join is pinned by leader CA only, not by client cert.**
Already exists: three `retry_join` stanzas (`deploy/flux-system/releases/openbao.yaml`, the `storage "raft"` block) use `leader_api_addr = https://openbao-N.openbao-internal:8200` + `leader_ca_cert_file = /openbao/tls/ca.crt`. Because `retry_join` targets the **API listener (8200)**, once that listener requires client certs, peers must also present `leader_client_cert_file`/`leader_client_key_file` or the cluster will not form. This issue adds those keys to all three stanzas.

**7. Client certificates do not exist; only a server cert does.**
Already exists: one cert-manager `Certificate` — `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` (`secretName: openbao-tls`, issuer `selfsigned-cluster-issuer` ClusterIssuer at `deploy/flux-system/infrastructure/cluster-issuer.yaml`, server DNS SANs + loopback IPs, `duration: 8760h`, `renewBefore: 720h`, no `usages` field). This issue adds **client-auth `Certificate`(s)** issued by the same `selfsigned-cluster-issuer` (the issue's "Out of scope" explicitly forbids replacing the self-signed issuer): at minimum one for ESO and one for the OpenBao pods/bootstrap. `tls_client_ca_file` points at the same self-signed CA (`/openbao/tls/ca.crt`), so client certs validate against the issuer's CA bundle.

**8. The production overlay is byte-frozen by a unit test.**
Already exists: `tests/unit/deploy/production_posture_test.sh:65-113` (`test_production_overlay_unchanged`) asserts `deploy/flux-system/fluxinstance.yaml` and `deploy/flux-system/releases/*` are byte-identical to `origin/main`, with a single `:(exclude)` carve-out for the CC-0097 chaos-mesh relocation (`production_posture_test.sh:84-87`). Editing `deploy/flux-system/releases/openbao.yaml` for mTLS **will fail this test**. This issue must extend the carve-out (add an `openbao.yaml` exclusion mirroring the existing chaos-mesh `:(exclude)` pathspec) and update the test's header comment to record why — see project pattern **Update documentation when referenced code behavior changes** and **Require inline comments for intentional convention deviations**.

**9. Auth model decision is left to this elaboration.**
The issue asks whether to switch ESO to the `cert` AuthMethod or keep K8s-token auth with mTLS as pure transport hardening. The smallest concrete change that satisfies the issue is **keep K8s-token auth** (`deploy/openbao/bootstrap/setup-auth.sh:54-105`, `eso-management` role binding `eso-management.hcl` + `push-keystone-keys.hcl`) and add mTLS strictly at the transport layer. Switching to the `cert` AuthMethod would rip out the `kubernetes/management` role/policy binding model and invalidate the CC-0009/CC-0083 audit invariants documented in `deploy/openbao/policies/eso-management.hcl:19-45` and `deploy/openbao/policies/push-keystone-keys.hcl` — a far larger blast radius. That swap is moved to **Non-Goals**.

**10. The observable health gate is the ESO stack, not OpenBao internals.**
Already exists: `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml:132-175` (Step 4) asserts `ClusterSecretStore/openbao-cluster-store` is `Ready=True reason:Valid` and the three `ExternalSecret`s reach `Ready=True reason:SecretSynced`. This is the existing observable invariant that mTLS **must not break**. `tests/e2e-chaos/openbao-pod-kill/` exercises Raft recovery and is the existing guard for boundary #6.

**11. Architecture rationale lives in an uninitialised submodule.**
`.gitmodules` declares `architecture` → `https://github.com/C5C3/C5C3`; the `architecture/` directory in this worktree is **empty** (only `.`/`..`). The design-rationale doc the OpenBao header references (`architecture/docs/09-implementation/09-openbao-deployment.md`, cited from `deploy/flux-system/releases/openbao.yaml` header and `docs/reference/infrastructure/infrastructure-manifests.md:311`) cannot be edited from this repo. Any architecture-doc update is tracked by a commit-message link to the external PR, per the **Verify cross-file consistency across the PR scope** project pattern (CC-0097/CC-0098 precedent) — do not silently claim a submodule edit.

**Motivation:**

The issue's "Why" is explicit: OpenBao is the root of trust for every credential in the stack (`kv-v2/bootstrap/*`, `kv-v2/infrastructure/mariadb`, `kv-v2/openstack/keystone/*`, the fernet/credential key backups). Server-side TLS proves OpenBao's identity to clients but proves **nothing about the client's identity at the transport layer** — anything with network reach to `openbao.openbao-system.svc:8200` and a valid ServiceAccount token (or, for the Raft path, merely the leader CA) is admitted. In a Zero-Trust / dedicated-tenant posture this is insufficient defense in depth. Requiring a client certificate at the listener closes that gap before any application-layer auth runs, and aligns with the **Secure by Design and Default** and **Kubernetes TLS and Certificate Management** patterns (TLS between all cluster components, not just ingress).

This is the OpenBao instance of a tracked hardening track — the issue's "Tracking" note states sibling issues cover MariaDB and Memcached TLS. Establishing the cert-manager-issued-client-cert + listener-`tls_client_ca_file` + per-client-secret-ref pattern here is the reference implementation those siblings will mirror, the same way the README describes the Keystone-first strategy. Getting the trust-chain wiring and the two-listener / three-exec-wrapper consistency right here is what makes the sibling tracks mechanical rather than novel.

Skipping this leaves the Raft inter-node path authenticated only by leader CA pinning (boundary #6) — peer authenticity is not cryptographically established per-connection — and leaves OpenBao's transport layer with no notion of client identity, so the entire access-control story rests on a single ServiceAccount-token bearer credential whose theft grants full read (and, for the management ESO role, write) of the secret store.

**Affected Areas:**

- `deploy/flux-system/releases/openbao.yaml` — add `tls_client_ca_file` + client-verification mode to the HA listener; add `leader_client_cert_file`/`leader_client_key_file` to all three `retry_join` stanzas; add a `server.volumes`/`server.volumeMounts` entry mounting the OpenBao client-cert Secret (alongside the existing `tls` mount).
- `deploy/kind/base/kustomization.yaml` — apply the same `tls_client_ca_file` + verification mode to the `standalone.config` listener block (no `retry_join` in standalone); decide and document the kind verification mode (recommend matching production; if relaxed, document the divergence per **Document intentional environment divergence in overlays**).
- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` (or a new sibling file under `deploy/flux-system/infrastructure/`) — new cert-manager `Certificate`(s) with `usages: ["client auth"]` issued by `selfsigned-cluster-issuer`: one producing the OpenBao-pod client-cert Secret (mounted into the StatefulSet), one producing the ESO client-cert Secret in `openbao-system`.
- `deploy/flux-system/infrastructure/kustomization.yaml` — register any new Certificate file (per **Verify new resources are referenced by parent manifests** / **Verify all implicit resource dependencies exist at apply time**).
- `deploy/eso/clustersecretstore.yaml` — add the ESO Vault-provider client-cert/key Secret references (issue names them `tls.clientCertSecretRef` / `tls.clientKeySecretRef`; confirm the exact `external-secrets.io/v1` Vault-provider field path against the pinned chart `>=0.10.0 <1.0.0`).
- `deploy/openbao/bootstrap/common.sh` — add `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` (in-pod paths) to the `env …` invocations in `bao_exec`/`bao_exec_stdin`.
- `deploy/openbao/bootstrap/init-unseal.sh` — add the same env vars to its private `kube_exec` (init/unseal run before any token exists; they still hit the require-and-verify listener).
- `hack/deploy-infra.sh` — add the same env vars to `openbao_kube_exec` and ensure the single-replica `openbao_init_unseal`/`openbao_bootstrap` paths still succeed under mTLS; thread a `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY` default alongside the existing `VAULT_CACERT` default (`hack/deploy-infra.sh:99`).
- `tests/unit/deploy/production_posture_test.sh` — extend the `:(exclude)` carve-out to cover `deploy/flux-system/releases/openbao.yaml`; update the header comment explaining the deviation.
- `tests/unit/deploy/` — new `*_test.sh` asserting the listener carries `tls_client_ca_file` in both the production and kind overlays, that `retry_join` carries the leader client cert/key, and that the ClusterSecretStore carries the client-cert refs (mirrors the existing shell-unit-test convention; runs via `make test-shell`, `Makefile:170-178`).
- `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml` — strengthen Step 4 (or add a sibling step) to assert the store/ExternalSecrets stay `Ready` *under mTLS* (the existing assertions remain the regression guard).
- `docs/reference/infrastructure/openbao-bootstrap.md` — update the **TLS Configuration** table (`docs/reference/infrastructure/openbao-bootstrap.md:438-459`), the Certificate-SANs table, the **setup-auth.sh** auth-method tables, and the **Environment Setup** / required-env-var section to document `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY`.
- `docs/reference/infrastructure/infrastructure-manifests.md` — update the OpenBao Helm-values table (`docs/reference/infrastructure/infrastructure-manifests.md:312-326`) and the OpenBao narrative (`:308-311`) to state mTLS is enforced and describe the client-cert wiring.

**Acceptance Criteria:**

- [ ] The production HA listener in `deploy/flux-system/releases/openbao.yaml` declares `tls_client_ca_file` and an explicit client-verification mode; a unit test under `tests/unit/deploy/` asserts its presence and fails if removed.
- [ ] The kind `standalone.config` listener in `deploy/kind/base/kustomization.yaml` declares the same `tls_client_ca_file`; the same unit test asserts both overlays carry it (catches the two-listener drift).
- [ ] All three `retry_join` stanzas in `deploy/flux-system/releases/openbao.yaml` declare `leader_client_cert_file` and `leader_client_key_file`; `make deploy-infra` brings up a healthy single-replica kind cluster and (where exercisable) the HA Raft cluster forms with all peers `Ready`.
- [ ] `tests/e2e-chaos/openbao-pod-kill/` still passes — Raft peers re-join under mutual auth after a pod kill.
- [ ] `kubectl get clustersecretstore openbao-cluster-store -o jsonpath='{.status.conditions}'` shows `Ready=True reason:Valid`, and `keystone-db`, `keystone-admin`, `mariadb-root-password` ExternalSecrets reach `Ready=True reason:SecretSynced` — i.e. `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml` Step 4 passes with mTLS enforced.
- [ ] A negative check demonstrates enforcement: a Vault/OpenBao API call from inside the cluster *without* a client cert against the 8200 listener is rejected at the TLS layer (documented as a runbook command in `docs/reference/infrastructure/openbao-bootstrap.md`, runnable by an operator).
- [ ] `deploy/openbao/bootstrap/{common.sh,init-unseal.sh}` and `hack/deploy-infra.sh` all pass `VAULT_CLIENT_CERT`/`VAULT_CLIENT_KEY`; `grep -rl VAULT_CLIENT_CERT deploy/openbao hack` returns all three wrappers (consistency guard per **Apply security mitigations consistently across all files**).
- [ ] The new client-cert `Certificate`(s) set `usages: ["client auth"]`, are issued by `selfsigned-cluster-issuer`, are referenced from `deploy/flux-system/infrastructure/kustomization.yaml`, and their Secrets exist in `openbao-system` before the consuming resources reconcile (no first-apply ordering failure).
- [ ] `bash tests/unit/deploy/production_posture_test.sh` passes: the `openbao.yaml` carve-out is in place and the header documents why the production overlay is no longer byte-frozen for that file.
- [ ] `make test-shell` and `chainsaw lint` (`Makefile:160-178`) pass; the new chainsaw assertions lint clean.
- [ ] `docs/reference/infrastructure/openbao-bootstrap.md` and `infrastructure-manifests.md` reflect the new client-cert env vars, the new Certificate(s), and the listener change; the doc tables stay structurally consistent with their siblings (per **Ensure parallel documentation structures are consistent**), and any required-tool/env-var additions appear in the Prerequisites/Environment sections.

**Non-Goals:**

- **Switching ESO (or any client) to the `cert` AuthMethod.** Per boundary #9, K8s-ServiceAccount-token authentication is retained; mTLS is transport-layer only. Replacing the `kubernetes/management` role/policy model is a separate, larger change that would invalidate the CC-0009/CC-0083 audit invariants in `deploy/openbao/policies/`.
- **Replacing the self-signed `selfsigned-cluster-issuer` with a real CA.** Explicitly out of scope per the issue; all client certs are issued by the existing self-signed ClusterIssuer and validated against the same CA bundle.
- **Integrating Vault Agent / the injector.** `injector.enabled: false` (`deploy/flux-system/releases/openbao.yaml`) stays unchanged; explicitly out of scope per the issue.
- **MariaDB and Memcached mTLS.** Tracked by the sibling issues referenced in the issue's "Tracking" note; this issue is OpenBao-only.
- **Editing the `architecture/` submodule.** It is not checked out in this worktree (boundary #11); architecture-doc rationale is handled by an external-PR link in the commit log, not a fabricated submodule bump.
- **Changing the OpenBao chart version or HA topology.** The `>=0.5.0 <1.0.0` constraint and 3-replica HA / kind-standalone topologies are unchanged; only the listener/Raft/volume config and client wiring change.

**References:**

- Issue #321 — `https://github.com/C5C3/forge/issues/321`
- `deploy/flux-system/releases/openbao.yaml` — production HA HelmRelease + listener + `retry_join` (boundaries #1, #6, #7)
- `deploy/kind/base/kustomization.yaml` — kind standalone listener patch (boundary #2)
- `deploy/eso/clustersecretstore.yaml` — ESO Vault provider, `caProvider`, K8s auth (boundary #3)
- `deploy/eso/externalsecrets/{keystone-db,keystone-admin,mariadb-root-password}.yaml` — ESO consumers
- `operators/keystone/internal/controller/{reconcile_secrets.go,reconcile_fernet.go,reconcile_credential.go}` — proof the operator is not a direct OpenBao client (boundary #3)
- `deploy/openbao/bootstrap/common.sh`, `init-unseal.sh`, `setup-auth.sh`, `setup-policies.sh`, `setup-secret-engines.sh`, `write-bootstrap-secrets.sh` — bootstrap exec wrappers and auth/policy model (boundaries #4, #9)
- `deploy/openbao/policies/eso-management.hcl`, `push-keystone-keys.hcl` — CC-0009/CC-0083 audit invariants (Non-Goals)
- `hack/deploy-infra.sh:99,652-655,664-744,752-791` — inline kind init/unseal/bootstrap (boundary #5)
- `deploy/flux-system/infrastructure/openbao-tls-cert.yaml`, `cluster-issuer.yaml`, `kustomization.yaml` — cert-manager wiring (boundary #7)
- `tests/unit/deploy/production_posture_test.sh:65-113` — frozen-overlay guard (boundary #8)
- `tests/e2e/infrastructure/infra-stack-health/chainsaw-test.yaml:132-175`, `tests/e2e-chaos/openbao-pod-kill/` — observable health/recovery gates (boundary #10)
- `docs/reference/infrastructure/openbao-bootstrap.md:438-459`, `infrastructure-manifests.md:308-326` — doc update targets
- `.github/workflows/ci.yaml:92-103,484-516` — `e2e_infra`/`e2e_chaos` path filters and the `e2e-infra` job; `Makefile:160-178` — `test-shell`/`chainsaw lint` runners
- Review patterns: *Kubernetes TLS and Certificate Management*, *Kubernetes Secrets Management*, *API Authentication and Authorization*, *Secure by Design and Default*; project patterns *Verify TLS trust chain completeness for internal CAs*, *Never skip TLS verification when CA cert is available*, *Apply security mitigations consistently across all files*, *Apply bug fixes to all instances of the same pattern*, *Document intentional environment divergence in overlays*, *Verify all implicit resource dependencies exist at apply time*, *Verify new resources are referenced by parent manifests*, *Ensure parallel documentation structures are consistent*, *Update documentation when referenced code behavior changes*

---

_Elaborated by [planwerk-review](https://github.com/planwerk/planwerk-review) with Claude Code_


**Labels:** enhancement

---
Source: https://github.com/C5C3/forge/issues/321