### PR TITLE
fix(CC-0110): make the c5c3 ControlPlane chain run end-to-end (+ WITH_CONTROLPLANE bring-up)

### DIFF
--- a/deploy/kind/controlplane/controlplane.yaml
+++ b/deploy/kind/controlplane/controlplane.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ControlPlane CR applied by `WITH_CONTROLPLANE=true make deploy-infra` (CC-0110).
+#
+# Managed mode: database/cache reference managed clusters by clusterRef, so the
+# c5c3-operator provisions the MariaDB ("openstack-db") and Memcached
+# ("openstack-memcached") itself — which is why deploy-infra does NOT create them
+# when WITH_CONTROLPLANE=true (hack/deploy-infra.sh). The c5c3-operator then
+# projects a {name}-keystone Keystone CR, mints the K-ORC admin Application
+# Credential from the admin password, mirrors it to OpenBao, and registers the
+# identity catalog.
+#
+# keystone replicas are pinned to 1 to fit the single-node kind cluster; the
+# MariaDB/Memcached topology is operator-derived (not exposed on the ControlPlane
+# spec), so on kind it follows the c5c3-operator defaults.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: controlplane
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  region: RegionOne
+  infrastructure:
+    database:
+      clusterRef:
+        name: openstack-db
+      database: keystone
+      secretRef:
+        name: keystone-db
+    cache:
+      clusterRef:
+        name: openstack-memcached
+      backend: dogpile.cache.pymemcache
+  services:
+    keystone:
+      replicas: 1
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+        secretName: k-orc-clouds-yaml
+      passwordSecretRef:
+        name: keystone-admin
+        key: password
+      applicationCredential:
+        restricted: true
+        rotation:
+          mode: PasswordDriven

--- a/deploy/kind/controlplane/kustomization.yaml
+++ b/deploy/kind/controlplane/kustomization.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Kustomize overlay for the kind-only, opt-in c5c3 ControlPlane bring-up.
+# Applied by `WITH_CONTROLPLANE=true make deploy-infra` after the operator stack
+# (keystone-operator, K-ORC, c5c3-operator) is up. The ControlPlane CR then
+# provisions the shared MariaDB/Memcached (which deploy-infra deliberately does
+# NOT create in this mode) and drives the full chain. Feature: CC-0110.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - controlplane.yaml

