### PR TITLE
chore(kind): rename the kind cluster from forge-e2e to forge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/c5c3
+  # Kind cluster name — single source of truth for every e2e job's
+  # helm/kind-action cluster_name and `kind load --name`. Mirrors the
+  # CLUSTER_NAME default in hack/deploy-infra.sh.
+  KIND_CLUSTER: forge
   # CC-0018: Pin tool versions for CI reproducibility (single source of truth).
   CONTROLLER_GEN_VERSION: v0.20.1
   GOFUMPT_VERSION: v0.9.2  # CC-0053
@@ -506,7 +510,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          cluster_name: ${{ env.KIND_CLUSTER }}
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra
@@ -737,7 +741,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          cluster_name: ${{ env.KIND_CLUSTER }}
       # Resolve which images this operator needs: always its operator image,
       # plus one service image per release that ships one. The release list
       # comes from source-refs.yaml (ci-service-image-releases.sh), so an
@@ -769,17 +773,18 @@ jobs:
           OPERATOR: ${{ matrix.operator }}
           IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           SERVICE_RELEASES: ${{ steps.e2e-images.outputs.releases }}
+          KIND_CLUSTER: ${{ env.KIND_CLUSTER }}
         run: |
-          kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}-operator:dev" --name forge-e2e
+          kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}-operator:dev" --name "${KIND_CLUSTER}"
           for release in ${SERVICE_RELEASES}; do
-            kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}:${release}" --name forge-e2e
+            kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}:${release}" --name "${KIND_CLUSTER}"
           done
           # The image-upgrade E2E test re-tags the 2025.2 service image; only
           # operators that ship a 2025.2 service image need it loaded.
           if printf '%s\n' ${SERVICE_RELEASES} | grep -qx 2025.2; then
             docker tag "${IMAGE_PREFIX}/${OPERATOR}:2025.2" \
               "${IMAGE_PREFIX}/${OPERATOR}:2025.2-upgraded"
-            kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}:2025.2-upgraded" --name forge-e2e
+            kind load docker-image "${IMAGE_PREFIX}/${OPERATOR}:2025.2-upgraded" --name "${KIND_CLUSTER}"
           fi
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
@@ -896,7 +901,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          cluster_name: ${{ env.KIND_CLUSTER }}
       # GH-310: Pull pre-built images from GHCR (run-scoped tag).
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
@@ -906,8 +911,8 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/keystone:2025.2
       - name: Load images into kind
         run: |
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name forge-e2e
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name ${{ env.KIND_CLUSTER }}
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       # CC-0097: Opt in to Chaos Mesh - required for the chaos suites; covers both matrix entries.
       - name: Setup E2E infrastructure
@@ -976,7 +981,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          cluster_name: ${{ env.KIND_CLUSTER }}
       # GH-310: Pull pre-built images from GHCR (run-scoped tag).
       - name: Load E2E images
         uses: ./.github/actions/load-e2e-images
@@ -986,8 +991,8 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/keystone:2025.2
       - name: Load images into kind
         run: |
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name forge-e2e
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name ${{ env.KIND_CLUSTER }}
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence.
       # CC-0100: Opt in to kube-prometheus-stack — required for the prometheus suite.
       - name: Setup E2E infrastructure
@@ -1056,7 +1061,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: hack/kind-config.yaml
-          cluster_name: forge-e2e
+          cluster_name: ${{ env.KIND_CLUSTER }}
       # -- Keystone --------------------------------------------------------
       # GH-310: Pull pre-built images from GHCR (run-scoped tag).
       - name: Load E2E images
@@ -1068,8 +1073,8 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/tempest:${{ matrix.release }}
       - name: Load images into kind
         run: |
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name forge-e2e
-          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:${{ matrix.release }} --name forge-e2e
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:${{ matrix.release }} --name ${{ env.KIND_CLUSTER }}
       # CC-0050: Use composite action for shared Flux CLI + test deps + deploy-infra sequence (REQ-005).
       - name: Setup E2E infrastructure
         uses: ./.github/actions/setup-e2e-infra

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -66,7 +66,7 @@ use `https://keystone.127-0-0-1.nip.io/v3` everywhere below. deploy-infra sets
 the ControlPlane's `publicEndpoint` to match whichever port it brought the
 cluster up with.
 
