### PR TITLE
fix(CC-0110): apply K-ORC via GitRepository + Kustomization, not a Helm chart

### DIFF
--- a/deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml
+++ b/deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml
@@ -19,9 +19,11 @@
 # in that SAME namespace (api/v1alpha1/credentials_ref.go GetCloudCredentialsRef
 # returns the resource's own Namespace). The admin clouds.yaml Secret MUST
 # therefore exist in "openstack" for K-ORC to authenticate — the first document
-# below. The second document keeps a copy in "orc-system" for the K-ORC
-# HelmRelease's globalCloudConfig default mount (deploy/flux-system/releases/
-# k-orc.yaml). Both read the same OpenBao path, so both stay in lockstep.
+# below. The second document keeps a copy in "orc-system" for any global default
+# clouds.yaml mount K-ORC uses there (deploy/flux-system/releases/k-orc.yaml
+# applies the upstream installer; the global mount is not on the credential
+# critical path — see C1 above). Both read the same OpenBao path, so both stay
+# in lockstep.
 #
 # Feature: CC-0110, REQ-023, REQ-024
 ---
@@ -47,7 +49,7 @@ spec:
         key: openstack/keystone/admin/app-credential
         property: clouds.yaml
 ---
-# Copy in orc-system for the K-ORC HelmRelease globalCloudConfig default mount.
+# Copy in orc-system for K-ORC's global default clouds.yaml mount.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/deploy/flux-system/releases/c5c3-operator.yaml
+++ b/deploy/flux-system/releases/c5c3-operator.yaml
@@ -4,8 +4,14 @@
 
 # Feature: CC-0110, REQ-023 — the c5c3-operator controller runs in its own
 # dedicated c5c3-system Namespace and orchestrates the Keystone ControlPlane.
-# It depends on the infrastructure + Keystone operators it projects CRs into and
-# on K-ORC, whose Application Credential / Service / Endpoint CRDs it drives.
+# It depends on the infrastructure + Keystone operators it projects CRs into.
+#
+# K-ORC is deliberately NOT in dependsOn: a HelmRelease dependsOn can only
+# reference other HelmReleases, and K-ORC is now a Flux Kustomization
+# (releases/k-orc.yaml), not a HelmRelease. Ordering is unnecessary anyway — the
+# reconciler tolerates the K-ORC CRDs being absent (it surfaces KORCReady=False
+# with reason KORCCRDNotInstalled via a NoKindMatchError instead of crash-looping),
+# so the operator may start before K-ORC and converge once the CRDs appear.
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -23,8 +29,6 @@ spec:
       namespace: mariadb-system
     - name: memcached-operator
       namespace: memcached-system
-    - name: k-orc
-      namespace: orc-system
   chart:
     spec:
       chart: c5c3-operator

--- a/deploy/flux-system/releases/k-orc.yaml
+++ b/deploy/flux-system/releases/k-orc.yaml
@@ -2,52 +2,44 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Feature: CC-0110, REQ-023 — K-ORC (OpenStack Resource Controller) provides the
-# declarative Keystone resource CRDs (ApplicationCredential, Service, Endpoint,
-# ...) that the c5c3-operator drives. Runs in the orc-system Namespace and reads
-# its admin clouds.yaml from the k-orc-clouds-yaml Secret materialised by ESO.
+# Feature: CC-0110, REQ-023 — Deploy K-ORC (OpenStack Resource Controller),
+# whose ApplicationCredential / Service / Endpoint CRDs the c5c3-operator drives.
+#
+# DECISION: a Flux Kustomization (kustomize.toolkit.fluxcd.io), not a HelmRelease.
+# K-ORC ships no Helm chart (see sources/k-orc.yaml) — only a flattened installer
+# manifest. The GitRepository source vendors ./dist (just dist/install.yaml, the
+# byte-identical copy of the pinned release asset), and this Kustomization applies
+# it. The path has no kustomization.yaml, so the kustomize-controller generates one
+# over all manifests in ./dist and applies install.yaml verbatim. install.yaml
+# already declares the orc-system Namespace and namespaces every resource into it,
+# so no spec.targetNamespace is set (orc-system is also declared in
+# deploy/flux-system/namespaces.yaml, which co-manages it for the ESO ExternalSecret
+# that must exist before this Kustomization reconciles).
+#
+# Credentials: the previous HelmRelease set globalCloudConfig.secretName, the chart
+# value for K-ORC's GLOBAL default clouds.yaml mount. The upstream installer has no
+# such knob, and it is not on the critical path: per CC-0110 C1 the c5c3-operator's
+# K-ORC CRs each carry a per-resource CloudCredentialsRef that K-ORC resolves in the
+# CR's OWN (control-plane) namespace. The orc-system copy of k-orc-clouds-yaml
+# (deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml) remains for any global default
+# K-ORC mounts; both copies read the same OpenBao path.
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
 metadata:
-  # DECISION: metadata.name "k-orc" (not the chart's own "openstack-resource-
-  # controller") so the c5c3-operator HelmRelease can dependsOn it by this short,
-  # stable name. Per repo convention the HelmRelease lives in its target Namespace
-  # (orc-system), so no explicit spec.targetNamespace is needed — the chart's
-  # resources deploy into orc-system. Reviewer: please verify.
+  # Short, stable name so other manifests/diagnostics reference K-ORC as "k-orc"
+  # (the upstream installer's own resources keep their openstack-resource-controller
+  # names). Flux Kustomizations live in flux-system alongside their source.
   name: k-orc
-  namespace: orc-system
+  namespace: flux-system
 spec:
   interval: 30m
-  chart:
-    spec:
-      chart: openstack-resource-controller
-      # DECISION: version range ">=0.1.0" follows
-      # architecture/docs/03-components/01-control-plane/05-korc.md (the documented
-      # K-ORC chart constraint). The bounded "<1.0.0" pattern used by in-repo
-      # c5c3-charts releases is intentionally NOT applied here because the upstream
-      # K-ORC chart version is not pinnable from the sandbox (no helm/network);
-      # Renovate coverage will pin it later. Reviewer: please verify.
-      version: ">=0.1.0"
-      sourceRef:
-        kind: HelmRepository
-        name: k-orc
-        namespace: flux-system
-  values:
-    # clouds.yaml admin Application Credential Secret — provided via OpenBao + ESO
-    # (deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml). This is K-ORC's GLOBAL
-    # default mount in orc-system. CC-0110, C1: the c5c3-operator's K-ORC CRs set a
-    # per-resource CloudCredentialsRef, which K-ORC resolves in the CR's OWN
-    # namespace (the control-plane namespace, "openstack"); that ExternalSecret
-    # materialises a co-located copy there. Both copies read the same OpenBao path.
-    globalCloudConfig:
-      secretName: k-orc-clouds-yaml
-  install:
-    crds: CreateReplace
-    createNamespace: true
-    remediation:
-      retries: 3
-  upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+  retryInterval: 2m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: k-orc
+    namespace: flux-system
+  path: ./dist
+  prune: true
+  wait: true

--- a/deploy/flux-system/sources/k-orc.yaml
+++ b/deploy/flux-system/sources/k-orc.yaml
@@ -1,12 +1,35 @@
 # SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Feature: CC-0110, REQ-023 — K-ORC (OpenStack Resource Controller) provides the