--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -100,6 +100,12 @@ main() {
       # eso-management stays read-only; write capability lives only in the
       # narrowly-scoped push-keystone-admin policy.
       token_policies+=",push-keystone-admin"
+      # CC-0110 (REQ-011): the c5c3-operator mirrors the minted admin Application
+      # Credential clouds.yaml to OpenBao via a PushSecret through the
+      # openbao-cluster-store (which binds this management role). Without the
+      # push-app-credentials policy that PushSecret 403s on the app-credential
+      # path and K-ORC silently falls back to the bootstrap admin password.
+      token_policies+=",push-app-credentials"
     fi
 
     log "Writing ESO role for cluster '${cluster}'..."

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -130,18 +130,21 @@ mark_eso_managed() {
 seed_korc_bootstrap_clouds_yaml() {
   local kv_path="kv-v2/openstack/keystone/admin/app-credential"
   local admin_path="kv-v2/bootstrap/keystone-admin"
+  # DECISION (CC-0110, REQ-024): auth_url MUST match the Keystone API Service the
+  # keystone-operator exposes. For the per-service Quick Start that Service is
+  # "keystone" (the default below). The c5c3 ControlPlane instead projects
+  # "{controlplane}-keystone" (keystoneName() / keystoneEndpointURL() in
+  # reconcile_korc.go), so callers that bring up a ControlPlane
+  # (WITH_CONTROLPLANE=true make deploy-infra) override KORC_KEYSTONE_AUTH_URL to
+  # that Service DNS. K-ORC uses this auth_url for the very first mint, so it has
+  # to be correct before the c5c3-operator runs.
+  local auth_url="${KORC_KEYSTONE_AUTH_URL:-http://keystone.openstack.svc:5000/v3}"
 
-  log "Seeding K-ORC bootstrap clouds.yaml at '${kv_path}' (if missing)..."
-  # DECISION (CC-0110, REQ-024): auth_url uses the in-cluster Keystone identity
-  # Service DNS the c5c3-operator also derives (keystoneEndpointURL:
-  # http://keystone.<ns>.svc:5000/v3, control-plane namespace "openstack"). It
-  # MUST match the Keystone API Service the keystone-operator exposes; this is the
-  # same convention as reconcile_korc.go's keystoneEndpointURL. Reviewer: please
-  # verify the Service DNS on a live cluster.
+  log "Seeding K-ORC bootstrap clouds.yaml at '${kv_path}' (auth_url=${auth_url}, if missing)..."
   # shellcheck disable=SC2016  # $vars are intentionally expanded IN-POD, not by the host shell.
   kubectl exec -n "$NAMESPACE" openbao-0 -- \
     env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" \
-    BAO_KV_PATH="${kv_path}" BAO_ADMIN_PATH="${admin_path}" \
+    BAO_KV_PATH="${kv_path}" BAO_ADMIN_PATH="${admin_path}" KORC_AUTH_URL="${auth_url}" \
     sh -c '
       set -eu
       if bao kv get "${BAO_KV_PATH}" >/dev/null 2>&1; then
@@ -152,7 +155,7 @@ seed_korc_bootstrap_clouds_yaml() {
       clouds="clouds:
   admin:
     auth:
-      auth_url: http://keystone.openstack.svc:5000/v3
+      auth_url: ${KORC_AUTH_URL}
       username: admin
       password: ${admin_pw}
       project_name: admin

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -13,45 +13,37 @@ admin application credential and to register the identity service catalog.
 
 Where the [Quick Start](./quick-start.md) and
 [Quick Start (Extended)](./quick-start-extended.md) stop at a hand-applied
-`Keystone` CR (the per-service operator), this page goes one level up: you apply
-a single `ControlPlane` CR and the c5c3-operator projects the `MariaDB`,
-`Memcached`, and `Keystone` children, mints the K-ORC admin application
-credential, mirrors it to OpenBao, and registers the K-ORC `Service` /
-`Endpoint` catalog — all reconciled link-by-link to an aggregate `Ready`.
+`Keystone` CR (the per-service operator), this page goes one level up: a single
+`ControlPlane` CR makes the c5c3-operator provision the `MariaDB`, `Memcached`,
+and `Keystone` children, mint the K-ORC admin application credential, mirror it to
+OpenBao, and register the K-ORC `Service` / `Endpoint` catalog — all reconciled
+link-by-link to an aggregate `Ready`.
 
-::: warning Local-build path — published artifacts are a pending fast-follow
-The published c5c3-operator Helm chart (GHCR OCI) is **not yet reachable**, so
-`make deploy-infra` deliberately **suspends** the `c5c3-operator` and `k-orc`
-Flux objects in kind (the K-ORC source is now a `GitRepository` + `Kustomization`
-over the upstream installer, but it stays suspended until the full chain is wired
-to run on a cluster). This guide therefore uses the **local-build** path: it
-builds and installs the c5c3-operator from the in-repo Helm chart and installs
-K-ORC from its upstream release manifest. Once the chart publishes to GHCR and
-the suspend is lifted from `hack/deploy-infra.sh`, the `ControlPlane` becomes a
-Flux happy-path (`kubectl apply -f` the manifests, exactly like the
-keystone-operator in the [Quick Start](./quick-start.md)) and this manual
-assembly is no longer needed.
-
-The end-to-end ControlPlane chain on kind is wired here by hand; the in-repo
-`tests/e2e/c5c3/full-controlplane-keystone` Chainsaw suite still **skips** when
-this stack is absent from the default kind bring-up. Treat this walkthrough as
-the manual recipe for that deferred wiring, not a CI-gated happy-path.
+::: tip One opt-in flag brings up the whole stack
+`WITH_CONTROLPLANE=true make deploy-infra` deploys the full ControlPlane stack
+(keystone-operator, K-ORC, c5c3-operator) from the **published** charts plus the
+pinned K-ORC installer, and applies a `ControlPlane` CR for you. In this mode
+deploy-infra does **not** create the shared MariaDB/Memcached — the ControlPlane
+provisions them itself (managed mode), as designed. The plain `make deploy-infra`
+(without the flag) leaves the ControlPlane stack suspended so the per-service
+Keystone Quick Start path stays light.
 :::
 
 ## Prerequisites
 
-Same toolchain as the [Quick Start](./quick-start.md), plus a working internet
-connection for the upstream K-ORC release manifest:
+Same toolchain as the [Quick Start](./quick-start.md), and an internet connection
+(the K-ORC source is cloned from GitHub at a pinned tag):
 
-- Docker Desktop running
+- Docker Desktop running, with enough resources for the full stack — the
+  ControlPlane provisions its own MariaDB with the operator's default
+  (production-shaped, Galera) topology, which is heavier than the single-replica
+  database the per-service Quick Start patches in. Give Docker ample CPU/memory.
 - Pinned `kind`, `kubectl`, `Helm`, `jq`, `yq` on `PATH`:
 
   ```bash
   make install-test-deps
   export PATH="${HOME}/.local/bin:${PATH}"
   ```
-
-`yq` is required because this guide overrides `KIND_HOST_PORT`.
 
 ## Step 1 — Clone
 
@@ -60,189 +52,40 @@ git clone https://github.com/c5c3/forge.git
 cd forge
 ```
 
-## Step 2 — Cluster + infrastructure stack
+## Step 2 — Cluster + ControlPlane stack
 
 ```bash
-KIND_HOST_PORT=8443 make deploy-infra
+WITH_CONTROLPLANE=true make deploy-infra
 ```
 
-This creates the `forge-e2e` kind cluster and the full shared stack the
-ControlPlane depends on: cert-manager, OpenBao (initialised, unsealed, and
-bootstrapped), the MariaDB and Memcached operators, External Secrets, and Envoy
-Gateway. Expect **5–10 minutes** on first run.
+This creates the `forge-e2e` kind cluster, the shared infrastructure
+(cert-manager, OpenBao initialised/unsealed/bootstrapped, the MariaDB and
+Memcached operators, External Secrets, Envoy Gateway), and then — because
+`WITH_CONTROLPLANE=true` — the ControlPlane stack on top:
 
-Beyond the stack the compact Quick Start uses, this step also prepares the
-ControlPlane-specific pieces:
+- deploys **keystone-operator**, **K-ORC** (a Flux `GitRepository` +
+  `Kustomization` over the pinned `v2.5.0` installer), and **c5c3-operator** from
+  the published charts — nothing is built locally;
+- does **not** create the `openstack-db` MariaDB / `openstack-memcached` Memcached
+  CRs — the ControlPlane provisions them;
+- seeds a password-based admin `clouds.yaml` in OpenBao and materialises
+  `k-orc-clouds-yaml` via ESO into `openstack` (where the projected K-ORC CRs
+  resolve it) and `orc-system`;
+- applies a `ControlPlane` CR (`deploy/kind/controlplane`) that drives the chain.
 
-- the `c5c3-system` and `orc-system` namespaces are created;
-- the OpenBao bootstrap **seeds a password-based `clouds.yaml`** at the path
-  `openstack/keystone/admin/app-credential` so the admin credential exists
-  before the operator mints the application credential;
-- the `k-orc-clouds-yaml` ExternalSecret is applied into **both** `openstack`
-  (where the projected K-ORC CRs resolve it) and `orc-system` (K-ORC's global
-  default mount);
-- the `c5c3-operator` and `k-orc` Flux releases are left **suspended** — you
-  install both yourself in Steps 4 and 5.
+Expect **5–10 minutes** for the infrastructure; the ControlPlane chain then
+reconciles in the background (Step 3).
 
-::: tip The seed avoids a chicken-and-egg deadlock
+::: tip The OpenBao seed avoids a chicken-and-egg deadlock
 K-ORC needs a `clouds.yaml` to authenticate, but the application credential it
 should use does not exist until the c5c3-operator mints it through K-ORC. The
 bootstrap seeds a *password-based* `clouds.yaml` so the first reconcile can
 authenticate; once the operator mints the application credential, its PushSecret
-overwrites the OpenBao path with the credential-based `clouds.yaml`, and ESO
+overwrites the OpenBao path with the credential-based `clouds.yaml` and ESO
 re-materialises it.
 :::
 
-## Step 3 — Keystone operator + service image
-
-The ControlPlane projects a `Keystone` CR, so the keystone-operator must be
-running and the Keystone service image must be loadable in the cluster.
-
-Re-apply the keystone-operator release file directly (this clears the kind
-`suspend` patch, so Flux installs the published chart and reconciles it):
-
-```bash
-kubectl apply -f deploy/flux-system/sources/c5c3-charts.yaml
-kubectl apply -f deploy/flux-system/releases/keystone-operator.yaml
-kubectl wait helmrelease/keystone-operator -n keystone-system \
-  --for=condition=Ready --timeout=120s
-```
-
-Load the Keystone service image the projected CR references
-(`ghcr.io/c5c3/keystone:<release>`):
-
-```bash
-RELEASE=2025.2
-docker pull ghcr.io/c5c3/keystone:${RELEASE}
-kind load docker-image ghcr.io/c5c3/keystone:${RELEASE} --name forge-e2e
-```
-
-## Step 4 — Install K-ORC
-
-K-ORC is installed from its upstream release manifest into the `orc-system`
-namespace (its default). The manifest ships the K-ORC CRDs
-(`applicationcredentials`, `services`, `endpoints`, … in the
-`openstack.k-orc.cloud` group) and the controller-manager:
-
-```bash
-# Latest release; pin a tag (…/download/v2.5.0/install.yaml) for reproducibility.
-kubectl apply --server-side \
-  -f https://github.com/k-orc/openstack-resource-controller/releases/latest/download/install.yaml
-
-kubectl wait --for=condition=Available deployment --all \
-  -n orc-system --timeout=120s
-```
-
-Confirm the CRDs the c5c3-operator drives are registered:
-
-```bash
-kubectl get crd applicationcredentials.openstack.k-orc.cloud \
-  services.openstack.k-orc.cloud endpoints.openstack.k-orc.cloud
-```
-
-::: tip K-ORC credential resolution
-Each K-ORC CR the c5c3-operator projects carries its own
-`cloudCredentialsRef`, which K-ORC resolves in the **CR's own namespace**
-(`openstack`) — that is the `k-orc-clouds-yaml` Secret materialised in Step 2.
-The copy in `orc-system` only backs K-ORC's global default mount and is not on
-the ControlPlane's critical path.
-:::
-
-## Step 5 — Build and install the c5c3-operator
-
-The published chart is not on GHCR yet, so build the operator image, load it
-into kind, and install the in-repo chart. The chart's validating/defaulting
-webhook is issued a certificate by cert-manager (installed in Step 2):
-
-```bash
-# 1. Build the operator image
-make docker-build OPERATOR=c5c3 IMG=ghcr.io/c5c3/c5c3-operator:dev
-
-# 2. Load it into the kind cluster (no registry needed)
-kind load docker-image ghcr.io/c5c3/c5c3-operator:dev --name forge-e2e
-
-# 3. Pre-install the CRDs so the API server watch cache is ready
-kubectl apply -f operators/c5c3/helm/c5c3-operator/crds/
-kubectl wait crd controlplanes.c5c3.io \
-  --for condition=Established --timeout=60s
-
-# 4. Install the chart into c5c3-system
-helm install c5c3-operator \
-  operators/c5c3/helm/c5c3-operator/ \
-  -n c5c3-system --create-namespace \
-  --set image.repository=ghcr.io/c5c3/c5c3-operator \
-  --set image.tag=dev \
-  --set image.pullPolicy=Never \
-  --wait --timeout 120s
-```
-
-Verify the operator is running:
-
-```bash
-kubectl get pods -n c5c3-system -l app.kubernetes.io/name=c5c3-operator
-```
-
-## Step 6 — Apply the ControlPlane CR
-
-This single CR drives the whole chain. It runs in **managed mode**: the
-`clusterRef` names match the clusters the deploy stack provisions, so the
-operator projects an owned `MariaDB` (`openstack-db`) and `Memcached`
-(`openstack-memcached`) in the `openstack` namespace, then a `{name}-keystone`
-Keystone CR, then the K-ORC admin application credential and the identity
-catalog.
-
-```yaml
-# controlplane.yaml
-apiVersion: c5c3.io/v1alpha1
-kind: ControlPlane
-metadata:
-  name: controlplane
-  namespace: openstack
-spec:
-  openStackRelease: "2025.2"
-  region: RegionOne
-  infrastructure:
-    database:
-      clusterRef:
-        name: openstack-db
-      database: keystone
-      secretRef:
-        name: keystone-db
-    cache:
-      clusterRef:
-        name: openstack-memcached
-      backend: dogpile.cache.pymemcache
-  services:
-    keystone:
-      replicas: 3
-  korc:
-    adminCredential:
-      cloudCredentialsRef:
-        cloudName: admin
-        secretName: k-orc-clouds-yaml
-      passwordSecretRef:
-        name: keystone-admin
-        key: password
-      applicationCredential:
-        restricted: true
-        rotation:
-          mode: PasswordDriven
-```
-
-```bash
-kubectl apply -f controlplane.yaml
-```
-
-::: tip No `gateway` block here
-The ControlPlane exposes a **curated subset** of the Keystone knobs and does not
-surface a `gateway` field, so the projected Keystone CR has no Gateway
-attachment and is reachable in-cluster only. Verification below therefore uses
-`kubectl port-forward` rather than the `nip.io` Gateway endpoint. If you also
-want external access, apply a separate `Keystone`-level Gateway route or use the
-per-service [Quick Start](./quick-start.md).
-:::
-
-## Step 7 — Watch the chain reconcile
+## Step 3 — Watch the chain reconcile
 
 The aggregate `Ready` becomes `True` only after all five sub-conditions are
 `True`, gated in dependency order:
@@ -254,7 +97,7 @@ InfrastructureReady → KeystoneReady → KORCReady → AdminCredentialReady →
 Watch the ControlPlane and its sub-conditions:
 
 ```bash
-kubectl get controlplane -n openstack -w
+kubectl get controlplane controlplane -n openstack -w
 kubectl get controlplane controlplane -n openstack \
   -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}){"\n"}{end}'
 ```
@@ -262,7 +105,7 @@ kubectl get controlplane controlplane -n openstack \
 Inspect the projected children:
 
 ```bash
-# Infrastructure + Keystone projected by the ControlPlane
+# Infrastructure + Keystone provisioned by the ControlPlane
 kubectl get mariadb,memcached,keystone -n openstack
 
 # K-ORC resources the operator drives (group openstack.k-orc.cloud)
@@ -270,23 +113,22 @@ kubectl get applicationcredentials,services,endpoints.openstack.k-orc.cloud -n o
 ```
 
 If `AdminCredentialReady` lingers on `WaitingForCloudsYaml`, force the
-`k-orc-clouds-yaml` ExternalSecret to sync (Step 2 does not wait on it
-explicitly, so it may otherwise refresh only on its hourly interval):
+`k-orc-clouds-yaml` ExternalSecret to sync (it is not in the deploy-infra wait
+list, so it may otherwise refresh only on its hourly interval):
 
 ```bash
 kubectl annotate externalsecret/k-orc-clouds-yaml -n openstack \
   force-sync="$(date +%s)" --overwrite
-kubectl get externalsecret k-orc-clouds-yaml -n openstack
 ```
 
 Then wait for the aggregate condition:
 
 ```bash
 kubectl wait controlplane/controlplane -n openstack \
-  --for=condition=Ready --timeout=10m
+  --for=condition=Ready --timeout=15m
 ```
 
-## Step 8 — Verify
+## Step 4 — Verify
 
 **The minted application credential** — the operator mints one restricted admin
 application credential through K-ORC and records its ID on the ControlPlane
@@ -303,7 +145,7 @@ re-materialised; a `SecretSynced` ExternalSecret confirms the loop closed:
 
 ```bash
 kubectl get externalsecret k-orc-clouds-yaml -n openstack \
-  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
 ```
 
 **The identity catalog** — the catalog sub-reconciler registers the Keystone
@@ -315,8 +157,9 @@ kubectl get controlplane controlplane -n openstack \
   -o jsonpath='{.status.catalogReady}{"\n"}'
 ```
 
-**An authenticated token** — port-forward the projected Keystone Service and
-issue a token with the admin password:
+**An authenticated token** — the ControlPlane exposes a curated Keystone subset
+with no `gateway` field, so the projected Keystone is reachable in-cluster only.
+Port-forward its Service and issue a token with the admin password:
 
 ```bash
 # In a separate terminal:
@@ -333,8 +176,15 @@ openstack token issue
 ```
 
 > The projected Keystone Service is named `{controlplane-name}-keystone` —
-> `controlplane-keystone` for the CR above. Confirm with
+> `controlplane-keystone` for the CR applied by deploy-infra. Confirm with
 > `kubectl get svc -n openstack`.
+
+## Customising the ControlPlane
+
+`WITH_CONTROLPLANE=true` applies the CR at `deploy/kind/controlplane/controlplane.yaml`.
+To drive your own, edit that manifest (or apply a different `ControlPlane` CR after
+the bring-up) — see the [ControlPlane CRD API Reference](./reference/c5c3/controlplane-crd.md)
+for every `spec.*` field.
 
 ## Teardown
 

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -512,6 +512,16 @@ preflight_checks() {
     fi
   done
 
+  # yq is a hard dependency only on the WITH_CONTROLPLANE path: Step 5 pipes the
+  # rendered infrastructure overlay through `yq eval` to drop the MariaDB/Memcached
+  # CRs (the ControlPlane provisions those in managed mode). Check it up front so
+  # the run fails here instead of deep in Step 5 after a kind cluster already
+  # exists. The default Quick Start stays yq-free (CC-0110).
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]] && ! command -v yq &>/dev/null; then
+    log "ERROR: WITH_CONTROLPLANE=true requires 'yq' on PATH (used to drop MariaDB/Memcached from the infrastructure overlay)."
+    exit 1
+  fi
+
   # Check that Docker is running.
   if ! docker info &>/dev/null; then
     log "ERROR: Docker is not running. Please start Docker and try again."

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -74,6 +74,14 @@ WITH_CHAOS_MESH="${WITH_CHAOS_MESH:-false}"
 # WITH_PROMETHEUS=true to install the monitoring stack (CC-0100, REQ-005).
 WITH_PROMETHEUS="${WITH_PROMETHEUS:-false}"
 
+# Gates the opt-in c5c3 ControlPlane bring-up (CC-0110). When true, deploy-infra
+# does NOT create the shared MariaDB/Memcached CRs — the c5c3 ControlPlane
+# provisions them in managed mode — and the c5c3-operator, K-ORC, and
+# keystone-operator are deployed (not suspended) so an applied ControlPlane CR
+# (deploy/kind/controlplane) reconciles the full chain end-to-end. Defaults to
+# false so the default Quick Start and the keystone E2E path are unchanged.
+WITH_CONTROLPLANE="${WITH_CONTROLPLANE:-false}"
+
 # Gateway API CRD release installed before the keystone-operator HelmRelease so
 # the operator's HTTPRoute watch has a registered kind at startup (CC-0065).
 # Keep aligned with sigs.k8s.io/gateway-api in operators/keystone/go.mod.
@@ -852,6 +860,7 @@ main() {
   log "Kind host port      : ${KIND_HOST_PORT} → 31443 (override via KIND_HOST_PORT)"
   log "Chaos Mesh         : ${WITH_CHAOS_MESH} (set WITH_CHAOS_MESH=true to install)"
   log "Prometheus stack    : ${WITH_PROMETHEUS} (set WITH_PROMETHEUS=true to install)"
+  log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
   log ""
 
   # Pre-flight checks
@@ -979,26 +988,35 @@ main() {
     log "Prometheus kind overlay applied (WITH_PROMETHEUS=true; CC-0100, REQ-005)."
   fi
 
-  # CC-0110 fast-follow: keep the ControlPlane stack out of the kind bring-up for
-  # now. The c5c3-operator chart is not yet published to GHCR
-  # (oci://ghcr.io/c5c3/charts/c5c3-operator -> 403), so its HelmRelease can never
-  # reconcile here. K-ORC is now a valid GitRepository + Kustomization (no longer a
-  # 404 HelmRepository), but it stays suspended too: exercising the full chain on a
-  # real cluster is a separate follow-up, and an unsuspended K-ORC would clone and
-  # deploy on every bring-up (network + reconcile churn competing with
-  # external-secrets / kube-prometheus-stack for the controllers) for a chain the
-  # absent c5c3-operator cannot complete anyway. None are awaited (see
-  # helm_releases below). Drop these suspends once the c5c3-operator chart is
-  # published and the chain is wired to run instead of skip.
-  log "Suspending the CC-0110 ControlPlane stack (c5c3-operator, k-orc) in the kind bring-up."
-  kubectl patch helmrelease c5c3-operator -n c5c3-system \
-    --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
-  kubectl patch kustomization k-orc -n flux-system \
-    --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
-  kubectl patch helmrepository c5c3-charts -n flux-system \
-    --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
-  kubectl patch gitrepository k-orc -n flux-system \
-    --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+  # CC-0110: the c5c3 ControlPlane stack (c5c3-operator + image and the K-ORC
+  # GitRepository/Kustomization) is published and valid, so it would reconcile —
+  # but running the full chain is opt-in. WITH_CONTROLPLANE=true deploys it; the
+  # default leaves it suspended so the bring-up stays light and the keystone E2E
+  # path is unchanged.
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    # Deploy the full ControlPlane stack via Flux from the published c5c3-operator
+    # chart and the K-ORC GitRepository/Kustomization. The kind base overlay
+    # suspends keystone-operator for the local-build E2E path; un-suspend it here
+    # so the c5c3-operator HelmRelease's dependsOn is satisfied and the projected
+    # Keystone CR can reconcile. c5c3-operator, k-orc, and the c5c3-charts /
+    # k-orc sources are left un-suspended (the base applied them active).
+    log "WITH_CONTROLPLANE=true: deploying the c5c3 ControlPlane stack (keystone-operator, k-orc, c5c3-operator)."
+    kubectl patch helmrelease keystone-operator -n keystone-system \
+      --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
+  else
+    # Suspend the stack (best-effort, not awaited — see helm_releases below) so it
+    # does not add idle reconcile churn competing with external-secrets /
+    # kube-prometheus-stack for the controllers.
+    log "Suspending the CC-0110 ControlPlane stack (c5c3-operator, k-orc); set WITH_CONTROLPLANE=true to deploy it."
+    kubectl patch helmrelease c5c3-operator -n c5c3-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch kustomization k-orc -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch helmrepository c5c3-charts -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch gitrepository k-orc -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+  fi
 
   # Force-reconcile HelmRepository sources so chart indexes are available
   # before HelmReleases attempt to resolve charts. Without this, the
@@ -1091,8 +1109,19 @@ main() {
   # Invalidate kubectl's client-side discovery cache so that the newly
   # registered CRDs are visible to kubectl apply.
   kubectl api-resources > /dev/null 2>&1 || true
-  kubectl apply -k "${REPO_ROOT}/deploy/kind/infrastructure"
-  log "Infrastructure kustomize overlay applied."
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    # The c5c3 ControlPlane provisions MariaDB/Memcached itself (managed mode), so
+    # render the infrastructure overlay and drop those two CRs before applying —
+    # everything else (TLS issuers, OpenBao certs, ESO ExternalSecrets, Gateway
+    # certs) is still required.
+    kubectl kustomize "${REPO_ROOT}/deploy/kind/infrastructure" \
+      | yq eval 'select(.kind != "MariaDB" and .kind != "Memcached")' - \
+      | kubectl apply -f -
+    log "Infrastructure overlay applied WITHOUT MariaDB/Memcached (WITH_CONTROLPLANE=true; the ControlPlane provisions them)."
+  else
+    kubectl apply -k "${REPO_ROOT}/deploy/kind/infrastructure"
+    log "Infrastructure kustomize overlay applied."
+  fi
 
   # Gateway/openstack-gw can only report Programmed=True after the
   # EnvoyProxy CR (applied via the infrastructure overlay above) binds
@@ -1140,20 +1169,59 @@ main() {
   wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
     keystone-admin keystone-db mariadb-root-password
 
-  # Trigger MariaDB operator re-reconciliation.
-  # The MariaDB CR was applied in Step 5 before the root password Secret
-  # existed (it is created by ExternalSecrets in this step). The operator
-  # may have stopped retrying; patching an annotation forces a new
-  # reconciliation now that the Secret is available.
-  log "Triggering MariaDB CR re-reconciliation..."
-  kubectl patch mariadb openstack-db -n openstack --type merge \
-    -p "{\"metadata\":{\"annotations\":{\"deploy.c5c3.io/reconcile-trigger\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}}"
+  if [[ "${WITH_CONTROLPLANE}" != "true" ]]; then
+    # Trigger MariaDB operator re-reconciliation.
+    # The MariaDB CR was applied in Step 5 before the root password Secret
+    # existed (it is created by ExternalSecrets in this step). The operator
+    # may have stopped retrying; patching an annotation forces a new
+    # reconciliation now that the Secret is available.
+    log "Triggering MariaDB CR re-reconciliation..."
+    kubectl patch mariadb openstack-db -n openstack --type merge \
+      -p "{\"metadata\":{\"annotations\":{\"deploy.c5c3.io/reconcile-trigger\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}}"
 
-  # Wait for MariaDB to become Ready before declaring deployment complete.
-  log "Waiting for MariaDB CR to become Ready..."
-  kubectl wait mariadb/openstack-db -n openstack \
-    --for=condition=Ready --timeout="${POD_TIMEOUT}s"
-  log "MariaDB CR is Ready."
+    # Wait for MariaDB to become Ready before declaring deployment complete.
+    log "Waiting for MariaDB CR to become Ready..."
+    kubectl wait mariadb/openstack-db -n openstack \
+      --for=condition=Ready --timeout="${POD_TIMEOUT}s"
+    log "MariaDB CR is Ready."
+  else
+    # WITH_CONTROLPLANE: the shared MariaDB/Memcached are NOT created here — the
+    # ControlPlane provisions them. Wait (best-effort) for the operator stack, then
+    # apply the ControlPlane CR; the chain reconciles in the background.
+    log "=== WITH_CONTROLPLANE: bringing up the c5c3 ControlPlane ==="
+    kubectl wait helmrelease/keystone-operator -n keystone-system \
+      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+      || log "  keystone-operator not Ready yet (continuing; the ControlPlane tolerates it)."
+    kubectl wait kustomization/k-orc -n flux-system \
+      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+      || log "  k-orc Kustomization not Ready yet (continuing)."
+    kubectl wait helmrelease/c5c3-operator -n c5c3-system \
+      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+      || log "  c5c3-operator not Ready yet (continuing)."
+
+    # The projected Keystone references ghcr.io/c5c3/keystone:<release>; preload it
+    # so kind need not pull it in-cluster. Best-effort — the image is public on GHCR.
+    local cp_release="2025.2"
+    if docker pull "ghcr.io/c5c3/keystone:${cp_release}" >/dev/null 2>&1; then
+      kind load docker-image "ghcr.io/c5c3/keystone:${cp_release}" --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+      log "  Preloaded ghcr.io/c5c3/keystone:${cp_release} into kind."
+    fi
+
+    # Apply the ControlPlane CR. Retry briefly: the c5c3-operator validating webhook
+    # may need a moment after the chart install before it accepts the CR.
+    local cp_attempt
+    for cp_attempt in 1 2 3 4 5; do
+      if kubectl apply -k "${REPO_ROOT}/deploy/kind/controlplane" 2>/dev/null; then
+        break
+      fi
+      log "  ControlPlane CR apply attempt ${cp_attempt} failed (webhook warming up?); retrying..."
+      sleep 10
+    done
+    log "  ControlPlane CR applied. Watch the chain with:"
+    log "    kubectl get controlplane -n openstack -w"
+    log "  It provisions MariaDB/Memcached, projects Keystone, mints the K-ORC admin"
+    log "  credential, and registers the identity catalog (not awaited here)."
+  fi
 
   log ""
   log "=========================================="

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -1138,6 +1138,14 @@ main() {
 
   # Step 7: OpenBao bootstrap (init, unseal, configure)
   log "=== Step 7/8: OpenBao bootstrap ==="
+  # WITH_CONTROLPLANE: the bootstrap seeds the K-ORC admin clouds.yaml, whose
+  # auth_url must point at the Keystone Service the ControlPlane projects. The
+  # deploy/kind/controlplane CR is named "controlplane", so its Keystone Service is
+  # "controlplane-keystone" (keystoneName = "{controlplane}-keystone"). Override the
+  # seed default ("keystone.openstack.svc") so K-ORC can authenticate the first mint.
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    export KORC_KEYSTONE_AUTH_URL="http://controlplane-keystone.openstack.svc:5000/v3"
+  fi
   openbao_init_unseal
   openbao_bootstrap
 

--- a/internal/common/testutil/envtest/integration_test.go
+++ b/internal/common/testutil/envtest/integration_test.go
@@ -45,10 +45,13 @@ func allExpectedCRDs() []expectedCRD {
 		{name: "externalsecrets.external-secrets.io", group: "external-secrets.io", version: "v1", kind: "ExternalSecret", namespaced: true},
 		// K-ORC fake CRDs (CC-0110): the c5c3 ControlPlane reconciler mints/owns
 		// these openstack.k-orc.cloud kinds; they are faked here to keep envtest
-		// forgiving (the real CRDs carry strict CEL rules).
+		// forgiving (the real CRDs carry strict CEL rules). Domain and User are
+		// imported as UNMANAGED resources to anchor the admin ApplicationCredential.
 		{name: "applicationcredentials.openstack.k-orc.cloud", group: "openstack.k-orc.cloud", version: "v1alpha1", kind: "ApplicationCredential", namespaced: true},
+		{name: "domains.openstack.k-orc.cloud", group: "openstack.k-orc.cloud", version: "v1alpha1", kind: "Domain", namespaced: true},
 		{name: "endpoints.openstack.k-orc.cloud", group: "openstack.k-orc.cloud", version: "v1alpha1", kind: "Endpoint", namespaced: true},
 		{name: "services.openstack.k-orc.cloud", group: "openstack.k-orc.cloud", version: "v1alpha1", kind: "Service", namespaced: true},
+		{name: "users.openstack.k-orc.cloud", group: "openstack.k-orc.cloud", version: "v1alpha1", kind: "User", namespaced: true},
 		{name: "grants.k8s.mariadb.com", group: "k8s.mariadb.com", version: "v1alpha1", kind: "Grant", namespaced: true},
 		{name: "mariadbs.k8s.mariadb.com", group: "k8s.mariadb.com", version: "v1alpha1", kind: "MariaDB", namespaced: true},
 		{name: "memcacheds.memcached.c5c3.io", group: "memcached.c5c3.io", version: "v1beta1", kind: "Memcached", namespaced: true},

--- a/internal/common/testutil/fake_crds/k-orc/domains.yaml
+++ b/internal/common/testutil/fake_crds/k-orc/domains.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal fake CRD for the K-ORC (OpenStack Resource Controller) Domain
+# resource (group openstack.k-orc.cloud). Used by envtest only — NOT a
+# production-grade schema. See applicationcredentials.yaml for the rationale.
+# The c5c3 reconciler imports the admin Domain as an UNMANAGED resource before
+# minting the admin ApplicationCredential (ensureKORCAdminImports), so envtest
+# must serve this kind or the K-ORC reconcile aborts with a no-match error.
+# Feature: CC-0110
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: domains.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    plural: domains
+    singular: domain
+    kind: Domain
+    listKind: DomainList
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                id:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                resource:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/internal/common/testutil/fake_crds/k-orc/users.yaml
+++ b/internal/common/testutil/fake_crds/k-orc/users.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal fake CRD for the K-ORC (OpenStack Resource Controller) User
+# resource (group openstack.k-orc.cloud). Used by envtest only — NOT a
+# production-grade schema. See applicationcredentials.yaml for the rationale.
+# The c5c3 reconciler imports the admin User as an UNMANAGED resource (scoped to
+# the imported admin Domain) before minting the admin ApplicationCredential
+# (ensureKORCAdminImports), so envtest must serve this kind or the K-ORC
+# reconcile aborts with a no-match error.
+# Feature: CC-0110
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: users.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    plural: users
+    singular: user
+    kind: User
+    listKind: UserList
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                id:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                resource:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/operators/c5c3/helm/c5c3-operator/templates/_helpers.tpl
+++ b/operators/c5c3/helm/c5c3-operator/templates/_helpers.tpl
@@ -172,14 +172,18 @@ coordination.k8s.io/leases rule required for leader election.
     - update
     - patch
     - delete
-# openstack.k-orc.cloud - applicationcredentials, services, endpoints (CC-0110)
-# Minted and Owned by reconcileKORC and reconcileCatalog.
+# openstack.k-orc.cloud - applicationcredentials, services, endpoints, users,
+# domains (CC-0110). Minted/owned by reconcileKORC and reconcileCatalog; users +
+# domains are imported (unmanaged) so the admin ApplicationCredential's UserRef
+# resolves (ensureKORCAdminImports).
 - apiGroups:
     - openstack.k-orc.cloud
   resources:
     - applicationcredentials
     - services
     - endpoints
+    - users
+    - domains
   verbs:
     - get
     - list

--- a/operators/c5c3/helm/c5c3-operator/tests/clusterrole_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/clusterrole_test.yaml
@@ -156,7 +156,7 @@ tests:
               - patch
               - delete
 
-  - it: should grant full CRUD on k-orc applicationcredentials, services, endpoints
+  - it: should grant full CRUD on k-orc applicationcredentials, services, endpoints, users, domains
     asserts:
       - contains:
           path: rules
@@ -167,6 +167,8 @@ tests:
               - applicationcredentials
               - services
               - endpoints
+              - users
+              - domains
             verbs:
               - get
               - list

--- a/operators/c5c3/helm/c5c3-operator/tests/role_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/role_test.yaml
@@ -241,7 +241,7 @@ tests:
               - patch
               - delete
 
-  - it: should grant full CRUD on k-orc applicationcredentials, services, endpoints
+  - it: should grant full CRUD on k-orc applicationcredentials, services, endpoints, users, domains
     set:
       rbac:
         namespaceScoped: true
@@ -257,6 +257,8 @@ tests:
               - applicationcredentials
               - services
               - endpoints
+              - users
+              - domains
             verbs:
               - get
               - list

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -78,7 +78,7 @@ type ControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups=k8s.mariadb.com,resources=mariadbs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=memcached.c5c3.io,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=keystone.openstack.c5c3.io,resources=keystones,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=applicationcredentials;services;endpoints,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=openstack.k-orc.cloud,resources=applicationcredentials;services;endpoints;users;domains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=external-secrets.io,resources=externalsecrets;pushsecrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=external-secrets.io,resources=clustersecretstores,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
@@ -273,6 +273,8 @@ func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&orcv1alpha1.ApplicationCredential{}).
 		Owns(&orcv1alpha1.Service{}).
 		Owns(&orcv1alpha1.Endpoint{}).
+		Owns(&orcv1alpha1.User{}).
+		Owns(&orcv1alpha1.Domain{}).
 		Owns(memcached).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
 			secretToControlPlaneMapper(mgr.GetClient()),

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -255,6 +255,23 @@ func simulateApplicationCredentialAvailableWhenPresent(t testing.TB, ctx context
 	g.Expect(c.Status().Update(ctx, ac)).To(Succeed(), "set ApplicationCredential Available=True")
 }
 
+// simulatePushSecretSyncedWhenPresent waits for the named PushSecret to be
+// created, then sets its Ready condition True via the shared simulator. There is
+// no ESO controller in envtest, so reconcileAdminCredential — which gates
+// AdminCredentialReady on the admin app-credential PushSecret actually syncing to
+// OpenBao (CC-0110, REQ-011) — would otherwise wait forever. SimulatePushSecretSynced
+// returns an error until the PushSecret exists, so polling it doubles as the
+// "WhenPresent" wait without needing the esov1alpha1 type here.
+func simulatePushSecretSyncedWhenPresent(t testing.TB, ctx context.Context, c client.Client, key client.ObjectKey) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	g.Eventually(func() error {
+		return simulators.SimulatePushSecretSynced(ctx, c, key)
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(),
+		"admin app-credential PushSecret should be created and synced")
+}
+
 // TestIntegration_FullReconcile_ManagedToReady drives a managed-mode ControlPlane
 // through every sub-reconciler to the aggregate Ready=True, simulating each
 // external dependency's readiness in dependency order. It is the single primary
@@ -315,10 +332,12 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 		client.ObjectKey{Name: adminAppCredentialName(cp), Namespace: ns.Name})
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeKORCReady, metav1.ConditionTrue, itEventuallyTimeout)
 
-	// --- Phase 4: AdminCredential push (gated on the clouds.yaml ES, already
-	// synced above). The owned minted-credential Secret and the OpenBao
-	// PushSecret are not status-gated, so AdminCredentialReady flips once the
-	// gate passes. ---
+	// --- Phase 4: AdminCredential push. Gated on the clouds.yaml ES (synced
+	// above) AND on the admin app-credential PushSecret syncing to OpenBao
+	// (CC-0110, REQ-011). The latter is status-gated, so simulate the ESO sync —
+	// otherwise AdminCredentialReady never flips in envtest. ---
+	simulatePushSecretSyncedWhenPresent(t, ctx, c,
+		client.ObjectKey{Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp)})
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
 
 	// --- Phase 5: Catalog (Service + Endpoint). Not status-gated. ---

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -171,7 +171,7 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 		Namespace: childNamespace(cp),
 	}
 	mariadb := &mariadbv1alpha1.MariaDB{}
-	err := r.Client.Get(ctx, key, mariadb)
+	err := r.Get(ctx, key, mariadb)
 	switch {
 	case apierrors.IsNotFound(err):
 		// Create fresh with the projected, production-shaped spec.
@@ -187,21 +187,34 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 		if serr := controllerutil.SetControllerReference(cp, mariadb, r.Scheme); serr != nil {
 			return false, fmt.Errorf("setting owner reference on MariaDB %q: %w", key.Name, serr)
 		}
-		if cerr := r.Client.Create(ctx, mariadb); cerr != nil {
+		if cerr := r.Create(ctx, mariadb); cerr != nil {
 			return false, fmt.Errorf("creating MariaDB %q: %w", key.Name, cerr)
 		}
 	case err != nil:
 		return false, fmt.Errorf("getting MariaDB %q: %w", key.Name, err)
 	default:
-		// Adoption-safe: a MariaDB with this clusterRef name already exists (e.g.
-		// the infrastructure stack provisions "openstack-db" under the same name).
-		// Adopt it as-is and reconcile against its status:
-		//   - its storage fields are immutable (the mariadb-operator webhook rejects
-		//     changing spec.storage.storageClassName / ephemeral), and
-		//   - its replica/Galera topology is authoritative for that cluster,
-		// so re-projecting our defaults would be rejected or would needlessly reshape
-		// a running database. We also do not claim GC ownership of a resource we did
-		// not create, so deleting the ControlPlane never cascades into shared infra.
+		// A MariaDB with this clusterRef name already exists. Two sub-cases:
+		//
+		//  1. It is OWNED by this ControlPlane (we created it on an earlier pass):
+		//     reconcile the MUTABLE projection — spec.replicas — so a changed
+		//     projection default (infraMariaDBReplicas) takes effect on the cluster
+		//     we own, rather than being frozen at first-creation. spec.storage is
+		//     deliberately NOT re-projected even when owned: the mariadb-operator
+		//     webhook rejects changing spec.storage.* on an existing CR, so storage
+		//     stays as first created.
+		//
+		//  2. It is NOT owned (e.g. the infrastructure stack provisions
+		//     "openstack-db" under the same name): adopt it as-is and reconcile only
+		//     against its status. Re-projecting our defaults would be rejected
+		//     (immutable storage) or needlessly reshape a running database, and we
+		//     never claim GC ownership of a resource we did not create, so deleting
+		//     the ControlPlane never cascades into shared infra.
+		if metav1.IsControlledBy(mariadb, cp) && mariadb.Spec.Replicas != infraMariaDBReplicas {
+			mariadb.Spec.Replicas = infraMariaDBReplicas
+			if uerr := r.Update(ctx, mariadb); uerr != nil {
+				return false, fmt.Errorf("updating owned MariaDB %q replicas: %w", key.Name, uerr)
+			}
+		}
 	}
 
 	return conditions.IsReady(mariadb.Status.Conditions), nil
@@ -218,7 +231,7 @@ func (r *ControlPlaneReconciler) ensureMemcached(ctx context.Context, cp *c5c3v1
 	}
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(memcachedGVK)
-	err := r.Client.Get(ctx, key, u)
+	err := r.Get(ctx, key, u)
 	switch {
 	case apierrors.IsNotFound(err):
 		u.SetName(key.Name)
@@ -230,14 +243,34 @@ func (r *ControlPlaneReconciler) ensureMemcached(ctx context.Context, cp *c5c3v1
 		if serr := controllerutil.SetControllerReference(cp, u, r.Scheme); serr != nil {
 			return false, fmt.Errorf("setting owner reference on Memcached %q: %w", key.Name, serr)
 		}
-		if cerr := r.Client.Create(ctx, u); cerr != nil {
+		if cerr := r.Create(ctx, u); cerr != nil {
 			return false, fmt.Errorf("creating Memcached %q: %w", key.Name, cerr)
 		}
 	case err != nil:
 		return false, fmt.Errorf("getting Memcached %q: %w", key.Name, err)
 	default:
-		// Adoption-safe: adopt an existing Memcached as-is and do not claim GC
-		// ownership — same rationale as ensureMariaDB.
+		// An existing Memcached. If this ControlPlane OWNS it (we created it on an
+		// earlier pass), reconcile spec.replicas so a ControlPlane spec change
+		// (cp.Spec.Infrastructure.Cache.Replicas) actually scales the cache we own
+		// instead of being ignored after first creation. If it is a pre-existing /
+		// externally-provisioned instance (NOT owned) we adopt it as-is and never
+		// reshape it — same rationale as ensureMariaDB — nor claim GC ownership of
+		// shared infra.
+		if metav1.IsControlledBy(u, cp) {
+			desired := int64(cp.Spec.Infrastructure.Cache.Replicas)
+			current, found, gerr := unstructured.NestedInt64(u.Object, "spec", "replicas")
+			if gerr != nil {
+				return false, fmt.Errorf("reading Memcached %q spec.replicas: %w", key.Name, gerr)
+			}
+			if !found || current != desired {
+				if serr := unstructured.SetNestedField(u.Object, desired, "spec", "replicas"); serr != nil {
+					return false, fmt.Errorf("setting Memcached %q spec.replicas: %w", key.Name, serr)
+				}
+				if uerr := r.Update(ctx, u); uerr != nil {
+					return false, fmt.Errorf("updating owned Memcached %q replicas: %w", key.Name, uerr)
+				}
+			}
+		}
 	}
 
 	return unstructuredReady(u), nil

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -164,25 +166,42 @@ func (r *ControlPlaneReconciler) reconcileInfrastructure(ctx context.Context, cp
 // ensureMariaDB create-or-updates the owned MariaDB CR named after
 // spec.infrastructure.database.clusterRef and reports whether it is Ready.
 func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (bool, error) {
-	size, err := resource.ParseQuantity(infraMariaDBStorageSize)
-	if err != nil {
-		return false, fmt.Errorf("parsing MariaDB storage size %q: %w", infraMariaDBStorageSize, err)
+	key := types.NamespacedName{
+		Name:      cp.Spec.Infrastructure.Database.ClusterRef.Name,
+		Namespace: childNamespace(cp),
 	}
-
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cp.Spec.Infrastructure.Database.ClusterRef.Name,
-			Namespace: childNamespace(cp),
-		},
-	}
-
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, mariadb, func() error {
+	mariadb := &mariadbv1alpha1.MariaDB{}
+	err := r.Client.Get(ctx, key, mariadb)
+	switch {
+	case apierrors.IsNotFound(err):
+		// Create fresh with the projected, production-shaped spec.
+		size, perr := resource.ParseQuantity(infraMariaDBStorageSize)
+		if perr != nil {
+			return false, fmt.Errorf("parsing MariaDB storage size %q: %w", infraMariaDBStorageSize, perr)
+		}
+		mariadb.Name = key.Name
+		mariadb.Namespace = key.Namespace
 		mariadb.Spec.Replicas = infraMariaDBReplicas
 		mariadb.Spec.Galera = &mariadbv1alpha1.Galera{Enabled: true}
 		mariadb.Spec.Storage = mariadbv1alpha1.Storage{Size: &size}
-		return controllerutil.SetControllerReference(cp, mariadb, r.Scheme)
-	}); err != nil {
-		return false, fmt.Errorf("create-or-update MariaDB %q: %w", mariadb.Name, err)
+		if serr := controllerutil.SetControllerReference(cp, mariadb, r.Scheme); serr != nil {
+			return false, fmt.Errorf("setting owner reference on MariaDB %q: %w", key.Name, serr)
+		}
+		if cerr := r.Client.Create(ctx, mariadb); cerr != nil {
+			return false, fmt.Errorf("creating MariaDB %q: %w", key.Name, cerr)
+		}
+	case err != nil:
+		return false, fmt.Errorf("getting MariaDB %q: %w", key.Name, err)
+	default:
+		// Adoption-safe: a MariaDB with this clusterRef name already exists (e.g.
+		// the infrastructure stack provisions "openstack-db" under the same name).
+		// Adopt it as-is and reconcile against its status:
+		//   - its storage fields are immutable (the mariadb-operator webhook rejects
+		//     changing spec.storage.storageClassName / ephemeral), and
+		//   - its replica/Galera topology is authoritative for that cluster,
+		// so re-projecting our defaults would be rejected or would needlessly reshape
+		// a running database. We also do not claim GC ownership of a resource we did
+		// not create, so deleting the ControlPlane never cascades into shared infra.
 	}
 
 	return conditions.IsReady(mariadb.Status.Conditions), nil
@@ -193,21 +212,32 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 // Memcached CR is handled as an unstructured.Unstructured because
 // memcached.c5c3.io ships no Go module (see memcachedGVK).
 func (r *ControlPlaneReconciler) ensureMemcached(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (bool, error) {
+	key := types.NamespacedName{
+		Name:      cp.Spec.Infrastructure.Cache.ClusterRef.Name,
+		Namespace: childNamespace(cp),
+	}
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(memcachedGVK)
-	u.SetName(cp.Spec.Infrastructure.Cache.ClusterRef.Name)
-	u.SetNamespace(childNamespace(cp))
-
-	replicas := cp.Spec.Infrastructure.Cache.Replicas
-
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, u, func() error {
+	err := r.Client.Get(ctx, key, u)
+	switch {
+	case apierrors.IsNotFound(err):
+		u.SetName(key.Name)
+		u.SetNamespace(key.Namespace)
 		// int32 must be widened to int64 for unstructured nested-field storage.
-		if err := unstructured.SetNestedField(u.Object, int64(replicas), "spec", "replicas"); err != nil {
-			return fmt.Errorf("setting spec.replicas: %w", err)
+		if serr := unstructured.SetNestedField(u.Object, int64(cp.Spec.Infrastructure.Cache.Replicas), "spec", "replicas"); serr != nil {
+			return false, fmt.Errorf("setting spec.replicas: %w", serr)
 		}
-		return controllerutil.SetControllerReference(cp, u, r.Scheme)
-	}); err != nil {
-		return false, fmt.Errorf("create-or-update Memcached %q: %w", u.GetName(), err)
+		if serr := controllerutil.SetControllerReference(cp, u, r.Scheme); serr != nil {
+			return false, fmt.Errorf("setting owner reference on Memcached %q: %w", key.Name, serr)
+		}
+		if cerr := r.Client.Create(ctx, u); cerr != nil {
+			return false, fmt.Errorf("creating Memcached %q: %w", key.Name, cerr)
+		}
+	case err != nil:
+		return false, fmt.Errorf("getting Memcached %q: %w", key.Name, err)
+	default:
+		// Adoption-safe: adopt an existing Memcached as-is and do not claim GC
+		// ownership — same rationale as ensureMariaDB.
 	}
 
 	return unstructuredReady(u), nil

--- a/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -231,6 +232,83 @@ func TestReconcileInfrastructure_ManagedAdoptsExistingWithoutMutating(t *testing
 	g.Expect(replicas).To(Equal(int64(1)), "existing Memcached replicas must be preserved")
 	g.Expect(u.GetOwnerReferences()).To(BeEmpty(),
 		"must not claim GC ownership of pre-existing Memcached")
+}
+
+// TestEnsureMariaDB_OwnedReconcilesReplicas verifies the owner-aware path: a
+// MariaDB this ControlPlane OWNS (created on an earlier pass) has its mutable
+// projection — spec.replicas — reconciled back to the projected default when it
+// has drifted, while its immutable storage is left untouched. This is what keeps
+// a ControlPlane-owned database evolving with the projection without reshaping a
+// pre-existing/adopted cluster (which the adoption test covers).
+func TestEnsureMariaDB_OwnedReconcilesReplicas(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := managedInfraControlPlane()
+
+	existingSize := resource.MustParse("100Gi")
+	ownedMariaDB := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "openstack-db", Namespace: childNamespace(cp)},
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Replicas: 1, // drifted below the projected default (infraMariaDBReplicas)
+			Storage: mariadbv1alpha1.Storage{
+				Size:             &existingSize,
+				StorageClassName: "standard",
+			},
+		},
+	}
+	// Mark the MariaDB as owned by this ControlPlane (controller owner reference).
+	g.Expect(controllerutil.SetControllerReference(cp, ownedMariaDB, s)).To(Succeed())
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ownedMariaDB).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.ensureMariaDB(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var mariadb mariadbv1alpha1.MariaDB
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: "openstack-db", Namespace: childNamespace(cp),
+	}, &mariadb)).To(Succeed())
+	g.Expect(mariadb.Spec.Replicas).To(Equal(infraMariaDBReplicas),
+		"an owned MariaDB must have its replicas reconciled to the projected default")
+	g.Expect(mariadb.Spec.Storage.StorageClassName).To(Equal("standard"),
+		"storage stays immutable even for an owned MariaDB")
+}
+
+// TestEnsureMemcached_OwnedReconcilesReplicas verifies the owner-aware path for
+// Memcached: a Memcached this ControlPlane OWNS has spec.replicas reconciled to
+// cp.Spec.Infrastructure.Cache.Replicas when they differ, so a ControlPlane spec
+// change scales the owned cache instead of being ignored after first creation.
+func TestEnsureMemcached_OwnedReconcilesReplicas(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := managedInfraControlPlane() // Cache.Replicas = 3
+
+	ownedMemcached := &unstructured.Unstructured{}
+	ownedMemcached.SetGroupVersionKind(memcachedGVK)
+	ownedMemcached.SetName("openstack-memcached")
+	ownedMemcached.SetNamespace(childNamespace(cp))
+	_ = unstructured.SetNestedField(ownedMemcached.Object, int64(1), "spec", "replicas") // drifted
+	g.Expect(controllerutil.SetControllerReference(cp, ownedMemcached, s)).To(Succeed())
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ownedMemcached).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.ensureMemcached(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(memcachedGVK)
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: "openstack-memcached", Namespace: childNamespace(cp),
+	}, u)).To(Succeed())
+	replicas, found, nerr := unstructured.NestedInt64(u.Object, "spec", "replicas")
+	g.Expect(nerr).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	g.Expect(replicas).To(Equal(int64(3)),
+		"an owned Memcached must have spec.replicas reconciled to the ControlPlane spec")
 }
 
 func TestReconcileInfrastructure_BrownfieldSkipsChildren(t *testing.T) {

--- a/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
@@ -12,6 +12,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -170,6 +171,66 @@ func TestReconcileInfrastructure_ManagedReadyWhenChildrenReady(t *testing.T) {
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeInfrastructureReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+}
+
+// TestReconcileInfrastructure_ManagedAdoptsExistingWithoutMutating verifies the
+// adoption-safe path: when a MariaDB / Memcached with the clusterRef name already
+// exists (e.g. the infrastructure stack provisions "openstack-db" / "openstack-
+// memcached" under the same name), reconcileInfrastructure adopts it as-is. It
+// must NOT overwrite immutable storage fields (which the mariadb-operator webhook
+// rejects) and must NOT claim GC ownership of a resource it did not create.
+func TestReconcileInfrastructure_ManagedAdoptsExistingWithoutMutating(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := managedInfraControlPlane()
+
+	existingSize := resource.MustParse("1Gi")
+	existingMariaDB := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "openstack-db", Namespace: childNamespace(cp)},
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Replicas: 1,
+			Storage: mariadbv1alpha1.Storage{
+				Size:             &existingSize,
+				StorageClassName: "standard",
+			},
+		},
+	}
+	existingMemcached := &unstructured.Unstructured{}
+	existingMemcached.SetGroupVersionKind(memcachedGVK)
+	existingMemcached.SetName("openstack-memcached")
+	existingMemcached.SetNamespace(childNamespace(cp))
+	_ = unstructured.SetNestedField(existingMemcached.Object, int64(1), "spec", "replicas")
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, existingMariaDB, existingMemcached).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileInfrastructure(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred(), "adopting pre-existing infra must not error")
+
+	// MariaDB: immutable storage preserved, topology untouched, NOT adopted for GC.
+	var mariadb mariadbv1alpha1.MariaDB
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: "openstack-db", Namespace: childNamespace(cp),
+	}, &mariadb)).To(Succeed())
+	g.Expect(mariadb.Spec.Storage.StorageClassName).To(Equal("standard"),
+		"existing storageClassName must be preserved (it is immutable)")
+	g.Expect(mariadb.Spec.Replicas).To(Equal(int32(1)),
+		"existing replica topology must be preserved, not reshaped to the projected default")
+	g.Expect(mariadb.OwnerReferences).To(BeEmpty(),
+		"must not claim GC ownership of pre-existing infrastructure")
+
+	// Memcached: replicas untouched, NOT adopted for GC.
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(memcachedGVK)
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: "openstack-memcached", Namespace: childNamespace(cp),
+	}, u)).To(Succeed())
+	replicas, _, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+	g.Expect(replicas).To(Equal(int64(1)), "existing Memcached replicas must be preserved")
+	g.Expect(u.GetOwnerReferences()).To(BeEmpty(),
+		"must not claim GC ownership of pre-existing Memcached")
 }
 
 func TestReconcileInfrastructure_BrownfieldSkipsChildren(t *testing.T) {

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -674,6 +674,33 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		return ctrl.Result{}, err
 	}
 