-This creates the `forge-e2e` kind cluster, the shared infrastructure
+This creates the `forge` kind cluster, the shared infrastructure
 (cert-manager, OpenBao initialised/unsealed/bootstrapped, the MariaDB and
 Memcached operators, External Secrets, Envoy Gateway and the shared
 `openstack-gw`), and then — because `WITH_CONTROLPLANE=true` — the ControlPlane

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -82,7 +82,7 @@ The project provides a `hack/kind-config.yaml` with a single control-plane node 
 
 ```bash
 kind create cluster \
-  --name forge-e2e \
+  --name forge \
   --config hack/kind-config.yaml \
   --wait 60s
 ```
@@ -90,7 +90,7 @@ kind create cluster \
 Verify the cluster is ready:
 
 ```bash
-kubectl cluster-info --context kind-forge-e2e
+kubectl cluster-info --context kind-forge
 ```
 
 ::: warning Host port 443 binding requirement
@@ -505,7 +505,7 @@ Build the operator image, load it into kind, and install the chart directly from
 make docker-build OPERATOR=keystone IMG=ghcr.io/c5c3/keystone-operator:dev
 
 # 2. Load the image into the kind cluster (no registry needed)
-kind load docker-image ghcr.io/c5c3/keystone-operator:dev --name forge-e2e
+kind load docker-image ghcr.io/c5c3/keystone-operator:dev --name forge
 
 # 3. Pre-install CRDs so the API server watch cache is ready before the
 #    operator starts (avoids missing initial watch events)
@@ -554,7 +554,7 @@ RELEASE=2025.2   # update to the target release
 
 ```bash
 docker pull ghcr.io/c5c3/keystone:"${RELEASE}"
-kind load docker-image ghcr.io/c5c3/keystone:"${RELEASE}" --name forge-e2e
+kind load docker-image ghcr.io/c5c3/keystone:"${RELEASE}" --name forge
 ```
 
 ### Build locally
@@ -585,7 +585,7 @@ docker build -t "ghcr.io/c5c3/keystone:${RELEASE}" \
   images/keystone/
 
 # Load into kind
-kind load docker-image "ghcr.io/c5c3/keystone:${RELEASE}" --name forge-e2e
+kind load docker-image "ghcr.io/c5c3/keystone:${RELEASE}" --name forge
 ```
 
 ---
@@ -984,4 +984,4 @@ Delete the kind cluster and all its resources:
 make teardown-infra
 ```
 
-This runs `kind delete cluster --name forge-e2e` and removes all local state.
+This runs `kind delete cluster --name forge` and removes all local state.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -36,7 +36,7 @@ cd forge
 KIND_HOST_PORT=8443 make deploy-infra
 ```
 
-Creates the `forge-e2e` kind cluster with `host:8443 → nodePort 31443`,
+Creates the `forge` kind cluster with `host:8443 → nodePort 31443`,
 then installs Flux, cert-manager, the Gateway API CRDs,
 prometheus-operator-crds, OpenBao (initialised, unsealed and bootstrapped),
 MariaDB operator + `openstack-db`, External Secrets, Memcached operator +
@@ -59,7 +59,7 @@ kubectl wait helmrelease/keystone-operator -n keystone-system \
 ```bash
 RELEASE=2025.2
 docker pull ghcr.io/c5c3/keystone:${RELEASE}
-kind load docker-image ghcr.io/c5c3/keystone:${RELEASE} --name forge-e2e
+kind load docker-image ghcr.io/c5c3/keystone:${RELEASE} --name forge
 ```
 
 ## Step 5 — Keystone CR

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -494,7 +494,7 @@ validates health of all operators, CRs, and ExternalSecrets.
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
 | 5 | `chainsaw test` | Runs E2E tests from `tests/e2e/infrastructure/` |
 | 6 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
@@ -560,7 +560,7 @@ Chainsaw E2E test suites.
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 5 | `kind load docker-image` | Loads operator, 2025.2 service, 2025.2-upgraded, and 2026.1 service images into kind |
 | 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
@@ -602,7 +602,7 @@ being proven in CI — failures are visible but do not block merges or the publi
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 3 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 4 | `kind load docker-image` | Loads keystone operator and 2025.2 service images into kind |
 | 5 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack with `WITH_CHAOS_MESH=true` |
@@ -667,7 +667,7 @@ genuine regression of the kind-only Quick Start observability story.
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 3 | `load-e2e-images` composite | Restores prebuilt operator and service images from the build-e2e-images artifact |
 | 4 | `kind load docker-image` | Loads operator and service images into kind |
 | 5 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack with `WITH_PROMETHEUS: "true"` |
@@ -719,7 +719,7 @@ these via `matrix.release`, `matrix.config-dir`, `matrix.cr-name`, and
 | --- | --- | --- |
 | 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge-e2e`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 5 | `kind load docker-image` | Loads keystone operator and service images into kind |
 | 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -25,7 +25,7 @@ ExternalSecrets) into a local kind cluster and validate it with Chainsaw E2E tes
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  Kind Cluster (forge-e2e)                                               │
+│  Kind Cluster (forge)                                               │
 │                                                                         │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐                   │
 │  │ cert-manager │  │   OpenBao    │  │     ESO      │                   │
