### PR TITLE
docs: remove internal CC/REQ feature IDs and gate against re-entry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -443,6 +443,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+      # Gate: published docs must describe behaviour, never cite internal
+      # feature/requirement IDs (CC-NNNN / REQ-NNN). Runs first so it fails fast
+      # without needing the Node toolchain.
+      - name: Check docs are free of internal feature IDs
+        run: make check-docs-ids
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24

--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,14 @@ verify-invalid-cr-fixtures:
 	@echo "Running CC-0094 invalid-CR fixture unit tests..."
 	@python3 tests/e2e/keystone/invalid-cr/test_generate.py
 
+.PHONY: check-docs-ids
+# check-docs-ids fails if any internal feature / requirement ID (CC-NNNN or
+# REQ-NNN) appears in the published documentation under docs/. User-facing docs
+# describe behaviour, not internal tracking IDs. Mirrors the CI docs-job gate
+# and needs no cluster or toolchain beyond grep.
+check-docs-ids:
+	@bash scripts/check-docs-no-feature-ids.sh
+
 .PHONY: e2e
 # CC-0088: chainsaw auto-discovers chainsaw-test.yaml recursively, so new suites
 # under tests/e2e/**/ (e.g. keystone/gateway-quick-start, infrastructure/gateway-quick-start-smoke)

--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -10,7 +10,7 @@ quadrant: operator
 # How-to: Enable Keystone Database TLS/mTLS
 
 This guide walks an operator through opting a `Keystone` CR into encrypted,
-mutually-authenticated connections to MariaDB/MaxScale (CC-0106). When enabled,
+mutually-authenticated connections to MariaDB/MaxScale. When enabled,
 the keystone-operator provisions a cert-manager `Certificate` from the shared
 OpenStack DB CA, mounts the resulting keypair into every Keystone workload that
 opens a database connection, and appends the `ssl_*` parameters to the database
@@ -36,8 +36,8 @@ and
    ```
 
 2. **`openstack-db-ca-issuer` ClusterIssuer Ready.** The dedicated DB CA is
-   declared in `deploy/flux-system/infrastructure/db-ca-issuer.yaml` (CC-0106,
-   REQ-009). `hack/deploy-infra.sh` applies it in Phase 2 so MariaDB can resolve
+   declared in `deploy/flux-system/infrastructure/db-ca-issuer.yaml`.
+   `hack/deploy-infra.sh` applies it in Phase 2 so MariaDB can resolve
    the issuer when it renders its server certificate. Verify:
 
    ```bash
@@ -50,7 +50,7 @@ and
 3. **MariaDB CR with `spec.tls.enabled=true, required=true`.** The MariaDB
    manifest under `deploy/flux-system/infrastructure/mariadb.yaml` enables TLS
    on the Galera nodes and the MaxScale listener via the same
-   `openstack-db-ca-issuer` (CC-0106, REQ-009). Confirm the cluster is healthy:
+   `openstack-db-ca-issuer`. Confirm the cluster is healthy:
 
    ```bash
    kubectl -n openstack get mariadb openstack-db
@@ -61,12 +61,12 @@ and
 4. **keystone-operator running.** Either via the Helm release in
    `deploy/flux-system/releases/keystone-operator.yaml` or a local
    `make deploy-operator`. The operator's RBAC must include the
-   `cert-manager.io/certificates` rule (CC-0106, REQ-008); the chart's
+   `cert-manager.io/certificates` rule; the chart's
    ClusterRole carries it by default.
 
 5. **A `Keystone` CR you control.** New CRs and existing plaintext CRs both
    work — the `tls` block is an optional pointer (a `nil` value preserves the
-   pre-CC-0106 plaintext behavior), so flipping it on is a no-mutation patch.
+   previous plaintext behavior), so flipping it on is a no-mutation patch.
 
 ---
 
@@ -114,7 +114,7 @@ spec:
 ```
 
 The mutating webhook does **not** materialize the `tls` block when it is
-omitted, and never sets `enabled` — TLS is strictly opt-in (CC-0106, REQ-013).
+omitted, and never sets `enabled` — TLS is strictly opt-in.
 When `tls` is present with an empty `mode`, the webhook materializes
 `mode: "require"` as the documented baseline.
 
@@ -124,7 +124,7 @@ When `tls` is present with an empty `mode`, the webhook materializes
 `<keystone-name>-db-client` with `issuerRef = openstack-db-ca-issuer`
 (ClusterIssuer). cert-manager writes the resulting keypair into a Secret of the
 same name. The reconciler reports progress via the `DatabaseTLSReady` status
-condition (CC-0106, REQ-002, REQ-014):
+condition:
 
 | Condition reason | Meaning |
 | --- | --- |
@@ -200,7 +200,7 @@ encrypted — re-check `DatabaseTLSReady` and confirm the MariaDB CR has
 
 ### 3. Plaintext connections are rejected by MariaDB
 
-Because the MariaDB CR sets `spec.tls.required=true` (CC-0106, REQ-009), any
+Because the MariaDB CR sets `spec.tls.required=true`, any
 connection that does not negotiate TLS is rejected at the transport layer
 before authentication. Probe from inside the Keystone Pod by deliberately
 omitting the `ssl=` kwarg:
@@ -223,7 +223,7 @@ Expected: `PLAINTEXT_REJECTED: …` from the server's TLS-required enforcement.
 ### 4. Run the end-to-end chainsaw test (canonical check)
 
 The repository ships a chainsaw E2E suite that pins all three of the above
-verifications (CC-0106, REQ-011):
+verifications:
 
 ```bash
 chainsaw test --test-dir tests/e2e/keystone/database-tls/
@@ -247,7 +247,7 @@ the Keystone CRD reference.
 > is a prerequisite for a working plaintext deployment.
 
 To revert a CR to plaintext without uninstalling the operator, drop the `tls`
-block. The mutating webhook never re-materializes it (CC-0106, REQ-013), so the
+block. The mutating webhook never re-materializes it, so the
 absence is persistent:
 
 ```bash
