### PR TITLE
feat(c5c3-operator): re-mint the admin K-ORC application credential on password rotation

### DIFF
--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -432,8 +432,8 @@ the ControlPlane provisioned:
 | File | `reconcile_korc.go` |
 | Condition | `KORCReady` |
 | Gate | none (but defers until the admin-password Secret is readable) |
-| Projects / Owns | one K-ORC `ApplicationCredential` named `{controlplane.Name}-admin-app-credential` in `childNamespace(cp)` |
-| Requeue | `korcRequeueAfter` = **10s** while deferring, while the CRD is missing, or while the AC is not yet Available |
+| Projects / Owns | one K-ORC `ApplicationCredential` named `{controlplane.Name}-admin-app-credential` and the password-based clouds.yaml Secret `{controlplane.Name}-admin-password-cloud`, both in `childNamespace(cp)` |
+| Requeue | `korcRequeueAfter` = **10s** while deferring, while the CRD is missing, while a re-mint is in progress, or while the AC is not yet Available |
 
 `reconcileKORC` create-or-updates an **owned** K-ORC `ApplicationCredential` CR
 that instructs K-ORC to mint the admin application credential, and drives re-mint. Key behaviours:
@@ -443,24 +443,44 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
   `spec.resource.unrestricted`: `restricted=true ⇒ Unrestricted=false`
   (`ptr.To(!restricted)`). `restricted` defaults to `true` (least-privilege)
   when unset, matching the defaulting webhook.
-- **CloudCredentialsRef / UserRef.** `CloudCredentialsRef` (`secretName` /
-  `cloudName`) is copied through; the required K-ORC `UserRef` is derived
-  conventionally from the admin `cloudName` (defaulting to `"admin"`), assuming a
-  sibling K-ORC `User` CR of that name.
+- **Password-cloud (breaks the self-referential deadlock).** The AC authenticates
+  via an operator-owned, password-based clouds.yaml Secret
+  `{controlplane.Name}-admin-password-cloud` (`ensureAdminPasswordCloud`), **not**
+  `k-orc-clouds-yaml`. That matters because `k-orc-clouds-yaml` *is* the minted
+  application credential itself, so deleting the AC to re-mint would invalidate the
+  very clouds.yaml needed to re-authenticate; a restricted application credential
+  also cannot mint a new application credential. The password-cloud is re-rendered
+  from the live admin password on every pass (so a rotation flows through to it)
+  and is not churned when the password is unchanged. The Domain/User imports and
+  the catalog Service/Endpoint keep using the spec's `CloudCredentialsRef`
+  (`k-orc-clouds-yaml`) and tolerate the brief auth gap during a re-mint by
+  requeueing.
+- **UserRef.** The required K-ORC `UserRef` is derived conventionally from the
+  admin `cloudName` (defaulting to `"admin"`), assuming a sibling K-ORC `User` CR
+  of that name (imported as unmanaged by `ensureKORCAdminImports`).
 - **Access rules.** `projectAccessRules` maps our `{service, method, path}` list
   onto K-ORC's rule shape: `service` becomes a `serviceRef` (Kubernetes name ref
   to an ORC `Service` CR, e.g. `identity`), `method` becomes the typed
   `HTTPMethod` enum, and `path` becomes a string pointer.
-- **Re-mint trigger.** The SHA-256 of the admin password is stamped onto the AC
-  CR under the `forge.c5c3.io/admin-password-hash` annotation
-  (`adminPasswordHashAnnotation`). On a later pass, a mismatch between the
-  freshly computed hash and the stamped annotation drives K-ORC to re-mint. The hash is computed by the package-level
-  `computeAdminPasswordHash`, shared with the CredentialRotation reconciler so
-  both agree on one derivation.
+- **Re-mint trigger (delete + recreate).** K-ORC's AC actuator implements only
+  Create + Delete, so a rotated admin password cannot re-mint in place. The SHA-256
+  of the admin password is stamped onto the AC CR under the
+  `forge.c5c3.io/admin-password-hash` annotation (`adminPasswordHashAnnotation`);
+  on a later pass a mismatch (the hash moved, or the CredentialRotation reconciler
+  zeroed the annotation to nudge) drives `reconcileKORC` to **delete** the AC — the
+  finalizer revokes the old Keystone credential, authenticating via the
+  password-cloud — and **regenerate** the secret `value`, so the next pass recreates
+  the AC for a fresh mint. The hash is computed by the package-level
+  `computeAdminPasswordHash`, shared with the CredentialRotation reconciler so both
+  agree on one derivation.
+- **Re-mint progress / stall.** While the old AC is `Terminating` the condition is
+  `KORCReady=False/ReMinting`; if it stays terminating longer than
+  `remintStallTimeout` (**5m**) — a finalizer K-ORC cannot clear, e.g. it cannot
+  reach Keystone to revoke — it escalates to `KORCReady=False/ReMintStalled`.
 - **Status reflection.** `updateAdminApplicationCredentialStatus` reflects the
   observed AC into `cp.Status.AdminApplicationCredential` (`ID`, the inverted
-  `Restricted`, and a `LastRotation` re-stamped whenever the credential ID
-  changes).
+  `Restricted`, and a `LastRotation` re-stamped whenever the credential ID changes —
+  i.e. advanced by a completed re-mint).
 - **Missing-CRD safety.** If the K-ORC CRD is absent the apiserver/RESTMapper
   returns a no-match error, detected via `meta.IsNoMatchError` and surfaced as a
   clean condition **without** crash-looping the operator.
@@ -469,8 +489,12 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | --- | --- | --- | --- |
 | Admin password Secret/key missing | False | `WaitingForAdminPassword` | requeue 10s (via `secrets.IsMissingSecretOrKey`) |
 | Admin password read fails otherwise | False | `AdminPasswordError` | returns the error |
+| Password-cloud ensure fails | False | `PasswordCloudError` | returns the error |
 | K-ORC AC CRD not installed | False | `KORCCRDNotInstalled` | requeue 10s (no hard error) |
-| AC create/update fails otherwise | False | `ApplicationCredentialError` | returns the error |
+| Hash mismatch → AC deleted for re-mint | False | `ReMinting` | requeue 10s; AC deleted + `value` regenerated, recreated next pass |
+| Re-mint stuck `Terminating` past `remintStallTimeout` (5m) | False | `ReMintStalled` | requeue 10s; finalizer cannot revoke the old credential |
+| AC create/update/delete/read fails otherwise | False | `ApplicationCredentialError` | returns the error |
+| `value` regeneration fails | False | `SecretError` | returns the error |
 | AC not yet `Available` | False | `WaitingForApplicationCredential` | requeue 10s; gated on `orcv1alpha1.IsAvailable(ac)` (K-ORC uses `Available`, not `Ready`) |
 | AC minted and Available | True | `ApplicationCredentialMinted` | — |
 
