### PR TITLE
docs(CC-0107): document OpenBao UI client-cert (mTLS) access

### DIFF
--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -365,11 +365,45 @@ export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n openbao-system \
 echo "$BAO_TOKEN"
 ```
 
-Open `https://localhost:8200/ui/` and paste the token to sign in.
+### Present a client certificate (mutual TLS)
 
-> **Note:** The OpenBao listener uses a self-signed certificate issued by the in-cluster
-> `selfsigned-cluster-issuer`. Your browser will warn that the certificate is not trusted —
-> this is expected for a kind cluster; accept the warning to reach the UI.
+The listener enforces **mutual TLS**: every connection must present a client certificate that
+chains to the in-cluster CA *before* the application-layer token login runs. A browser without
+one never reaches the login screen — the TLS handshake is reset, which the tooling surfaces as
+`connection reset by peer` / `lost connection to pod`. The kind overlay matches the production
+mTLS posture here.
+
+Build a PKCS#12 bundle from the `openbao-client-tls` Secret. Its keypair is signed by the same
+`selfsigned-cluster-issuer` CA as the server cert, and the listener verifies only chain-to-CA
+(not SANs) on client auth, so this certificate is accepted:
+
+```bash
+kubectl get secret openbao-client-tls -n openbao-system \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > openbao-client.crt
+kubectl get secret openbao-client-tls -n openbao-system \
+  -o jsonpath='{.data.tls\.key}' | base64 -d > openbao-client.key
+kubectl get secret openbao-client-tls -n openbao-system \
+  -o jsonpath='{.data.ca\.crt}'  | base64 -d > openbao-ca.crt
+# The passphrase only protects this throwaway local .p12 during the browser
+# import — it is not an OpenBao credential, so pick any value you like.
+openssl pkcs12 -export -inkey openbao-client.key -in openbao-client.crt \
+  -certfile openbao-ca.crt -name "OpenBao Client (kind)" \
+  -out openbao-client.p12 -passout pass:changeit
+```
+
+Import the bundle into Firefox once. This walkthrough is verified with Firefox;
+Chrome, Edge, and Safari also accept client certificates but import them through
+the OS keychain / system certificate store, so the menu path differs:
+
+1. *Settings → Privacy & Security → Certificates → View Certificates…*
+2. Tab **Your Certificates → Import…** → select `openbao-client.p12` and enter the
+   passphrase you chose above.
+3. *(Optional — removes the trust warning.)* Tab **Authorities → Import…** → select
+   `openbao-ca.crt` → tick "Trust this CA to identify websites". The server cert carries
+   `IP:127.0.0.1` as a SAN, so `https://localhost:8200` then validates cleanly.
+
+Open `https://localhost:8200/ui/`. Firefox asks which client certificate to send — pick
+**"OpenBao Client (kind)"** — then paste the root token to sign in.
 
 For the full token lifecycle, secret engines, auth methods, and the bootstrap sequence that
 produced this token, see

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -54,7 +54,7 @@ kubectl wait helmrelease/keystone-operator -n keystone-system \
 
 ## Step 4 — Keystone service image
 
-> Note: the keystone-operator controller runs in `keystone-system`; the Keystone workload it manages runs in `openstack` (controller-vs-workload split, CC-0105).
+> Note: the keystone-operator controller runs in `keystone-system`; the Keystone workload it manages runs in `openstack` (controller-vs-workload split).
 
 ```bash
 RELEASE=2025.2
@@ -168,8 +168,11 @@ kubectl get secret openbao-init-keys -n openbao-system \
 kubectl port-forward svc/openbao -n openbao-system 8200:8200
 ```
 
-Open <https://localhost:8200/ui/>, accept the self-signed cert warning,
-paste the token.
+The listener enforces mutual TLS, so the browser must present a client
+certificate before it reaches the UI. Build a PKCS#12 bundle from the
+`openbao-client-tls` Secret, import it into Firefox, and sign in with the
+token — see [Extended Quick Start — Step 4b](./quick-start-extended.md#step-4b-openbao-ui)
+for the exact commands, CA trust, and browser notes.
 
 > **Grafana (kind-only, opt-in):** for the keystone-operator metrics dashboard, run `WITH_PROMETHEUS=true make deploy-infra` and follow [Extended Quick Start — Step 4c](./quick-start-extended.md#step-4c-grafana-ui). The compact path stays Grafana-free by default.
 


### PR DESCRIPTION
## Summary

The OpenBao API listener enforces mutual TLS (client-cert auth), so a browser without a client certificate has its TLS handshake reset *before* it reaches the UI. The quick starts still told readers to "accept the self-signed cert warning", which no longer works — it surfaces as a connection reset / lost `kubectl port-forward`.

This documents the working path in both quick starts:

- **`quick-start-extended.md`** — new Step 4b subsection "Present a client certificate (mutual TLS)": build a PKCS#12 bundle from the `openbao-client-tls` Secret and import it into Firefox (Your Certificates, plus optional CA trust under Authorities), then pick the client cert when prompted.
- **`quick-start.md`** — compact variant of the same steps with a pointer to the extended walkthrough.
- Also drops a stray internal feature-ID reference from the compact quick start prose.

Documentation only — no source or infrastructure changes.

## Test plan

- [x] Reproduced the failure: `curl` without a client cert is reset at the TLS handshake against the mTLS listener
- [x] Verified the documented path: `curl --cacert ca.crt --cert tls.crt --key tls.key https://127.0.0.1:8200/v1/sys/health` returns `200`
- [x] Confirmed `openbao-client-tls` carries `tls.crt` / `tls.key` / `ca.crt`, and the server cert SANs include `IP:127.0.0.1` (clean verification against `localhost`)
- [x] `grep -E 'CC-[0-9]'` over both quick starts is clean