+	// Gate AdminCredentialReady on the PushSecret actually syncing to OpenBao — not
+	// merely on the CR existing. Otherwise a backend permission failure (e.g. the
+	// ESO role missing the push-app-credentials policy) yields a false-positive
+	// Ready while OpenBao still serves the password-based bootstrap clouds.yaml.
+	pushed := &esov1alpha1.PushSecret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, pushed); err != nil {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminCredentialReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "PushSecretError",
+			Message:            fmt.Sprintf("reading admin app-credential PushSecret: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
+	if !pushSecretReady(pushed) {
+		logger.Info("admin app-credential PushSecret not yet synced, requeuing")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminCredentialReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "WaitingForPushSecret",
+			Message:            "admin app-credential PushSecret has not synced to OpenBao yet",
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
 	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 		Type:               conditionTypeAdminCredentialReady,
 		Status:             metav1.ConditionTrue,
@@ -682,6 +709,17 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		Message:            "Admin application credential committed and mirrored to OpenBao",
 	})
 	return ctrl.Result{}, nil
+}
+
+// pushSecretReady reports whether an ESO PushSecret has synced to its backend
+// (its "Ready" condition is True).
+func pushSecretReady(ps *esov1alpha1.PushSecret) bool {
+	for _, c := range ps.Status.Conditions {
+		if c.Type == esov1alpha1.PushSecretReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // adminAppCredentialPushSecret builds the PushSecret that mirrors the minted

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -600,11 +600,11 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		}
 		endpoint.Spec.Resource.Interface = "public"
 		// DECISION (Endpoint URL): our spec carries no catalog URL, but K-ORC's
-		// EndpointResourceSpec.URL is REQUIRED. We derive a conventional in-cluster
-		// Keystone identity URL from the ControlPlane namespace
-		// (http://keystone.<ns>.svc:5000/v3), matching the keystone operator's
-		// in-cluster Service name. Sites that expose Keystone externally should
-		// override via bootstrap resources. Reviewer: please verify the Service DNS.
+		// EndpointResourceSpec.URL is REQUIRED. We derive the in-cluster Keystone
+		// identity URL from the PROJECTED Keystone Service — keystoneName(cp) =
+		// "{cp.Name}-keystone" in the ControlPlane namespace — which is the Service
+		// the keystone-operator actually exposes. Sites that expose Keystone
+		// externally should override via bootstrap resources.
 		endpoint.Spec.Resource.URL = keystoneEndpointURL(cp)
 		endpoint.Spec.Resource.ServiceRef = orcv1alpha1.KubernetesNameRef(keystoneServiceName(cp))
 		endpoint.Spec.Resource.Enabled = ptr.To(true)
@@ -658,8 +658,11 @@ func keystoneEndpointName(cp *c5c3v1alpha1.ControlPlane) string {
 	return cp.Name + "-identity-endpoint"
 }
 
-// keystoneEndpointURL derives the conventional in-cluster Keystone identity URL
-// (see DECISION on Endpoint URL in reconcileCatalog).
+// keystoneEndpointURL derives the in-cluster Keystone identity URL from the
+// projected Keystone Service — keystoneName(cp) = "{cp.Name}-keystone" — in the
+// ControlPlane namespace (see DECISION on Endpoint URL in reconcileCatalog). It
+// must NOT hard-code "keystone": the keystone-operator names the Service after
+// the projected Keystone CR, so a fixed name would not resolve.
 func keystoneEndpointURL(cp *c5c3v1alpha1.ControlPlane) string {
-	return fmt.Sprintf("http://keystone.%s.svc:5000/v3", childNamespace(cp))
+	return fmt.Sprintf("http://%s.%s.svc:5000/v3", keystoneName(cp), childNamespace(cp))
 }

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -5,6 +5,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -17,6 +18,7 @@ import (
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -629,32 +631,71 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      adminAppCredentialSecretName(cp),
-			Namespace: childNamespace(cp),
-		},
+	// The operator-owned Secret (with its generated "value" and owner reference)
+	// was created by ensureAppCredentialSecret during reconcileKORC, which KORCReady
+	// — gated above — guarantees has run and K-ORC has read the "value" to mint.
+	// Get it directly rather than CreateOrUpdate: a NotFound here is an invariant
+	// violation (the minted secret vanished), NOT a create opportunity — minting a
+	// fresh "value" would not match the credential Keystone already issued, so we
+	// requeue and let reconcileKORC re-establish the Secret instead of writing a
+	// brand-new empty one that would immediately fail the "value" check.
+	secretKey := types.NamespacedName{
+		Name:      adminAppCredentialSecretName(cp),
+		Namespace: childNamespace(cp),
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		if secret.Data == nil {
-			secret.Data = map[string][]byte{}
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, secretKey, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("app-credential secret not found, deferring credential assembly", "secret", secretKey.Name)
+			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+				Type:               conditionTypeAdminCredentialReady,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cp.Generation,
+				Reason:             "WaitingForAppCredentialSecret",
+				Message:            fmt.Sprintf("app-credential secret %q does not exist yet", secretKey.Name),
+			})
+			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 		}
-		value := secret.Data[appCredSecretValueKey]
-		if len(value) == 0 {
-			return fmt.Errorf("app-credential secret %q has no %q key (mint not complete?)",
-				secret.Name, appCredSecretValueKey)
-		}
-		secret.Data[appCredCloudsYAMLKey] = []byte(buildAppCredCloudsYAML(cp, acID, string(value)))
-		return controllerutil.SetControllerReference(cp, secret, r.Scheme)
-	}); err != nil {
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeAdminCredentialReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: cp.Generation,
 			Reason:             "SecretError",
-			Message:            fmt.Sprintf("assembling admin app-credential clouds.yaml: %v", err),
+			Message:            fmt.Sprintf("reading admin app-credential secret %q: %v", secretKey.Name, err),
 		})
 		return ctrl.Result{}, err