@@ -555,13 +579,13 @@ The `CredentialRotationReconciler` drives one-shot rotations of a control-plane
 credential by **nudging** the ControlPlane reconciler rather than duplicating any
 mint logic. Its model:
 
-- **Nudge, never mint.** To force a re-mint it simply **clears** (zeroes) the
-  `forge.c5c3.io/admin-password-hash` annotation on the owned AC CR via
-  `clearPasswordHashAnnotation` (a no-op `Update` when already empty). On its
-  next pass `reconcileKORC` observes the mismatch and re-mints, re-stamping the
-  fresh hash. Clearing (rather than deleting the AC) avoids a window where the
-  admin credential is absent and keeps K-ORC's resource lifecycle owned solely by
-  the ControlPlane reconciler.
+- **Nudge, never mint or delete.** To force a re-mint it simply **clears** (zeroes)
+  the `forge.c5c3.io/admin-password-hash` annotation on the owned AC CR via
+  `clearPasswordHashAnnotation` (a no-op `Update` when already empty). On its next
+  pass `reconcileKORC` observes the mismatch and performs the delete+recreate
+  re-mint, re-stamping the fresh hash. Keeping the AC's resource lifecycle
+  (including the delete) owned solely by the ControlPlane reconciler avoids two
+  controllers racing on the same object.
 - **ControlPlane resolution (one-per-namespace).** A `CredentialRotation`
   carries no explicit ControlPlane reference, so `resolveControlPlane` lists
   ControlPlanes in the CredentialRotation's **own** namespace and requires

--- a/operators/c5c3/internal/controller/credential_invariant_test.go
+++ b/operators/c5c3/internal/controller/credential_invariant_test.go
@@ -100,13 +100,15 @@ func invariantControlPlane() *c5c3v1alpha1.ControlPlane {
 	return cp
 }
 
-// availableAC pre-seeds an Available ApplicationCredential so reconcileKORC flips
-// KORCReady=True on its single pass.
+// availableAC pre-seeds an Available ApplicationCredential whose stamped password
+// hash already matches, so reconcileKORC flips KORCReady=True on its single pass
+// (a missing/mismatched hash would instead trigger a delete+recreate re-mint).
 func availableAC(cp *c5c3v1alpha1.ControlPlane) *orcv1alpha1.ApplicationCredential {
 	return &orcv1alpha1.ApplicationCredential{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      adminAppCredentialName(cp),
-			Namespace: childNamespace(cp),
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
 		},
 		Status: orcv1alpha1.ApplicationCredentialStatus{
 			ID: ptr.To("ac-id-invariant"),
@@ -258,6 +260,44 @@ func TestCredentialInvariant_NoWorkloadReferencesAppCredentialSecret(t *testing.
 	g.Expect(leaks).To(BeEmpty(),
 		"REQ-013: no operator-created workload Pod template may reference the app-credential "+
 			"or keystone-admin Secret in an env var or volume. Leaks: %v", leaks)
+}
+
+// TestCredentialInvariant_PasswordCloudConfinedToAC asserts the operator-owned
+// password-cloud — which carries the CLEARTEXT admin password in its clouds.yaml —
+// is confined to the admin ApplicationCredential's CloudCredentialsRef: it must not
+// appear in the projected Keystone CR spec, and (like the app-credential secret)
+// must not leak into any operator-created workload Pod template.
+func TestCredentialInvariant_PasswordCloudConfinedToAC(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := invariantScheme(t)
+	cp := invariantControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), availableAC(cp), readyCloudsYamlES(cp)).
+		Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	driveCredentialChain(t, r, cp)
+
+	ctx := context.Background()
+	pwCloud := adminPasswordCloudSecretName(cp)
+
+	// (a) The password-cloud name must NOT appear in the projected Keystone CR.
+	k := &keystonev1alpha1.Keystone{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: keystoneName(cp), Namespace: childNamespace(cp)}, k)).To(Succeed())
+	g.Expect(renderObjectStrings(k.Spec)).NotTo(ContainSubstring(pwCloud),
+		"the password-cloud secret (cleartext admin password) must not appear in the Keystone CR spec")
+
+	// (b) The admin AC references it via CloudCredentialsRef — the one allowed use.
+	ac := getAC(t, c, cp)
+	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(pwCloud),
+		"the admin AC is the only object that may reference the password-cloud")
+
+	// (c) No operator-created workload references it (c5c3 creates none).
+	workloadCount, leaks := walkPodTemplatesForSecretLeaks(ctx, t, c, pwCloud)
+	g.Expect(workloadCount).To(BeZero())
+	g.Expect(leaks).To(BeEmpty(),
+		"no operator-created workload Pod template may reference the password-cloud. Leaks: %v", leaks)
 }
 
 // --- shared walkers / helpers ---

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -411,7 +411,9 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g.Expect(ac.Spec.Resource.Unrestricted).NotTo(BeNil())
 	g.Expect(*ac.Spec.Resource.Unrestricted).To(BeFalse(),
 		"restricted:true (default) MUST project to K-ORC Unrestricted=false (critical inversion)")
-	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(korcCloudsYamlSecretName))
+	// The AC mints via the operator-owned password-cloud (so a delete+recreate
+	// re-mint can always re-authenticate), NOT k-orc-clouds-yaml.
+	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(adminPasswordCloudSecretName(final)))
 
 	// Catalog: identity Service + public Endpoint shape.
 	svc := &orcv1alpha1.Service{}
@@ -419,6 +421,9 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 		To(Succeed(), "get projected identity Service CR")
 	g.Expect(svc.Spec.Resource).NotTo(BeNil())
 	g.Expect(svc.Spec.Resource.Type).To(Equal("identity"), "Service type must be identity")
