### PR TITLE
fix(CC-0110): point K-ORC's clouds.yaml at the internal identity endpoint

### DIFF
--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -141,6 +141,16 @@ seed_korc_bootstrap_clouds_yaml() {
   local auth_url="${KORC_KEYSTONE_AUTH_URL:-http://keystone.openstack.svc:5000/v3}"
 
   log "Seeding K-ORC bootstrap clouds.yaml at '${kv_path}' (auth_url=${auth_url}, if missing)..."
+  # endpoint_type MUST be "internal", and the key MUST be "endpoint_type" (NOT
+  # "interface"): gophercloud uses auth_url only to mint a token, then resolves every
+  # subsequent call against the catalog endpoint for this interface. K-ORC runs
+  # in-cluster and only honours clientconfig.Cloud.EndpointType (the endpoint_type
+  # key) — it drops the "interface" key entirely. A missing/"interface" value
+  # defaults to "public", whose catalog endpoint becomes the external Gateway host
+  # (https://keystone.<host>.nip.io:8443/v3) once Keystone is exposed; that is
+  # unreachable from a pod, and K-ORC swallows the connection error and reports the
+  # admin Domain/User imports as empty ("Waiting for OpenStack resource to be created
+  # externally"), so the application credential never mints.
   # shellcheck disable=SC2016  # $vars are intentionally expanded IN-POD, not by the host shell.
   kubectl exec -n "$NAMESPACE" openbao-0 -- \
     env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" VAULT_CACERT="${VAULT_CACERT}" \
@@ -162,7 +172,7 @@ seed_korc_bootstrap_clouds_yaml() {
       user_domain_name: Default
       project_domain_name: Default
     region_name: RegionOne
-    interface: public
+    endpoint_type: internal
     identity_api_version: 3
 "
       bao kv put "${BAO_KV_PATH}" clouds.yaml="${clouds}"

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -147,6 +147,25 @@ func generateAppCredSecretValue() (string, error) {
 // control plane authenticates K-ORC with after minting: the credential id comes
 // from the minted AC, the secret from the generated "value", and the auth_url from
 // the projected Keystone Service (keystoneEndpointURL).
+//
+// CRITICAL (endpoint_type: internal): gophercloud only uses the auth_url to obtain
+// a token; for every subsequent API call it resolves the endpoint from the returned
+// service catalog, picking the interface set here. K-ORC runs IN-CLUSTER, so it
+// must use the "internal" (cluster-DNS) identity endpoint. Once the ControlPlane
+// exposes Keystone via the shared Gateway the catalog's "public" identity endpoint
+// becomes the external host (e.g. https://keystone.<host>.nip.io:8443/v3), which
+// from inside a pod is unreachable — so "public" makes every list/get fail. Worse,
+// K-ORC swallows that failure (osclients ListDomains does `_ = pager.EachPage(...)`)
+// and reports it as an EMPTY import, so the admin Domain/User imports hang forever
+// on "Waiting for OpenStack resource to be created externally".
+//
+// The key MUST be "endpoint_type", NOT "interface": K-ORC's scope builder copies
+// only clientconfig.Cloud.EndpointType (the `endpoint_type` key) into the client
+// options and drops Cloud.Interface (the `interface` key) — see vendored
+// internal/scope/provider.go NewProviderClient. An "interface:" value is therefore
+// ignored and the endpoint defaults to "public". The auth_url already points at the
+// in-cluster Service for the same reason (keystoneEndpointURL, never the external
+// endpoint).
 func buildAppCredCloudsYAML(cp *c5c3v1alpha1.ControlPlane, acID, secret string) string {
 	region := cp.Spec.Region
 	if region == "" {
@@ -160,7 +179,7 @@ func buildAppCredCloudsYAML(cp *c5c3v1alpha1.ControlPlane, acID, secret string) 
       application_credential_secret: %q
     auth_type: v3applicationcredential
     region_name: %q
-    interface: public
+    endpoint_type: internal
     identity_api_version: 3
 `, keystoneEndpointURL(cp), acID, secret, region)
 }


### PR DESCRIPTION
## Problem

A `ControlPlane` never reached `Ready`: the admin `ApplicationCredential` stayed
`Available=False` ("Waiting for User/admin to be ready"), which traced down to the
unmanaged K-ORC `Domain` import hanging on **"Waiting for OpenStack resource to be
created externally"** — i.e. `KORCReady=False` forever.

## Root cause

The bootstrap-seeded clouds.yaml and the post-mint clouds.yaml assembled by
`buildAppCredCloudsYAML` both selected the endpoint with `interface: public`. K-ORC
runs in-cluster, so it must use the **internal** (cluster-DNS) identity endpoint:
gophercloud only contacts `auth_url` to mint a token and then resolves every
subsequent call against the service catalog at the selected interface. Since the
ControlPlane now exposes Keystone via the shared Gateway (#402), the catalog's
`public` identity endpoint is the external host
(`https://keystone.<host>.nip.io:8443/v3`), which is unreachable from inside the
cluster.

Two compounding behaviours turned this into a silent stall instead of an error:

- **Wrong key.** K-ORC's scope builder (vendored `internal/scope/provider.go`
  `NewProviderClient`) copies only `clientconfig.Cloud.EndpointType` — the
  `endpoint_type` key — and drops `Cloud.Interface` (the `interface` key). An
  `interface:` value is ignored and the endpoint type defaults to `public`. The key
  **must** be `endpoint_type`.
- **Swallowed error.** K-ORC's `osclients` `ListDomains` does
  `_ = pager.EachPage(...)`, discarding the connection error, so the import reports
  an *empty* result. The Domain/User imports therefore hang on "created externally",
  cascading up as `User/admin` not ready → `ApplicationCredential` not Available →
  `KORCReady=False`; the admin application credential never mints.

## Fix

Switch both clouds.yaml producers to `endpoint_type: internal`:

- `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` (bootstrap seed)
- `operators/c5c3/internal/controller/reconcile_korc.go` (`buildAppCredCloudsYAML`,
  the post-mint assembly)

Both carry a comment explaining the `endpoint_type` vs `interface` trap and the
swallowed-error symptom.

## Verification

Reproduced the failure on a live ControlPlane and confirmed the fix end-to-end
(via a gophercloud-equivalent `keystoneauth1` check and by correcting the live
OpenBao value): the admin `ApplicationCredential` mints and the ControlPlane
reaches `Ready=True` with `KORCReady` / `AdminCredentialReady` / `CatalogReady`
all `True`. `go build` and the KORC-related unit tests pass.

## Deploy note

The running c5c3-operator must be rebuilt/redeployed to pick up the
`buildAppCredCloudsYAML` change — until then it keeps pushing the
`interface: public` clouds.yaml to OpenBao, so a live cluster will regress on the
next ESO refresh.