+	}
+
+	value := secret.Data[appCredSecretValueKey]
+	if len(value) == 0 {
+		logger.Info("app-credential secret has no value yet, deferring credential assembly", "secret", secretKey.Name)
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminCredentialReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "WaitingForAppCredentialSecret",
+			Message: fmt.Sprintf("app-credential secret %q has no %q key (mint not complete?)",
+				secret.Name, appCredSecretValueKey),
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
+	// Persist the assembled clouds.yaml under appCredCloudsYAMLKey, leaving the
+	// "value" key untouched. Skip the write when it already matches so repeated
+	// reconciles do not churn the Secret (and wake ESO to re-push).
+	cloudsYAML := []byte(buildAppCredCloudsYAML(cp, acID, string(value)))
+	if !bytes.Equal(secret.Data[appCredCloudsYAMLKey], cloudsYAML) {
+		secret.Data[appCredCloudsYAMLKey] = cloudsYAML
+		if err := r.Update(ctx, secret); err != nil {
+			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+				Type:               conditionTypeAdminCredentialReady,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cp.Generation,
+				Reason:             "SecretError",
+				Message:            fmt.Sprintf("assembling admin app-credential clouds.yaml: %v", err),
+			})
+			return ctrl.Result{}, err
+		}
 	}
 
 	// CLOBBER-SAFE PushSecret: EnsurePushSecret is idempotent — it only Updates