+# declarative Keystone resource CRDs (ApplicationCredential, Service, Endpoint,
+# ...) that the c5c3-operator drives.
+#
+# DECISION: GitRepository, not HelmRepository. K-ORC does NOT publish a Helm
+# chart — https://k-orc.github.io/openstack-resource-controller serves no Helm
+# index (404). Upstream ships a single flattened installer manifest as a release
+# asset (releases/download/<tag>/install.yaml), which is byte-identical to the
+# dist/install.yaml committed at the tag. So we pin a GitRepository to the
+# release tag and apply ./dist via a Flux Kustomization (releases/k-orc.yaml).
+#
+# The clone is scoped to /dist via spec.ignore so the source artifact stays small
+# (the full upstream repo carries a website/, examples/, tooling, etc.).
+#
+# Renovate: the pinned tag below is tracked by a customManager rule (see the
+# follow-up tracked in the GitHub issue that finalises the c5c3-operator stack).
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+kind: GitRepository
 metadata:
   name: k-orc
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://k-orc.github.io/openstack-resource-controller
+  url: https://github.com/k-orc/openstack-resource-controller
+  ref:
+    tag: v2.5.0
+  ignore: |
+    # Vendor only the released installer manifest; skip the rest of the repo.
+    /*
+    !/dist

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -20,16 +20,17 @@ credential, mirrors it to OpenBao, and registers the K-ORC `Service` /
 `Endpoint` catalog — all reconciled link-by-link to an aggregate `Ready`.
 
 ::: warning Local-build path — published artifacts are a pending fast-follow
-The published c5c3-operator Helm chart (GHCR OCI) and the upstream K-ORC Helm
-repository are **not yet reachable**, so `make deploy-infra` deliberately
-**suspends** the `c5c3-operator` and `k-orc` Flux releases in kind. This guide
-therefore uses the **local-build** path: it builds and installs the
-c5c3-operator from the in-repo Helm chart and installs K-ORC from its upstream
-release manifest. Once the chart publishes to GHCR, the K-ORC chart repo comes
-online, and the suspend is lifted from `hack/deploy-infra.sh`, the
-`ControlPlane` becomes a Flux happy-path (`kubectl apply -f` the release files,
-exactly like the keystone-operator in the [Quick Start](./quick-start.md)) and
-this manual assembly is no longer needed.
+The published c5c3-operator Helm chart (GHCR OCI) is **not yet reachable**, so
+`make deploy-infra` deliberately **suspends** the `c5c3-operator` and `k-orc`
+Flux objects in kind (the K-ORC source is now a `GitRepository` + `Kustomization`
+over the upstream installer, but it stays suspended until the full chain is wired
+to run on a cluster). This guide therefore uses the **local-build** path: it
+builds and installs the c5c3-operator from the in-repo Helm chart and installs
+K-ORC from its upstream release manifest. Once the chart publishes to GHCR and
+the suspend is lifted from `hack/deploy-infra.sh`, the `ControlPlane` becomes a
+Flux happy-path (`kubectl apply -f` the manifests, exactly like the
+keystone-operator in the [Quick Start](./quick-start.md)) and this manual
+assembly is no longer needed.
 
 The end-to-end ControlPlane chain on kind is wired here by hand; the in-repo
 `tests/e2e/c5c3/full-controlplane-keystone` Chainsaw suite still **skips** when

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -124,7 +124,7 @@ applied via `kubectl apply -f install.yaml`) before this kustomization is applie
 
 ## HelmRepository Sources
 
-Seven HelmRepository CRs define the Helm chart registries that FluxCD pulls from. All
+Six HelmRepository CRs define the Helm chart registries that FluxCD pulls from. All
 use `apiVersion: source.toolkit.fluxcd.io/v1`, are deployed to the `flux-system`
 namespace, and poll at `interval: 1h`.
 
@@ -135,8 +135,14 @@ namespace, and poll at `interval: 1h`.
 | `sources/external-secrets.yaml` | `external-secrets` | `https://charts.external-secrets.io` | HTTPS |
 | `sources/openbao.yaml` | `openbao` | `https://openbao.github.io/openbao-helm` | HTTPS |
 | `sources/c5c3-charts.yaml` | `c5c3-charts` | `oci://ghcr.io/c5c3/charts` | OCI |
-| `sources/k-orc.yaml` | `k-orc` | `https://k-orc.github.io/openstack-resource-controller` | HTTPS |
 | `sources/prometheus-community.yaml` | `prometheus-community` | `oci://ghcr.io/prometheus-community/charts` | OCI |
+
+**K-ORC is sourced from Git, not Helm.** K-ORC publishes no Helm chart (its
+`github.io` page serves no Helm index), so `sources/k-orc.yaml` is a `GitRepository`
+— still `source.toolkit.fluxcd.io/v1`, in `flux-system`, polling at `interval: 1h`
+— pinned to the upstream release tag `v2.5.0` and scoped to `/dist` via `spec.ignore`.
+It is applied by a Flux `Kustomization`, not a HelmRelease; see
+[K-ORC (OpenStack Resource Controller)](#k-orc-openstack-resource-controller).
 
 The `chaos-mesh` HelmRepository ships in the kind-only opt-in overlay at
 `deploy/kind/chaos-mesh/source.yaml` — it is intentionally absent
@@ -151,7 +157,9 @@ use standard HTTPS Helm registries.
 
 ## HelmRelease Operators
 
-Ten HelmRelease CRs deploy the infrastructure operators and CRD charts. All use
+Nine HelmRelease CRs deploy the infrastructure operators and CRD charts (K-ORC is
+applied separately via a Flux `Kustomization` — see
+[K-ORC (OpenStack Resource Controller)](#k-orc-openstack-resource-controller)). All use
 `apiVersion: helm.toolkit.fluxcd.io/v2` and share these common settings:
 
 | Setting | Value | Purpose |
@@ -178,16 +186,21 @@ mariadb-operator-crds     (no dependencies)
 ├── memcached-operator    dependsOn: cert-manager, prometheus-operator-crds
 ├── openbao               dependsOn: cert-manager
 ├── keystone-operator     dependsOn: cert-manager, mariadb-operator, memcached-operator, external-secrets
-├── k-orc                 (no dependsOn — installs the OpenStack resource CRDs the c5c3-operator drives)
-└── c5c3-operator         dependsOn: keystone-operator, external-secrets, mariadb-operator, memcached-operator, k-orc
+└── c5c3-operator         dependsOn: keystone-operator, external-secrets, mariadb-operator, memcached-operator
 ```
+
+K-ORC is **not** in this graph: it is applied by a Flux `Kustomization`, not a
+HelmRelease, and a HelmRelease `dependsOn` can only reference other HelmReleases. The
+c5c3-operator therefore does **not** `dependsOn` K-ORC — the reconciler tolerates the
+K-ORC CRDs being absent (it surfaces `KORCReady=False` / `KORCCRDNotInstalled` rather
+than crash-looping) and converges once they appear.
 
 The `c5c3-operator` HelmRelease sits at the top of this graph: it
 `dependsOn` the four operators whose CRs it projects (keystone-operator,
-external-secrets, mariadb-operator, memcached-operator) plus `k-orc`, whose
-ApplicationCredential / Service / Endpoint CRDs it drives. `k-orc` itself declares no
-`dependsOn` — it only needs its own chart CRDs installed before the c5c3-operator
-reconciles a `ControlPlane`.
+external-secrets, mariadb-operator, memcached-operator). It also drives K-ORC's
+ApplicationCredential / Service / Endpoint CRDs, but K-ORC is applied by the separate
+Flux `Kustomization` above, so it is not a `dependsOn` edge — the c5c3-operator simply
+waits out `KORCCRDNotInstalled` until those CRDs are present.
 
 FluxCD resolves this dependency graph and installs operators in the correct order.
 If cert-manager is not ready, dependent operators are held in a pending state.
@@ -412,30 +425,32 @@ provisioning, memcached-operator for caching, and external-secrets for secret ma
 
 | Property | Value |
 | --- | --- |
-| Target namespace | `orc-system` |
-| Chart | `openstack-resource-controller` |
-| Version constraint | `>=0.1.0` |
-| Source | `k-orc` HelmRepository |
+| Kind | `Kustomization` (`kustomize.toolkit.fluxcd.io/v1`) |
+| Target namespace | `orc-system` (the upstream installer self-namespaces) |
+| Source | `k-orc` `GitRepository` (tag `v2.5.0`) |
+| Path | `./dist` |
 | Dependencies | None |
 
 K-ORC (the OpenStack Resource Controller) installs the declarative Keystone resource
 CRDs — `ApplicationCredential`, `Service`, `Endpoint`, and related kinds — that the
 c5c3-operator drives to project a `ControlPlane`'s desired state into Keystone.
-The HelmRelease `metadata.name` is the short, stable `k-orc` (not
-the chart's own `openstack-resource-controller`) so the c5c3-operator HelmRelease can
-`dependsOn` it by that name. Per repo convention the HelmRelease lives in its target
-namespace (`orc-system`), so no explicit `spec.targetNamespace` is needed.
-`globalCloudConfig` mounts the `orc-system` copy of the `k-orc-clouds-yaml` Secret
-as K-ORC's global default; however K-ORC authenticates **per resource** via each
-CR's `CloudCredentialsRef`, resolved in the CR's own (control-plane) namespace, so
-the credential chain below also materialises a co-located copy there.
-See [Admin Credential Chain](#admin-credential-chain) below.
 
-**Helm values:**
+K-ORC ships no Helm chart, so it is applied as a Flux `Kustomization` over the upstream
+release manifest rather than a HelmRelease. The `GitRepository` source vendors `./dist`
+from the pinned tag `v2.5.0`; `dist/install.yaml` there is byte-identical to the
+published `install.yaml` release asset. The path carries no `kustomization.yaml`, so the
+kustomize-controller generates one over `dist/install.yaml` and applies it verbatim
+(`prune: true`, `wait: true`). The installer already declares the `orc-system`
+Namespace and namespaces every resource into it, so no `spec.targetNamespace` is set.
+The short, stable name `k-orc` (not the upstream `openstack-resource-controller`) keeps
+diagnostics and cross-references terse.
 
-| Key | Value | Purpose |
-| --- | --- | --- |
-| `globalCloudConfig.secretName` | `k-orc-clouds-yaml` | Secret holding the admin `clouds.yaml` Application Credential that K-ORC authenticates to Keystone with |
+The upstream installer has no global-cloud-config knob (the previous HelmRelease set
+`globalCloudConfig.secretName`). That is not on the credential critical path: K-ORC
+authenticates **per resource** via each CR's `CloudCredentialsRef`, resolved in the
+CR's own (control-plane) namespace, so the credential chain below materialises a
+co-located `k-orc-clouds-yaml` copy there. The `orc-system` copy remains for any global
+default K-ORC mounts. See [Admin Credential Chain](#admin-credential-chain) below.
 
 ### c5c3-operator
 
@@ -447,14 +462,16 @@ See [Admin Credential Chain](#admin-credential-chain) below.
 | Chart | `c5c3-operator` |
 | Version constraint | `>=0.1.0 <1.0.0` |
 | Source | `c5c3-charts` HelmRepository (shared OCI registry) |
-| Dependencies | `keystone-operator`, `external-secrets`, `mariadb-operator`, `memcached-operator`, `k-orc` |
+| Dependencies | `keystone-operator`, `external-secrets`, `mariadb-operator`, `memcached-operator` |
 
 The c5c3-operator runs the `ControlPlane` reconciler that orchestrates a Keystone
 control plane end-to-end. It depends on the four operators whose CRs
 it projects — `keystone-operator` for the Keystone instance, `external-secrets` and
-`mariadb-operator` and `memcached-operator` for the supporting platform services — plus
-`k-orc`, whose `ApplicationCredential` / `Service` / `Endpoint` CRDs it drives to
-register the catalog and rotate the admin credential. The operator child CRs are created
+`mariadb-operator` and `memcached-operator` for the supporting platform services. It
+also drives K-ORC's `ApplicationCredential` / `Service` / `Endpoint` CRDs to register
+the catalog and rotate the admin credential, but K-ORC is the separate Flux
+`Kustomization` above, not a `dependsOn` edge (the reconciler tolerates those CRDs being
+absent — `KORCCRDNotInstalled` — until they appear). The operator child CRs are created
 in the `ControlPlane`'s own namespace, not a hard-coded one. For the reconciliation
 contract see the upstream design chapter
 `architecture/docs/09-implementation/08-c5c3-operator.md`.
@@ -482,8 +499,11 @@ Each HelmRelease `sourceRef.name` must match a HelmRepository `metadata.name` in
 | `memcached-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `openbao` | `openbao` | `sources/openbao.yaml` |
 | `keystone-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
-| `k-orc` | `k-orc` | `sources/k-orc.yaml` |
 | `c5c3-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
+
+`k-orc` is not in this table: it is a Flux `Kustomization` whose `sourceRef` is the
+`k-orc` `GitRepository` (`sources/k-orc.yaml`), not a HelmRelease backed by a
+HelmRepository.
 
 The kind-only `chaos-mesh` HelmRelease ships in the opt-in overlay at
 `deploy/kind/chaos-mesh/release.yaml`, with its own local
@@ -662,7 +682,7 @@ materialising the Kubernetes Secret `k-orc-clouds-yaml` from the same OpenBao ke
 | Namespace | Purpose |
 | --- | --- |
 | `openstack` (control-plane) | **C1 co-location** — the c5c3-operator creates the K-ORC `ApplicationCredential`/`Service`/`Endpoint` CRs in the control-plane namespace, and K-ORC resolves each CR's `CloudCredentialsRef` Secret in that *same* namespace, so the admin clouds.yaml must live here for K-ORC to authenticate. This is the copy the `AdminCredentialReady` gate waits on. |
-| `orc-system` | The copy the K-ORC HelmRelease's `globalCloudConfig.secretName` mounts as K-ORC's global default. |
+| `orc-system` | The copy K-ORC mounts as its global default `clouds.yaml` (off the credential critical path — see the [K-ORC section](#k-orc-openstack-resource-controller)). |
 
 Both read the OpenBao key `openstack/keystone/admin/app-credential` (property
 `clouds.yaml`, store-relative to the KV-v2 mount). On a fresh cluster that key is
@@ -708,8 +728,10 @@ These resources do not depend on any custom CRDs.
 | --- | --- | --- |
 | Namespace | 10 | cert-manager, mariadb-system, external-secrets, monitoring, memcached-system, keystone-system, openstack, openbao-system, c5c3-system, orc-system |
 | FluxInstance | 1 | flux (drives the flux-operator) |
-| HelmRepository | 7 | cert-manager, mariadb-operator, external-secrets, openbao, c5c3-charts, k-orc, prometheus-community |
-| HelmRelease | 10 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, openbao, keystone-operator, k-orc, c5c3-operator |
+| HelmRepository | 6 | cert-manager, mariadb-operator, external-secrets, openbao, c5c3-charts, prometheus-community |
+| GitRepository | 1 | k-orc |
+| HelmRelease | 9 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, openbao, keystone-operator, c5c3-operator |
+| Kustomization | 1 | k-orc |
 | **Total** | **28** | |
 
 The `chaos-mesh` HelmRepository, HelmRelease, and Namespace ship in the

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -979,23 +979,25 @@ main() {
     log "Prometheus kind overlay applied (WITH_PROMETHEUS=true; CC-0100, REQ-005)."
   fi
 
-  # CC-0110 fast-follow: the c5c3-operator chart is not yet published to GHCR
-  # (oci://ghcr.io/c5c3/charts/c5c3-operator -> 403) and the k-orc HelmRepository
-  # index 404s, so both releases can never reconcile in the kind bring-up. They
-  # are not awaited (see helm_releases below), but left active they retry on
-  # interval and add reconcile churn that competes with external-secrets and
-  # kube-prometheus-stack for the helm/source controllers under the heavier
-  # WITH_PROMETHEUS deploy. Suspend them (best-effort) so the controllers spend
-  # their budget on the releases deploy-infra actually waits on. Drop this once
-  # the c5c3-operator chart + k-orc source are reachable in CI.
-  log "Suspending unreconcilable CC-0110 releases (c5c3-operator, k-orc) in the kind bring-up."
+  # CC-0110 fast-follow: keep the ControlPlane stack out of the kind bring-up for
+  # now. The c5c3-operator chart is not yet published to GHCR
+  # (oci://ghcr.io/c5c3/charts/c5c3-operator -> 403), so its HelmRelease can never
+  # reconcile here. K-ORC is now a valid GitRepository + Kustomization (no longer a
+  # 404 HelmRepository), but it stays suspended too: exercising the full chain on a
+  # real cluster is a separate follow-up, and an unsuspended K-ORC would clone and
+  # deploy on every bring-up (network + reconcile churn competing with
+  # external-secrets / kube-prometheus-stack for the controllers) for a chain the
+  # absent c5c3-operator cannot complete anyway. None are awaited (see
+  # helm_releases below). Drop these suspends once the c5c3-operator chart is
+  # published and the chain is wired to run instead of skip.
+  log "Suspending the CC-0110 ControlPlane stack (c5c3-operator, k-orc) in the kind bring-up."
   kubectl patch helmrelease c5c3-operator -n c5c3-system \
     --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
-  kubectl patch helmrelease k-orc -n orc-system \
+  kubectl patch kustomization k-orc -n flux-system \
     --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
   kubectl patch helmrepository c5c3-charts -n flux-system \
     --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
-  kubectl patch helmrepository k-orc -n flux-system \
+  kubectl patch gitrepository k-orc -n flux-system \
     --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
 
   # Force-reconcile HelmRepository sources so chart indexes are available


### PR DESCRIPTION
## Summary

The K-ORC GitOps wiring could never reconcile: `sources/k-orc.yaml` pointed a `HelmRepository` at `https://k-orc.github.io/openstack-resource-controller`, which serves **no Helm index (404)** — K-ORC publishes no Helm chart. Upstream ships a single flattened `install.yaml`, and the `dist/install.yaml` committed at each release tag is byte-identical to the published release asset.

This replaces the dead Helm wiring with a Flux `GitRepository` + `Kustomization` that applies the pinned upstream installer.

- **`sources/k-orc.yaml`** — `HelmRepository` → `GitRepository` pinned to tag `v2.5.0`, scoped to `/dist` via `spec.ignore` (keeps the source artifact small).
- **`releases/k-orc.yaml`** — `HelmRelease` → Flux `Kustomization` (`kustomize.toolkit.fluxcd.io/v1`) applying `./dist` (`install.yaml` verbatim, since the path has no `kustomization.yaml`) with `prune: true`, `wait: true`. The installer self-namespaces into `orc-system`, so no `targetNamespace` is set.
- **`releases/c5c3-operator.yaml`** — drop `k-orc` from `dependsOn`: a HelmRelease `dependsOn` can only reference other HelmReleases, and the reconciler already tolerates absent K-ORC CRDs (`KORCReady=False` / `KORCCRDNotInstalled`) instead of crash-looping, so ordering is unnecessary.
- **`hack/deploy-infra.sh`** — retarget the kind suspend patches to the new kinds (`gitrepository` / `kustomization`) and update the rationale comment. K-ORC stays suspended in the kind bring-up; un-suspending and exercising the full chain is a separate follow-up.
- **Docs/comments** — align the ESO comment, `docs/reference/infrastructure/infrastructure-manifests.md` (sources table, HelmRelease count 10→9, GitRepository/Kustomization rows, dependency graph, K-ORC section, cross-reference, resource counts), and the ControlPlane quick-start banner with the Git-sourced installer.

Addresses the first item of #398 (does not close it).

## Test plan

- [x] `kubectl kustomize deploy/flux-system` (28 docs) and `deploy/kind/base` (40 docs) both render
- [x] Rendered output contains the `k-orc` `GitRepository` + `Kustomization`; `c5c3-operator` no longer `dependsOn` k-orc; no `HelmRelease`/`HelmRepository` k-orc references remain in `deploy/`
- [x] Confirmed the K-ORC release manifest: `dist/install.yaml` @ `v2.5.0` is byte-identical (488827 bytes) to the published `install.yaml` release asset and self-declares the `orc-system` Namespace
- [x] Verified on a live `kind-forge-e2e` cluster built from this change: `gitrepository/k-orc` (`ref=v2.5.0`) and `kustomization/k-orc` (`path=./dist`) exist with **no** stale HelmRepository/HelmRelease; both `k-orc-clouds-yaml` ExternalSecrets (`openstack` + `orc-system`) are `SecretSynced=True`
- [x] `docs/` carry no CC/REQ feature IDs (the new `make check-docs-ids` gate)
- [ ] **Not yet exercised end-to-end** — K-ORC remains suspended in the kind bring-up by design, so the GitRepository clone → Kustomization apply → CRDs + controller pods have not been driven on a cluster. That live validation rides with the un-suspend / run-the-chain follow-up in #398.