+	// The catalog keeps using k-orc-clouds-yaml (only the AC moves to the
+	// password-cloud); this locks in that split.
+	g.Expect(svc.Spec.CloudCredentialsRef.SecretName).To(Equal(korcCloudsYamlSecretName))
 
 	ep := &orcv1alpha1.Endpoint{}
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: keystoneEndpointName(final), Namespace: ns.Name}, ep)).

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation.go
@@ -64,15 +64,15 @@ type CredentialRotationReconciler struct {
 //     credential; an operator must split the control planes into separate
 //     namespaces or add an explicit reference (a later-level field).
 //
-// DECISION (re-mint nudge): the reconciler NEVER mints the credential itself.
-// reconcileKORC stamps the SHA-256 of the admin password onto the owned AC CR via
-// adminPasswordHashAnnotation and re-mints whenever its computed hash differs
-// from that annotation. To force a re-mint this reconciler simply CLEARS
+// DECISION (re-mint nudge): the reconciler NEVER mints or deletes the credential
+// itself. reconcileKORC stamps the SHA-256 of the admin password onto the owned
+// AC CR via adminPasswordHashAnnotation and, on a hash mismatch, re-mints by
+// deleting + recreating the AC. To force a re-mint this reconciler simply CLEARS
 // (zeroes) the annotation on the AC CR — the lightest possible nudge. On its next
-// pass reconcileKORC observes the mismatch (computed hash != "") and re-mints,
-// re-stamping the fresh hash. Clearing the annotation (rather than deleting the
-// AC CR) avoids a window where the admin credential is absent and keeps K-ORC's
-// resource lifecycle owned solely by the ControlPlane reconciler.
+// pass reconcileKORC observes the mismatch (computed hash != "") and performs the
+// delete+recreate re-mint, re-stamping the fresh hash. Keeping the AC's resource
+// lifecycle (including the delete) owned solely by the ControlPlane reconciler
+// avoids two controllers racing on the same object.
 func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -172,8 +172,8 @@ func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Perform the nudge: clear the password-hash annotation so reconcileKORC
-	// re-mints on its next pass. Clearing (vs deleting the key) keeps the AC CR
-	// schema-valid and the change minimal.
+	// deletes+recreates the AC (the re-mint) on its next pass. Clearing (vs
+	// deleting the key) keeps the AC CR schema-valid and the change minimal.
 	if err := r.clearPasswordHashAnnotation(ctx, ac); err != nil {
 		return ctrl.Result{}, fmt.Errorf("clearing password-hash annotation to nudge re-mint: %w", err)
 	}

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
@@ -13,6 +13,7 @@ import (
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -142,11 +143,12 @@ func TestRotation_ReMintClearsHashAnnotation(t *testing.T) {
 
 // TestRotation_ReMintFullCycleReStampsHash drives the COMPLETE re-mint mutation
 // cycle, not just the nudge half (CC-0110, TE7). It (1) runs the CredentialRotation
-// reconciler to clear the password-hash annotation (the nudge), then (2) runs the
-// ControlPlane reconciler's reconcileKORC pass against the SAME client to prove the
-// nudge is consumed: reconcileKORC observes the now-empty annotation, re-mints, and
-// re-stamps the current password hash. Asserting both halves guards against a
-// regression where the nudge fires but the re-stamp never happens (or vice versa).
+// reconciler to clear the password-hash annotation (the nudge), then runs two
+// reconcileKORC passes against the SAME client to prove the nudge is consumed:
+// (2a) the cleared annotation drives reconcileKORC to DELETE the AC (the re-mint
+// trigger), and (2b) the next pass recreates it stamped with the current hash.
+// Asserting all three steps guards against a regression where the nudge fires but
+// the delete+recreate never happens (or vice versa).
 func TestRotation_ReMintFullCycleReStampsHash(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -173,14 +175,25 @@ func TestRotation_ReMintFullCycleReStampsHash(t *testing.T) {
 	g.Expect(nudged.Annotations[adminPasswordHashAnnotation]).To(BeEmpty(),
 		"reMint must clear the password-hash annotation to nudge a re-mint")
 
-	// --- Half 2: the ControlPlane reconciler consumes the nudge and re-stamps. ---
+	// --- Half 2a: reconcileKORC consumes the nudge and DELETES the AC to re-mint. ---
 	cpr := &ControlPlaneReconciler{Client: c, Scheme: s}
+	_, err = cpr.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	deleted := &orcv1alpha1.ApplicationCredential{}
+	getErr := c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialName(cp), Namespace: childNamespace(cp),
+	}, deleted)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"the cleared annotation must drive reconcileKORC to delete the AC for a re-mint")
+
+	// --- Half 2b: the next pass recreates the AC stamped with the current hash. ---
 	_, err = cpr.reconcileKORC(context.Background(), cp)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	reminted := getAC(t, c, cp)
 	g.Expect(reminted.Annotations).To(HaveKeyWithValue(adminPasswordHashAnnotation, testPasswordHash()),
-		"reconcileKORC must consume the cleared annotation and re-stamp the current password hash (re-mint)")
+		"reconcileKORC must recreate the AC and stamp the current password hash (re-mint)")
 }
 
 func TestRotation_PasswordHashChangeTriggersNudge(t *testing.T) {

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -80,10 +81,27 @@ const adminPasswordHashAnnotation = "forge.c5c3.io/admin-password-hash" //nolint
 // REQ-023).
 const korcCloudsYamlSecretName = "k-orc-clouds-yaml" //nolint:gosec // G101 false positive: Secret name, not a credential.
 
+// adminPasswordCloudSecretSuffix names the operator-owned Secret holding a
+// PASSWORD-based clouds.yaml that always tracks the current admin password. The
+// admin ApplicationCredential mints against THIS secret (not k-orc-clouds-yaml),
+// which breaks the self-referential bootstrap deadlock: k-orc-clouds-yaml is the
+// minted app-credential itself, so deleting the AC to re-mint would invalidate
+// the very clouds.yaml needed to re-authenticate. A restricted application
+// credential also cannot mint a new application credential — only a
+// password-authenticated session can — so password auth is required for the
+// delete+recreate re-mint to work at all.
+const adminPasswordCloudSecretSuffix = "-admin-password-cloud" //nolint:gosec // G101 false positive: Secret name suffix, not a credential.
+
 // adminAppCredentialName returns the deterministic name of the owned K-ORC
 // ApplicationCredential CR for the given ControlPlane.
 func adminAppCredentialName(cp *c5c3v1alpha1.ControlPlane) string {
 	return cp.Name + adminAppCredentialNameSuffix
+}
+
+// adminPasswordCloudSecretName returns the name of the operator-owned Secret that
+// holds the password-based clouds.yaml the admin ApplicationCredential mints with.
+func adminPasswordCloudSecretName(cp *c5c3v1alpha1.ControlPlane) string {
+	return cp.Name + adminPasswordCloudSecretSuffix
 }
 
 // adminAppCredentialSecretName returns the name of the operator-owned Secret that
@@ -184,6 +202,71 @@ func buildAppCredCloudsYAML(cp *c5c3v1alpha1.ControlPlane, acID, secret string) 
 `, keystoneEndpointURL(cp), acID, secret, region)
 }
 
+// ensureAdminPasswordCloud ensures the operator-owned Secret holding the
+// PASSWORD-based clouds.yaml the admin ApplicationCredential mints with exists and
+// always tracks the CURRENT admin password. Unlike ensureAppCredentialSecret's
+// "value" (generated once and preserved), this clouds.yaml is rebuilt from the
+// live admin password on every pass, so a password rotation flows through to it —
+// the credential K-ORC uses to re-authenticate and revoke/re-mint never goes
+// stale. CreateOrUpdate only writes when the rendered clouds.yaml differs, so a
+// steady-state pass does not churn the Secret (and does not wake any consumer).
+//
+// The Secret lives in childNamespace(cp) — the same namespace as the K-ORC CRs —
+// because K-ORC resolves CloudCredentialsRef in the resource's own namespace (C1).
+func (r *ControlPlaneReconciler) ensureAdminPasswordCloud(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, password string) error {
+	cloudsYAML := []byte(buildPasswordCloudsYAML(cp, password))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminPasswordCloudSecretName(cp),
+			Namespace: childNamespace(cp),
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[appCredCloudsYAMLKey] = cloudsYAML
+		return controllerutil.SetControllerReference(cp, secret, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("ensuring admin password-cloud secret %q: %w", secret.Name, err)
+	}
+	return nil
+}
+
+// buildPasswordCloudsYAML assembles the password-based clouds.yaml the admin
+// ApplicationCredential authenticates with to mint (and, on re-mint, revoke) the
+// Keystone credential. It mirrors the bootstrap seed
+// (deploy/openbao/bootstrap/write-bootstrap-secrets.sh) so the in-cluster and
+// operator-owned credentials are byte-compatible: the cloud key matches the
+// CloudCredentialsRef.CloudName, auth_url is the in-cluster Keystone Service
+// (keystoneEndpointURL — never the external endpoint), and endpoint_type is
+// "internal" (the key MUST be "endpoint_type", not "interface"; see
+// buildAppCredCloudsYAML for the full rationale).
+func buildPasswordCloudsYAML(cp *c5c3v1alpha1.ControlPlane, password string) string {
+	region := cp.Spec.Region
+	if region == "" {
+		region = "RegionOne"
+	}
+	cloudName := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName
+	if cloudName == "" {
+		cloudName = korcAdminUsername
+	}
+	return fmt.Sprintf(`clouds:
+  %s:
+    auth:
+      auth_url: %q
+      username: %q
+      password: %q
+      project_name: %q
+      user_domain_name: %q
+      project_domain_name: %q
+    region_name: %q
+    endpoint_type: internal
+    identity_api_version: 3
+`, cloudName, keystoneEndpointURL(cp), korcAdminUsername, password,
+		korcAdminUsername, korcAdminDomainName, korcAdminDomainName, region)
+}
+
 // adminAppCredentialPushSecretName returns the PushSecret name backing up the
 // minted application credential to OpenBao.
 func adminAppCredentialPushSecretName(cp *c5c3v1alpha1.ControlPlane) string {
@@ -196,16 +279,20 @@ func adminAppCredentialPushSecretName(cp *c5c3v1alpha1.ControlPlane) string {
 // It create-or-updates an OWNED ApplicationCredential CR that instructs K-ORC to
 // mint the admin application credential. The CR maps the ControlPlane's
 // AdminCredential spec onto the K-ORC ApplicationCredentialSpec, taking care of
-// the Restricted <-> Unrestricted inversion (see below). Re-mint (REQ-012) is
-// driven here by comparing the SHA-256 of the admin password against the
-// adminPasswordHashAnnotation stamped on the AC CR.
+// the Restricted <-> Unrestricted inversion (see below). The AC authenticates via
+// the operator-owned password-cloud (ensureAdminPasswordCloud), NOT
+// k-orc-clouds-yaml, so it can always re-authenticate as admin even while the
+// minted app credential is being revoked.
 //
-// DECISION (re-mint placement): the password-hash compare and re-mint trigger
-// live in reconcileKORC rather than reconcileAdminCredential. The AC CR is the
-// object K-ORC reacts to, so stamping the hash annotation here keeps the
-// re-mint signal co-located with the resource whose change actually causes
-// K-ORC to rotate the credential. reconcileAdminCredential then only deals with
-// committing/pushing the already-(re-)minted secret. Reviewer: please verify.
+// RE-MINT (REQ-012): K-ORC's AC actuator implements only Create + Delete, so a
+// rotated admin password cannot re-mint the credential in place. reconcileKORC
+// therefore compares the SHA-256 of the current admin password against the
+// adminPasswordHashAnnotation stamped on the AC; on a mismatch it DELETES the AC
+// (the finalizer revokes the old credential) and regenerates the secret "value"
+// (remintAdminApplicationCredential), and the next pass recreates it for a fresh
+// mint. The hash compare and the delete+recreate live here, co-located with the
+// resource K-ORC reacts to; reconcileAdminCredential only commits/pushes the
+// already-(re-)minted secret.
 //
 // MISSING-CRD SAFETY: if the K-ORC CRD is not installed the apiserver / RESTMapper
 // returns a no-match error; this is detected via meta.IsNoMatchError and surfaced
@@ -216,11 +303,12 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 
 	adminCred := cp.Spec.KORC.AdminCredential
 
-	// Compute the SHA-256 of the admin password used to (re-)mint the AC
-	// (REQ-012). A read failure (missing Secret/key) is surfaced as KORCReady
-	// False with a requeue rather than a hard error so a not-yet-seeded admin
-	// password simply defers minting.
-	pwHash, err := r.adminPasswordHash(ctx, cp)
+	// Read the admin password used to (re-)mint the AC (REQ-012). The cleartext is
+	// needed both to derive the rotation hash AND to render the password-based
+	// clouds.yaml the AC mints with. A read failure (missing Secret/key) is
+	// surfaced as KORCReady False with a requeue rather than a hard error so a
+	// not-yet-seeded admin password simply defers minting.
+	password, err := readAdminPassword(ctx, r.Client, cp)
 	if err != nil {
 		if secrets.IsMissingSecretOrKey(err) {
 			logger.Info("admin password not yet available, deferring K-ORC mint")
@@ -242,6 +330,23 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		})
 		return ctrl.Result{}, err
 	}
+	pwHash := hashAdminPassword(password)
+
+	// Ensure the operator-owned password-based clouds.yaml the AC mints with always
+	// tracks the current admin password. This is what breaks the self-referential
+	// bootstrap deadlock and lets the delete+recreate re-mint below re-authenticate
+	// as admin even while k-orc-clouds-yaml still holds the (about-to-be-revoked)
+	// app credential.
+	if err := r.ensureAdminPasswordCloud(ctx, cp, password); err != nil {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "PasswordCloudError",
+			Message:            fmt.Sprintf("ensuring admin password-cloud secret: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
 
 	// restricted defaults to true (the safe least-privilege baseline) when unset,
 	// matching the +kubebuilder:default=true marker and the defaulting webhook.
@@ -250,8 +355,18 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		restricted = *adminCred.ApplicationCredential.Restricted
 	}
 
-	credRef := orcv1alpha1.CloudCredentialsReference{
+	// importCredRef authenticates the Domain/User imports and the catalog
+	// Service/Endpoint: they stay on the spec's CloudCredentialsRef
+	// (k-orc-clouds-yaml) and tolerate the brief auth gap during a re-mint by
+	// requeueing. acCredRef points the AC itself at the operator-owned
+	// password-cloud so a delete+recreate can always re-authenticate (see
+	// adminPasswordCloudSecretSuffix).
+	importCredRef := orcv1alpha1.CloudCredentialsReference{
 		SecretName: adminCred.CloudCredentialsRef.SecretName,
+		CloudName:  adminCred.CloudCredentialsRef.CloudName,
+	}
+	acCredRef := orcv1alpha1.CloudCredentialsReference{
+		SecretName: adminPasswordCloudSecretName(cp),
 		CloudName:  adminCred.CloudCredentialsRef.CloudName,
 	}
 
@@ -260,7 +375,7 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// Default domain, so import it (and its domain) as UNMANAGED K-ORC resources
 	// before minting — otherwise the AC blocks forever on "Waiting for User/admin
 	// to be created".
-	if err := r.ensureKORCAdminImports(ctx, cp, credRef); err != nil {
+	if err := r.ensureKORCAdminImports(ctx, cp, importCredRef); err != nil {
 		if meta.IsNoMatchError(err) {
 			logger.Info("K-ORC User/Domain CRD not installed; KORCReady=False")
 			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
@@ -298,6 +413,45 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		return ctrl.Result{}, err
 	}
 
+	// Decide between steady-state convergence and a re-mint BEFORE the
+	// CreateOrUpdate: K-ORC's ApplicationCredential actuator only implements
+	// Create + Delete (no in-place re-mint), so the only way to a fresh Keystone
+	// credential on a password rotation is to delete the AC (finalizer revokes the
+	// old credential) and let the next pass recreate it. A hash mismatch — a stale
+	// stamped hash after a password rotation, or the empty annotation the
+	// CredentialRotation reconciler writes to nudge — is the re-mint signal.
+	acKey := types.NamespacedName{Name: adminAppCredentialName(cp), Namespace: childNamespace(cp)}
+	existing := &orcv1alpha1.ApplicationCredential{}
+	switch getErr := r.Get(ctx, acKey, existing); {
+	case getErr == nil:
+		if existing.Annotations[adminPasswordHashAnnotation] != pwHash {
+			return r.remintAdminApplicationCredential(ctx, cp, existing)
+		}
+		// Hash matches: fall through to the idempotent CreateOrUpdate below, which
+		// converges the spec without re-minting (no-op when nothing changed).
+	case apierrors.IsNotFound(getErr):
+		// First mint, or the recreate after a re-mint delete: CreateOrUpdate below.
+	case meta.IsNoMatchError(getErr):
+		logger.Info("K-ORC ApplicationCredential CRD not installed; KORCReady=False")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "KORCCRDNotInstalled",
+			Message:            "K-ORC ApplicationCredential CRD is not installed",
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	default:
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "ApplicationCredentialError",
+			Message:            fmt.Sprintf("reading ApplicationCredential: %v", getErr),
+		})
+		return ctrl.Result{}, getErr
+	}
+
 	ac := &orcv1alpha1.ApplicationCredential{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      adminAppCredentialName(cp),
@@ -307,7 +461,7 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, ac, func() error {
 		ac.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
-		ac.Spec.CloudCredentialsRef = credRef
+		ac.Spec.CloudCredentialsRef = acCredRef
 
 		if ac.Spec.Resource == nil {
 			ac.Spec.Resource = &orcv1alpha1.ApplicationCredentialResourceSpec{}
@@ -319,10 +473,10 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		ac.Spec.Resource.SecretRef = orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp))
 		ac.Spec.Resource.AccessRules = projectAccessRules(adminCred.ApplicationCredential.AccessRules)
 
-		// Stamp the password hash so a later spec change (admin password rotated)
-		// flips the annotation and triggers K-ORC to re-mint (REQ-012). Because
-		// the AC ResourceSpec is immutable in K-ORC, the annotation is the
-		// rotation signal the CredentialRotation flow (task 2.10) reacts to.
+		// Stamp the password hash this credential was minted against. On a later
+		// pass a mismatch (the hash moved because the admin password rotated, or
+		// the CredentialRotation reconciler zeroed the annotation to nudge) is what
+		// the re-mint decision above keys off to delete+recreate the AC (REQ-012).
 		if ac.Annotations == nil {
 			ac.Annotations = map[string]string{}
 		}
@@ -386,6 +540,121 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		Message:            "K-ORC admin application credential is minted and available",
 	})
 	return ctrl.Result{}, nil
+}
+
+// remintAdminApplicationCredential drives the actual re-mint when the stamped
+// password hash no longer matches the current admin password. K-ORC's AC actuator
+// has no in-place re-mint, so it DELETES the AC (the finalizer revokes the old
+// Keystone credential, authenticating via the operator-owned password-cloud) and
+// regenerates the app-credential secret "value" so the recreated AC mints a
+// brand-new credential. The next reconcileKORC pass observes the now-absent AC and
+// recreates it via CreateOrUpdate.
+//
+// While the old AC is Terminating it reports KORCReady=False/ReMinting, escalating
+// to ReMintStalled once it has been deleting longer than remintStallTimeout — a
+// stuck finalizer (e.g. K-ORC cannot reach Keystone to revoke) otherwise loops on
+// ReMinting forever with no operator-visible signal.
+func (r *ControlPlaneReconciler) remintAdminApplicationCredential(
+	ctx context.Context, cp *c5c3v1alpha1.ControlPlane, ac *orcv1alpha1.ApplicationCredential,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Already Terminating: wait for K-ORC's finalizer to revoke + remove the AC
+	// before the next pass recreates it. Escalate to ReMintStalled past the timeout.
+	if !ac.DeletionTimestamp.IsZero() {
+		reason := "ReMinting"
+		message := fmt.Sprintf("re-minting admin application credential %q; awaiting revoke of the previous credential", ac.Name)
+		if time.Since(ac.DeletionTimestamp.Time) > remintStallTimeout {
+			reason = "ReMintStalled"
+			message = fmt.Sprintf("admin application credential %q has been Terminating longer than %s; "+
+				"K-ORC may be unable to revoke the previous Keystone credential", ac.Name, remintStallTimeout)
+			logger.Info("admin application credential re-mint stalled",
+				"name", ac.Name, "terminatingSince", ac.DeletionTimestamp.Time)
+		}
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             reason,
+			Message:            message,
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
+	// Trigger the re-mint: delete the AC, then regenerate the secret "value" so the
+	// recreated AC mints a fresh credential (a NotFound on delete is benign — the
+	// AC is already gone, the recreate happens next pass).
+	if err := r.Delete(ctx, ac); err != nil && !apierrors.IsNotFound(err) {
+		if meta.IsNoMatchError(err) {
+			logger.Info("K-ORC ApplicationCredential CRD not installed; KORCReady=False")
+			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+				Type:               conditionTypeKORCReady,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cp.Generation,
+				Reason:             "KORCCRDNotInstalled",
+				Message:            "K-ORC ApplicationCredential CRD is not installed",
+			})
+			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+		}
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "ApplicationCredentialError",
+			Message:            fmt.Sprintf("deleting ApplicationCredential for re-mint: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
+
+	if err := r.regenerateAppCredentialSecretValue(ctx, cp); err != nil {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "SecretError",
+			Message:            fmt.Sprintf("regenerating application-credential secret value for re-mint: %v", err),
+		})
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("deleted admin application credential to trigger re-mint", "name", ac.Name)
+	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeKORCReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: cp.Generation,
+		Reason:             "ReMinting",
+		Message:            fmt.Sprintf("deleted admin application credential %q; a fresh credential will be minted from the rotated admin password", ac.Name),
+	})
+	return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+}
+
+// regenerateAppCredentialSecretValue overwrites the app-credential secret "value"
+// with a fresh random secret and drops any stale assembled clouds.yaml. The new
+// "value" makes the recreated AC mint a NEW Keystone credential; dropping the
+// clouds.yaml forces reconcileAdminCredential to rebuild it from the fresh id+value
+// rather than keep serving the just-revoked credential.
+func (r *ControlPlaneReconciler) regenerateAppCredentialSecretValue(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminAppCredentialSecretName(cp),
+			Namespace: childNamespace(cp),
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		v, gerr := generateAppCredSecretValue()
+		if gerr != nil {
+			return gerr
+		}
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[appCredSecretValueKey] = []byte(v)
+		delete(secret.Data, appCredCloudsYAMLKey)
+		return controllerutil.SetControllerReference(cp, secret, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("regenerating app-credential secret value: %w", err)
+	}
+	return nil
 }
 
 // adminUserRef derives the name of the K-ORC User CR the admin application
@@ -496,40 +765,44 @@ func projectAccessRules(rules []c5c3v1alpha1.AccessRule) []orcv1alpha1.Applicati
 	return out
 }
 
-// adminPasswordHash reads the admin password from the configured PasswordSecretRef
-// and returns its SHA-256 as a lowercase hex string (CC-0110, REQ-012). It
-// delegates to the package-level computeAdminPasswordHash so the ControlPlane
-// reconciler (which stamps the hash onto the AC CR during a mint) and the
-// CredentialRotation reconciler (which compares the hash to drive a re-mint
-// nudge, task 2.10) share ONE source of truth for the hash derivation.
-func (r *ControlPlaneReconciler) adminPasswordHash(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (string, error) {
-	return computeAdminPasswordHash(ctx, r.Client, cp)
-}
-
 // computeAdminPasswordHash reads the admin password from the ControlPlane's
 // configured PasswordSecretRef and returns its SHA-256 as a lowercase hex string
 // (CC-0110, REQ-012). The data key defaults to "password" when the SecretRef.Key
 // is unset, matching the keystone admin-password Secret convention.
 //
 // DECISION (hash-helper extraction): the hash derivation lives here as a
-// package-level function (rather than only as a method on ControlPlaneReconciler)
-// so BOTH the ControlPlane reconciler and the CredentialRotation reconciler
-// (task 2.10) compute the SAME hash without duplicating the SHA-256 logic. The
-// ControlPlaneReconciler.adminPasswordHash method is retained as a thin delegator
-// so reconcile_korc.go's external behaviour and tests are unchanged.
+// package-level function so BOTH the ControlPlane reconciler (which reads the
+// cleartext via readAdminPassword and hashes it via hashAdminPassword inline) and
+// the CredentialRotation reconciler compute the SAME hash without duplicating the
+// SHA-256 logic.
 func computeAdminPasswordHash(ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane) (string, error) {
+	pw, err := readAdminPassword(ctx, c, cp)
+	if err != nil {
+		return "", err
+	}
+	return hashAdminPassword(pw), nil
+}
+
+// readAdminPassword reads the cleartext admin password from the configured
+// PasswordSecretRef (data key defaults to "password"). reconcileKORC needs the
+// cleartext — not just its hash — to render the password-based clouds.yaml the
+// admin ApplicationCredential mints with, so the read is factored out here and the
+// hash derived from it via hashAdminPassword.
+func readAdminPassword(ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane) (string, error) {
 	ref := cp.Spec.KORC.AdminCredential.PasswordSecretRef
 	key := ref.Key
 	if key == "" {
 		key = "password"
 	}
-	pw, err := secrets.GetSecretValue(ctx, c,
+	return secrets.GetSecretValue(ctx, c,
 		types.NamespacedName{Namespace: cp.Namespace, Name: ref.Name}, key)
-	if err != nil {
-		return "", err
-	}
+}
+
+// hashAdminPassword returns the SHA-256 of the admin password as a lowercase hex
+// string — the value stamped onto the AC CR's adminPasswordHashAnnotation.
+func hashAdminPassword(pw string) string {
 	sum := sha256.Sum256([]byte(pw))
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:])
 }
 
 // updateAdminApplicationCredentialStatus reflects the observed AC CR into

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
@@ -215,8 +216,11 @@ func TestReconcileKORC_OwnerRefAndCloudCredsAndManagementPolicy(t *testing.T) {
 	g.Expect(ac.OwnerReferences[0].Name).To(Equal("cp"))
 	g.Expect(ac.OwnerReferences[0].Kind).To(Equal("ControlPlane"))
 
-	// CloudCredentialsRef.SecretName matches the admin clouds.yaml secret.
-	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal("k-orc-clouds-yaml"))
+	// CloudCredentialsRef.SecretName points at the operator-owned password-cloud
+	// (NOT k-orc-clouds-yaml) so a delete+recreate re-mint can always re-authenticate
+	// as admin. The CloudName is preserved from the spec.
+	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(adminPasswordCloudSecretName(cp)))
+	g.Expect(ac.Spec.CloudCredentialsRef.CloudName).To(Equal("admin"))
 	g.Expect(ac.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyManaged))
 
 	// SecretRef points at the operator-owned minted-credential Secret.
@@ -245,9 +249,14 @@ func TestReconcileKORC_KORCReadyTrueWhenACAvailable(t *testing.T) {
 
 	s := korcTestScheme(t)
 	cp := korcControlPlane()
-	// Pre-create an Available AC so KORCReady flips True on this pass.
+	// Pre-create an Available AC stamped with the CURRENT password hash so KORCReady
+	// flips True on this pass (a missing/mismatched hash would trigger a re-mint).
 	existing := &orcv1alpha1.ApplicationCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: adminAppCredentialName(cp), Namespace: childNamespace(cp)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+		},
 		Status: orcv1alpha1.ApplicationCredentialStatus{
 			ID: ptr.To("ac-id-123"),
 			Conditions: []metav1.Condition{{
@@ -521,12 +530,17 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 
 // --- 2.8: re-mint (hash) ---
 
-func TestReconcileKORC_HashMismatchRemintsAndStampsNewHash(t *testing.T) {
+// TestReconcileKORC_HashMismatchDeletesACForRemint asserts the re-mint trigger:
+// K-ORC's AC actuator cannot re-mint in place, so a stale stamped hash (the admin
+// password rotated) must DELETE the AC — driving K-ORC's finalizer to revoke the
+// old Keystone credential — and regenerate the secret "value" so the recreated AC
+// mints a fresh credential. KORCReady reports the transient ReMinting reason.
+func TestReconcileKORC_HashMismatchDeletesACForRemint(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	s := korcTestScheme(t)
 	cp := korcControlPlane()
-	// Pre-create an Available AC stamped with a STALE hash and an old ID.
+	// Pre-create an Available AC stamped with a STALE hash (the rotation signal).
 	existing := &orcv1alpha1.ApplicationCredential{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        adminAppCredentialName(cp),
@@ -543,17 +557,103 @@ func TestReconcileKORC_HashMismatchRemintsAndStampsNewHash(t *testing.T) {
 			}},
 		},
 	}
-	// Seed prior status so a re-mint (ID change) is observable as a new rotation.
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "old-id"}
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret(), existing).Build()
+	// Seed the app-credential secret with a KNOWN value so the regeneration is observable.
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), existing, mintedAppCredSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
-	_, err := r.reconcileKORC(context.Background(), cp)
+	res, err := r.reconcileKORC(context.Background(), cp)
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
 
-	ac := getAC(t, c, cp)
-	g.Expect(ac.Annotations).To(HaveKeyWithValue(adminPasswordHashAnnotation, testPasswordHash()),
-		"hash mismatch must re-stamp the annotation with the new password hash")
+	// The AC was deleted (no finalizer in the fake client => removed immediately).
+	deleted := &orcv1alpha1.ApplicationCredential{}
+	getErr := c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialName(cp), Namespace: childNamespace(cp),
+	}, deleted)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"a hash mismatch must delete the AC to trigger a re-mint")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ReMinting"))
+
+	// The secret "value" was regenerated so the recreated AC mints a NEW credential.
+	sec := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp),
+	}, sec)).To(Succeed())
+	g.Expect(sec.Data[appCredSecretValueKey]).NotTo(Equal([]byte("generated-app-cred-secret")),
+		"the app-credential secret value must be regenerated on re-mint")
+}
+
+// TestReconcileKORC_RemintStalledAfterTimeout asserts the ReMintStalled escape: an
+// AC stuck Terminating longer than remintStallTimeout (a finalizer K-ORC cannot
+// clear because it cannot revoke the old credential) escalates KORCReady from the
+// transient ReMinting reason to the operator-visible ReMintStalled reason.
+func TestReconcileKORC_RemintStalledAfterTimeout(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	// An AC mid-delete (DeletionTimestamp + finalizer) whose stamped hash mismatches,
+	// terminating since well before the stall timeout.
+	staleDeletion := metav1.NewTime(metav1.Now().Add(-2 * remintStallTimeout))
+	existing := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              adminAppCredentialName(cp),
+			Namespace:         childNamespace(cp),
+			Annotations:       map[string]string{adminPasswordHashAnnotation: "stale-hash"},
+			Finalizers:        []string{"openstack.k-orc.cloud/applicationcredential"},
+			DeletionTimestamp: &staleDeletion,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), existing).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ReMintStalled"),
+		"an AC Terminating past remintStallTimeout must escalate to ReMintStalled")
+}
+
+// TestReconcileKORC_RemintTerminatingReportsReMinting asserts that an AC mid-delete
+// but WITHIN the stall timeout reports the transient ReMinting reason (not stalled).
+func TestReconcileKORC_RemintTerminatingReportsReMinting(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	justDeleted := metav1.Now()
+	existing := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              adminAppCredentialName(cp),
+			Namespace:         childNamespace(cp),
+			Annotations:       map[string]string{adminPasswordHashAnnotation: "stale-hash"},
+			Finalizers:        []string{"openstack.k-orc.cloud/applicationcredential"},
+			DeletionTimestamp: &justDeleted,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), existing).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ReMinting"))
 }
 
 func TestReconcileKORC_HashMatchNoRemint(t *testing.T) {
@@ -589,6 +689,152 @@ func TestReconcileKORC_HashMatchNoRemint(t *testing.T) {
 	// ResourceVersion stable (CC-0110, TE7 full-mutation-cycle).
 	g.Expect(*ac2.Spec.Resource).To(Equal(specBefore),
 		"hash match must not otherwise mutate the ApplicationCredential ResourceSpec")
+}
+
+// TestReconcileKORC_FreshMintUsesPasswordCloud asserts the first mint renders the
+// operator-owned password-based clouds.yaml tracking the current admin password,
+// and points the AC's CloudCredentialsRef at it (not k-orc-clouds-yaml).
+func TestReconcileKORC_FreshMintUsesPasswordCloud(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret()).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	sec := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordCloudSecretName(cp), Namespace: childNamespace(cp),
+	}, sec)).To(Succeed())
+	clouds := string(sec.Data[appCredCloudsYAMLKey])
+	g.Expect(clouds).To(ContainSubstring(testAdminPassword), "password-cloud must carry the live admin password")
+	g.Expect(clouds).To(ContainSubstring("username:"), "password-cloud must be password-based")
+	g.Expect(clouds).To(ContainSubstring("endpoint_type: internal"))
+	g.Expect(sec.OwnerReferences).To(HaveLen(1), "password-cloud must be owned by the ControlPlane")
+
+	ac := getAC(t, c, cp)
+	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(adminPasswordCloudSecretName(cp)),
+		"the AC must mint via the password-cloud, not k-orc-clouds-yaml")
+}
+
+// TestReconcileKORC_PasswordCloudTracksRotation asserts the password-cloud is
+// re-rendered when the admin password rotates and is not churned otherwise.
+func TestReconcileKORC_PasswordCloudTracksRotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret()).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+	pcKey := types.NamespacedName{Name: adminPasswordCloudSecretName(cp), Namespace: childNamespace(cp)}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	sec1 := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), pcKey, sec1)).To(Succeed())
+	g.Expect(string(sec1.Data[appCredCloudsYAMLKey])).To(ContainSubstring(testAdminPassword))
+
+	// Unchanged password => no churn.
+	_, err = r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	sec2 := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), pcKey, sec2)).To(Succeed())
+	g.Expect(sec2.ResourceVersion).To(Equal(sec1.ResourceVersion),
+		"an unchanged admin password must not churn the password-cloud")
+
+	// Rotate the admin password; the password-cloud must track the new value.
+	pw := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "keystone-admin", Namespace: "default"}, pw)).To(Succeed())
+	pw.Data["password"] = []byte("rotated-admin-password")
+	g.Expect(c.Update(context.Background(), pw)).To(Succeed())
+
+	_, err = r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	sec3 := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), pcKey, sec3)).To(Succeed())
+	g.Expect(string(sec3.Data[appCredCloudsYAMLKey])).To(ContainSubstring("rotated-admin-password"))
+	g.Expect(string(sec3.Data[appCredCloudsYAMLKey])).NotTo(ContainSubstring(testAdminPassword),
+		"the password-cloud must drop the stale password after rotation")
+}
+
+// TestReconcileKORC_RecreatePreservesRegeneratedValue asserts the recreate after a
+// re-mint delete mints with the regenerated "value" (rather than generating yet
+// another), stamps the current hash, and points at the password-cloud.
+func TestReconcileKORC_RecreatePreservesRegeneratedValue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	// State right after a re-mint delete: no AC, the app-cred secret carries a
+	// freshly regenerated value.
+	freshValue := []byte("freshly-regenerated-value")
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp)},
+		Data:       map[string][]byte{appCredSecretValueKey: freshValue},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret(), appSecret).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ac := getAC(t, c, cp)
+	g.Expect(ac.Annotations).To(HaveKeyWithValue(adminPasswordHashAnnotation, testPasswordHash()))
+	g.Expect(ac.Spec.CloudCredentialsRef.SecretName).To(Equal(adminPasswordCloudSecretName(cp)))
+	g.Expect(string(ac.Spec.Resource.SecretRef)).To(Equal(adminAppCredentialSecretName(cp)))
+
+	sec := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialSecretName(cp), Namespace: childNamespace(cp),
+	}, sec)).To(Succeed())
+	g.Expect(sec.Data[appCredSecretValueKey]).To(Equal(freshValue),
+		"recreate must mint with the regenerated value, not generate a new one")
+}
+
+// TestReconcileKORC_FreshCredentialIDAdvancesLastRotation asserts that once the
+// recreated AC reports a NEW credential id, status.adminApplicationCredential
+// advances lastRotation (the observable signal a re-mint completed).
+func TestReconcileKORC_FreshCredentialIDAdvancesLastRotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	oldRotation := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{
+		ID: "old-id", LastRotation: &oldRotation,
+	}
+	// A recreated, now-Available AC with a NEW id whose hash already matches.
+	existing := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+		},
+		Status: orcv1alpha1.ApplicationCredentialStatus{
+			ID: ptr.To("new-id"),
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), existing, mintedAppCredSecret(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(cp.Status.AdminApplicationCredential).NotTo(BeNil())
+	g.Expect(cp.Status.AdminApplicationCredential.ID).To(Equal("new-id"))
+	g.Expect(cp.Status.AdminApplicationCredential.LastRotation).NotTo(BeNil())
+	g.Expect(cp.Status.AdminApplicationCredential.LastRotation.Time.After(oldRotation.Time)).To(BeTrue(),
+		"a re-minted credential with a new id must advance lastRotation")
 }
 
 // --- 2.8: reconcileCatalog ---

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -32,4 +32,12 @@ const (
 	// admin ApplicationCredential CR (Bootstrap) or for a ControlPlane / admin
 	// password Secret to appear (CC-0110, REQ-015).
 	credentialRotationWaitInterval = 10 * time.Second
+
+	// remintStallTimeout bounds how long the admin ApplicationCredential may stay
+	// Terminating during a re-mint before reconcileKORC escalates KORCReady from
+	// the transient "ReMinting" reason to "ReMintStalled". A stuck finalizer (e.g.
+	// K-ORC cannot reach Keystone to revoke the old credential) otherwise loops on
+	// "ReMinting" indefinitely with no operator-visible signal. The window is
+	// generous so a slow-but-progressing revoke is not flagged as stalled.
+	remintStallTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
## Summary

Closes #401. K-ORC's `ApplicationCredential` actuator implements only Create + Delete, so a rotated admin password never produced a fresh Keystone credential — `reconcileKORC` merely re-stamped the password-hash annotation while the live credential stayed byte-identical and the OpenBao `openstack/keystone/admin/app-credential` clouds.yaml was never refreshed. This PR makes the re-mint actually happen.

## Approach (password-driven, in-place)

- **Break the self-referential deadlock.** A new operator-owned, password-based clouds.yaml Secret `{controlplane}-admin-password-cloud` is rendered from the *current* admin password on every pass (`ensureAdminPasswordCloud`). The admin AC now mints against **this** secret instead of `k-orc-clouds-yaml`. That matters because `k-orc-clouds-yaml` *is* the minted application credential itself, and a restricted application credential cannot mint another — so password auth is required for a delete+recreate to re-authenticate at all.
- **Real re-mint trigger.** On a password-hash mismatch (the hash moved, or the `CredentialRotation` reconciler zeroed the annotation to nudge), `reconcileKORC` **deletes** the AC — the finalizer revokes the old Keystone credential — and **regenerates** the secret `value` (dropping the stale assembled clouds.yaml). The next pass recreates the AC for a fresh mint with a new `status.id`; `status.adminApplicationCredential.lastRotation` advances.
- **Progress / stall visibility.** `KORCReady=False/ReMinting` while the old AC is `Terminating`, escalating to `KORCReady=False/ReMintStalled` once it has been terminating longer than `remintStallTimeout` (5m) — a finalizer K-ORC cannot clear (e.g. it cannot reach Keystone to revoke).
- **Imports/catalog unchanged.** Domain/User imports and the catalog Service/Endpoint keep using `k-orc-clouds-yaml` and tolerate the brief auth gap during a re-mint by requeueing.

## Acceptance criteria

- [x] Admin-password rotation yields a NEW Keystone credential (new `status.id`), a regenerated AC secret value, and a refreshed `openstack/keystone/admin/app-credential` clouds.yaml.
- [x] `cp.status.adminApplicationCredential.lastRotation` advances on re-mint.
- [x] `KORCReady` transitions through `ReMinting` during the window; steady state does not churn the AC/secret when the hash matches.
- [x] CRD-absent gating preserved (`KORCReady=False/KORCCRDNotInstalled`, no crash).
- [x] `ReMintStalled` escape after a timeout (built in directly).
- [x] Unit tests: fresh mint via password-cloud, password-cloud tracks rotation (+ no-churn), hash-mismatch deletes the AC, recreate mints fresh value+id, stall escalation, full nudge→delete→recreate cycle, password-cloud confinement invariant.

## Out of scope (intentionally unchanged)

- `architecture/**` documentation (kept untouched per request; the `c5c3-operator` reference under `docs/` is updated instead).
- `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` seed and the `k-orc-clouds-yaml` ExternalSecret (still needed for the first-mint imports/catalog).
- No CRD/spec changes; existing RBAC already covers secret + AC delete.

## Testing

`go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), and `go test ./...` for the c5c3 module all pass.

## Known limitations

- Auth window between delete and the new app-credential landing in `k-orc-clouds-yaml` (PushSecret→OpenBao→ESO, `refreshInterval: 1h`): imports/catalog fail transiently and self-heal. A shorter ESO refresh is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)