@@ -679,7 +720,7 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 	// ESO role missing the push-app-credentials policy) yields a false-positive
 	// Ready while OpenBao still serves the password-based bootstrap clouds.yaml.
 	pushed := &esov1alpha1.PushSecret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, pushed); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, pushed); err != nil {
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeAdminCredentialReady,
 			Status:             metav1.ConditionFalse,

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -6,7 +6,9 @@ package controller
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 
@@ -82,10 +84,83 @@ func adminAppCredentialName(cp *c5c3v1alpha1.ControlPlane) string {
 	return cp.Name + adminAppCredentialNameSuffix
 }
 
-// adminAppCredentialSecretName returns the name of the operator-owned Secret
-// K-ORC writes the minted application credential into.
+// adminAppCredentialSecretName returns the name of the operator-owned Secret that
+// holds the application-credential secret K-ORC mints with (key "value") and,
+// after minting, the assembled app-credential clouds.yaml pushed to OpenBao.
 func adminAppCredentialSecretName(cp *c5c3v1alpha1.ControlPlane) string {
 	return cp.Name + adminAppCredentialSecretSuffix
+}
+
+// appCredSecretValueKey is the Secret data key K-ORC reads the application
+// credential's secret from (the actuator reads Secret.Data["value"]).
+const appCredSecretValueKey = "value"
+
+// appCredCloudsYAMLKey is the Secret data key the assembled app-credential
+// clouds.yaml is stored under; the PushSecret mirrors it to OpenBao and the
+// k-orc-clouds-yaml ExternalSecret reads it back as the "clouds.yaml" property.
+const appCredCloudsYAMLKey = "clouds.yaml"
+
+// ensureAppCredentialSecret ensures the operator-owned Secret that K-ORC reads the
+// application-credential secret from exists with a generated "value". K-ORC's
+// managed ApplicationCredential reads Secret.Data["value"] and creates the AC in
+// Keystone with it, so this MUST exist before the AC is reconciled. The value is
+// generated once and preserved across reconciles — regenerating it would force a
+// re-mint and invalidate the stored clouds.yaml.
+func (r *ControlPlaneReconciler) ensureAppCredentialSecret(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminAppCredentialSecretName(cp),
+			Namespace: childNamespace(cp),
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		if len(secret.Data[appCredSecretValueKey]) == 0 {
+			v, gerr := generateAppCredSecretValue()
+			if gerr != nil {
+				return gerr
+			}
+			secret.Data[appCredSecretValueKey] = []byte(v)
+		}
+		return controllerutil.SetControllerReference(cp, secret, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("ensuring app-credential secret %q: %w", secret.Name, err)
+	}
+	return nil
+}
+
+// generateAppCredSecretValue returns a 256-bit, URL-safe random string used as the
+// application credential's secret.
+func generateAppCredSecretValue() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating application-credential secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// buildAppCredCloudsYAML assembles the application-credential clouds.yaml the
+// control plane authenticates K-ORC with after minting: the credential id comes
+// from the minted AC, the secret from the generated "value", and the auth_url from
+// the projected Keystone Service (keystoneEndpointURL).
+func buildAppCredCloudsYAML(cp *c5c3v1alpha1.ControlPlane, acID, secret string) string {
+	region := cp.Spec.Region
+	if region == "" {
+		region = "RegionOne"
+	}
+	return fmt.Sprintf(`clouds:
+  admin:
+    auth:
+      auth_url: %q
+      application_credential_id: %q
+      application_credential_secret: %q
+    auth_type: v3applicationcredential
+    region_name: %q
+    interface: public
+    identity_api_version: 3
+`, keystoneEndpointURL(cp), acID, secret, region)
 }
 
 // adminAppCredentialPushSecretName returns the PushSecret name backing up the
@@ -182,6 +257,22 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 			ObservedGeneration: cp.Generation,
 			Reason:             "AdminImportError",
 			Message:            fmt.Sprintf("ensuring K-ORC admin User/Domain imports: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
+
+	// K-ORC's managed ApplicationCredential reads the DESIRED secret from
+	// Secret.Data["value"] and passes it to Keystone when creating the credential
+	// (it does NOT generate or write the secret itself). So the operator-owned
+	// Secret MUST exist with a generated "value" BEFORE the AC is reconciled —
+	// otherwise the AC blocks on "Waiting for Secret … to be created".
+	if err := r.ensureAppCredentialSecret(ctx, cp); err != nil {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "SecretError",
+			Message:            fmt.Sprintf("ensuring application-credential secret: %v", err),
 		})
 		return ctrl.Result{}, err
 	}
