### PR TITLE
chore: add Claude Code maintenance skills and apply first drift fixes

### DIFF
--- a/.claude/skills/check-condition-coverage/SKILL.md
+++ b/.claude/skills/check-condition-coverage/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: check-condition-coverage
+description: >-
+  Audit Keystone Status condition coverage end-to-end — every condition
+  type set by a sub-reconciler must appear in the
+  subReconcilerConditionTypes map (so metrics labels resolve), every
+  sub-reconciler must have a unit test, and every condition the docs
+  document must be set somewhere in code. Use when asked to check
+  condition coverage, after adding or renaming a sub-reconciler or a
+  condition type, or when a Prometheus condition_type label suddenly
+  shows up as UNKNOWN.
+---
+
+# Check condition coverage
+
+This skill verifies that the Keystone operator's **status conditions
+are wired end-to-end**: every condition type literal set in the
+sub-reconcilers is registered in the
+`subReconcilerConditionTypes` map (so the
+`keystone_reconcile_errors_total{condition_type=…}` Prometheus label
+resolves to a known value), every sub-reconciler has a unit test, and
+every condition type the architecture docs name is set somewhere in
+code.
+
+It is repeatable — run it any time, especially after editing
+`reconcile_*.go`, the `subReconcilerConditionTypes` map, or the
+condition-type constants in `keystone_types.go`.
+
+## What condition coverage means here
+
+A Keystone condition threads through five layers. Drift in any one
+shows up as a missed alert, a stale doc, an orphan condition type, or
+an `UNKNOWN` Prometheus label:
+
+| Layer | Where it lives | Source of truth |
+|---|---|---|
+| Declared condition type | `operators/keystone/api/v1alpha1/keystone_types.go` (Status struct doc) and the const blocks in `operators/keystone/internal/controller/` (e.g. `conditionTypeDatabaseTLSReady`, `conditionTypeLoggingHealthy`) | the literal `"<Name>Ready"` string |
+| Set in code | `operators/keystone/internal/controller/reconcile_*.go` (`conditions.SetCondition` with `Type: "<Name>Ready"` or `Type: conditionType<X>Ready`) | the sub-reconciler that actually computes the status |
+| Instrumentation map | `operators/keystone/internal/controller/instrumentation.go` (`subReconcilerConditionTypes`) | the canonical sub-reconciler → condition-type label binding for Prometheus |
+| Unit tests | `operators/keystone/internal/controller/reconcile_*_test.go` plus drift-guard tests `TestSubReconcilerConditionTypesCoversAllNames` and `TestSubReconcilerConditionTypesCoversAllCallSites` (in `instrumentation_test.go`) | test functions named after the sub-reconciler |
+| Docs | `architecture/docs/09-implementation/03-crd-implementation.md` | the table or list of condition types |
+
+The authoritative gate is the pair of drift-guard tests in
+`instrumentation_test.go`. This skill defers to them as the source of
+truth for the map vs call-site invariant and adds the inventory checks
+the guards cannot express on their own.
+
+A coverage finding is any place a condition type is set without being
+registered in the map (alerts emit `UNKNOWN`), declared but never set
+(orphan declaration), or set/declared but undocumented (operator
+discovers a condition the docs do not describe).
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **K1** — every condition-type literal set in `reconcile_*.go`
+  (`Type: "<Name>Ready"`) appears in
+  `subReconcilerConditionTypes`. A miss means the `condition_type`
+  Prometheus label emits as `UNKNOWN` whenever this sub-reconciler
+  errors — the existing drift-guard test in `instrumentation_test.go`
+  is the authoritative gate.
+- **K2** — every condition-type constant used as `Type: conditionType<X>Ready`
+  is defined exactly once and used in at least one sub-reconciler.
+  A dead constant means a renamed condition that was not cleaned up.
+- **K3** — every `reconcile_*.go` (excluding `_test.go`) has a paired
+  `reconcile_*_test.go`. A missing test means the sub-reconciler can
+  silently break.
+- **K4** — every condition type set in code appears at least once in
+  the docs (`architecture/docs/09-implementation/03-crd-implementation.md`).
+  A miss means an operator reading the docs cannot find the condition.
+- **K5** — every condition type referenced in the docs is set in code
+  by at least one sub-reconciler. A miss means a stale doc condition
+  that was renamed in code but not in prose.
+- The **inventory** lists, per sub-reconciler:
+  - the condition type(s) it sets,
+  - the entry in `subReconcilerConditionTypes` it expects,
+  - the test function(s) that exercise it.
+
+### 2. Cross-reference the inventory
+
+The script does not resolve Go const ⇢ string values. Using the
+printed inventory, confirm:
+
+1. For each `conditionType<X>Ready` constant that K1 surfaced, walk
+   the const definition to confirm the string literal value matches
+   the map entry exactly (the map's right-hand side may itself use
+   the constant — drift between the literal and the constant is the
+   most common K1 false-positive).
+2. For each sub-reconciler in the inventory, confirm by hand that
+   the `*_test.go` actually exercises the condition transitions the
+   `reconcile_*.go` performs (Reason / Message / Status). Counting
+   tests by file existence is necessary but not sufficient.
+3. For each `[FAIL]` from K4 / K5, decide: doc fix or code fix.
+
+### 3. Run the authoritative gates
+
+The script does not run Go tests. Run the drift-guard tests directly:
+
+```bash
+go test ./operators/keystone/internal/controller/... -run TestSubReconcilerConditionTypesCovers -count=1
+```
+
+These two tests (`TestSubReconcilerConditionTypesCoversAllNames` and
+`TestSubReconcilerConditionTypesCoversAllCallSites`) are the
+authoritative gate for the call-site / map invariant.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — a condition type set in code is missing from
+  `subReconcilerConditionTypes` (Prometheus emits `UNKNOWN`); a
+  drift-guard test fails; a constant is referenced but undefined.
+- **MEDIUM** — a sub-reconciler without a paired test file; a
+  condition type set in code but undocumented; a doc condition type
+  with no code anchor.
+- **LOW** — a constant defined but unused (dead code); a condition
+  type with an inconsistent suffix (e.g. `Healthy` mixed in with
+  `Ready` set); a sub-reconciler whose test file exists but is
+  almost empty.
+
+For each finding give one line with a `file:line` reference for both
+the call-site and the map / doc / test side. End with a per-condition
+health verdict.
+
+## Coverage patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **Renamed condition, stale map entry.** A `Type: "OldNameReady"`
+   call was updated to `"NewNameReady"`, but the
+   `subReconcilerConditionTypes` map still has `"OldNameReady"`. The
+   metric label resolves to `UNKNOWN` until the map is patched.
+2. **New sub-reconciler, no map entry.** A `reconcile_<new>.go` was
+   added with `Type: "<New>Ready"`, but the
+   `subReconcilerConditionTypes` map was not extended. The first
+   error from the new reconciler shows up as `UNKNOWN` in alerts.
+3. **Mixed suffix drift.** A condition is named `<Name>Healthy`
+   instead of `<Name>Ready`. The instrumentation map and the
+   meta.IsStatusConditionTrue helpers all expect the `Ready` suffix;
+   the off-pattern name silently bypasses generic readiness wiring.
+4. **Orphan constant.** A const like `conditionTypeOldReady = "OldReady"`
+   stayed behind after the last call site was deleted. The constant
+   is dead code that suggests the condition is still active.
+5. **Doc-only condition.** The docs list a condition type that no
+   sub-reconciler actually sets. Operators monitoring for it see it
+   as perpetually `Unknown` and assume the controller is broken.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (extend the map, add the test, update the docs) as a
+  separate, explicitly-scoped task.
+- The Go `const` ⇢ string mapping is intentionally not resolved by
+  the script — the existing `TestSubReconcilerConditionTypesCovers*`
+  drift-guard tests do that with full Go AST awareness. Treat K1 as
+  a smoke check and the test as the authoritative gate.
+- Pair this with [[check-doc-drift]] — that skill confirms the prose
+  reference matches the code (sub-reconciler chain, OPERATORS list);
+  this skill drills into the condition-type wiring specifically.