@@ -199,7 +199,7 @@ The deployment script supports configurable timeouts via environment variables:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `CLUSTER_NAME` | `forge-e2e` | Kind cluster name |
+| `CLUSTER_NAME` | `forge` | Kind cluster name |
 | `FLUX_OPERATOR_VERSION` | _pinned in script_ | Tag of the flux-operator `install.yaml` release applied in Step 2; kept in sync by Renovate via a `customManager` on `hack/deploy-infra.sh` |
 | `HELMRELEASE_TIMEOUT` | `600` | Seconds to wait for HelmReleases Ready (also bounds the `wait_for_fluxinstance` poll in Step 2) |
 | `POD_TIMEOUT` | `300` | Seconds to wait for OpenBao pods Ready |

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -46,7 +46,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # ---------------------------------------------------------------------------
 # Configuration (REQ-012)
 # ---------------------------------------------------------------------------
-CLUSTER_NAME="${CLUSTER_NAME:-forge-e2e}"
+CLUSTER_NAME="${CLUSTER_NAME:-forge}"
 HELMRELEASE_TIMEOUT="${HELMRELEASE_TIMEOUT:-600}"
 POD_TIMEOUT="${POD_TIMEOUT:-300}"
 EXTERNALSECRET_TIMEOUT="${EXTERNALSECRET_TIMEOUT:-120}"

--- a/hack/teardown-infra.sh
+++ b/hack/teardown-infra.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-CLUSTER_NAME="${CLUSTER_NAME:-forge-e2e}"
+CLUSTER_NAME="${CLUSTER_NAME:-forge}"
 
 # ---------------------------------------------------------------------------
 # log — Print a timestamped log message (ISO 8601 UTC).

--- a/tests/ci/verify_chaos_ci_pipeline.sh
+++ b/tests/ci/verify_chaos_ci_pipeline.sh
@@ -380,9 +380,9 @@ test_e2e_chaos_kind_cluster() {
     "config: hack/kind-config.yaml"
 
   assert_contains \
-    "e2e-chaos cluster name is forge-e2e" \
+    "e2e-chaos cluster name resolves to the shared KIND_CLUSTER env" \
     "$E2E_CHAOS_JOB_SECTION" \
-    "cluster_name: forge-e2e"
+    "cluster_name: \${{ env.KIND_CLUSTER }}"
 
   assert_contains \
     "e2e-chaos uses setup-e2e-infra composite" \


### PR DESCRIPTION
## Summary

The kind cluster was named `forge-e2e`, but it is not e2e-specific: the same
cluster backs **local development** via `hack/deploy-infra.sh` and every quick
start, not just the CI e2e jobs. This drops the misleading `-e2e` suffix so the
cluster is simply `forge` across CI, tooling, and docs.

## Changes

Renamed the literal cluster name only (`forge-e2e` → `forge`):

- **`.github/workflows/ci.yaml`** — every `cluster_name:` and `kind load --name`.
- **`hack/deploy-infra.sh`, `hack/teardown-infra.sh`** — the `CLUSTER_NAME` default.
- **`tests/ci/verify_chaos_ci_pipeline.sh`** — the cluster-name assertion.
- **`docs/quick-start*.md`, `docs/reference/**`** — prose, diagrams, and the
  derived kubectl context (`kind-forge-e2e` → `kind-forge`).

## Deliberately untouched

- The composite actions (`setup-e2e-infra`, `load-e2e-images`) and
  `hack/kind-config.yaml` derive the name rather than hardcode it.
- The `e2e-*` job names and the `e2e-${run_id}` image tags do not contain the
  cluster name.
- Historical `.planwerk/` plan and review archives keep the old name as a
  point-in-time record.

## Verification

- `tests/ci/verify_chaos_ci_pipeline.sh` — the `cluster name is forge` assertion
  passes; the 4 pre-existing failures on `main` are unrelated and unchanged.
- Repo-wide grep confirms no `forge-e2e` remains outside the `.planwerk/` archives.

> [!NOTE]
> A cluster created under the old name keeps running as `forge-e2e`. Run
> `kind delete cluster --name forge-e2e` once before the next local
> `make deploy-infra`.