@@ -516,11 +607,28 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
-	// Ensure the operator-owned Secret K-ORC writes the minted AC into exists.
-	// CLOBBER-SAFE: the operator only owns the Secret's metadata/owner-reference;
-	// the .data is written by K-ORC (Resource.SecretRef target). The mutate
-	// closure deliberately never touches secret.Data so a reconcile can never
-	// overwrite a freshly minted credential.
+	// Assemble the application-credential clouds.yaml into the operator-owned Secret
+	// so the PushSecret mirrors it to OpenBao (and ESO re-materialises it as the
+	// admin clouds.yaml, replacing the password-based bootstrap seed). K-ORC does
+	// NOT write this — it only consumed Secret.Data["value"] to mint — so we build
+	// it from the minted credential id (AC status, surfaced on cp.Status) and the
+	// generated secret value. The "value" key is preserved untouched.
+	acID := ""
+	if cp.Status.AdminApplicationCredential != nil {
+		acID = cp.Status.AdminApplicationCredential.ID
+	}
+	if acID == "" {
+		logger.Info("admin application credential id not yet reported, deferring credential assembly")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminCredentialReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "WaitingForCredentialID",
+			Message:            "minted application credential id is not yet reported by K-ORC",
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      adminAppCredentialSecretName(cp),
@@ -528,7 +636,15 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		// Do NOT touch secret.Data — K-ORC owns it.
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		value := secret.Data[appCredSecretValueKey]
+		if len(value) == 0 {
+			return fmt.Errorf("app-credential secret %q has no %q key (mint not complete?)",
+				secret.Name, appCredSecretValueKey)
+		}
+		secret.Data[appCredCloudsYAMLKey] = []byte(buildAppCredCloudsYAML(cp, acID, string(value)))
 		return controllerutil.SetControllerReference(cp, secret, r.Scheme)
 	}); err != nil {
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
@@ -536,7 +652,7 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: cp.Generation,
 			Reason:             "SecretError",
-			Message:            fmt.Sprintf("ensuring admin app-credential secret: %v", err),
+			Message:            fmt.Sprintf("assembling admin app-credential clouds.yaml: %v", err),
 		})
 		return ctrl.Result{}, err
 	}

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -154,6 +154,38 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		restricted = *adminCred.ApplicationCredential.Restricted
 	}
 