--- a/.claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh
+++ b/.claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-condition-coverage.sh — mechanical condition-coverage checks for
+# the Keystone operator:
+#   K1  every condition-type literal set in reconcile_*.go is registered in
+#       subReconcilerConditionTypes
+#   K2  every conditionType<X>Ready constant is defined once and used in code
+#   K3  every reconcile_*.go has a paired _test.go
+#   K4  every condition type set in code is documented
+#   K5  every condition type referenced in docs is set in code
+#
+# Defers Go-AST-aware checks to the existing drift-guard tests:
+#   TestSubReconcilerConditionTypesCoversAllNames
+#   TestSubReconcilerConditionTypesCoversAllCallSites
+# Exit code 1 on [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+CONTROLLER_DIR="operators/keystone/internal/controller"
+INSTRUMENTATION="${CONTROLLER_DIR}/instrumentation.go"
+CRD_DOC="architecture/docs/09-implementation/03-crd-implementation.md"
+
+if [[ ! -f "${INSTRUMENTATION}" ]]; then
+  fail "missing ${INSTRUMENTATION}"
+  exit 1
+fi
+
+# Build the union of literal condition types declared in the map (right-hand side).
+# Captures both `"FooReady"` and `conditionTypeFooReady` (the latter is resolved
+# below by reading const definitions).
+map_lits=$(grep -oE '"[A-Z][A-Za-z]+Ready"' "${INSTRUMENTATION}" | tr -d '"' | sort -u)
+map_consts=$(grep -oE 'conditionType[A-Z][A-Za-z]+Ready' "${INSTRUMENTATION}" | sort -u)
+
+info "literal condition types in instrumentation map:"
+echo "${map_lits}" | sed 's/^/[INFO]   /'
+info "const-ref condition types in instrumentation map:"
+echo "${map_consts}" | sed 's/^/[INFO]   /'
+
+# Resolve const ⇢ string from any *.go file in the controller package.
+resolve_const() {
+  local name="$1"
+  grep -hE "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[A-Z][A-Za-z]+Ready\"" "${CONTROLLER_DIR}"/*.go 2>/dev/null \
+    | sed -nE "s/.*${name}[[:space:]]*=[[:space:]]*\"([A-Z][A-Za-z]+Ready)\".*/\1/p" \
+    | head -1
+}
+
+# Resolved string set (literals plus resolved constants).
+resolved_set="${map_lits}"
+while IFS= read -r c; do
+  [[ -z "${c}" ]] && continue
+  v=$(resolve_const "${c}")
+  if [[ -n "${v}" ]]; then
+    resolved_set="${resolved_set}"$'\n'"${v}"
+  else
+    info "could not resolve const ${c} to a literal — confirm by hand"
+  fi
+done <<< "${map_consts}"
+resolved_set=$(echo "${resolved_set}" | sort -u)
+
+# ---------------------------------------------------------------------------
+# K1 — every literal Type: "<X>Ready" in reconcile_*.go is in the map (resolved)
+# ---------------------------------------------------------------------------
+hdr "K1: every literal Type: \"<X>Ready\" set in reconcile_*.go is registered"
+callsite_lits=$(grep -hrE 'Type:[[:space:]]+"[A-Z][A-Za-z]+Ready"' "${CONTROLLER_DIR}"/reconcile_*.go 2>/dev/null \
+  | grep -oE '"[A-Z][A-Za-z]+Ready"' | tr -d '"' | sort -u || true)
+for t in ${callsite_lits}; do
+  if echo "${resolved_set}" | grep -qx "${t}"; then
+    pass "callsite literal ${t} is registered in instrumentation map"
+  else
+    fail "callsite literal ${t} is NOT in instrumentation map — Prometheus condition_type will resolve to UNKNOWN"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# K2 — every conditionType<X>Ready constant is defined exactly once and used
+# ---------------------------------------------------------------------------
+hdr "K2: every conditionType<X>Ready constant is defined once and used"
+all_const_refs=$(grep -hrEo 'conditionType[A-Z][A-Za-z]+Ready' "${CONTROLLER_DIR}"/*.go 2>/dev/null \
+  | sort -u || true)
+for c in ${all_const_refs}; do
+  defs=$(grep -hcE "^[[:space:]]*${c}[[:space:]]*=" "${CONTROLLER_DIR}"/*.go 2>/dev/null \
+    | awk -F: '{s+=$1} END {print s+0}')
+  uses=$(grep -hcE "\\b${c}\\b" "${CONTROLLER_DIR}"/*.go 2>/dev/null \
+    | awk -F: '{s+=$1} END {print s+0}')
+  if [[ "${defs}" -eq 0 ]]; then
+    fail "const ${c} referenced but never defined"
+  elif [[ "${defs}" -gt 1 ]]; then
+    fail "const ${c} defined ${defs} times — must be unique"
+  elif [[ "${uses}" -le 1 ]]; then
+    info "const ${c} defined but referenced only ${uses} time(s) — potential dead code"
+  else
+    pass "const ${c} defined once, referenced ${uses} times"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# K3 — every reconcile_*.go has a paired _test.go
+# ---------------------------------------------------------------------------
+hdr "K3: every reconcile_*.go has a paired _test.go"
+for f in "${CONTROLLER_DIR}"/reconcile_*.go; do
+  case "${f}" in
+    *_test.go) continue ;;
+  esac
+  paired="${f%.go}_test.go"
+  if [[ -f "${paired}" ]]; then
+    pass "$(basename "${f}") has paired test $(basename "${paired}")"
+  else
+    fail "$(basename "${f}") has no paired test (expected $(basename "${paired}"))"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# K4 — every condition type set in code is mentioned in the CRD doc
+# ---------------------------------------------------------------------------
+hdr "K4: every condition type set in code is mentioned in ${CRD_DOC}"
+if [[ -f "${CRD_DOC}" ]]; then
+  while IFS= read -r t; do
+    [[ -z "${t}" ]] && continue
+    if grep -q "${t}" "${CRD_DOC}"; then
+      pass "${t} documented"
+    else
+      fail "${t} set in code but absent from ${CRD_DOC}"
+    fi
+  done <<< "${resolved_set}"
+else
+  info "missing ${CRD_DOC} — skipping K4"
+fi
+
+# ---------------------------------------------------------------------------
+# K5 — every condition type referenced in the doc is set in code
+# ---------------------------------------------------------------------------
+hdr "K5: every condition type referenced in ${CRD_DOC} is set in code"
+if [[ -f "${CRD_DOC}" ]]; then
+  doc_types=$(grep -oE '\b[A-Z][A-Za-z]+Ready\b' "${CRD_DOC}" 2>/dev/null | sort -u || true)
+  for t in ${doc_types}; do
+    if echo "${resolved_set}" | grep -qx "${t}"; then
+      pass "${t} (doc) is set somewhere in code"
+    else
+      # Could be set via constant we did not resolve, or could be stale doc.
+      if grep -rqE "\"${t}\"|conditionType${t}|${t}\b" "${CONTROLLER_DIR}"; then
+        info "${t} (doc) appears in code but not via the instrumentation map — confirm by hand"
+      else
+        fail "${t} (doc) is not set anywhere in code — stale documentation?"
+      fi
+    fi
+  done
+else
+  info "missing ${CRD_DOC} — skipping K5"
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory — per-reconciler condition types and tests
+# ---------------------------------------------------------------------------
+hdr "Inventory — sub-reconcilers and the condition types they set"
+for f in "${CONTROLLER_DIR}"/reconcile_*.go; do
+  case "${f}" in
+    *_test.go) continue ;;
+  esac
+  fname=$(basename "${f}")
+  lits=$(grep -oE 'Type:[[:space:]]+"[A-Z][A-Za-z]+Ready"' "${f}" 2>/dev/null \
+    | grep -oE '"[A-Z][A-Za-z]+Ready"' | tr -d '"' | sort -u | tr '\n' ',' | sed 's/,$//')
+  cnst=$(grep -oE 'Type:[[:space:]]+conditionType[A-Z][A-Za-z]+Ready' "${f}" 2>/dev/null \
+    | grep -oE 'conditionType[A-Z][A-Za-z]+Ready' | sort -u | tr '\n' ',' | sed 's/,$//')
+  info "${fname}: literals=[${lits}] consts=[${cnst}]"
+done
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no condition-coverage findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} condition-coverage finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-crd-drift/SKILL.md
+++ b/.claude/skills/check-crd-drift/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: check-crd-drift
+description: >-
+  Audit whether every forge operator CRD is in sync across its three
+  representations — the Go +kubebuilder source under operators/<op>/api/,
+  the controller-gen output under operators/<op>/config/crd/bases/, and
+  the Helm chart copy under operators/<op>/helm/<op>-operator/crds/.
+  Use when asked to check CRD drift, after editing a *_types.go file or
+  a kubebuilder marker, or before a release to catch a CRD that the
+  cluster will reject because the schema is older than the controller.
+---
+
+# Check CRD drift
+
+This skill verifies that the forge generated CRDs still **reflect their
+Go +kubebuilder source**: every kubebuilder marker is regenerable into
+the YAML under `config/crd/bases/`, every Helm chart `crds/` file is a
+byte-for-byte mirror of the corresponding base, and `make verify-crd-sync`
+leaves the working tree clean.
+
+It is repeatable — run it any time, especially after touching a type
+file or a marker, before tagging a release.
+
+## What CRD drift means here
+
+Each operator owns one or more CRDs, and each CRD threads through three
+layers — Go source, generator output, Helm chart copy. Drift can land
+in any one of them:
+
+| Layer | Where it lives | Source of truth |
+|---|---|---|
+| Go +kubebuilder source | `operators/<op>/api/v1alpha1/*_types.go` | the `// +kubebuilder:*` markers, struct fields, JSON tags |
+| Generated CRD YAML | `operators/<op>/config/crd/bases/*.yaml` | `make manifests` output (controller-gen) |
+| Helm chart copy | `operators/<op>/helm/<op>-operator/crds/*.yaml` | `make sync-crds` output — a comment-prefixed mirror of the base |
+| DeepCopy stubs | `operators/<op>/api/v1alpha1/zz_generated.deepcopy.go` | `make generate-common` output (controller-gen object) |
+
+The authoritative drift gate is `make verify-crd-sync` (and, behind it,
+`make sync-crds` ⇢ `make manifests`). It strips the cross-reference
+comment header (`^#` lines) from each `helm/.../crds/*.yaml` and diffs
+the result against the corresponding `config/crd/bases/` file; any
+non-comment delta fails the build. This skill defers to that gate as
+the source of truth and adds the inventories and orphan checks the
+gate cannot express on its own.
+
+A drift finding is any place a generated artefact and its source
+disagree, or a CRD is present that no live operator claims.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-crd-drift/scripts/audit-crd-drift.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **C1** — every `operators/<op>/` with an `api/` directory has a
+  matching `config/crd/bases/` directory and at least one CRD YAML
+  inside it. A missing base means `make manifests` was never run for
+  this operator, or the chart was added without wiring controller-gen.
+- **C2** — every `config/crd/bases/*.yaml` for an operator has a
+  byte-equivalent copy under `helm/<op>-operator/crds/` (after
+  stripping leading `#` comment lines, matching the gate). A missing
+  or differing copy means `make sync-crds` was skipped after the last
+  marker edit.
+- **C3** — every `helm/<op>-operator/crds/*.yaml` traces back to a
+  `config/crd/bases/` file. An orphan copy is a CRD that controller-gen
+  no longer emits but the chart still ships — the next install will
+  register a CRD with no controller behind it.
+- **C4** — every `*_types.go` with a `+kubebuilder:object:root=true`
+  marker has a corresponding generated DeepCopy block in
+  `zz_generated.deepcopy.go`. A missing block means `make generate-common`
+  was skipped — the operator will fail to build.
+- The **inventory** lists, per operator, every CRD with its
+  `spec.versions[].name`, its kubebuilder printer columns, and the size
+  delta between the base and the helm copy in bytes (after stripping
+  comments). Cross-reference each by hand in step 2.
+
+### 2. Cross-reference the inventory
+
+The script cannot run controller-gen (it would require the toolchain on
+`PATH`). Using the printed inventory, confirm:
+
+1. Every CRD listed under `config/crd/bases/` corresponds to a Go type
+   in the same operator's `api/v1alpha1/` with a matching `kind`.
+2. Every `+kubebuilder:printcolumn` in the Go source is present as a
+   `additionalPrinterColumns` entry in the generated CRD.
+3. Every `+kubebuilder:validation:XValidation` rule in the Go source
+   shows up as a CEL `x-kubernetes-validations` entry in the CRD.
+4. No two operators define the same CRD `metadata.name` — chart
+   installs would overwrite each other.
+
+Flag any pair where the source and the generated YAML disagree.
+
+### 3. Run the authoritative drift gate
+
+The script does no regeneration. Run the real gates and report the
+exact outcomes:
+
+```bash
+make manifests          # regenerate CRD bases from kubebuilder markers
+make sync-crds          # copy bases into the Helm chart crds/ dir
+make verify-crd-sync    # authoritative diff gate (also runs in CI)
+```
+
+`make verify-crd-sync` is the authoritative gate — trust it over the
+C1–C4 smoke checks. It is fast (a `find` + `diff` over a handful of
+files) but does require `controller-gen` on `PATH` for `make manifests`.
+Pass `--full` to the script to chain `make verify-crd-sync` after the
+inventory.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — `make verify-crd-sync` fails, or a Helm `crds/` copy and
+  its base disagree on a non-comment line, or a `*_types.go` exists
+  without a generated CRD base.
+- **MEDIUM** — an orphan helm `crds/*.yaml` with no live base; a
+  printcolumn or XValidation in the source that is absent from the
+  generated CRD; a CRD listed under one operator's `config/crd/bases/`
+  whose Go type lives in another operator.
+- **LOW** — a comment-only delta between base and helm copy (the gate
+  strips these — informational only); a missing kubebuilder printer
+  column on a CRD that has none documented either.
+
+For each finding give one line with a `file:line` reference for both
+the source side and the generated side. End with a two- to three-sentence
+health verdict per operator. The C1–C4 results and the step-3 gate
+outcome go in the report verbatim.
+
+## Drift patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **Stale Helm chart copy.** A marker edit hit `*_types.go`, `make
+   manifests` ran (so `config/crd/bases/` is fresh), but `make
+   sync-crds` was skipped. The chart still ships the previous schema.
+   `make verify-crd-sync` catches this by definition.
+2. **Hand-edit on a generated CRD.** A YAML change on top of a
+   marker-clean HEAD that the next `make manifests` would silently
+   overwrite. Often surfaces as a `+kubebuilder` marker that the source
+   does not actually express.
+3. **Orphan CRD in the Helm chart.** A type was renamed or deleted in
+   Go but the corresponding `helm/<op>-operator/crds/*.yaml` was not
+   removed. `helm install` registers the dead CRD, and the cluster
+   has a kind no controller reconciles.
+4. **DeepCopy drift.** A new struct field landed in `*_types.go`
+   without `make generate-common` — the build fails before the CRD
+   gate ever runs.
+5. **Cross-operator CRD ownership.** A CRD `kind` ended up under the
+   wrong operator's `config/crd/bases/` (e.g. duplicated during a
+   refactor). Both operators' Helm charts then ship it, and `helm
+   install` order decides which schema wins.
+
+## Reference — regenerating after a marker change
+
+When a marker or struct field changes, the checklist is:
+
+1. **Edit the Go source.** Pick `operators/<op>/api/v1alpha1/*_types.go`.
+2. **Regenerate.** `make manifests` rebuilds `config/crd/bases/*.yaml`;
+   `make generate-common` rebuilds `zz_generated.deepcopy.go`;
+   `make sync-crds` mirrors the bases into the Helm chart crds/ dir
+   (and prepends the cross-reference comment header).
+3. **Verify drift gate clean.** `make verify-crd-sync` must exit `0` —
+   it is the same check CI runs.
+4. **Commit all sides together.** The source change, the regenerated
+   bases, the regenerated deepcopy, and the Helm copies go in the same
+   commit so a future `git bisect` always sees a self-consistent tree.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (`make manifests && make sync-crds`, delete the orphan)
+  as a separate, explicitly-scoped task.
+- The audit script does not assume `controller-gen` is on `PATH` — it
+  defers regeneration to `make verify-crd-sync`. The `--full` flag
+  chains that gate after the inventory; without it the script is a
+  fast smoke check that runs cleanly on a laptop without the kubebuilder
+  toolchain installed.
+- Pair this with [[check-fixture-drift]] — that skill confirms each
+  CR fixture under `tests/e2e/` still validates against the *current*
+  CRD schema; this skill confirms each CRD still mirrors its Go source.

--- a/.claude/skills/check-crd-drift/scripts/audit-crd-drift.sh
+++ b/.claude/skills/check-crd-drift/scripts/audit-crd-drift.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-crd-drift.sh — mechanical CRD-drift checks for the forge repo.
+# Verifies, per operator:
+#   C1  every operators/<op>/api/ has a matching config/crd/bases/ with >=1 CRD
+#   C2  every config/crd/bases/*.yaml is byte-equivalent (modulo leading `#`
+#       comments) to helm/<op>-operator/crds/<same>
+#   C3  every helm/<op>-operator/crds/*.yaml traces back to a base
+#   C4  every *_types.go with +kubebuilder:object:root=true has a DeepCopy
+#       block in zz_generated.deepcopy.go
+#
+# Defers regeneration to `make verify-crd-sync`. Pass --full to chain that
+# gate after the inventory. Exit code 1 on any [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FULL=0
+if [[ "${1:-}" == "--full" ]]; then
+  FULL=1
+fi
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+# Discover operators that have an api/ directory.
+OPERATORS=()
+for d in operators/*/; do
+  op="$(basename "${d}")"
+  if [[ -d "operators/${op}/api" ]]; then
+    OPERATORS+=("${op}")
+  fi
+done
+
+if [[ ${#OPERATORS[@]} -eq 0 ]]; then
+  fail "no operators with api/ found under operators/"
+  exit 1
+fi
+
+hdr "Discovered operators"
+for op in "${OPERATORS[@]}"; do
+  info "operator: ${op}"
+done
+
+# ---------------------------------------------------------------------------
+# C1 — every operator has config/crd/bases/*.yaml
+# ---------------------------------------------------------------------------
+hdr "C1: every operators/<op>/api/ has config/crd/bases/*.yaml"
+for op in "${OPERATORS[@]}"; do
+  base_dir="operators/${op}/config/crd/bases"
+  if [[ ! -d "${base_dir}" ]]; then
+    fail "${op}: missing ${base_dir} (run: make manifests OPERATOR=${op})"
+    continue
+  fi
+  count=$(find "${base_dir}" -maxdepth 1 -name '*.yaml' -type f | wc -l | tr -d ' ')
+  if [[ "${count}" -eq 0 ]]; then
+    fail "${op}: ${base_dir} has no CRD YAML (run: make manifests OPERATOR=${op})"
+  else
+    pass "${op}: ${count} CRD base(s) under ${base_dir}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# C2 — every base matches its helm copy modulo `^#` comment lines
+# ---------------------------------------------------------------------------
+hdr "C2: helm chart crds/ mirrors config/crd/bases/ (modulo comments)"
+for op in "${OPERATORS[@]}"; do
+  base_dir="operators/${op}/config/crd/bases"
+  helm_dir="operators/${op}/helm/${op}-operator/crds"
+  if [[ ! -d "${helm_dir}" ]]; then
+    fail "${op}: missing ${helm_dir}"
+    continue
+  fi
+  shopt -s nullglob
+  for base in "${base_dir}"/*.yaml; do
+    fname="$(basename "${base}")"
+    helm="${helm_dir}/${fname}"
+    if [[ ! -f "${helm}" ]]; then
+      fail "${op}: ${fname} present in bases/ but missing under helm/${op}-operator/crds/"
+      continue
+    fi
+    if diff -q \
+        <(grep -v '^#' "${base}") \
+        <(grep -v '^#' "${helm}") >/dev/null 2>&1; then
+      pass "${op}: ${fname} mirrors base (modulo comments)"
+    else
+      fail "${op}: ${fname} drifts from base — run: make sync-crds OPERATOR=${op}"
+    fi
+  done
+  shopt -u nullglob
+done
+
+# ---------------------------------------------------------------------------
+# C3 — every helm crds/*.yaml has a base
+# ---------------------------------------------------------------------------
+hdr "C3: no orphan CRDs under helm/<op>-operator/crds/"
+for op in "${OPERATORS[@]}"; do
+  base_dir="operators/${op}/config/crd/bases"
+  helm_dir="operators/${op}/helm/${op}-operator/crds"
+  [[ -d "${helm_dir}" ]] || continue
+  shopt -s nullglob
+  for helm in "${helm_dir}"/*.yaml; do
+    fname="$(basename "${helm}")"
+    if [[ ! -f "${base_dir}/${fname}" ]]; then
+      fail "${op}: orphan ${fname} in helm/${op}-operator/crds/ — no base under ${base_dir}/"
+    else
+      pass "${op}: helm ${fname} traces back to a base"
+    fi
+  done
+  shopt -u nullglob
+done
+
+# ---------------------------------------------------------------------------
+# C4 — every +kubebuilder:object:root=true type has a DeepCopy block
+# ---------------------------------------------------------------------------
+hdr "C4: every CRD kind has a DeepCopy block"
+for op in "${OPERATORS[@]}"; do
+  api_dir="operators/${op}/api/v1alpha1"
+  deepcopy="${api_dir}/zz_generated.deepcopy.go"
+  if [[ ! -f "${deepcopy}" ]]; then
+    fail "${op}: missing ${deepcopy} — run: make generate-common"
+    continue
+  fi
+  # Find every Go struct preceded by +kubebuilder:object:root=true.
+  while IFS= read -r line; do
+    # Line looks like: operators/keystone/api/v1alpha1/keystone_types.go:31:type Keystone struct {
+    file="${line%%:*}"
+    rest="${line#*:}"
+    lineno="${rest%%:*}"
+    # Extract the kind name from the next "type <Name> struct {" line at or
+    # after the marker. Uses tail+sed for portability (BSD awk has no match() 3rd-arg).
+    kind=$(tail -n "+${lineno}" "${file}" \
+      | sed -nE 's/^type ([A-Z][A-Za-z0-9_]+) struct.*/\1/p' \
+      | head -n 1)
+    if [[ -z "${kind}" ]]; then
+      info "${op}: marker at ${file}:${lineno} has no struct directly after it"
+      continue
+    fi
+    if grep -q "^func (in \*${kind}) DeepCopyInto" "${deepcopy}"; then
+      pass "${op}: ${kind} has DeepCopy block"
+    else
+      fail "${op}: ${kind} marked as CRD root but no DeepCopy in ${deepcopy} — run: make generate-common"
+    fi
+  done < <(grep -rn '+kubebuilder:object:root=true' "${api_dir}" || true)
+done
+
+# ---------------------------------------------------------------------------
+# Inventory — per CRD, version names, printer columns, byte delta vs helm copy
+# ---------------------------------------------------------------------------
+hdr "Inventory"
+for op in "${OPERATORS[@]}"; do
+  base_dir="operators/${op}/config/crd/bases"
+  helm_dir="operators/${op}/helm/${op}-operator/crds"
+  [[ -d "${base_dir}" ]] || continue
+  shopt -s nullglob
+  for base in "${base_dir}"/*.yaml; do
+    fname="$(basename "${base}")"
+    helm="${helm_dir}/${fname}"
+    versions=$(awk '/^  versions:/{flag=1;next} /^[a-zA-Z]/{flag=0} flag && /- name:/{print $3}' "${base}" | tr '\n' ',' | sed 's/,$//')
+    printer_columns=$(grep -c '^    - jsonPath:' "${base}" || true)
+    cel_rules=$(grep -c 'x-kubernetes-validations:' "${base}" || true)
+    base_bytes=$(grep -cv '^#' "${base}" || true)
+    helm_bytes=0
+    [[ -f "${helm}" ]] && helm_bytes=$(grep -cv '^#' "${helm}" || true)
+    delta=$((base_bytes - helm_bytes))
+    info "${op}/${fname}: versions=[${versions}] printer-cols=${printer_columns} cel-rules=${cel_rules} non-comment-lines base=${base_bytes} helm=${helm_bytes} delta=${delta}"
+  done
+  shopt -u nullglob
+done
+
+# ---------------------------------------------------------------------------
+# Optional: chain the authoritative gate
+# ---------------------------------------------------------------------------
+if [[ "${FULL}" -eq 1 ]]; then
+  hdr "Authoritative gate — make verify-crd-sync"
+  if make verify-crd-sync; then
+    pass "make verify-crd-sync: clean"
+  else
+    fail "make verify-crd-sync: drift detected (see output above)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no CRD-drift findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} CRD-drift finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-doc-drift/SKILL.md
+++ b/.claude/skills/check-doc-drift/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: check-doc-drift
+description: >-
+  Audit the forge documentation for drift against the implementation —
+  the architecture/docs/ chapters vs the operator code, the docs/
+  user-facing reference vs the deploy/ infrastructure stack, and the
+  CC-NNNN feature IDs cited in prose vs the markers that appear in the
+  code. Use when asked to check documentation drift, after adding or
+  removing a sub-reconciler, status condition, operator binary, or
+  infrastructure component, or before tagging a release.
+---
+
+# Check documentation drift
+
+This skill verifies that the forge documentation still **describes what
+the code actually does**: every sub-reconciler, status condition,
+operator binary, CRD field, FluxCD component, and CC-NNNN feature ID
+named in `architecture/docs/` or `docs/` (and `README.md`) is checked
+against its source of truth, so a reader is never handed a reference
+page that contradicts the implementation.
+
+It is repeatable — run it any time, especially after shipping a feature
+that touched a documented surface, or before cutting a release.
+
+## What documentation drift means here
+
+Drift is any place a doc and the code it documents disagree. The audit
+splits the corpus into four areas, each with a single source of truth:
+
+| Doc area | Files | Source of truth |
+|---|---|---|
+| Operator architecture | `architecture/docs/09-implementation/04-keystone-reconciler.md`, `architecture/docs/09-implementation/02-shared-library.md`, `architecture/docs/04-architecture/*.md` | `operators/keystone/internal/controller/reconcile_*.go` + `operators/keystone/api/v1alpha1/keystone_types.go` + `internal/common/` |
+| CRD reference | `architecture/docs/09-implementation/03-crd-implementation.md` | `operators/keystone/api/v1alpha1/keystone_types.go` and the generated CRD under `operators/keystone/config/crd/bases/` |
+| Infrastructure stack | `architecture/docs/09-implementation/01-project-setup.md`, `architecture/docs/09-implementation/05-keystone-dependencies.md`, `architecture/docs/09-implementation/09-openbao-deployment.md`, `docs/guides/`, `docs/quick-start*.md` | `deploy/` kustomize tree + `hack/deploy-infra.sh` + `releases/<version>/source-refs.yaml` |
+| Feature ID coverage | every `architecture/docs/**/*.md` that names a `CC-NNNN` | every `// CC-NNNN` / `# CC-NNNN` / `Feature: CC-NNNN` marker in `operators/`, `internal/`, `tests/`, `hack/`, `Makefile`, `deploy/` |
+
+A doc that contradicts its source is a defect even when the build is
+green: the compiler never reads prose. The audit's job is to surface
+every disagreement, then let you judge severity and fix.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
+```
+
+The script catches the mechanically-checkable drift and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **D1** — `OPERATORS ?=` default in `Makefile` vs the actual
+  `operators/*/` directories. An operator added under `operators/` but
+  not added to the Makefile default (or vice versa) means the new
+  binary never gets built/tested by `make build` / `make test` /
+  `make lint`.
+- **D2** — count of `reconcile_*.go` files under
+  `operators/keystone/internal/controller/` vs the count of
+  `### reconcile…()` sections in
+  `architecture/docs/09-implementation/04-keystone-reconciler.md`. A
+  delta means a new sub-reconciler shipped without a doc section, or
+  a section names a sub-reconciler that was removed.
+- **D3** — every `### reconcile…()` heading in the reconciler doc
+  names a function that exists in the controller package. A renamed
+  reconciler leaves the heading stranded.
+- **D4** — every condition type set in the sub-reconcilers (literal
+  string in `meta.SetStatusCondition` / `conditions.SetCondition`
+  calls) is documented under
+  `architecture/docs/09-implementation/03-crd-implementation.md`.
+- **D5** — every `CC-NNNN` cited in `architecture/docs/` has at
+  least one matching marker in the code tree. A doc that cites a
+  feature ID with no implementation anchor is either premature (the
+  feature is not done) or stale (the markers were cleaned up). Cited
+  but unreferenced IDs are flagged as `[INFO]`, not `[FAIL]`, because
+  some architectural CCs are tracked only in issues — confirm by hand.
+- **D6** — every `deploy/<component>/` directory mentioned by name in
+  `architecture/docs/09-implementation/` exists. A renamed or removed
+  infra component leaves the doc page pointing at nothing.
+- The **inventories** are review aids, not pass/fail: every spelled-out
+  numeric claim in the docs ("11 sub-conditions", "8-step deployment",
+  "three states"), every FluxCD release name documented vs declared.
+  Cross-reference each by hand in step 2.
+
+### 2. Cross-reference the four areas by hand
+
+The script cannot read prose meaning. For each area, open the doc and
+its source of truth and confirm they agree. This is the real work —
+delegate the four areas to parallel sub-agents for a large corpus.
+
+- **Operator architecture** — for each `### reconcile…()` section in
+  `04-keystone-reconciler.md`, confirm the description matches the
+  current implementation under `operators/keystone/internal/controller/`
+  (what it touches, what condition it sets, what it requeues on).
+- **CRD reference** — for each Spec field listed in
+  `03-crd-implementation.md`, confirm the type, JSON tag, default,
+  required-ness, and CEL validation rule match
+  `keystone_types.go`. Then walk the generated CRD under
+  `operators/keystone/config/crd/bases/` and confirm no Spec field is
+  undocumented.
+- **Infrastructure stack** — for each component named in
+  `01-project-setup.md` and `05-keystone-dependencies.md`, confirm a
+  matching directory exists under `deploy/` and that
+  `hack/deploy-infra.sh` still installs it in the documented order.
+- **Feature ID coverage** — for each `CC-NNNN` flagged by D5, decide
+  whether the doc is premature (delete the citation) or the markers
+  were prematurely cleaned (restore at least one anchor in code, or
+  cross-reference a GitHub issue).
+
+Flag any pair where the doc and the source disagree.
+
+### 3. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — `OPERATORS` Makefile default disagrees with the
+  `operators/` tree; a `### reconcile…()` doc heading names a function
+  that does not exist; a documented condition type is never set by
+  any sub-reconciler; an infrastructure component named in the docs
+  has no matching `deploy/` directory.
+- **MEDIUM** — sub-reconciler count drift; a condition type set in
+  the code that is not documented; a Spec field with a `+kubebuilder`
+  marker that is not described in the CRD reference doc; a numeric
+  claim ("11 sub-conditions") that no longer matches the code count.
+- **LOW** — a `CC-NNNN` cited in the docs with no code anchor
+  (informational, may be tracked elsewhere); a stale link target
+  inside `architecture/docs/`; a typo or formatting drift.
+
+For each finding give one line with a `file:line` reference for both
+the doc side and the source side. End with a two- to three-sentence
+health verdict per doc area.
+
+## Drift patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **New sub-reconciler, no doc section.** A `reconcile_<thing>.go`
+   was added but `04-keystone-reconciler.md` still lists the old
+   sub-reconciler set. The new condition type is then set by the
+   controller but not described under `03-crd-implementation.md`
+   either.
+2. **Renamed condition type.** A condition was renamed in
+   `keystone_types.go` and the sub-reconciler code, but the docs
+   still use the old type name in a table row. Operators looking up
+   the new name in the docs find nothing.
+3. **Removed Spec field.** A field was deleted from `keystone_types.go`
+   but the CRD reference doc still lists it. CR fixtures that use the
+   field then fail with an obscure unknown-field error and the doc
+   is the only place that knew what it meant.
+4. **OPERATORS drift.** A new operator binary was added under
+   `operators/` but the Makefile default still lists only the
+   originals. `make test` / `make lint` silently skip the new
+   operator until someone notices a CI gap.
+5. **Stale CC-NNNN citation.** A feature page in `architecture/docs/`
+   cites a `CC-NNNN` that was never implemented or was rolled into
+   another ID. The doc still reads as authoritative.
+6. **Renamed infra release.** `deploy/<component>/` was renamed
+   (e.g. `cert-manager` ⇢ `cert-manager-istio`) but
+   `01-project-setup.md` or `05-keystone-dependencies.md` still uses
+   the old name. New operators copy the wrong reference.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (update the doc, delete the stale citation, add the
+  missing condition row) as a separate, explicitly-scoped task.
+- The CC-NNNN check is intentionally informational. Some feature IDs
+  exist only as architecture-level tracking and never receive a code
+  marker; treat D5 findings as a prompt to confirm by hand, not as a
+  hard failure.
+- Pair this with [[check-crd-drift]] — that skill confirms the CRD
+  YAML still mirrors the Go source; this skill confirms the prose
+  reference still mirrors both.
+- Pair this with [[check-condition-coverage]] — that skill confirms
+  every condition type set in the code is wired to the instrumentation
+  map; this skill adds the doc-side check.

--- a/.claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
+++ b/.claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-doc-drift.sh — mechanical doc-drift checks for the forge repo.
+# Verifies that architecture/docs/ + docs/ still describe the operator code
+# and infrastructure stack accurately:
+#   D1  Makefile OPERATORS default matches operators/*/
+#   D2  count of reconcile_*.go matches doc-side sub-reconciler section count
+#   D3  every doc-side reconcileX() heading names a real function
+#   D4  every condition type literal set in reconcile_*.go is documented
+#   D5  every CC-NNNN cited in architecture/docs/ has a code anchor
+#   D6  every deploy/<component>/ named in architecture/docs/09-implementation/
+#       still exists
+#
+# Defers prose-meaning checks to a human reviewer. Exit code 1 on any [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+RECONCILER_DOC="architecture/docs/09-implementation/04-keystone-reconciler.md"
+CRD_DOC="architecture/docs/09-implementation/03-crd-implementation.md"
+CONTROLLER_DIR="operators/keystone/internal/controller"
+
+# ---------------------------------------------------------------------------
+# D1 — Makefile OPERATORS default matches operators/*/
+# ---------------------------------------------------------------------------
+hdr "D1: Makefile OPERATORS default matches operators/*/"
+makefile_ops=$(grep -E '^OPERATORS \?=' Makefile | head -1 | sed -E 's/^OPERATORS \?= *//' | tr ' ' '\n' | sort)
+fs_ops=$(for d in operators/*/; do basename "${d}"; done | sort)
+if diff <(echo "${makefile_ops}") <(echo "${fs_ops}") >/dev/null 2>&1; then
+  pass "Makefile OPERATORS default matches operators/* (${fs_ops//$'\n'/, })"
+else
+  fail "OPERATORS drift — Makefile: $(echo "${makefile_ops}" | tr '\n' ',' | sed 's/,$//') vs filesystem: $(echo "${fs_ops}" | tr '\n' ',' | sed 's/,$//')"
+fi
+
+# ---------------------------------------------------------------------------
+# D2 — count of reconcile_*.go matches doc heading count
+# ---------------------------------------------------------------------------
+hdr "D2: reconcile_*.go file count vs ### reconcileX() heading count in ${RECONCILER_DOC}"
+recon_files=$(find "${CONTROLLER_DIR}" -maxdepth 1 -name 'reconcile_*.go' -not -name '*_test.go' | wc -l | tr -d ' ')
+if [[ -f "${RECONCILER_DOC}" ]]; then
+  doc_headings=$(grep -cE '^### reconcile[A-Z][A-Za-z]*\(\)' "${RECONCILER_DOC}" || true)
+  info "reconcile_*.go files: ${recon_files}; ### reconcileX() headings: ${doc_headings}"
+  if [[ "${recon_files}" -ne "${doc_headings}" ]]; then
+    fail "sub-reconciler count drift: ${recon_files} files vs ${doc_headings} doc headings (delta=$((recon_files - doc_headings)))"
+  else
+    pass "sub-reconciler count consistent"
+  fi
+else
+  fail "missing reconciler doc: ${RECONCILER_DOC}"
+fi
+
+# ---------------------------------------------------------------------------
+# D3 — every ### reconcileX() heading names a real Go function
+# ---------------------------------------------------------------------------
+hdr "D3: every ### reconcileX() heading names a real Go function"
+if [[ -f "${RECONCILER_DOC}" ]]; then
+  while IFS= read -r heading; do
+    fn=$(echo "${heading}" | sed -nE 's/^### (reconcile[A-Z][A-Za-z]*)\(\).*/\1/p')
+    [[ -z "${fn}" ]] && continue
+    if grep -rqE "^func .*\) ${fn}\(" "${CONTROLLER_DIR}"; then
+      pass "doc heading ### ${fn}() resolves to a Go function"
+    else
+      fail "doc heading ### ${fn}() has no matching func in ${CONTROLLER_DIR} — renamed/removed?"
+    fi
+  done < <(grep -E '^### reconcile[A-Z]' "${RECONCILER_DOC}")
+fi
+
+# ---------------------------------------------------------------------------
+# D4 — every condition type literal set in reconcile_*.go is documented
+# ---------------------------------------------------------------------------
+hdr "D4: condition types set in code are documented in ${CRD_DOC}"
+# Extract condition type literals from instrumentation.go map (the canonical set).
+INSTRUMENTATION="${CONTROLLER_DIR}/instrumentation.go"
+if [[ -f "${INSTRUMENTATION}" && -f "${CRD_DOC}" ]]; then
+  # Map values in the form `"<Name>Ready"` or `conditionType<X>Ready` (constant).
+  # We take the literal-quoted ones directly; the const ones require resolving in code.
+  literal_types=$(grep -oE '"[A-Z][A-Za-z]+Ready"' "${INSTRUMENTATION}" | tr -d '"' | sort -u)
+  for t in ${literal_types}; do
+    if grep -q "${t}" "${CRD_DOC}"; then
+      pass "condition type ${t} documented in ${CRD_DOC}"
+    else
+      fail "condition type ${t} set in code but not documented in ${CRD_DOC}"
+    fi
+  done
+  # Also list constant-referenced types for the human to cross-check.
+  const_refs=$(grep -oE 'conditionType[A-Z][A-Za-z]+Ready' "${INSTRUMENTATION}" | sort -u)
+  for c in ${const_refs}; do
+    info "condition type constant ${c} — confirm doc coverage by hand"
+  done
+else
+  info "skipping D4: missing ${INSTRUMENTATION} or ${CRD_DOC}"
+fi
+
+# ---------------------------------------------------------------------------
+# D5 — every CC-NNNN cited in architecture/docs/ has a code anchor
+# ---------------------------------------------------------------------------
+hdr "D5: CC-NNNN citations in architecture/docs/ have a code anchor"
+if [[ -d architecture/docs ]]; then
+  doc_ccs=$(grep -rhoE 'CC-[0-9]{4}' architecture/docs/ | sort -u)
+  code_ccs=$(grep -rhoE 'CC-[0-9]{4}' \
+    --include='*.go' --include='*.sh' --include='*.yaml' --include='*.yml' \
+    --include='Makefile' --include='*.toml' \
+    operators/ internal/ tests/ hack/ scripts/ deploy/ Makefile 2>/dev/null | sort -u || true)
+  missing_anchor=0
+  for cc in ${doc_ccs}; do
+    if ! echo "${code_ccs}" | grep -qx "${cc}"; then
+      info "doc cites ${cc} with no code anchor — confirm by hand (issue-only or stale?)"
+      missing_anchor=$((missing_anchor + 1))
+    fi
+  done
+  total_doc_ccs=$(echo "${doc_ccs}" | wc -w | tr -d ' ')
+  total_code_ccs=$(echo "${code_ccs}" | wc -w | tr -d ' ')
+  info "CC-NNNN totals: docs=${total_doc_ccs} unique; code=${total_code_ccs} unique; docs without code anchor=${missing_anchor}"
+  pass "D5 complete (informational — see [INFO] above)"
+else
+  info "skipping D5: no architecture/docs/ directory"
+fi
+
+# ---------------------------------------------------------------------------
+# D6 — every deploy/<component> named in architecture/docs/09-implementation/
+#       exists on disk
+# ---------------------------------------------------------------------------
+hdr "D6: deploy/<component>/ references in architecture/docs/09-implementation/ exist"
+if [[ -d architecture/docs/09-implementation && -d deploy ]]; then
+  refs=$(grep -rhoE 'deploy/[a-z][a-z0-9-]+/' architecture/docs/09-implementation/ 2>/dev/null \
+    | sort -u || true)
+  for ref in ${refs}; do
+    # ref is like "deploy/cert-manager/"; strip trailing slash for stat
+    path="${ref%/}"
+    if [[ -d "${path}" ]]; then
+      pass "doc reference ${ref} exists on disk"
+    else
+      fail "doc reference ${ref} has no matching directory under deploy/"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory — spelled-out numeric claims (review aid)
+# ---------------------------------------------------------------------------
+hdr "Inventory — numeric claims in docs (review aid)"
+if [[ -d architecture/docs ]]; then
+  # Match common patterns like "11 sub-conditions", "8-step", "three states".
+  grep -rEn '[0-9]+[- ](sub-condition|step|reconciler|operator|condition|phase|version)' \
+    architecture/docs/ 2>/dev/null | head -20 || true
+fi
+
+hdr "Inventory — FluxCD HelmReleases declared under deploy/"
+if [[ -d deploy/flux-system/releases ]]; then
+  ls deploy/flux-system/releases/*.yaml 2>/dev/null | xargs -I{} basename {} .yaml | sort | sed 's/^/[INFO] flux release: /'
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no documentation-drift findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} documentation-drift finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-fixture-drift/SKILL.md
+++ b/.claude/skills/check-fixture-drift/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: check-fixture-drift
+description: >-
+  Audit whether every Keystone / c5c3 CR fixture under tests/e2e/ and
+  tests/e2e-chaos/ still validates against the *current* CRD schema —
+  no removed Spec field is still referenced, every fixture's
+  apiVersion / kind matches a real CRD, every invalid-cr fixture is
+  reachable from a Chainsaw test, and the existing
+  verify-invalid-cr-fixtures generator stays in sync with its hand-edited
+  outputs. Use when asked to check fixture drift, after editing the
+  Keystone CRD or the validating webhook, or before a release.
+---
+
+# Check fixture drift
+
+This skill verifies that the forge **test fixtures still match the CRD
+they claim to instantiate**: every `apiVersion: keystone.openstack.c5c3.io/v1alpha1`
+fixture under `tests/e2e/` and `tests/e2e-chaos/` uses only Spec fields
+that the current CRD schema accepts, every invalid-cr fixture is
+referenced from a Chainsaw test that exercises it, and the
+`verify-invalid-cr-fixtures` generator's outputs stay in sync.
+
+It is repeatable — run it any time, especially after editing
+`operators/keystone/api/v1alpha1/keystone_types.go`, the validating
+webhook, or any `kubebuilder:validation:*` marker.
+
+## What fixture drift means here
+
+A fixture lives in one of three roles, each anchored to its own source
+of truth:
+
+| Fixture role | Where it lives | Source of truth |
+|---|---|---|
+| Happy-path e2e CR | `tests/e2e/keystone/<scenario>/*.yaml` (filename pattern `<NN>-*.yaml`, referenced from `chainsaw-test.yaml`) | the Keystone CRD `operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml` and the webhook in `operators/keystone/internal/controller/` |
+| Chaos / scale e2e CR | `tests/e2e-chaos/<scenario>/*.yaml`, `tests/e2e/infrastructure/*` | same CRD |
+| Invalid-CR webhook reject | `tests/e2e/keystone/invalid-cr/<NN>-*.yaml` (paired with the Python generator `_generate.py` and the unit test `test_generate.py`) | `keystone_types.go` `+kubebuilder:validation:*` markers and the webhook validation logic |
+| Chainsaw test wiring | `tests/e2e/<area>/<scenario>/chainsaw-test.yaml` | references the local `<NN>-*.yaml` files by relative path |
+
+The authoritative gate for the invalid-cr corpus is
+`make verify-invalid-cr-fixtures` — it re-runs the Python generator in
+`--check` mode plus the generator's own unit tests. This skill defers
+to that gate and adds the broader fixture inventory checks the gate
+does not cover.
+
+A drift finding is any place a fixture references a Spec field that
+the current CRD does not declare, a fixture file that no Chainsaw test
+references, or a Chainsaw test that points at a fixture that has been
+moved or renamed.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-fixture-drift/scripts/audit-fixture-drift.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **X1** — every fixture with `kind: Keystone` uses the current
+  apiVersion (`keystone.openstack.c5c3.io/v1alpha1`). A fixture on
+  an old apiVersion fails to apply but the failure is generic.
+- **X2** — every top-level Spec field in every `kind: Keystone`
+  fixture appears in the CRD schema. A removed/renamed field is the
+  most common fixture-drift source after a CRD edit; the cluster
+  rejects the CR with `unknown field`, which is hard to diff against
+  the original intent.
+- **X3** — every `<NN>-*.yaml` fixture next to a `chainsaw-test.yaml`
+  is referenced from that Chainsaw test (via `apply`, `assert`,
+  `error`, or `patch`). An orphan fixture is a dead test artefact —
+  the scenario it was written for was removed but the file stayed.
+- **X4** — every file referenced from a `chainsaw-test.yaml` exists
+  on disk under the same directory. A renamed fixture leaves a
+  Chainsaw step pointing at nothing.
+- **X5** — the invalid-cr generator + unit tests still pass when
+  invoked as `make verify-invalid-cr-fixtures` (gated check; skipped
+  if `python3` is not on PATH).
+- The **inventories** are review aids: per Chainsaw test directory,
+  the count of `<NN>-*.yaml` fixtures vs `chainsaw-test.yaml` step
+  references; per invalid-cr fixture, the matching `+kubebuilder`
+  marker the rejection should reference.
+
+### 2. Cross-reference the inventory
+
+The script does no schema validation against the live cluster. Using
+the printed inventory, confirm:
+
+1. For each Spec field that X2 flagged, decide: was the field renamed
+   (update the fixture), removed (delete the fixture lines), or
+   moved into a sub-struct (re-indent the fixture)?
+2. For each orphan fixture from X3, confirm whether the scenario was
+   intentionally removed (delete the YAML) or whether the
+   `chainsaw-test.yaml` lost a step (restore the reference).
+3. For each invalid-cr fixture, walk the corresponding webhook
+   rejection path to confirm the error message the Chainsaw test
+   asserts still matches the webhook output. The Python generator
+   carries the expected error string in its source — cross-check.
+4. For server-side validation, optionally run a dry-run apply against
+   a kind cluster:
+   ```bash
+   for f in $(find tests/e2e/keystone -name '*keystone*.yaml' | xargs grep -l '^kind: Keystone'); do
+     kubectl apply --dry-run=server -f "${f}" 2>&1 | tail -1
+   done
+   ```
+   This requires `kubectl` configured against a cluster with the
+   Keystone CRD installed.
+
+### 3. Run the authoritative gate
+
+The script defers to the existing make target for the invalid-cr
+corpus. Run it explicitly and report the outcome:
+
+```bash
+make verify-invalid-cr-fixtures
+```
+
+This re-runs `_generate.py --check` and `test_generate.py` and fails
+on any divergence between the generator and the committed YAML files.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — a Spec field referenced in a fixture is absent from the
+  current CRD; a Chainsaw step references a file that does not exist;
+  `make verify-invalid-cr-fixtures` fails.
+- **MEDIUM** — an orphan fixture under a `chainsaw-test.yaml`
+  directory; an invalid-cr fixture whose expected-error string no
+  longer matches the webhook output; a fixture using an older
+  apiVersion than the CRD currently serves.
+- **LOW** — formatting drift inside fixtures (inconsistent
+  indentation, comment-style differences between siblings); a
+  scenario directory whose name suggests a different focus than its
+  fixtures actually exercise.
+
+For each finding give one line with a `file:line` reference for both
+the fixture side and the CRD-source side. End with a verdict per
+fixture role.
+
+## Drift patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **Removed Spec field still referenced.** A `+kubebuilder` field
+   was renamed in `keystone_types.go`; the CRD regenerated; the
+   fixtures still use the old name. `kubectl apply --dry-run=server`
+   would catch this but is not in the existing CI surface.
+2. **Orphan fixture under a test directory.** A scenario was reduced
+   from 5 steps to 3 but the now-unused `04-*.yaml` and `05-*.yaml`
+   files were not deleted. The Chainsaw test still passes; the dead
+   files outlast their purpose.
+3. **Renamed test directory, stale Chainsaw reference.** A directory
+   was renamed (e.g. `basic-deployment` ⇢ `basic-deployment-2026-1`)
+   and the new `chainsaw-test.yaml` still references files via the
+   old relative path.
+4. **Webhook rejection string drift.** The webhook reject message
+   was reworded; the invalid-cr Chainsaw assertion still matches on
+   the old string. The test fails with an obscure mismatch instead
+   of confirming the new error path.
+5. **apiVersion lag.** The CRD declares `v1alpha1` and `v1beta1` as
+   served, but the fixtures still use `v1alpha1` exclusively. Either
+   the fixtures need an update (after the bump) or the served list
+   needs the older version dropped.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (rename the fixture field, delete the orphan, update
+  the Chainsaw step) as a separate, explicitly-scoped task.
+- Server-side validation is intentionally not in the script — it
+  requires a live cluster. The X1–X4 checks are the lightweight
+  smoke; X5 wraps the existing make-target gate.
+- Pair this with [[check-crd-drift]] — that skill confirms the CRD
+  YAML mirrors the Go source; this skill confirms the fixtures
+  exercise that CRD correctly.
+- Pair this with [[check-condition-coverage]] — that skill confirms
+  every condition is set by some sub-reconciler; the e2e fixtures
+  exercise those conditions and the Chainsaw assertions verify they
+  reach the expected status.

--- a/.claude/skills/check-fixture-drift/scripts/audit-fixture-drift.sh
+++ b/.claude/skills/check-fixture-drift/scripts/audit-fixture-drift.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-fixture-drift.sh — mechanical fixture-drift checks for the forge repo.
+# Verifies that test fixtures still match the CRD they claim to instantiate:
+#   X1  every kind: Keystone fixture uses the current apiVersion
+#   X2  every Spec field in a kind: Keystone fixture appears in the CRD schema
+#   X3  every <NN>-*.yaml next to a chainsaw-test.yaml is referenced from it
+#   X4  every file referenced from a chainsaw-test.yaml exists
+#   X5  invalid-cr generator gate (make verify-invalid-cr-fixtures)
+#
+# Pass --full to chain make verify-invalid-cr-fixtures. Exit code 1 on [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FULL=0
+if [[ "${1:-}" == "--full" ]]; then
+  FULL=1
+fi
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+CRD_FILE="operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml"
+EXPECTED_APIVERSION="keystone.openstack.c5c3.io/v1alpha1"
+
+if [[ ! -f "${CRD_FILE}" ]]; then
+  fail "missing CRD file ${CRD_FILE} — run: make manifests"
+  exit 1
+fi
+
+# Discover all Keystone fixtures (kind: Keystone) under tests/.
+KEYSTONE_FIXTURES_LIST=$(grep -lrE '^kind:[[:space:]]*Keystone[[:space:]]*$' tests/ 2>/dev/null | sort -u || true)
+KEYSTONE_FIXTURES_COUNT=$(echo "${KEYSTONE_FIXTURES_LIST}" | grep -c . || true)
+info "Found ${KEYSTONE_FIXTURES_COUNT} kind: Keystone fixture(s) under tests/"
+
+# ---------------------------------------------------------------------------
+# X1 — every fixture uses the current apiVersion
+# ---------------------------------------------------------------------------
+hdr "X1: every kind: Keystone fixture uses ${EXPECTED_APIVERSION}"
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  apiver=$(grep -E '^apiVersion:' "${f}" | head -1 | awk '{print $2}')
+  if [[ "${apiver}" == "${EXPECTED_APIVERSION}" ]]; then
+    pass "${f}: apiVersion ${apiver}"
+  else
+    fail "${f}: apiVersion='${apiver}' but expected '${EXPECTED_APIVERSION}'"
+  fi
+done <<< "${KEYSTONE_FIXTURES_LIST}"
+
+# ---------------------------------------------------------------------------
+# X2 — every top-level Spec field in fixtures appears in the CRD schema
+# ---------------------------------------------------------------------------
+hdr "X2: top-level spec fields used in fixtures appear in the CRD schema"
+# Extract the set of top-level spec field names from the CRD by reading the
+# openAPIV3Schema properties list. We rely on the controller-gen output style:
+# a section header `      spec:` followed by `        properties:` and then
+# 10-space-indented `<field>:` lines.
+crd_fields=$(awk '
+  /^      spec:/{in_spec=1; next}
+  in_spec && /^        properties:/{in_props=1; next}
+  in_props && /^          [a-z][A-Za-z0-9]+:/{
+    # capture field name
+    gsub(/^[[:space:]]+/,""); sub(":.*","",$0); print
+  }
+  in_props && /^        [a-z]/{exit}
+' "${CRD_FILE}" | sort -u)
+
+if [[ -z "${crd_fields}" ]]; then
+  info "could not extract spec properties from ${CRD_FILE} — X2 skipped (parse heuristic mismatched)"
+else
+  info "CRD spec top-level fields: $(echo "${crd_fields}" | tr '\n' ',' | sed 's/,$//')"
+  while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+    # Skip patch files (Chainsaw partial objects without a full spec block) — heuristic:
+    # files whose name starts with the patch convention "<NN>-patch-…".
+    base=$(basename "${f}")
+    if [[ "${base}" =~ ^[0-9]+-patch- ]]; then
+      info "${f}: skipped (patch fixture; partial spec by design)"
+      continue
+    fi
+    # Extract top-level spec field names — first level under `spec:` (2-space indent).
+    fixture_fields=$(awk '
+      /^spec:/{in_spec=1; next}
+      in_spec && /^[a-zA-Z]/{exit}
+      in_spec && /^  [a-z][A-Za-z0-9]+:/{
+        gsub(/^[[:space:]]+/,""); sub(":.*","",$0); print
+      }
+    ' "${f}" | sort -u)
+    [[ -z "${fixture_fields}" ]] && continue
+    fail_in_file=0
+    for fld in ${fixture_fields}; do
+      if echo "${crd_fields}" | grep -qx "${fld}"; then
+        :
+      else
+        fail "${f}: spec field '${fld}' not in CRD schema"
+        fail_in_file=$((fail_in_file + 1))
+      fi
+    done
+    if [[ "${fail_in_file}" -eq 0 ]]; then
+      pass "${f}: all $(echo "${fixture_fields}" | wc -w | tr -d ' ') top-level spec fields exist in CRD"
+    fi
+  done <<< "${KEYSTONE_FIXTURES_LIST}"
+fi
+
+# ---------------------------------------------------------------------------
+# X3 — every <NN>-*.yaml next to a chainsaw-test.yaml is referenced
+# ---------------------------------------------------------------------------
+hdr "X3: every <NN>-*.yaml is referenced from its sibling chainsaw-test.yaml"
+CHAINSAW_DIRS_LIST=$(find tests/e2e tests/e2e-chaos -name 'chainsaw-test.yaml' 2>/dev/null | xargs -n1 dirname 2>/dev/null | sort -u || true)
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  ct="${d}/chainsaw-test.yaml"
+  [[ -f "${ct}" ]] || continue
+  shopt -s nullglob
+  for fx in "${d}"/[0-9][0-9]-*.yaml; do
+    base=$(basename "${fx}")
+    if grep -q "${base}" "${ct}"; then
+      pass "${d}/${base}: referenced from chainsaw-test.yaml"
+    else
+      fail "${d}/${base}: orphan — not referenced from chainsaw-test.yaml"
+    fi
+  done
+  shopt -u nullglob
+done <<< "${CHAINSAW_DIRS_LIST}"
+
+# ---------------------------------------------------------------------------
+# X4 — every file referenced from a chainsaw-test.yaml exists
+# ---------------------------------------------------------------------------
+hdr "X4: every <NN>-*.yaml referenced from chainsaw-test.yaml exists on disk"
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  ct="${d}/chainsaw-test.yaml"
+  [[ -f "${ct}" ]] || continue
+  # Reference style is typically: file: ./00-foo.yaml  OR  file: 00-foo.yaml
+  refs=$(grep -oE '[0-9]{2}-[A-Za-z0-9_-]+\.yaml' "${ct}" | sort -u || true)
+  for ref in ${refs}; do
+    if [[ -f "${d}/${ref}" ]]; then
+      pass "${d}: chainsaw step ${ref} exists"
+    else
+      fail "${d}: chainsaw step ${ref} referenced but missing on disk"
+    fi
+  done
+done <<< "${CHAINSAW_DIRS_LIST}"
+
+# ---------------------------------------------------------------------------
+# X5 — invalid-cr generator gate (only with --full or explicit Python)
+# ---------------------------------------------------------------------------
+hdr "X5: invalid-cr generator gate (make verify-invalid-cr-fixtures)"
+if [[ "${FULL}" -eq 1 ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    if make verify-invalid-cr-fixtures; then
+      pass "make verify-invalid-cr-fixtures: clean"
+    else
+      fail "make verify-invalid-cr-fixtures: drift detected"
+    fi
+  else
+    info "python3 not on PATH — skipping X5"
+  fi
+else
+  info "skipped (run with --full to chain make verify-invalid-cr-fixtures)"
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory
+# ---------------------------------------------------------------------------
+hdr "Inventory — Chainsaw test directories (review aid)"
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  fx_count=$(find "${d}" -maxdepth 1 -name '[0-9][0-9]-*.yaml' | wc -l | tr -d ' ')
+  info "${d}: ${fx_count} fixture(s)"
+done <<< "${CHAINSAW_DIRS_LIST}"
+
+hdr "Inventory — invalid-cr fixtures (review aid)"
+shopt -s nullglob
+for fx in tests/e2e/keystone/invalid-cr/[0-9][0-9]-*.yaml; do
+  # Pull the REQ-NNN and feature ID from the SPDX/comment header.
+  hint=$(grep -m1 -E 'REQ-[0-9]+|CC-[0-9]+' "${fx}" 2>/dev/null | head -1 | sed 's/^[#[:space:]]*//')
+  info "$(basename "${fx}"): ${hint}"
+done
+shopt -u nullglob
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no fixture-drift findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} fixture-drift finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-go-workspace-deps/SKILL.md
+++ b/.claude/skills/check-go-workspace-deps/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: check-go-workspace-deps
+description: >-
+  Audit the forge Go workspace for dependency-version drift between
+  the operators/<op>/go.mod files and internal/common/go.mod —
+  controller-runtime, k8s.io/api, k8s.io/apimachinery, k8s.io/client-go,
+  the Go directive, and the toolchain pin must stay in lockstep so
+  the workspace builds the same versions everywhere. Use when asked to
+  check workspace deps, after running `go get` in one module, or after
+  Renovate bumps controller-runtime in only one of the modules.
+---
+
+# Check Go workspace consistency
+
+This skill verifies that the forge **Go workspace's shared dependencies
+stay in lockstep** across all modules. The repo uses a Go workspace
+(`go.work` lists `internal/common`, `operators/c5c3`, `operators/keystone`),
+which means the *build* picks one version per dep — but each module's
+`go.mod` declares its own pin. If those pins drift, `go mod tidy` per
+module rewrites them, and the next CI matrix leg sees a different
+build than the laptop.
+
+It is repeatable — run it any time, especially after a `go get` in one
+module, or after a Renovate PR that touched only one `go.mod`.
+
+## What workspace consistency means here
+
+The repo declares three things that have to agree:
+
+| Layer | Where it lives | Source of truth |
+|---|---|---|
+| Workspace member set | `go.work` (`use (…)` block) | the directories listed are exactly the modules participating in workspace mode |
+| Go directive | `go.work` `go <ver>` and each `operators/<op>/go.mod` / `internal/common/go.mod` `go <ver>` | a single version string (e.g. `1.25.10`) shared across all modules |
+| Shared dependency versions | each `go.mod` `require ( … )` block — specifically the k8s.io/* and sigs.k8s.io/controller-runtime entries | identical version per module (controller-runtime, k8s.io/api, k8s.io/apimachinery, k8s.io/client-go, k8s.io/apiextensions-apiserver) |
+| Workspace sum file | `go.work.sum` | a *tracked* file per CC-0001 REQ-009 (gitignore intentionally does *not* exclude it) |
+
+The authoritative gate is `go build ./...` from each module root, which
+fails if a workspace member references a missing or incompatible
+dependency. This skill defers to that as the source of truth and adds
+the per-module version-pin diff the build does not surface (a divergent
+`go.mod` is still valid Go — the workspace just silently picks one of
+the pins to build against).
+
+A drift finding is any place two `go.mod` files pin different versions
+of the same dep, the `go.work` `go` directive disagrees with any
+member's `go` directive, or the workspace member set diverges from the
+directories on disk.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-go-workspace-deps/scripts/audit-go-workspace-deps.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **W1** — every directory listed in `go.work`'s `use (…)` block
+  exists on disk and contains a `go.mod`. A stale entry breaks
+  `go build` from the workspace root.
+- **W2** — every directory containing a `go.mod` under `operators/`
+  or `internal/` is listed in `go.work`. An unlisted module silently
+  builds with its own resolution path — workspace replace directives
+  do not apply.
+- **W3** — the `go` directive in `go.work` matches the `go` directive
+  in every member's `go.mod` (exact string match, e.g. `1.25.10`).
+  A delta is a real toolchain hazard: the workspace uses one Go
+  version, the per-module CI legs use another.
+- **W4** — for each shared dep (controller-runtime, k8s.io/api,
+  k8s.io/apimachinery, k8s.io/client-go, k8s.io/apiextensions-apiserver),
+  every module that requires it (direct or indirect) pins the same
+  version. A divergent pin is the most common workspace drift: one
+  module bumped, the others did not.
+- **W5** — `go.work.sum` is present (CC-0001 REQ-009).
+- The **inventory** lists, per shared dep, the pin in each module
+  side-by-side.
+
+### 2. Cross-reference the inventory
+
+The script does not run `go mod tidy`. Using the printed inventory,
+confirm:
+
+1. For each `[FAIL]` from W4, decide which version is canonical
+   (usually the newer one) and propagate to every module:
+   ```bash
+   cd operators/<lagging-op>
+   go get <module>@<version>
+   go mod tidy
+   ```
+2. For W3 deltas, bump the lagging module's `go` directive (or the
+   `go.work` directive) so they match. The Go compiler's behaviour
+   under workspace mode does *not* mix toolchain versions per-module
+   at build time — only the workspace-root `go.work` toolchain wins.
+3. After any change, run `go build ./...` from the repo root to
+   confirm the workspace still resolves cleanly.
+
+### 3. Run the authoritative gate
+
+The script does not invoke the Go toolchain. Run the real gates and
+report the exact outcomes:
+
+```bash
+go build ./...            # workspace-root build
+make test                 # per-module tests via the workspace
+go mod tidy && git diff   # in each module — any diff is W4 drift
+```
+
+`go build ./...` is the authoritative gate for workspace resolution.
+`go mod tidy && git diff` per module is the authoritative gate for
+per-module pin consistency; an empty diff means the `go.mod` already
+reflects what tidy would compute.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — `go build ./...` fails; the `go` directive disagrees
+  between `go.work` and any member; a workspace member directory does
+  not exist.
+- **MEDIUM** — two modules pin different versions of the same shared
+  dep; a module under `operators/` or `internal/` is missing from
+  the workspace; `go.work.sum` is absent.
+- **LOW** — a workspace member that has no `require` entry for a
+  shared dep that all siblings need (likely OK, but worth a check —
+  the module may legitimately not depend on it).
+
+For each finding give one line with the dep, the per-module versions,
+and the suggested fix. End with a per-shared-dep verdict.
+
+## Drift patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **Single-module Renovate bump.** Renovate created a PR bumping
+   `sigs.k8s.io/controller-runtime` in only one module's `go.mod`.
+   The workspace silently still resolves to the older version (or
+   the newer, depending on which module wins the workspace minimum-version
+   selection). CI passes; the build's actual dependency does not
+   match what humans think they pinned.
+2. **`go get` ran in one module only.** A developer ran `go get …`
+   in `operators/keystone` to add a feature, but the same package is
+   needed in `internal/common` for tests. `go mod tidy` in
+   `internal/common` would add it; without the tidy, the indirect
+   resolution differs.
+3. **Toolchain drift.** A `go.work` edit bumped the `go` directive
+   to `1.26.x` but one of the `operators/<op>/go.mod` still says
+   `1.25.x`. `go build` from the workspace root uses `1.26.x`;
+   running tests from inside the module without the workspace uses
+   `1.25.x`.
+4. **Workspace member missing.** A new `operators/<new>/` was added
+   with its own `go.mod` but the developer forgot to add it to
+   `go.work`'s `use (…)` block. The new module compiles in isolation
+   but the workspace ignores it.
+5. **Stale workspace member.** An old `operators/<dead>/` was deleted
+   but `go.work` still references it. `go build ./...` fails with a
+   missing-directory error.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (`go get`, `go mod tidy`, edit `go.work`) as a separate,
+  explicitly-scoped task.
+- The shared-dep list at the top of the script is opinionated —
+  controller-runtime + the k8s.io/* family. If forge later adds
+  another cross-cutting dep (e.g. a metrics library, a tracing
+  client), extend that list so the W4 check covers it.
+- `go.work.sum` is intentionally tracked per CC-0001 REQ-009. Do not
+  add it to `.gitignore`.
+- Pair this with [[check-renovate-coverage]] — that skill ensures
+  Renovate has a manager for these deps in the first place; this
+  skill ensures Renovate's bumps land consistently.

--- a/.claude/skills/check-go-workspace-deps/scripts/audit-go-workspace-deps.sh
+++ b/.claude/skills/check-go-workspace-deps/scripts/audit-go-workspace-deps.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-go-workspace-deps.sh — mechanical workspace consistency checks.
+#   W1  every directory in go.work's use(…) block exists with go.mod
+#   W2  every go.mod under operators/ or internal/ is in go.work
+#   W3  go.work `go` directive matches every member's go.mod `go` directive
+#   W4  every shared dep is pinned identically across modules that require it
+#   W5  go.work.sum is present (CC-0001 REQ-009)
+#
+# Defers `go build ./...` and `go mod tidy && git diff` to the human. Exit 1 on [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+# Shared deps the operators+common library are expected to align on.
+SHARED_DEPS=(
+  "sigs.k8s.io/controller-runtime"
+  "k8s.io/api"
+  "k8s.io/apimachinery"
+  "k8s.io/client-go"
+  "k8s.io/apiextensions-apiserver"
+)
+
+if [[ ! -f go.work ]]; then
+  fail "missing go.work at repo root"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# W1 — every directory in go.work use(…) exists with go.mod
+# ---------------------------------------------------------------------------
+hdr "W1: every go.work use(…) directory exists and contains go.mod"
+use_dirs=$(awk '/^use \(/,/^\)/' go.work \
+  | sed -nE 's|^[[:space:]]+\./?([^[:space:]]+).*|\1|p' \
+  | sort -u)
+if [[ -z "${use_dirs}" ]]; then
+  fail "could not parse go.work use(…) block"
+else
+  while IFS= read -r d; do
+    [[ -z "${d}" ]] && continue
+    if [[ -f "${d}/go.mod" ]]; then
+      pass "go.work member ./${d}/ has go.mod"
+    else
+      fail "go.work member ./${d}/ missing or has no go.mod"
+    fi
+  done <<< "${use_dirs}"
+fi
+
+# ---------------------------------------------------------------------------
+# W2 — every go.mod under operators/ or internal/ is in go.work
+# ---------------------------------------------------------------------------
+hdr "W2: every operators/ + internal/ go.mod is listed in go.work"
+fs_mods=$(find operators internal -name go.mod 2>/dev/null \
+  | xargs -n1 dirname | sort -u)
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  if echo "${use_dirs}" | grep -qx "${d}"; then
+    pass "fs module ${d} is in go.work"
+  else
+    fail "fs module ${d} has go.mod but is not listed in go.work — workspace ignores it"
+  fi
+done <<< "${fs_mods}"
+
+# ---------------------------------------------------------------------------
+# W3 — go directive consistency
+# ---------------------------------------------------------------------------
+hdr "W3: 'go' directive matches across go.work and every member go.mod"
+workspace_go=$(grep -E '^go ' go.work | head -1 | awk '{print $2}')
+info "go.work go directive: ${workspace_go}"
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  [[ -f "${d}/go.mod" ]] || continue
+  mod_go=$(grep -E '^go ' "${d}/go.mod" | head -1 | awk '{print $2}')
+  if [[ "${mod_go}" == "${workspace_go}" ]]; then
+    pass "${d}/go.mod go directive: ${mod_go}"
+  else
+    fail "${d}/go.mod go directive: ${mod_go} (workspace: ${workspace_go})"
+  fi
+done <<< "${use_dirs}"
+
+# ---------------------------------------------------------------------------
+# W4 — shared deps pinned identically per module that requires them
+# ---------------------------------------------------------------------------
+hdr "W4: shared deps pinned identically across modules"
+# Collect (module, dep, version) — version is the field after the dep name
+# in a require line, regardless of direct vs // indirect.
+for dep in "${SHARED_DEPS[@]}"; do
+  info "checking dep: ${dep}"
+  versions=""
+  while IFS= read -r d; do
+    [[ -z "${d}" ]] && continue
+    [[ -f "${d}/go.mod" ]] || continue
+    v=$(grep -E "\s${dep}\s+v[0-9]" "${d}/go.mod" | head -1 | awk '{print $2}')
+    if [[ -z "${v}" ]]; then
+      # Some modules only depend transitively; skip rather than flag.
+      continue
+    fi
+    info "  ${d} pins ${dep} ${v}"
+    versions="${versions}${v}"$'\n'
+  done <<< "${use_dirs}"
+  unique=$(echo "${versions}" | sort -u | grep -c . || true)
+  if [[ "${unique}" -le 1 ]]; then
+    pass "${dep}: consistent across modules"
+  else
+    fail "${dep}: divergent versions across modules — pick one and run 'go get ${dep}@<v>' in each module"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# W5 — go.work.sum present
+# ---------------------------------------------------------------------------
+hdr "W5: go.work.sum tracked (CC-0001 REQ-009)"
+if [[ -f go.work.sum ]]; then
+  pass "go.work.sum present"
+  if git ls-files --error-unmatch go.work.sum >/dev/null 2>&1; then
+    pass "go.work.sum tracked by git"
+  else
+    fail "go.work.sum exists but is not tracked by git (REQ-009 violation)"
+  fi
+else
+  fail "go.work.sum missing (CC-0001 REQ-009 requires it tracked)"
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory — per-dep version table
+# ---------------------------------------------------------------------------
+hdr "Inventory — shared-dep version table"
+printf '[INFO] %-45s' "dependency"
+while IFS= read -r d; do
+  [[ -z "${d}" ]] && continue
+  printf ' %-25s' "${d}"
+done <<< "${use_dirs}"
+printf '\n'
+for dep in "${SHARED_DEPS[@]}"; do
+  printf '[INFO] %-45s' "${dep}"
+  while IFS= read -r d; do
+    [[ -z "${d}" ]] && continue
+    [[ -f "${d}/go.mod" ]] || { printf ' %-25s' '(no go.mod)'; continue; }
+    v=$(grep -E "\s${dep}\s+v[0-9]" "${d}/go.mod" | head -1 | awk '{print $2}')
+    [[ -z "${v}" ]] && v='—'
+    printf ' %-25s' "${v}"
+  done <<< "${use_dirs}"
+  printf '\n'
+done
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no workspace-dep findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} workspace-dep finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-renovate-coverage/SKILL.md
+++ b/.claude/skills/check-renovate-coverage/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: check-renovate-coverage
+description: >-
+  Audit whether every pinned version in the forge repo — OpenStack
+  release tags under releases/<version>/source-refs.yaml, shell-script
+  VERSION constants under hack/, kind / FluxCD HelmRelease versions
+  under deploy/kind/ and deploy/flux-system/, and tool-version pins in
+  Makefile + .github/workflows — is covered by either a native Renovate
+  manager or a customManager rule in renovate.json with a paired
+  packageRules entry. Use when asked to check Renovate coverage, after
+  adding a new pinned dependency, or when a previously-bumped pin
+  silently stopped receiving updates.
+---
+
+# Check Renovate coverage
+
+This skill verifies that the forge **dependency pins are all reachable
+by Renovate**: every version literal that a human edits when bumping a
+dependency must be paired with a matcher (native or custom) that
+Renovate can crank, and every customManager must have a packageRules
+entry that decides triage rules (major/minor split, automerge, release
+age, grouping). A pin without a manager is a pin that silently goes
+stale.
+
+It is repeatable — run it any time, especially after introducing a new
+version literal or after editing `renovate.json`.
+
+## What Renovate coverage means here
+
+A version pin in forge typically threads through three things, all of
+which Renovate has to understand:
+
+| Layer | Where it lives | Renovate handle |
+|---|---|---|
+| OpenStack release tags | `releases/<release>/source-refs.yaml` (one line per component: `keystone: "29.0.0"`) | customManager #1 — matches `^(?<depName>[\w.-]+):\s*"(?<currentValue>\d+\.\d+\.\d+)"` per file under `releases/.*/source-refs.yaml` |
+| Shell script constants | `hack/deploy-infra.sh` (`FLUX_OPERATOR_VERSION="v…"`, `GATEWAY_API_VERSION="${…:-v…}"`) | customManager — one regex per constant; the existing managers cover `FLUX_OPERATOR_VERSION` only |
+| kind base manifests | `deploy/kind/base/flux-web.yaml` (`- version: "…"`), `deploy/kind/base/envoy-gateway.yaml` (range like `">=0.0.0 <0.0.0"`) | customManager — one regex per file shape |
+| FluxCD HelmRelease versions | `deploy/flux-system/releases/*.yaml` (`spec.chart.spec.version`) | native `flux` / `helm-values` manager (no customManager needed) |
+| Go module deps | `operators/*/go.mod`, `internal/common/go.mod` | native `gomod` manager (no customManager needed) |
+| GitHub Actions versions | `.github/workflows/*.yaml` (`uses: org/action@v…`) | native `github-actions` manager |
+| Dockerfile base images | `operators/*/Dockerfile` (`FROM image:tag`) | native `dockerfile` manager |
+| Tool pins in Makefile | `Makefile` (`GOFUMPT_VERSION ?= v0.9.2`, `ENVTEST_K8S_VERSION ?= 1.35`) | **no manager** — must be a customManager, or manually tracked |
+
+The authoritative gate is the `renovate-config-validator` (run via the
+existing shell unit tests under `tests/unit/renovate/`). This skill
+defers to those tests for `renovate.json` correctness and adds the
+coverage check the validator cannot express: "is every version literal
+on disk claimed by some manager?"
+
+A coverage finding is any version literal that no Renovate manager
+matches, or a customManager with no packageRules to triage its PRs.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-renovate-coverage/scripts/audit-renovate-coverage.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **R1** — every line in every `releases/*/source-refs.yaml` that
+  looks like `<name>: "<x.y.z>"` is matched by the source-refs
+  customManager regex. A line that does not match is either a
+  formatting drift (added quotes, switched to single quotes) or a
+  component whose version style the regex does not support yet.
+- **R2** — every `<NAME>_VERSION="…"` constant in `hack/*.sh` is
+  matched by at least one customManager pattern. A constant added
+  without a paired customManager is a silent pin: humans edit it but
+  Renovate ignores it.
+- **R3** — every `version: "…"` literal in `deploy/kind/base/*.yaml`
+  is matched by a customManager pattern. The two existing managers
+  cover `flux-web.yaml` and `envoy-gateway.yaml`; any other file in
+  the same dir is flagged.
+- **R4** — every customManager entry in `renovate.json` has at least
+  one paired entry in `packageRules` (otherwise updates land
+  untriaged: no major-bump gate, no minimumReleaseAge, no automerge
+  policy).
+- **R5** — every entry in `releases/*/source-refs.yaml` has a paired
+  packageRule that disables major bumps (the OpenStack tags rule).
+  A new entry that bypasses the rule silently allows major bumps.
+- **R6** — the shell-script tests under `tests/unit/renovate/` still
+  exist for every customManager (so the rule has a regression test).
+- The **inventories** are review aids: every version literal found on
+  disk, grouped by file; every Renovate manager (native or custom)
+  with its matched paths.
+
+### 2. Cross-reference the inventory
+
+The script cannot run Renovate itself. Using the printed inventory,
+confirm:
+
+1. For each `[FAIL]` from R1–R3, decide whether to add a new
+   customManager or normalise the file to match an existing one.
+2. For each `[FAIL]` from R4–R5, add the missing packageRules entry
+   (with `matchUpdateTypes: [major]` disabled by default, paired
+   automerge + 3-day `minimumReleaseAge` for minor/patch, matching
+   the existing pattern).
+3. Confirm by hand that every newly added customManager has a
+   regression test under `tests/unit/renovate/`.
+4. For tool pins in `Makefile` (`GOFUMPT_VERSION`, `ENVTEST_K8S_VERSION`),
+   decide whether to add a customManager. These are often
+   intentionally pinned and not auto-bumped — but document the
+   decision in `renovate.json` (or in a comment in the Makefile)
+   either way.
+
+### 3. Run the authoritative gates
+
+The script does not invoke Renovate. Run the real gates and report the
+exact outcomes:
+
+```bash
+bash tests/unit/renovate/fluxoperator_custommanager_test.sh
+bash tests/unit/renovate/flux_web_chart_custommanager_test.sh
+bash tests/unit/renovate/envoy_gateway_manager_test.sh
+# Optionally, with npx available:
+npx --package renovate -- renovate-config-validator renovate.json
+```
+
+These confirm `renovate.json` is syntactically valid and that the
+existing customManagers still match the on-disk constants. Trust their
+outcome over the R1–R6 smoke checks when they disagree.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — `renovate-config-validator` fails; a version literal on
+  disk is not matched by any manager; a customManager has no
+  paired packageRules entry; a `releases/*/source-refs.yaml` entry
+  has no major-bump-disable rule.
+- **MEDIUM** — a tool pin in `Makefile` or `.github/workflows/*` is
+  uncovered; a customManager has no regression test under
+  `tests/unit/renovate/`; a customManager regex uses an inconsistent
+  versioning template vs the existing rules.
+- **LOW** — formatting drift inside a tracked file (single vs double
+  quotes, extra whitespace) that the regex still matches but is
+  inconsistent with siblings; a stale comment in `renovate.json`.
+
+For each finding give one line with a `file:line` reference for both
+the pin side and the renovate.json side. End with a verdict per layer.
+
+## Coverage patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **New shell constant, no customManager.** A `NEW_VERSION="…"`
+   constant added to `hack/deploy-infra.sh` for a one-off install
+   step. Renovate has no idea — the constant ages until a human spots
+   the upstream release notes.
+2. **New `releases/<release>/source-refs.yaml` entry style drift.**
+   A component switched from `name: "x.y.z"` to `name: "vx.y.z"` (or
+   to a SHA pin). The existing regex requires `\d+\.\d+\.\d+`; the
+   new style silently falls outside its match set.
+3. **customManager without packageRules.** A new manager was added
+   to extend coverage but the `packageRules` block was not extended
+   to triage its PRs. Renovate raises untriaged PRs (major bumps not
+   gated, no minimumReleaseAge), so reviewers waste time closing them.
+4. **New kind base manifest, no customManager.** A new YAML under
+   `deploy/kind/base/` with a `version: "…"` line. The two existing
+   managers are file-name-anchored; a sibling needs its own manager.
+5. **Tool pin in Makefile.** `GOFUMPT_VERSION ?= v0.9.2` or similar
+   is a real pin that gets bumped manually. No native Renovate
+   manager catches Makefile constants; a customManager (with regex
+   `^([A-Z_]+_VERSION) \?= (v[0-9.]+)`) would close the gap.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (add the customManager, add the packageRule, add the
+  unit test) as a separate, explicitly-scoped task.
+- Some pins are *intentionally* not Renovate-tracked (e.g. a tool
+  whose upstream release cadence is too aggressive). When the
+  decision is to skip, document it: either an empty customManager
+  matchStrings (`"matchStrings": []` with a description), or an
+  HCL-style comment in the Makefile near the pin.
+- The existing tests under `tests/unit/renovate/` are the source of
+  truth for "what is covered today". If you add a customManager, add
+  a sibling test there — the audit script flags missing tests as a
+  MEDIUM.
+- Pair this with [[check-doc-drift]] — that skill checks that
+  infrastructure version pins documented in the prose match the
+  `deploy/` reality; this skill checks that the pins themselves are
+  trackable.

--- a/.claude/skills/check-renovate-coverage/scripts/audit-renovate-coverage.sh
+++ b/.claude/skills/check-renovate-coverage/scripts/audit-renovate-coverage.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-renovate-coverage.sh — mechanical Renovate-coverage checks.
+# Verifies that every version literal on disk is reachable by some
+# Renovate manager (native or custom) and that each customManager is
+# paired with packageRules and a regression test:
+#   R1  every line in releases/*/source-refs.yaml matches the source-refs regex
+#   R2  every <NAME>_VERSION="…" constant in hack/*.sh is matched by a
+#       customManager managerFilePatterns entry
+#   R3  every version: "…" literal in deploy/kind/base/*.yaml is matched by a
+#       customManager managerFilePatterns entry
+#   R4  every customManager has at least one packageRules entry pointing at
+#       the same file (matched by managerFilePatterns vs matchFileNames)
+#   R5  every source-refs.yaml entry is covered by a packageRule that disables
+#       major bumps
+#   R6  every customManager has a sibling regression test in tests/unit/renovate/
+#
+# Defers JSON-shape validation to `renovate-config-validator`. Exit code 1 on [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+RENOVATE="renovate.json"
+if [[ ! -f "${RENOVATE}" ]]; then
+  fail "missing ${RENOVATE} at repo root"
+  exit 1
+fi
+
+# Helpers that read renovate.json with jq if present; otherwise grep fallbacks.
+have_jq=0
+if command -v jq >/dev/null 2>&1; then
+  have_jq=1
+else
+  info "jq not on PATH — falling back to grep-only inspection (less precise)"
+fi
+
+# ---------------------------------------------------------------------------
+# R1 — releases/*/source-refs.yaml lines match the source-refs regex
+# ---------------------------------------------------------------------------
+hdr "R1: releases/*/source-refs.yaml entries match the source-refs customManager regex"
+# The current regex (per renovate.json): ^(?<depName>[\w.-]+):\s*"(?<currentValue>\d+\.\d+\.\d+)"
+# Express the positive form in extended POSIX regex.
+SR_RE='^[A-Za-z0-9_.-]+:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"'
+shopt -s nullglob
+for f in releases/*/source-refs.yaml; do
+  while IFS= read -r line; do
+    # Skip blanks, comments, and the SPDX header.
+    [[ -z "${line}" || "${line}" =~ ^# ]] && continue
+    if [[ "${line}" =~ ${SR_RE} ]]; then
+      pass "${f}: '${line}' matches source-refs regex"
+    else
+      fail "${f}: '${line}' does not match source-refs customManager regex"
+    fi
+  done < "${f}"
+done
+shopt -u nullglob
+
+# ---------------------------------------------------------------------------
+# R2 — hack/*.sh VERSION constants are matched by a managerFilePatterns entry
+# ---------------------------------------------------------------------------
+hdr "R2: hack/*.sh <NAME>_VERSION=… constants are claimed by a customManager"
+# Collect managerFilePatterns from renovate.json.
+if [[ "${have_jq}" -eq 1 ]]; then
+  cm_files_raw=$(jq -r '.customManagers[].managerFilePatterns[]' "${RENOVATE}" | sort -u)
+else
+  cm_files_raw=$(grep -oE '"/[^"]+/"' "${RENOVATE}" | tr -d '"' | sort -u)
+fi
+# Normalise regex form (/path/to/file\.ext$/ or /path/.*/file\.ext$/) into a bare,
+# anchored ERE we can match against absolute paths with grep -E.
+cm_files=$(echo "${cm_files_raw}" \
+  | sed -E 's|^/||; s|/$||; s|\$$||; s|\\\.|.|g')
+info "customManager managerFilePatterns (raw): $(echo "${cm_files_raw}" | tr '\n' ',' | sed 's/,$//')"
+info "customManager managerFilePatterns (normalised): $(echo "${cm_files}" | tr '\n' ',' | sed 's/,$//')"
+
+# matches_cm returns 0 if the given path is claimed by any customManager file pattern.
+matches_cm() {
+  local path="$1" cmf
+  while IFS= read -r cmf; do
+    [[ -z "${cmf}" ]] && continue
+    if echo "${path}" | grep -qE "^${cmf}$"; then
+      return 0
+    fi
+  done <<< "${cm_files}"
+  return 1
+}
+
+for f in hack/*.sh; do
+  [[ -f "${f}" ]] || continue
+  while IFS= read -r ln; do
+    var=$(echo "${ln}" | sed -nE 's/^([A-Z_]+_VERSION)=.*/\1/p')
+    [[ -z "${var}" ]] && var=$(echo "${ln}" | sed -nE 's/^([A-Z_]+_VERSION)=\$\{[A-Z_]+:-.*/\1/p')
+    [[ -z "${var}" ]] && continue
+    if matches_cm "${f}"; then
+      pass "${f}:${var} claimed by a customManager managerFilePatterns entry"
+    else
+      fail "${f}:${var} not claimed by any customManager — pin will not be bumped"
+    fi
+  done < "${f}"
+done
+
+# ---------------------------------------------------------------------------
+# R3 — deploy/kind/base/*.yaml version: "…" literals are claimed
+# ---------------------------------------------------------------------------
+hdr "R3: deploy/kind/base/*.yaml version: \"…\" literals are claimed"
+shopt -s nullglob
+for f in deploy/kind/base/*.yaml; do
+  if grep -qE '^\s*-?\s*version:\s*"' "${f}"; then
+    if matches_cm "${f}"; then
+      pass "${f}: version literal claimed by a customManager"
+    else
+      fail "${f}: version literal not claimed by any customManager"
+    fi
+  fi
+done
+shopt -u nullglob
+
+# ---------------------------------------------------------------------------
+# R4 — every customManager has a paired packageRules entry
+# ---------------------------------------------------------------------------
+hdr "R4: every customManager has a paired packageRules entry (same file pattern)"
+if [[ "${have_jq}" -eq 1 ]]; then
+  pr_files=$(jq -r '.packageRules[]?.matchFileNames[]?' "${RENOVATE}" | sort -u)
+  info "packageRules matchFileNames: $(echo "${pr_files}" | tr '\n' ',' | sed 's/,$//')"
+  while IFS= read -r cmf; do
+    # Strip leading/trailing slashes and the regex anchors to match packageRules glob style.
+    glob=$(echo "${cmf}" | sed -E 's|^/||; s|\$/$||; s|\\\.|.|g; s|\.\*|**|g')
+    # Heuristic match: any packageRule matchFileNames entry containing the basename.
+    base=$(basename "${glob}")
+    if echo "${pr_files}" | grep -q "${base}"; then
+      pass "customManager for ${cmf} has packageRules coverage (matched on ${base})"
+    else
+      fail "customManager for ${cmf} has NO packageRules entry — updates land untriaged"
+    fi
+  done < <(echo "${cm_files}")
+else
+  info "skipping R4: jq not available"
+fi
+
+# ---------------------------------------------------------------------------
+# R5 — source-refs.yaml has a major-bump-disable packageRule
+# ---------------------------------------------------------------------------
+hdr "R5: source-refs.yaml has a major-bump-disable packageRule"
+if [[ "${have_jq}" -eq 1 ]]; then
+  match=$(jq -r '
+    .packageRules[]?
+    | select((.matchFileNames // []) | any(test("source-refs")))
+    | select((.matchUpdateTypes // []) | index("major"))
+    | select(.enabled == false)
+    | "found"
+  ' "${RENOVATE}" | head -1)
+  if [[ "${match}" == "found" ]]; then
+    pass "source-refs.yaml has a major-bump-disable packageRule"
+  else
+    fail "source-refs.yaml has no packageRule disabling major bumps — accidental release.major bumps will land"
+  fi
+else
+  if grep -q "source-refs" "${RENOVATE}" && grep -q '"major"' "${RENOVATE}"; then
+    info "source-refs + major appear in renovate.json — confirm by hand (no jq)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# R6 — every customManager has a sibling regression test
+# ---------------------------------------------------------------------------
+hdr "R6: each customManager has a regression test under tests/unit/renovate/"
+if [[ -d tests/unit/renovate ]]; then
+  test_count=$(find tests/unit/renovate -name '*_test.sh' | wc -l | tr -d ' ')
+  cm_count=$(echo "${cm_files}" | grep -c '.' || true)
+  info "customManagers: ${cm_count}; tests under tests/unit/renovate: ${test_count}"
+  if [[ "${cm_count}" -gt "${test_count}" ]]; then
+    fail "more customManagers (${cm_count}) than tests (${test_count}) — at least one is untested"
+  else
+    pass "each customManager appears to have a sibling test (counts match)"
+  fi
+else
+  fail "missing tests/unit/renovate/ directory"
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory — Makefile and workflow tool pins (R-MEDIUM candidates)
+# ---------------------------------------------------------------------------
+hdr "Inventory — tool pins outside Renovate coverage (review aid)"
+grep -nE '^[A-Z_]+_VERSION \?= ' Makefile 2>/dev/null | sed 's/^/[INFO] Makefile pin: /' || true
+grep -rEn '^[[:space:]]*[A-Z_]+_VERSION:\s*' .github/workflows/ 2>/dev/null | sed 's/^/[INFO] workflow env pin: /' || true
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no Renovate-coverage findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} Renovate-coverage finding(s)"
+  exit 1
+fi

--- a/.claude/skills/check-spdx-reuse/SKILL.md
+++ b/.claude/skills/check-spdx-reuse/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: check-spdx-reuse
+description: >-
+  Audit SPDX / REUSE compliance across the forge source tree — every
+  *.go, *.sh, hand-authored YAML, and CI workflow file should carry
+  matching SPDX-FileCopyrightText and SPDX-License-Identifier headers,
+  every license referenced in a header has a corresponding text under
+  LICENSES/, and architecture/REUSE.toml stays well-formed. Use when
+  asked to check SPDX or REUSE coverage, after adding a new source
+  file, or before tagging a release where SAP supply-chain audits
+  require clean REUSE output.
+---
+
+# Check SPDX / REUSE coverage
+
+This skill verifies that the forge source tree stays **REUSE-compliant**:
+every file that needs a copyright/licence header has one, every header
+references a licence that ships under `LICENSES/`, and the
+`architecture/REUSE.toml` rules cover the prose corpus that lives
+without inline headers.
+
+It is repeatable — run it any time, especially after adding a new file
+type or directory, or before cutting a release.
+
+## What SPDX / REUSE means here
+
+The repo follows the REUSE specification (`https://reuse.software`).
+There are two ways a file can carry a licence statement:
+
+| Mechanism | Where it applies | Source of truth |
+|---|---|---|
+| Inline header | Every hand-authored `*.go`, `*.sh`, `*.py`, `Dockerfile`, `Makefile`, `*.yaml` (excluding controller-gen / sqlc output and Helm chart copies) | Two adjacent comment lines: `SPDX-FileCopyrightText: …` and `SPDX-License-Identifier: …` |
+| `REUSE.toml` annotation | The `docs/` prose corpus, vendored chart copies, and a few well-known asset paths | `architecture/REUSE.toml` (top-level `[[annotations]]` blocks with `path` globs) |
+| Licence text inventory | Every licence identifier used anywhere | A matching file under `LICENSES/` (e.g. `Apache-2.0.txt`) |
+
+The authoritative gate is `reuse lint` from the
+[reuse-tool](https://github.com/fsfe/reuse-tool) Python package. This
+skill defers to that gate as the source of truth and adds the
+inventory checks the lint output is verbose about.
+
+A coverage finding is any file without a header that the REUSE.toml
+also does not cover, a header that references a missing licence text,
+or a licence text in `LICENSES/` that no file references.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Run the deterministic audit
+
+```bash
+bash .claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh
+```
+
+The script catches the mechanically-checkable gaps and prints an
+inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
+
+- **S1** — every hand-authored `*.go` under `operators/`, `internal/`,
+  `tests/` has both `SPDX-FileCopyrightText` and `SPDX-License-Identifier`
+  headers in the first 5 lines. Generated files
+  (`zz_generated.*.go`, `// Code generated … DO NOT EDIT.` banner)
+  are exempted from the inline check — they are expected to be
+  REUSE.toml-covered.
+- **S2** — every `*.sh` under `hack/`, `scripts/`, `tests/scripts/`,
+  `tests/unit/`, `tests/lib/` has both headers.
+- **S3** — every hand-authored YAML / TOML under `deploy/`,
+  `operators/<op>/config/`, `releases/` has both headers (controller-gen
+  CRD output is exempted — its first line is the CRD apiVersion).
+- **S4** — every licence identifier appearing in any `SPDX-License-Identifier:`
+  header has a matching `<id>.txt` under `LICENSES/`.
+- **S5** — every `<id>.txt` under `LICENSES/` is referenced by at
+  least one file (no unused licence inventory).
+- **S6** — `architecture/REUSE.toml` is valid TOML (parses with
+  `python3 -c 'import tomllib; tomllib.load(open(…, "rb"))'`).
+- The **inventory** lists, per check, the number of files scanned,
+  the number that passed, and the per-extension breakdown of
+  failures.
+
+### 2. Cross-reference the inventory
+
+The script applies a coarse "first 5 lines" header check; the real
+REUSE rules are subtler (multi-line comments, `<!-- … -->` HTML, etc.).
+For each `[FAIL]`, confirm by hand:
+
+1. The flagged file is genuinely hand-authored (not a vendored copy,
+   not generated, not a binary blob).
+2. The fix is either (a) add the SPDX header inline, or (b) add a
+   matching `[[annotations]]` block to `architecture/REUSE.toml` that
+   covers the path.
+3. For S4 failures, add the missing licence text to `LICENSES/`
+   (most often by running `reuse download <SPDX-ID>` to fetch the
+   canonical text).
+
+### 3. Run the authoritative gate
+
+The script defers to `reuse lint`. Run it explicitly and report the
+outcome:
+
+```bash
+# Requires the reuse-tool Python package
+pipx install reuse  # one-time
+reuse lint
+```
+
+`reuse lint` is the authoritative gate — trust it over the S1–S6
+smoke checks when they disagree. It understands every comment style
+the spec recognises and walks the full file tree.
+
+### 4. Report
+
+Produce a concise summary grouped by severity:
+
+- **HIGH** — `reuse lint` fails; an SPDX header references a licence
+  that ships no text under `LICENSES/`; a `REUSE.toml` parse error.
+- **MEDIUM** — a hand-authored source file with no SPDX header that
+  is also not covered by `REUSE.toml`; a `LICENSES/<id>.txt` referenced
+  by zero files (unused licence inventory).
+- **LOW** — a header on the wrong line (S1–S3 expect first-five-lines
+  placement but the spec is more flexible); a `[[annotations]]` block
+  whose `path` glob does not match any current file (over-broad cover).
+
+For each finding give one line with a `file:line` reference. End with
+a two- to three-sentence verdict per file type (Go / shell / YAML).
+
+## Coverage patterns
+
+These recurring shapes are worth grepping for first:
+
+1. **New Go file, missing SPDX header.** A new `reconcile_<thing>.go`
+   was added by hand without copying the header from a sibling. The
+   build passes; only `reuse lint` flags it.
+2. **New licence used, no text shipped.** A vendored dependency was
+   added with an unusual SPDX-License-Identifier (e.g. `MPL-2.0`)
+   without the corresponding `LICENSES/MPL-2.0.txt`. The next REUSE
+   audit fails.
+3. **Helm chart copy missing exemption.** The `helm/<op>-operator/crds/`
+   files are byte-mirrors of `config/crd/bases/`. They carry SPDX in
+   comment form because `sync-crds` prepends a `#`-comment block; if
+   that step is skipped, the copies fail S3.
+4. **REUSE.toml over-broad path glob.** A `[[annotations]]` block
+   uses `**` and accidentally covers a file that *should* carry its
+   own inline header. The lint silently passes; the file's
+   provenance is wrong.
+5. **Generated file picks up an inline header.** A controller-gen
+   regeneration overwrites a file that previously carried a manual
+   header. Counter-intuitively, the regeneration removes the SPDX
+   line because the generator's template does not include it. The
+   REUSE.toml exemption is what is supposed to cover it; check the
+   path glob still matches after the rename.
+
+## Notes
+
+- This skill is read-only; the deterministic script edits nothing.
+  Apply fixes (add the header, extend REUSE.toml, fetch the licence
+  text) as a separate, explicitly-scoped task.
+- The S1–S3 checks are coarse heuristics. `reuse lint` is the
+  authoritative source for compliance and is what the SAP supply-chain
+  audit consumes. The audit script's job is to triage findings the
+  lint reports in machine-friendly form.
+- Generated files are exempted in the script by detecting either
+  `zz_generated.` in the file name or a `// Code generated … DO NOT
+  EDIT.` banner in the first 10 lines. If a new generator's output
+  pattern differs, extend the exemption list at the top of the script.

--- a/.claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh
+++ b/.claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# audit-spdx-reuse.sh — mechanical SPDX / REUSE coverage checks.
+#   S1  *.go under operators/, internal/, tests/ has both SPDX headers
+#       (zz_generated and "Code generated … DO NOT EDIT." files exempted)
+#   S2  *.sh under hack/, scripts/, tests/{scripts,unit,lib} has both headers
+#   S3  hand-authored *.yaml / *.toml under deploy/, operators/<op>/config/,
+#       releases/ has both headers (CRDs that are pure controller-gen output
+#       are exempted)
+#   S4  every SPDX-License-Identifier value has a matching LICENSES/<id>.txt
+#   S5  every LICENSES/<id>.txt is referenced by at least one file
+#   S6  architecture/REUSE.toml parses as valid TOML
+#
+# Defers full compliance to `reuse lint`. Exit code 1 on [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+hdr()  { echo; echo "=== $* ==="; }
+
+# Header check: returns 0 if both SPDX headers exist in the first 20 lines.
+# Reads the first 20 lines into a variable so each grep sees the full slice
+# (a single pipe would let the first grep consume the stream).
+has_spdx_pair() {
+  local f="$1"
+  local head_buf
+  head_buf=$(head -20 "${f}" 2>/dev/null) || return 1
+  echo "${head_buf}" | grep -q 'SPDX-FileCopyrightText' || return 1
+  echo "${head_buf}" | grep -q 'SPDX-License-Identifier' || return 1
+  return 0
+}
+
+# Generated-file exemption.
+is_generated_go() {
+  local f="$1"
+  case "$(basename "${f}")" in
+    zz_generated.*) return 0 ;;
+  esac
+  head -10 "${f}" 2>/dev/null | grep -q 'Code generated .* DO NOT EDIT'
+}
+
+# Heuristic: a YAML is "pure controller-gen output" if it lives under
+# config/crd/ AND starts with `---` followed by `apiVersion: apiextensions.k8s.io`.
+is_generated_yaml() {
+  local f="$1"
+  case "${f}" in
+    */config/crd/*) ;;
+    *) return 1 ;;
+  esac
+  head -3 "${f}" 2>/dev/null | grep -qE 'apiextensions\.k8s\.io|controller-gen\.kubebuilder\.io'
+}
+
+# ---------------------------------------------------------------------------
+# S1 — *.go under operators/, internal/, tests/
+# ---------------------------------------------------------------------------
+hdr "S1: *.go under operators/, internal/, tests/ has SPDX headers"
+go_total=0
+go_fail=0
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  go_total=$((go_total + 1))
+  if is_generated_go "${f}"; then
+    continue
+  fi
+  if ! has_spdx_pair "${f}"; then
+    fail "S1: ${f} missing SPDX header(s)"
+    go_fail=$((go_fail + 1))
+  fi
+done < <(find operators internal tests -type f -name '*.go' 2>/dev/null)
+info "S1 totals: scanned=${go_total} fail=${go_fail}"
+[[ "${go_fail}" -eq 0 ]] && pass "S1 clean (${go_total} files scanned)"
+
+# ---------------------------------------------------------------------------
+# S2 — *.sh
+# ---------------------------------------------------------------------------
+hdr "S2: *.sh under hack/, scripts/, tests/{scripts,unit,lib} has SPDX headers"
+sh_total=0
+sh_fail=0
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  sh_total=$((sh_total + 1))
+  if ! has_spdx_pair "${f}"; then
+    fail "S2: ${f} missing SPDX header(s)"
+    sh_fail=$((sh_fail + 1))
+  fi
+done < <(find hack scripts tests/scripts tests/unit tests/lib -type f -name '*.sh' 2>/dev/null)
+info "S2 totals: scanned=${sh_total} fail=${sh_fail}"
+[[ "${sh_fail}" -eq 0 ]] && pass "S2 clean (${sh_total} files scanned)"
+
+# ---------------------------------------------------------------------------
+# S3 — hand-authored YAML / TOML
+# ---------------------------------------------------------------------------
+hdr "S3: hand-authored YAML/TOML under deploy/, operators/<op>/config/, releases/ has SPDX headers"
+yaml_total=0
+yaml_fail=0
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  yaml_total=$((yaml_total + 1))
+  if is_generated_yaml "${f}"; then
+    continue
+  fi
+  if ! has_spdx_pair "${f}"; then
+    fail "S3: ${f} missing SPDX header(s)"
+    yaml_fail=$((yaml_fail + 1))
+  fi
+done < <(find deploy operators/*/config releases -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.toml' \) 2>/dev/null)
+info "S3 totals: scanned=${yaml_total} fail=${yaml_fail}"
+[[ "${yaml_fail}" -eq 0 ]] && pass "S3 clean (${yaml_total} files scanned)"
+
+# ---------------------------------------------------------------------------
+# S4 / S5 — licence inventory
+# ---------------------------------------------------------------------------
+hdr "S4: every SPDX-License-Identifier value has a matching LICENSES/<id>.txt"
+ids=$(grep -rhE 'SPDX-License-Identifier:[[:space:]]*[A-Za-z0-9.+-]+' \
+  --include='*.go' --include='*.sh' --include='*.yaml' --include='*.yml' \
+  --include='*.toml' --include='*.py' --include='Makefile' --include='Dockerfile' \
+  . 2>/dev/null \
+  | sed -nE 's/.*SPDX-License-Identifier:[[:space:]]*([A-Za-z0-9.+-]+).*/\1/p' \
+  | sort -u || true)
+for id in ${ids}; do
+  if [[ -f "LICENSES/${id}.txt" ]]; then
+    pass "licence ${id} has LICENSES/${id}.txt"
+  else
+    fail "licence ${id} referenced in header(s) but no LICENSES/${id}.txt — run: reuse download ${id}"
+  fi
+done
+
+hdr "S5: every LICENSES/<id>.txt is referenced by at least one file"
+if [[ -d LICENSES ]]; then
+  for lf in LICENSES/*.txt; do
+    [[ -f "${lf}" ]] || continue
+    id=$(basename "${lf}" .txt)
+    if echo "${ids}" | grep -qx "${id}"; then
+      pass "${id} referenced"
+    else
+      info "${id} in LICENSES/ but no file references it — unused inventory"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# S6 — REUSE.toml parses
+# ---------------------------------------------------------------------------
+hdr "S6: architecture/REUSE.toml parses as valid TOML"
+if [[ -f architecture/REUSE.toml ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    if python3 -c 'import tomllib,sys; tomllib.load(open("architecture/REUSE.toml","rb"))' 2>/dev/null; then
+      pass "architecture/REUSE.toml parses"
+    else
+      fail "architecture/REUSE.toml does not parse as TOML"
+    fi
+  else
+    info "python3 not on PATH — S6 skipped"
+  fi
+else
+  info "no architecture/REUSE.toml — S6 skipped"
+fi
+
+# ---------------------------------------------------------------------------
+# Inventory — counts by extension
+# ---------------------------------------------------------------------------
+hdr "Inventory — header coverage breakdown by extension"
+info "Go files scanned=${go_total} missing-header=${go_fail}"
+info "Shell scripts scanned=${sh_total} missing-header=${sh_fail}"
+info "YAML/TOML scanned=${yaml_total} missing-header=${yaml_fail}"
+
+# ---------------------------------------------------------------------------
+hdr "Summary"
+if [[ ${FAIL_COUNT} -eq 0 ]]; then
+  echo "[PASS] no SPDX/REUSE findings"
+  exit 0
+else
+  echo "[FAIL] ${FAIL_COUNT} SPDX/REUSE finding(s)"
+  exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.claude
+.claude/*
+!.claude/skills/
 .planwerk/.secrets.toml
 .serena
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Makefile for CC-0001 Go Workspace
 # Manages build, test, lint, and deployment operations for operators and common modules
 #

--- a/README.md
+++ b/README.md
@@ -21,16 +21,7 @@ Chainsaw E2E).
 
 ## Roadmap
 
-The full implementation plan is documented in [`.planwerk/PLAN.md`](.planwerk/PLAN.md) and spans 11 phases:
-
-1. **Project Foundation & Test Infrastructure** — Go Workspace monorepo, build system, test harnesses, and CI pipeline
-2. **Shared Library Packages** — Common types, conditions, config rendering, and Kubernetes helpers in `internal/common/`
-3. **Keystone Container Image Build Pipeline** — Multi-stage Docker builds for the Keystone service image
-4. **Infrastructure Deployment Stack** — FluxCD HelmReleases, OpenBao HA, ESO integration, MariaDB & Memcached
-5. **Keystone CRD & Webhooks** — API type definitions with Kubebuilder markers, defaulting, and validation
-6. **Keystone Reconciler** — Sequential sub-reconciler pattern with condition progression
-7. **Keystone Dependencies & E2E Tests** — Detailed dependency interactions and Chainsaw E2E test suite
-8. **Keystone Operator Packaging** — Operator image, Helm chart, and complete CI pipeline
-9. **c5c3-operator** — ControlPlane CRD with Keystone-only orchestration and auxiliary CRDs
-10. **End-to-End Integration Hardening** — Full-stack validation, failure recovery, and stress tests
-11. **Release Preparation** — Release workflow, documentation, and CI gate validation
+Outstanding work is tracked in [GitHub Issues](https://github.com/c5c3/forge/issues) — the issue
+tracker is the single source of truth for planned features (`CC-NNNN` labels), production-hardening
+gaps, and release milestones. See the architecture handbook under [`architecture/docs/`](architecture/docs/)
+for the design context behind individual feature IDs.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -89,6 +89,12 @@ export default defineConfig({
           },
         ],
       },
+      {
+        text: 'Contributing',
+        items: [
+          { text: 'Claude Code Skills', link: '/contributing/claude-skills' },
+        ],
+      },
     ],
     socialLinks: [
       { icon: 'github', link: 'https://github.com/c5c3/forge' },

--- a/docs/contributing/claude-skills.md
+++ b/docs/contributing/claude-skills.md
@@ -1,0 +1,161 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+---
+title: Claude Code skills
+description: The repository-specific Claude Code skill suite under .claude/skills/ — what each audit covers, how to invoke it, and where its deterministic script lives.
+---
+
+# Claude Code skills
+
+This repository ships a suite of repository-specific
+[Claude Code](https://docs.claude.com/en/docs/claude-code) skills under
+[`.claude/skills/`](https://github.com/c5c3/forge/tree/main/.claude/skills).
+Each skill is a focused **audit** that compares one surface of the
+codebase against its source of truth — the Keystone CRD, the
+sub-reconciler chain, the FluxCD infrastructure stack, the Renovate
+configuration, the e2e fixture corpus, the SPDX/REUSE coverage, the Go
+workspace — and reports drift before it reaches a release.
+
+The skills complement the CI gates configured in
+[`.github/workflows/`](https://github.com/c5c3/forge/tree/main/.github/workflows)
+and the Makefile drift-guard targets (`make verify-crd-sync`,
+`make verify-invalid-cr-fixtures`, the
+`TestSubReconcilerConditionTypesCovers*` Go tests). CI is the
+authoritative gate; the skills give a contributor (or an agent acting on
+the contributor's behalf) a structured, repeatable way to walk a
+surface and explain the findings in prose.
+
+## When to use a skill
+
+- After changing a surface the skill audits (a `+kubebuilder` marker, a
+  sub-reconciler, a condition type, a pinned version, a CR fixture, a
+  documentation page, …).
+- Before opening a release PR, as a final sweep across every surface.
+- When a CI gate is red and you want a per-surface diagnostic that
+  goes deeper than the gate's failure message.
+
+The skills are read-only by design: each one runs a deterministic Bash
+script and walks the relevant sources, then produces a findings report
+grouped by severity. Fixes are a separate, explicitly-scoped task.
+
+## How to invoke a skill
+
+The skills are loaded automatically by Claude Code when it sees the
+repository's `.claude/` directory. There are two ways to run one:
+
+- **Explicit slash command.** Type `/<skill-name>` in the Claude Code
+  prompt — for example `/check-doc-drift` — and Claude follows the
+  procedure in the skill's `SKILL.md`.
+- **Implicit trigger.** Each skill's description names the situations
+  where it should be used proactively ("after editing a `*_types.go`
+  file or a kubebuilder marker", "after adding a new pinned
+  dependency", …). Claude Code may invoke the skill on its own when
+  it recognises the trigger.
+
+Every skill ships a `scripts/audit-<name>.sh` companion that runs the
+deterministic part of the audit and exits non-zero on a `[FAIL]`. The
+script is safe to run by hand from a shell — it reads files and prints
+inventories; it never writes to the tree.
+
+```bash
+bash .claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
+```
+
+Where applicable, passing `--full` chains the authoritative gate after
+the smoke inventory (for example,
+`bash .claude/skills/check-crd-drift/scripts/audit-crd-drift.sh --full`
+runs `make verify-crd-sync` after the inventory). The skill's
+`SKILL.md` describes the prose-level checks the script cannot do
+(cross-referencing the doc to the source of truth, judging severity),
+the gate commands to run alongside the audit, and the report format.
+
+## Catalogue
+
+The seven skills are grouped by the surface they audit. Each entry
+links to the skill's `SKILL.md` (the procedure) and its companion Bash
+script (the deterministic part of the audit).
+
+### CRDs, configuration, and dependencies
+
+| Skill | Audits | Use when |
+|---|---|---|
+| [`check-crd-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-crd-drift/SKILL.md) | Every operator CRD across its three representations — the Go `+kubebuilder` source under `operators/<op>/api/`, the controller-gen output under `operators/<op>/config/crd/bases/`, and the Helm chart copy under `operators/<op>/helm/<op>-operator/crds/`. Defers to `make verify-crd-sync` as the authoritative gate. | After editing a `*_types.go` file or a kubebuilder marker, before a release. |
+| [`check-renovate-coverage`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-renovate-coverage/SKILL.md) | Every pinned version in the repo — OpenStack release tags under `releases/<version>/source-refs.yaml`, shell-script `VERSION` constants under `hack/`, FluxCD HelmRelease versions under `deploy/flux-system/releases/`, and tool-version pins in `Makefile` and `.github/workflows/` — for coverage by either a native Renovate manager or a `customManager` in `renovate.json` with a paired `packageRules` entry. | After adding a new pinned dependency; when a previously-bumped pin silently stopped receiving updates. |
+| [`check-go-workspace-deps`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-go-workspace-deps/SKILL.md) | Shared dependency versions across `internal/common/go.mod` and every `operators/<op>/go.mod` — `sigs.k8s.io/controller-runtime`, `k8s.io/api`, `k8s.io/apimachinery`, `k8s.io/client-go`, `k8s.io/apiextensions-apiserver` — plus the Go directive and the `go.work` member list. | After running `go get` in one module; after Renovate bumps controller-runtime in only one of the modules. |
+
+### Reconcilers, conditions, and fixtures
+
+| Skill | Audits | Use when |
+|---|---|---|
+| [`check-condition-coverage`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-condition-coverage/SKILL.md) | Keystone Status condition coverage end to end — every condition type set by a sub-reconciler must appear in the `subReconcilerConditionTypes` map, every sub-reconciler must have a paired unit test, and every condition the docs document must be set somewhere in code. Defers to `TestSubReconcilerConditionTypesCoversAllNames` and `TestSubReconcilerConditionTypesCoversAllCallSites` as the authoritative gate. | After adding or renaming a sub-reconciler or a condition type; when a Prometheus `condition_type` label suddenly shows up as `UNKNOWN`. |
+| [`check-fixture-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-fixture-drift/SKILL.md) | Every Keystone CR fixture under `tests/e2e/` and `tests/e2e-chaos/` against the *current* CRD schema — no removed `Spec` field is still referenced, every fixture's `apiVersion` / `kind` matches a real CRD, every invalid-cr fixture is reachable from a Chainsaw test. Defers to `make verify-invalid-cr-fixtures` as the authoritative gate. | After editing the Keystone CRD or the validating webhook, before a release. |
+
+### Documentation and compliance
+
+| Skill | Audits | Use when |
+|---|---|---|
+| [`check-doc-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-drift/SKILL.md) | The forge documentation against the implementation — the `architecture/docs/` chapters vs the operator code, the `docs/` user-facing reference vs the `deploy/` infrastructure stack, and the `CC-NNNN` feature IDs cited in prose vs the markers that appear in the code. | After adding or removing a sub-reconciler, status condition, operator binary, or infrastructure component, before tagging a release. |
+| [`check-spdx-reuse`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-spdx-reuse/SKILL.md) | SPDX / REUSE compliance across the source tree — every `*.go`, `*.sh`, hand-authored YAML, and CI workflow file should carry matching `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers; every licence referenced has a corresponding text under `LICENSES/`; `architecture/REUSE.toml` stays well-formed. Defers to `reuse lint` as the authoritative gate. | After adding a new source file; before tagging a release where SAP supply-chain audits require clean REUSE output. |
+
+## What a skill is, structurally
+
+Every skill in this suite follows the same layout:
+
+```text
+.claude/skills/<name>/
+├── SKILL.md                 # the procedure Claude follows
+└── scripts/
+    └── audit-<name>.sh      # the deterministic, read-only audit
+```
+
+`SKILL.md` opens with a YAML frontmatter block carrying `name` and
+`description` — the description is what Claude Code matches the user's
+prompt against when deciding whether to load the skill. The body
+documents the audit's procedure (a numbered step list with the script
+invocation, the hand-cross-reference work, the authoritative gate to
+run alongside, and the report format), the drift patterns that recur
+on the surface, and the severity-grouped reporting format with
+`file:line` citations on both the source and the source-of-truth side.
+
+The Bash script is the deterministic part of the audit. It performs no
+build, writes nothing, and reads from a fixed list of source-of-truth
+files. Exit code `0` means no `[FAIL]`; `1` means at least one
+mechanically-checkable assertion failed. Scripts are written to be
+portable across Bash 3.2 (macOS default) and BSD `awk` / `sed`, so they
+run cleanly on a contributor laptop without GNU coreutils.
+
+## Authoring or modifying a skill
+
+When you add a new skill or modify an existing one, keep the suite
+internally consistent:
+
+- **Frontmatter.** Every `SKILL.md` carries `name` and `description`.
+  The description is the discoverability surface — write it as a
+  single sentence in the form "Audit … — … . Use when …".
+- **Read-only.** The companion script reads files and prints reports;
+  it never writes to the tree, never runs `make generate`, never
+  triggers a build.
+- **Findings report.** The report groups findings by severity (HIGH /
+  MEDIUM / LOW) with one line per finding and a `file:line` reference
+  on both sides of the drift.
+- **Pair with a gate.** If the audit overlaps a CI gate or a Makefile
+  drift-guard, name the gate in `SKILL.md` and tell the reader to
+  trust the gate's verdict over the script's. The script is a
+  debugging aid; the gate is the source of truth.
+- **Portable shell.** Target Bash 3.2 (no `mapfile`, no `[[ ]]`
+  regex captures), BSD `awk` (no `match($0, /re/, arr)`), and BSD
+  `sed` (no `\s`, use `[[:space:]]`). Verify by running the script
+  on macOS before committing.
+- **SPDX headers.** Both the `SKILL.md` (HTML-comment form) and the
+  Bash script carry an SPDX-FileCopyrightText / SPDX-License-Identifier
+  pair. The [`check-spdx-reuse`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-spdx-reuse/SKILL.md)
+  skill audits this.
+- **Stay in English.** Skill bodies, frontmatter, and script comments
+  follow the repository-wide English-only rule.
+
+The skills are not a substitute for CI gates — they are an aid for the
+contributor (or the agent) who has to read a surface deeply and explain
+what changed. When in doubt, run the gate listed in the skill's
+`SKILL.md` and trust its verdict.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -37,10 +37,11 @@ KIND_HOST_PORT=8443 make deploy-infra
 ```
 
 Creates the `forge-e2e` kind cluster with `host:8443 → nodePort 31443`,
-then installs Flux, cert-manager, OpenBao (initialised, unsealed and
-bootstrapped), MariaDB operator + `openstack-db`, Memcached operator +
-`openstack-memcached`, External Secrets, Envoy Gateway and the shared
-`openstack-gw`. Expect **5–10 minutes** on first run (image pulls dominate).
+then installs Flux, cert-manager, the Gateway API CRDs,
+prometheus-operator-crds, OpenBao (initialised, unsealed and bootstrapped),
+MariaDB operator + `openstack-db`, External Secrets, Memcached operator +
+`openstack-memcached`, Envoy Gateway and the shared `openstack-gw`. Expect
+**5–10 minutes** on first run (image pulls dominate).
 
 ## Step 3 — Keystone operator
 

--- a/go.work
+++ b/go.work
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
 go 1.25.10
 
 use (

--- a/operators/c5c3/main.go
+++ b/operators/c5c3/main.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entrypoint for the C5C3 operator (CC-0001).
 //
 // DEVIATION from architecture/01-project-setup.md (CC-0001):

--- a/operators/keystone/main.go
+++ b/operators/keystone/main.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entrypoint for the Keystone operator (CC-0001).
 //
 // DEVIATION from architecture/01-project-setup.md (CC-0001):

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/releases/.*/test-refs\\.yaml$/"
+      ],
+      "matchStrings": [
+        "(?m)^(?<depName>[\\w.-]+):\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/hack/deploy-infra\\.sh$/"
       ],
       "matchStrings": [
@@ -27,6 +38,59 @@
       "depNameTemplate": "controlplaneio-fluxcd/flux-operator",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "controlplaneio-fluxcd/flux-operator",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/hack/install-test-deps\\.sh$/"
+      ],
+      "matchStrings": [
+        "CHAINSAW_VERSION=\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "kyverno/chainsaw",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "kyverno/chainsaw",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/hack/install-test-deps\\.sh$/"
+      ],
+      "matchStrings": [
+        "FLUX_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "fluxcd/flux2",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "fluxcd/flux2",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/hack/install-test-deps\\.sh$/"
+      ],
+      "matchStrings": [
+        "KIND_VERSION=\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "kubernetes-sigs/kind",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/hack/install-test-deps\\.sh$/"
+      ],
+      "matchStrings": [
+        "KUBECTL_VERSION=\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "kubernetes/kubernetes",
       "versioningTemplate": "semver"
     },
     {
@@ -55,6 +119,72 @@
       "packageNameTemplate": "envoyproxy/gateway",
       "extractVersionTemplate": "^v(?<version>.+)$",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/deploy/kind/base/headlamp\\.yaml$/"
+      ],
+      "matchStrings": [
+        "version:\\s*\">=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s+<\\d+\\.\\d+\\.\\d+\""
+      ],
+      "depNameTemplate": "headlamp",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://kubernetes-sigs.github.io/headlamp/",
+      "versioningTemplate": "helm"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/Makefile$/",
+        "/\\.github/workflows/.*\\.yaml$/"
+      ],
+      "matchStrings": [
+        "GOFUMPT_VERSION\\s*[?=:]+\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "mvdan/gofumpt",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "mvdan/gofumpt",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yaml$/"
+      ],
+      "matchStrings": [
+        "CONTROLLER_GEN_VERSION:\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "kubernetes-sigs/controller-tools",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "kubernetes-sigs/controller-tools",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yaml$/"
+      ],
+      "matchStrings": [
+        "GOLANGCI_LINT_VERSION:\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "golangci/golangci-lint",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yaml$/"
+      ],
+      "matchStrings": [
+        "YQ_VERSION:\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "mikefarah/yq",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "mikefarah/yq",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
@@ -71,6 +201,20 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "OpenStack upstream tags"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["releases/**/test-refs.yaml"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["releases/**/test-refs.yaml"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "OpenStack test tooling (PyPI)"
     },
     {
       "matchManagers": ["custom.regex"],
@@ -103,6 +247,74 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "envoy-gateway"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/kind/base/headlamp.yaml"],
+      "matchPackageNames": ["headlamp"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/kind/base/headlamp.yaml"],
+      "matchPackageNames": ["headlamp"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "headlamp"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["hack/install-test-deps.sh"],
+      "matchPackageNames": [
+        "kyverno/chainsaw",
+        "fluxcd/flux2",
+        "kubernetes-sigs/kind",
+        "kubernetes/kubernetes"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["hack/install-test-deps.sh"],
+      "matchPackageNames": [
+        "kyverno/chainsaw",
+        "fluxcd/flux2",
+        "kubernetes-sigs/kind",
+        "kubernetes/kubernetes"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "test tooling (install-test-deps)"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["Makefile", ".github/workflows/**.yaml"],
+      "matchPackageNames": [
+        "mvdan/gofumpt",
+        "golangci/golangci-lint",
+        "kubernetes-sigs/controller-tools",
+        "mikefarah/yq"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["Makefile", ".github/workflows/**.yaml"],
+      "matchPackageNames": [
+        "mvdan/gofumpt",
+        "golangci/golangci-lint",
+        "kubernetes-sigs/controller-tools",
+        "mikefarah/yq"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "Go build tooling"
     }
   ]
 }

--- a/tests/unit/renovate/headlamp_chart_custommanager_test.sh
+++ b/tests/unit/renovate/headlamp_chart_custommanager_test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has a customManager for the headlamp Helm chart
+# version range in deploy/kind/base/headlamp.yaml. The manager must:
+#   - target the file, not the broader kind/base/ dir
+#   - use datasource=helm with the kubernetes-sigs/headlamp registry URL
+#   - capture the lower bound from `version: ">=x.y.z <X.Y.Z"`
+#   - be paired with a packageRule that disables majors and automerges
+#     minor/patch with minimumReleaseAge=3 days
+#
+# Usage: bash tests/unit/renovate/headlamp_chart_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+CHART_FILE="$PROJECT_ROOT/deploy/kind/base/headlamp.yaml"
+
+test_custom_manager_uses_helm_datasource() {
+  echo "Test: headlamp customManager uses datasource=helm with the kubernetes-sigs registry"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local entry
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("headlamp"))' \
+    "$RENOVATE_FILE")"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting deploy/kind/base/headlamp.yaml"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  assert_eq "headlamp customManager.datasourceTemplate is helm" \
+    "helm" \
+    "$(jq -r '.datasourceTemplate' <<<"$entry")"
+  assert_eq "headlamp customManager.depNameTemplate is headlamp" \
+    "headlamp" \
+    "$(jq -r '.depNameTemplate' <<<"$entry")"
+  assert_contains "headlamp customManager.registryUrlTemplate points at kubernetes-sigs.github.io" \
+    "$(jq -r '.registryUrlTemplate' <<<"$entry")" \
+    "kubernetes-sigs.github.io/headlamp"
+}
+
+test_regex_captures_chart_lower_bound() {
+  echo "Test: headlamp customManager regex captures the chart-range lower bound"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if [[ ! -f "$CHART_FILE" ]]; then
+    echo "  SKIP: $CHART_FILE missing"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local entry match_string version_line captured expected_value
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("headlamp"))' \
+    "$RENOVATE_FILE")"
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+
+  version_line="$(grep -E '^[[:space:]]*version:[[:space:]]*"' "$CHART_FILE" | head -1)"
+  assert_not_empty "chart version line present in deploy/kind/base/headlamp.yaml" \
+    "$version_line"
+
+  captured="$(REGEX="$match_string" LINE="$version_line" perl -e '
+    my $re = $ENV{REGEX};
+    my $line = $ENV{LINE};
+    if ($line =~ /$re/) { print $+{currentValue} // ""; }
+  ')"
+
+  expected_value="$(printf '%s' "$version_line" \
+    | sed -E 's/.*">=([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+
+  assert_eq "matchStrings regex captures the headlamp chart lower-bound version" \
+    "$expected_value" "$captured"
+}
+
+test_package_rules_for_headlamp() {
+  echo "Test: packageRules disable major headlamp bumps, automerge minor/patch"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index("headlamp")) != null
+         or ((.matchFileNames   // []) | index("deploy/kind/base/headlamp.yaml")) != null)
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index("headlamp")) != null
+         or ((.matchFileNames   // []) | index("deploy/kind/base/headlamp.yaml")) != null)
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule scoping major updates for headlamp"
+    FAIL=$((FAIL + 2))
+  else
+    assert_eq "major headlamp updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule scoping minor/patch updates for headlamp"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_eq "minor/patch headlamp updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch headlamp rule waits minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+  assert_eq "minor/patch headlamp rule groupName is headlamp" \
+    "headlamp" \
+    "$(jq -r '.groupName' <<<"$minor_rule")"
+}
+
+test_custom_manager_uses_helm_datasource
+test_regex_captures_chart_lower_bound
+test_package_rules_for_headlamp
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/install_test_deps_custommanager_test.sh
+++ b/tests/unit/renovate/install_test_deps_custommanager_test.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has customManagers for the four tool pins in
+# hack/install-test-deps.sh (CC-0010): CHAINSAW_VERSION, FLUX_VERSION,
+# KIND_VERSION, KUBECTL_VERSION.
+#
+# For each, assert:
+#   - a customManager exists with packageNameTemplate matching the expected
+#     GitHub org/repo
+#   - its matchStrings regex captures the current literal in the script
+#   - a paired packageRule disables majors
+#
+# Usage: bash tests/unit/renovate/install_test_deps_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+INSTALL_FILE="$PROJECT_ROOT/hack/install-test-deps.sh"
+
+# Map: tool_var → expected packageName
+TOOLS=(
+  "CHAINSAW_VERSION:kyverno/chainsaw"
+  "FLUX_VERSION:fluxcd/flux2"
+  "KIND_VERSION:kubernetes-sigs/kind"
+  "KUBECTL_VERSION:kubernetes/kubernetes"
+)
+
+test_each_tool_has_manager_and_regex_matches() {
+  echo "Test: every install-test-deps.sh pin has a customManager whose regex matches (CC-0010)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if [[ ! -f "$INSTALL_FILE" ]]; then
+    echo "  SKIP: $INSTALL_FILE missing"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local pair tool_var pkg_name entry match_string captured
+  for pair in "${TOOLS[@]}"; do
+    tool_var="${pair%%:*}"
+    pkg_name="${pair##*:}"
+
+    entry="$(jq -c --arg pkg "$pkg_name" '.customManagers[]
+      | select(.packageNameTemplate == $pkg
+               and ((.managerFilePatterns // []) | join(",") | contains("install-test-deps")))' \
+      "$RENOVATE_FILE")"
+
+    if [ -z "$entry" ]; then
+      echo "  FAIL: no customManager for ${tool_var} → ${pkg_name}"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+
+    match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+    captured="$(REGEX="$match_string" FILE="$INSTALL_FILE" perl -e '
+      my $re = $ENV{REGEX};
+      local $/; open my $fh, "<", $ENV{FILE} or die $!;
+      my $content = <$fh>;
+      if ($content =~ /$re/) { print $+{currentValue} // ""; }
+    ')"
+
+    if [ -n "$captured" ]; then
+      echo "  PASS: ${tool_var} → ${pkg_name} regex captures ${captured}"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: ${tool_var} → ${pkg_name} regex did not match install-test-deps.sh"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+}
+
+test_package_rule_disables_majors() {
+  echo "Test: packageRule disables major updates for install-test-deps tools (CC-0010)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("hack/install-test-deps.sh")) != null
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("hack/install-test-deps.sh")) != null
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule disabling majors for install-test-deps.sh"
+    FAIL=$((FAIL + 1))
+  else
+    assert_eq "major install-test-deps updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule for minor/patch install-test-deps updates"
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  assert_eq "minor/patch install-test-deps updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch install-test-deps rule waits minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+}
+
+test_each_tool_has_manager_and_regex_matches
+test_package_rule_disables_majors
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/makefile_pin_custommanager_test.sh
+++ b/tests/unit/renovate/makefile_pin_custommanager_test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has a customManager covering the GOFUMPT_VERSION pin
+# in the root Makefile (which must stay in sync with the workflow env var of
+# the same name). The manager is shared with workflow files via a multi-entry
+# managerFilePatterns array.
+#
+# Usage: bash tests/unit/renovate/makefile_pin_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+MAKEFILE="$PROJECT_ROOT/Makefile"
+
+test_makefile_in_a_manager_file_pattern() {
+  echo "Test: at least one customManager.managerFilePatterns covers the root Makefile"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local hit
+  hit="$(jq -r '.customManagers[].managerFilePatterns[]?
+    | select(test("/Makefile\\$/"))' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$hit" ]; then
+    echo "  FAIL: no customManager.managerFilePatterns matches /Makefile\$/"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: customManager covers Makefile via $hit"
+  PASS=$((PASS + 1))
+}
+
+test_gofumpt_regex_matches_makefile_pin() {
+  echo "Test: GOFUMPT_VERSION regex captures the literal in Makefile"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if [[ ! -f "$MAKEFILE" ]]; then
+    echo "  SKIP: $MAKEFILE missing"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local entry match_string captured expected
+  entry="$(jq -c '.customManagers[]
+    | select(.packageNameTemplate == "mvdan/gofumpt")' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManager has packageNameTemplate=mvdan/gofumpt"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+  captured="$(REGEX="$match_string" FILE="$MAKEFILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    if ($content =~ /$re/) { print $+{currentValue} // ""; }
+  ')"
+  expected="$(grep -E '^GOFUMPT_VERSION' "$MAKEFILE" | head -1 \
+    | sed -E 's/.*(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+
+  assert_eq "GOFUMPT_VERSION regex captures the Makefile pin" \
+    "$expected" "$captured"
+}
+
+test_gofumpt_package_rule_disables_majors() {
+  echo "Test: packageRule disables majors for mvdan/gofumpt across Makefile + workflows"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchPackageNames // []) | index("mvdan/gofumpt")) != null
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchPackageNames // []) | index("mvdan/gofumpt")) != null
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule disables majors for mvdan/gofumpt"
+    FAIL=$((FAIL + 1))
+  else
+    assert_eq "major mvdan/gofumpt updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule for minor/patch mvdan/gofumpt updates"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_eq "minor/patch mvdan/gofumpt updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+}
+
+test_makefile_in_a_manager_file_pattern
+test_gofumpt_regex_matches_makefile_pin
+test_gofumpt_package_rule_disables_majors
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/source_refs_custommanager_test.sh
+++ b/tests/unit/renovate/source_refs_custommanager_test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has the source-refs.yaml customManager + packageRules
+# described by CC-0017 (OpenStack release tag tracking):
+#   - a customManagers entry targeting releases/<release>/source-refs.yaml
+#     whose matchStrings regex extracts (depName, x.y.z) from every entry
+#   - a paired packageRule set that disables majors and automerges minor/patch
+#     with minimumReleaseAge=3 days, groupName="OpenStack upstream tags"
+#
+# Prefers `renovate-config-validator` when available (via npx); otherwise
+# performs a regex-only validation using Perl (which speaks the same PCRE
+# syntax Renovate uses).
+#
+# Usage: bash tests/unit/renovate/source_refs_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+SOURCE_REFS_FILE="$PROJECT_ROOT/releases/2026.1/source-refs.yaml"
+
+test_renovate_config_valid() {
+  echo "Test: renovate.json validates via renovate-config-validator (CC-0017)"
+
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "  SKIP: npx not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local output status=0
+  output="$(cd "$PROJECT_ROOT" && npx --yes --package renovate@latest -- \
+    renovate-config-validator renovate.json 2>&1)" || status=$?
+
+  if [ "$status" -ne 0 ]; then
+    echo "  FAIL: renovate-config-validator rejected renovate.json"
+    echo "$output" | head -40
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: renovate-config-validator accepted renovate.json"
+  PASS=$((PASS + 1))
+}
+
+test_custom_manager_regex_captures_depname_and_version() {
+  echo "Test: customManagers regex extracts (depName, x.y.z) from source-refs.yaml (CC-0017)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local entry
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("source-refs"))' \
+    "$RENOVATE_FILE")"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting releases/*/source-refs.yaml"
+    FAIL=$((FAIL + 5))
+    return
+  fi
+
+  assert_eq "customManagers.datasourceTemplate is git-tags" \
+    "git-tags" \
+    "$(jq -r '.datasourceTemplate' <<<"$entry")"
+
+  assert_eq "customManagers.versioningTemplate is semver" \
+    "semver" \
+    "$(jq -r '.versioningTemplate' <<<"$entry")"
+
+  assert_contains "customManagers.packageNameTemplate references opendev.org/openstack" \
+    "$(jq -r '.packageNameTemplate' <<<"$entry")" \
+    "opendev.org/openstack"
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+  if [[ ! -f "$SOURCE_REFS_FILE" ]]; then
+    echo "  SKIP: $SOURCE_REFS_FILE missing (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local match_string
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+
+  local captured_dep captured_ver
+  captured_dep="$(REGEX="$match_string" FILE="$SOURCE_REFS_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    if ($content =~ /$re/m) { print $+{depName} // ""; }
+  ')"
+  captured_ver="$(REGEX="$match_string" FILE="$SOURCE_REFS_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    if ($content =~ /$re/m) { print $+{currentValue} // ""; }
+  ')"
+
+  assert_not_empty "matchStrings regex captures a depName from source-refs.yaml" \
+    "$captured_dep"
+  assert_not_empty "matchStrings regex captures an x.y.z currentValue" \
+    "$captured_ver"
+}
+
+test_package_rules_disable_majors_and_group() {
+  echo "Test: packageRules disable major source-refs bumps, automerge minor/patch (CC-0017)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("releases/**/source-refs.yaml")) != null
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("releases/**/source-refs.yaml")) != null
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule scoping major updates for releases/**/source-refs.yaml"
+    FAIL=$((FAIL + 2))
+  else
+    assert_eq "major source-refs updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule scoping minor/patch updates for source-refs.yaml"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_eq "minor/patch source-refs updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch source-refs updates carry matchUpdateTypes=patch" \
+    "true" \
+    "$(jq -r '(.matchUpdateTypes // []) | index("patch") != null' <<<"$minor_rule")"
+  assert_eq "minor/patch source-refs rule waits minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+  assert_eq "minor/patch source-refs rule groupName is 'OpenStack upstream tags'" \
+    "OpenStack upstream tags" \
+    "$(jq -r '.groupName' <<<"$minor_rule")"
+}
+
+test_renovate_config_valid
+test_custom_manager_regex_captures_depname_and_version
+test_package_rules_disable_majors_and_group
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/test_refs_custommanager_test.sh
+++ b/tests/unit/renovate/test_refs_custommanager_test.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has the test-refs.yaml (PyPI) customManager described
+# by CC-0051 REQ-001:
+#   - a customManagers entry targeting releases/<release>/test-refs.yaml
+#     whose matchStrings regex extracts (depName, x.y.z) per PyPI pin
+#   - datasource=pypi, versioning=pep440 (distinct from source-refs.yaml)
+#   - a paired packageRule set that disables majors and automerges minor/patch
+#     with minimumReleaseAge=3 days
+#
+# Usage: bash tests/unit/renovate/test_refs_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+TEST_REFS_FILE="$PROJECT_ROOT/releases/2026.1/test-refs.yaml"
+
+test_custom_manager_uses_pypi_datasource() {
+  echo "Test: test-refs.yaml customManager uses datasource=pypi, versioning=pep440 (CC-0051)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local entry
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("test-refs"))' \
+    "$RENOVATE_FILE")"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting releases/*/test-refs.yaml"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  assert_eq "test-refs customManager.datasourceTemplate is pypi" \
+    "pypi" \
+    "$(jq -r '.datasourceTemplate' <<<"$entry")"
+  assert_eq "test-refs customManager.versioningTemplate is pep440" \
+    "pep440" \
+    "$(jq -r '.versioningTemplate' <<<"$entry")"
+  assert_eq "test-refs customManager has a depName capture (no fixed depNameTemplate)" \
+    "null" \
+    "$(jq -r '.depNameTemplate // "null"' <<<"$entry")"
+}
+
+test_regex_captures_tempest_and_plugin() {
+  echo "Test: test-refs.yaml regex captures tempest and keystone-tempest-plugin (CC-0051)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+  if [[ ! -f "$TEST_REFS_FILE" ]]; then
+    echo "  SKIP: $TEST_REFS_FILE missing (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local entry match_string
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("test-refs"))' \
+    "$RENOVATE_FILE")"
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+
+  local captured
+  captured="$(REGEX="$match_string" FILE="$TEST_REFS_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    my @hits;
+    while ($content =~ /$re/gm) { push @hits, $+{depName} . "=" . $+{currentValue}; }
+    print join("\n", @hits);
+  ')"
+
+  assert_contains "regex captures tempest from test-refs.yaml" \
+    "$captured" "tempest="
+  assert_contains "regex captures keystone-tempest-plugin from test-refs.yaml" \
+    "$captured" "keystone-tempest-plugin="
+}
+
+test_package_rules_for_test_refs() {
+  echo "Test: packageRules disable major test-refs bumps, automerge minor/patch (CC-0051)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("releases/**/test-refs.yaml")) != null
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index("releases/**/test-refs.yaml")) != null
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule scoping major updates for releases/**/test-refs.yaml"
+    FAIL=$((FAIL + 2))
+  else
+    assert_eq "major test-refs updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule scoping minor/patch updates for test-refs.yaml"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_eq "minor/patch test-refs updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch test-refs rule waits minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+  assert_contains "minor/patch test-refs rule groupName mentions PyPI" \
+    "$(jq -r '.groupName' <<<"$minor_rule")" \
+    "PyPI"
+}
+
+test_custom_manager_uses_pypi_datasource
+test_regex_captures_tempest_and_plugin
+test_package_rules_for_test_refs
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/workflow_pins_custommanager_test.sh
+++ b/tests/unit/renovate/workflow_pins_custommanager_test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has customManagers for the four GitHub Actions env-var
+# tool pins:
+#   - CONTROLLER_GEN_VERSION → kubernetes-sigs/controller-tools
+#   - GOFUMPT_VERSION        → mvdan/gofumpt
+#   - GOLANGCI_LINT_VERSION  → golangci/golangci-lint
+#   - YQ_VERSION             → mikefarah/yq
+#
+# For each: regex must capture the literal in the workflow file that pins it,
+# and the paired packageRule must disable majors and automerge minor/patch.
+#
+# Usage: bash tests/unit/renovate/workflow_pins_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+
+# Map: env_var:expected_packageName:workflow_file
+TOOLS=(
+  "CONTROLLER_GEN_VERSION:kubernetes-sigs/controller-tools:.github/workflows/ci.yaml"
+  "GOFUMPT_VERSION:mvdan/gofumpt:.github/workflows/ci.yaml"
+  "GOLANGCI_LINT_VERSION:golangci/golangci-lint:.github/workflows/ci.yaml"
+  "YQ_VERSION:mikefarah/yq:.github/workflows/verify-container-images.yaml"
+)
+
+test_each_workflow_pin_has_manager() {
+  echo "Test: every workflow env-var pin has a customManager whose regex matches"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local triplet env_var pkg_name wf_file entry match_string captured
+  for triplet in "${TOOLS[@]}"; do
+    env_var="${triplet%%:*}"
+    pkg_name="$(printf '%s' "$triplet" | cut -d: -f2)"
+    wf_file="${triplet##*:}"
+
+    if [[ ! -f "$PROJECT_ROOT/$wf_file" ]]; then
+      echo "  SKIP: $wf_file missing (skipping $env_var)"
+      SKIP=$((SKIP + 1))
+      continue
+    fi
+
+    entry="$(jq -c --arg pkg "$pkg_name" '.customManagers[]
+      | select(.packageNameTemplate == $pkg
+               and ((.managerFilePatterns // []) | join(",") | contains("workflows")))' \
+      "$RENOVATE_FILE" | head -1)"
+
+    if [ -z "$entry" ]; then
+      echo "  FAIL: no customManager for ${env_var} → ${pkg_name} covering workflows"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+
+    match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+    captured="$(REGEX="$match_string" FILE="$PROJECT_ROOT/$wf_file" perl -e '
+      my $re = $ENV{REGEX};
+      local $/; open my $fh, "<", $ENV{FILE} or die $!;
+      my $content = <$fh>;
+      if ($content =~ /$re/) { print $+{currentValue} // ""; }
+    ')"
+
+    if [ -n "$captured" ]; then
+      echo "  PASS: ${env_var} → ${pkg_name} regex captures ${captured} in ${wf_file}"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: ${env_var} regex did not match in ${wf_file}"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+}
+
+test_workflow_pins_share_a_package_rule() {
+  echo "Test: workflow tool pins share a major-disable + minor-automerge packageRule"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local pkg
+  for pkg in kubernetes-sigs/controller-tools golangci/golangci-lint mikefarah/yq; do
+    local major_rule
+    major_rule="$(jq -c --arg pkg "$pkg" '.packageRules[]
+      | select(
+          ((.matchPackageNames // []) | index($pkg)) != null
+          and (((.matchUpdateTypes // []) | index("major")) != null)
+        )' "$RENOVATE_FILE" | head -1)"
+
+    if [ -z "$major_rule" ]; then
+      echo "  FAIL: no major-disable packageRule covering ${pkg}"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+    assert_eq "major ${pkg} updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  done
+
+  local minor_rule
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        ((.matchPackageNames // []) | index("mikefarah/yq")) != null
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no minor/patch packageRule covering mikefarah/yq"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_eq "minor/patch workflow tool updates wait minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+}
+
+test_each_workflow_pin_has_manager
+test_workflow_pins_share_a_package_rule
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a suite of seven repeatable maintenance-audit skills under `.claude/skills/` and apply the first round of drift fixes each one surfaced when run against `main`.

### Skills added (commit 17e66b05 / c6f3cad0)
- `check-doc-drift` — architecture prose vs implementation
- `check-crd-drift` — Go +kubebuilder source ↔ generated CRD ↔ Helm chart copy
- `check-fixture-drift` — `tests/e2e/` CR fixtures vs current CRD schema
- `check-go-workspace-deps` — per-module `go.mod` lockstep across the workspace
- `check-condition-coverage` — call-site / `subReconcilerConditionTypes` / docs / tests invariant
- `check-renovate-coverage` — every static version pin claimed by a manager
- `check-spdx-reuse` — REUSE / SPDX header coverage

Each skill ships with a deterministic shell-script smoke check plus a documented hand-off to the authoritative gate (Go test, `make verify-crd-sync`, `renovate-config-validator`, `reuse lint`, etc.). The suite is documented under `docs/contributing/claude-skills.md` and surfaced on the VitePress site.

### Drift fixes applied
- **`baee7903` (README + quick-start)** — drop the dead `.planwerk/PLAN.md` link, point the roadmap at GitHub Issues; complete the `make deploy-infra` infra list with `Gateway API CRDs` + `prometheus-operator-crds`.
- **`79343186` (SPDX/REUSE)** — add canonical three-line SPDX headers to the two `main.go` entrypoints, root `Makefile`, and `go.work`. Brings S1 (Go) from 2/120 missing to 0/120.
- **`6f2a17b7` (Renovate coverage)** — 10 new customManagers + paired packageRules covering: `hack/install-test-deps.sh` (chainsaw/flux2/kind/kubectl), `releases/*/test-refs.yaml` (PyPI), `deploy/kind/base/headlamp.yaml` (Helm), and `GOFUMPT_VERSION` / `CONTROLLER_GEN_VERSION` / `GOLANGCI_LINT_VERSION` / `YQ_VERSION` across `Makefile` + workflows. Six new regression tests under `tests/unit/renovate/` (78 assertions, all green); `renovate-config-validator` with `renovate@latest` accepts the new configuration.

### Deferred to the `architecture/` submodule

The check-doc-drift and check-condition-coverage runs surfaced load-bearing drift inside `architecture/docs/09-implementation/` (6 missing sub-reconciler sections, 5 missing condition rows, 11+ undocumented Spec fields, OpenBao kind-vs-prod replica gap, etc.). Those fixes live in the submodule and will follow as a separate PR there.

## Test plan
- [ ] `bash .claude/skills/check-doc-drift/scripts/audit-doc-drift.sh` — confirm only architecture-tabu findings remain
- [ ] `bash .claude/skills/check-crd-drift/scripts/audit-crd-drift.sh` + `make verify-crd-sync` — confirm `[PASS] no CRD-drift findings`
- [ ] `bash .claude/skills/check-fixture-drift/scripts/audit-fixture-drift.sh` — confirm only the `08-replicas-zero.yaml` documented numbering-gap false-positive remains
- [ ] `bash .claude/skills/check-go-workspace-deps/scripts/audit-go-workspace-deps.sh` + `go build ./internal/common/... ./operators/c5c3/... ./operators/keystone/...` — confirm lockstep
- [ ] `bash .claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh` + `go test ./operators/keystone/internal/controller/... -run TestSubReconcilerConditionTypesCovers -count=1` — confirm only architecture-tabu K4 findings remain
- [ ] `bash .claude/skills/check-renovate-coverage/scripts/audit-renovate-coverage.sh` — confirm only the 3 documented false-positives (Runtime-resolved `TEMPEST_VERSION` / `KTP_VERSION` / `SERVICE_VERSION`) remain
- [ ] `bash .claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh` — confirm only the controller-gen webhook-manifest finding remains (REUSE.toml fix lives in `architecture/`)
- [ ] `for t in tests/unit/renovate/*_test.sh; do bash "$t"; done` — 9 files, 78 passing assertions
- [ ] `npx --package renovate@latest -- renovate-config-validator renovate.json` — `INFO: Config validated successfully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)