@@ -270,4 +270,4 @@ turned off (see warning above).
 - [Keystone CRD — Mode → connect-args mapping](../reference/keystone/keystone-crd.md#mode--connect-args-mapping) — DSN parameters per mode.
 - [Infrastructure Manifests — OpenStack DB CA Issuer](../reference/infrastructure/infrastructure-manifests.md#openstack-db-ca-issuer) — CA keypair and ClusterIssuer.
 - [Infrastructure Manifests — MariaDB Galera Cluster](../reference/infrastructure/infrastructure-manifests.md#mariadb-galera-cluster) — server-side TLS configuration.
-- [`tests/e2e/keystone/database-tls/`](https://github.com/c5c3/forge/tree/main/tests/e2e/keystone/database-tls) — chainsaw E2E suite (CC-0106, REQ-011).
+- [`tests/e2e/keystone/database-tls/`](https://github.com/c5c3/forge/tree/main/tests/e2e/keystone/database-tls) — chainsaw E2E suite.

--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -8,7 +8,7 @@ quadrant: operator
 
 ---
 
-<!-- CC-0105: operator namespace is `keystone-system`; workload (Keystone CR) stays in `openstack`. -->
+<!-- operator namespace is `keystone-system`; workload (Keystone CR) stays in `openstack`. -->
 
 # How-to: Enable the Keystone Operator Metrics Endpoint
 
@@ -21,7 +21,7 @@ For the authoritative metric catalogue (names, labels, buckets), see
 For the controller-side instrumentation contract, see
 [Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation).
 
-::: tip On kind (CC-0100)
+::: tip On kind
 If you are running the kind Quick Start, the prometheus-operator CRDs,
 Prometheus, Grafana, and the bundled `Keystone Operator` dashboard are
 already wrapped behind a single opt-in flag — none of the manual steps

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -3,7 +3,7 @@ title: Enable the Keystone Operator NetworkPolicy
 quadrant: operator
 ---
 
-<!-- CC-0105: operator namespace is `keystone-system`; workload (Keystone CR) stays in `openstack`. -->
+<!-- operator namespace is `keystone-system`; workload (Keystone CR) stays in `openstack`. -->
 
 # How-to: Enable the Keystone Operator NetworkPolicy
 

--- a/docs/guides/keystone-admin-password-rotation.md
+++ b/docs/guides/keystone-admin-password-rotation.md
@@ -13,7 +13,7 @@ Unlike Fernet/credential-key rotation, the admin password has no rotation
 CronJob: the value lives in OpenBao and is projected into the cluster by the
 External Secrets Operator (ESO). The Keystone operator observes the resulting
 Secret and re-runs `keystone-manage bootstrap` to update the admin credential
-in place (CC-0108).
+in place.
 
 For the reconciler-side contract (when the bootstrap Job is recreated, the
 event reasons, the failure path), see
@@ -280,5 +280,5 @@ only new authentications with the old password are rejected.
 
 - [reconcileBootstrap](../reference/keystone/keystone-reconciler.md#reconcilebootstrap) — the authoritative contract for the bootstrap sub-reconciler and the admin-password-hash re-run gate.
 - [Labels and Annotations](../reference/keystone/keystone-reconciler.md#labels-and-annotations) — stable metadata keys, including `forge.c5c3.io/admin-password-hash` and `forge.c5c3.io/pod-spec-hash`.
-- See also [Schedule Keystone Admin Password Rotation](keystone-admin-password-scheduled-rotation.md) — the Model B (CC-0109) scheduled flow, where a CronJob mints the password instead of an operator writing OpenBao by hand.
+- See also [Schedule Keystone Admin Password Rotation](keystone-admin-password-scheduled-rotation.md) — the Model B scheduled flow, where a CronJob mints the password instead of an operator writing OpenBao by hand.
 - Chainsaw test: `tests/e2e/keystone/admin-password-rotation/chainsaw-test.yaml` asserts this guide's happy path end-to-end — re-bootstrap on Secret change, old-password `401` / new-password `201` cutover, and unchanged API pod UIDs.

--- a/docs/guides/keystone-admin-password-scheduled-rotation.md
+++ b/docs/guides/keystone-admin-password-scheduled-rotation.md
@@ -6,16 +6,16 @@ quadrant: operator
 # Schedule Keystone Admin Password Rotation
 
 This guide walks an operator through enabling *scheduled* rotation of a Keystone
-instance's admin password (CC-0109, "Model B"), understanding the resource chain
+instance's admin password ("Model B"), understanding the resource chain
 it stands up, and proving end-to-end that a rotation reached the running Keystone.
 
 This is a companion to
 [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md), which
 covers the **manual** flow. The difference in one line:
 
-- **Manual (CC-0108).** *You* write the new password into OpenBao by hand; ESO
+- **Manual.** *You* write the new password into OpenBao by hand; ESO
   projects it into the admin Secret and the operator re-bootstraps.
-- **Scheduled / Model B (CC-0109).** A CronJob *mints* a fresh password on a
+- **Scheduled / Model B.** A CronJob *mints* a fresh password on a
   schedule, the operator validates it and pushes it to OpenBao, and then the same
   re-bootstrap path applies it. You configure the schedule once and the operator
   does the minting.
@@ -57,7 +57,7 @@ spec:
       passwordLength: 32       # default; minimum 24
 ```
 
-The four fields of `passwordRotation` (CC-0109):
+The four fields of `passwordRotation`:
 
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
@@ -67,7 +67,7 @@ The four fields of `passwordRotation` (CC-0109):
 | `passwordLength` | int | `32` (minimum `24`) | Length of the generated password. |
 
 > **Note.** The defaulting webhook only fills `schedule` and `passwordLength`
-> *once `enabled: true`* (CC-0109, REQ-004). A **nil** `passwordRotation` block is
+> *once `enabled: true`*. A **nil** `passwordRotation` block is
 > never materialized — upgrading a CR that never set it must not silently enable
 > rotation. The leaf fields above are shown explicitly for clarity; you can omit
 > `schedule`, `suspend`, and `passwordLength` and let the webhook default them.
@@ -256,7 +256,7 @@ never clobbers the credential the running Keystone is using mid-flight.
 ## 4. Single-CR precondition
 
 Model B hardcodes the OpenBao RemoteKey to the flat path
-`bootstrap/keystone-admin` (CC-0109, REQ-014). It therefore assumes a **single**
+`bootstrap/keystone-admin`. It therefore assumes a **single**
 Model-B-enabled Keystone CR per cluster, sharing that one OpenBao object with the
 `keystone-admin` ExternalSecret.
 

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -418,7 +418,7 @@ Grafana + the prometheus-operator) under the `monitoring` namespace. This is a
 **kind-only opt-in** — production overlays (`deploy/flux-system/`) deliberately
 omit the stack so production clusters can wire their own Prometheus. If you
 have not already opted in, see the
-[Enabling Prometheus & Grafana](#enabling-prometheus--grafana-cc-0100) tip in
+[Enabling Prometheus & Grafana](#enabling-prometheus--grafana) tip in
 Step 3 (`WITH_PROMETHEUS=true make deploy-infra`).
 
 Forward the Grafana service port:

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -6,7 +6,7 @@ quadrant: operator
 # ControlPlane CRD API Reference
 
 Reference documentation for the c5c3-operator ControlPlane Custom Resource
-Definition (CC-0110). The ControlPlane CRD is the top-level aggregate that
+Definition. The ControlPlane CRD is the top-level aggregate that
 projects an OpenStack control plane: it owns the shared infrastructure
 references (database, cache), a curated set of per-service specs (today:
 Keystone), and the K-ORC (OpenStack Resource Controller) integration that
@@ -175,8 +175,8 @@ status:
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.\d$` (CC-0110, REQ-006), enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. |
-| `region` | `string` | No | `"RegionOne"` | OpenStack region name applied across the control plane. Projected into the Keystone CR's `bootstrap.region`. Defaulted to `RegionOne` by **both** the `+kubebuilder:default` marker (normal admission) and the defaulting webhook (callers that bypass the CRD default) (CC-0110, plan decision #4). |
+| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.\d$`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. |
+| `region` | `string` | No | `"RegionOne"` | OpenStack region name applied across the control plane. Projected into the Keystone CR's `bootstrap.region`. Defaulted to `RegionOne` by **both** the `+kubebuilder:default` marker (normal admission) and the defaulting webhook (callers that bypass the CRD default). |
 | `infrastructure` | [`InfrastructureSpec`](#infrastructurespec) | Yes | — | Shared backing services (database, cache) the control plane's services connect to. |
 | `services` | [`ServicesSpec`](#servicesspec) | Yes | — | Per-service configuration projected into the individual service CRs. |
 | `global` | [`*commonv1.PolicySpec`](../keystone/keystone-crd.md#policyspec) | No | `nil` | oslo.policy overrides applied across every service in the control plane. Per-service overrides (e.g. `services.keystone.policyOverrides`) take precedence over these global rules when both are set. |
@@ -186,7 +186,7 @@ status:
 
 ## InfrastructureSpec
 
-Declares the shared backing services for the control plane (CC-0110). Both
+Declares the shared backing services for the control plane. Both
 fields reuse the canonical `commonv1` shapes so the ControlPlane and the
 per-service CRs validate the database/cache the same way.
 
@@ -206,7 +206,7 @@ services.
 
 ## ServicesSpec
 
-Declares the per-service configuration of the control plane (CC-0110). Today
+Declares the per-service configuration of the control plane. Today
 only Keystone is modeled; additional services are added as fields as the
 operator grows.
 
@@ -219,10 +219,10 @@ operator grows.
 ## ServiceKeystoneSpec
 
 A **curated local subset** of the knobs the ControlPlane exposes for the
-Keystone service (CC-0110).
+Keystone service.
 
-> **DECISION (CC-0110, plan decision #2):** This struct is intentionally **not**
-> an import of `keystonev1alpha1.KeystoneSpec`. Per REQ-009 the reconciler (L2)
+> **DECISION:** This struct is intentionally **not**
+> an import of `keystonev1alpha1.KeystoneSpec`. The reconciler (L2)
 > **projects** this struct into a Keystone CR; the database, cache, and Fernet
 > rotation schedule of that Keystone CR are **derived** from the ControlPlane
 > (`infrastructure.*` and operator policy) rather than set by the user here.
@@ -244,7 +244,7 @@ Keystone service (CC-0110).
 ## KORCSpec
 
 Configures the K-ORC (OpenStack Resource Controller) integration of the control
-plane (CC-0110). It declares how the admin application credential is
+plane. It declares how the admin application credential is
 bootstrapped and rotated and which bootstrap resources are reconciled.
 
 | Field | Type | Required | Default | Description |
@@ -256,7 +256,7 @@ bootstrapped and rotated and which bootstrap resources are reconciled.
 ## AdminCredentialSpec
 
 Declares the admin OpenStack credential and the application-credential rotation
-policy for the control plane (CC-0110).
+policy for the control plane.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -270,18 +270,18 @@ policy for the control plane (CC-0110).
 ## CloudCredentialsRef
 
 References the `clouds.yaml` Secret and the cloud entry within it that K-ORC
-authenticates as (CC-0110).
+authenticates as.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `cloudName` | `string` | Yes | — | The entry in `clouds.yaml` K-ORC authenticates as. Also used by the reconciler as the conventional K-ORC `User` reference name (defaulting to `admin` when empty) and projected onto the catalog `Service`/`Endpoint` CRs. |
-| `secretName` | `string` | No | `"k-orc-clouds-yaml"` | Name of the Secret holding the `clouds.yaml` document. Defaulted to `k-orc-clouds-yaml` by **both** the `+kubebuilder:default` marker and the defaulting webhook (CC-0110). |
+| `secretName` | `string` | No | `"k-orc-clouds-yaml"` | Name of the Secret holding the `clouds.yaml` document. Defaulted to `k-orc-clouds-yaml` by **both** the `+kubebuilder:default` marker and the defaulting webhook. |
 
 ---
 
 ## ApplicationCredentialSpec
 
-Declares the K-ORC admin application-credential policy (CC-0110).
+Declares the K-ORC admin application-credential policy.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -294,7 +294,7 @@ Declares the K-ORC admin application-credential policy (CC-0110).
 The ControlPlane spec exposes a **`restricted`** flag (the safe, least-privilege
 posture). K-ORC's `ApplicationCredentialResourceSpec` exposes the inverse field,
 **`unrestricted`**. The reconciler performs the inversion when projecting the
-K-ORC `ApplicationCredential` CR (CC-0110, REQ-010):
+K-ORC `ApplicationCredential` CR:
 
 ```
 restricted=true  → K-ORC spec.resource.unrestricted=false
@@ -308,8 +308,8 @@ state back into `status.adminApplicationCredential.restricted`.
 
 ## AccessRule
 
-Narrows an application credential to a specific service endpoint and method
-(CC-0110), mirroring the Keystone application-credential access-rule shape.
+Narrows an application credential to a specific service endpoint and method,
+mirroring the Keystone application-credential access-rule shape.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -321,7 +321,7 @@ Narrows an application credential to a specific service endpoint and method
 
 ## RotationSpec
 
-Declares the rotation policy for the admin application credential (CC-0110).
+Declares the rotation policy for the admin application credential.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -335,15 +335,15 @@ Declares the rotation policy for the admin application credential (CC-0110).
 | Value | Status | Meaning |
 | --- | --- | --- |
 | `PasswordDriven` | Active (default) | Re-mints the application credential whenever the underlying admin password changes. The reconciler compares the SHA-256 of the admin password against an annotation stamped on the K-ORC `ApplicationCredential` CR; a mismatch drives a re-mint. |
-| `Scheduled` | **Reserved** | Rotates the application credential on a schedule. Surfaced in the enum now so the CRD schema is stable, but the scheduled-rotation logic is deferred to a later level (CC-0110). |
+| `Scheduled` | **Reserved** | Rotates the application credential on a schedule. Surfaced in the enum now so the CRD schema is stable, but the scheduled-rotation logic is deferred to a later level. |
 | `Manual` | **Reserved** | Rotates only when a [`CredentialRotation`](#credentialrotationspec) CR requests it. The `CredentialRotation` flow is the mechanism; the `Manual` mode value itself is reserved at this level. |
 
 ---
 
 ## BootstrapResourceSpec
 
-Declares an OpenStack resource K-ORC bootstraps with the control plane
-(CC-0110). The shape is intentionally minimal at L1 — the reconciler interprets
+Declares an OpenStack resource K-ORC bootstraps with the control plane.
+The shape is intentionally minimal at L1 — the reconciler interprets
 the kind/name and applies it.
 
 | Field | Type | Required | Default | Description |
@@ -366,7 +366,7 @@ the kind/name and applies it.
 
 ### ServiceStatus
 
-Reports the observed readiness of a single projected service CR (CC-0110).
+Reports the observed readiness of a single projected service CR.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -375,7 +375,7 @@ Reports the observed readiness of a single projected service CR (CC-0110).
 
 ### AdminApplicationCredentialStatus
 
-Reports the observed state of the K-ORC admin application credential (CC-0110).
+Reports the observed state of the K-ORC admin application credential.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -388,7 +388,7 @@ Reports the observed state of the K-ORC admin application credential (CC-0110).
 `UpdatePhase` is a string enum
 (`+kubebuilder:validation:Enum=Idle;Updating;UpdatingServices;Verifying;RollingBack`).
 
-> **DECISION (CC-0110):** the enum surfaces the future phases alongside the
+> **DECISION:** the enum surfaces the future phases alongside the
 > active ones so the CRD schema is stable across levels and does not need a
 > breaking change when the update state machine is implemented. The reserved
 > values below are never set by the current reconciler; they are documented so
@@ -407,7 +407,7 @@ Reports the observed state of the K-ORC admin application credential (CC-0110).
 ## CredentialRotationSpec
 
 Defines the desired state of a `CredentialRotation` — a one-shot request to
-rotate a control-plane credential (CC-0110). The reconciler re-mints the target
+rotate a control-plane credential. The reconciler re-mints the target
 credential and reports progress via status conditions.
 
 | Field | Type | Required | Default | Description |
@@ -419,7 +419,7 @@ credential and reports progress via status conditions.
 | `preRotationDays` | `*int32` | No | `nil` | **Deferred** — accepted but ignored. Days before expiry a replacement credential is minted (the overlap window). Minimum: 0. |
 | `gracePeriodDays` | `*int32` | No | `nil` | **Deferred** — accepted but ignored. Days the superseded credential remains valid after a rotation before it is revoked. Minimum: 0. |
 
-> **DECISION (CC-0110):** the scheduled-rotation fields (`intervalDays`,
+> **DECISION:** the scheduled-rotation fields (`intervalDays`,
 > `preRotationDays`, `gracePeriodDays`) surface in the CRD schema now so the
 > contract is stable, but the L1 reconciler **ignores** them — scheduled
 > rotation (and the two-credential pre-rotation/grace overlap) is implemented in
@@ -448,20 +448,20 @@ credential and reports progress via status conditions.
 ## SecretAggregate
 
 `SecretAggregate` aggregates the Secrets produced by a control plane into a
-single materialized Secret (CC-0110).
+single materialized Secret.
 
-> **DECISION (CC-0110):** this is **types-only** at this level — there is **no
-> controller**. The reconciler is **deferred to CC-0023**, and the operator RBAC
+> **DECISION:** this is **types-only** at this level — there is **no
+> controller**. The reconciler is **deferred to a later level**, and the operator RBAC
 > for this kind is **read-only** (`get`/`list`/`watch`) until that reconciler
 > lands, so the operator can observe `SecretAggregate` CRs without being granted
 > write access to a kind it does not yet manage. The `Spec`/`Status` below are
-> intentionally minimal placeholders; CC-0023 will flesh them out.
+> intentionally minimal placeholders; a later level will flesh them out.
 
 ### SecretAggregateSpec
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `targetSecretName` | `string` | No | `""` | Name of the materialized aggregate Secret the (deferred, CC-0023) reconciler will produce. |
+| `targetSecretName` | `string` | No | `""` | Name of the materialized aggregate Secret the (deferred) reconciler will produce. |
 
 ### SecretAggregateStatus
 
@@ -491,7 +491,7 @@ truth.
 | `PolicySpec` | `global`, `services.keystone.policyOverrides` | [Keystone CRD → PolicySpec](../keystone/keystone-crd.md#policyspec) |
 
 > **Note on `DatabaseSpec.tls` / `CacheSpec`:** the `commonv1` shapes carry the
-> full Keystone field set, including the optional `database.tls` block (CC-0106).
+> full Keystone field set, including the optional `database.tls` block.
 > Those fields are part of the reused struct and are validated by the API server,
 > but the ControlPlane reconciler projects the `DatabaseSpec`/`CacheSpec` onto the
 > Keystone CR verbatim — TLS behavior is therefore governed by the
@@ -526,7 +526,7 @@ Keystone discipline:
 
 | Field | Rule |
 | --- | --- |
-| `spec.openStackRelease` | Pattern `^\d{4}\.\d$` (CC-0110, REQ-006) |
+| `spec.openStackRelease` | Pattern `^\d{4}\.\d$` |
 | `spec.korc.adminCredential.applicationCredential.rotation.mode` | Enum: `PasswordDriven`, `Scheduled`, `Manual` |
 | `spec.services.keystone.replicas` | Minimum: 1 |
 | `CredentialRotation spec.target` | Enum: `adminApplicationCredential` |
@@ -544,10 +544,10 @@ short-circuit on the first error.
 
 | Rule | Field Path | Error Type | Condition |
 | --- | --- | --- | --- |
-| Release pattern | `spec.openStackRelease` | `field.Invalid` | Value does not match `^\d{4}\.\d$`. Defense-in-depth alongside the CRD `+kubebuilder:validation:Pattern` marker (CC-0110, REQ-006). |
+| Release pattern | `spec.openStackRelease` | `field.Invalid` | Value does not match `^\d{4}\.\d$`. Defense-in-depth alongside the CRD `+kubebuilder:validation:Pattern` marker. |
 | Database mutual exclusivity | `spec.infrastructure.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither (`(clusterRef != nil) == (host != "")`). **Webhook-only** — there is no CEL rule for this on the c5c3 CRD. |
 | Cache mutual exclusivity | `spec.infrastructure.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither (`(clusterRef != nil) == (len(servers) > 0)`). **Webhook-only**. |
-| Admin password Secret required | `spec.korc.adminCredential.passwordSecretRef.name` | `field.Required` | `name` is empty — without it the reconciler cannot (re-)mint the admin application credential. **Webhook-only** (CC-0110, REQ-006). |
+| Admin password Secret required | `spec.korc.adminCredential.passwordSecretRef.name` | `field.Required` | `name` is empty — without it the reconciler cannot (re-)mint the admin application credential. **Webhook-only**. |
 
 ---
 
@@ -587,8 +587,8 @@ Fills only zero-valued fields with their documented defaults, leaving any
 explicit value untouched. It is **idempotent**: applying it twice produces the
 same result. Each default is also expressed as a `+kubebuilder:default` marker
 on the corresponding spec field, so the two layers agree — the markers cover the
-normal admission path; the webhook covers callers that bypass the CRD default
-(CC-0110, REQ-005). The defaulting constants `DefaultRegion` (`"RegionOne"`) and
+normal admission path; the webhook covers callers that bypass the CRD default.
+The defaulting constants `DefaultRegion` (`"RegionOne"`) and
 `DefaultCloudCredentialsSecretName` (`"k-orc-clouds-yaml"`) are the single source
 of truth shared with the markers' documented values.
 
@@ -621,7 +621,7 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
 The ControlPlane status is driven by five sub-reconcilers, each owning one
 condition type, plus an aggregate `Ready` condition. The condition-type
 constants in `controlplane_controller.go` are the single source of truth; call
-sites reference the constants rather than inline literals (CC-0110, REQ-007).
+sites reference the constants rather than inline literals.
 
 The sub-reconcilers run in dependency order, each **gated** on the previous
 one's condition being `True`:
@@ -637,7 +637,7 @@ InfrastructureReady → KeystoneReady → KORCReady → AdminCredentialReady →
 
 ### InfrastructureReady
 
-Set by `reconcileInfrastructure` (CC-0110, REQ-008).
+Set by `reconcileInfrastructure`.
 
 | Status | Reason | When |
 | --- | --- | --- |
@@ -649,7 +649,7 @@ Set by `reconcileInfrastructure` (CC-0110, REQ-008).
 
 ### KeystoneReady
 
-Set by `reconcileKeystone` (gated on `InfrastructureReady`) (CC-0110, REQ-009).
+Set by `reconcileKeystone` (gated on `InfrastructureReady`).
 
 | Status | Reason | When |
 | --- | --- | --- |
@@ -661,7 +661,7 @@ Set by `reconcileKeystone` (gated on `InfrastructureReady`) (CC-0110, REQ-009).
 
 ### KORCReady
 
-Set by `reconcileKORC` (CC-0110, REQ-010, REQ-012).
+Set by `reconcileKORC`.
 
 | Status | Reason | When |
 | --- | --- | --- |
@@ -675,7 +675,7 @@ Set by `reconcileKORC` (CC-0110, REQ-010, REQ-012).
 ### AdminCredentialReady
 
 Set by `reconcileAdminCredential` (gated on `KORCReady` **and** the K-ORC
-`clouds.yaml` ExternalSecret being Ready) (CC-0110, REQ-011).
+`clouds.yaml` ExternalSecret being Ready).
 
 | Status | Reason | When |
 | --- | --- | --- |
@@ -688,7 +688,7 @@ Set by `reconcileAdminCredential` (gated on `KORCReady` **and** the K-ORC
 
 ### CatalogReady
 
-Set by `reconcileCatalog` (gated on `AdminCredentialReady`) (CC-0110, REQ-014).
+Set by `reconcileCatalog` (gated on `AdminCredentialReady`).
 Also flips `status.catalogReady` to `true`.
 
 | Status | Reason | When |
@@ -701,7 +701,7 @@ Also flips `status.catalogReady` to `true`.
 
 ### Ready (aggregate)
 
-Set by `setReadyCondition` (CC-0110, REQ-007).
+Set by `setReadyCondition`.
 
 | Status | Reason | When |
 | --- | --- | --- |
@@ -712,7 +712,7 @@ Set by `setReadyCondition` (CC-0110, REQ-007).
 
 ## Child Namespace
 
-> **DECISION (CC-0110):** every child the reconciler projects — the `MariaDB`,
+> **DECISION:** every child the reconciler projects — the `MariaDB`,
 > `Memcached`, and `Keystone` CRs, the K-ORC `ApplicationCredential` /
 > `Service` / `Endpoint` CRs, the owned Secret, and the OpenBao `PushSecret` —
 > is created in the **ControlPlane's own namespace** (`childNamespace =

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -6,7 +6,7 @@ quadrant: operator
 # ControlPlane Reconciler Architecture
 
 Reference documentation for the `ControlPlaneReconciler`, the
-`CredentialRotationReconciler`, and their sub-reconciler contracts (CC-0110).
+`CredentialRotationReconciler`, and their sub-reconciler contracts.
 The `ControlPlaneReconciler` implements the control loop that drives a
 `ControlPlane` CR from desired state to a fully operational Keystone control
 plane: backing infrastructure, the projected Keystone service, the K-ORC admin
@@ -28,8 +28,7 @@ owns child CRs (MariaDB, Memcached, Keystone, K-ORC `ApplicationCredential` /
 re-implement the per-service logic those child operators already own. As a
 consequence the c5c3 API surface is deliberately smaller than the
 [Keystone reconciler](../keystone/keystone-reconciler.md)'s: there is no
-finalizer, no parallel sub-reconciler group, and no per-CR metric cardinality
-(CC-0110).
+finalizer, no parallel sub-reconciler group, and no per-CR metric cardinality.
 
 ## Controller Registration
 
@@ -38,8 +37,7 @@ controller manager in `operators/c5c3/main.go` via the shared bootstrap package
 (`github.com/c5c3/forge/internal/common/bootstrap`). The bootstrap helper builds
 the manager, wires leader election, and invokes the operator's `SetupFunc`; the
 same pattern is documented in detail under
-[Keystone Reconciler — Controller Registration](../keystone/keystone-reconciler.md#controller-registration)
-(CC-0110, REQ-007).
+[Keystone Reconciler — Controller Registration](../keystone/keystone-reconciler.md#controller-registration).
 
 ```go
 import (
@@ -87,7 +85,7 @@ bootstrap.Run(bootstrap.ManagerConfig{
 ### Scheme Registration
 
 The operator registers these schemes in `main.go`'s `init()` so the reconcilers
-can interact with the typed child CRDs (CC-0110):
+can interact with the typed child CRDs:
 
 | Module | Scheme | Types Used |
 | --- | --- | --- |
@@ -105,7 +103,7 @@ can interact with the typed child CRDs (CC-0110):
 > `*unstructured.Unstructured` carrying the shared `memcachedGVK`
 > (`memcached.c5c3.io/v1beta1`, kind `Memcached`), and `SetupWithManager`
 > `Owns` the same unstructured GVK. The GVK is resolved against the cluster
-> `RESTMapper` at runtime, so no scheme entry is required (CC-0110).
+> `RESTMapper` at runtime, so no scheme entry is required.
 
 ### Watches
 
@@ -130,8 +128,7 @@ it is owned by the ExternalSecret controller, not by the ControlPlane CR — so 
 owner-reference filter would never match it. The index-backed namespace List is
 exactly what wakes the ControlPlane when its admin password rotates, so the
 re-mint chain (see [K-ORC admin credential chain](#k-orc-admin-credential-chain))
-converges on watch delivery instead of waiting for the next periodic requeue
-(CC-0110, REQ-012).
+converges on watch delivery instead of waiting for the next periodic requeue.
 
 #### Secret Field Indexer
 
@@ -139,7 +136,7 @@ The controller registers a controller-runtime field indexer on the
 `ControlPlane` kind so that a Secret event resolves to the referencing
 ControlPlane CR(s) via an O(1) cache lookup instead of an unfiltered
 namespace-scoped List, mirroring the keystone operator's
-`KeystoneSecretNameIndexKey` (CC-0110, REQ-012).
+`KeystoneSecretNameIndexKey`.
 
 | Aspect | Value |
 | --- | --- |
@@ -153,7 +150,7 @@ namespace-scoped List, mirroring the keystone operator's
 > mapper has a **pure index-backed** lookup with no owner-reference fallback
 > branch — the ControlPlane projects no rotation-staging Secrets that are
 > owned-but-unreferenced, so the union/owner-ref complexity of
-> `secretToKeystoneMapper` is not needed here (CC-0110).
+> `secretToKeystoneMapper` is not needed here.
 
 ---
 
@@ -294,7 +291,7 @@ This guarantees:
 
 Only when all five sub-reconcilers return a zero result with no error does
 control reach `setReadyCondition(&cp)` and the final `updateStatus(ctx, &cp,
-ctrl.Result{}, nil)` (CC-0110, REQ-007).
+ctrl.Result{}, nil)`.
 
 ### Status Update Pattern
 
@@ -312,8 +309,7 @@ remains visible in controller-runtime logs:
 | non-nil | fails | `errors.Join(reconcileErr, fmt.Errorf("updating status: %w", statusErr))` |
 
 Because `ObservedGeneration` is stamped on **every** `updateStatus` call (early
-return or final), a stale status is always distinguishable from a current one
-(CC-0110, REQ-007).
+return or final), a stale status is always distinguishable from a current one.
 
 ### Ready Condition Aggregation
 
@@ -334,7 +330,7 @@ InfrastructureReady, KeystoneReady, KORCReady, AdminCredentialReady, CatalogRead
 ```
 
 The `Ready` condition carries `ObservedGeneration = cp.Generation` so clients can
-detect a stale aggregate (CC-0110, REQ-007).
+detect a stale aggregate.
 
 ---
 
@@ -345,7 +341,7 @@ each one's gate, what it projects/owns, and the condition reasons it sets on the
 `True`, requeue, and error paths. All condition constants are the exported
 source-of-truth strings in `controlplane_controller.go`; sub-reconcilers
 reference the constants (never inline literals) so a rename is a compile error
-and is caught by the no-inline-literals drift guard (CC-0110, REQ-007).
+and is caught by the no-inline-literals drift guard.
 
 Every condition is stamped with `ObservedGeneration = cp.Generation` on every
 path.
@@ -385,7 +381,7 @@ occurs; readiness is evaluated collectively afterwards.
 > `conditions.IsReady(mariadb.Status.Conditions)`; Memcached readiness is read
 > from the unstructured `status.conditions[type=Ready].status == "True"`
 > (`unstructuredReady`), where a missing/malformed list is treated as not-ready
-> rather than an error (CC-0110, REQ-008).
+> rather than an error.
 
 ### reconcileKeystone
 
@@ -440,8 +436,7 @@ the ControlPlane provisioned:
 | Requeue | `korcRequeueAfter` = **10s** while deferring, while the CRD is missing, or while the AC is not yet Available |
 
 `reconcileKORC` create-or-updates an **owned** K-ORC `ApplicationCredential` CR
-that instructs K-ORC to mint the admin application credential, and drives re-mint
-(CC-0110, REQ-010, REQ-012). Key behaviours:
+that instructs K-ORC to mint the admin application credential, and drives re-mint. Key behaviours:
 
 - **Restricted → Unrestricted inversion (CRITICAL).** Our
   `ApplicationCredentialSpec.restricted` is the inverse of K-ORC's
@@ -459,8 +454,7 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 - **Re-mint trigger.** The SHA-256 of the admin password is stamped onto the AC
   CR under the `forge.c5c3.io/admin-password-hash` annotation
   (`adminPasswordHashAnnotation`). On a later pass, a mismatch between the
-  freshly computed hash and the stamped annotation drives K-ORC to re-mint
-  (CC-0110, REQ-012). The hash is computed by the package-level
+  freshly computed hash and the stamped annotation drives K-ORC to re-mint. The hash is computed by the package-level
   `computeAdminPasswordHash`, shared with the CredentialRotation reconciler so
   both agree on one derivation.
 - **Status reflection.** `updateAdminApplicationCredentialStatus` reflects the
@@ -491,7 +485,7 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | Requeue | `korcRequeueAfter` = **10s** while either gate is unmet |
 
 `reconcileAdminCredential` commits the minted credential and mirrors it to
-OpenBao (CC-0110, REQ-011):
+OpenBao:
 
 - **Clobber-safe operator Secret.** The Secret K-ORC writes the minted
   credential into is ensured by the operator, but the `CreateOrUpdate` mutate
@@ -503,7 +497,7 @@ OpenBao (CC-0110, REQ-011):
   The Secret is co-located with the K-ORC CRs (C1) because K-ORC resolves
   `CloudCredentialsRef` in the resource's own namespace; on a fresh cluster the
   underlying OpenBao path is seeded with a password-based bootstrap clouds.yaml by
-  `write-bootstrap-secrets.sh` (CC-0110, REQ-024) so the ExternalSecret can
+  `write-bootstrap-secrets.sh` so the ExternalSecret can
   materialise — the c5c3 PushSecret then overwrites it with the minted credential.
 - **PushSecret to OpenBao.** `secrets.EnsurePushSecret` (idempotent; only Updates
   on a `DeepEqual` diff so ESO is not woken to re-push an unchanged credential)
@@ -532,7 +526,7 @@ OpenBao (CC-0110, REQ-011):
 | Requeue | `korcRequeueAfter` = **10s** while gated or while the K-ORC CRD is missing |
 
 `reconcileCatalog` registers the OpenStack service-catalog entries for Keystone
-as owned K-ORC CRs (CC-0110, REQ-014): an `identity`-type `Service` named
+as owned K-ORC CRs: an `identity`-type `Service` named
 `keystone`, plus a `public` `Endpoint` whose URL defaults to the conventional
 in-cluster identity URL `http://keystone.<namespace>.svc:5000/v3` and whose
 `serviceRef` points at the identity Service. Both children are idempotent
@@ -559,7 +553,7 @@ create-or-updates; the K-ORC missing-CRD safety mirrors `reconcileKORC` via
 
 The `CredentialRotationReconciler` drives one-shot rotations of a control-plane
 credential by **nudging** the ControlPlane reconciler rather than duplicating any
-mint logic (CC-0110, REQ-015). Its model:
+mint logic. Its model:
 
 - **Nudge, never mint.** To force a re-mint it simply **clears** (zeroes) the
   `forge.c5c3.io/admin-password-hash` annotation on the owned AC CR via
@@ -599,15 +593,14 @@ mint logic (CC-0110, REQ-015). Its model:
 
 The CredentialRotation reconciler is registered with the manager via a plain
 `For(&CredentialRotation{})` — it owns no children and registers no watches or
-field indexers (CC-0110, REQ-015).
+field indexers.
 
 ---
 
 ## K-ORC admin credential chain
 
 The end-to-end path that delivers the admin application credential to the K-ORC
-controller spans three sub-reconcilers and the ESO/OpenBao backend
-(CC-0110, REQ-010, REQ-011, REQ-012, REQ-013):
+controller spans three sub-reconcilers and the ESO/OpenBao backend:
 
 ```text
 keystone-admin Secret (admin password; ESO-managed, read by c5c3-operator)
@@ -655,7 +648,7 @@ owner).
 > [Keystone reconciler](../keystone/keystone-reconciler.md#finalizer), the
 > ControlPlane reconciler installs **no finalizer**. Teardown is driven entirely
 > by owner-reference garbage collection — there is no ordered external cleanup
-> the operator must perform before the CR leaves etcd (CC-0110).
+> the operator must perform before the CR leaves etcd.
 
 > **Children live in the owner's namespace.** Every projected child is created in
 > `childNamespace(cp) = cp.Namespace`, **not** a hardcoded `openstack`. A
@@ -664,8 +657,7 @@ owner).
 > single namespace; co-locating children with their owner keeps the owner
 > reference valid and the GC cascade intact. In production the ControlPlane is
 > deployed into the `openstack` namespace, so the children land there exactly as
-> before — the namespace is now *derived from the owner* rather than assumed
-> (CC-0110).
+> before — the namespace is now *derived from the owner* rather than assumed.
 
 | Resource | Name | Owner | Notes |
 | --- | --- | --- | --- |
@@ -678,11 +670,11 @@ owner).
 | `Service` (K-ORC) | `{name}-identity-service` | ControlPlane CR | identity catalog entry |
 | `Endpoint` (K-ORC) | `{name}-identity-endpoint` | ControlPlane CR | public interface |
 
-### Security invariant (REQ-013)
+### Security invariant
 
 The admin password and the minted application-credential Secret are read **only**
 by the c5c3-operator and the K-ORC controller pods — they are **never** mounted
-into Keystone or any OpenStack service workload (CC-0110, REQ-013). Keystone
+into Keystone or any OpenStack service workload. Keystone
 receives the admin password solely through its own bootstrap Secret ref for the
 one-time `keystone-manage bootstrap`; the long-lived application credential lives
 exclusively on the c5c3↔K-ORC↔OpenBao path. `restricted: true` (the default)
@@ -696,8 +688,7 @@ invariants are enforced by the `credential_invariant_test.go` checks
 The `PushSecret`'s `DeletionPolicy: None` is the one deliberate exception to the
 GC cascade: tearing down a ControlPlane removes the PushSecret CR but leaves the
 last-pushed credential in OpenBao, so a fresh control plane (or a consumer that
-already depends on the shared bootstrap secret) is not locked out mid-rotation
-(CC-0110, REQ-011).
+already depends on the shared bootstrap secret) is not locked out mid-rotation.
 
 ---
 
@@ -707,7 +698,7 @@ Every sub-reconciler invocation is instrumented for Prometheus via a single
 helper, `instrumentSubReconciler`, defined in
 `operators/c5c3/internal/controller/instrumentation.go`. `Reconcile` wraps every
 sub-reconciler call with it; a direct call that bypasses the helper is a contract
-violation (CC-0110, REQ-026).
+violation.
 
 ```go
 func instrumentSubReconciler(
@@ -730,8 +721,7 @@ Behavioural contract:
 - Carries **no per-CR labels** (no `controlplane` / `namespace`). The two label
   dimensions (`sub_reconciler`, and `condition_type` on the error counter) are
   bounded by the number of sub-reconcilers, keeping the series count
-  fleet-independent. Per-CR collectors are intentionally out of scope (CC-0110,
-  REQ-026).
+  fleet-independent. Per-CR collectors are intentionally out of scope.
 
 Both vectors are registered exactly once on the controller-runtime registry via
 `sync.Once`; the histogram buckets are a fixed contract
@@ -759,7 +749,7 @@ visible in dashboards/alerts. Two static drift guards keep the map honest:
 `TestSubReconcilerConditionTypesCoversAllCallSites` walks the source AST to
 assert every `instrumentSubReconciler` call-site name is a map key. Adding a new
 sub-reconciler therefore requires updating `subConditionTypes` **and**
-`subReconcilerConditionTypes` or CI fails (CC-0110, REQ-026).
+`subReconcilerConditionTypes` or CI fails.
 
 ---
 
@@ -779,7 +769,7 @@ test that drives the full chain in a real manager against a live API server.
 ### Integration test
 
 `TestIntegration_FullReconcile_ManagedToReady` (`integration_test.go`, build tag
-`integration`, CC-0110 REQ-027) registers the real controller wiring (the inline
+`integration`) registers the real controller wiring (the inline
 builder is kept byte-for-byte in step with `SetupWithManager`) and drives a
 managed-mode ControlPlane through every sub-reconciler to the aggregate
 `Ready=True`. It simulates each external dependency's readiness **in dependency
@@ -790,7 +780,7 @@ every sub-condition and the aggregate `Ready` (reason `AllReady`) reach `True`,
 that `status.observedGeneration` and every condition's `ObservedGeneration` match
 the CR generation, and that `status.adminApplicationCredential` mirrors the
 simulated AC. Beyond the aggregate condition it also asserts the **intermediate
-projected specs** (REQ-027) so a projection regression is caught: the Keystone
+projected specs** so a projection regression is caught: the Keystone
 image tag derived from `openStackRelease`, the database/cache `clusterRef`s wired
 to the infra CRs, the merged `policyOverrides`, the `restricted→Unrestricted=false`
 inversion on the AC, and the identity `Service`/`Endpoint` shape.
@@ -857,7 +847,7 @@ operators/c5c3/
 The `ControlPlane` reconciler and the K-ORC self-credentialing chain implement
 the following upstream architecture chapters (in the `architecture/` submodule,
 [github.com/C5C3/C5C3](https://github.com/C5C3/C5C3)). They are the authoritative
-design source for this reconciler (CC-0110):
+design source for this reconciler:
 
 - `architecture/docs/09-implementation/08-c5c3-operator.md` — the c5c3-operator
   `ControlPlane` reconciler contract and sub-reconciler ordering.

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -37,14 +37,14 @@ deploy/
     │   ├── memcached-operator.yaml       Memcached Operator (from c5c3-charts)
     │   ├── openbao.yaml                  OpenBao HA Raft cluster
     │   ├── keystone-operator.yaml        Keystone Operator (from c5c3-charts)
-    │   ├── k-orc.yaml                    K-ORC OpenStack Resource Controller (CC-0110)
-    │   ├── c5c3-operator.yaml            c5c3-operator ControlPlane orchestrator (from c5c3-charts, CC-0110)
+    │   ├── k-orc.yaml                    K-ORC OpenStack Resource Controller
+    │   ├── c5c3-operator.yaml            c5c3-operator ControlPlane orchestrator (from c5c3-charts)
     │   └── chaos-mesh.yaml               Chaos Mesh (kind-only addon — see "Kind Overlay Demo Addons")
     └── infrastructure/                   CRD-dependent infrastructure resources
         ├── kustomization.yaml            Infrastructure kustomize overlay
         ├── cluster-issuer.yaml           Self-signed ClusterIssuer (requires cert-manager CRDs)
-        ├── db-ca-issuer.yaml             OpenStack DB CA Certificate + ClusterIssuer (CC-0106, REQ-009)
-        ├── mariadb.yaml                  MariaDB Galera cluster for OpenStack (with TLS, CC-0106, REQ-009)
+        ├── db-ca-issuer.yaml             OpenStack DB CA Certificate + ClusterIssuer
+        ├── mariadb.yaml                  MariaDB Galera cluster for OpenStack (with TLS)
         └── memcached.yaml                Memcached cluster for OpenStack
 ```
 
@@ -68,8 +68,8 @@ created.
 | `keystone-system` | Keystone Operator controller (workload CRs continue to live in `openstack`) |
 | `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster) |
 | `openbao-system` | OpenBao HA Raft cluster |
-| `c5c3-system` | c5c3-operator controller (CC-0110, REQ-023); the `ControlPlane` and its child CRs are created in the `ControlPlane`'s own namespace |
-| `orc-system` | K-ORC (OpenStack Resource Controller) and the `k-orc-clouds-yaml` admin Secret (CC-0110, REQ-023) |
+| `c5c3-system` | c5c3-operator controller; the `ControlPlane` and its child CRs are created in the `ControlPlane`'s own namespace |
+| `orc-system` | K-ORC (OpenStack Resource Controller) and the `k-orc-clouds-yaml` admin Secret |
 
 The `chaos-mesh` namespace is **not** part of the production base. It is created
 inline by the kind-only opt-in overlay at `deploy/kind/chaos-mesh/` when
@@ -182,7 +182,7 @@ mariadb-operator-crds     (no dependencies)
 └── c5c3-operator         dependsOn: keystone-operator, external-secrets, mariadb-operator, memcached-operator, k-orc
 ```
 
-The `c5c3-operator` HelmRelease (CC-0110, REQ-023) sits at the top of this graph: it
+The `c5c3-operator` HelmRelease sits at the top of this graph: it
 `dependsOn` the four operators whose CRs it projects (keystone-operator,
 external-secrets, mariadb-operator, memcached-operator) plus `k-orc`, whose
 ApplicationCredential / Service / Endpoint CRDs it drives. `k-orc` itself declares no
@@ -324,7 +324,7 @@ OCI registry (`oci://ghcr.io/c5c3/charts`), not a dedicated HelmRepository. The
 | Dependencies | `cert-manager` in `cert-manager` namespace |
 
 OpenBao is deployed as a 3-replica HA Raft cluster with **mutual TLS (mTLS)
-enforced on the API listener** (CC-0107). The injector is disabled. The server
+enforced on the API listener**. The injector is disabled. The server
 TLS certificate is sourced from a cert-manager-provisioned Secret
 (`openbao-tls`), and two additional cert-manager-provisioned client
 certificates (`openbao-client-tls`, `eso-openbao-client-tls`) are required so
@@ -349,15 +349,15 @@ rationale.
 | `server.ha.enabled` | `true` | Enable HA mode |
 | `server.ha.replicas` | `3` | 3-node Raft cluster |
 | `server.ha.raft.enabled` | `true` | Use Raft storage backend |
-| `server.ha.raft.config` listener `tls_client_ca_file` (CC-0107) | `/openbao/tls/ca.crt` | CA the listener uses to verify presented client certs (same bundle as server cert) |
-| `server.ha.raft.config` listener `tls_require_and_verify_client_cert` (CC-0107) | `true` | Reject any TLS handshake without a valid client cert before app-layer auth runs |
-| `server.ha.raft.config` `retry_join.leader_client_cert_file` × 3 (CC-0107) | `/openbao/client-tls/tls.crt` | Client cert each Raft peer presents on `retry_join` to every other peer (same value in all three stanzas) |
-| `server.ha.raft.config` `retry_join.leader_client_key_file` × 3 (CC-0107) | `/openbao/client-tls/tls.key` | Matching private key for `leader_client_cert_file` |
-| `server.volumes` / `server.volumeMounts` — `client-tls` (CC-0107) | Secret `openbao-client-tls` → `/openbao/client-tls` (`readOnly: true`) | Mounts the in-pod client keypair distinct from the server cert at `/openbao/tls` so server and client lifecycles do not collide |
+| `server.ha.raft.config` listener `tls_client_ca_file` | `/openbao/tls/ca.crt` | CA the listener uses to verify presented client certs (same bundle as server cert) |
+| `server.ha.raft.config` listener `tls_require_and_verify_client_cert` | `true` | Reject any TLS handshake without a valid client cert before app-layer auth runs |
+| `server.ha.raft.config` `retry_join.leader_client_cert_file` × 3 | `/openbao/client-tls/tls.crt` | Client cert each Raft peer presents on `retry_join` to every other peer (same value in all three stanzas) |
+| `server.ha.raft.config` `retry_join.leader_client_key_file` × 3 | `/openbao/client-tls/tls.key` | Matching private key for `leader_client_cert_file` |
+| `server.volumes` / `server.volumeMounts` — `client-tls` | Secret `openbao-client-tls` → `/openbao/client-tls` (`readOnly: true`) | Mounts the in-pod client keypair distinct from the server cert at `/openbao/tls` so server and client lifecycles do not collide |
 | `server.dataStorage.size` | `10Gi` | Persistent volume size |
 | `injector.enabled` | `false` | Disable the Vault/Bao agent injector |
 
-**Client certificates (CC-0107).** The two client `Certificate` resources are
+**Client certificates.** The two client `Certificate` resources are
 declared in `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml`
 and registered in `deploy/flux-system/infrastructure/kustomization.yaml`
 immediately after `openbao-tls-cert.yaml`, so cert-manager reconciles them
@@ -388,7 +388,7 @@ operator interface, and the runnable mTLS-enforcement probe.
 
 | Property | Value |
 | --- | --- |
-| Target namespace | `keystone-system` (controller); operator-managed Keystone workload remains in `openstack` (CC-0105, REQ-001) |
+| Target namespace | `keystone-system` (controller); operator-managed Keystone workload remains in `openstack` |
 | Chart | `keystone-operator` |
 | Version constraint | `>=0.1.0 <1.0.0` |
 | Source | `c5c3-charts` HelmRepository (shared OCI registry) |
@@ -420,15 +420,15 @@ provisioning, memcached-operator for caching, and external-secrets for secret ma
 
 K-ORC (the OpenStack Resource Controller) installs the declarative Keystone resource
 CRDs — `ApplicationCredential`, `Service`, `Endpoint`, and related kinds — that the
-c5c3-operator drives to project a `ControlPlane`'s desired state into Keystone
-(CC-0110, REQ-023). The HelmRelease `metadata.name` is the short, stable `k-orc` (not
+c5c3-operator drives to project a `ControlPlane`'s desired state into Keystone.
+The HelmRelease `metadata.name` is the short, stable `k-orc` (not
 the chart's own `openstack-resource-controller`) so the c5c3-operator HelmRelease can
 `dependsOn` it by that name. Per repo convention the HelmRelease lives in its target
 namespace (`orc-system`), so no explicit `spec.targetNamespace` is needed.
 `globalCloudConfig` mounts the `orc-system` copy of the `k-orc-clouds-yaml` Secret
 as K-ORC's global default; however K-ORC authenticates **per resource** via each
 CR's `CloudCredentialsRef`, resolved in the CR's own (control-plane) namespace, so
-the credential chain below also materialises a co-located copy there (CC-0110, C1).
+the credential chain below also materialises a co-located copy there.
 See [Admin Credential Chain](#admin-credential-chain) below.
 
 **Helm values:**
@@ -450,14 +450,14 @@ See [Admin Credential Chain](#admin-credential-chain) below.
 | Dependencies | `keystone-operator`, `external-secrets`, `mariadb-operator`, `memcached-operator`, `k-orc` |
 
 The c5c3-operator runs the `ControlPlane` reconciler that orchestrates a Keystone
-control plane end-to-end (CC-0110, REQ-023). It depends on the four operators whose CRs
+control plane end-to-end. It depends on the four operators whose CRs
 it projects — `keystone-operator` for the Keystone instance, `external-secrets` and
 `mariadb-operator` and `memcached-operator` for the supporting platform services — plus
 `k-orc`, whose `ApplicationCredential` / `Service` / `Endpoint` CRDs it drives to
 register the catalog and rotate the admin credential. The operator child CRs are created
 in the `ControlPlane`'s own namespace, not a hard-coded one. For the reconciliation
 contract see the upstream design chapter
-`architecture/docs/09-implementation/08-c5c3-operator.md` (CC-0110).
+`architecture/docs/09-implementation/08-c5c3-operator.md`.
 
 **Helm values:**
 
@@ -517,7 +517,7 @@ by the cert-manager HelmRelease.
 **File:** `deploy/flux-system/infrastructure/db-ca-issuer.yaml`
 
 Provisions the dedicated cert-manager CA that anchors the OpenStack database trust
-domain (CC-0106, REQ-009). The file declares two resources:
+domain. The file declares two resources:
 
 | Resource | API version | Kind | Name | Namespace |
 | --- | --- | --- | --- | --- |
@@ -538,7 +538,7 @@ the OpenStack DB trust domain:
   `reconcileDatabaseTLS` sub-reconciler — the constant
   [`dbCAIssuerName`](https://github.com/c5c3/forge/blob/main/operators/keystone/internal/controller/reconcile_databasetls.go)
   hard-codes the same string (`"openstack-db-ca-issuer"`), so a rename here MUST be
-  matched in the operator (CC-0106, REQ-002).
+  matched in the operator.
 
 **Apply ordering.** This manifest is also applied out-of-band from the infrastructure
 kustomization by `hack/deploy-infra.sh` (Phase 2, alongside `cluster-issuer.yaml` and
@@ -580,7 +580,7 @@ The root password is sourced from a Kubernetes Secret (`mariadb-root-password`, 
 
 **Monitoring:** Prometheus metrics are enabled (`spec.metrics.enabled: true`).
 
-**TLS (CC-0106, REQ-009).** Galera inter-node replication, the MaxScale client
+**TLS.** Galera inter-node replication, the MaxScale client
 listener, and every Keystone-to-database connection all sit inside the OpenStack DB
 trust domain rooted at the `openstack-db-ca-issuer` ClusterIssuer documented above.
 The MariaDB CR enables TLS in `spec.tls` and the MaxScale sub-spec inherits it:
@@ -650,7 +650,7 @@ shipped by the [memcached-operator](https://github.com/C5C3/memcached-operator) 
 
 The c5c3-operator mints a single restricted admin Application Credential per cluster and
 mirrors it to OpenBao, from where the External Secrets Operator materialises it as the
-`clouds.yaml` Secret that K-ORC authenticates with (CC-0110). Two manifests wire this
+`clouds.yaml` Secret that K-ORC authenticates with. Two manifests wire this
 chain:
 
 **ESO ExternalSecrets** — `deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml`
@@ -667,15 +667,14 @@ materialising the Kubernetes Secret `k-orc-clouds-yaml` from the same OpenBao ke
 Both read the OpenBao key `openstack/keystone/admin/app-credential` (property
 `clouds.yaml`, store-relative to the KV-v2 mount). On a fresh cluster that key is
 seeded with a password-based bootstrap clouds.yaml by
-`deploy/openbao/bootstrap/write-bootstrap-secrets.sh` (CC-0110, REQ-024) so the
+`deploy/openbao/bootstrap/write-bootstrap-secrets.sh` so the
 ExternalSecrets can materialise before any credential is minted; once the
 c5c3-operator mints the admin Application Credential its PushSecret overwrites the
-key with the App-Cred-based clouds.yaml (CC-0110, REQ-023, REQ-024).
+key with the App-Cred-based clouds.yaml.
 
 **OpenBao policy** — `deploy/openbao/policies/push-app-credentials.hcl`
 
-This policy grants the write path for the admin credential PushSecret (CC-0110,
-REQ-024). The pre-existing mid-path grant `kv-v2/data/openstack/*/app-credential`
+This policy grants the write path for the admin credential PushSecret. The pre-existing mid-path grant `kv-v2/data/openstack/*/app-credential`
 matches only a single mid-segment (`openstack/<svc>/app-credential`) and therefore does
 **not** cover the two-segment `openstack/keystone/admin/app-credential`. Rather than
 widening that glob, the policy adds two narrow, single-leaf grants:
@@ -688,7 +687,7 @@ widening that glob, the policy adds two narrow, single-leaf grants:
 Both grants stay scoped to the single literal admin-credential leaf, adding no blast
 radius beyond this one credential. For the mTLS transport gate and the
 `openbao-cluster-store` auth path these manifests ride on, see
-[OpenBao Bootstrap Procedure](./openbao-bootstrap.md) (CC-0110).
+[OpenBao Bootstrap Procedure](./openbao-bootstrap.md).
 
 ## Kustomization
 
@@ -732,17 +731,16 @@ CA-type ClusterIssuer that signs from it).
 | Category | Count | Resources |
 | --- | --- | --- |
 | ClusterIssuer | 3 | `selfsigned-cluster-issuer`, `openstack-db-ca-issuer`, `openbao-ca-issuer` (all require cert-manager CRDs) |
-| Certificate | 2 | `openstack-db-ca` (CC-0106, REQ-009), `openbao-ca` (CC-0107) — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
+| Certificate | 2 | `openstack-db-ca`, `openbao-ca` — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
 | MariaDB | 1 | `openstack-db` (requires mariadb-operator CRDs; TLS enabled per [MariaDB Galera Cluster](#mariadb-galera-cluster)) |
 | Memcached | 1 | `openstack-memcached` (requires memcached-operator CRDs) |
 | **Total** | **6** | |
 
-<!-- DECISION: count excludes openbao-tls-cert.yaml and the ../../eso overlay that
-the infrastructure kustomization also references. Those resources predate
-CC-0106 and are documented in their own reference pages
-(reference/infrastructure/openbao-bootstrap.md and the ESO reference docs); a
-full audit of the kustomization resource list is out of scope for this CC-0106
-change. Reviewer: please verify the scope choice. -->
+<!-- NOTE: count excludes openbao-tls-cert.yaml and the ../../eso overlay that
+the infrastructure kustomization also references. Those resources are documented
+in their own reference pages (reference/infrastructure/openbao-bootstrap.md and
+the ESO reference docs); a full audit of the kustomization resource list is out
+of scope here. -->
 
 
 ## Deployment
@@ -766,8 +764,8 @@ kubectl apply -k deploy/flux-system/infrastructure/
 
 This applies the CRD-dependent resources: the `selfsigned-cluster-issuer`
 ClusterIssuer, the `openstack-db-ca-issuer` ClusterIssuer plus its backing CA
-`Certificate` (CC-0106, REQ-009), the `openbao-ca-issuer` ClusterIssuer plus
-its backing CA `Certificate` (CC-0107), the MariaDB Galera cluster, and the
+`Certificate`, the `openbao-ca-issuer` ClusterIssuer plus
+its backing CA `Certificate`, the MariaDB Galera cluster, and the
 Memcached cluster. These resources require CRDs that are installed by the operator
 HelmReleases in step 1. If CRDs are not yet available, the apply will fail — wait
 for the operators to finish installing and retry.
@@ -866,7 +864,7 @@ internally-built charts to `oci://ghcr.io/c5c3/charts` (see
 ### c5c3-operator and K-ORC design source
 
 The upstream design for the c5c3-operator, K-ORC, and the admin-credential lifecycle
-documented above lives in the `architecture/` git submodule (CC-0110):
+documented above lives in the `architecture/` git submodule:
 
 - `architecture/docs/09-implementation/08-c5c3-operator.md` — the c5c3-operator `ControlPlane` reconciler contract
 - `architecture/docs/03-components/01-control-plane/05-korc.md` — the K-ORC component and chart constraint
@@ -874,7 +872,7 @@ documented above lives in the `architecture/` git submodule (CC-0110):
 
 These chapters are the authoritative design source. They are **updated upstream only**
 and reach this repository through a submodule pointer bump — they are **not** edited from
-this repository or worktree (CC-0110). Treat any divergence between these chapters and
+this repository or worktree. Treat any divergence between these chapters and
 the manifests above as a drift to reconcile at the source, not by editing the submodule
 in place.
 
@@ -1004,12 +1002,12 @@ WITH_CHAOS_MESH=true make deploy-infra
 This is the prerequisite for `make e2e-chaos`. See
 [Chaos E2E Tests](../testing/chaos-e2e-tests.md) for the full workflow.
 
-### kube-prometheus-stack (kind-only opt-in, CC-0100)
+### kube-prometheus-stack (kind-only opt-in)
 
 **File:** `deploy/kind/prometheus/kustomization.yaml`
 
 [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-ships as a separate **opt-in** kind overlay (CC-0100). The default
+ships as a separate **opt-in** kind overlay. The default
 `make deploy-infra` flow does **not** install it — the `monitoring`
 namespace stays absent, and Prometheus / Grafana / the prometheus-operator
 pods do not consume any of the kind node's CPU or memory budget unless a
@@ -1038,7 +1036,7 @@ the production tree). The overlay bundles the resources with:
 
 **Kind-tuned values** (deliberately too lean for a real workload — they exist
 so the stack fits in a single-node kind cluster alongside Flux, the operators,
-and the OpenStack control plane — CC-0100, REQ-002, REQ-003):
+and the OpenStack control plane):
 
 | Helm value | Override | Purpose |
 | --- | --- | --- |
@@ -1052,7 +1050,7 @@ and the OpenStack control plane — CC-0100, REQ-002, REQ-003):
 | `prometheus.prometheusSpec.serviceMonitorNamespaceSelector` | `{}` | Match every namespace (kind only — see above) |
 | `prometheus.prometheusSpec.resources` / `grafana.resources` | `100m CPU / 256Mi mem` caps | Hard cap on kind resource use |
 
-**Dashboard provisioning** (CC-0100, REQ-004). The overlay also adds a
+**Dashboard provisioning**. The overlay also adds a
 `configMapGenerator` that bundles the keystone-operator dashboard JSON
 (`operators/keystone/dashboards/keystone-operator.json` — the **single source
 of truth**, never forked into the overlay) with the
@@ -1083,7 +1081,7 @@ deploy time, so local renders match CI exactly. `make deploy-infra`
 re-runs the copy on every invocation, so explicit staging is not needed
 when going through the full deploy path.
 
-**ServiceMonitor enablement** (CC-0100, REQ-005). The keystone-operator
+**ServiceMonitor enablement**. The keystone-operator
 chart defaults to `monitoring.serviceMonitor.enabled=false` so production
 overlays inherit the safe default. When `WITH_PROMETHEUS=true`,
 `hack/deploy-infra.sh` waits for the `kube-prometheus-stack` HelmRelease to
@@ -1118,4 +1116,4 @@ documented name (`WITH_PROMETHEUS`), and the kind overlay is self-contained
 under `deploy/kind/prometheus/` so the production kustomization root is
 untouched. The
 [`document-intentional-environment-divergence-in-overlays`](https://github.com/c5c3/forge/blob/main/.planwerk/review_patterns/document-intentional-environment-divergence-in-overlays.md)
-review pattern's CC-0100 follow-up section catalogues the full surface area.
+review pattern catalogues the full surface area.

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -157,8 +157,8 @@ injection:
 | --- | --- | --- |
 | `BAO_ADDR` | `https://127.0.0.1:8200` | OpenBao API address (pod-local loopback) |
 | `VAULT_CACERT` | `/openbao/tls/ca.crt` | CA certificate path for TLS verification |
-| `VAULT_CLIENT_CERT` (CC-0107) | `/openbao/client-tls/tls.crt` | Client certificate the in-pod `bao` CLI presents on every API call. Required because `tls_require_and_verify_client_cert = true` is enabled on the listener; without it the TLS handshake fails before any application-layer auth runs. |
-| `VAULT_CLIENT_KEY` (CC-0107) | `/openbao/client-tls/tls.key` | Matching private key for `VAULT_CLIENT_CERT`. Both files are mounted from the `openbao-client-tls` Secret at `/openbao/client-tls`. |
+| `VAULT_CLIENT_CERT` | `/openbao/client-tls/tls.crt` | Client certificate the in-pod `bao` CLI presents on every API call. Required because `tls_require_and_verify_client_cert = true` is enabled on the listener; without it the TLS handshake fails before any application-layer auth runs. |
+| `VAULT_CLIENT_KEY` | `/openbao/client-tls/tls.key` | Matching private key for `VAULT_CLIENT_CERT`. Both files are mounted from the `openbao-client-tls` Secret at `/openbao/client-tls`. |
 
 Defaults are set in `deploy/openbao/bootstrap/common.sh` and forwarded by every
 `bao`-invoking wrapper (`bao_exec`, `bao_exec_stdin` in `common.sh`, the private
@@ -456,8 +456,8 @@ headless service DNS names (`openbao-0.openbao-internal`, `openbao-1.openbao-int
 | Certificate source | `openbao-tls` Secret (cert-manager) |
 | Certificate duration | `8760h` (1 year) |
 | Renewal window | `720h` (30 days before expiry) |
-| `tls_client_ca_file` (CC-0107) | `/openbao/tls/ca.crt` — CA the listener uses to verify presented client certs. The file resolves to the `openbao-ca` CA bundle because the server cert (`openbao-tls`) and every client cert are signed by the same `openbao-ca-issuer` (see below) |
-| `tls_require_and_verify_client_cert` (CC-0107) | `true` — every TLS handshake on `:8200` must present a valid client cert; the listener rejects any connection that does not, before any application-layer auth (Kubernetes JWT, AppRole, root token) runs |
+| `tls_client_ca_file` | `/openbao/tls/ca.crt` — CA the listener uses to verify presented client certs. The file resolves to the `openbao-ca` CA bundle because the server cert (`openbao-tls`) and every client cert are signed by the same `openbao-ca-issuer` (see below) |
+| `tls_require_and_verify_client_cert` | `true` — every TLS handshake on `:8200` must present a valid client cert; the listener rejects any connection that does not, before any application-layer auth (Kubernetes JWT, AppRole, root token) runs |
 
 The TLS certificate is issued by the `openbao-ca-issuer` (a CA-type ClusterIssuer)
 via a cert-manager Certificate resource at
@@ -465,9 +465,9 @@ via a cert-manager Certificate resource at
 is bootstrapped by `selfsigned-cluster-issuer` in
 `deploy/flux-system/infrastructure/openbao-ca-issuer.yaml` — a SelfSigned issuer
 cannot sign leaves for a separate trust chain, so the openbao trust domain owns
-its own CA (mirrors the `openstack-db-ca` precedent in CC-0106).
+its own CA (mirrors the `openstack-db-ca` precedent).
 
-**Client certificates (CC-0107).** Two additional `cert-manager.io/v1` Certificates
+**Client certificates.** Two additional `cert-manager.io/v1` Certificates
 issue *client*-auth keypairs from the same `openbao-ca-issuer`, both
 declared in `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml`:
 
@@ -491,8 +491,8 @@ the OpenBao listener does not verify SANs on client auth, only the issuing CA.
 | `openbao.openbao-system.svc` | DNS | `openbao-tls` (server) | `server auth` | Kubernetes Service endpoint |
 | `127.0.0.1` | IP | `openbao-tls` (server) | `server auth` | Pod-local loopback (bootstrap scripts, `bao_exec`) |
 | `::1` | IP | `openbao-tls` (server) | `server auth` | IPv6 loopback |
-| `openbao-client.openbao-system.svc` | DNS | `openbao-client-tls` (CC-0107) | `client auth` | Identifier only; presented by OpenBao pods on Raft `retry_join` and in-pod `bao` exec. SANs are not verified by the listener for client auth — chain-to-CA is. |
-| `eso-openbao-client.openbao-system.svc` | DNS | `eso-openbao-client-tls` (CC-0107) | `client auth` | Identifier only; presented by ESO `ClusterSecretStore/openbao-cluster-store` on every Vault call. SANs are not verified. |
+| `openbao-client.openbao-system.svc` | DNS | `openbao-client-tls` | `client auth` | Identifier only; presented by OpenBao pods on Raft `retry_join` and in-pod `bao` exec. SANs are not verified by the listener for client auth — chain-to-CA is. |
+| `eso-openbao-client.openbao-system.svc` | DNS | `eso-openbao-client-tls` | `client auth` | Identifier only; presented by ESO `ClusterSecretStore/openbao-cluster-store` on every Vault call. SANs are not verified. |
 
 ### Resource Limits
 
@@ -586,7 +586,7 @@ Common causes:
 - OpenBao is sealed (re-run `init-unseal.sh`)
 - ESO service account missing (verify `external-secrets` SA exists in `external-secrets` namespace)
 - TLS trust failure (verify `openbao-tls` Secret contains `ca.crt` key)
-- Missing client certificate (CC-0107): verify the `eso-openbao-client-tls`
+- Missing client certificate: verify the `eso-openbao-client-tls`
   Secret exists in `openbao-system` and the `ClusterSecretStore`
   `spec.provider.vault.tls.certSecretRef` / `keySecretRef` point at it. With
   `tls_require_and_verify_client_cert = true` on the listener, an absent or
@@ -594,7 +594,7 @@ Common causes:
   ESO controller log (`remote error: tls: bad certificate` or similar), not as
   an HTTP 401/403.
 
-### Verify mTLS enforcement (CC-0107)
+### Verify mTLS enforcement
 
 Confirm the listener rejects a client that does not present a valid certificate.
 The probe runs entirely inside the pod (so the CA bundle is on the
@@ -638,6 +638,6 @@ reconciled (`kubectl get helmrelease openbao -n openbao-system`).
 - [Infrastructure Manifests](./infrastructure-manifests.md) — FluxCD base deployment
 - `deploy/flux-system/releases/openbao.yaml` — OpenBao HelmRelease
 - `deploy/flux-system/infrastructure/openbao-tls-cert.yaml` — server TLS Certificate
-- `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml` — client TLS Certificates (CC-0107)
-- `deploy/eso/clustersecretstore.yaml` — ClusterSecretStore configuration (CC-0107: now uses client-cert mTLS)
+- `deploy/flux-system/infrastructure/openbao-client-tls-cert.yaml` — client TLS Certificates
+- `deploy/eso/clustersecretstore.yaml` — ClusterSecretStore configuration (now uses client-cert mTLS)
 - `deploy/eso/externalsecrets/` — ExternalSecret resources

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -164,7 +164,7 @@ status:
 | --- | --- | --- | --- | --- |
 | `replicas` | `int32` | No | `3` | Number of Keystone API replicas. Minimum: 1. The webhook provides a secondary default of 3 when zero. |
 | `image` | [`ImageSpec`](#imagespec) | Yes | — | Keystone container image reference. |
-| `database` | [`DatabaseSpec`](#databasespec) | Yes | — | MariaDB connection configuration. Includes the optional [`tls`](#databasetlsspec) sub-block that opts in to TLS / mTLS for the connection (CC-0106, REQ-001); when `nil`, the connection is plaintext TCP — preserving pre-CC-0106 behavior for all existing CRs. |
+| `database` | [`DatabaseSpec`](#databasespec) | Yes | — | MariaDB connection configuration. Includes the optional [`tls`](#databasetlsspec) sub-block that opts in to TLS / mTLS for the connection; when `nil`, the connection is plaintext TCP — preserving the previous behavior for all existing CRs. |
 | `cache` | [`CacheSpec`](#cachespec) | Yes | — | Memcached cache configuration. |
 | `fernet` | [`FernetSpec`](#fernetspec) | No | See below | Fernet key rotation configuration. |
 | `credentialKeys` | [`CredentialKeysSpec`](#credentialkeysspec) | No | See below | Credential-key rotation configuration. Drives the per-CR CronJob that rotates and `credential_migrate`s the credential keys used for encrypting application credentials. |
@@ -195,8 +195,8 @@ webhooks are invoked:
 | Field | Rule | Error Message |
 | --- | --- | --- |
 | `spec.database` | `has(self.clusterRef) != has(self.host)` | "exactly one of clusterRef or host must be set" |
-| `spec.database` | `!has(self.tls) \|\| !self.tls.enabled \|\| (self.tls.caBundleSecretRef.name != '' && self.tls.clientCertSecretRef.name != '')` | "when database.tls.enabled is true, both database.tls.caBundleSecretRef.name and database.tls.clientCertSecretRef.name must be set" (CC-0106, REQ-007) |
-| `spec.database.tls.mode` | Enum: `prefer`, `require`, `verify-ca`, `verify-full` | — (CC-0106, REQ-001) |
+| `spec.database` | `!has(self.tls) \|\| !self.tls.enabled \|\| (self.tls.caBundleSecretRef.name != '' && self.tls.clientCertSecretRef.name != '')` | "when database.tls.enabled is true, both database.tls.caBundleSecretRef.name and database.tls.clientCertSecretRef.name must be set" |
+| `spec.database.tls.mode` | Enum: `prefer`, `require`, `verify-ca`, `verify-full` | — |
 | `spec.cache` | `has(self.clusterRef) != (has(self.servers) && size(self.servers) > 0)` | "exactly one of clusterRef or servers must be set" |
 | `spec.policyOverrides` | `(has(self.rules) && size(self.rules) > 0) \|\| self.configMapRef != null` | "at least one of rules or configMapRef must be set" |
 | `spec.policyOverrides.rules` | `!has(self.rules) \|\| self.rules.all(k, k != '')` | "policy rule name must not be empty" |
@@ -1005,15 +1005,15 @@ operator CRDs.
 | `port` | `int32` | No | Database port (brownfield mode, default 3306). |
 | `database` | `string` | Yes | Database name. |
 | `secretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | Secret with database credentials. |
-| `tls` | [`*DatabaseTLSSpec`](#databasetlsspec) | No | Optional TLS/mTLS configuration (CC-0106, REQ-001). The pointer keeps the field opt-in and non-mutating: a `nil` `tls` means plaintext TCP, preserving the pre-CC-0106 behavior for all existing CRs. |
+| `tls` | [`*DatabaseTLSSpec`](#databasetlsspec) | No | Optional TLS/mTLS configuration. The pointer keeps the field opt-in and non-mutating: a `nil` `tls` means plaintext TCP, preserving the previous behavior for all existing CRs. |
 
 Exactly one of `clusterRef` or `host` must be set (enforced by CEL validation).
 
 ### DatabaseTLSSpec
 
-Configures opt-in TLS (and mutual TLS) for the Keystone-to-database connection
-(CC-0106, REQ-001). Referenced as an optional pointer from
-[`DatabaseSpec`](#databasespec); a `nil` value preserves the pre-CC-0106 plaintext
+Configures opt-in TLS (and mutual TLS) for the Keystone-to-database connection.
+Referenced as an optional pointer from
+[`DatabaseSpec`](#databasespec); a `nil` value preserves the previous plaintext
 behavior.
 
 | Field | Type | Required | Default | Description |
@@ -1027,9 +1027,9 @@ behavior.
 
 The reconciler's `reconcile_dbconnection_secret.go` appends `ssl_*` query parameters
 to the database DSN according to `mode`. The mapping is implemented by
-`modeToSSLParams` in `operators/keystone/internal/controller/dbtls_mode.go`
-(CC-0106, REQ-004). The on-pod paths come from the read-only volume `db-tls`
-mounted at `/etc/keystone/db-tls/` (CC-0106, REQ-005):
+`modeToSSLParams` in `operators/keystone/internal/controller/dbtls_mode.go`.
+The on-pod paths come from the read-only volume `db-tls`
+mounted at `/etc/keystone/db-tls/`:
 
 | `mode` | `ssl_ca` | `ssl_cert` | `ssl_key` | `ssl_verify_cert` | `ssl_verify_identity` |
 | --- | --- | --- | --- | --- | --- |
@@ -1047,7 +1047,7 @@ DSN is assembled, so a partially-formed DSN can never reach a workload.
 #### Status condition
 
 `reconcileDatabaseTLS` reports its outcome via the `DatabaseTLSReady` status
-condition (CC-0106, REQ-002, REQ-014) using these typed reasons:
+condition using these typed reasons:
 
 | Reason | When |
 | --- | --- |
@@ -1135,7 +1135,7 @@ Sets spec fields to their documented defaults when they carry zero values. Expli
 | `spec.uwsgi.threads` | `== 0` (when `spec.uwsgi` is non-nil) | `1` — same nil-pointer caveat as processes. |
 | `spec.uwsgi.httpKeepAlive` | Field absent from JSON payload | `true` — defaulted by the CRD schema (`+kubebuilder:default=true`), **not** by the webhook. The webhook cannot distinguish "not set" from "explicitly false" for a bool field. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting-caveat). |
 | `spec.resources` | `== nil` or empty (`requests` and `limits` both unset) | `{requests: {memory: 256Mi, cpu: 100m}, limits: {memory: 512Mi, cpu: 500m}}` — ensures Burstable QoS class and enables HPA utilization calculations. |
-| `spec.database.tls.mode` | `spec.database.tls != nil && mode == ""` | `"require"` — `DefaultDatabaseTLSMode` in `keystone_webhook.go` (CC-0106, REQ-013). Only materialized when the `tls` block is explicitly present; the webhook never materializes the block itself. |
+| `spec.database.tls.mode` | `spec.database.tls != nil && mode == ""` | `"require"` — `DefaultDatabaseTLSMode` in `keystone_webhook.go`. Only materialized when the `tls` block is explicitly present; the webhook never materializes the block itself. |
 
 **Not defaulted by the webhook:**
 
@@ -1146,7 +1146,7 @@ Sets spec fields to their documented defaults when they carry zero values. Expli
   (inject zone+hostname defaults) from `[]` (opt out), so the webhook must not
   materialise a struct.
 - `spec.database.tls` itself and `spec.database.tls.enabled` — the webhook never
-  materializes the `tls` block and never sets `enabled` (CC-0106, REQ-013). TLS
+  materializes the `tls` block and never sets `enabled`. TLS
   is strictly opt-in, so an upgrade of a previously plaintext CR cannot silently
   turn encryption on (which would also trigger Certificate provisioning). The
   webhook only partial-fills `tls.mode` when the parent block is explicitly
@@ -1183,9 +1183,9 @@ single `apierrors.NewInvalid` error. It does **not** short-circuit on the first 
 | Replicas minimum | `spec.replicas` | `field.Invalid` | `replicas < 1`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=1` marker. |
 | Cache mutual exclusivity | `spec.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither. Defense-in-depth alongside the CEL XValidation rule. |
 | Database mutual exclusivity | `spec.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither. Defense-in-depth alongside the CEL XValidation rule. |
-| Database TLS mode out-of-enum | `spec.database.tls.mode` | `field.NotSupported` | `tls.mode` is non-empty but not one of `prefer`/`require`/`verify-ca`/`verify-full`. Defense-in-depth alongside the `+kubebuilder:validation:Enum` marker. Empty `mode` is tolerated because `Default()` materializes `"require"` before validation in the normal admission path (CC-0106, REQ-007). |
-| Database TLS caBundleSecretRef required | `spec.database.tls.caBundleSecretRef.name` | `field.Required` | `tls.enabled=true` but `caBundleSecretRef.name` is empty. Defense-in-depth alongside the CEL XValidation rule on `spec.database` (CC-0106, REQ-007). |
-| Database TLS clientCertSecretRef required | `spec.database.tls.clientCertSecretRef.name` | `field.Required` | `tls.enabled=true` but `clientCertSecretRef.name` is empty. Defense-in-depth alongside the CEL XValidation rule on `spec.database` (CC-0106, REQ-007). |
+| Database TLS mode out-of-enum | `spec.database.tls.mode` | `field.NotSupported` | `tls.mode` is non-empty but not one of `prefer`/`require`/`verify-ca`/`verify-full`. Defense-in-depth alongside the `+kubebuilder:validation:Enum` marker. Empty `mode` is tolerated because `Default()` materializes `"require"` before validation in the normal admission path. |
+| Database TLS caBundleSecretRef required | `spec.database.tls.caBundleSecretRef.name` | `field.Required` | `tls.enabled=true` but `caBundleSecretRef.name` is empty. Defense-in-depth alongside the CEL XValidation rule on `spec.database`. |
+| Database TLS clientCertSecretRef required | `spec.database.tls.clientCertSecretRef.name` | `field.Required` | `tls.enabled=true` but `clientCertSecretRef.name` is empty. Defense-in-depth alongside the CEL XValidation rule on `spec.database`. |
 | Fernet maxActiveKeys minimum | `spec.fernet.maxActiveKeys` | `field.Invalid` | `maxActiveKeys < 3`. Defense-in-depth alongside the `+kubebuilder:validation:Minimum=3` marker. |
 | Fernet schedule required | `spec.fernet.rotationSchedule` | `field.Required` | Empty after admission (bypass paths). |
 | Fernet cron expression | `spec.fernet.rotationSchedule` | `field.Invalid` | `cron.ParseStandard()` fails. Error message includes the parse failure details. |
@@ -1337,7 +1337,7 @@ rejection in a real cluster with the operator deployed. For the full reconciler
 E2E test suite inventory (basic-deployment, scale, fernet-rotation,
 credential-rotation, network-policy, topology-spread, priority-class,
 release-upgrade, schema-drift-detection, events, healthcheck, graceful-shutdown,
-policy-validation, config-pruning, `database-tls` (CC-0106, REQ-011), …), see
+policy-validation, config-pruning, `database-tls`, …), see
 [Keystone E2E Test Suites](../testing/keystone-e2e-tests.md).
 
 #### invalid-cr Suite
@@ -1498,7 +1498,7 @@ tests/e2e/keystone/
 ├── policy-overrides/                 oslo.policy integration E2E
 ├── middleware-config/                Middleware pipeline E2E
 ├── brownfield-database/              External database mode E2E
-├── database-tls/                     Database TLS/mTLS E2E (CC-0106, REQ-011)
+├── database-tls/                     Database TLS/mTLS E2E
 │   ├── chainsaw-test.yaml            Chainsaw E2E test definition
 │   └── 00-keystone-cr.yaml           Keystone CR with spec.database.tls (verify-full)
 ├── image-upgrade/                    Rolling image upgrade E2E

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -227,7 +227,7 @@ controller-observable semantics and are stable across releases — consumers
 | --- | --- | --- | --- | --- |
 | `forge.c5c3.io/rotation-target` | Label | Staging Secrets (`{name}-fernet-keys-rotation`, `{name}-credential-keys-rotation`, `{name}-admin-password-rotation`) | `fernet-keys`, `credential-keys`, `admin-password` | Distinguishes rotation staging Secrets from production key Secrets so the operator's Secret→Keystone mapper can enqueue the owning Keystone on staging PATCHes. |
 | `forge.c5c3.io/rotation-completed-at` | Annotation | Staging Secrets (written by the rotation CronJob) | RFC3339 UTC timestamp (e.g. `2026-04-18T12:34:56Z`) | Single-shot commit marker. The operator only applies a staging Secret's data to the production Secret when this annotation is present and parses cleanly; the annotation is removed implicitly when the staging Secret is deleted at the end of a successful apply. |
-| `forge.c5c3.io/admin-password-hash` | Annotation | Bootstrap Job pod template (`{name}-bootstrap`) | `hex(SHA-256(password))` of the `password` key of the admin Secret | Carries the admin-password digest into the pod template so a rotated password changes the pod-spec hash and re-runs the idempotent bootstrap Job (CC-0108, REQ-007). See [`reconcileBootstrap`](#reconcilebootstrap). |
+| `forge.c5c3.io/admin-password-hash` | Annotation | Bootstrap Job pod template (`{name}-bootstrap`) | `hex(SHA-256(password))` of the `password` key of the admin Secret | Carries the admin-password digest into the pod template so a rotated password changes the pod-spec hash and re-runs the idempotent bootstrap Job. See [`reconcileBootstrap`](#reconcilebootstrap). |
 | `forge.c5c3.io/pod-spec-hash` | Annotation | Operator-managed Jobs (`{name}-bootstrap`, migration Jobs) | `hex(SHA-256(PodTemplateSpec))` stamped at creation time | Change-detection gate for completed Jobs. `job.RunJob` compares the desired hash against this annotation and recreates the Job (so it re-runs) when they differ, without normalizing API-server defaults. |
 
 The Go constants backing the rotation keys are exported from
@@ -1483,14 +1483,14 @@ and disaster recovery backup to OpenBao.
 | Schedule | `spec.fernet.rotationSchedule` |
 | ServiceAccount | `{name}-fernet-rotate` |
 | Init container | Copies keys from `fernet-keys-src` (Secret) to `fernet-keys` (emptyDir) |
-| Command | `/scripts/fernet_rotate.sh` (CC-0073) |
-| Volume `fernet-keys-src` | Secret `{name}-fernet-keys` (read-only source, `defaultMode: 0400`) (CC-0099) |
-| Volume `fernet-keys` | emptyDir (writable working copy; init container writes files with `install -m 0400`) (CC-0099) |
-| Volume `credential-keys` | Secret `{name}-credential-keys` (read-only, required by config, `defaultMode: 0400`) (CC-0099) |
+| Command | `/scripts/fernet_rotate.sh` |
+| Volume `fernet-keys-src` | Secret `{name}-fernet-keys` (read-only source, `defaultMode: 0400`) |
+| Volume `fernet-keys` | emptyDir (writable working copy; init container writes files with `install -m 0400`) |
+| Volume `credential-keys` | Secret `{name}-credential-keys` (read-only, required by config, `defaultMode: 0400`) |
 | Volume `config` | ConfigMap `{configMapName}` |
-| Volume `scripts` | ConfigMap `{name}-fernet-rotate-script-{hash}` (`defaultMode: 0555`) (CC-0073) |
-| Pod `fsGroup` | `42424` (openstack GID — grants the rotation Pod's UID 42424 group access to projected key files at mode `0400`) (CC-0099) |
-| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning (CC-0099) |
+| Volume `scripts` | ConfigMap `{name}-fernet-rotate-script-{hash}` (`defaultMode: 0555`) |
+| Pod `fsGroup` | `42424` (openstack GID — grants the rotation Pod's UID 42424 group access to projected key files at mode `0400`) |
+| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning |
 
 **PushSecret:**
 
@@ -1654,14 +1654,14 @@ with credential migration, and disaster recovery backup to OpenBao.
 | Schedule | `spec.credentialKeys.rotationSchedule` |
 | ServiceAccount | `{name}-credential-rotate` |
 | Init container | Copies keys from `credential-keys-src` (Secret) to `credential-keys` (emptyDir) |
-| Command | `/scripts/credential_rotate.sh` (CC-0073) |
-| Volume `credential-keys-src` | Secret `{name}-credential-keys` (read-only source, `defaultMode: 0400`) (CC-0099) |
-| Volume `credential-keys` | emptyDir (writable working copy; init container writes files with `install -m 0400`) (CC-0099) |
-| Volume `fernet-keys` | Secret `{name}-fernet-keys` (read-only, required by config, `defaultMode: 0400`) (CC-0099) |
+| Command | `/scripts/credential_rotate.sh` |
+| Volume `credential-keys-src` | Secret `{name}-credential-keys` (read-only source, `defaultMode: 0400`) |
+| Volume `credential-keys` | emptyDir (writable working copy; init container writes files with `install -m 0400`) |
+| Volume `fernet-keys` | Secret `{name}-fernet-keys` (read-only, required by config, `defaultMode: 0400`) |
 | Volume `config` | ConfigMap `{configMapName}` |
-| Volume `scripts` | ConfigMap `{name}-credential-rotate-script-{hash}` (`defaultMode: 0555`) (CC-0073) |
-| Pod `fsGroup` | `42424` (openstack GID — grants the rotation Pod's UID 42424 group access to projected key files at mode `0400`) (CC-0099) |
-| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning (CC-0099) |
+| Volume `scripts` | ConfigMap `{name}-credential-rotate-script-{hash}` (`defaultMode: 0555`) |
+| Pod `fsGroup` | `42424` (openstack GID — grants the rotation Pod's UID 42424 group access to projected key files at mode `0400`) |
+| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning |
 
 > **Note:** The `credential_rotate.sh` script runs both `credential_rotate` and
 > `credential_migrate`. The migrate step re-encrypts existing credentials in the
@@ -2050,15 +2050,15 @@ The liveness and readiness probes are intentionally separated. The liveness prob
 | Volume Name | Mount Path | Source | ReadOnly |
 | --- | --- | --- | --- |
 | `config` | `/etc/keystone/keystone.conf.d/` | ConfigMap `{configMapName}` | Yes |
-| `fernet-keys` | `/etc/keystone/fernet-keys/` | Secret `keystone-fernet-keys` (`defaultMode: 0400`) (CC-0099) | Yes |
-| `credential-keys` | `/etc/keystone/credential-keys/` | Secret `keystone-credential-keys` (`defaultMode: 0400`) (CC-0099) | Yes |
+| `fernet-keys` | `/etc/keystone/fernet-keys/` | Secret `keystone-fernet-keys` (`defaultMode: 0400`) | Yes |
+| `credential-keys` | `/etc/keystone/credential-keys/` | Secret `keystone-credential-keys` (`defaultMode: 0400`) | Yes |
 
 **Pod-level Security:**
 
 | Field | Value |
 | --- | --- |
-| `spec.template.spec.securityContext.fsGroup` | `42424` (openstack GID — grants the API Pod's UID 42424 group access to projected key files at mode `0400`) (CC-0099) |
-| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning (CC-0099) |
+| `spec.template.spec.securityContext.fsGroup` | `42424` (openstack GID — grants the API Pod's UID 42424 group access to projected key files at mode `0400`) |
+| Rationale | Mirrors upstream Keystone's `keystone.common.fernet_utils._check_key_repository`, which logs a `WARNING` when the key directory or any key file is world-readable (`stat.S_IROTH`); pinning `defaultMode: 0400` plus `fsGroup: 42424` keeps the projected files group-readable to UID 42424 only and silences the warning |
 
 **Service Spec:**
 
@@ -2489,7 +2489,7 @@ project, roles, and service catalog entries.
 | `--bootstrap-public-url` | `http://keystone.{namespace}.svc.cluster.local:5000/v3` |
 | `--bootstrap-region-id` | `spec.bootstrap.region` |
 
-**Admin-password rotation re-run (CC-0108, REQ-007):** Before building the Job,
+**Admin-password rotation re-run:** Before building the Job,
 the reconciler reads the `password` key of the admin Secret named by
 `spec.bootstrap.adminPasswordSecretRef.Name` and stamps its digest —
 `hex(SHA-256(password))` — onto the bootstrap Job's pod template as the
@@ -2636,13 +2636,12 @@ func (r *KeystoneReconciler) reconcilePasswordRotation(ctx context.Context,
 The third parameter is the shared config ConfigMap name. It is accepted only for
 sub-reconciler call-site symmetry with `reconcileFernetKeys` and
 `reconcileTrustFlush` — the controller wires this sub-reconciler as
-`instrumentSubReconciler(ctx, "PasswordRotation", ...)` passing `configMapName`
-(CC-0109, REQ-009). It is intentionally unused (named `_`) because the rotate
+`instrumentSubReconciler(ctx, "PasswordRotation", ...)` passing `configMapName`.
+It is intentionally unused (named `_`) because the rotate
 script never runs `keystone-manage` and therefore needs no keystone
 configuration.
 
-**Purpose:** Drive Model B scheduled admin-password rotation (CC-0109, REQ-002,
-REQ-003, REQ-009). A CronJob mints a fresh strong password and PATCHes it onto a
+**Purpose:** Drive Model B scheduled admin-password rotation. A CronJob mints a fresh strong password and PATCHes it onto a
 staging Secret; the operator validates and commits it onto an operator-owned
 push-source Secret; a PushSecret mirrors that to OpenBao at the flat path
 `bootstrap/keystone-admin`; External Secrets Operator (ESO) then syncs it back
@@ -2680,7 +2679,7 @@ Two lifecycle paths:
    the next reconcile picks up the freshest timestamp once the apply re-stamps
    the push-source annotation.
 4. **Apply any completed rotation** — `applyAdminPasswordRotation` validates and
-   commits a staged rotation if one is present (REQ-007, REQ-011). On a
+   commits a staged rotation if one is present. On a
    successful apply it sets `PasswordRotationReady=True` with reason
    `AdminPasswordRotated` ("rotation applied; staging secret cleared") and
    short-circuits with `Requeue: true` so the next pass re-enters the happy path
@@ -2697,7 +2696,7 @@ Two lifecycle paths:
    `adminPasswordPushSourceReady` reports the push-source Secret holds a valid
    password (≥ minLength). Before the first rotation completes the push-source is
    empty, and pushing it would overwrite the seeded `bootstrap/keystone-admin`
-   value with nothing (REQ-007, REQ-011, REQ-014).
+   value with nothing.
 9. **Report ready** — sets `PasswordRotationReady=True` with reason
    `PasswordRotationConfigured` ("Admin password rotation CronJob is
    configured").
@@ -2733,7 +2732,7 @@ push-source Secret (see the RBAC split below).
 | Name | `{name}-admin-password-backup` |
 | Store | `ClusterSecretStore/openbao-cluster-store` |
 | Source Secret | `{name}-admin-password-next` (push-source) |
-| Remote Key | `bootstrap/keystone-admin` (hardcoded flat path — single-CR assumption, REQ-014, boundary 8) |
+| Remote Key | `bootstrap/keystone-admin` (hardcoded flat path — single-CR assumption, boundary 8) |
 | Property | `password` |
 | DeletionPolicy | `None` |
 
@@ -2774,7 +2773,7 @@ The rotation path separates the **compute** of the new password (performed by
 the rotation CronJob) from the **write** onto the push-source Secret and the
 commit (performed by the operator). `ensureAdminPasswordRotationRBAC` creates a
 ServiceAccount, Role, and RoleBinding all named `{name}-admin-password-rotate`,
-mirroring `ensureFernetRotationRBAC`'s split shape (CC-0081, CC-0109).
+mirroring `ensureFernetRotationRBAC`'s split shape.
 
 **Staging Secret naming.** Per `adminPasswordStagingSecretName`, the staging
 Secret is `{keystone.Name}-admin-password-rotation`. It is created and owned by
@@ -2807,8 +2806,7 @@ with strictly disjoint capabilities:
 | Operator ServiceAccount | Secret `{name}-admin-password-next` (push-source) | `get`, `create`, `update`, `patch`, `delete`, `list`, `watch` | Cluster-scoped core `secrets` verbs (see [RBAC Permissions](#rbac-permissions)) |
 | Operator ServiceAccount | Secret `{name}-admin-password-rotation` (staging) | `get`, `create`, `update`, `patch`, `delete`, `list`, `watch` | Cluster-scoped core `secrets` verbs |
 
-**Operator output contract.** `validateAdminPasswordRotationOutput` (REQ-007,
-REQ-011) requires a non-empty `password` value of at least minLength bytes, where
+**Operator output contract.** `validateAdminPasswordRotationOutput` requires a non-empty `password` value of at least minLength bytes, where
 minLength is the normalized `PasswordLength` (webhook default 32, defense-in-depth
 floor 24 via `adminPasswordMinLength`). On rejection the operator emits a Warning
 event `AdminPasswordRotationRejected` and **retains the staging Secret** for

--- a/docs/reference/testing/chaos-e2e-tests.md
+++ b/docs/reference/testing/chaos-e2e-tests.md
@@ -305,7 +305,7 @@ invisible to the CR's status conditions.
 | --- | --- | --- | --- |
 | 1 | Apply Keystone CR | `apply` | Applies `00-keystone-cr.yaml` — Keystone CR `keystone-chaos-op` with database `keystone_chaos_op` |
 | 2 | Assert baseline Ready=True | `assert` (5m) | Ready=True with reason AllReady — confirms healthy state before fault injection |
-| 3 | Inject PodChaos | `apply` | Applies `01-podchaos.yaml` — PodChaos `kill-operator` targeting `app.kubernetes.io/name: keystone-operator` in `keystone-system` (CC-0105: the operator controller lives in its own Namespace; the PodChaos CR itself is still created in the test's `openstack` namespace) |
+| 3 | Inject PodChaos | `apply` | Applies `01-podchaos.yaml` — PodChaos `kill-operator` targeting `app.kubernetes.io/name: keystone-operator` in `keystone-system` (the operator controller lives in its own Namespace; the PodChaos CR itself is still created in the test's `openstack` namespace) |
 | 4 | Wait for operator pod crash and recovery | `wait` (2m + 2m) | Condition-based waits: operator pod `Ready=false` (kill took effect), then `Ready=true` (Deployment controller restarted pod) |
 | 5 | Delete PodChaos | `delete` | Removes PodChaos `kill-operator` to clean up |
 | 6 | Assert Ready=True after re-reconciliation | `assert` (5m) | Ready=True with reason AllReady — no sub-condition stuck in False state |
@@ -526,7 +526,7 @@ recovery to confirm the new leader processes spec changes end-to-end.
 
 **Design notes:**
 
-- The operator pod runs in the `keystone-system` Namespace (CC-0105 — see
+- The operator pod runs in the `keystone-system` Namespace (see
   [Infrastructure Manifests › Keystone Operator](../infrastructure/infrastructure-manifests.md#keystone-operator));
   the operator-managed Keystone workload remains in `openstack`. The PodChaos
   `selector.namespaces` targets `keystone-system` accordingly.
@@ -751,7 +751,7 @@ spec:
 | Field | Value | Rationale |
 | --- | --- | --- |
 | `mode` | `all` | Kills every operator pod — unlike SC-CHAOS-004 (`mode: one`) which leaves other replicas running |
-| `selector.namespaces` | `keystone-system` | Operator controller runs in `keystone-system` (CC-0105); the operator-managed Keystone workload stays in `openstack` |
+| `selector.namespaces` | `keystone-system` | Operator controller runs in `keystone-system`; the operator-managed Keystone workload stays in `openstack` |
 
 ### Fault cleanup
 

--- a/docs/reference/testing/keystone-e2e-tests.md
+++ b/docs/reference/testing/keystone-e2e-tests.md
@@ -612,7 +612,7 @@ patching with a valid class sets it; patching with empty string removes it.
 
 **File:** `tests/e2e/keystone/semantic-invariants/chainsaw-test.yaml`
 
-**Purpose:** Asserts five Keystone CR `status` semantic invariants that no other E2E suite gates today: `status.endpoint` URL format (CC-0101 REQ-001), `ownerReferences` fan-out across every operator-managed kind (CC-0101 REQ-002), `status.observedGeneration` catch-up after a `spec` change (CC-0101 REQ-003), `condition.lastTransitionTime` monotonicity across a `True → False → True` flip (CC-0101 REQ-004), and immutability of the generated config ConfigMap (CC-0101 REQ-005). The fixture intentionally omits `spec.gateway`, `spec.networkPolicy`, and `spec.autoscaling` so the cluster-local `status.endpoint` surfaces and the `observedGeneration` assertion stays exact regardless of optional sub-condition reasons.
+**Purpose:** Asserts five Keystone CR `status` semantic invariants that no other E2E suite gates today: `status.endpoint` URL format, `ownerReferences` fan-out across every operator-managed kind, `status.observedGeneration` catch-up after a `spec` change, `condition.lastTransitionTime` monotonicity across a `True → False → True` flip, and immutability of the generated config ConfigMap. The fixture intentionally omits `spec.gateway`, `spec.networkPolicy`, and `spec.autoscaling` so the cluster-local `status.endpoint` surfaces and the `observedGeneration` assertion stays exact regardless of optional sub-condition reasons.
 
 **Steps:**
 
@@ -626,8 +626,6 @@ patching with a valid class sets it; patching with empty string removes it.
 | 6 | Assert ConfigMap immutability | `script` | Resolves the active config ConfigMap by `forge.c5c3.io/config-base=keystone-invariants-config` (never by hash suffix), runs `kubectl patch` against `data.keystone.conf`, and asserts non-zero exit with `field is immutable` in stderr |
 
 **Fixtures:** `00-keystone-cr.yaml`
-
-**Requirements covered:** CC-0101 REQ-001, REQ-002, REQ-003, REQ-004, REQ-005.
 
 **Source files contributing managed kinds.** Step 3 is the tracked counterpart of these files — a reviewer adding a new managed kind in any of them MUST extend the iteration list in Step 3, otherwise the ownership invariant can regress unnoticed:
 
@@ -762,7 +760,7 @@ Deployment/Job/CronJob is identifiable. Mirrors the catch-block shape from
 
 **Cross-references:**
 
-- Feature: **CC-0104** (this test).
+- Feature: **Pod Security Standards (restricted) admission gate** (this test).
 - Parent issue: **#317** — PSS-restricted admission gate for Keystone.
 - Phase 1 baseline: **#277** — security/compliance baseline. The Keystone
   unit-test evidence for `restrictedSecurityContext()` lives in
@@ -956,7 +954,7 @@ tests/e2e/keystone/
 │   ├── 01-patch-update-ingress.yaml    Patch ingress rule
 │   └── 02-patch-disable-networkpolicy.yaml Patch to disable NetworkPolicy
 ├── pod-security-restricted/
-│   ├── chainsaw-test.yaml              PSS-restricted admission gate (CC-0104)
+│   ├── chainsaw-test.yaml              PSS-restricted admission gate
 │   ├── 00-namespace.yaml               PSS-labelled test namespace + plain Secrets
 │   ├── 00-brownfield-db-setup.yaml     Brownfield Database/User/Grant + db-pw Secret
 │   └── 01-keystone-cr.yaml             Keystone CR with brownfield db + cache

--- a/scripts/check-docs-no-feature-ids.sh
+++ b/scripts/check-docs-no-feature-ids.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CI-runnable gate that keeps the published documentation under `docs/` free of
+# internal feature/requirement identifiers. The user-facing docs describe
+# *behaviour*; internal tracking IDs of the form `CC-NNNN` (feature / change
+# IDs) and `REQ-NNN` (requirement IDs) are meaningless to site readers and must
+# never appear in the documentation source.
+#
+# The scan is case-insensitive so lowercase forms that creep in through anchor
+# slugs (e.g. a `#enabling-prometheus--grafana-cc-0100` link target) are caught
+# alongside prose mentions. A non-letter — or start of line — is required
+# immediately before the ID so unrelated tokens such as `ecc-256` do not trip
+# the gate.
+#
+# Generated VitePress build output (`docs/.vitepress/dist`, `.../cache`) is
+# excluded: it is git-ignored and regenerates from the source this gate guards.
+# This script lives under `scripts/`, not `docs/`, so it never scans itself
+# even though it names the patterns verbatim.
+#
+# Exit codes:
+#   0 — no internal IDs found in docs/
+#   1 — at least one occurrence; offending file:line:match printed to stderr
+#   2 — internal error (docs/ directory missing)
+#
+# Usage:
+#   scripts/check-docs-no-feature-ids.sh
+#   make check-docs-ids
+
+set -euo pipefail
+
+# Resolve the repository root from the script's location so the script works
+# regardless of the caller's working directory.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+DOCS_DIR="${REPO_ROOT}/docs"
+if [ ! -d "${DOCS_DIR}" ]; then
+  printf 'error: docs directory not found at %s\n' "${DOCS_DIR}" >&2
+  exit 2
+fi
+
+# Match CC-NNNN / REQ-NNN preceded by start-of-line or a non-letter, so the gate
+# catches `(CC-0106)`, `pre-CC-0106`, and `#...-cc-0100` but not `ecc-256`. With
+# `-i`, the bracket class `[^a-z]` also excludes uppercase letters.
+pattern='(^|[^a-z])(cc|req)-[0-9]+'
+
+# `|| true` suppresses grep's exit-1 on "no matches" — the exit code is driven
+# explicitly below. `--binary-files=without-match` skips any binary assets.
+hits="$(grep -rniE --binary-files=without-match \
+  --exclude-dir='dist' \
+  --exclude-dir='cache' \
+  "${pattern}" "${DOCS_DIR}" || true)"
+
+if [ -z "${hits}" ]; then
+  echo "ok: no internal CC-/REQ- identifiers found in docs/"
+  exit 0
+fi
+
+{
+  echo "error: internal feature/requirement IDs found in docs/ (CC-NNNN / REQ-NNN)."
+  echo
+  echo "User-facing documentation must describe behaviour, not cite internal"
+  echo "tracking IDs. Remove each ID below; if it carried meaning, reword the"
+  echo "surrounding text so the explanation survives without the identifier."
+  echo
+  # Strip the absolute REPO_ROOT prefix so paths are repo-relative and stable.
+  printf '%s\n' "${hits}" | sed "s#^${REPO_ROOT}/##"
+} >&2
+exit 1

--- a/tests/unit/docs/infrastructure_manifests_flux_web_test.sh
+++ b/tests/unit/docs/infrastructure_manifests_flux_web_test.sh
@@ -8,7 +8,7 @@
 #   - a subsection references deploy/kind/base/flux-web.yaml
 #   - the chart URL oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
 #     is cited in that subsection
-#   - the Renovate customManager / pin story is mentioned (REQ-004 cross-link)
+#   - the Renovate customManager / pin story is mentioned
 #   - an explicit note clarifies that deploy/flux-system/kustomization.yaml
 #     does NOT reference this file (production stays opt-out)
 #   - the document still parses as a sequence of well-formed Markdown
@@ -86,16 +86,13 @@ test_helm_values_cited() {
     'installCRDs'
 }
 
-# --- Test 6: Renovate customManager cross-reference (CC-0086, REQ-008, REQ-004) ---
+# --- Test 6: Renovate customManager cross-reference (CC-0086, REQ-008) ---
 test_renovate_cross_reference() {
-  echo "Test: the flux-web subsection cross-references the Renovate customManager (CC-0086, REQ-008 → REQ-004)"
+  echo "Test: the flux-web subsection cross-references the Renovate customManager (CC-0086, REQ-008)"
 
   assert_file_contains "Renovate customManager cross-reference present" \
     "$MANIFESTS_DOC" \
     'customManager'
-  assert_file_contains "REQ-004 cross-reference present" \
-    "$MANIFESTS_DOC" \
-    'REQ-004'
 }
 
 # --- Test 7: explicit note that production flux-system does NOT reference


### PR DESCRIPTION
## Summary

The published documentation under `docs/` carried internal feature/change (`CC-NNNN`) and requirement (`REQ-NNN`) tracking IDs as inline traceability tags, e.g. `(CC-0106, REQ-009)`. These are meaningless to site readers and leak internal process metadata — user-facing docs should describe behaviour.

This removes every CC-/REQ-ID from the 14 affected pages, reworking the prose so each passage still reads coherently rather than blindly deleting:

- Pure parenthetical tags dropped — the surrounding sentence already states the behaviour.
- ID + explanation keeps the explanation, loses the ID (e.g. `(CC-0105: the controller lives in its own Namespace …)`).
- Named concepts keep their name (`Model A` / `Model B`, not `Model B (CC-0109)`).
- ID-as-content reworded to the behaviour it named (e.g. the PSS-restricted admission gate) or dropped where the prose above already covers it.
- Headings with IDs renamed; line-wrapped tags merged into the prior line.
- `DECISION` notes and "deferred to" future-work references keep their rationale, lose the ID.

It also adds a gate so IDs can never re-enter:

- `scripts/check-docs-no-feature-ids.sh` scans `docs/` case-insensitively (so anchor slugs are caught too), excluding generated `.vitepress/dist` and `cache`, and fails with the offending `file:line` on any match.
- `make check-docs-ids` exposes it for local runs.
- A first step in the CI `docs` job runs it before the Node toolchain, so it fails fast.

`architecture/` (a read-only submodule) and `// CC-NNNN` markers in source code are out of scope and untouched.

## Test plan

- [x] `make check-docs-ids` → clean (exit 0)
- [x] `grep -rinE '(cc|req)-[0-9]+' docs --include='*.md'` → 0 matches
- [x] `npm run docs:build` → succeeds, no dead links
- [x] Negative test: injecting a synthetic `CC-0999` makes the gate exit 1
- [x] Diff touches only `docs/`, `scripts/`, `Makefile`, and the CI workflow — nothing in `architecture/` or Go sources