+	credRef := orcv1alpha1.CloudCredentialsReference{
+		SecretName: adminCred.CloudCredentialsRef.SecretName,
+		CloudName:  adminCred.CloudCredentialsRef.CloudName,
+	}
+
+	// The admin ApplicationCredential's UserRef points at a K-ORC User that must
+	// already exist. The Keystone bootstrap creates the real admin user in the
+	// Default domain, so import it (and its domain) as UNMANAGED K-ORC resources
+	// before minting — otherwise the AC blocks forever on "Waiting for User/admin
+	// to be created".
+	if err := r.ensureKORCAdminImports(ctx, cp, credRef); err != nil {
+		if meta.IsNoMatchError(err) {
+			logger.Info("K-ORC User/Domain CRD not installed; KORCReady=False")
+			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+				Type:               conditionTypeKORCReady,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cp.Generation,
+				Reason:             "KORCCRDNotInstalled",
+				Message:            "K-ORC User/Domain CRD is not installed",
+			})
+			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+		}
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "AdminImportError",
+			Message:            fmt.Sprintf("ensuring K-ORC admin User/Domain imports: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
+
 	ac := &orcv1alpha1.ApplicationCredential{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      adminAppCredentialName(cp),
@@ -163,10 +195,7 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, ac, func() error {
 		ac.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
-		ac.Spec.CloudCredentialsRef = orcv1alpha1.CloudCredentialsReference{
-			SecretName: adminCred.CloudCredentialsRef.SecretName,
-			CloudName:  adminCred.CloudCredentialsRef.CloudName,
-		}
+		ac.Spec.CloudCredentialsRef = credRef
 
 		if ac.Spec.Resource == nil {
 			ac.Spec.Resource = &orcv1alpha1.ApplicationCredentialResourceSpec{}
@@ -247,22 +276,71 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	return ctrl.Result{}, nil
 }
 
-// adminUserRef derives the K-ORC User reference the admin application credential
-// is associated with.
-//
-// DECISION (UserRef): our AdminCredentialSpec has no UserRef field, but K-ORC's
-// ApplicationCredentialResourceSpec.UserRef is REQUIRED. We derive it
-// conventionally from the CloudName the admin authenticates as (defaulting to
-// "admin" when unset), assuming a sibling K-ORC User CR of that name exists in
-// the same namespace. This keeps the CR deterministic and valid; if a site uses
-// a different admin user-CR name the bootstrap resources (REQ-014) should
-// provision a User CR matching the CloudName. Reviewer: please verify the User
-// naming convention matches the deploy stack.
+// adminUserRef derives the name of the K-ORC User CR the admin application
+// credential is associated with. AdminCredentialSpec has no UserRef field, but
+// K-ORC's ApplicationCredentialResourceSpec.UserRef is REQUIRED, so we derive it
+// from the CloudName the admin authenticates as (defaulting to "admin"). The
+// matching User CR is provisioned by ensureKORCAdminImports as an unmanaged
+// import, so the reference always resolves.
 func adminUserRef(cp *c5c3v1alpha1.ControlPlane) string {
 	if name := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName; name != "" {
 		return name
 	}
 	return "admin"
+}
+
+// korcAdminUsername / korcAdminDomainName identify the OpenStack admin user and
+// its domain that the Keystone bootstrap creates; the c5c3-operator imports them
+// into K-ORC (unmanaged) rather than creating them.
+const (
+	korcAdminUsername   = "admin"
+	korcAdminDomainName = "Default"
+)
+
+// adminDomainRef is the deterministic name of the K-ORC Domain CR the admin User
+// import is scoped to.
+func adminDomainRef(cp *c5c3v1alpha1.ControlPlane) string {
+	return cp.Name + "-domain-default"
+}
+
+// ensureKORCAdminImports ensures the K-ORC Domain and User that the admin
+// ApplicationCredential's UserRef depends on exist as UNMANAGED imports. The
+// Keystone bootstrap creates the real admin user (in the Default domain); K-ORC
+// must import — not create — it, otherwise the ApplicationCredential blocks on
+// "Waiting for User/admin to be created". Both CRs are owned by the ControlPlane
+// for GC and reuse the admin clouds.yaml credentials.
+func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) error {
+	domain := &orcv1alpha1.Domain{
+		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, domain, func() error {
+		domain.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
+		domain.Spec.CloudCredentialsRef = credRef
+		domain.Spec.Import = &orcv1alpha1.DomainImport{
+			Filter: &orcv1alpha1.DomainFilter{Name: ptr.To(orcv1alpha1.KeystoneName(korcAdminDomainName))},
+		}
+		return controllerutil.SetControllerReference(cp, domain, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
+	}
+
+	user := &orcv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: adminUserRef(cp), Namespace: childNamespace(cp)},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, user, func() error {
+		user.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
+		user.Spec.CloudCredentialsRef = credRef
+		user.Spec.Import = &orcv1alpha1.UserImport{
+			Filter: &orcv1alpha1.UserFilter{
+				Name:      ptr.To(orcv1alpha1.OpenStackName(korcAdminUsername)),
+				DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(adminDomainRef(cp))),
+			},
+		}
+		return controllerutil.SetControllerReference(cp, user, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("admin User import %q: %w", user.Name, err)
+	}
+	return nil
 }
 
 // projectAccessRules maps our AccessRule{Service,Method,Path} list onto K-ORC's

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -716,3 +716,41 @@ func TestKeystoneEndpointURL_DerivesFromProjectedService(t *testing.T) {
 	g.Expect(keystoneEndpointURL(cp)).
 		To(Equal("http://controlplane-keystone.openstack.svc:5000/v3"))
 }
+
+// TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain verifies that the
+// admin ApplicationCredential's prerequisites are provisioned as UNMANAGED K-ORC
+// imports — without them K-ORC blocks on "Waiting for User/admin to be created".
+func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	credRef := orcv1alpha1.CloudCredentialsReference{SecretName: "k-orc-clouds-yaml", CloudName: "admin"}
+	g.Expect(r.ensureKORCAdminImports(context.Background(), cp, credRef)).To(Succeed())
+
+	var domain orcv1alpha1.Domain
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminDomainRef(cp), Namespace: childNamespace(cp),
+	}, &domain)).To(Succeed())
+	g.Expect(domain.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyUnmanaged))
+	g.Expect(domain.Spec.Import).NotTo(BeNil())
+	g.Expect(domain.Spec.Import.Filter).NotTo(BeNil())
+	g.Expect(domain.Spec.Import.Filter.Name).NotTo(BeNil())
+	g.Expect(string(*domain.Spec.Import.Filter.Name)).To(Equal("Default"))
+	g.Expect(domain.OwnerReferences).To(HaveLen(1))
+
+	var user orcv1alpha1.User
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminUserRef(cp), Namespace: childNamespace(cp),
+	}, &user)).To(Succeed())
+	g.Expect(user.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyUnmanaged))
+	g.Expect(user.Spec.Import).NotTo(BeNil())
+	g.Expect(user.Spec.Import.Filter).NotTo(BeNil())
+	g.Expect(user.Spec.Import.Filter.Name).NotTo(BeNil())
+	g.Expect(string(*user.Spec.Import.Filter.Name)).To(Equal("admin"))
+	g.Expect(user.Spec.Import.Filter.DomainRef).NotTo(BeNil())
+	g.Expect(string(*user.Spec.Import.Filter.DomainRef)).To(Equal(adminDomainRef(cp)))
+	g.Expect(user.OwnerReferences).To(HaveLen(1))
+}

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -410,7 +410,7 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
+		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -452,7 +452,7 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
+		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -697,6 +697,18 @@ func mintedAppCredSecret(cp *c5c3v1alpha1.ControlPlane) *corev1.Secret {
 	}
 }
 
+// readyAppCredPushSecret returns the admin app-credential PushSecret with the exact
+// spec the operator builds (so EnsurePushSecret performs no update) plus a Ready
+// condition — the state after ESO has successfully synced it to OpenBao. The
+// AdminCredentialReady gate requires the PushSecret to be Ready.
+func readyAppCredPushSecret(cp *c5c3v1alpha1.ControlPlane) *esov1alpha1.PushSecret {
+	ps := adminAppCredentialPushSecret(cp)
+	ps.Status.Conditions = []esov1alpha1.PushSecretStatusCondition{
+		{Type: esov1alpha1.PushSecretReady, Status: corev1.ConditionTrue},
+	}
+	return ps
+}
+
 func setAdminCredentialReady(cp *c5c3v1alpha1.ControlPlane) {
 	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 		Type:               conditionTypeAdminCredentialReady,
@@ -799,4 +811,29 @@ func TestReconcileKORC_CreatesAppCredentialSecretWithValue(t *testing.T) {
 	g.Expect(sec.Data).To(HaveKey(appCredSecretValueKey))
 	g.Expect(sec.Data[appCredSecretValueKey]).NotTo(BeEmpty(), "value must be a generated secret")
 	g.Expect(sec.OwnerReferences).To(HaveLen(1))
+}
+
+// TestReconcileAdminCredential_WaitsForPushSecretSync verifies AdminCredentialReady
+// does NOT go True merely because the PushSecret CR exists: until it has synced to
+// OpenBao (Ready), a backend permission failure must surface as WaitingForPushSecret
+// rather than a false-positive Ready (Befund #7).
+func TestReconcileAdminCredential_WaitsForPushSecretSync(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	// No pre-existing Ready PushSecret — EnsurePushSecret creates it, but it has not
+	// synced to the backend yet.
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForPushSecret"))
 }

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -408,7 +408,9 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	s := korcTestScheme(t)
 	cp := korcControlPlane()
 	setKORCReady(cp)
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyCloudsYamlES(cp)).Build()
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -430,11 +432,16 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(adminAppCredentialRemoteKey))
 	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/admin/app-credential"))
 
-	// Operator-owned minted-credential Secret ensured (clobber-safe: data untouched).
+	// The operator-owned Secret now carries the assembled app-credential clouds.yaml
+	// (id from cp.Status, secret from the preserved "value") for the OpenBao push.
 	sec := &corev1.Secret{}
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp),
 	}, sec)).To(Succeed())
+	g.Expect(sec.Data).To(HaveKey("value"), "the K-ORC-read \"value\" must be preserved")
+	g.Expect(sec.Data).To(HaveKey("clouds.yaml"))
+	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("application_credential_id"))
+	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("test-ac-id"))
 }
 
 func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
@@ -443,7 +450,9 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	s := korcTestScheme(t)
 	cp := korcControlPlane()
 	setKORCReady(cp)
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyCloudsYamlES(cp)).Build()
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -674,6 +683,20 @@ func setKORCReady(cp *c5c3v1alpha1.ControlPlane) {
 	})
 }
 
+// mintedAppCredSecret returns the operator-owned Secret pre-populated with the
+// generated application-credential "value" — the state reconcileKORC's
+// ensureAppCredentialSecret leaves before reconcileAdminCredential assembles the
+// clouds.yaml.
+func mintedAppCredSecret(cp *c5c3v1alpha1.ControlPlane) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminAppCredentialSecretName(cp),
+			Namespace: childNamespace(cp),
+		},
+		Data: map[string][]byte{appCredSecretValueKey: []byte("generated-app-cred-secret")},
+	}
+}
+
 func setAdminCredentialReady(cp *c5c3v1alpha1.ControlPlane) {
 	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 		Type:               conditionTypeAdminCredentialReady,
@@ -753,4 +776,27 @@ func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
 	g.Expect(user.Spec.Import.Filter.DomainRef).NotTo(BeNil())
 	g.Expect(string(*user.Spec.Import.Filter.DomainRef)).To(Equal(adminDomainRef(cp)))
 	g.Expect(user.OwnerReferences).To(HaveLen(1))
+}
+
+// TestReconcileKORC_CreatesAppCredentialSecretWithValue verifies that reconcileKORC
+// provisions the operator-owned Secret with a generated "value" BEFORE the AC —
+// K-ORC's managed ApplicationCredential reads Secret.Data["value"] to mint, so
+// without this it blocks on "Waiting for Secret … to be created".
+func TestReconcileKORC_CreatesAppCredentialSecretWithValue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret()).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	sec := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp),
+	}, sec)).To(Succeed(), "the app-credential Secret must exist before the AC is reconciled")
+	g.Expect(sec.Data).To(HaveKey(appCredSecretValueKey))
+	g.Expect(sec.Data[appCredSecretValueKey]).NotTo(BeEmpty(), "value must be a generated secret")
+	g.Expect(sec.OwnerReferences).To(HaveLen(1))
 }

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -402,6 +402,50 @@ func TestReconcileAdminCredential_FreshClusterWithoutCloudsYamlSeedDoesNotPush(t
 			"otherwise the bootstrap cycle is masked")
 }
 
+// TestReconcileAdminCredential_MissingAppCredSecretDefers verifies the Get-and-fail
+// flow: the operator-owned app-credential Secret is created with its "value" by
+// ensureAppCredentialSecret during reconcileKORC, so by the time the credential is
+// assembled it MUST exist. If it is absent (invariant violation), reconcileAdminCredential
+// must defer with a clear reason — NOT CreateOrUpdate a fresh, value-less Secret and
+// then push an empty credential to OpenBao.
+func TestReconcileAdminCredential_MissingAppCredSecretDefers(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	// clouds.yaml ExternalSecret is Ready, but the app-credential Secret is absent.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyCloudsYamlES(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForAppCredentialSecret"))
+
+	// No empty app-credential Secret may be created as a side effect — that Secret
+	// is owned by ensureAppCredentialSecret, not by this assembly step.
+	sec := &corev1.Secret{}
+	secErr := c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp),
+	}, sec)
+	g.Expect(apierrors.IsNotFound(secErr)).To(BeTrue(),
+		"a missing app-credential Secret must not be re-created here with an empty value")
+
+	// And nothing may be pushed to OpenBao while the credential is unassembled.
+	ps := &esov1alpha1.PushSecret{}
+	psErr := c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp),
+	}, ps)
+	g.Expect(apierrors.IsNotFound(psErr)).To(BeTrue(),
+		"no PushSecret may be created while the app-credential Secret is missing")
+}
+
 func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -702,3 +702,17 @@ func readyCloudsYamlES(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
 		},
 	}
 }
+
+// TestKeystoneEndpointURL_DerivesFromProjectedService locks in that the catalog
+// Endpoint URL points at the PROJECTED Keystone Service ("{cp.Name}-keystone")
+// rather than a hardcoded "keystone" — the keystone-operator names the Service
+// after the projected Keystone CR, so a fixed name does not resolve (the K-ORC
+// auth / catalog otherwise fails with "lookup keystone.<ns>.svc: no such host").
+func TestKeystoneEndpointURL_DerivesFromProjectedService(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := &c5c3v1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "controlplane", Namespace: "openstack"},
+	}
+	g.Expect(keystoneEndpointURL(cp)).
+		To(Equal("http://controlplane-keystone.openstack.svc:5000/v3"))
+}

--- a/tests/unit/hack/deploy_infra_preflight_test.sh
+++ b/tests/unit/hack/deploy_infra_preflight_test.sh
@@ -69,6 +69,22 @@ run_preflight() {
   ) 2>&1
 }
 
+# run_preflight_with_controlplane <stub_dir>
+# As run_preflight, but with WITH_CONTROLPLANE=true exported so the yq gate on
+# the ControlPlane path is exercised (CC-0110).
+run_preflight_with_controlplane() {
+  local stub_dir="$1"
+  (
+    PATH="$stub_dir"
+    export PATH
+    WITH_CONTROLPLANE=true
+    export WITH_CONTROLPLANE
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    preflight_checks
+  ) 2>&1
+}
+
 # ---------------------------------------------------------------------------
 # Test 1: preflight passes when flux is absent (CC-0085, REQ-005)
 # ---------------------------------------------------------------------------
@@ -114,10 +130,54 @@ test_preflight_fails_without_kubectl() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 3: preflight fails when WITH_CONTROLPLANE=true but yq is absent (CC-0110)
+# ---------------------------------------------------------------------------
+test_preflight_fails_without_yq_when_controlplane() {
+  echo "Test: preflight_checks fails when WITH_CONTROLPLANE=true and yq is missing (CC-0110)"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Every base tool present, but NOT yq — the WITH_CONTROLPLANE path needs it to
+  # drop MariaDB/Memcached from the infrastructure overlay in Step 5.
+  make_stub_path "$tmp" docker kind kubectl jq
+
+  local output exit_code
+  output="$(run_preflight_with_controlplane "$tmp")"
+  exit_code=$?
+
+  assert_nonzero_exit "preflight_checks exits non-zero without yq under WITH_CONTROLPLANE" "$exit_code"
+  assert_contains "preflight reports yq required for WITH_CONTROLPLANE" "$output" "requires 'yq'"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: preflight passes when WITH_CONTROLPLANE=true and yq is present (CC-0110)
+# ---------------------------------------------------------------------------
+test_preflight_passes_with_yq_when_controlplane() {
+  echo "Test: preflight_checks passes when WITH_CONTROLPLANE=true and yq is present (CC-0110)"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_stub_path "$tmp" docker kind kubectl jq yq
+
+  local output exit_code
+  output="$(run_preflight_with_controlplane "$tmp")"
+  exit_code=$?
+
+  assert_eq "preflight_checks exits 0 with yq under WITH_CONTROLPLANE" "0" "$exit_code"
+  assert_contains "preflight log reports success" "$output" "Pre-flight checks passed."
+}
+
+# ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
 test_preflight_passes_without_flux
 test_preflight_fails_without_kubectl
+test_preflight_fails_without_yq_when_controlplane
+test_preflight_passes_with_yq_when_controlplane
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"


### PR DESCRIPTION
## Summary

Running the c5c3 ControlPlane chain on a real cluster for the first time — the in-repo `tests/e2e/c5c3/full-controlplane-keystone` Chainsaw suite **skips** when the stack is absent, so the headline flow had never actually executed — surfaced a chain of integration bugs, each guarded by a "Reviewer: please verify" comment that was never verified. This PR fixes them and adds an opt-in bring-up so the chain can run, and verifies it end-to-end.

**Result:** on a live `kind-forge-e2e` cluster the `ControlPlane` reaches `Ready=True (AllReady)` — Infrastructure → Keystone → KORC → AdminCredential → Catalog all `True` — and K-ORC authenticates with the minted **restricted** application credential (not the bootstrap admin password): the app-credential `clouds.yaml` round-trips OpenBao → ESO and every K-ORC resource (ApplicationCredential, User, Domain, Service, Endpoint) stays `Available`.

### Fixes (the bug chain)
- **Adopt pre-existing infra** (`reconcile_infrastructure.go`): managed mode did a create-or-update that blanked the existing MariaDB's immutable `spec.storage` (the mariadb-operator webhook rejected it → `InfrastructureReady=False`). Now: create-when-absent, otherwise adopt the existing CR as-is (don't reshape immutable storage / topology, don't claim GC ownership of infra it didn't create).
- **Point K-ORC at the projected Keystone Service** (`reconcile_korc.go`, `write-bootstrap-secrets.sh`): `keystoneEndpointURL` and the bootstrap `clouds.yaml` `auth_url` hardcoded `keystone.<ns>.svc`, but the ControlPlane projects `{cp}-keystone`. Derive it from `keystoneName(cp)`; parameterise the seed via `KORC_KEYSTONE_AUTH_URL` (default unchanged for the per-service path).
- **Import the admin User + Domain** (`reconcile_korc.go`): the AC's `UserRef` referenced a K-ORC `User` nothing created. Provision the `Domain` (Default) and `User` (admin) as **unmanaged imports** before minting; grant RBAC for `users`/`domains`.
- **Assemble the credential round-trip** (`reconcile_korc.go`): K-ORC's managed AC *reads* `Secret.Data["value"]` to mint (it does not write the secret). Generate the `value` before the AC, then assemble the app-credential `clouds.yaml` (auth_url + id from the minted AC + secret) so the PushSecret delivers it to OpenBao.
- **Deliver it to OpenBao + honest gate** (`setup-auth.sh`, `reconcile_korc.go`): the PushSecret 403'd because `push-app-credentials` was bound to no ESO role; bind it to the management role. Gate `AdminCredentialReady` on the PushSecret actually syncing (not just existing), so a backend failure no longer reports a false-positive Ready.

### Feature + docs
- **`WITH_CONTROLPLANE=true make deploy-infra`** (`hack/deploy-infra.sh`, `deploy/kind/controlplane/`): opt-in bring-up that skips the deploy-infra MariaDB/Memcached CRs (the ControlPlane provisions them), deploys the c5c3-operator + K-ORC + keystone-operator, and applies a `ControlPlane` CR. Default path unchanged.
- **ControlPlane quick start** rewritten to the `WITH_CONTROLPLANE` happy-path (drops the local-build recipe).

Addresses the critical path of #398 (all three items now checked there).

## Test plan

- [x] `go test ./operators/c5c3/internal/controller/...` green, incl. new unit tests: infra adoption preserves immutable storage + no owner-ref; `keystoneEndpointURL` derivation; unmanaged User/Domain imports; pre-mint `value` secret; clouds.yaml assembly; `AdminCredentialReady` waits for PushSecret-Ready.
- [x] `go vet`, `gofumpt` (v0.9.2), `helm-unittest` (clusterrole/role incl. users/domains), `make shellcheck` all clean.
- [x] `kubectl kustomize deploy/flux-system` / `deploy/kind/base` / `deploy/kind/controlplane` render.
- [x] **Live end-to-end** on `kind-forge-e2e`: `ControlPlane` `Ready=True (AllReady)`; K-ORC ApplicationCredential `Available` with a minted id + `restricted`; `k-orc-clouds-yaml` re-materialised as the **app-credential** clouds.yaml (no password); Service/Endpoint catalog registered.
- [ ] **Not yet fresh-run-tested:** the `WITH_CONTROLPLANE=true make deploy-infra` *fresh-create* path (operator provisions a new MariaDB) is structurally validated only — the operator's hardcoded 3-replica-Galera/100Gi MariaDB projection likely will not schedule on single-node kind. A kind-appropriate/configurable DB topology is the remaining follow-up (tracked in #398). The live verification ran on the adopted-infra path (E2E fixture CR reusing the existing `openstack-db`).