### PR TITLE
feat(CC-0112): Scope admin/K-ORC credentials per ControlPlane in OpenBao

### DIFF
--- a/.planwerk/completed/CC-0112-scope-admin-k-orc-credentials-per-controlplane-in.json
+++ b/.planwerk/completed/CC-0112-scope-admin-k-orc-credentials-per-controlplane-in.json
@@ -2,8 +2,8 @@
   "feature_id": "CC-0112",
   "title": "Scope admin/K-ORC credentials per ControlPlane in OpenBao",
   "slug": "scope-admin-k-orc-credentials-per-controlplane-in",
-  "status": "prepared",
-  "phase": null,
+  "status": "completed",
+  "phase": "awaiting_external_review",
   "summary": "",
   "description": "# GitHub Issue #414: feat(c5c3-operator): make the admin/K-ORC credential path multi-instance safe (per-ControlPlane OpenBao scoping)\n\n**Description:**\n\n`c5c3-operator` already projects N `ControlPlane` CRs into N namespaces in a way that *creates* them all without name collisions. The Helm chart watches cluster-wide by default (`operators/c5c3/helm/c5c3-operator/values.yaml:24` — `rbac.namespaceScoped: false`) and `bootstrap.Run` leaves `cache.Options.DefaultNamespaces` unset (`internal/common/bootstrap/manager.go:68–78`) so every namespace's `ControlPlane` is reconciled. `childNamespace(cp) = cp.Namespace` (`operators/c5c3/internal/controller/reconcile_infrastructure.go:43–45`) projects every child (`MariaDB`, `Memcached`, `Keystone`, K-ORC `ApplicationCredential`/`User`/`Domain`/`Service`/`Endpoint`, the operator-owned admin Secret and the backup `PushSecret`) into the owning ControlPlane's namespace, and every name is `cp.Name`-prefixed (`adminAppCredentialName`, `adminPasswordCloudSecretName`, `adminAppCredentialSecretName`, `keystoneServiceName`, `keystoneEndpointName`, `adminDomainRef` — all in `reconcile_korc.go:97–113`, `1219–1225`, `683–685`).\n\nThe collision is purely on the **remote** identifiers: OpenBao is a single cluster-global backend reached via one `ClusterSecretStore` (`openbao-cluster-store`, `reconcile_korc.go:42`), and four objects on that backend are *not* parameterised per CR.\n\n### Concrete boundaries (already exists ↔ this issue adds)\n\n1. **Admin AC OpenBao path — hardcoded across consumers.**\n   - *Exists:* `const adminAppCredentialRemoteKey = \"openstack/keystone/admin/app-credential\"` (`operators/c5c3/internal/controller/reconcile_korc.go:58`), used by `adminAppCredentialPushSecret` at `reconcile_korc.go:1086`. The matching consumer reads the same key in *both* the control-plane namespace and `orc-system`: `deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml:49,69`. The OpenBao ACL grants this literal leaf and only this leaf — `deploy/openbao/policies/push-app-credentials.hcl:34,38`. The bootstrap seed writes this exact path in `deploy/openbao/bootstrap/write-bootstrap-secrets.sh:131,214`.\n   - *Issue adds:* a builder `adminAppCredentialRemoteKeyFor(cp *ControlPlane) string` returning `openstack/keystone/<cp.Namespace>/<cp.Name>/admin/app-credential`. Replace the constant at every write call site (the c5c3 PushSecret builder) and at every read consumer (the operator-owned `k-orc-clouds-yaml` ExternalSecret(s) — see boundary 7). Broaden the policy from one literal leaf to one `+`/`+` two-segment template that *still* excludes the read-only `db` and `+/fernet-keys`/`+/credential-keys` shapes already granted by `push-keystone-keys.hcl`.\n\n2. **Admin-password OpenBao path — hardcoded in `keystone-operator`.**\n   - *Exists:* `RemoteKey: \"bootstrap/keystone-admin\"` (`operators/keystone/internal/controller/reconcile_passwordrotation.go:603`), with the same single-CR assumption documented on the type (`operators/keystone/api/v1alpha1/keystone_types.go:403–407` — *\"Model B assumes a single Model-B-enabled Keystone CR per cluster\"*) and reiterated in the policy header (`deploy/openbao/policies/push-keystone-admin.hcl:18–29`). The consumer `ExternalSecret` reads this same flat key (`deploy/eso/externalsecrets/keystone-admin.yaml:27`). The bootstrap seed writes it at `write-bootstrap-secrets.sh:192`.\n   - *Issue adds:* a builder that returns `bootstrap/<keystone.Namespace>/<keystone.Name>/admin` (or `…/<keystone.Name>/admin`). Repoint the consumer to the matching per-CR key and migrate the bootstrap seed (boundaries 5, 6, 7).\n\n3. **K-ORC `User` import name not CR-scoped.**\n   - *Exists:* `adminUserRef(cp)` returns `cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName` (`reconcile_korc.go:666–671`), default `\"admin\"`. The sibling helper `adminDomainRef` *does* return `cp.Name + \"-domain-default\"` (`reconcile_korc.go:683–685`), so the inconsistency is local to the `User` import. Two `ControlPlane` CRs in the *same* namespace would `CreateOrUpdate` the same `User` object via `ensureKORCAdminImports` at `reconcile_korc.go:708–723`, flapping `ownerReferences` and spec.\n   - *Issue adds:* prefix the import CR's `metadata.name` with `cp.Name` (e.g. `cp.Name + \"-user-admin\"`), mirroring `adminDomainRef`. Keep `User.Spec.Import.Filter.Name = openstack name \"admin\"` so the underlying OpenStack user resolved by K-ORC is unchanged — only the Kubernetes object name changes.\n\n4. **Per-CR fernet/credential paths still collide across namespaces on identical CR names.**\n   - *Exists:* CC-0093 already moved fernet/credential PushSecrets to `openstack/keystone/{keystone.Name}/{fernet,credential}-keys` (`operators/keystone/internal/controller/reconcile_fernet.go:455`, `reconcile_credential.go:459`) and the policy to the `+` single-segment template `kv-v2/data/openstack/keystone/+/{fernet,credential}-keys` (`deploy/openbao/policies/push-keystone-keys.hcl:73–85`). Two `Keystone` CRs with identical names in different namespaces still resolve to the same OpenBao leaf.\n   - *Issue adds:* a per-CR-name **and** per-namespace segment. Decide explicitly: either add a `{keystone.Namespace}` segment (`openstack/keystone/<ns>/<name>/{fernet,credential}-keys`) — robust to name collisions, requires broadening the policy template to `kv-v2/data/openstack/keystone/+/+/{fernet,credential}-keys` — or enforce CR-name uniqueness via the admission guard from boundary 8 so the existing `+` template stays valid. Pick one and record it as a Decision in the source.\n\n5. **Bootstrap seed is single-tenant.**\n   - *Exists:* `seed_korc_bootstrap_clouds_yaml()` at `deploy/openbao/bootstrap/write-bootstrap-secrets.sh:130–182` writes exactly one `kv-v2/openstack/keystone/admin/app-credential`. `main()` (`write-bootstrap-secrets.sh:187–217`) seeds exactly one `kv-v2/bootstrap/keystone-admin`. Both paths are then `mark_eso_managed` so ESO can adopt them.\n   - *Issue adds:* either (a) make the bootstrap script accept a list of ControlPlane identities (e.g. `KORC_CONTROLPLANES=\"openstack/controlplane-keystone openstack/controlplane-staging\"`) and seed one per-CR path per identity, or (b) move the seed responsibility into the c5c3-operator itself so the first reconcile pass writes the per-CR seed. Option (b) is the natural endpoint when combined with the operator-owned `k-orc-clouds-yaml` ExternalSecret called out in #412 / boundary 7; (a) is the lower-risk interim option that keeps the cluster-bootstrap path unchanged. Pick one explicitly.\n\n6. **No admission guard on `ControlPlane` count per namespace.**\n   - *Exists:* `ControlPlaneWebhook.validate()` at `operators/c5c3/api/v1alpha1/controlplane_webhook.go:123–193` enforces release-pattern, database XOR, cache XOR, password-secret-ref required, rotation-interval admissibility — but does *not* count existing CRs in the namespace. The only signal today is `CredentialRotationReconciler.resolveControlPlane` returning Reason `\"AmbiguousControlPlane\"` (`reconcile_credentialrotation.go:202–230`, documented at `docs/reference/c5c3/controlplane-reconciler.md:589–610`) *after* the clobber has already happened.\n   - *Issue adds:* a Decision and the corresponding implementation: either (a) enforce one `ControlPlane` per namespace in `ControlPlaneWebhook.ValidateCreate` (using the injected `Client` to list `ControlPlanes` in the request namespace), and matching the CredentialRotation contract by then dropping the `AmbiguousControlPlane` branch; or (b) make the cluster genuinely multi-instance (boundaries 1–5 already on this issue) and replace the `resolveControlPlane` ambiguity check with a `ControlPlaneRef` field on `CredentialRotation`. Note that path (b) is a CRD schema addition. The issue's title and \"multi-instance safe\" framing implies (b); (a) is the minimal-change option if multi-instance per namespace is rejected.\n\n7. **K-ORC `clouds.yaml` ExternalSecret is statically named and not per-CR.**\n   - *Exists:* `deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml` defines two static `ExternalSecret`s, both named `k-orc-clouds-yaml`, one in `openstack` and one in `orc-system`, both reading the fixed key `openstack/keystone/admin/app-credential`. `reconcileAdminCredential` gates on `secrets.WaitForExternalSecret(childNamespace(cp)/CloudCredentialsRef.SecretName)` (`reconcile_korc.go:880–902`) — `CloudCredentialsRef.SecretName` defaults to `\"k-orc-clouds-yaml\"` via the CRD default and the webhook (`controlplane_webhook.go:32–33,80–83`).\n   - *Issue adds:* the operator owns and templates this ExternalSecret per `ControlPlane` (one per CR in `childNamespace(cp)`, name = `CloudCredentialsRef.SecretName`, key = the per-CR OpenBao path from boundary 1). The `orc-system` global copy is either removed (the AdminCredentialReady gate is already against the CP-namespace ExternalSecret) or also operator-owned and made per-CR. This is the work #412 covers; #414 cannot move the OpenBao path without it because the static `key:` would otherwise drift from the writer.\n\n8. **Existing single-tenant data needs a migration plan.**\n   - *Exists:* clusters that already ran the operator hold one `openstack/keystone/admin/app-credential` and one `bootstrap/keystone-admin` object. Pre-existing fernet/credential PushSecrets at `openstack/keystone/{name}/{fernet,credential}-keys` are already per-CR (CC-0093).\n   - *Issue adds:* a written one-time migration step (operator runbook): for each ControlPlane, copy the legacy values into the new per-CR paths before bringing the new operator up, then orphan the legacy leaves (the operator does not write them). Boundary 4's decision also implies, in the namespace-segment variant, a one-time copy of fernet/credential leaves into the namespace-prefixed shape.\n\n9. **What this issue does NOT touch.**\n   - The K-ORC `Service`/`Endpoint`/`Domain`/`ApplicationCredential` CRs themselves: they already embed `cp.Name` and live in `childNamespace(cp)`. The admin password Secret (`PasswordSecretRef`) and the cleartext-cloudsyaml `<cp.Name>-admin-password-cloud` Secret (`reconcile_korc.go:101–105,216–234`): they are already per-CR. The K-ORC `cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName` value: defaulted today, kept defaulted but documented as the per-CR ExternalSecret name once boundary 7 lands.\n\n**Motivation:**\n\nThe current behaviour already provisions N `ControlPlane` CRs in N namespaces without any in-cluster name clash — the operator's own owner-reference and `cp.Name` prefixing discipline is sound. What breaks at *operate* time is purely the four OpenBao identifiers in boundaries 1, 2, 3, and 4: the last writer wins, K-ORC then authenticates with the wrong namespace's credential, and `CredentialRotation` only flags the situation under reason `AmbiguousControlPlane` *after* the clobber. The shape of the bug (the operator advertises namespace-scoped projection but the backing store is cluster-flat) is the same class of issue as CC-0093, which already proved out the per-CR path layout, the `+`-glob policy template, and the migration-note discipline for the fernet/credential leaves; this issue extends the same pattern to the admin AC and admin password.\n\nClosing #414 unblocks two follow-on goals: (a) running a staging and a production `ControlPlane` side-by-side in two namespaces on a single cluster — the documented test setup of `tests/e2e/c5c3/full-controlplane-keystone/` only has one — and (b) the namespace-isolation story the CC-0110 reconciler-reference doc already frames around C1 (`docs/reference/c5c3/controlplane-reconciler.md:507,519`). #412 (operator-owned `k-orc-clouds-yaml` ExternalSecret) is the tightest coupling: that issue cannot land without this one (the read key has to match the per-CR write), and this issue cannot fully land without that one (a per-CR write path with no matching per-CR reader is dead work). They should ship together, with the OpenBao paths and User name landing here and the ExternalSecret templating landing under #412.\n\nThe work also pays back debt elsewhere: every \"single Model-B-enabled Keystone CR per cluster\" sentence in the source (`reconcile_passwordrotation.go:571–574`, `keystone_types.go:403–407`) and policy headers (`push-keystone-admin.hcl:18–29`, `push-app-credentials.hcl:14–22`) becomes deletable.\n\n**Affected Areas:**\n\n- operators/c5c3/internal/controller/reconcile_korc.go (replace the adminAppCredentialRemoteKey constant at line 58 with a builder taking *c5c3v1alpha1.ControlPlane; thread it through adminAppCredentialPushSecret at line 1066–1092; rename adminUserRef at line 666–671 to return cp.Name + \"-user-admin\" while keeping the OpenStack-name filter inside ensureKORCAdminImports unchanged; reconcileAdminCredential at 854–1045 keeps reading the per-CR ExternalSecret name from CloudCredentialsRef.SecretName)\n- operators/c5c3/internal/controller/reconcile_korc_test.go (update every assertion pinning the literal openstack/keystone/admin/app-credential at lines 81, 220, 373, 389, 696, 720, 878, 1012, 1083 and expectations on adminUserRef results to the per-CR builder)\n- operators/c5c3/internal/controller/integration_test.go (adjust envtest scenarios to bring up two ControlPlanes; today only one is exercised)\n- operators/c5c3/api/v1alpha1/controlplane_webhook.go (Decision-dependent: either add the one-per-namespace admission check using the injected Client at lines 47–49, or leave the webhook untouched per the boundary 6 Decision (b) path)\n- operators/c5c3/api/v1alpha1/credentialrotation_types.go (Decision-dependent: if multi-instance per namespace is chosen, add a ControlPlaneRef *corev1.LocalObjectReference to CredentialRotationSpec and document the AmbiguousControlPlane deprecation)\n- operators/c5c3/internal/controller/reconcile_credentialrotation.go (keep the resolveControlPlane indirection but switch the body to either \"exactly one allowed by admission, never see >1\" or \"use the explicit ControlPlaneRef\")\n- operators/c5c3/api/v1alpha1/controlplane_types.go, operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml, operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml (regenerate via make manifests/make sync-crds if the CRD surface changes per boundary 6 path b)\n- operators/keystone/internal/controller/reconcile_passwordrotation.go (replace the hardcoded RemoteKey: \"bootstrap/keystone-admin\" at line 603 with a per-CR builder such as fmt.Sprintf(\"bootstrap/%s/%s/admin\", keystone.Namespace, keystone.Name); update the type comment on PasswordRotationSpec at keystone_types.go:403–407 to drop the single-CR assumption)\n- operators/keystone/internal/controller/reconcile_passwordrotation_test.go (update adminPasswordPushSecret test assertions on RemoteKey)\n- operators/keystone/internal/controller/reconcile_fernet.go and reconcile_credential.go (Decision-dependent on boundary 4: if the namespace-segment variant is chosen, broaden the RemoteKey builder to include keystone.Namespace)\n- operators/keystone/internal/controller/reconcile_fernet_test.go, reconcile_credential_test.go, integration_test.go (matching test updates per the boundary 4 Decision)\n- deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml (eliminated or templated by #412; the c5c3 PushSecret writer in this issue and the ExternalSecret reader in #412 must agree on the per-CR key:)\n- deploy/eso/externalsecrets/keystone-admin.yaml (eliminated or templated to match the per-CR bootstrap/<ns>/<name>/admin key; if left static, this issue is incomplete)\n- deploy/openbao/policies/push-app-credentials.hcl (replace lines 34–40 with a +/+ two-segment template covering kv-v2/{data,metadata}/openstack/keystone/+/+/admin/app-credential; keep the data-only-vs-metadata rationale block)\n- deploy/openbao/policies/push-keystone-admin.hcl (replace the two literal leaves at lines 54–60 with kv-v2/{data,metadata}/bootstrap/+/+/admin; rewrite the policy header at lines 18–29 to drop the single-CR justification and document the new two-segment-glob semantics)\n- deploy/openbao/policies/push-keystone-keys.hcl (boundary 4 path-dependent: if the namespace-segment variant is chosen, update from kv-v2/data/openstack/keystone/+/{fernet,credential}-keys to kv-v2/data/openstack/keystone/+/+/{fernet,credential}-keys and update the comment on /db exclusion)\n- deploy/openbao/policies/eso-management.hcl (verify the trailing wildcard kv-v2/data/openstack/keystone/* at line 34 still covers the new shape for the read side; widen if needed)\n- deploy/openbao/bootstrap/write-bootstrap-secrets.sh (boundary 5 path-dependent: if the bootstrap remains responsible for seeding, take a list of <namespace>/<name> ControlPlane identities as env var or CLI and loop the seed + mark_eso_managed calls; update seed_korc_bootstrap_clouds_yaml() at lines 130–182 and main() at lines 187–217 accordingly)\n- deploy/kind/controlplane/controlplane.yaml (confirm the example matches the new naming convention; surface that the kind dev cluster still ships one ControlPlane by default)\n- tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml (update sub-asserts if the literal openstack/keystone/admin/app-credential path appears, since assertions reference it indirectly through the k-orc-clouds-yaml Secret name)\n- tests/e2e/c5c3/multi-controlplane/ (new sibling test directory exercising two ControlPlane CRs in tenant-a and tenant-b namespaces in parallel; covers both CRs reaching Ready=True simultaneously, killing AC-A not disturbing CP-B, and kubectl describe controlplane showing distinct status.adminApplicationCredential.id)\n- docs/reference/c5c3/controlplane-reconciler.md (update lines 507, 519, 529, 641 to reference the per-CR remote key; replace the AmbiguousControlPlane row at line 609 per the boundary 6 decision; add a \"Multi-instance\" section explaining the per-CR path layout, the one-per-namespace contract or its removal, and the migration note)\n- docs/reference/c5c3/controlplane-crd.md (update the CloudCredentialsRef.SecretName default doc if anything changes; record the per-CR layout under a Status / Multi-instance section)\n- docs/reference/keystone/keystone-reconciler.md (update the admin password rotation PushSecret table at lines 2728–2744 and remove the \"single-CR assumption, boundary 8\" caveat)\n- docs/reference/infrastructure/infrastructure-manifests.md (update lines 687, 699, 704–705 to describe the per-CR template)\n- architecture/docs/09-implementation/* (git submodule per .gitmodules; record the architecture-level change as a separate upstream PR — do not modify from this worktree, matching the discipline used in CC-0093 REQ-008)\n\n**Acceptance Criteria:**\n\n- [ ] adminAppCredentialRemoteKey is no longer a package-level constant; in its place a builder adminAppCredentialRemoteKeyFor(cp) returns a path that contains both cp.Namespace and cp.Name as path segments, and every write (the c5c3 PushSecret builder) plus every documented read (the per-CR ExternalSecret materialised by #412) targets it.\n- [ ] The keystone-operator's adminPasswordPushSecret RemoteKey is computed per-CR (contains both keystone.Namespace and keystone.Name segments) and the matching ExternalSecret (deploy/eso/externalsecrets/keystone-admin.yaml or its replacement) reads the same key.\n- [ ] ensureKORCAdminImports creates a K-ORC User whose Kubernetes metadata.name is cp.Name + \"-user-admin\" (or equivalent prefix) so two ControlPlanes in the same namespace produce two distinct User objects; the inner Spec.Import.Filter.Name still resolves to OpenStack user admin so the K-ORC import behaviour is unchanged.\n- [ ] Boundary 4 is resolved by a documented Decision: either (a) the fernet/credential keys' RemoteKey includes a keystone.Namespace segment and the policy template adopts +/+/{fernet,credential}-keys; or (b) the admission guard from boundary 6 enforces CR-name uniqueness cluster-wide for Keystone CRs. The Decision is recorded as a comment block at the call site (reconcile_fernet.go:455, reconcile_credential.go:459).\n- [ ] Boundary 6 is resolved by a documented Decision and matching implementation: either (a) ControlPlaneWebhook.ValidateCreate rejects a ControlPlane when another exists in the same namespace, AND CredentialRotationReconciler keeps AmbiguousControlPlane purely as a defense-in-depth fallback; or (b) CredentialRotationSpec carries an explicit ControlPlaneRef and the AmbiguousControlPlane branch is removed from resolveControlPlane and from the reconciler docs.\n- [ ] deploy/openbao/policies/push-app-credentials.hcl and deploy/openbao/policies/push-keystone-admin.hcl grant create/update/read/delete on data-and-metadata paths matching the per-CR templates, still deny anything outside those templates, and carry rationale comments referencing this issue's ID.\n- [ ] deploy/openbao/bootstrap/write-bootstrap-secrets.sh either accepts and iterates a list of ControlPlane identities (option a on boundary 5) or has its seed responsibility removed in favour of operator-owned seeding (option b). The script does not silently keep seeding the legacy flat paths on a multi-CR cluster.\n- [ ] An E2E suite under tests/e2e/c5c3/multi-controlplane/ (or equivalent) brings up two ControlPlane CRs in two namespaces in the same kind cluster, asserts both reach Ready=True simultaneously with distinct status.adminApplicationCredential.id, rotates the admin AC of one CR via CredentialRotation, and asserts the other CR's AC is unaffected (status.adminApplicationCredential.lastRotation unchanged, AC Available=True throughout).\n- [ ] Existing tests/e2e/c5c3/full-controlplane-keystone/ chainsaw test still passes against the per-CR path layout — i.e. the new write/read agreement does not regress the single-CR happy path.\n- [ ] docs/reference/c5c3/controlplane-reconciler.md, controlplane-crd.md, docs/reference/keystone/keystone-reconciler.md, and docs/reference/infrastructure/infrastructure-manifests.md describe the per-CR path layout and the multi-instance contract; the \"one Model-B-enabled Keystone CR per cluster\" and \"single admin AC per cluster\" wording in source code comments and the policy file headers is removed.\n- [ ] A MIGRATION.md (or a \"Migration\" section in the controlplane-reconciler doc) describes the one-time copy of kv-v2/openstack/keystone/admin/app-credential and kv-v2/bootstrap/keystone-admin (and, on path-(a) of boundary 4, the fernet/credential leaves) into the per-CR layout, including the bao kv put/bao kv list commands and the order with respect to the operator upgrade.\n\n**Non-Goals:**\n\n- Implementing the scheduled rotation loop on CredentialRotation (intervalDays, preRotationDays, gracePeriodDays) — it remains \"read-but-ignored\" per reconcile_credentialrotation.go:96–110 and credentialrotation_types.go:67–95, out of scope for the multi-instance safety work.\n- Adding multi-cluster (Cluster.multitenant style) tenancy — the change is per-namespace within a single cluster, not cross-cluster.\n- Re-architecting the cluster-global openbao-cluster-store — the ClusterSecretStore stays cluster-scoped because it has to reach OpenBao from every namespace; only the paths underneath become per-CR.\n- Changing the K-ORC CloudCredentialsRef.SecretName default (controlplane_webhook.go:33) or the cloudName default — they continue to default to \"k-orc-clouds-yaml\" / \"admin\" so a single-CR cluster's manifests are untouched.\n- Modifying the architecture/ submodule from this worktree — architecture-doc updates ship as a separate upstream PR, matching CC-0093 REQ-008 discipline.\n- Backfilling per-CR data on the live OpenBao backend automatically — the one-time migration is operator-driven via bao kv put per the migration note; the operator does not read or copy the legacy paths.\n\n**References:**\n\n- operators/c5c3/internal/controller/reconcile_korc.go (admin AC path constant, push-secret builder, User import name)\n- operators/c5c3/internal/controller/reconcile_credentialrotation.go (one-per-namespace contract and AmbiguousControlPlane)\n- operators/c5c3/internal/controller/controlplane_controller.go (sub-reconciler ordering, cp.Namespace projection model)\n- operators/c5c3/internal/controller/reconcile_infrastructure.go:43–45 (childNamespace(cp) = cp.Namespace)\n- operators/c5c3/api/v1alpha1/controlplane_webhook.go (defaulting + validation; injected Client)\n- operators/c5c3/api/v1alpha1/controlplane_types.go, credentialrotation_types.go\n- operators/keystone/internal/controller/reconcile_passwordrotation.go:571–610 (bootstrap/keystone-admin hardcoded)\n- operators/keystone/internal/controller/reconcile_fernet.go:455, reconcile_credential.go:459 (existing per-CR pattern from CC-0093)\n- deploy/openbao/bootstrap/write-bootstrap-secrets.sh:130–182,187–217\n- deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml, keystone-admin.yaml, keystone-db.yaml\n- deploy/openbao/policies/push-app-credentials.hcl, push-keystone-admin.hcl, push-keystone-keys.hcl, eso-management.hcl\n- internal/common/bootstrap/manager.go:63–78,113–134 (DefaultNamespaces cache scoping)\n- tests/e2e/c5c3/full-controlplane-keystone/ (single-CR happy path)\n- tests/e2e/keystone/concurrent-cr-conflicts/ (existing pattern for two CRs in one namespace; mirror for two namespaces)\n- docs/reference/c5c3/controlplane-reconciler.md (sections reconcileAdminCredential, CredentialRotation reconciler, K-ORC admin credential chain)\n- docs/reference/keystone/keystone-reconciler.md:2720–2766 (Model B PushSecret table)\n- docs/reference/infrastructure/infrastructure-manifests.md:687–705 (push-app-credentials policy doc)\n- Related issue CC-0093 (per-CR RemoteKey for fernet/credential keys; same template-glob pattern this issue extends) — .planwerk/completed/CC-0093-parameterize-openbao-remotekey-per-keystone-cr.json\n- Related issue CC-0110 (introduces ControlPlane, reconcileKORC, reconcileAdminCredential) — .planwerk/completed/CC-0110-implement-c5c3-operator-controlplane-for-keystone.json\n- Related issue CC-0109 (Model B admin-password rotation, owner of bootstrap/keystone-admin writer) — .planwerk/completed/CC-0109-schedule-keystone-admin-password-rotation-via.json\n- Related issue #412 (operator-owned k-orc-clouds-yaml ExternalSecret) — lands together with this for the k-orc-clouds-yaml half\n- Review patterns drawn on: Hardcoded sub-resource names prevent multi-instance support, Centralize duplicated status condition strings, Apply security mitigations consistently across all files, Cross-reference access policies against all consumers, Enforce least-privilege on wildcard access paths, Verify migration notes cover brownfield upgrade paths\n\n---\n\n_Elaborated by [planwerk-review](https://github.com/planwerk/planwerk-review) with Claude Code_\n\n\n**Labels:** enhancement\n\n---\nSource: https://github.com/C5C3/forge/issues/414",
   "stories": [
@@ -599,6 +599,7 @@
       "title": "In operators/c5c3/internal/controller/reconcile_korc.go replace the const adminAppCredentialRemoteKey (line 58) with a builder adminAppCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string returning fmt.Sprintf(\"openstack/keystone/%s/%s/admin/app-credential\", cp.Namespace, cp.Name); update its godoc to drop the 'single admin AC per cluster' sentence and cite CC-0112. (REQ-001)",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-001"
       ]
@@ -608,6 +609,7 @@
       "title": "Update adminAppCredentialPushSecret (reconcile_korc.go:1066-1092) line 1086 to RemoteKey: adminAppCredentialRemoteKeyFor(cp) and update the builder godoc (lines 1058-1060) to describe the per-CR path; keep DeletionPolicy=None and the cluster-store ref. (REQ-001)",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-001"
       ]
@@ -617,6 +619,7 @@
       "title": "Change adminUserRef (reconcile_korc.go:666-671) to return fmt.Sprintf(\"%s-user-admin\", cp.Name) mirroring adminDomainRef; keep ensureKORCAdminImports' User.Spec.Import.Filter.Name = OpenStackName(korcAdminUsername) ('admin') unchanged; update the godoc to explain the K8s-name vs OpenStack-name split (CC-0112). (REQ-003)",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-003"
       ]
@@ -626,6 +629,7 @@
       "title": "Update reconcile_korc_test.go: replace every literal 'openstack/keystone/admin/app-credential' assertion (lines 81,220,373,389,696,720,878,1012,1083 and the 485-486 RemoteKey assert) with To(Equal(adminAppCredentialRemoteKeyFor(cp))); add TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName (table over two CPs). (REQ-001)",
       "level": 1,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-001"
       ]
@@ -635,6 +639,7 @@
       "title": "Update reconcile_korc_test.go TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain: assert User name Equal(cp.Name+\"-user-admin\") (lines 1098-1099) and keep Filter.Name Equal(\"admin\") (line 1105); add TestAdminUserRef_IsControlPlaneScoped. (REQ-003)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-003"
       ]
@@ -644,6 +649,7 @@
       "title": "In operators/keystone/internal/controller/reconcile_passwordrotation.go:603 replace RemoteKey: \"bootstrap/keystone-admin\" with fmt.Sprintf(\"bootstrap/%s/%s/admin\", keystone.Namespace, keystone.Name); rewrite the builder godoc (lines 568-581) to drop the single-CR assumption and cite CC-0112. (REQ-002)",
       "level": 1,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-002"
       ]
@@ -653,6 +659,7 @@
       "title": "Delete the 'Model B assumes a single Model-B-enabled Keystone CR per cluster' comment block in operators/keystone/api/v1alpha1/keystone_types.go:403-407 and replace with a per-CR note referencing CC-0112. (REQ-002, REQ-014)",
       "level": 1,
       "estimate_minutes": 10,
+      "status": "done",
       "requirements": [
         "REQ-002",
         "REQ-014"
@@ -663,6 +670,7 @@
       "title": "Update reconcile_passwordrotation_test.go:450 to Equal(fmt.Sprintf(\"bootstrap/%s/%s/admin\", ks.Namespace, ks.Name)) and update integration_test.go:4637 (and its CC-0109 comment); add TestAdminPasswordPushSecret_RemoteKeyIsPerCR (two same-name CRs in different namespaces). (REQ-002)",
       "level": 1,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-002"
       ]
@@ -672,6 +680,7 @@
       "title": "DECISION boundary 4 = option (a): in reconcile_fernet.go:455 and reconcile_credential.go:459 add the keystone.Namespace segment -> \"openstack/keystone/\"+keystone.Namespace+\"/\"+keystone.Name+\"/{fernet,credential}-keys\"; record a DECISION comment block (boundary 4, CC-0112) at both call sites and update the godoc. (REQ-004)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-004"
       ]
@@ -681,6 +690,7 @@
       "title": "Update reconcile_fernet_test.go:414 and reconcile_credential_test.go:418 to the namespace-segmented RemoteKey; add TestFernetKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped (two same-name CRs in different namespaces, distinct keys). (REQ-004)",
       "level": 1,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-004"
       ]
@@ -690,6 +700,7 @@
       "title": "DECISION boundary 6 = option (a): in operators/c5c3/api/v1alpha1/controlplane_webhook.go un-blank the ctx in ValidateCreate and add a one-ControlPlane-per-namespace check using w.Client.List(ctx, &ControlPlaneList, client.InNamespace(obj.Namespace)); reject when len>=1 with field.Forbidden naming the existing CR; do NOT run the check in ValidateUpdate; record the Decision in the validate godoc (CC-0112). (REQ-010)",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-010"
       ]
@@ -699,6 +710,7 @@
       "title": "Verify ControlPlaneWebhook.Client is wired (non-nil) at operator startup (cmd/main wiring); if it is only set to a Reader that lacks List in tests, ensure the controller-runtime client is injected. Add a short DECISION comment if the wiring is confirmed already present. (REQ-010)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-010"
       ]
@@ -708,6 +720,7 @@
       "title": "Add controlplane_webhook_test.go tests TestValidateCreate_RejectsSecondControlPlaneInNamespace and TestValidateCreate_AllowsFirstControlPlane_AndUpdate using fake.NewClientBuilder() seeded with an existing ControlPlane; keep the 5 existing rule tests green. (REQ-010)",
       "level": 2,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-010"
       ]
@@ -717,6 +730,7 @@
       "title": "In reconcile_credentialrotation.go:198-230 keep the AmbiguousControlPlane branch but update its comment to mark it defense-in-depth (unreachable when the webhook guard is active); add/adjust TestResolveControlPlane_AmbiguousIsDefenseInDepth in reconcile_credentialrotation_test.go. (REQ-010)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-010"
       ]
@@ -726,6 +740,7 @@
       "title": "Rewrite deploy/openbao/policies/push-app-credentials.hcl: replace the literal openstack/keystone/admin/app-credential data+metadata blocks (lines 34-40) with kv-v2/{data,metadata}/openstack/keystone/+/+/admin/app-credential [create,update,read]; rewrite the header (lines 14-32) to document the namespace+name +/+ segments, keep the metadata-path rationale, cite CC-0112, drop the single-CR justification. (REQ-005)",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-005"
       ]
@@ -735,6 +750,7 @@
       "title": "Rewrite deploy/openbao/policies/push-keystone-admin.hcl: replace the two literal bootstrap/keystone-admin leaves (lines 54-60) with kv-v2/{data,metadata}/bootstrap/+/+/admin [create,update,read,delete]; rewrite the header (lines 18-29) to remove the single-CR justification and document the two-segment-glob + sibling-bootstrap-protection rationale, cite CC-0112. (REQ-006)",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-006"
       ]
@@ -744,6 +760,7 @@
       "title": "Widen deploy/openbao/policies/push-keystone-keys.hcl (lines 73-87) from +/{fernet,credential}-keys to +/+/{fernet,credential}-keys on data+metadata; update the header (lines 14-56) to add the CC-0112 namespace segment while retaining the upstream +-glob citation and the /db exclusion paragraph. (REQ-007)",
       "level": 2,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-007"
       ]
@@ -753,6 +770,7 @@
       "title": "Verify deploy/openbao/policies/eso-management.hcl read coverage: confirm kv-v2/data/openstack/keystone/* and kv-v2/data/bootstrap/* trailing wildcards cover the new per-CR shapes; widen and add a CC-0112 verification comment only if not covered; keep the policy read-only. (REQ-008)",
       "level": 2,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-008"
       ]
@@ -762,6 +780,7 @@
       "title": "Repoint deploy/eso/externalsecrets/keystone-admin.yaml remoteRef.key (line 27) to the per-CR bootstrap/{ns}/{keystone}/admin for the default deployment's Keystone identity (verify against the e2e/Quick Start fixture); keep property: password; add a CC-0112 comment. (REQ-011)",
       "level": 3,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-011"
       ]
@@ -771,6 +790,7 @@
       "title": "Repoint both ExternalSecrets in deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml remoteRef.key (lines 49,69) to openstack/keystone/openstack/controlplane/admin/app-credential (default ControlPlane identity from deploy/kind/controlplane/controlplane.yaml); add a comment that #412 supersedes this static shim with operator-owned per-CR templating. (REQ-011)",
       "level": 3,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-011"
       ]
@@ -780,6 +800,7 @@
       "title": "Refactor deploy/openbao/bootstrap/write-bootstrap-secrets.sh (boundary 5 option a): add a KORC_CONTROLPLANES list (default = the single canonical '<ns>/<cp>' identity), loop seed_korc_bootstrap_clouds_yaml + mark_eso_managed per identity writing openstack/keystone/{ns}/{cp}/admin/app-credential, and loop the bootstrap/{ns}/{keystone}/admin seed; remove the unconditional legacy flat writes; keep set -euo pipefail and in-pod generation. (REQ-009)",
       "level": 3,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-009"
       ]
@@ -789,6 +810,7 @@
       "title": "Trace callers of write-bootstrap-secrets.sh (hack/deploy-infra.sh ~line 814, setup-policies.sh) and confirm KORC_KEYSTONE_AUTH_URL and the new KORC_CONTROLPLANES default keep the single-CR deploy path unchanged; add a DECISION comment documenting the default identity. (REQ-009)",
       "level": 3,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-009"
       ]
@@ -798,6 +820,7 @@
       "title": "Extend operators/c5c3/internal/controller/integration_test.go with TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths: bring up two ControlPlanes in two namespaces (reuse setupControlPlaneEnvTest + integrationManagedControlPlane), drive both to AdminCredentialReady, assert distinct PushSecret RemoteKeys (containing each Namespace+Name) and distinct User CR names. (REQ-012)",
       "level": 4,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-012"
       ]
@@ -807,6 +830,7 @@
       "title": "Confirm the existing single-ControlPlane envtest path (TestIntegration_SingleControlPlane_AdminCredentialReady or equivalent) still drives AdminCredentialReady=True with the per-CR RemoteKey; adjust any assertion pinning the flat path. (REQ-013)",
       "level": 4,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-013"
       ]
@@ -816,6 +840,7 @@
       "title": "In operators/keystone/internal/controller/integration_test.go extend TestIntegrationKeystone_PushSecretRemoteKeyIsPerCR (lines 3799-3866) to also cover two CRs of the SAME name in DIFFERENT namespaces, asserting the namespace-segmented fernet/credential and bootstrap/admin RemoteKeys are disjoint. (REQ-004, REQ-002)",
       "level": 4,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-004",
         "REQ-002"
@@ -826,6 +851,7 @@
       "title": "Create tests/e2e/c5c3/multi-controlplane/ with ControlPlane fixtures for tenant-a and tenant-b namespaces and a chainsaw-test.yaml that creates both namespaces+CRs and asserts both reach Ready=True with distinct status.adminApplicationCredential.id (mirror full-controlplane-keystone + concurrent-cr-conflicts idioms). (REQ-012)",
       "level": 5,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-012"
       ]
@@ -835,6 +861,7 @@
       "title": "Add a multi-controlplane chainsaw step that kubectl-execs bao kv get for both openstack/keystone/{ns}/{cp}/admin/app-credential paths (asserting both exist and differ), rotates tenant-a's admin AC via CredentialRotation, and asserts tenant-b status.adminApplicationCredential.lastRotation is unchanged and its AC stays Available=True. (REQ-012)",
       "level": 5,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-012"
       ]
@@ -844,6 +871,7 @@
       "title": "Update tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml: change any direct OpenBao-path sub-assert (around lines 95-103, 227-237) to openstack/keystone/openstack/controlplane/admin/app-credential; keep the ${CP_NAME}-admin-app-credential-backup PushSecret-name binding unchanged. (REQ-013)",
       "level": 5,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-013"
       ]
@@ -853,6 +881,7 @@
       "title": "Update tests/e2e/keystone/concurrent-cr-conflicts/chainsaw-test.yaml (lines 63-173) so the four asserted per-CR kv-v2 paths use the namespace-segmented openstack/keystone/{ns}/{name}/{fernet,credential}-keys shape; confirm the deletion-cleanup test (if it asserts these paths) is consistent. (REQ-007)",
       "level": 5,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-007"
       ]
@@ -862,6 +891,7 @@
       "title": "Update docs/reference/c5c3/controlplane-reconciler.md (lines ~507,519,529,641) to the per-CR admin AC remote key; update the AmbiguousControlPlane row (~609) to describe the webhook guard + defense-in-depth fallback; add a 'Multi-instance' section explaining the per-CR path layout and the one-ControlPlane-per-namespace contract. (REQ-014)",
       "level": 6,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-014"
       ]
@@ -871,6 +901,7 @@
       "title": "Update docs/reference/c5c3/controlplane-crd.md (around line 317) for the CloudCredentialsRef.SecretName default note and add a Status/Multi-instance note that the admin AC OpenBao path is per-ControlPlane (namespace+name). (REQ-014)",
       "level": 6,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-014"
       ]
@@ -880,6 +911,7 @@
       "title": "Update docs/reference/keystone/keystone-reconciler.md Model B admin-password PushSecret table (lines ~2728-2744) to bootstrap/{ns}/{name}/admin and remove the single-CR caveat (~2744); extend the existing CC-0093 migration note (lines ~863-902) to cover the admin-password path. (REQ-014, REQ-015)",
       "level": 6,
       "estimate_minutes": 25,
+      "status": "done",
       "requirements": [
         "REQ-014",
         "REQ-015"
@@ -890,6 +922,7 @@
       "title": "Update docs/reference/infrastructure/infrastructure-manifests.md (lines ~687,699,704-705) to describe the +/+ admin-app-credential and bootstrap/+/+/admin policy templates and the per-CR read keys. (REQ-014)",
       "level": 6,
       "estimate_minutes": 15,
+      "status": "done",
       "requirements": [
         "REQ-014"
       ]
@@ -899,6 +932,7 @@
       "title": "Add a Migration section (in controlplane-reconciler.md, cross-linked from keystone-reconciler.md) giving the one-time bao kv get (legacy) -> bao kv put (per-CR) copy for openstack/keystone/admin/app-credential and bootstrap/keystone-admin and the boundary-4 fernet/credential leaves, the ACL re-apply, the operator-upgrade order, and the bao kv metadata delete purge; mirror CC-0093 'orphaned but harmless' wording. (REQ-015)",
       "level": 6,
       "estimate_minutes": 30,
+      "status": "done",
       "requirements": [
         "REQ-015"
       ]
@@ -908,6 +942,7 @@
       "title": "Sweep: rg 'openstack/keystone/admin/app-credential|bootstrap/keystone-admin|single Model-B-enabled Keystone CR per cluster|single admin AC' across operators/ deploy/ docs/ and confirm every remaining match is a migration-note legacy reference; do NOT edit architecture/ (submodule); flag the architecture/docs/09-implementation update as a separate upstream PR in the PR description. (REQ-014, REQ-016)",
       "level": 6,
       "estimate_minutes": 20,
+      "status": "done",
       "requirements": [
         "REQ-014",
         "REQ-016"
@@ -1166,6 +1201,1364 @@
       "story": "Operator and reference docs describe the per-CR layout and drop the single-CR caveats",
       "expected": "[review] Any architecture/docs/09-implementation flat-path mention is recorded as a deferred upstream change (not edited from this worktree); git submodule status shows architecture/ unchanged",
       "requirement_id": "REQ-016"
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RestrictedTrueGivesUnrestrictedFalse",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RestrictedFalseGivesUnrestrictedTrue",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RestrictedNilDefaultsToUnrestrictedFalse",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_AccessRulesProjected",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_OwnerRefAndCloudCredsAndManagementPolicy",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_PasswordHashAnnotationStamped",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_KORCReadyTrueWhenACAvailable",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_KORCReadyFalseWhileACNotAvailable",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_MissingCRDNoPanic",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_WaitsForAdminPassword",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileAdminCredential_GatedOnKORC",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileAdminCredential_FreshClusterWithoutCloudsYamlSeedDoesNotPush",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileAdminCredential_MissingAppCredSecretDefers",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileAdminCredential_PushSecretClobberSafeNoChurn",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_HashMismatchDeletesACForRemint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RemintStalledAfterTimeout",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RemintTerminatingReportsReMinting",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_HashMatchNoRemint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_FreshMintUsesPasswordCloud",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_PasswordCloudTracksRotation",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_RecreatePreservesRegeneratedValue",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_FreshCredentialIDAdvancesLastRotation",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileCatalog_GatedOnAdminCredential",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileCatalog_RegistersServiceAndEndpoint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileCatalog_Idempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileCatalog_MissingCRDNoPanic",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestKeystoneEndpointURL_DerivesFromProjectedService",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestKeystoneCatalogURL_PrefersPublicEndpoint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileKORC_CreatesAppCredentialSecretWithValue",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_korc_test.go",
+      "test_function": "TestReconcileAdminCredential_WaitsForPushSecretSync",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FullReconcile_Brownfield",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ConditionProgression",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ResourceCreation",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_StatusEndpoint",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ObservedGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FullReconcile_Managed",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_CronJobDetailedSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_BootstrapJobDetailedSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PDBSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PDBUpdatedOnReplicaChange",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HPASpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HPAUpdatedOnAutoscalingChange",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HPADeletedWhenAutoscalingRemoved",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FreshDeployment_InstalledReleaseTracking",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_UpgradeCycle_ExpandMigrateContract",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_TrustFlush_CronJobCreated",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_TrustFlush_SuspendTruePreservesCronJob",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_TrustFlush_OmittedFieldMaterializedAndCronJobCreated",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_TrustFlush_PatchToNullReDefaultsAndPreservesCronJob",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_GracefulShutdownSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PolicyValidation_GatesDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PolicyValidation_NotRequired",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HTTPRoute_CreatedWhenGatewaySet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HTTPRoute_DeletedWhenGatewayRemoved",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HTTPRoute_UpdatedWhenGatewayChanged",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_HTTPRoute_EndpointDerivedFromGateway",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FinalizerLifecycle_AddAndRemove",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FinalizerBrownfieldDeletion",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestRotationApplyEndToEnd_EnvTest",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestRotationApplyRejectsMalformedKeys_EnvTest",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestRotationApplyReplacesDisjointIndices_EnvTest",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_KeystonePodReachesDatabaseViaEnvOverride",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_RecreateDerivedSecretWhenDeleted",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_OpenBaoFinalizerLifecycle_AddAndRemove",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_OpenBaoFinalizer_BlockedWhenPushSecretStuck",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegrationKeystone_DeleteRacingESOAdoption",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_SecretEventTriggersReconcileViaIndexer",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_UnrelatedSecretDoesNotTriggerReconcile",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_IndexerRegistrationFailsManagerStartCleanly",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_TerminationGracePeriodAppliedToDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_DefaultStrategyAppliedToDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_StrategyOverrideAppliedToDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegrationKeystone_PushSecretRemoteKeyIsPerCR",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_ReconcileProducesRenamedSubResources",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FreshReconcileEmitsNoLegacyApiSuffixedResources",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestMetricsEndpointServesKeystoneOperatorCollectors",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_LoggingDebugTogglesRollsConfigMapAndDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_LoggingNoOpReconcileDoesNotRollDeployment",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_DatabaseTLS_CertificateLifecycle",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_AdminPasswordRotationCutover",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_AdminPasswordUnchangedNoChurn",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PasswordRotation_CronJobShape",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PasswordRotation_SuspendTruePreservesSiblings",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PasswordRotation_ApplyCommitsAndPushes",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_PasswordRotation_DisableTearsDownAllResources",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_NoSecret_CreatesSecretAndRequeues",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_SecretAlreadyExists",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_CronJobScheduleUpdated",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_GeneratedKeysAreValid",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_CronJobScheduleMatchesSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_PushSecretDeletionPolicyDelete",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_PushSecretReferencesCorrectSecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialKeysPushSecret_RemoteKeyIsCRScoped",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialKeysPushSecret_PreservesDeletionPolicyAndStoreRef",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialKeyGeneration_Valid",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialKeyGeneration_Unique",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_MinActiveKeysFloor",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_ConditionMessages",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_SecurityContext",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_CronJobSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_PodSecurityContextSetsFSGroup",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_KeySecretVolumesSetDefaultMode0400",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_CopyKeysInitContainerPreservesNonWorldReadableMode",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_RotateContainerVolumeMountsUnchanged",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_RotationContainerSecurityContextUnchanged",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotateScript_EmbeddedContent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotateScript_RotateBeforeMigrate",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_ConditionObservedGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_PriorityClassNameSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialRotationCronJob_PriorityClassNameNil",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestEnsureCredentialRotationRBAC_MainSecretIsReadOnly",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestEnsureCredentialRotationRBAC_StagingSecretHasGetPatchOnly",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_CreatesEmptyStagingSecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestEnsureCredentialRotationRBAC_IsIdempotent_CC0081",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestReconcileCredentialKeys_AppliesStagedKeysWhenAnnotationPresent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialReconcileUpdatesRotationAgeGauge",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_credential_test.go",
+      "test_function": "TestCredentialReconcileSkipsRotationAgeGaugeWhenAnnotationAbsent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_NoSecret_CreatesSecretAndRequeues",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_SecretAlreadyExists",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_CronJobScheduleUpdated",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_GeneratedKeysAreValid",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_CronJobScheduleMatchesSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_PushSecretDeletionPolicyDelete",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_PushSecretReferencesCorrectSecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetKeysPushSecret_RemoteKeyIsCRScoped",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetKeysPushSecret_PreservesDeletionPolicyAndStoreRef",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestGenerateFernetKey_Valid",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestGenerateFernetKey_Unique",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_MinActiveKeysFloor",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_ConditionMessages",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_SecurityContext",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_CronJobSpec",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_PodSecurityContextSetsFSGroup",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_KeySecretVolumesSetDefaultMode0400",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_CopyKeysInitContainerPreservesNonWorldReadableMode",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_RotateContainerVolumeMountsUnchanged",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_RotationContainerSecurityContextUnchanged",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotateScript_EmbeddedContent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_ConditionObservedGeneration",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_PriorityClassNameSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetRotationCronJob_PriorityClassNameNil",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestEnsureFernetRotationRBAC_MainSecretIsReadOnly",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestEnsureFernetRotationRBAC_StagingSecretHasGetPatchOnly",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_CreatesEmptyStagingSecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestReconcileFernetKeys_AppliesStagedKeysWhenAnnotationPresent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestEnsureFernetRotationRBAC_IsIdempotent_CC0081",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetReconcileUpdatesRotationAgeGauge",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_fernet_test.go",
+      "test_function": "TestFernetReconcileSkipsRotationAgeGaugeWhenAnnotationAbsent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestAdminPasswordRotateScript_EmbeddedContent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestAdminPasswordRotation_NameHelpers",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestEnsureAdminPasswordPushSourceSecret_CreatesOwnedEmptySecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestEnsureStagingSecret_AdminPasswordLabel",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestEnsureAdminPasswordRotationRBAC_SplitRoleShape",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestAdminPasswordRotationCronJob_Shape",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestAdminPasswordRotationCronJob_Suspend",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestValidateAdminPasswordRotationOutput",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestApplyAdminPasswordRotation_ValidCommit",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestApplyAdminPasswordRotation_RejectsShortPassword",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestApplyAdminPasswordRotation_AbsentStaging_NoOp",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestApplyAdminPasswordRotation_MissingAnnotation_NoOp",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestApplyAdminPasswordRotation_MalformedAnnotation_Warns",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestAdminPasswordPushSourceReady_Gating",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_Enabled_HappyPath",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_Enabled_Suspended",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_ValidPushSource_EnsuresPushSecret",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_AppliesCompletedRotation_Requeues",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_Disabled_TearsDownEverything",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/keystone/internal/controller/reconcile_passwordrotation_test.go",
+      "test_function": "TestReconcilePasswordRotation_NilSpec_TeardownIdempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestDefault_SetsZeroValueDefaults",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestDefault_IsIdempotent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestDefault_PreservesExplicitValues",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_AcceptsValidControlPlane",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsBadOpenStackRelease",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsDatabaseBothSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsDatabaseNeitherSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsCacheBothSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsCacheNeitherSet",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsMissingPasswordSecretRef",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_AccumulatesAllErrors",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_RejectsBadRotationInterval",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateCreate_AcceptsDailyAndWeeklyRotationIntervals",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateUpdate_AcceptsValidChange",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/api/v1alpha1/controlplane_webhook_test.go",
+      "test_function": "TestValidateDelete_AlwaysAllowed",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_BootstrapNoOpWhenACExists",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_BootstrapWaitsWhenACAbsent",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_ReMintClearsHashAnnotation",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_ReMintFullCycleReStampsHash",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_PasswordHashChangeTriggersNudge",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_HashMatchIsNoOp",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_UnsupportedTargetReadyFalse",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_NoControlPlaneReadyFalse",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/reconcile_credentialrotation_test.go",
+      "test_function": "TestRotation_ScheduledFieldsAcceptedNoError",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
+    },
+    {
+      "test_file": "operators/c5c3/internal/controller/integration_test.go",
+      "test_function": "TestIntegration_FullReconcile_ManagedToReady",
+      "story": "",
+      "expected": "Discovered during implementation",
+      "requirement_id": ""
     }
   ],
   "affected_files": [],
@@ -1201,8 +2594,18 @@
     "prepared": {
       "github_account": "berendt",
       "timestamp": "2026-06-05T18:56:12.996043"
+    },
+    "processing": {
+      "github_account": "berendt",
+      "timestamp": "2026-06-05T18:56:51.991218"
+    },
+    "completed": {
+      "github_account": "berendt",
+      "timestamp": "2026-06-08T12:57:15.664350"
     }
   },
+  "github_pr": "https://github.com/C5C3/forge/pull/418",
+  "pr_number": 418,
   "execution_history": [
     {
       "run_id": "0509a2ac-0a0c-44ae-a746-3485d300332a",
@@ -1214,6 +2617,68 @@
           "name": "prepare",
           "duration": 1504.116595506668,
           "type": "prepare",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "run_id": "3b61071f-863d-4e85-ba9a-568fb64aca20",
+      "timestamp": "2026-06-05T22:04:54.223530",
+      "total_duration": 8368.320229291916,
+      "status": "completed",
+      "timings": [
+        {
+          "name": "Level 1 (10 tasks)",
+          "duration": 785.7685623168945,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 2 (8 tasks)",
+          "duration": 944.3209364414215,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 3 (4 tasks)",
+          "duration": 876.2663886547089,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 4 (3 tasks)",
+          "duration": 1998.3615741729736,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 5 (4 tasks)",
+          "duration": 905.5622823238373,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "Level 6 (6 tasks)",
+          "duration": 1122.282550573349,
+          "type": "level",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0112] Code Review",
+          "duration": 673.7700753211975,
+          "type": "review",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0112] Improvements",
+          "duration": 904.5902497768402,
+          "type": "improve",
+          "status": "done"
+        },
+        {
+          "name": "[CC-0112] Simplify",
+          "duration": 157.39760971069336,
+          "type": "simplify",
           "status": "done"
         }
       ]

--- a/.planwerk/patterns/per-cr-openbao-remotekey-builder-embedding-namespacename-path-segments.md
+++ b/.planwerk/patterns/per-cr-openbao-remotekey-builder-embedding-namespacename-path-segments.md
@@ -1,0 +1,35 @@
+# Pattern: Per-CR OpenBao RemoteKey builder embedding namespace+name path segments
+
+**Component**: operators/c5c3/internal/controller, operators/keystone/internal/controller
+**Category**: data-access
+**Applies-When**: Building an ESO PushSecret RemoteRef.RemoteKey (or its read consumer) that mirrors a per-CR credential to the cluster-global OpenBao backend — the path must embed the owning CR's {namespace}/{name} so two CRs never clobber a shared leaf
+
+## Description
+
+Each credential family computes its OpenBao RemoteKey from the owning CR's Namespace and Name as explicit path segments (openstack/keystone/{ns}/{name}/... or bootstrap/{ns}/{name}/admin) instead of a package-level constant or single CR field. The matching OpenBao ACL grants the shape with one '+' single-segment glob per CR axis (kv-v2/{data,metadata}/.../+/+/<leaf>) so the grant still terminates at the literal leaf and never widens to a trailing '*'. Distinctness is locked by tests that assert the new key AND assert NotTo(Equal(legacy/superseded key)). This PR (CC-0112) extends the CC-0093 per-name layout by adding the leading {namespace} segment across all four families.
+
+## Examples
+
+### `operators/c5c3/internal/controller/reconcile_korc.go:61`
+
+```go
+func adminAppCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("openstack/keystone/%s/%s/admin/app-credential", cp.Namespace, cp.Name)
+}
+```
+
+### `operators/keystone/internal/controller/reconcile_passwordrotation.go:604`
+
+```go
+RemoteKey: fmt.Sprintf("bootstrap/%s/%s/admin", keystone.Namespace, keystone.Name),
+```
+
+### `operators/keystone/internal/controller/reconcile_fernet.go:460`
+
+```go
+// DECISION: boundary 4 (CC-0112, REQ-004) — chose option (a), a keystone.Namespace
+// path segment, so two Keystone CRs with the same Name in different namespaces
+// resolve to distinct OpenBao leaves. Reviewer: please verify.
+RemoteKey: "openstack/keystone/" + keystone.Namespace + "/" + keystone.Name + "/fernet-keys",
+```
+

--- a/.planwerk/reviews/CC-0112-scope-admin-k-orc-credentials-per-controlplane-in-review-1.json
+++ b/.planwerk/reviews/CC-0112-scope-admin-k-orc-credentials-per-controlplane-in-review-1.json
@@ -1,0 +1,131 @@
+{
+  "summary": "CC-0112 scopes the admin/K-ORC OpenBao credentials per ControlPlane. The c5c3 admin AC RemoteKey is now built by adminAppCredentialRemoteKeyFor(cp) -> openstack/keystone/{ns}/{name}/admin/app-credential (the package constant is gone); adminUserRef returns cp.Name+\"-user-admin\" while the K-ORC User import keeps Filter.Name=OpenStackName(\"admin\"); the keystone Model-B admin password writes bootstrap/{ns}/{name}/admin and the fernet/credential RemoteKeys gain a namespace segment (boundary-4 option a, DECISION-commented). The three push-* policies move to +/+ two-segment globs with no trailing-* write widening and /db + sibling-bootstrap lock-outs intact; eso-management read coverage is verified. ControlPlaneWebhook.ValidateCreate enforces one-ControlPlane-per-namespace via w.Client.List (boundary-6 option a) with no CRD schema change, and CredentialRotation keeps AmbiguousControlPlane as defense-in-depth. Static ESO readers, the per-CR bootstrap-seed loop (KORC_CONTROLPLANES), unit tests, two-CP envtest integration test, and a new tests/e2e/c5c3/multi-controlplane chainsaw suite all agree on the per-CR paths. Build, go vet, gofmt, c5c3 + keystone unit and integration (envtest) tests all pass; the architecture submodule is untouched. The implementation is high quality and feature-complete. The gap is documentation drift: the docs/-wide sweep (task 8.6) updated the four in-scope reference docs thoroughly (per-CR layout, Multi-instance section, AmbiguousControlPlane row, full migration runbook) but missed several other docs/ files that document the exact artifacts this PR changed and now misdescribe them — including the literal 'single Model-B-enabled Keystone CR per cluster' precondition that REQ-014 requires removed.",
+  "verdict": "NEEDS_CHANGES",
+  "tests_checklist": [
+    {"item": "Unit tests updated at every pinned legacy literal (reconcile_korc_test.go incl. 485-486, passwordrotation_test.go:450, fernet/credential _test.go) and new distinctness tests added with concrete literals + negative assertions", "checked": true},
+    {"item": "Two-ControlPlane envtest integration test present (TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths) and passing", "checked": true},
+    {"item": "Single-ControlPlane envtest path locks the per-CR RemoteKey (TestIntegration_FullReconcile_ManagedToReady)", "checked": true},
+    {"item": "Keystone integration test exercises both distinctness axes (same-ns/different-name, same-name/different-ns) plus bootstrap-admin", "checked": true},
+    {"item": "E2E tests/e2e/c5c3/multi-controlplane asserts two CPs Ready=True with distinct AC ids + OpenBao isolation + rotation non-interference", "checked": true},
+    {"item": "full-controlplane-keystone and concurrent-cr-conflicts / deletion-cleanup updated to the per-CR layout; concurrent test guards both regression boundaries", "checked": true},
+    {"item": "go vet, gofmt, build, c5c3+keystone unit and integration (envtest) tests all pass", "checked": true},
+    {"item": "E2E multi-controlplane worst-case sequential poll budget (3000s) fits the 20m script timeout", "checked": false}
+  ],
+  "code_quality_checklist": [
+    {"item": "Follows existing per-CR RemoteKey builder + DECISION-comment conventions", "checked": true},
+    {"item": "Webhook mirrors KeystoneWebhook typed-generic shape; nil-Client guard documented", "checked": true},
+    {"item": "No dead code; legacy constant fully removed and all call sites threaded", "checked": true},
+    {"item": "Documentation consistent with changed behavior across ALL docs/ (not only the 4 in-scope reference docs)", "checked": false}
+  ],
+  "security_checklist": [
+    {"item": "Policies grant only +/+ two-segment per-CR shapes; no trailing-* write widening", "checked": true},
+    {"item": "/db leaf and sibling-bootstrap secrets remain unwritable by the broadened globs", "checked": true},
+    {"item": "eso-management stays read-only; read coverage verified for the new shapes", "checked": true},
+    {"item": "Bootstrap seeds generated in-pod; bao reads use VAULT_CACERT (no skip-verify); no secrets in argv; e2e hashes credential material before logging", "checked": true},
+    {"item": "One-ControlPlane-per-namespace enforced at admission; AmbiguousControlPlane retained as defense-in-depth", "checked": true}
+  ],
+  "architecture_checklist": [
+    {"item": "Solution scopes only the four colliding OpenBao identifiers; ClusterSecretStore stays cluster-scoped (non-goal respected)", "checked": true},
+    {"item": "No CRD schema/byte change on the c5c3 ControlPlane CRD (boundary 6 = option a)", "checked": true},
+    {"item": "Keystone CRD regenerated consistently (both copies) for the field-doc change only", "checked": true},
+    {"item": "architecture/ submodule untouched (git submodule status clean)", "checked": true}
+  ],
+  "dry_yagni_checklist": [
+    {"item": "Per-CR RemoteKey builder reused across admin AC / admin password / fernet / credential", "checked": true},
+    {"item": "Keystone integration test consolidated into shared helpers; no speculative abstractions", "checked": true},
+    {"item": "bootstrap admin_path computed in both main() loop and seed_korc_bootstrap_clouds_yaml() (minor parallel derivation)", "checked": false}
+  ],
+  "fail_fast_checklist": [
+    {"item": "Webhook List error surfaces as InternalError; invalid KORC_CONTROLPLANES entry exits 1", "checked": true},
+    {"item": "CredentialRotation fails safe (Ready=False AmbiguousControlPlane) rather than picking Items[0]", "checked": true}
+  ],
+  "defensive_checklist": [
+    {"item": "Webhook validateUniqueInNamespace guards nil Client; runs only on CREATE not UPDATE", "checked": true},
+    {"item": "PushSecret push gated on push-source readiness so empty payload never clobbers the seed", "checked": true},
+    {"item": "Distinctness tests assert absence of the legacy/superseded paths, not just presence of the new ones", "checked": true}
+  ],
+  "security_findings": [],
+  "architecture_findings": [],
+  "issues_found": [
+    {
+      "check_id": "DA1",
+      "severity": "MAJOR",
+      "description": "docs/guides/keystone-admin-password-scheduled-rotation.md still contains the 'single Model-B-enabled Keystone CR per cluster' precondition that this PR eliminates. Section 4 'Single-CR precondition' states the RemoteKey is 'hardcoded to the flat path bootstrap/keystone-admin' and that two enabled CRs 'would both push to the same bootstrap/keystone-admin object and clobber each other's rotations' — the exact wording REQ-014 requires removed, and now factually false (adminPasswordPushSecret writes the per-CR bootstrap/{keystone.Namespace}/{keystone.Name}/admin). The PushSecret table (line 109), the dataflow diagram (line 93), the clobber-safe/ESO-marker notes (lines 126-137), and the confirm/disable sections (lines 212, 297) all still show bootstrap/keystone-admin. Task 8.6 mandated a docs/-wide sweep confirming only migration references remain; this is a live (non-migration) reference.",
+      "location": "docs/guides/keystone-admin-password-scheduled-rotation.md:256-265 (also 93,109,126-137,212,297)",
+      "fix": "Replace the 'Single-CR precondition' section with the per-CR reality (each Model-B Keystone CR writes its own bootstrap/{namespace}/{name}/admin object; multiple CRs no longer collide), and repoint every bootstrap/keystone-admin reference to bootstrap/{keystone.Namespace}/{keystone.Name}/admin, mirroring the keystone-reconciler.md Model B table and migration note already updated in this PR.",
+      "evidence": "## 4. Single-CR precondition\\nModel B hardcodes the OpenBao RemoteKey to the flat path `bootstrap/keystone-admin`. It therefore assumes a **single** Model-B-enabled Keystone CR per cluster ... > Two enabled CRs would both push to the same `bootstrap/keystone-admin` object and clobber each other's rotations.",
+      "fix_classification": "ASK"
+    },
+    {
+      "check_id": "D6",
+      "severity": "MAJOR",
+      "description": "docs/reference/infrastructure/openbao-bootstrap.md is now stale: it documents kv-v2/bootstrap/keystone-admin as 'Provisioned By write-bootstrap-secrets.sh' and 'Consumed By ExternalSecret keystone-admin', and shows the ESO mapping 'keystone-admin | openstack | bootstrap/keystone-admin | password'. This PR deleted the flat write_secret_if_missing \"kv-v2/bootstrap/keystone-admin\" block (the script now seeds bootstrap/{ns}/{keystone}/admin per KORC_CONTROLPLANES) and repointed deploy/eso/externalsecrets/keystone-admin.yaml to bootstrap/openstack/controlplane-keystone/admin. The doc's seed table, ESO mapping table, and the example 'Writing kv-v2/bootstrap/keystone-admin...' status lines now describe a path nothing provisions or reads.",
+      "location": "docs/reference/infrastructure/openbao-bootstrap.md:325,337-338,394,406",
+      "fix": "Update the bootstrap-secrets table, the ESO Integration table, and the example status messages to the per-CR path bootstrap/{namespace}/{keystone}/admin (default identity bootstrap/openstack/controlplane-keystone/admin), matching write-bootstrap-secrets.sh and keystone-admin.yaml as changed in this PR.",
+      "evidence": "| `kv-v2/bootstrap/keystone-admin` | `password` | `write-bootstrap-secrets.sh` | ExternalSecret `keystone-admin` |  ...  | `keystone-admin` | `openstack` | `bootstrap/keystone-admin` | `password` | `keystone-admin-credentials` | `password` |",
+      "fix_classification": "AUTO_FIX"
+    },
+    {
+      "check_id": "D6",
+      "severity": "MAJOR",
+      "description": "docs/guides/keystone-admin-password-rotation.md (the manual-rotation guide) instructs operators to write/read the admin password at the flat path, e.g. 'bao kv put kv-v2/bootstrap/keystone-admin password=<new-password>' and 'bao kv get kv-v2/bootstrap/keystone-admin', and the prerequisites/ESO tables list 'OpenBao path bootstrap/keystone-admin, property password'. After CC-0112 the keystone-admin ExternalSecret reads bootstrap/openstack/controlplane-keystone/admin, so following these commands writes a path the live ExternalSecret no longer consumes.",
+      "location": "docs/guides/keystone-admin-password-rotation.md:37-38,62,66,70,241",
+      "fix": "Repoint the documented bao kv put/get commands and the prerequisites/ESO tables to the per-CR path bootstrap/{namespace}/{keystone}/admin (default identity bootstrap/openstack/controlplane-keystone/admin), consistent with the repointed keystone-admin.yaml ExternalSecret.",
+      "evidence": "bao kv put kv-v2/bootstrap/keystone-admin password=<new-password>  ...  | External Secrets Operator (ESO) | ... | OpenBao path `bootstrap/keystone-admin`, property `password` |",
+      "fix_classification": "AUTO_FIX"
+    },
+    {
+      "check_id": "DA1",
+      "severity": "MINOR",
+      "description": "docs/reference/testing/keystone-e2e-tests.md describes the keystone-admin ExternalSecret as pulling 'bootstrap/keystone-admin from OpenBao' (step table line 687 and summary line 744). If this suite consumes the shared deploy/eso/externalsecrets/keystone-admin.yaml manifest (repointed in this PR) the description is stale; if it uses its own fixture, that fixture should be reconciled with the per-CR layout. Lower confidence than the openbao-bootstrap.md / guide findings — verify which path the pss-restricted suite actually binds before editing.",
+      "location": "docs/reference/testing/keystone-e2e-tests.md:687,744",
+      "fix": "Confirm the source of the keystone-admin ExternalSecret used by the pss-restricted suite; update the doc (and/or fixture) to the per-CR bootstrap path if it tracks the shared manifest.",
+      "evidence": "plus ExternalSecrets `keystone-admin` (pulls `bootstrap/keystone-admin` from OpenBao) and `keystone-db` ...",
+      "fix_classification": "ASK"
+    },
+    {
+      "check_id": "TE4",
+      "severity": "MINOR",
+      "description": "The new tests/e2e/c5c3/multi-controlplane chainsaw step packs all sequential condition/OpenBao/rotation polls into one script whose individual timeouts sum to a worst-case ~3000s (wait_cp_condition 900+900, wait_bao_clouds_sha 300+300, rotation wait 600) while spec.timeouts.exec and script.timeout are 20m (1200s). On a genuine hang in a later poll the chainsaw framework kills the script mid-poll with a generic timeout instead of emitting the precise 'condition X not True within Ns' error the loops are written to print. The test SKIPs in current CI (stack absent), so impact is deferred, but the budget should still exceed worst case.",
+      "location": "tests/e2e/c5c3/multi-controlplane/chainsaw-test.yaml:74-78 (timeouts) vs the per-loop bounds in step 1",
+      "fix": "Either raise exec/script.timeout above the summed worst case (~50m) or tighten the per-loop deadlines so their sum stays under the script timeout with margin (matches the test-script-timeout-must-exceed-worst-case-loop-duration guidance).",
+      "evidence": "timeouts:\\n    assert: 5m\\n    exec: 20m  ...  wait_cp_condition \\\"${CP_A}\\\" \\\"${NS_A}\\\" Ready 900 ... wait_bao_clouds_sha \\\"${PATH_A}\\\" 300 ... rot_deadline=$(( $(date +%s) + 600 ))",
+      "fix_classification": "ASK"
+    },
+    {
+      "check_id": "Q3",
+      "severity": "MINOR",
+      "description": "TestFernetKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped and TestCredentialKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped are near-identical (only fernet vs credential and the literal leaf differ). The same consolidation feedback was raised on CC-0093 for the sibling tests. Non-blocking; the existing file already keeps fernet/credential tests separate, so this only mirrors established structure.",
+      "location": "operators/keystone/internal/controller/reconcile_fernet_test.go:447 and reconcile_credential_test.go:451",
+      "fix": "Optional: extract a shared helper or table-driven form parameterized by material so the per-namespace distinctness assertion lives in one place.",
+      "evidence": "keyA := fernetKeysPushSecret(ksA)... g.Expect(keyA).To(Equal(\"openstack/keystone/openstack/keystone/fernet-keys\")) // mirrored verbatim in credential_test with /credential-keys",
+      "fix_classification": "AUTO_FIX"
+    }
+  ],
+  "suggested_improvements": [
+    "Run the same task-8.6 sweep one more time across the FULL docs/ tree (rg 'bootstrap/keystone-admin|openstack/keystone/admin/app-credential|single Model-B-enabled Keystone CR per cluster|single admin AC') and confirm every remaining hit is inside a migration/legacy paragraph — openbao-bootstrap.md and the two rotation guides currently fail that bar.",
+    "Consider deriving admin_path once in write-bootstrap-secrets.sh (compute in the loop and pass into seed_korc_bootstrap_clouds_yaml) to avoid the same path formula living in two places.",
+    "When issue #412 lands the operator-owned per-CR k-orc-clouds-yaml ExternalSecret, delete the static single-identity shim and the lockstep CONTROLPLANE_NAME note now documented in k-orc-clouds-yaml.yaml / keystone-admin.yaml / deploy-infra.sh."
+  ],
+  "next_steps": [
+    "Update docs/reference/infrastructure/openbao-bootstrap.md seed + ESO tables and example status lines to bootstrap/{namespace}/{keystone}/admin.",
+    "Rewrite docs/guides/keystone-admin-password-scheduled-rotation.md Section 4 to the per-CR model and repoint all bootstrap/keystone-admin references; remove the 'single Model-B-enabled Keystone CR per cluster' wording (REQ-014).",
+    "Repoint the bao kv put/get commands and prerequisite/ESO tables in docs/guides/keystone-admin-password-rotation.md to the per-CR path.",
+    "Verify docs/reference/testing/keystone-e2e-tests.md (and the pss-restricted fixture it describes) against the repointed keystone-admin ExternalSecret.",
+    "Raise/tighten the tests/e2e/c5c3/multi-controlplane timeout budget so worst-case sequential polls fit within the chainsaw script timeout."
+  ],
+  "detected_patterns": [
+    {
+      "name": "Per-CR OpenBao RemoteKey builder embedding namespace+name path segments",
+      "component": "operators/c5c3/internal/controller, operators/keystone/internal/controller",
+      "category": "data-access",
+      "applies_when": "Building an ESO PushSecret RemoteRef.RemoteKey (or its read consumer) that mirrors a per-CR credential to the cluster-global OpenBao backend — the path must embed the owning CR's {namespace}/{name} so two CRs never clobber a shared leaf",
+      "description": "Each credential family computes its OpenBao RemoteKey from the owning CR's Namespace and Name as explicit path segments (openstack/keystone/{ns}/{name}/... or bootstrap/{ns}/{name}/admin) instead of a package-level constant or single CR field. The matching OpenBao ACL grants the shape with one '+' single-segment glob per CR axis (kv-v2/{data,metadata}/.../+/+/<leaf>) so the grant still terminates at the literal leaf and never widens to a trailing '*'. Distinctness is locked by tests that assert the new key AND assert NotTo(Equal(legacy/superseded key)). This PR (CC-0112) extends the CC-0093 per-name layout by adding the leading {namespace} segment across all four families.",
+      "examples": [
+        {"location": "operators/c5c3/internal/controller/reconcile_korc.go:61", "code": "func adminAppCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string {\n\treturn fmt.Sprintf(\"openstack/keystone/%s/%s/admin/app-credential\", cp.Namespace, cp.Name)\n}"},
+        {"location": "operators/keystone/internal/controller/reconcile_passwordrotation.go:604", "code": "RemoteKey: fmt.Sprintf(\"bootstrap/%s/%s/admin\", keystone.Namespace, keystone.Name),"},
+        {"location": "operators/keystone/internal/controller/reconcile_fernet.go:460", "code": "// DECISION: boundary 4 (CC-0112, REQ-004) — chose option (a), a keystone.Namespace\n// path segment, so two Keystone CRs with the same Name in different namespaces\n// resolve to distinct OpenBao leaves. Reviewer: please verify.\nRemoteKey: \"openstack/keystone/\" + keystone.Namespace + \"/\" + keystone.Name + \"/fernet-keys\","}
+      ]
+    }
+  ]
+}

--- a/deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml
+++ b/deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml
@@ -4,13 +4,28 @@
 
 # ExternalSecret(s) for the K-ORC admin Application Credential clouds.yaml.
 #
-# Both ExternalSecrets pull the admin clouds.yaml from the OpenBao path
-# "openstack/keystone/admin/app-credential" (store-relative to the kv-v2 mount)
-# and materialise it as the Kubernetes Secret "k-orc-clouds-yaml". On a fresh
-# cluster that OpenBao path is SEEDED with a password-based bootstrap clouds.yaml
-# by deploy/openbao/bootstrap/write-bootstrap-secrets.sh (CC-0110, REQ-024); once
+# Both ExternalSecrets pull the admin clouds.yaml from the per-ControlPlane
+# OpenBao path "openstack/keystone/openstack/controlplane/admin/app-credential"
+# (store-relative to the kv-v2 mount) and materialise it as the Kubernetes Secret
+# "k-orc-clouds-yaml". On a fresh cluster that OpenBao path is SEEDED with a
+# password-based bootstrap clouds.yaml by
+# deploy/openbao/bootstrap/write-bootstrap-secrets.sh (CC-0110, REQ-024); once
 # the c5c3-operator mints the admin Application Credential its PushSecret
 # overwrites the path with the App-Cred-based clouds.yaml.
+#
+# CC-0112 (REQ-011): the admin Application Credential path is now scoped per
+# ControlPlane (openstack/keystone/{namespace}/{name}/admin/app-credential, see
+# adminAppCredentialRemoteKeyFor in reconcile_korc.go) so two ControlPlanes never
+# clobber each other's admin credential on the cluster-global OpenBao backend.
+# The identity below is the default ControlPlane Quick Start's CR: ControlPlane
+# "controlplane" in namespace "openstack" (deploy/kind/controlplane/
+# controlplane.yaml).
+#
+# This static, single-identity remoteRef.key is a deployment shim:
+# https://github.com/.../issues/412 supersedes it with operator-owned per-CR
+# templating that renders one k-orc-clouds-yaml ExternalSecret per ControlPlane
+# automatically. Until then, bringing up a non-default ControlPlane requires
+# editing this key (and CONTROLPLANE_NAME in `make deploy-infra`) in lockstep.
 #
 # CC-0110, C1 (co-location): the c5c3-operator creates the K-ORC
 # ApplicationCredential/Service/Endpoint CRs in the ControlPlane's OWN namespace
@@ -46,7 +61,7 @@ spec:
   data:
     - secretKey: clouds.yaml
       remoteRef:
-        key: openstack/keystone/admin/app-credential
+        key: openstack/keystone/openstack/controlplane/admin/app-credential
         property: clouds.yaml
 ---
 # Copy in orc-system for K-ORC's global default clouds.yaml mount.
@@ -66,5 +81,5 @@ spec:
   data:
     - secretKey: clouds.yaml
       remoteRef:
-        key: openstack/keystone/admin/app-credential
+        key: openstack/keystone/openstack/controlplane/admin/app-credential
         property: clouds.yaml

--- a/deploy/eso/externalsecrets/keystone-admin.yaml
+++ b/deploy/eso/externalsecrets/keystone-admin.yaml
@@ -3,10 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # ExternalSecret for the Keystone admin credentials.
-# Pulls the admin password from the OpenBao path "bootstrap/keystone-admin"
-# and materialises it as a Kubernetes Secret named "keystone-admin" in the
-# openstack namespace.
-# Feature: CC-0009
+# Pulls the admin password from the per-ControlPlane OpenBao path
+# "bootstrap/openstack/controlplane-keystone/admin" and materialises it as a
+# Kubernetes Secret named "keystone-admin" in the openstack namespace.
+#
+# CC-0112 (REQ-011): the admin-password path is now scoped per Keystone CR
+# (bootstrap/{namespace}/{keystone}/admin) so two Model-B-enabled Keystone CRs
+# never collide on the cluster-global OpenBao backend. The identity below is the
+# default ControlPlane Quick Start's projected Keystone: ControlPlane
+# "controlplane" in namespace "openstack" projects the Keystone CR
+# "controlplane-keystone" (keystoneName = "{controlplane}-keystone"), which the
+# keystone-operator's Model B rotation PushSecret
+# (reconcile_passwordrotation.go) and deploy/openbao/bootstrap/
+# write-bootstrap-secrets.sh both target. Keep this key in lockstep with the
+# CONTROLPLANE_NAME used by `make deploy-infra` (default "controlplane").
+# Feature: CC-0009, CC-0112
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -24,5 +35,5 @@ spec:
   data:
     - secretKey: password
       remoteRef:
-        key: bootstrap/keystone-admin
+        key: bootstrap/openstack/controlplane-keystone/admin
         property: password

--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -96,9 +96,10 @@ main() {
       # CC-0083: back up rotated fernet-keys / credential-keys to OpenBao.
       token_policies+=",push-keystone-keys"
       # CC-0109 (REQ-008): write the operator-rotated admin password to the
-      # shared bootstrap/keystone-admin path (Model B scheduled rotation).
-      # eso-management stays read-only; write capability lives only in the
-      # narrowly-scoped push-keystone-admin policy.
+      # per-ControlPlane bootstrap/{namespace}/{keystone}/admin path (Model B
+      # scheduled rotation; per-CR since CC-0112, REQ-002). eso-management stays
+      # read-only; write capability lives only in the narrowly-scoped
+      # push-keystone-admin policy.
       token_policies+=",push-keystone-admin"
       # CC-0110 (REQ-011): the c5c3-operator mirrors the minted admin Application
       # Credential clouds.yaml to OpenBao via a PushSecret through the

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -20,6 +20,19 @@ source "${SCRIPT_DIR}/common.sh"
 ###############################################################################
 BAO_TOKEN="${BAO_TOKEN:?BAO_TOKEN must be set}"
 
+# KORC_CONTROLPLANES: whitespace-separated list of "<namespace>/<controlplane>"
+# identities to seed per-ControlPlane bootstrap secrets for (CC-0112, REQ-009).
+# For each identity the script seeds:
+#   - the Model B admin password at  kv-v2/bootstrap/<namespace>/<controlplane>-keystone/admin
+#   - the K-ORC bootstrap clouds.yaml at kv-v2/openstack/keystone/<namespace>/<controlplane>/admin/app-credential
+# The default is the single canonical ControlPlane the Quick Start brings up
+# (deploy/kind/controlplane/controlplane.yaml: ControlPlane "controlplane" in
+# namespace "openstack"), so the single-CR `make deploy-infra` path is unchanged
+# (CC-0112, REQ-009; see hack/deploy-infra.sh). Override it to bring up several
+# ControlPlanes (e.g. KORC_CONTROLPLANES="tenant-a/cp tenant-b/cp"); each entry
+# MUST be "<namespace>/<controlplane>".
+KORC_CONTROLPLANES="${KORC_CONTROLPLANES:-openstack/controlplane}"
+
 # Marker value: use as a key's value to generate a cryptographically random
 # password (base64, 32 bytes) inside the pod using OpenBao's sys/tools/random
 # API.  Generating in-pod avoids cleartext passwords appearing in host process
@@ -83,9 +96,10 @@ write_secret_if_missing() {
 # "secret not managed by external-secrets"
 # (external-secrets providers/v1/vault/client_push.go). A path seeded above with
 # `bao kv put` carries no custom_metadata, so the Model B scheduled
-# admin-password rotation backup PushSecret (RemoteKey bootstrap/keystone-admin,
-# see operators/keystone/internal/controller/reconcile_passwordrotation.go) could
-# never mirror the rotated password back into OpenBao without this marker
+# admin-password rotation backup PushSecret (per-CR RemoteKey
+# bootstrap/{namespace}/{keystone}/admin, see
+# operators/keystone/internal/controller/reconcile_passwordrotation.go; CC-0112)
+# could never mirror the rotated password back into OpenBao without this marker
 # (CC-0109). Stamping the exact marker ESO itself writes lets ESO treat the
 # seeded value as its own on the first push.
 #
@@ -104,41 +118,63 @@ mark_eso_managed() {
   log "Secret '${kv_path}' marked ESO-managed."
 }
 
-# Seed a PASSWORD-based bootstrap clouds.yaml for the K-ORC admin Application
-# Credential, breaking the K-ORC credential bootstrap cycle (CC-0110, REQ-024).
+# Seed a PASSWORD-based bootstrap clouds.yaml for ONE ControlPlane's K-ORC admin
+# Application Credential, breaking the K-ORC credential bootstrap cycle (CC-0110,
+# REQ-024). Per-ControlPlane scoped (CC-0112, REQ-009): called once per
+# KORC_CONTROLPLANES identity from main().
+#
+# Usage: seed_korc_bootstrap_clouds_yaml <namespace> <controlplane> <keystone> <admin_path>
+#   <namespace>    — the ControlPlane's namespace
+#   <controlplane> — the ControlPlane CR name (scopes the app-credential path)
+#   <keystone>     — the projected Keystone CR name ("<controlplane>-keystone";
+#                    used to derive the in-cluster auth_url default)
+#   <admin_path>   — the kv-v2 admin-password path this seed reads to derive the
+#                    bootstrap clouds.yaml. Computed once by the caller (main's
+#                    loop) and passed in so the per-CR path formula
+#                    `kv-v2/bootstrap/<namespace>/<keystone>/admin` lives in a
+#                    single place rather than being recomputed here (CC-0112).
 #
 # THE CYCLE: the c5c3-operator gates its admin-Application-Credential PushSecret
-# (which WRITES openstack/keystone/admin/app-credential) on the k-orc-clouds-yaml
-# ExternalSecret being Ready — but that ExternalSecret materialises FROM this
-# exact OpenBao path. On a fresh cluster the path is empty, so the ExternalSecret
-# never goes Ready, the PushSecret is never created, and the path stays empty
-# forever (permanent deadlock).
+# (which WRITES openstack/keystone/<namespace>/<controlplane>/admin/app-credential)
+# on the k-orc-clouds-yaml ExternalSecret being Ready — but that ExternalSecret
+# materialises FROM this exact OpenBao path. On a fresh cluster the path is empty,
+# so the ExternalSecret never goes Ready, the PushSecret is never created, and the
+# path stays empty forever (permanent deadlock).
 #
 # THE SEED: we write a password-based clouds.yaml derived from the admin password
-# at bootstrap/keystone-admin so K-ORC can authenticate AS admin and mint the
-# restricted application credential. Once K-ORC mints it, the c5c3-operator's
-# PushSecret OVERWRITES this path with the application-credential-based clouds.yaml
-# — hence mark_eso_managed below grants ESO ownership so that overwrite is allowed.
+# at bootstrap/<namespace>/<keystone>/admin so K-ORC can authenticate AS admin and
+# mint the restricted application credential. Once K-ORC mints it, the
+# c5c3-operator's PushSecret OVERWRITES this path with the
+# application-credential-based clouds.yaml — hence mark_eso_managed (called by
+# main() after this) grants ESO ownership so that overwrite is allowed.
 #
 # Idempotent: skips the write when the path already exists, so a re-run never
 # clobbers a real minted credential. The admin password is read and the clouds.yaml
 # assembled ENTIRELY IN-POD (single-quoted sh -c) so the cleartext password never
 # appears in a host process argument list (mirrors write_secret_if_missing's
 # in-pod generation discipline). The admin password is a hex string
-# (bootstrap/keystone-admin is seeded via `bao write ... format=hex`), so it
-# carries no YAML/shell metacharacters.
+# (bootstrap/<namespace>/<keystone>/admin is seeded via `bao write ... format=hex`),
+# so it carries no YAML/shell metacharacters.
 seed_korc_bootstrap_clouds_yaml() {
-  local kv_path="kv-v2/openstack/keystone/admin/app-credential"
-  local admin_path="kv-v2/bootstrap/keystone-admin"
-  # DECISION (CC-0110, REQ-024): auth_url MUST match the Keystone API Service the
-  # keystone-operator exposes. For the per-service Quick Start that Service is
-  # "keystone" (the default below). The c5c3 ControlPlane instead projects
-  # "{controlplane}-keystone" (keystoneName() / keystoneEndpointURL() in
-  # reconcile_korc.go), so callers that bring up a ControlPlane
-  # (WITH_CONTROLPLANE=true make deploy-infra) override KORC_KEYSTONE_AUTH_URL to
-  # that Service DNS. K-ORC uses this auth_url for the very first mint, so it has
-  # to be correct before the c5c3-operator runs.
-  local auth_url="${KORC_KEYSTONE_AUTH_URL:-http://keystone.openstack.svc:5000/v3}"
+  local ns="$1"
+  local cp="$2"
+  local keystone="$3"
+  local admin_path="$4"
+  local kv_path="kv-v2/openstack/keystone/${ns}/${cp}/admin/app-credential"
+  # DECISION (CC-0112, REQ-009): auth_url MUST match the Keystone API Service the
+  # c5c3-operator projects for this ControlPlane — "<controlplane>-keystone"
+  # (keystoneName() / keystoneEndpointURL() in reconcile_korc.go) — so the default
+  # below is derived per identity as http://<keystone>.<namespace>.svc:5000/v3.
+  # K-ORC uses this auth_url for the very first mint, so it has to be correct
+  # before the c5c3-operator runs. KORC_KEYSTONE_AUTH_URL still overrides it for
+  # the single-CR deploy path (hack/deploy-infra.sh exports the matching
+  # <controlplane>-keystone URL under WITH_CONTROLPLANE=true, which equals this
+  # derived default for the canonical openstack/controlplane identity). A single
+  # override is correct only for a single identity; multi-ControlPlane callers
+  # MUST leave KORC_KEYSTONE_AUTH_URL unset and rely on the per-identity default.
+  # Reviewer: please verify the override-applies-to-all-identities semantics is
+  # acceptable (it is, because the default KORC_CONTROLPLANES is a single entry).
+  local auth_url="${KORC_KEYSTONE_AUTH_URL:-http://${keystone}.${ns}.svc:5000/v3}"
 
   log "Seeding K-ORC bootstrap clouds.yaml at '${kv_path}' (auth_url=${auth_url}, if missing)..."
   # endpoint_type MUST be "internal", and the key MUST be "endpoint_type" (NOT
@@ -189,13 +225,6 @@ main() {
   log "Namespace : ${NAMESPACE}"
   log "BAO_ADDR  : ${BAO_ADDR}"
 
-  write_secret_if_missing "kv-v2/bootstrap/keystone-admin" \
-    "password=${GENERATED_PASSWORD}"
-  # CC-0109: let the Model B admin-password rotation PushSecret overwrite this
-  # pre-seeded path (ESO's managed-by guard rejects it otherwise). See
-  # mark_eso_managed.
-  mark_eso_managed "kv-v2/bootstrap/keystone-admin"
-
   write_secret_if_missing "kv-v2/infrastructure/mariadb" \
     "root-password=${GENERATED_PASSWORD}"
 
@@ -203,15 +232,51 @@ main() {
     "username=keystone" \
     "password=${GENERATED_PASSWORD}"
 
-  # CC-0110, REQ-024: seed the K-ORC admin Application Credential clouds.yaml so
-  # the k-orc-clouds-yaml ExternalSecret can materialise on a fresh cluster and
-  # K-ORC can bootstrap-authenticate, breaking the credential cycle. Must run
-  # AFTER bootstrap/keystone-admin is written (it derives the password from it).
-  seed_korc_bootstrap_clouds_yaml
-  # Let the c5c3-operator's admin-Application-Credential PushSecret overwrite the
-  # seeded path with the minted application credential (ESO's managed-by guard
-  # rejects an unmarked pre-existing path otherwise — see mark_eso_managed).
-  mark_eso_managed "kv-v2/openstack/keystone/admin/app-credential"
+  # CC-0112 (REQ-009): per-ControlPlane bootstrap seeding. For each
+  # "<namespace>/<controlplane>" identity in KORC_CONTROLPLANES (default
+  # "openstack/controlplane"), seed BOTH the Model B admin password and the K-ORC
+  # bootstrap clouds.yaml on the now per-CR OpenBao paths so two ControlPlanes
+  # never collide on the cluster-global OpenBao backend. The legacy flat writes
+  # (bootstrap/keystone-admin, openstack/keystone/admin/app-credential) are gone:
+  # the keystone-operator Model B rotation PushSecret and the c5c3-operator admin
+  # AC PushSecret now target bootstrap/{ns}/{keystone}/admin and
+  # openstack/keystone/{ns}/{cp}/admin/app-credential respectively (CC-0112,
+  # REQ-001/REQ-002).
+  # shellcheck disable=SC2086  # KORC_CONTROLPLANES is intentionally word-split on whitespace into identities.
+  for identity in ${KORC_CONTROLPLANES}; do
+    if [[ "${identity}" != */* ]]; then
+      log "ERROR: KORC_CONTROLPLANES entry '${identity}' is not in '<namespace>/<controlplane>' form."
+      exit 1
+    fi
+    local cp_ns="${identity%%/*}"
+    local cp_name="${identity#*/}"
+    local keystone_name="${cp_name}-keystone"
+    local admin_path="kv-v2/bootstrap/${cp_ns}/${keystone_name}/admin"
+    local ac_path="kv-v2/openstack/keystone/${cp_ns}/${cp_name}/admin/app-credential"
+
+    log "--- Seeding ControlPlane '${identity}' (keystone='${keystone_name}') ---"
+
+    # Model B admin password (the bootstrap source the keystone-admin
+    # ExternalSecret reads and the rotation PushSecret later overwrites).
+    write_secret_if_missing "${admin_path}" \
+      "password=${GENERATED_PASSWORD}"
+    # CC-0109: let the Model B admin-password rotation PushSecret overwrite this
+    # pre-seeded path (ESO's managed-by guard rejects it otherwise). See
+    # mark_eso_managed.
+    mark_eso_managed "${admin_path}"
+
+    # CC-0110, REQ-024: seed the K-ORC admin Application Credential clouds.yaml so
+    # the k-orc-clouds-yaml ExternalSecret can materialise on a fresh cluster and
+    # K-ORC can bootstrap-authenticate, breaking the credential cycle. Must run
+    # AFTER the admin password above (it derives the password from it). Pass the
+    # already-computed admin_path so the per-CR path formula is not duplicated
+    # inside the function (CC-0112).
+    seed_korc_bootstrap_clouds_yaml "${cp_ns}" "${cp_name}" "${keystone_name}" "${admin_path}"
+    # Let the c5c3-operator's admin-Application-Credential PushSecret overwrite the
+    # seeded path with the minted application credential (ESO's managed-by guard
+    # rejects an unmarked pre-existing path otherwise — see mark_eso_managed).
+    mark_eso_managed "${ac_path}"
+  done
 
   log "=== Done ==="
 }

--- a/deploy/openbao/policies/eso-management.hcl
+++ b/deploy/openbao/policies/eso-management.hcl
@@ -8,6 +8,9 @@
 # kubernetes/management auth mount.
 # Feature: CC-0009
 
+# CC-0112: the per-CR bootstrap admin password now lives at
+# `bootstrap/{namespace}/{name}/admin`. The trailing `*` already matches that
+# extra depth, so this read grant covers the new shape with no widening needed.
 path "kv-v2/data/bootstrap/*" {
   capabilities = ["read"]
 }
@@ -31,6 +34,12 @@ path "kv-v2/data/infrastructure/*" {
 # is bound alongside eso-management on the management cluster's auth role.
 # The separation preserves the audit invariant that a leaked management-cluster
 # ESO token on eso-management alone cannot write to OpenBao (CC-0083).
+#
+# CC-0112 verification: the per-CR paths are now namespace+name-scoped —
+# `openstack/keystone/{namespace}/{name}/{admin/app-credential,fernet-keys,
+# credential-keys}`. The trailing `*` wildcard already matches any remaining
+# depth, so it covers these new shapes with no widening required; this policy
+# stays read-only.
 path "kv-v2/data/openstack/keystone/*" {
   capabilities = ["read"]
 }

--- a/deploy/openbao/policies/push-app-credentials.hcl
+++ b/deploy/openbao/policies/push-app-credentials.hcl
@@ -11,14 +11,22 @@ path "kv-v2/data/openstack/*/app-credential" {
   capabilities = ["create", "update", "read"]
 }
 
-# CC-0110, REQ-024 — narrow, single-leaf grant for the c5c3-operator's admin
-# Application Credential PushSecret. The operator mints ONE restricted admin AC
-# per cluster and mirrors it to the flat path below via the openbao-cluster-store
-# (KV-v2). This is a LITERAL leaf, deliberately NOT a trailing "*" or "+" glob:
-# the existing kv-v2/data/openstack/*/app-credential grant above matches only a
+# CC-0112 — per-ControlPlane grant for the c5c3-operator's admin Application
+# Credential PushSecret. The operator mints ONE restricted admin AC PER
+# ControlPlane and mirrors it to that ControlPlane's CR-scoped KV-v2 path via the
+# openbao-cluster-store. The path is therefore per-ControlPlane, shaped
+# `openstack/keystone/{namespace}/{name}/admin/app-credential`; the two `+/+`
+# segments below are the ControlPlane's namespace and name (in that order).
+#
+# The two `+/+` globs are used (rather than a literal leaf or a trailing "*")
+# precisely because the namespace and name segments vary per ControlPlane: a
+# literal leaf could not cover every ControlPlane's path, while a `+` matches
+# exactly one segment so the grant still ends at the literal
+# `/admin/app-credential` leaf — it admits no deeper or sibling paths. The
+# existing kv-v2/data/openstack/*/app-credential grant above matches only a
 # SINGLE mid-segment (openstack/<svc>/app-credential) and so does NOT cover the
-# two-segment openstack/keystone/admin/app-credential — hence this explicit path
-# rather than widening the glob above.
+# four-segment openstack/keystone/{namespace}/{name}/admin/app-credential shape —
+# hence these explicit `+/+` paths.
 #
 # READ is already granted cluster-wide for this subtree by the eso-management
 # policy's trailing glob (kv-v2/data/openstack/keystone/* — see eso-management.hcl);
@@ -29,12 +37,12 @@ path "kv-v2/data/openstack/*/app-credential" {
 # (managed-by=external-secrets, used by DeleteSecret ownership checks). A data-only
 # grant 403s on the metadata PUT and the PushSecret never reaches Ready — same
 # rationale documented in push-keystone-admin.hcl. The grant stays scoped to the
-# single literal admin AC leaf, adding no blast radius beyond this one credential.
+# per-CR admin AC leaf, adding no blast radius beyond admin app-credentials.
 # Reviewer: please verify.
-path "kv-v2/data/openstack/keystone/admin/app-credential" {
+path "kv-v2/data/openstack/keystone/+/+/admin/app-credential" {
   capabilities = ["create", "update", "read"]
 }
 
-path "kv-v2/metadata/openstack/keystone/admin/app-credential" {
+path "kv-v2/metadata/openstack/keystone/+/+/admin/app-credential" {
   capabilities = ["create", "update", "read"]
 }

--- a/deploy/openbao/policies/push-keystone-admin.hcl
+++ b/deploy/openbao/policies/push-keystone-admin.hcl
@@ -15,18 +15,23 @@
 # OpenBao — write capability lives only in this narrowly-scoped policy
 # (CC-0083). Pattern source: deploy/openbao/policies/push-keystone-keys.hcl.
 #
-# Scope — boundary 8, option (a): a single FLAT, literal path. The production
-# sink for this credential is OpenBao itself (not an in-cluster Secret): a
-# value written here round-trips through ESO into the keystone-admin Secret
-# and drives a cluster-wide admin re-bootstrap. The grant is therefore the two
-# exact leaves below and deliberately does NOT use a trailing `*` wildcard or
-# a `+` single-segment glob over the bootstrap subtree. eso-management already
-# grants read on `kv-v2/data/bootstrap/*` (every bootstrap secret, including
-# this one); a write wildcard here would let a compromised ESO controller
-# overwrite ANY other bootstrap secret (e.g. database root credentials),
-# escalating a single-credential rotation grant into write access over the
-# whole bootstrap subtree. Because the path is cluster-global, at most one
-# Model-B-enabled Keystone CR may exist per cluster (documented precondition).
+# Scope — boundary 8 (CC-0112): a per-CR path shaped
+# `bootstrap/{namespace}/{name}/admin`, granted via a two-segment `+/+` glob.
+# The production sink for this credential is OpenBao itself (not an in-cluster
+# Secret): a value written here round-trips through ESO into the keystone-admin
+# Secret and drives that CR's admin re-bootstrap. The grant is therefore the two
+# `+/+`-globbed leaves below and deliberately does NOT use a trailing `*`
+# wildcard over the bootstrap subtree. eso-management already grants read on
+# `kv-v2/data/bootstrap/*` (every bootstrap secret, including these); a write
+# `*` wildcard here would let a compromised ESO controller overwrite ANY other
+# bootstrap secret (e.g. database root credentials), escalating a single-
+# credential rotation grant into write access over the whole bootstrap subtree.
+# By contrast `bootstrap/+/+/admin` only matches paths shaped
+# `bootstrap/<seg>/<seg>/admin`, so a compromised ESO token still CANNOT
+# overwrite unrelated bootstrap secrets such as database-root credentials —
+# those do not live under the `/admin` two-segment-glob shape. This is precisely
+# why the grant is a bounded `+/+/admin` glob and NOT a trailing `*` over
+# `bootstrap/*`.
 #
 # ESO's Vault/OpenBao provider writes to BOTH the data and the metadata
 # endpoint on every PushSecret for KV v2: it stamps `custom_metadata:
@@ -42,19 +47,21 @@
 # (operators/keystone/internal/controller/reconcile_passwordrotation.go), so ESO
 # never issues a DELETE against OpenBao when the PushSecret is torn down — the
 # last-pushed admin password is deliberately left intact at
-# bootstrap/keystone-admin so disabling rotation can never lock the admin out.
+# bootstrap/{namespace}/{name}/admin so disabling rotation can never lock the
+# admin out.
 # The capability is kept (rather than dropped) so re-binding this policy under a
 # future DeletionPolicy=Delete would not silently 403 on teardown; because the
-# grant stays scoped to the two exact admin leaves, `delete` adds no blast
-# radius beyond the very credential this policy already lets the holder write.
+# grant stays scoped to the per-CR `bootstrap/{namespace}/{name}/admin` leaf,
+# `delete` adds no blast radius beyond the very credentials this policy already
+# lets the holder write.
 #
 # `read` is retained for PushSecret pre-flight reads and policy-portability,
 # matching the convention in push-keystone-keys.hcl.
 # Feature: CC-0109
-path "kv-v2/data/bootstrap/keystone-admin" {
+path "kv-v2/data/bootstrap/+/+/admin" {
   capabilities = ["create", "update", "read", "delete"]
 }
 
-path "kv-v2/metadata/bootstrap/keystone-admin" {
+path "kv-v2/metadata/bootstrap/+/+/admin" {
   capabilities = ["create", "update", "read", "delete"]
 }

--- a/deploy/openbao/policies/push-keystone-keys.hcl
+++ b/deploy/openbao/policies/push-keystone-keys.hcl
@@ -11,48 +11,51 @@
 # eso-management Kubernetes auth role; eso-management itself stays read-only.
 # Pattern source: deploy/openbao/policies/push-app-credentials.hcl.
 #
-# Per-CR path layout (CC-0093): the operator now writes each Keystone CR's
-# fernet-keys and credential-keys to a CR-scoped KV-v2 path of the form
-# `openstack/keystone/{keystone.Name}/fernet-keys` (and …/credential-keys),
-# replacing the previous flat leaves `openstack/keystone/fernet-keys` and
-# `openstack/keystone/credential-keys`. The policy therefore switches from
-# two exact literal paths per leaf to a `+` single-segment glob over the
-# CR-name position. OpenBao ACL syntax supports `+` as "any number of
-# characters bounded within a single path segment" (verbatim, upstream docs
-# at https://openbao.org/docs/concepts/policies — "OpenBao > Architecture >
-# Policies > Path Syntax"), and allows `+` between literal segments: the
-# canonical upstream example `path "secret/+/teamb"` matches
-# `secret/foo/teamb` but not `secret/foo/bar/teamb`. The patterns below
-# apply the same shape: `kv-v2/data/openstack/keystone/+/fernet-keys`
-# matches exactly one CR-name segment followed by the literal leaf.
+# Per-CR path layout: the operator writes each Keystone CR's fernet-keys and
+# credential-keys to a CR-scoped KV-v2 path. The original CC-0093 layout used a
+# single CR-name segment — `openstack/keystone/{keystone.Name}/fernet-keys`
+# (and …/credential-keys) — behind one `+` glob. As of CC-0112 the path is
+# additionally scoped by namespace, shaped
+# `openstack/keystone/{namespace}/{name}/fernet-keys` (namespace then name); the
+# policy therefore uses a two-segment `+/+` glob, the added segment (CC-0112)
+# being the CR's namespace ahead of the existing name segment. OpenBao ACL
+# syntax supports `+` as "any number of characters bounded within a single path
+# segment" (verbatim, upstream docs at https://openbao.org/docs/concepts/policies
+# — "OpenBao > Architecture > Policies > Path Syntax"), and allows `+` between
+# literal segments: the canonical upstream example `path "secret/+/teamb"`
+# matches `secret/foo/teamb` but not `secret/foo/bar/teamb`. The patterns below
+# apply the same shape: `kv-v2/data/openstack/keystone/+/+/fernet-keys` matches
+# exactly the namespace and name segments followed by the literal leaf.
 #
 # Scope is still intentionally restricted to the two leaf kinds
 # (fernet-keys, credential-keys) and does NOT use a trailing `*` wildcard
 # over the whole Keystone subtree, because that subtree also holds the
 # read-only MariaDB credentials consumed by Keystone at
-# `kv-v2/data/openstack/keystone/db`; granting write over a trailing-star
-# wildcard would let a compromised ESO controller overwrite those
-# credentials and lock Keystone out of its own database.
+# `kv-v2/data/openstack/keystone/{namespace}/db`; granting write over a
+# trailing-star wildcard would let a compromised ESO controller overwrite
+# those credentials and lock Keystone out of its own database.
 #
-# The read-only MariaDB credentials at `kv-v2/data/openstack/keystone/db`
+# The read-only MariaDB credentials at `kv-v2/data/openstack/keystone/{namespace}/db`
 # remain unwritable: `db` is a flat leaf and the patterns above require
-# the literal `/fernet-keys` or `/credential-keys` suffix, so the `db`
-# secret itself is not in the match set. A holder of this policy could
-# write to the two sibling paths `kv-v2/…/keystone/db/fernet-keys` and
-# `kv-v2/…/keystone/db/credential-keys` (via `+ = "db"`), but those are
-# independent KV-v2 keys and writes to them do not affect the `db` secret;
-# the "MariaDB credentials locked out of their own database" failure mode
-# a trailing-star wildcard would enable is therefore still prevented.
+# the literal `/fernet-keys` or `/credential-keys` suffix after the two
+# `+/+` segments, so the `db` secret itself is not in the match set. A
+# holder of this policy could write to the two sibling paths
+# `kv-v2/…/keystone/<ns>/db/fernet-keys` and
+# `kv-v2/…/keystone/<ns>/db/credential-keys` (via name `= "db"`), but those
+# are independent KV-v2 keys and writes to them do not affect the `db`
+# secret; the "MariaDB credentials locked out of their own database"
+# failure mode a trailing-star wildcard would enable is therefore still
+# prevented.
 #
 # The `read` capability on each path is retained for policy-portability
 # and to match the convention in push-app-credentials.hcl. At the current
 # binding it is redundant: the management cluster's ESO role also binds
 # eso-management.hcl, whose `kv-v2/data/openstack/keystone/*` wildcard
 # already grants read on every descendant path — including the new
-# per-CR leaves `kv-v2/data/openstack/keystone/{name}/fernet-keys` and
-# `kv-v2/data/openstack/keystone/{name}/credential-keys` (CC-0093). If
-# this policy is later bound elsewhere (another cluster, a different
-# role) without eso-management, the explicit `read` keeps PushSecret
+# per-CR leaves `kv-v2/data/openstack/keystone/{namespace}/{name}/fernet-keys`
+# and `kv-v2/data/openstack/keystone/{namespace}/{name}/credential-keys`
+# (CC-0112). If this policy is later bound elsewhere (another cluster, a
+# different role) without eso-management, the explicit `read` keeps PushSecret
 # pre-flight reads working.
 #
 # ESO's Vault/OpenBao provider writes to BOTH the data and the metadata
@@ -70,18 +73,18 @@
 # (soft-delete) followed by DELETE on the metadata path (hard-delete);
 # without both grants ESO loops on 403 and never clears its cleanup
 # finalizer, which would stall the Keystone CR in Terminating forever.
-path "kv-v2/data/openstack/keystone/+/fernet-keys" {
+path "kv-v2/data/openstack/keystone/+/+/fernet-keys" {
   capabilities = ["create", "update", "read", "delete"]
 }
 
-path "kv-v2/metadata/openstack/keystone/+/fernet-keys" {
+path "kv-v2/metadata/openstack/keystone/+/+/fernet-keys" {
   capabilities = ["create", "update", "read", "delete"]
 }
 
-path "kv-v2/data/openstack/keystone/+/credential-keys" {
+path "kv-v2/data/openstack/keystone/+/+/credential-keys" {
   capabilities = ["create", "update", "read", "delete"]
 }
 
-path "kv-v2/metadata/openstack/keystone/+/credential-keys" {
+path "kv-v2/metadata/openstack/keystone/+/+/credential-keys" {
   capabilities = ["create", "update", "read", "delete"]
 }

--- a/docs/guides/keystone-admin-password-rotation.md
+++ b/docs/guides/keystone-admin-password-rotation.md
@@ -34,8 +34,8 @@ The admin password is not stored on the Keystone CR. It flows through three hops
 
 | Actor | Writes to | Reads from |
 | --- | --- | --- |
-| Operator/secrets-tooling | OpenBao path `kv-v2/bootstrap/keystone-admin` (key `password`) | — |
-| External Secrets Operator (ESO) | The admin Secret `<admin-secret>` (key `password`, `creationPolicy: Owner`) | OpenBao path `bootstrap/keystone-admin`, property `password` |
+| Operator/secrets-tooling | OpenBao path `kv-v2/bootstrap/<ns>/<ks>/admin` (key `password`) | — |
+| External Secrets Operator (ESO) | The admin Secret `<admin-secret>` (key `password`, `creationPolicy: Owner`) | OpenBao path `bootstrap/<ns>/<ks>/admin`, property `password` |
 | Keystone operator | The `{ks}-bootstrap` Job's pod template | The admin Secret `<admin-secret>` (key `password`) |
 
 On every reconcile the operator reads the `password` key of the admin Secret,
@@ -59,18 +59,23 @@ so an ESO write triggers a reconcile with **no CR edit**. During the re-run
 
 ## 1. Write the new password to OpenBao
 
-The admin password is sourced from OpenBao at `kv-v2/bootstrap/keystone-admin`
+The admin password is sourced from OpenBao at `kv-v2/bootstrap/<ns>/<ks>/admin`
 (key `password`). Write the new value there:
 
 ```bash
-bao kv put kv-v2/bootstrap/keystone-admin password=<new-password>
+bao kv put kv-v2/bootstrap/<ns>/<ks>/admin password=<new-password>
 ```
 
-> **Path convention.** This is the path the ESO `keystone-admin` ExternalSecret
-> reads (`remoteRef.key: bootstrap/keystone-admin`, `property: password`) and
-> the path `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` seeds. If your
-> deployment uses a different KV mount or path, substitute it here and in step 2's
-> ExternalSecret name accordingly.
+> **Path convention (per-CR).** The admin-password path is
+> scoped per Keystone CR as `bootstrap/<ns>/<ks>/admin`, so two
+> Model-B-enabled Keystone CRs never collide on a shared OpenBao object. This is
+> the path the ESO `keystone-admin` ExternalSecret reads
+> (`remoteRef.key: bootstrap/<ns>/<ks>/admin`, `property: password`) and the path
+> `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` seeds — for the default
+> Quick Start CR `controlplane-keystone` in `openstack`, that is
+> `bootstrap/openstack/controlplane-keystone/admin`. If your deployment uses a
+> different KV mount or path, substitute it here and in step 2's ExternalSecret
+> name accordingly.
 
 Nothing happens in the cluster yet — OpenBao now holds the new value, but the
 admin Secret still carries the old one until ESO syncs.
@@ -238,7 +243,7 @@ kubectl -n <ns> get externalsecret keystone-admin \
 ### Remediate
 
 1. Fix the source. Ensure the OpenBao path holds a non-empty `password`
-   (`bao kv get kv-v2/bootstrap/keystone-admin`), then re-sync ESO as in step 2.
+   (`bao kv get kv-v2/bootstrap/<ns>/<ks>/admin`), then re-sync ESO as in step 2.
 2. Once ESO repopulates the admin Secret, the operator's pending requeue (or a
    fresh `secretToKeystoneMapper` event from the Secret write) re-runs bootstrap
    automatically; `BootstrapReady` returns to `True`/`BootstrapComplete`. No CR

--- a/docs/guides/keystone-admin-password-scheduled-rotation.md
+++ b/docs/guides/keystone-admin-password-scheduled-rotation.md
@@ -90,7 +90,7 @@ staging Secret <ks>-admin-password-rotation
 push-source Secret <ks>-admin-password-next   (operator-owned)
   │  PushSecret <ks>-admin-password-backup mirrors it
   ▼
-OpenBao  bootstrap/keystone-admin
+OpenBao  bootstrap/<ns>/<ks>/admin   (per-CR path)
   │  ESO keystone-admin ExternalSecret syncs it
   ▼
 admin Secret <admin-secret>
@@ -106,7 +106,7 @@ The resources, by name:
 | CronJob | `<ks>-admin-password-rotate` | Mints a fresh password on `schedule` and PATCHes it onto the staging Secret. Mounts only the rotation script; never runs `keystone-manage`. |
 | Staging Secret | `<ks>-admin-password-rotation` | Drop box the CronJob writes; the only Secret the CronJob SA may patch. |
 | Push-source Secret | `<ks>-admin-password-next` | Operator-owned. The operator commits the validated password here; the PushSecret selects it. |
-| PushSecret | `<ks>-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/keystone-admin`. |
+| PushSecret | `<ks>-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/<ns>/<ks>/admin` (per-CR path). |
 | RBAC trio | `<ks>-admin-password-rotate` (ServiceAccount, Role, RoleBinding) | The CronJob's split-RBAC identity. |
 | Script ConfigMap | `<ks>-admin-password-rotate-script` (content-hash suffixed) | Immutable mount of `admin_password_rotate.sh`. |
 
@@ -123,18 +123,18 @@ Two safety properties are worth calling out:
 > Secret actually holds a valid password (non-empty, at least the minimum length).
 > Before the first rotation completes the push-source Secret is empty, so the
 > operator does not push — it would otherwise overwrite the seeded
-> `bootstrap/keystone-admin` value with nothing.
+> `bootstrap/<ns>/<ks>/admin` value with nothing.
 
 > **ESO-managed source path.** The PushSecret can only write
-> `bootstrap/keystone-admin` if that OpenBao path carries the custom-metadata
+> `bootstrap/<ns>/<ks>/admin` if that OpenBao path carries the custom-metadata
 > marker `managed-by=external-secrets`. The ESO Vault/OpenBao provider refuses to
 > overwrite a path it does not own and fails the PushSecret with `secret not
 > managed by external-secrets`. The standard bootstrap
 > (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) stamps the marker when it
 > seeds the path, and re-running it adopts a path written by an older bootstrap
-> that predates this marker. If you seed `bootstrap/keystone-admin` by hand, set
+> that predates this marker. If you seed `bootstrap/<ns>/<ks>/admin` by hand, set
 > the marker too:
-> `bao kv metadata put -custom-metadata=managed-by=external-secrets kv-v2/bootstrap/keystone-admin`.
+> `bao kv metadata put -custom-metadata=managed-by=external-secrets kv-v2/bootstrap/<ns>/<ks>/admin`.
 
 For the full sub-reconciler contract (validation rules, event reasons, the
 clobber-safe gate, RBAC shape) see
@@ -209,7 +209,7 @@ LAST SEEN   TYPE     REASON               OBJECT          MESSAGE
 ### 3.4 Confirm the OpenBao value changed and ESO synced it
 
 The PushSecret mirrors the push-source Secret into OpenBao at
-`bootstrap/keystone-admin`, and the `keystone-admin` ExternalSecret projects it
+`bootstrap/<ns>/<ks>/admin`, and the `keystone-admin` ExternalSecret projects it
 back into the admin Secret `<admin-secret>`. Use the manual guide's
 force-sync + fingerprint technique to confirm the admin Secret carries the new
 value: see
@@ -253,16 +253,23 @@ never clobbers the credential the running Keystone is using mid-flight.
 
 ---
 
-## 4. Single-CR precondition
+## 4. Per-CR path isolation
 
-Model B hardcodes the OpenBao RemoteKey to the flat path
-`bootstrap/keystone-admin`. It therefore assumes a **single**
-Model-B-enabled Keystone CR per cluster, sharing that one OpenBao object with the
-`keystone-admin` ExternalSecret.
+Model B scopes the OpenBao RemoteKey **per Keystone CR** to
+`bootstrap/<ns>/<ks>/admin`, where `<ns>`/`<ks>` are the
+Keystone CR's namespace and name. Each Model-B-enabled Keystone CR therefore
+writes its admin password to its **own** OpenBao object, and the matching
+`keystone-admin` ExternalSecret reads that same per-CR path. Two Model-B-enabled
+Keystone CRs in the same cluster no longer share one OpenBao object — they cannot
+clobber each other's rotations, so scheduled rotation can be enabled on multiple
+Keystone CRs concurrently.
 
-> **Precondition.** Do not enable `passwordRotation` on more than one Keystone CR
-> in the same cluster. Two enabled CRs would both push to the same
-> `bootstrap/keystone-admin` object and clobber each other's rotations.
+> **Path in lockstep.** The `keystone-admin` ExternalSecret's `remoteRef.key` must
+> match the per-CR path of the Keystone CR whose rotation feeds it. The bootstrap
+> seed (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) seeds
+> `bootstrap/<ns>/<ks>/admin` for each ControlPlane identity in
+> `KORC_CONTROLPLANES` (default `openstack/controlplane`, whose projected Keystone
+> CR is `controlplane-keystone`, i.e. `bootstrap/openstack/controlplane-keystone/admin`).
 
 ---
 
@@ -294,7 +301,7 @@ Secrets, the RBAC trio, the PushSecret, and the script ConfigMap — and reports
 
 > **Safety note.** Disabling does **not** remove the last-pushed password from
 > OpenBao. The PushSecret uses `DeletionPolicy: None`, so the value already in
-> `bootstrap/keystone-admin` stays put when the PushSecret is deleted. Disabling
+> `bootstrap/<ns>/<ks>/admin` stays put when the PushSecret is deleted. Disabling
 > rotation can never lock the admin out of Keystone.
 
 ---

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -319,7 +319,7 @@ authenticates as.
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `cloudName` | `string` | Yes | — | The entry in `clouds.yaml` K-ORC authenticates as. Also used by the reconciler as the conventional K-ORC `User` reference name (defaulting to `admin` when empty) and projected onto the catalog `Service`/`Endpoint` CRs. |
-| `secretName` | `string` | No | `"k-orc-clouds-yaml"` | Name of the Secret holding the `clouds.yaml` document. Defaulted to `k-orc-clouds-yaml` by **both** the `+kubebuilder:default` marker and the defaulting webhook. |
+| `secretName` | `string` | No | `"k-orc-clouds-yaml"` | Name of the Secret holding the `clouds.yaml` document. Defaulted to `k-orc-clouds-yaml` by **both** the `+kubebuilder:default` marker and the defaulting webhook. The Secret is namespace-local to the ControlPlane's child namespace; because the operator enforces one ControlPlane per namespace, the shared default name does not collide across control planes. |
 
 ---
 
@@ -420,6 +420,17 @@ Reports the observed readiness of a single projected service CR.
 ### AdminApplicationCredentialStatus
 
 Reports the observed state of the K-ORC admin application credential.
+
+> **Multi-instance — per-ControlPlane OpenBao path.** The minted admin
+> application credential is mirrored to OpenBao at the **per-ControlPlane** path
+> `openstack/keystone/{namespace}/{name}/admin/app-credential` (for the default
+> deployment identity `openstack/controlplane`, this is
+> `openstack/keystone/openstack/controlplane/admin/app-credential`), replacing the
+> earlier flat path shared across control planes. Because the validating webhook
+> permits exactly one ControlPlane per namespace, these per-CR paths are disjoint
+> across namespaces by construction. See the
+> [ControlPlane Reconciler reference](./controlplane-reconciler.md) for the full
+> OpenBao layout and the migration from the legacy flat path.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -525,10 +525,13 @@ OpenBao:
   materialise — the c5c3 PushSecret then overwrites it with the minted credential.
 - **PushSecret to OpenBao.** `secrets.EnsurePushSecret` (idempotent; only Updates
   on a `DeepEqual` diff so ESO is not woken to re-push an unchanged credential)
-  builds the PushSecret to `openbao-cluster-store` at remote key
-  `openstack/keystone/admin/app-credential` with **`DeletionPolicy: None`** — the
-  admin credential is a shared bootstrap secret, so deleting the PushSecret on
-  ControlPlane teardown leaves the last-pushed credential intact in OpenBao.
+  builds the PushSecret to `openbao-cluster-store` at the per-ControlPlane remote
+  key `openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential`
+  (`adminAppCredentialRemoteKeyFor`) with **`DeletionPolicy: None`** — the
+  admin credential is a per-ControlPlane persistent bootstrap secret, so deleting
+  the PushSecret on ControlPlane teardown (or when rotation is disabled) leaves the
+  last-pushed credential intact in OpenBao at that CR's own path, so re-adoption
+  works and the admin is never locked out.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
@@ -591,7 +594,11 @@ mint logic. Its model:
   ControlPlanes in the CredentialRotation's **own** namespace and requires
   exactly one. Zero → `Ready=False` reason `NoControlPlane` with a short requeue;
   multiple → `Ready=False` reason `AmbiguousControlPlane` with **no** requeue (an
-  arbitrary pick could rotate the wrong credential).
+  arbitrary pick could rotate the wrong credential). The one-ControlPlane-per-namespace
+  contract is now enforced at admission by the ControlPlane validating webhook
+  (`validateUniqueInNamespace`), so the `AmbiguousControlPlane` branch is
+  **defense-in-depth**: it is retained as a safety fallback but is unreachable while
+  the webhook is active.
 - **Bootstrap is idempotent.** With `spec.bootstrap`, an already-existing AC is a
   no-op success (`BootstrapComplete`); a missing AC waits (`WaitingForBootstrap`)
   for the ControlPlane reconciler to mint it.
@@ -606,7 +613,7 @@ mint logic. Its model:
 | --- | --- | --- | --- |
 | target not `adminApplicationCredential` | False | `UnsupportedTarget` | no requeue |
 | no ControlPlane in namespace | False | `NoControlPlane` | requeue 10s |
-| multiple ControlPlanes | False | `AmbiguousControlPlane` | no requeue |
+| multiple ControlPlanes | False | `AmbiguousControlPlane` | no requeue; defense-in-depth — unreachable while the one-per-namespace webhook is active |
 | ControlPlane List errors | False | `ControlPlaneListError` | no requeue |
 | bootstrap, AC exists | True | `BootstrapComplete` | no-op success |
 | bootstrap, AC absent | False | `WaitingForBootstrap` | requeue 10s |
@@ -638,8 +645,8 @@ K-ORC writes the minted credential into the operator-owned Secret
    {controlplane.Name}-admin-app-credential   (Resource.SecretRef target)
         │
         ▼  (reconcileAdminCredential, gated on KORCReady + clouds.yaml ES)
-PushSecret  →  OpenBao kv  openstack/keystone/admin/app-credential
-   (DeletionPolicy: None — shared bootstrap secret survives teardown)
+PushSecret  →  OpenBao kv  openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential
+   (DeletionPolicy: None — per-ControlPlane bootstrap secret survives teardown)
         │
         ▼
 ExternalSecret  →  {control-plane ns}/k-orc-clouds-yaml  (the clouds.yaml gate;
@@ -657,6 +664,42 @@ the annotation (which guarantees a mismatch). The admin-password Secret watch
 (see [Secret Field Indexer](#secret-field-indexer)) wakes the ControlPlane the
 moment the password rotates so the chain converges without waiting for the next
 periodic requeue.
+
+---
+
+## Multi-instance
+
+The ControlPlane reconciler scopes every admin / K-ORC credential it owns to
+the individual ControlPlane CR, so multiple control planes can coexist in a single
+cluster without sharing OpenBao state.
+
+- **One ControlPlane per namespace (admission-enforced).** The ControlPlane
+  validating webhook's `validateUniqueInNamespace` check runs in
+  `ValidateCreate` **only** (not `ValidateUpdate`): it lists ControlPlanes in the
+  object's namespace and returns `field.Forbidden` naming the incumbent if one
+  already exists. The cluster therefore admits **exactly one** ControlPlane per
+  namespace. This is what makes the CredentialRotation reconciler's
+  `AmbiguousControlPlane` branch defense-in-depth (see
+  [CredentialRotation reconciler](#credentialrotation-reconciler)).
+- **Per-CR OpenBao path for the admin AC.** The admin application credential is
+  pushed to the per-ControlPlane key
+  `openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential`
+  (`adminAppCredentialRemoteKeyFor`), so two ControlPlanes never write to the same
+  OpenBao object. The K-ORC admin `User` CR is named `{cp.Name}-user-admin` (its
+  Kubernetes `metadata.name`), while the **OpenStack** username it imports stays
+  `admin` (set via the import `Filter.Name`) — the K8s-name and the OpenStack-name
+  are deliberately split so the per-CR Kubernetes object is unique while the
+  OpenStack identity is unchanged.
+- **Running multiple control planes.** Because the webhook caps a namespace at one
+  ControlPlane and the OpenBao paths are keyed by `{namespace}/{name}`, operating
+  several control planes means deploying each into its **own** namespace. Each gets
+  a disjoint OpenBao prefix
+  (`openstack/keystone/{namespace}/{name}/admin/app-credential`), disjoint child CRs
+  in its own namespace, and an independent rotation lifecycle — no two control
+  planes can clobber one another's credentials.
+
+See [Migration: legacy flat paths → per-ControlPlane paths](#migration-legacy-flat-paths--per-controlplane-paths)
+for moving an existing single-instance cluster onto the per-CR layout.
 
 ---
 
@@ -711,8 +754,10 @@ invariants are enforced by the `credential_invariant_test.go` checks
 
 The `PushSecret`'s `DeletionPolicy: None` is the one deliberate exception to the
 GC cascade: tearing down a ControlPlane removes the PushSecret CR but leaves the
-last-pushed credential in OpenBao, so a fresh control plane (or a consumer that
-already depends on the shared bootstrap secret) is not locked out mid-rotation.
+last-pushed credential in OpenBao at this ControlPlane's own per-CR path
+(`openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential`), so a
+re-created control plane in the same namespace re-adopts that per-ControlPlane
+bootstrap secret rather than being locked out mid-rotation.
 
 ---
 
@@ -865,6 +910,87 @@ operators/c5c3/
     │   └── collectors.go                        c5c3_operator_* duration/error vectors
     └── testutil/                                c5c3 envtest setup helpers
 ```
+
+## Migration: legacy flat paths → per-ControlPlane paths
+
+Earlier releases wrote the admin / K-ORC credentials to cluster-global,
+flat OpenBao paths that assumed a single control plane per cluster. The operator
+now writes every credential family onto a per-CR path keyed by the owning
+ControlPlane's (or projected Keystone CR's) `{namespace}/{name}`, so multiple
+control planes (one per
+namespace; see [Multi-instance](#multi-instance)) never collide in OpenBao. This is
+a one-time operator runbook to migrate an **existing** cluster; new clusters need
+no migration.
+
+The new `RemoteKey` lands the moment the operator is upgraded — the next reconcile
+of each CR emits the per-CR path — so re-apply the OpenBao ACLs **first or
+concurrently** with the operator upgrade. Without the updated policies ESO returns
+`403` on the backup/push and the corresponding Ready conditions flip `False`
+(`AdminCredentialReady` for the admin AC; `PasswordRotationReady` for the Model-B
+admin password; `FernetKeysReady` / `CredentialKeysReady` for the signing keys).
+
+**Path mapping (legacy → per-CR):**
+
+| Credential family | Legacy flat path | Per-CR path |
+| --- | --- | --- |
+| Admin application credential (K-ORC) | `openstack/keystone/admin/app-credential` | `openstack/keystone/{namespace}/{name}/admin/app-credential` |
+| Admin bootstrap password (Model B) | `bootstrap/keystone-admin` | `bootstrap/{namespace}/{name}/admin` |
+| Fernet / credential keys (boundary-4) | `openstack/keystone/{name}/{fernet,credential}-keys` | `openstack/keystone/{namespace}/{name}/{fernet,credential}-keys` |
+
+For the admin AC the `{namespace}/{name}` is the **ControlPlane** CR's
+(`adminAppCredentialRemoteKeyFor`); for the admin password and the Fernet /
+credential keys it is the projected **Keystone** CR's (`{cp.Name}-keystone`). The
+Fernet / credential move adds the namespace segment **on top of** the prior
+flat→per-name migration (see the keystone reconciler's
+[Migration note: legacy flat paths](../keystone/keystone-reconciler.md#migration-note-legacy-flat-paths));
+this change only adds the leading `{namespace}/` segment.
+
+**One-time copy (preserve the last-pushed value so nothing is locked out):**
+
+```sh
+# admin application credential (per ControlPlane <ns>/<cp>)
+bao kv get kv-v2/openstack/keystone/admin/app-credential
+bao kv put kv-v2/openstack/keystone/<ns>/<cp>/admin/app-credential clouds.yaml=@-
+# admin bootstrap password (per Keystone CR <ns>/<name>, name = <cp>-keystone)
+bao kv get kv-v2/bootstrap/keystone-admin
+bao kv put kv-v2/bootstrap/<ns>/<name>/admin password=<value>
+# fernet / credential keys (per Keystone CR <ns>/<name>)
+bao kv get kv-v2/openstack/keystone/<name>/fernet-keys
+bao kv put kv-v2/openstack/keystone/<ns>/<name>/fernet-keys value=<value>
+bao kv get kv-v2/openstack/keystone/<name>/credential-keys
+bao kv put kv-v2/openstack/keystone/<ns>/<name>/credential-keys value=<value>
+```
+
+**Re-apply the OpenBao ACLs.** Re-run
+`deploy/openbao/bootstrap/setup-policies.sh` (the kind/dev path; also invoked by
+`hack/deploy-infra.sh`), or for production clusters managed outside the bootstrap
+flow apply the updated policy files directly with `bao policy write …`:
+
+| Policy file | Grants write to |
+| --- | --- |
+| `push-app-credentials.hcl` | the per-CR admin AC path `…/keystone/+/+/admin/app-credential` |
+| `push-keystone-admin.hcl` | the per-CR admin-password path `bootstrap/+/+/admin` |
+| `push-keystone-keys.hcl` | the per-CR `…/keystone/+/+/{fernet,credential}-keys` paths |
+
+Until the matching policy is re-applied, ESO's push to the new path returns `403`
+and the credential's Ready condition stays `False`.
+
+**Orphaned but harmless.** After migration the legacy flat paths are **orphaned but
+harmless**: the live control plane no longer reads or refreshes them, no live
+PushSecret references them, and they are otherwise inert. Operators who want a clean
+OpenBao state can purge them once the per-CR paths are confirmed populated and Ready:
+
+```sh
+bao kv metadata delete kv-v2/openstack/keystone/admin/app-credential
+bao kv metadata delete kv-v2/bootstrap/keystone-admin
+bao kv metadata delete kv-v2/openstack/keystone/<name>/fernet-keys
+bao kv metadata delete kv-v2/openstack/keystone/<name>/credential-keys
+```
+
+`metadata delete` removes the current version and all historical versions at the
+path — the canonical KV-v2 purge and the right inverse of the now-superseded write.
+(The Fernet / credential families were previously migrated flat→per-name in an
+earlier release, and the boundary-4 change layers the namespace segment on top.)
 
 ## Architecture references
 

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -684,8 +684,15 @@ materialising the Kubernetes Secret `k-orc-clouds-yaml` from the same OpenBao ke
 | `openstack` (control-plane) | **C1 co-location** — the c5c3-operator creates the K-ORC `ApplicationCredential`/`Service`/`Endpoint` CRs in the control-plane namespace, and K-ORC resolves each CR's `CloudCredentialsRef` Secret in that *same* namespace, so the admin clouds.yaml must live here for K-ORC to authenticate. This is the copy the `AdminCredentialReady` gate waits on. |
 | `orc-system` | The copy K-ORC mounts as its global default `clouds.yaml` (off the credential critical path — see the [K-ORC section](#k-orc-openstack-resource-controller)). |
 
-Both read the OpenBao key `openstack/keystone/admin/app-credential` (property
-`clouds.yaml`, store-relative to the KV-v2 mount). On a fresh cluster that key is
+Both read the per-ControlPlane OpenBao key
+`openstack/keystone/{namespace}/{name}/admin/app-credential` (property
+`clouds.yaml`, store-relative to the KV-v2 mount) — keyed by the ControlPlane's
+namespace and name so each CR owns an isolated admin-credential path.
+For the default deployment identity (ControlPlane `openstack/controlplane`) this
+resolves to `openstack/keystone/openstack/controlplane/admin/app-credential`, and
+both ExternalSecrets currently read that single per-CR default key as a static
+single-identity deployment shim — operator-owned per-CR ExternalSecret templating
+is a follow-up (#412). On a fresh cluster that key is
 seeded with a password-based bootstrap clouds.yaml by
 `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` so the
 ExternalSecrets can materialise before any credential is minted; once the
@@ -694,18 +701,27 @@ key with the App-Cred-based clouds.yaml.
 
 **OpenBao policy** — `deploy/openbao/policies/push-app-credentials.hcl`
 
-This policy grants the write path for the admin credential PushSecret. The pre-existing mid-path grant `kv-v2/data/openstack/*/app-credential`
+This policy grants the write path for each ControlPlane's admin credential
+PushSecret. Because the admin credential path is keyed per
+ControlPlane (`openstack/keystone/{namespace}/{name}/admin/app-credential`), the
+grants template the namespace and name as two `+/+` segments. The pre-existing
+mid-path grant `kv-v2/data/openstack/*/app-credential`
 matches only a single mid-segment (`openstack/<svc>/app-credential`) and therefore does
-**not** cover the two-segment `openstack/keystone/admin/app-credential`. Rather than
-widening that glob, the policy adds two narrow, single-leaf grants:
+**not** cover the four-segment per-CR shape. Rather than
+widening that glob, the policy adds two per-ControlPlane `+/+` grants:
 
 | Path | Capabilities | Purpose |
 | --- | --- | --- |
-| `kv-v2/data/openstack/keystone/admin/app-credential` | `create`, `update`, `read` | Write the admin Application Credential `clouds.yaml` data leaf |
-| `kv-v2/metadata/openstack/keystone/admin/app-credential` | `create`, `update`, `read` | Allow ESO's Vault provider to write `custom_metadata` on the KV-v2 PushSecret (a data-only grant 403s on the metadata PUT and the PushSecret never reaches Ready) |
+| `kv-v2/data/openstack/keystone/+/+/admin/app-credential` | `create`, `update`, `read` | Write each ControlPlane's admin Application Credential `clouds.yaml` data leaf (the two `+` segments are its namespace and name) |
+| `kv-v2/metadata/openstack/keystone/+/+/admin/app-credential` | `create`, `update`, `read` | Allow ESO's Vault provider to write `custom_metadata` on the KV-v2 PushSecret (a data-only grant 403s on the metadata PUT and the PushSecret never reaches Ready) |
 
-Both grants stay scoped to the single literal admin-credential leaf, adding no blast
-radius beyond this one credential. For the mTLS transport gate and the
+A `+` matches exactly one path segment, so even though the namespace and name vary
+per ControlPlane the grant still terminates at the literal `/admin/app-credential`
+leaf and admits no deeper or sibling paths. Read coverage needs no widening:
+eso-management's read-only `kv-v2/data/openstack/keystone/*` trailing wildcard
+already covers every per-CR `+/+/admin/app-credential` leaf. Both grants stay
+scoped to the per-ControlPlane `+/+` admin-credential leaves, adding no blast
+radius beyond admin app-credentials. For the mTLS transport gate and the
 `openbao-cluster-store` auth path these manifests ride on, see
 [OpenBao Bootstrap Procedure](./openbao-bootstrap.md).
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -322,7 +322,7 @@ into the KV v2 secret engine.
 
 | KV v2 Path | Secret Keys | Description |
 | --- | --- | --- |
-| `kv-v2/bootstrap/keystone-admin` | `password` | Keystone admin user password |
+| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | Keystone admin user password, scoped per ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default `openstack/controlplane` seeds `kv-v2/bootstrap/openstack/controlplane-keystone/admin`. |
 | `kv-v2/infrastructure/mariadb` | `root-password` | MariaDB root password |
 | `kv-v2/openstack/keystone/db` | `username`, `password` | Keystone database credentials (username is `keystone`) |
 
@@ -334,8 +334,8 @@ host `/proc/<pid>/cmdline` process argument lists.
 
 **Security:** Generated passwords are never echoed to stdout or stderr and never
 appear as command-line arguments visible to host process listings. The script
-outputs only status messages (e.g., `Writing kv-v2/bootstrap/keystone-admin...` or
-`Skipping kv-v2/bootstrap/keystone-admin (already exists)`).
+outputs only status messages (e.g., `Writing kv-v2/bootstrap/openstack/controlplane-keystone/admin...` or
+`Skipping kv-v2/bootstrap/openstack/controlplane-keystone/admin (already exists)`).
 
 **Idempotency:** Before writing each secret, the script checks `bao kv get` for the
 path. If the secret already exists, the write is skipped to prevent overwriting
@@ -391,7 +391,7 @@ All secrets are stored under the `kv-v2/` mount point (KV version 2 engine).
 
 | Path | Keys | Provisioned By | Consumed By |
 | --- | --- | --- | --- |
-| `kv-v2/bootstrap/keystone-admin` | `password` | `write-bootstrap-secrets.sh` | ExternalSecret `keystone-admin` |
+| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | `write-bootstrap-secrets.sh` | ExternalSecret `keystone-admin` |
 | `kv-v2/infrastructure/mariadb` | `root-password` | `write-bootstrap-secrets.sh` | ExternalSecret `mariadb-root-password` |
 | `kv-v2/openstack/keystone/db` | `username`, `password` | `write-bootstrap-secrets.sh` | ExternalSecret `keystone-db` |
 
@@ -403,7 +403,7 @@ Kubernetes.
 
 | ExternalSecret | Namespace | Remote Path | Remote Property | K8s Secret Name | K8s Secret Key |
 | --- | --- | --- | --- | --- | --- |
-| `keystone-admin` | `openstack` | `bootstrap/keystone-admin` | `password` | `keystone-admin-credentials` | `password` |
+| `keystone-admin` | `openstack` | `bootstrap/openstack/controlplane-keystone/admin` | `password` | `keystone-admin-credentials` | `password` |
 | `keystone-db` | `openstack` | `openstack/keystone/db` | `username`, `password` | `keystone-db-credentials` | `username`, `password` |
 | `mariadb-root-password` | `openstack` | `infrastructure/mariadb` | `root-password` | `mariadb-root-password` | `password` |
 

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -837,8 +837,8 @@ PushSecret CRs (both in the Keystone's namespace):
 
 | PushSecret | API Group | KV-v2 Path (OpenBao) |
 | --- | --- | --- |
-| `{keystone.Name}-fernet-keys-backup` | `external-secrets.io` | `kv-v2/data/openstack/keystone/{keystone.Name}/fernet-keys` |
-| `{keystone.Name}-credential-keys-backup` | `external-secrets.io` | `kv-v2/data/openstack/keystone/{keystone.Name}/credential-keys` |
+| `{keystone.Name}-fernet-keys-backup` | `external-secrets.io` | `kv-v2/data/openstack/keystone/{keystone.Namespace}/{keystone.Name}/fernet-keys` |
+| `{keystone.Name}-credential-keys-backup` | `external-secrets.io` | `kv-v2/data/openstack/keystone/{keystone.Namespace}/{keystone.Name}/credential-keys` |
 
 The names are produced by `openBaoBackupPushSecretNames(keystone)` so that
 adding a third backup target in the future is a one-line change. Both
@@ -854,20 +854,29 @@ built-in Kubernetes garbage collector via owner references — see
 [Owned Resources](#owned-resources).
 
 > **Path scoping:** Both KV-v2 paths are per-CR-scoped via
-> `openstack/keystone/{keystone.Name}/<leaf>` (where `<leaf>` is `fernet-keys`
-> or `credential-keys`), so multiple Keystone CRs in the same namespace write
-> to disjoint paths and cannot collide. See
+> `openstack/keystone/{keystone.Namespace}/{keystone.Name}/<leaf>` (where `<leaf>`
+> is `fernet-keys` or `credential-keys`), so multiple Keystone CRs — in the same
+> namespace or across namespaces — write to disjoint paths and cannot collide. The
+> leading `{keystone.Namespace}` segment was the most recent addition, layered on
+> top of an earlier per-name scoping. See
 > [Migration note: legacy flat paths](#migration-note-legacy-flat-paths)
 > for upgrade behaviour and recommended cleanup of orphaned legacy paths.
 
 ### Migration note: legacy flat paths
 
-Earlier, both backup PushSecrets wrote to the cluster-global, flat
-KV-v2 paths `kv-v2/openstack/keystone/fernet-keys` and
-`kv-v2/openstack/keystone/credential-keys`. The operator now writes to the
-per-CR-scoped paths
-`kv-v2/openstack/keystone/{keystone.Name}/fernet-keys` and
-`kv-v2/openstack/keystone/{keystone.Name}/credential-keys`.
+The KV-v2 path layout for these backups has evolved in two steps:
+
+1. **Flat → per-name.** Originally both backup PushSecrets wrote to
+   the cluster-global, flat KV-v2 paths `kv-v2/openstack/keystone/fernet-keys`
+   and `kv-v2/openstack/keystone/credential-keys`. A first migration scoped them
+   per CR by adding the CR-name segment:
+   `kv-v2/openstack/keystone/{keystone.Name}/fernet-keys` and
+   `…/{keystone.Name}/credential-keys`.
+2. **Per-name → namespace+name.** A later migration added
+   the leading namespace segment so the paths are unique across namespaces as
+   well as within one. The operator now writes to
+   `kv-v2/openstack/keystone/{keystone.Namespace}/{keystone.Name}/fernet-keys`
+   and `…/{keystone.Namespace}/{keystone.Name}/credential-keys`.
 
 The RemoteKey change lands the moment the Keystone operator is upgraded —
 the next reconcile of each Keystone CR emits the new path. For existing
@@ -881,32 +890,62 @@ is re-run; for production clusters managed outside the bootstrap flow the
 equivalent is a single `bao policy write push-keystone-keys …` against the
 updated HCL file.
 
-The legacy flat paths are **orphaned but harmless** after upgrade:
-the live Keystone control plane reads its Fernet and credential keys from
-the local Kubernetes `Secret` (`{name}-fernet-keys`, `{name}-credential-keys`),
-not from the OpenBao backup. The OpenBao copy is a disaster-recovery
-artefact only; the legacy entries simply stop being refreshed, never get
-deleted by `DeletionPolicy=Delete` (no live PushSecret references them
-anymore), and are otherwise inert.
+The superseded paths (both the original flat paths **and** the
+per-name paths that lacked the namespace segment) are **orphaned but
+harmless** after upgrade: the live Keystone control plane reads its Fernet
+and credential keys from the local Kubernetes `Secret`
+(`{name}-fernet-keys`, `{name}-credential-keys`), not from the OpenBao
+backup. The OpenBao copy is a disaster-recovery artefact only; the legacy
+entries simply stop being refreshed, never get deleted by
+`DeletionPolicy=Delete` (no live PushSecret references them anymore), and
+are otherwise inert.
 
-Operators who want a clean OpenBao state can purge the legacy entries
-manually after upgrade:
+Operators who want a clean OpenBao state can purge the superseded entries
+manually after upgrade — both the original flat paths and the
+per-name (namespace-less) paths:
 
 ```sh
+# original flat paths
 bao kv metadata delete kv-v2/openstack/keystone/fernet-keys
 bao kv metadata delete kv-v2/openstack/keystone/credential-keys
+# per-name paths that lacked the namespace segment
+bao kv metadata delete kv-v2/openstack/keystone/<name>/fernet-keys
+bao kv metadata delete kv-v2/openstack/keystone/<name>/credential-keys
 ```
 
 `metadata delete` removes both the current version and all historical
 versions of the secret at that path; this is the canonical KV-v2 purge
 operation and the right inverse of the now-superseded write.
 
+#### Admin-password path migration (Model B)
+
+The Model-B admin-password PushSecret moves onto the same
+per-CR layout. The flat `bootstrap/keystone-admin` object becomes the per-CR
+`bootstrap/{keystone.Namespace}/{keystone.Name}/admin`. As above, the new
+RemoteKey lands on operator upgrade, so the matching ACL
+(`deploy/openbao/policies/push-keystone-admin.hcl`) must be re-applied first or
+concurrently — re-run `deploy/openbao/bootstrap/setup-policies.sh` or
+`bao policy write push-keystone-admin …` — otherwise ESO returns `403` on the
+push and `PasswordRotationReady` flips to `False`. The legacy
+`bootstrap/keystone-admin` object is **orphaned but harmless** after migration
+and can be purged once the per-CR path is populated and Ready:
+
+```sh
+bao kv metadata delete kv-v2/bootstrap/keystone-admin
+```
+
+For the end-to-end, multi-credential operator runbook (admin application
+credential + admin password + Fernet/credential keys, with the one-time copy
+commands and the full ACL re-apply set), see the c5c3 controlplane reconciler's
+[Migration: legacy flat paths → per-ControlPlane paths](../c5c3/controlplane-reconciler.md#migration-legacy-flat-paths--per-controlplane-paths).
+
 ### DeletionPolicy=Delete Wiring Through ESO
 
 The Keystone operator has no OpenBao credentials and does not talk to the
 OpenBao API directly. Remote purge of the KV-v2 path is delegated to ESO
 via the PushSecret field `Spec.DeletionPolicy`. The `RemoteKey` follows the
-per-CR layout `openstack/keystone/{keystone.Name}/<leaf>`,
+per-CR layout `openstack/keystone/{keystone.Namespace}/{keystone.Name}/<leaf>`
+(scoped by the CR's namespace and name),
 so each Keystone CR writes to its own KV-v2 prefix:
 
 ```go
@@ -920,7 +959,7 @@ Spec: esov1alpha1.PushSecretSpec{
     Data: []esov1alpha1.PushSecretData{{
         Match: esov1alpha1.PushSecretMatch{
             RemoteRef: esov1alpha1.PushSecretRemoteRef{
-                RemoteKey: fmt.Sprintf("openstack/keystone/%s/fernet-keys", keystone.Name),
+                RemoteKey: fmt.Sprintf("openstack/keystone/%s/%s/fernet-keys", keystone.Namespace, keystone.Name),
             },
         },
     }},
@@ -1123,7 +1162,7 @@ before ESO has installed its own cleanup finalizer, the API server
 immediately garbage-collects the PushSecret object, and ESO never observes
 the `DeletionTimestamp` — so `DeletionPolicy=Delete` never runs and the
 referenced kv-v2 path is orphaned in OpenBao. The observed stuck path now
-takes the per-CR form `kv-v2/openstack/keystone/{name}/fernet-keys`;
+takes the per-CR form `kv-v2/openstack/keystone/{namespace}/{name}/fernet-keys`;
 this was originally seen in CI run 24842115250 against the
 now-legacy flat path
 `kv-v2/openstack/keystone/fernet-keys`. The race itself is path-shape
@@ -1462,7 +1501,7 @@ and disaster recovery backup to OpenBao.
 4. **Ensure rotation CronJob** — Create or update `{name}-fernet-rotate` CronJob
    with the schedule from `spec.fernet.rotationSchedule`.
 5. **Ensure PushSecret** — Create or update `{name}-fernet-keys-backup` PushSecret
-   targeting `kv-v2/data/openstack/keystone/{name}/fernet-keys` in the `openbao`
+   targeting `kv-v2/data/openstack/keystone/{namespace}/{name}/fernet-keys` in the `openbao`
    ClusterSecretStore.
 
 **Key Generation:**
@@ -1499,7 +1538,7 @@ and disaster recovery backup to OpenBao.
 | Name | `{name}-fernet-keys-backup` |
 | Store | `ClusterSecretStore/openbao` |
 | Source Secret | `{name}-fernet-keys` |
-| Remote Key | `kv-v2/data/openstack/keystone/{name}/fernet-keys` |
+| Remote Key | `kv-v2/data/openstack/keystone/{namespace}/{name}/fernet-keys` |
 
 **Condition Contract:**
 
@@ -1633,7 +1672,7 @@ with credential migration, and disaster recovery backup to OpenBao.
 4. **Ensure rotation CronJob** — Create or update `{name}-credential-rotate` CronJob
    with the schedule from `spec.credentialKeys.rotationSchedule`.
 5. **Ensure PushSecret** — Create or update `{name}-credential-keys-backup` PushSecret
-   targeting `kv-v2/data/openstack/keystone/{name}/credential-keys` in the `openbao`
+   targeting `kv-v2/data/openstack/keystone/{namespace}/{name}/credential-keys` in the `openbao`
    ClusterSecretStore.
 
 **Key Generation:**
@@ -1675,7 +1714,7 @@ with credential migration, and disaster recovery backup to OpenBao.
 | Name | `{name}-credential-keys-backup` |
 | Store | `ClusterSecretStore/openbao` |
 | Source Secret | `{name}-credential-keys` |
-| Remote Key | `kv-v2/data/openstack/keystone/{name}/credential-keys` |
+| Remote Key | `kv-v2/data/openstack/keystone/{namespace}/{name}/credential-keys` |
 
 **Condition Contract:**
 
@@ -2649,10 +2688,11 @@ configuration.
 
 **Purpose:** Drive Model B scheduled admin-password rotation. A CronJob mints a fresh strong password and PATCHes it onto a
 staging Secret; the operator validates and commits it onto an operator-owned
-push-source Secret; a PushSecret mirrors that to OpenBao at the flat path
-`bootstrap/keystone-admin`; External Secrets Operator (ESO) then syncs it back
-into the admin Secret and [`reconcileBootstrap`](#reconcilebootstrap) re-runs
-`keystone-manage bootstrap` (admin-password-hash gate) to apply it.
+push-source Secret; a PushSecret mirrors that to OpenBao at the per-CR path
+`bootstrap/{keystone.Namespace}/{keystone.Name}/admin`; External Secrets
+Operator (ESO) then syncs it back into the admin Secret and
+[`reconcileBootstrap`](#reconcilebootstrap) re-runs `keystone-manage bootstrap`
+(admin-password-hash gate) to apply it.
 
 Two lifecycle paths:
 
@@ -2701,8 +2741,8 @@ Two lifecycle paths:
 8. **Clobber-safe PushSecret** — only ensure `adminPasswordPushSecret` once
    `adminPasswordPushSourceReady` reports the push-source Secret holds a valid
    password (≥ minLength). Before the first rotation completes the push-source is
-   empty, and pushing it would overwrite the seeded `bootstrap/keystone-admin`
-   value with nothing.
+   empty, and pushing it would overwrite the seeded per-CR
+   `bootstrap/{keystone.Namespace}/{keystone.Name}/admin` value with nothing.
 9. **Report ready** — sets `PasswordRotationReady=True` with reason
    `PasswordRotationConfigured` ("Admin password rotation CronJob is
    configured").
@@ -2738,16 +2778,17 @@ push-source Secret (see the RBAC split below).
 | Name | `{name}-admin-password-backup` |
 | Store | `ClusterSecretStore/openbao-cluster-store` |
 | Source Secret | `{name}-admin-password-next` (push-source) |
-| Remote Key | `bootstrap/keystone-admin` (hardcoded flat path — single-CR assumption, boundary 8) |
+| Remote Key | `bootstrap/{keystone.Namespace}/{keystone.Name}/admin` (per-CR path) |
 | Property | `password` |
 | DeletionPolicy | `None` |
 
-The `RemoteKey` is hardcoded (not CR-scoped): Model B assumes a single
-Model-B-enabled Keystone CR per cluster sharing the `bootstrap/keystone-admin`
-object with the keystone-admin ExternalSecret. `DeletionPolicy=None` is chosen
-because `bootstrap/keystone-admin` is a shared, persistent bootstrap secret;
-keeping the last-pushed password in OpenBao when rotation is disabled (the
-teardown path deletes this PushSecret) means the admin is never locked out.
+The `RemoteKey` is CR-scoped to `bootstrap/{keystone.Namespace}/{keystone.Name}/admin`,
+so each Model-B-enabled Keystone CR writes its admin password to
+its own OpenBao object and multiple Keystone CRs never collide on a shared
+`bootstrap/keystone-admin` key. `DeletionPolicy=None` is chosen because this is a
+per-Keystone-CR **persistent** bootstrap secret: keeping the last-pushed password in
+OpenBao on teardown (or when rotation is disabled — the teardown path deletes this
+PushSecret) means re-adoption works and the admin is never locked out.
 
 **Condition Contract:**
 
@@ -2837,7 +2878,7 @@ rotation-age gauge can refresh on every reconcile.
 
 **Downstream consumer.** [`reconcileBootstrap`](#reconcilebootstrap) is the
 consumer of the rotated password: once ESO syncs the new value from
-`bootstrap/keystone-admin` into the admin Secret, the bootstrap reconciler's
+`bootstrap/{keystone.Namespace}/{keystone.Name}/admin` into the admin Secret, the bootstrap reconciler's
 `forge.c5c3.io/admin-password-hash` gate re-runs the idempotent bootstrap Job to
 apply it. See the [Labels and Annotations](#labels-and-annotations) entries for
 `forge.c5c3.io/rotation-target` (value `admin-password` for the staging Secret),

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -1167,13 +1167,36 @@ main() {
 
   # Step 7: OpenBao bootstrap (init, unseal, configure)
   log "=== Step 7/8: OpenBao bootstrap ==="
-  # WITH_CONTROLPLANE: the bootstrap seeds the K-ORC admin clouds.yaml, whose
-  # auth_url must point at the Keystone Service the ControlPlane projects. The
-  # c5c3-operator names that Service "{CONTROLPLANE_NAME}-keystone" (keystoneName =
-  # "{controlplane}-keystone"), so derive the auth_url from CONTROLPLANE_NAME and
-  # override the seed default ("keystone.openstack.svc") — K-ORC needs it correct
-  # before the first mint. Keep CONTROLPLANE_NAME in lockstep with the applied CR.
+  # WITH_CONTROLPLANE: the bootstrap (write-bootstrap-secrets.sh, run inside
+  # openbao_bootstrap below) seeds the K-ORC admin clouds.yaml AND the Model B
+  # admin password on per-ControlPlane OpenBao paths (CC-0112, REQ-009).
+  #
+  # DECISION (CC-0112, REQ-009): the default deployment's ControlPlane identity is
+  # "openstack/${CONTROLPLANE_NAME}". The ControlPlane CR always lives in the
+  # "openstack" namespace (deploy/kind/controlplane/controlplane.yaml; there is no
+  # CONTROLPLANE_NAMESPACE knob), and its name is CONTROLPLANE_NAME (default
+  # "controlplane"). Export it as KORC_CONTROLPLANES so write-bootstrap-secrets.sh
+  # seeds bootstrap/openstack/${CONTROLPLANE_NAME}-keystone/admin and
+  # openstack/keystone/openstack/${CONTROLPLANE_NAME}/admin/app-credential — the
+  # exact paths the keystone-operator Model B rotation PushSecret and the
+  # c5c3-operator admin Application Credential PushSecret target. Pre-CC-0112 the
+  # AC path was a single identity-agnostic leaf, so a CONTROLPLANE_NAME override
+  # needed no seed change; now the seed must track CONTROLPLANE_NAME explicitly.
+  # With the default CONTROLPLANE_NAME this equals write-bootstrap-secrets.sh's
+  # built-in KORC_CONTROLPLANES default ("openstack/controlplane"), so the
+  # canonical single-CR deploy path is unchanged. Reviewer: please verify.
+  # (The static keystone-admin / k-orc-clouds-yaml ExternalSecrets are pinned to
+  # the default identity; a CONTROLPLANE_NAME override also requires editing those
+  # two manifests until issue #412 replaces them with per-CR templating.)
+  #
+  # auth_url must also point at the Keystone Service the ControlPlane projects,
+  # "${CONTROLPLANE_NAME}-keystone" (keystoneName() in reconcile_korc.go). The seed
+  # now derives http://<keystone>.<namespace>.svc:5000/v3 per identity, which for
+  # this identity already equals the URL below; the explicit override is kept for
+  # clarity. K-ORC needs it correct before the first mint. Keep CONTROLPLANE_NAME
+  # in lockstep with the applied CR.
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    export KORC_CONTROLPLANES="openstack/${CONTROLPLANE_NAME}"
     export KORC_KEYSTONE_AUTH_URL="http://${CONTROLPLANE_NAME}-keystone.openstack.svc:5000/v3"
   fi
   openbao_init_unseal

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -40,9 +41,8 @@ const (
 var controlPlaneReleaseRegexp = regexp.MustCompile(`^\d{4}\.\d$`)
 
 // ControlPlaneWebhook implements defaulting and validation webhooks for the
-// ControlPlane CRD (CC-0110). Client is injected at startup for any future
-// cluster-scoped lookups; it is currently unused by validate() but kept to
-// mirror the KeystoneWebhook shape and to avoid a signature change later.
+// ControlPlane CRD (CC-0110). Client is injected at startup and used by
+// ValidateCreate to enforce one ControlPlane per namespace (CC-0112, REQ-010).
 // +kubebuilder:object:generate=false
 type ControlPlaneWebhook struct {
 	Client client.Reader
@@ -100,8 +100,20 @@ func (w *ControlPlaneWebhook) Default(_ context.Context, obj *ControlPlane) erro
 }
 
 // ValidateCreate implements admission.Validator[*ControlPlane] (CC-0110, REQ-006).
-func (w *ControlPlaneWebhook) ValidateCreate(_ context.Context, obj *ControlPlane) (admission.Warnings, error) {
-	return nil, w.validate(obj)
+// CC-0112, REQ-010 — DECISION boundary 6 = option (a): in addition to the spec
+// checks in validate(), a CREATE is rejected when another ControlPlane already
+// exists in the same namespace. The per-CR OpenBao credential paths (admin AC,
+// bootstrap admin password, fernet/credential keys) are scoped by namespace+name
+// and the CredentialRotation reconciler resolves its target by listing
+// ControlPlanes in the namespace and expecting exactly one; enforcing
+// one-ControlPlane-per-namespace at admission keeps that resolution unambiguous.
+// The check runs only on CREATE (not UPDATE) so an existing CR stays mutable.
+// Reviewer: please verify boundary 6 = option (a).
+func (w *ControlPlaneWebhook) ValidateCreate(ctx context.Context, obj *ControlPlane) (admission.Warnings, error) {
+	if err := w.validate(obj); err != nil {
+		return nil, err
+	}
+	return nil, w.validateUniqueInNamespace(ctx, obj)
 }
 
 // ValidateUpdate implements admission.Validator[*ControlPlane] (CC-0110, REQ-006).
@@ -190,4 +202,38 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) error {
 		)
 	}
 	return nil
+}
+
+// validateUniqueInNamespace enforces the one-ControlPlane-per-namespace contract
+// (CC-0112, REQ-010). It lists existing ControlPlanes in the new object's
+// namespace; any pre-existing CR (len >= 1, since the object under admission is
+// not yet persisted) makes this CREATE a Forbidden error naming the incumbent.
+//
+// DECISION: when w.Client is nil (spec-level unit tests that construct a bare
+// &ControlPlaneWebhook{}, or any caller that did not inject a client) the check
+// is skipped rather than panicking. Production and envtest wiring always inject
+// mgr.GetClient() (operators/c5c3/main.go, integration_test.go), so the guard
+// never trips at runtime; it only keeps the spec-validation unit tests
+// client-free. Reviewer: please verify.
+func (w *ControlPlaneWebhook) validateUniqueInNamespace(ctx context.Context, obj *ControlPlane) error {
+	if w.Client == nil {
+		return nil
+	}
+	var existing ControlPlaneList
+	if err := w.Client.List(ctx, &existing, client.InNamespace(obj.Namespace)); err != nil {
+		return apierrors.NewInternalError(
+			fmt.Errorf("listing ControlPlanes in namespace %q to enforce one-per-namespace: %w", obj.Namespace, err))
+	}
+	if len(existing.Items) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: "ControlPlane"},
+		obj.Name,
+		field.ErrorList{field.Forbidden(
+			field.NewPath("metadata", "namespace"),
+			fmt.Sprintf("only one ControlPlane is permitted per namespace; %q already exists in namespace %q (CC-0112)",
+				existing.Items[0].Name, obj.Namespace),
+		)},
+	)
 }

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
@@ -278,5 +280,60 @@ func TestValidateDelete_AlwaysAllowed(t *testing.T) {
 	w := &ControlPlaneWebhook{}
 
 	_, err := w.ValidateDelete(context.Background(), &ControlPlane{})
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// --- One-ControlPlane-per-namespace tests (CC-0112, REQ-010) ---
+
+// webhookScheme builds a runtime.Scheme with the c5c3 API types registered, for
+// the fake client backing the one-ControlPlane-per-namespace tests.
+func webhookScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	s := runtime.NewScheme()
+	g.Expect(AddToScheme(s)).To(Succeed())
+	return s
+}
+
+// TestValidateCreate_RejectsSecondControlPlaneInNamespace verifies the
+// one-ControlPlane-per-namespace contract: a CREATE is Forbidden when another
+// ControlPlane already exists in the same namespace (CC-0112, REQ-010).
+func TestValidateCreate_RejectsSecondControlPlaneInNamespace(t *testing.T) {
+	g := NewGomegaWithT(t)
+	existing := validControlPlane()
+	existing.Name = "incumbent"
+	existing.Namespace = "tenant-a"
+	c := fake.NewClientBuilder().WithScheme(webhookScheme(t)).WithObjects(existing).Build()
+	w := &ControlPlaneWebhook{Client: c}
+
+	second := validControlPlane()
+	second.Name = "newcomer"
+	second.Namespace = "tenant-a"
+
+	_, err := w.ValidateCreate(context.Background(), second)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("incumbent"))
+	g.Expect(err.Error()).To(ContainSubstring("tenant-a"))
+}
+
+// TestValidateCreate_AllowsFirstControlPlane_AndUpdate verifies the first CREATE
+// in an empty namespace is allowed, and that UPDATE never trips the
+// one-per-namespace check even though the CR is present (CC-0112, REQ-010).
+func TestValidateCreate_AllowsFirstControlPlane_AndUpdate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	c := fake.NewClientBuilder().WithScheme(webhookScheme(t)).Build()
+	w := &ControlPlaneWebhook{Client: c}
+
+	first := validControlPlane()
+	first.Name = "first"
+	first.Namespace = "tenant-b"
+	_, err := w.ValidateCreate(context.Background(), first)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cWith := fake.NewClientBuilder().WithScheme(webhookScheme(t)).WithObjects(first).Build()
+	wWith := &ControlPlaneWebhook{Client: cWith}
+	updated := first.DeepCopy()
+	updated.Spec.OpenStackRelease = "2026.1"
+	_, err = wWith.ValidateUpdate(context.Background(), first, updated)
 	g.Expect(err).NotTo(HaveOccurred())
 }

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
@@ -433,4 +434,156 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g.Expect(string(ep.Spec.Resource.ServiceRef)).To(Equal(keystoneServiceName(final)),
 		"Endpoint serviceRef must reference the identity Service CR")
 	g.Expect(ep.Spec.Resource.URL).NotTo(BeEmpty(), "Endpoint URL must be derived")
+
+	// --- Per-CR OpenBao RemoteKey lock (CC-0112, REQ-013). ---
+	//
+	// On the single-ControlPlane path the admin app-credential PushSecret must
+	// already mirror to the per-CR OpenBao path scoped by the CR's Namespace and
+	// Name (adminAppCredentialRemoteKeyFor), NOT the legacy flat
+	// openstack/keystone/admin/app-credential. Locking this here on the baseline
+	// end-to-end test guards the single-CP rendering of the path the multi-CP test
+	// asserts is distinct between CRs.
+	adminPS := &esov1alpha1.PushSecret{}
+	g.Expect(c.Get(ctx, types.NamespacedName{
+		Namespace: childNamespace(final), Name: adminAppCredentialPushSecretName(final),
+	}, adminPS)).To(Succeed(), "get admin app-credential PushSecret")
+	g.Expect(adminPS.Spec.Data).NotTo(BeEmpty(), "admin app-credential PushSecret must declare a Data entry")
+	g.Expect(adminPS.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(adminAppCredentialRemoteKeyFor(final)),
+		"admin app-credential PushSecret RemoteKey must be the per-CR OpenBao path (CC-0112, REQ-013)")
+}
+
+// driveControlPlaneToAdminCredentialReady provisions the full per-ControlPlane
+// dependency set in cp.Namespace and drives the CR through phases 1-4 of the
+// sub-reconciler chain (Infrastructure -> Keystone -> KORC -> AdminCredential) to
+// conditionTypeAdminCredentialReady=True, simulating each external dependency's
+// readiness exactly as TestIntegration_FullReconcile_ManagedToReady does. It
+// stops short of the Catalog/aggregate-Ready phases, which the multi-CP test
+// (CC-0112, REQ-012) does not need. The namespace and the CR must already exist.
+func driveControlPlaneToAdminCredentialReady(
+	t testing.TB, ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane,
+) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	ns := cp.Namespace
+
+	// Admin password Secret the KORC sub-reconciler hashes to drive the mint.
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone-admin", Namespace: ns},
+		Data:       map[string][]byte{"password": []byte("super-secret-admin-password")},
+	}
+	g.Expect(c.Create(ctx, adminSecret)).To(Succeed(), "create admin password Secret")
+
+	// The K-ORC clouds.yaml ExternalSecret AdminCredentialReady gates on, in the
+	// CR's own namespace (the C1 co-location fix), plus its simulated ESO sync.
+	cloudsYamlES := &esov1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: korcCloudsYamlSecretName, Namespace: ns},
+		Spec: esov1.ExternalSecretSpec{
+			SecretStoreRef: esov1.SecretStoreRef{Kind: "ClusterSecretStore", Name: "openbao-cluster-store"},
+			Target:         esov1.ExternalSecretTarget{Name: korcCloudsYamlSecretName},
+		},
+	}
+	g.Expect(c.Create(ctx, cloudsYamlES)).To(Succeed(), "create k-orc clouds.yaml ExternalSecret")
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c,
+		client.ObjectKey{Namespace: ns, Name: korcCloudsYamlSecretName})).
+		To(Succeed(), "simulate k-orc clouds.yaml ExternalSecret sync")
+
+	cpKey := types.NamespacedName{Name: cp.Name, Namespace: ns}
+
+	// --- Phase 1: Infrastructure (MariaDB + Memcached). ---
+	simulateMariaDBReadyWhenPresent(t, ctx, c, client.ObjectKey{Name: "openstack-db", Namespace: ns})
+	simulateMemcachedReadyWhenPresent(t, ctx, c, client.ObjectKey{Name: "openstack-memcached", Namespace: ns})
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeInfrastructureReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	// --- Phase 2: Keystone child. ---
+	simulateKeystoneReadyWhenPresent(t, ctx, c, client.ObjectKey{Name: keystoneName(cp), Namespace: ns})
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeKeystoneReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	// --- Phase 3: K-ORC admin ApplicationCredential. ---
+	simulateApplicationCredentialAvailableWhenPresent(t, ctx, c,
+		client.ObjectKey{Name: adminAppCredentialName(cp), Namespace: ns})
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeKORCReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	// --- Phase 4: AdminCredential push (gated on the synced clouds.yaml ES and the
+	// admin app-credential PushSecret syncing to OpenBao). ---
+	simulatePushSecretSyncedWhenPresent(t, ctx, c,
+		client.ObjectKey{Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp)})
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
+}
+
+// TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths brings up TWO
+// ControlPlanes and drives both to AdminCredentialReady=True, then asserts each
+// CR's admin-credential OpenBao path (the app-credential PushSecret RemoteKey) and
+// its imported admin User CR name are scoped per-ControlPlane and distinct, so two
+// ControlPlanes never clobber each other's admin credential on the cluster-global
+// OpenBao backend (CC-0112, REQ-012).
+//
+// DECISION (CC-0112, REQ-012): the two ControlPlanes use DIFFERENT names (cp-a,
+// cp-b) in DIFFERENT namespaces (generated from test-mcp-a- / test-mcp-b-). The
+// validating webhook enforces one ControlPlane per namespace (CC-0112, task 3.1),
+// so the CRs MUST live in separate namespaces; the distinct names additionally
+// make the imported admin User CR names (adminUserRef = "<name>-user-admin")
+// differ, which the per-CR-name assertion below requires. The per-CR OpenBao path
+// is scoped by BOTH Namespace and Name (adminAppCredentialRemoteKeyFor), so either
+// axis alone would distinguish them — using both is the realistic deployment shape.
+func TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	// Two isolated namespaces (namespace-per-CR with GenerateName).
+	nsA := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcp-a-"}}
+	nsB := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcp-b-"}}
+	g.Expect(c.Create(ctx, nsA)).To(Succeed(), "create namespace A")
+	g.Expect(c.Create(ctx, nsB)).To(Succeed(), "create namespace B")
+
+	// Distinct names in distinct namespaces (see DECISION above).
+	cpA := integrationManagedControlPlane("cp-a", nsA.Name)
+	cpB := integrationManagedControlPlane("cp-b", nsB.Name)
+	g.Expect(c.Create(ctx, cpA)).To(Succeed(), "create ControlPlane A")
+	g.Expect(c.Create(ctx, cpB)).To(Succeed(), "create ControlPlane B")
+
+	driveControlPlaneToAdminCredentialReady(t, ctx, c, cpA)
+	driveControlPlaneToAdminCredentialReady(t, ctx, c, cpB)
+
+	// --- Assert the admin app-credential OpenBao paths are per-CR and distinct. ---
+	psA := &esov1alpha1.PushSecret{}
+	psB := &esov1alpha1.PushSecret{}
+	g.Expect(c.Get(ctx, types.NamespacedName{
+		Namespace: childNamespace(cpA), Name: adminAppCredentialPushSecretName(cpA),
+	}, psA)).To(Succeed(), "get admin app-credential PushSecret for cp-a")
+	g.Expect(c.Get(ctx, types.NamespacedName{
+		Namespace: childNamespace(cpB), Name: adminAppCredentialPushSecretName(cpB),
+	}, psB)).To(Succeed(), "get admin app-credential PushSecret for cp-b")
+
+	g.Expect(psA.Spec.Data).NotTo(BeEmpty(), "cp-a PushSecret must declare a Data entry")
+	g.Expect(psB.Spec.Data).NotTo(BeEmpty(), "cp-b PushSecret must declare a Data entry")
+	keyA := psA.Spec.Data[0].Match.RemoteRef.RemoteKey
+	keyB := psB.Spec.Data[0].Match.RemoteRef.RemoteKey
+
+	g.Expect(keyA).To(Equal(adminAppCredentialRemoteKeyFor(cpA)),
+		"cp-a OpenBao path must be the per-CR path (CC-0112, REQ-012)")
+	g.Expect(keyB).To(Equal(adminAppCredentialRemoteKeyFor(cpB)),
+		"cp-b OpenBao path must be the per-CR path (CC-0112, REQ-012)")
+	g.Expect(keyA).NotTo(Equal(keyB), "the two ControlPlanes' admin OpenBao paths must be distinct")
+
+	// Each path is scoped by its own ControlPlane's Namespace AND Name.
+	g.Expect(keyA).To(ContainSubstring(cpA.Namespace), "cp-a path must contain cp-a's namespace")
+	g.Expect(keyA).To(ContainSubstring(cpA.Name), "cp-a path must contain cp-a's name")
+	g.Expect(keyB).To(ContainSubstring(cpB.Namespace), "cp-b path must contain cp-b's namespace")
+	g.Expect(keyB).To(ContainSubstring(cpB.Name), "cp-b path must contain cp-b's name")
+
+	// --- Assert the imported admin User CRs are per-CR and distinctly named. ---
+	userA := &orcv1alpha1.User{}
+	userB := &orcv1alpha1.User{}
+	g.Expect(c.Get(ctx, types.NamespacedName{
+		Namespace: childNamespace(cpA), Name: adminUserRef(cpA),
+	}, userA)).To(Succeed(), "get imported admin User CR for cp-a")
+	g.Expect(c.Get(ctx, types.NamespacedName{
+		Namespace: childNamespace(cpB), Name: adminUserRef(cpB),
+	}, userB)).To(Succeed(), "get imported admin User CR for cp-b")
+
+	g.Expect(userA.Name).To(Equal(adminUserRef(cpA)), "cp-a admin User CR must be named per-CR")
+	g.Expect(userB.Name).To(Equal(adminUserRef(cpB)), "cp-b admin User CR must be named per-CR")
+	g.Expect(userA.Name).NotTo(Equal(userB.Name), "the two ControlPlanes' admin User CR names must be distinct")
 }

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation.go
@@ -198,7 +198,11 @@ type controlPlaneCondition struct {
 // resolveControlPlane finds the single ControlPlane in the CredentialRotation's
 // namespace. On success it returns the ControlPlane and a zero condition; on a
 // zero/multiple-match it returns a nil ControlPlane plus the result+condition the
-// caller should persist (see the DECISION on Reconcile).
+// caller should persist (see the DECISION on Reconcile). The multiple-match case
+// is defense-in-depth: the ControlPlane validating webhook now enforces one
+// ControlPlane per namespace on CREATE (CC-0112, REQ-010), so it should be
+// unreachable in practice and only fires for CRs that predate the guard or
+// callers that bypass the webhook.
 func (r *CredentialRotationReconciler) resolveControlPlane(
 	ctx context.Context, cr *c5c3v1alpha1.CredentialRotation,
 ) (*c5c3v1alpha1.ControlPlane, ctrl.Result, controlPlaneCondition) {
@@ -221,6 +225,13 @@ func (r *CredentialRotationReconciler) resolveControlPlane(
 			message: fmt.Sprintf("no ControlPlane found in namespace %q", cr.Namespace),
 		}
 	default:
+		// AmbiguousControlPlane is defense-in-depth (CC-0112, REQ-010): the
+		// ControlPlane validating webhook enforces one ControlPlane per namespace
+		// on CREATE (operators/c5c3/api/v1alpha1/controlplane_webhook.go), so a
+		// namespace should never hold two. This branch remains as an explicit,
+		// safe failure for CRs created before that guard shipped or callers that
+		// bypass the webhook — it fails the rotation rather than silently picking
+		// cps.Items[0].
 		return nil, ctrl.Result{}, controlPlaneCondition{
 			status:  metav1.ConditionFalse,
 			reason:  "AmbiguousControlPlane",

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
@@ -268,6 +268,31 @@ func TestRotation_NoControlPlaneReadyFalse(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal("NoControlPlane"))
 }
 
+// TestResolveControlPlane_AmbiguousIsDefenseInDepth verifies that when two
+// ControlPlanes coexist in a namespace (a state the ControlPlane validating
+// webhook now prevents on CREATE — CC-0112, REQ-010), the CredentialRotation
+// reconciler fails safe with Ready=False reason "AmbiguousControlPlane" rather
+// than silently picking one. This branch is defense-in-depth for CRs that
+// predate the webhook guard or callers that bypass it.
+func TestResolveControlPlane_AmbiguousIsDefenseInDepth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp1 := korcControlPlane()
+	cp2 := korcControlPlane()
+	cp2.Name = cp1.Name + "-second" // same namespace, distinct name => ambiguous
+	cp2.UID = types.UID("cp-uid-second")
+
+	cr := credentialRotation()
+	cr.Spec.ReMint = true
+
+	got, _ := runRotationReconcile(t, cp1, cp2, cr)
+
+	cond := rotationReadyCondition(got)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("AmbiguousControlPlane"))
+}
+
 // --- Scheduled fields accepted but loop not run ---
 
 func TestRotation_ScheduledFieldsAcceptedNoError(t *testing.T) {

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -52,10 +52,15 @@ const adminAppCredentialNameSuffix = "-admin-app-credential" //nolint:gosec // G
 // push source for the OpenBao PushSecret (CC-0110, REQ-010, REQ-011).
 const adminAppCredentialSecretSuffix = "-admin-app-credential" //nolint:gosec // G101 false positive: Secret name suffix, not a credential.
 
-// adminAppCredentialRemoteKey is the flat OpenBao path the minted admin
-// application credential is mirrored to (CC-0110, REQ-011). A single admin AC
-// per cluster shares this object, matching the K-ORC clouds.yaml consumer.
-const adminAppCredentialRemoteKey = "openstack/keystone/admin/app-credential"
+// adminAppCredentialRemoteKeyFor returns the per-ControlPlane OpenBao path the
+// minted admin application credential is mirrored to (CC-0112, REQ-001). The
+// path is scoped by both the ControlPlane's Namespace and Name so two
+// ControlPlanes never clobber each other's admin credential on the cluster-
+// global OpenBao backend. The matching read consumer (the per-CR k-orc
+// clouds.yaml ExternalSecret) targets the same key.
+func adminAppCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("openstack/keystone/%s/%s/admin/app-credential", cp.Namespace, cp.Name)
+}
 
 // adminPasswordHashAnnotation stamps the SHA-256 of the admin password the
 // application credential was last minted against onto the owned AC CR (CC-0110,
@@ -657,17 +662,18 @@ func (r *ControlPlaneReconciler) regenerateAppCredentialSecretValue(ctx context.
 	return nil
 }
 
-// adminUserRef derives the name of the K-ORC User CR the admin application
-// credential is associated with. AdminCredentialSpec has no UserRef field, but
-// K-ORC's ApplicationCredentialResourceSpec.UserRef is REQUIRED, so we derive it
-// from the CloudName the admin authenticates as (defaulting to "admin"). The
-// matching User CR is provisioned by ensureKORCAdminImports as an unmanaged
-// import, so the reference always resolves.
+// adminUserRef returns the Kubernetes metadata.name of the imported K-ORC User
+// CR the admin application credential is associated with. AdminCredentialSpec has
+// no UserRef field, but K-ORC's ApplicationCredentialResourceSpec.UserRef is
+// REQUIRED, so we derive a deterministic name scoped by cp.Name (mirroring
+// adminDomainRef) — this way two ControlPlanes in one namespace produce DISTINCT
+// User objects rather than colliding on a shared name (CC-0112, REQ-003). The
+// inner OpenStack username the import resolves to is still "admin": it is set
+// independently via Spec.Import.Filter.Name = OpenStackName(korcAdminUsername) in
+// ensureKORCAdminImports. The matching User CR is provisioned there as an
+// unmanaged import, so the reference always resolves.
 func adminUserRef(cp *c5c3v1alpha1.ControlPlane) string {
-	if name := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName; name != "" {
-		return name
-	}
-	return "admin"
+	return fmt.Sprintf("%s-user-admin", cp.Name)
 }
 
 // korcAdminUsername / korcAdminDomainName identify the OpenStack admin user and
@@ -1056,8 +1062,10 @@ func pushSecretReady(ps *esov1alpha1.PushSecret) bool {
 }
 
 // adminAppCredentialPushSecret builds the PushSecret that mirrors the minted
-// admin application-credential Secret to OpenBao at the flat, single-AC path
-// openstack/keystone/admin/app-credential (CC-0110, REQ-011).
+// admin application-credential Secret to OpenBao at the per-ControlPlane path
+// openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential
+// (CC-0112, REQ-001), scoping the credential so two ControlPlanes never clobber
+// each other's admin credential on the cluster-global OpenBao backend.
 //
 // DECISION (DeletionPolicy): None — the admin application credential is a shared
 // bootstrap secret other consumers may depend on; deleting the PushSecret (e.g.
@@ -1083,7 +1091,7 @@ func adminAppCredentialPushSecret(cp *c5c3v1alpha1.ControlPlane) *esov1alpha1.Pu
 			Data: []esov1alpha1.PushSecretData{{
 				Match: esov1alpha1.PushSecretMatch{
 					RemoteRef: esov1alpha1.PushSecretRemoteRef{
-						RemoteKey: adminAppCredentialRemoteKey,
+						RemoteKey: adminAppCredentialRemoteKeyFor(cp),
 					},
 				},
 			}},

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -225,8 +225,8 @@ func TestReconcileKORC_OwnerRefAndCloudCredsAndManagementPolicy(t *testing.T) {
 
 	// SecretRef points at the operator-owned minted-credential Secret.
 	g.Expect(string(ac.Spec.Resource.SecretRef)).To(Equal(adminAppCredentialSecretName(cp)))
-	// UserRef derived from the CloudName (DECISION).
-	g.Expect(string(ac.Spec.Resource.UserRef)).To(Equal("admin"))
+	// UserRef is the cp.Name-scoped K-ORC User name (CC-0112, REQ-003).
+	g.Expect(string(ac.Spec.Resource.UserRef)).To(Equal("cp-user-admin"))
 }
 
 func TestReconcileKORC_PasswordHashAnnotationStamped(t *testing.T) {
@@ -371,8 +371,8 @@ func TestReconcileAdminCredential_GatedOnKORC(t *testing.T) {
 // TestReconcileAdminCredential_FreshClusterWithoutCloudsYamlSeedDoesNotPush is
 // the NON-MASKING bootstrap test (CC-0110, FC4/TE9). It reproduces a FRESH
 // cluster: KORC has minted the AC, but the k-orc-clouds-yaml ExternalSecret is
-// absent (its OpenBao path openstack/keystone/admin/app-credential is empty
-// until deploy/openbao/bootstrap/write-bootstrap-secrets.sh seeds a
+// absent (its per-CR OpenBao path openstack/keystone/{ns}/{name}/admin/app-credential
+// is empty until deploy/openbao/bootstrap/write-bootstrap-secrets.sh seeds a
 // password-based bootstrap clouds.yaml). It asserts the gate holds AND, crucially,
 // that NO PushSecret is created — proving the OpenBao path is never written while
 // the clouds.yaml is unseeded. This is exactly the circular dependency the
@@ -399,8 +399,8 @@ func TestReconcileAdminCredential_FreshClusterWithoutCloudsYamlSeedDoesNotPush(t
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).To(Equal("WaitingForCloudsYaml"))
 
-	// The push that writes openstack/keystone/admin/app-credential to OpenBao must
-	// NOT have happened — the OpenBao path stays empty, which is precisely why a
+	// The push that writes the per-CR openstack/keystone/{ns}/{name}/admin/app-credential
+	// path to OpenBao must NOT have happened — the path stays empty, which is precisely why a
 	// fresh cluster needs the bootstrap seed to break the cycle.
 	ps := &esov1alpha1.PushSecret{}
 	err = c.Get(context.Background(), types.NamespacedName{
@@ -482,8 +482,7 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g.Expect(ps.Spec.SecretStoreRefs[0].Name).To(Equal(openBaoClusterStoreName))
 	g.Expect(ps.Spec.Selector.Secret.Name).To(Equal(adminAppCredentialSecretName(cp)))
 	g.Expect(ps.Spec.Data).To(HaveLen(1))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(adminAppCredentialRemoteKey))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/admin/app-credential"))
+	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(adminAppCredentialRemoteKeyFor(cp)))
 
 	// The operator-owned Secret now carries the assembled app-credential clouds.yaml
 	// (id from cp.Status, secret from the preserved "value") for the OpenBao push.
@@ -495,6 +494,56 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g.Expect(sec.Data).To(HaveKey("clouds.yaml"))
 	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("application_credential_id"))
 	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("test-ac-id"))
+}
+
+// TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName locks in the per-CR
+// OpenBao path (CC-0112, REQ-001): the RemoteKey is scoped by both the
+// ControlPlane's Namespace and Name so two ControlPlanes never clobber each
+// other's admin credential on the cluster-global OpenBao backend, and neither
+// reuses the legacy flat single-AC path.
+func TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName(t *testing.T) {
+	g := NewWithT(t)
+
+	const legacyFlatKey = "openstack/keystone/admin/app-credential"
+
+	cases := []struct {
+		name      string
+		namespace string
+		cpName    string
+		want      string
+	}{
+		{
+			name:      "default control plane",
+			namespace: "openstack",
+			cpName:    "controlplane",
+			want:      "openstack/keystone/openstack/controlplane/admin/app-credential",
+		},
+		{
+			name:      "second tenant control plane",
+			namespace: "tenant-b",
+			cpName:    "cp-b",
+			want:      "openstack/keystone/tenant-b/cp-b/admin/app-credential",
+		},
+	}
+
+	keys := make([]string, 0, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cp := &c5c3v1alpha1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.cpName, Namespace: tc.namespace},
+			}
+			got := adminAppCredentialRemoteKeyFor(cp)
+			g.Expect(got).To(Equal(tc.want))
+			g.Expect(got).NotTo(Equal(legacyFlatKey),
+				"the per-CR key must not collapse back to the legacy flat path")
+		})
+		keys = append(keys, tc.want)
+	}
+
+	// Two distinct ControlPlanes must produce distinct OpenBao paths.
+	g.Expect(keys[0]).NotTo(Equal(keys[1]),
+		"two ControlPlanes must not share a RemoteKey")
 }
 
 func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
@@ -1098,6 +1147,9 @@ func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: adminUserRef(cp), Namespace: childNamespace(cp),
 	}, &user)).To(Succeed())
+	// The User CR name is cp.Name-scoped (CC-0112, REQ-003) so two ControlPlanes
+	// in one namespace produce distinct User objects.
+	g.Expect(user.Name).To(Equal(cp.Name + "-user-admin"))
 	g.Expect(user.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyUnmanaged))
 	g.Expect(user.Spec.Import).NotTo(BeNil())
 	g.Expect(user.Spec.Import.Filter).NotTo(BeNil())
@@ -1106,6 +1158,21 @@ func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
 	g.Expect(user.Spec.Import.Filter.DomainRef).NotTo(BeNil())
 	g.Expect(string(*user.Spec.Import.Filter.DomainRef)).To(Equal(adminDomainRef(cp)))
 	g.Expect(user.OwnerReferences).To(HaveLen(1))
+}
+
+// TestAdminUserRef_IsControlPlaneScoped locks in that the K-ORC User CR name the
+// admin ApplicationCredential references is scoped by cp.Name (CC-0112, REQ-003),
+// mirroring adminDomainRef, so two ControlPlanes never collide on a shared "admin"
+// User name — and that it no longer returns the bare OpenStack username.
+func TestAdminUserRef_IsControlPlaneScoped(t *testing.T) {
+	g := NewWithT(t)
+	cp := &c5c3v1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "controlplane", Namespace: "openstack"},
+	}
+	g.Expect(adminUserRef(cp)).To(Equal(cp.Name + "-user-admin"))
+	g.Expect(adminUserRef(cp)).To(Equal("controlplane-user-admin"))
+	g.Expect(adminUserRef(cp)).NotTo(Equal("admin"),
+		"the User ref must be cp.Name-scoped, not the bare OpenStack username")
 }
 
 // TestReconcileKORC_CreatesAppCredentialSecretWithValue verifies that reconcileKORC

--- a/operators/c5c3/main.go
+++ b/operators/c5c3/main.go
@@ -79,6 +79,9 @@ func main() {
 				return err
 			}
 			if webhooks {
+				// DECISION (CC-0112, REQ-010): Client must be non-nil for the
+				// one-ControlPlane-per-namespace ValidateCreate check; mgr.GetClient()
+				// satisfies it (a client.Reader implementing List).
 				if err := (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 					return err
 				}

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -400,11 +400,9 @@ type FederationSpec struct {
 // +kubebuilder:default markers below remain as defense-in-depth for callers that
 // bypass the webhook (e.g. envtest without the defaulter wired up).
 //
-// Model B assumes a single Model-B-enabled Keystone CR per cluster (REQ-014,
-// boundary 8, option a): the push path is the single flat OpenBao key
-// bootstrap/keystone-admin shared with the hardcoded keystone-admin
-// ExternalSecret. Enabling rotation on more than one CR would clobber that
-// shared object.
+// The admin-password backup is scoped per Keystone CR: the push path is the
+// per-CR OpenBao key bootstrap/{namespace}/{name}/admin (CC-0112, REQ-002), so
+// enabling rotation on multiple CRs no longer collides on a shared object.
 type PasswordRotationSpec struct {
 	// Enabled turns on scheduled admin-password rotation. Default false: the
 	// feature is opt-in, and disabling it tears down every Model B resource.
@@ -456,7 +454,7 @@ type BootstrapSpec struct {
 	// PasswordRotation optionally enables scheduled rotation of the admin
 	// password (CC-0109). Nil (the default) leaves the feature off and the
 	// sub-reconciler is a clean no-op. See PasswordRotationSpec for the opt-in
-	// and single-CR semantics.
+	// and per-CR semantics.
 	// +optional
 	PasswordRotation *PasswordRotationSpec `json:"passwordRotation,omitempty"`
 }

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -115,7 +115,7 @@ spec:
                       PasswordRotation optionally enables scheduled rotation of the admin
                       password (CC-0109). Nil (the default) leaves the feature off and the
                       sub-reconciler is a clean no-op. See PasswordRotationSpec for the opt-in
-                      and single-CR semantics.
+                      and per-CR semantics.
                     properties:
                       enabled:
                         default: false

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -118,7 +118,7 @@ spec:
                       PasswordRotation optionally enables scheduled rotation of the admin
                       password (CC-0109). Nil (the default) leaves the feature off and the
                       sub-reconciler is a clean no-op. See PasswordRotationSpec for the opt-in
-                      and single-CR semantics.
+                      and per-CR semantics.
                     properties:
                       enabled:
                         default: false

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -3818,16 +3818,24 @@ func TestIntegration_StrategyOverrideAppliedToDeployment(t *testing.T) {
 }
 
 // TestIntegrationKeystone_PushSecretRemoteKeyIsPerCR verifies that two
-// Keystone CRs in the same namespace produce two backup PushSecrets with
-// distinct, per-CR-scoped RemoteKey values for both fernet-keys
-// (CC-0093, REQ-001) and credential-keys (CC-0093, REQ-002) materials.
+// distinct Keystone CRs produce two backup PushSecrets with disjoint,
+// fully-segmented RemoteKey values for the fernet-keys (CC-0093, REQ-001)
+// and credential-keys (CC-0093, REQ-002) materials and for the Model B
+// bootstrap/admin password material (CC-0112, REQ-002).
 //
-// Regression guard: before CC-0093, both PushSecrets wrote to the shared
-// path openstack/keystone/<material>, causing concurrent two-CR
-// deployments in the same namespace to race on the remote kv-v2 store.
-// The table-driven form keeps per-CR assertions for every key material in
-// one place so adding a new material (or changing the path layout)
-// requires a single edit (sourcery-review-1).
+// Two CR-distinctness axes are exercised for every material:
+//   - same namespace, DIFFERENT name (the original CC-0093 guard) — the
+//     {name} path segment is what makes the RemoteKeys disjoint; and
+//   - SAME name, DIFFERENT namespace (CC-0112, REQ-004/REQ-002) — names are
+//     identical, so disjointness comes entirely from the {namespace} path
+//     segment. This proves the namespace segment is load-bearing and that two
+//     same-named Keystones in different namespaces never collide on the remote
+//     kv-v2 store.
+//
+// Regression guard: before CC-0093, the fernet/credential PushSecrets wrote to
+// the shared path openstack/keystone/<material>; before CC-0112 the per-CR
+// paths still omitted the namespace segment, so two same-named CRs in
+// different namespaces would race on the remote kv-v2 store.
 func TestIntegrationKeystone_PushSecretRemoteKeyIsPerCR(t *testing.T) {
 	testutil.SkipIfEnvTestUnavailable(t)
 
@@ -3841,60 +3849,194 @@ func TestIntegrationKeystone_PushSecretRemoteKeyIsPerCR(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.material, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-
 			c, ctx, _ := setupEnvTestWithController(t)
 
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-per-cr-" + tc.material + "-",
-			}}
-			g.Expect(c.Create(ctx, ns)).To(Succeed())
+			// Axis 1 — same namespace, different name (original CC-0093 guard):
+			// the {name} segment makes the two RemoteKeys disjoint.
+			t.Run("same-namespace/different-name", func(t *testing.T) {
+				assertFernetCredentialRemoteKeysDisjoint(
+					t, ctx, c, tc.material, tc.requirement,
+					"keystone-a", "keystone-b", false /* differentNamespaces */)
+			})
 
-			createPrerequisites(t, ctx, c, ns.Name)
-
-			// kA and kB intentionally share the namespace-scoped keystone-db and
-			// keystone-admin Secret refs created by createPrerequisites: this test
-			// asserts PushSecret RemoteKey distinctness (CC-0093, REQ-001 for
-			// fernet / REQ-002 for credential), not isolation of the read-only
-			// credential Secrets.
-			kA := integrationBrownfieldKeystone("keystone-a", ns.Name)
-			kB := integrationBrownfieldKeystone("keystone-b", ns.Name)
-			g.Expect(c.Create(ctx, kA)).To(Succeed())
-			g.Expect(c.Create(ctx, kB)).To(Succeed())
-
-			driveFullReconciliation(t, ctx, c, kA.Name, ns.Name)
-			driveFullReconciliation(t, ctx, c, kB.Name, ns.Name)
-
-			psA := &esov1alpha1.PushSecret{}
-			psB := &esov1alpha1.PushSecret{}
-			nameA := kA.Name + "-" + tc.material + "-backup"
-			nameB := kB.Name + "-" + tc.material + "-backup"
-			g.Eventually(func() error {
-				return c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: nameA}, psA)
-			}, eventuallyTimeout).Should(Succeed())
-			g.Eventually(func() error {
-				return c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: nameB}, psB)
-			}, eventuallyTimeout).Should(Succeed())
-
-			g.Expect(psA.Spec.Data).ToNot(BeEmpty())
-			g.Expect(psB.Spec.Data).ToNot(BeEmpty())
-
-			keyA := psA.Spec.Data[0].Match.RemoteRef.RemoteKey
-			keyB := psB.Spec.Data[0].Match.RemoteRef.RemoteKey
-
-			wantA := "openstack/keystone/" + kA.Name + "/" + tc.material
-			wantB := "openstack/keystone/" + kB.Name + "/" + tc.material
-
-			g.Expect(keyA).To(Equal(wantA),
-				kA.Name+" RemoteKey must embed CR name ("+tc.requirement+")")
-			g.Expect(keyB).To(Equal(wantB),
-				kB.Name+" RemoteKey must embed CR name ("+tc.requirement+")")
-			g.Expect(keyA).ToNot(Equal(keyB),
-				"RemoteKeys must be distinct per-CR to prevent concurrent write collision")
-			g.Expect(keyA).To(ContainSubstring(kA.Name))
-			g.Expect(keyB).To(ContainSubstring(kB.Name))
+			// Axis 2 — same name, different namespace (CC-0112, REQ-004): with
+			// identical names, disjointness comes solely from the {namespace}
+			// path segment.
+			t.Run("same-name/different-namespace", func(t *testing.T) {
+				assertFernetCredentialRemoteKeysDisjoint(
+					t, ctx, c, tc.material, "REQ-004",
+					"keystone-shared", "keystone-shared", true /* differentNamespaces */)
+			})
 		})
 	}
+
+	// bootstrap/admin (Model B) — same name, different namespace (CC-0112,
+	// REQ-002). The admin-password backup PushSecret is Model B only and
+	// clobber-safe, so it must be driven through the rotation apply flow.
+	t.Run("bootstrap-admin/same-name/different-namespace", func(t *testing.T) {
+		assertBootstrapAdminRemoteKeysDisjoint(t)
+	})
+}
+
+// assertFernetCredentialRemoteKeysDisjoint creates two brownfield Keystone CRs
+// (kA, kB), drives each to a full reconciliation, reads the per-material backup
+// PushSecret ({name}-{material}-backup) for each, and asserts the two
+// openstack/keystone/{namespace}/{name}/{material} RemoteKeys are disjoint and
+// per-CR (CC-0093 / CC-0112, REQ-004). When differentNamespaces is false the two
+// CRs share one namespace and disjointness is driven by the {name} segment; when
+// true each CR lives in its own GenerateName namespace (with its own
+// createPrerequisites) and disjointness is driven by the {namespace} segment —
+// every RemoteKey must then still contain its own namespace.
+func assertFernetCredentialRemoteKeysDisjoint(
+	t *testing.T,
+	ctx context.Context,
+	c client.Client,
+	material, requirement string,
+	nameA, nameB string,
+	differentNamespaces bool,
+) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	makeNamespace := func() string {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-per-cr-" + material + "-",
+		}}
+		g.Expect(c.Create(ctx, ns)).To(Succeed())
+		createPrerequisites(t, ctx, c, ns.Name)
+		return ns.Name
+	}
+
+	nsA := makeNamespace()
+	nsB := nsA
+	if differentNamespaces {
+		nsB = makeNamespace()
+	}
+
+	// In the shared-namespace axis kA and kB intentionally reuse the
+	// namespace-scoped keystone-db and keystone-admin Secret refs created by
+	// createPrerequisites: this asserts PushSecret RemoteKey distinctness, not
+	// isolation of the read-only credential Secrets.
+	kA := integrationBrownfieldKeystone(nameA, nsA)
+	kB := integrationBrownfieldKeystone(nameB, nsB)
+	g.Expect(c.Create(ctx, kA)).To(Succeed())
+	g.Expect(c.Create(ctx, kB)).To(Succeed())
+
+	driveFullReconciliation(t, ctx, c, kA.Name, kA.Namespace)
+	driveFullReconciliation(t, ctx, c, kB.Name, kB.Namespace)
+
+	psA := &esov1alpha1.PushSecret{}
+	psB := &esov1alpha1.PushSecret{}
+	pushSecretName := func(ks *keystonev1alpha1.Keystone) string {
+		return ks.Name + "-" + material + "-backup"
+	}
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: kA.Namespace, Name: pushSecretName(kA)}, psA)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: kB.Namespace, Name: pushSecretName(kB)}, psB)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+
+	g.Expect(psA.Spec.Data).ToNot(BeEmpty())
+	g.Expect(psB.Spec.Data).ToNot(BeEmpty())
+
+	keyA := psA.Spec.Data[0].Match.RemoteRef.RemoteKey
+	keyB := psB.Spec.Data[0].Match.RemoteRef.RemoteKey
+
+	wantA := "openstack/keystone/" + kA.Namespace + "/" + kA.Name + "/" + material
+	wantB := "openstack/keystone/" + kB.Namespace + "/" + kB.Name + "/" + material
+
+	g.Expect(keyA).To(Equal(wantA),
+		kA.Name+" RemoteKey must embed namespace and CR name ("+requirement+")")
+	g.Expect(keyB).To(Equal(wantB),
+		kB.Name+" RemoteKey must embed namespace and CR name ("+requirement+")")
+	g.Expect(keyA).ToNot(Equal(keyB),
+		"RemoteKeys must be disjoint per-CR to prevent concurrent write collision")
+
+	// Whichever axis distinguishes the two CRs, both segments must be present
+	// in each RemoteKey; for the same-name/different-namespace axis the
+	// {namespace} segment is the sole source of disjointness (CC-0112, REQ-004).
+	g.Expect(keyA).To(ContainSubstring(kA.Namespace))
+	g.Expect(keyA).To(ContainSubstring(kA.Name))
+	g.Expect(keyB).To(ContainSubstring(kB.Namespace))
+	g.Expect(keyB).To(ContainSubstring(kB.Name))
+}
+
+// assertBootstrapAdminRemoteKeysDisjoint brings up two SAME-name Model B
+// Keystones in two DIFFERENT namespaces, drives the scheduled admin-password
+// rotation apply flow in each so the clobber-safe bootstrap/admin backup
+// PushSecret is ensured, then asserts the two
+// bootstrap/{namespace}/{name}/admin RemoteKeys are per-CR and disjoint with
+// the {namespace} segment as the sole source of disjointness (CC-0112, REQ-002).
+//
+// The bootstrap/admin PushSecret is withheld until the push-source Secret holds
+// a valid (>=32-byte) password, so each CR must be driven through the same
+// staging/commit sequence as TestIntegration_PasswordRotation_ApplyCommitsAndPushes.
+func assertBootstrapAdminRemoteKeysDisjoint(t *testing.T) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	const sharedName = "keystone-shared"
+
+	// driveAdminPasswordBackup stands up one Model B Keystone named sharedName
+	// in its own namespace, drives the rotation apply flow, and returns the
+	// RemoteKey of the resulting bootstrap/admin backup PushSecret.
+	driveAdminPasswordBackup := func() (string, string) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-per-cr-bootstrap-admin-",
+		}}
+		g.Expect(c.Create(ctx, ns)).To(Succeed())
+		createPrerequisites(t, ctx, c, ns.Name)
+
+		ks := integrationBrownfieldKeystoneWithPasswordRotation(sharedName, ns.Name, "0 0 1 * *")
+		g.Expect(c.Create(ctx, ks)).To(Succeed())
+		driveFullReconciliation(t, ctx, c, ks.Name, ns.Name)
+
+		// Simulate the CronJob run: stage a fresh >=32-byte password + completion
+		// annotation so the operator commits it onto the push-source Secret and,
+		// once that holds a valid password, ensures the clobber-safe PushSecret
+		// (mirrors TestIntegration_PasswordRotation_ApplyCommitsAndPushes).
+		const newPassword = "rotated-admin-password-0123456789abcdef" // 39 bytes >= 32 minimum
+		stagingKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name + "-admin-password-rotation"}
+		g.Expect(cronJobStrategicMergePatch(ctx, c, stagingKey, map[string][]byte{
+			adminPasswordSecretKey: []byte(newPassword),
+		})).To(Succeed(), "stage CronJob rotation output onto the staging Secret (CC-0109, REQ-007)")
+
+		pushSourceKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name + "-admin-password-next"}
+		g.Eventually(func(ig Gomega) {
+			got := &corev1.Secret{}
+			ig.Expect(c.Get(ctx, pushSourceKey, got)).To(Succeed())
+			ig.Expect(got.Data).To(HaveKeyWithValue(adminPasswordSecretKey, []byte(newPassword)))
+			ig.Expect(got.Annotations).To(HaveKey(RotationCompletedAnnotation))
+		}, eventuallyTimeout, pollInterval).Should(Succeed(),
+			"push-source Secret should receive the rotated password and completion annotation (CC-0109, REQ-007)")
+
+		pushSecretKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name + "-admin-password-backup"}
+		ps := &esov1alpha1.PushSecret{}
+		g.Eventually(func() error {
+			return c.Get(ctx, pushSecretKey, ps)
+		}, eventuallyTimeout, pollInterval).Should(Succeed(),
+			"bootstrap/admin PushSecret should be ensured once the push-source holds a valid password (CC-0109, REQ-007)")
+		g.Expect(ps.Spec.Data).To(HaveLen(1))
+
+		key := ps.Spec.Data[0].Match.RemoteRef.RemoteKey
+		g.Expect(key).To(Equal(fmt.Sprintf("bootstrap/%s/%s/admin", ks.Namespace, ks.Name)),
+			"RemoteKey must be the per-CR OpenBao path bootstrap/{namespace}/{name}/admin (CC-0112, REQ-002)")
+		return key, ns.Name
+	}
+
+	keyA, nsA := driveAdminPasswordBackup()
+	keyB, nsB := driveAdminPasswordBackup()
+
+	g.Expect(nsA).ToNot(Equal(nsB), "the two same-name Keystones must live in different namespaces")
+	g.Expect(keyA).To(ContainSubstring(nsA),
+		"each bootstrap/admin RemoteKey must embed its own namespace (CC-0112, REQ-002)")
+	g.Expect(keyB).To(ContainSubstring(nsB),
+		"each bootstrap/admin RemoteKey must embed its own namespace (CC-0112, REQ-002)")
+	g.Expect(keyA).ToNot(Equal(keyB),
+		"bootstrap/admin RemoteKeys for two same-name CRs must be disjoint via the namespace segment (CC-0112, REQ-002)")
 }
 
 // --- CC-0095: Sub-resource rename to bare CR name (REQ-003, REQ-004) ---
@@ -4582,7 +4724,7 @@ func TestIntegration_PasswordRotation_SuspendTruePreservesSiblings(t *testing.T)
 // annotation onto the staging Secret; the reconciler commits the password onto
 // the push-source Secret, deletes staging, emits AdminPasswordRotated, and — now
 // that the push-source holds a valid password — ensures the clobber-safe
-// PushSecret targeting the flat single-CR OpenBao path.
+// PushSecret targeting the per-CR OpenBao path (CC-0112, REQ-002).
 func TestIntegration_PasswordRotation_ApplyCommitsAndPushes(t *testing.T) {
 	testutil.SkipIfEnvTestUnavailable(t)
 	g := NewGomegaWithT(t)
@@ -4610,8 +4752,8 @@ func TestIntegration_PasswordRotation_ApplyCommitsAndPushes(t *testing.T) {
 	g.Expect(pushSource.Data).To(BeEmpty(), "push-source Secret Data should start empty (CC-0109, REQ-007)")
 
 	// Clobber-safe gate: no PushSecret while the push-source is empty, so the
-	// shared bootstrap/keystone-admin OpenBao value is never overwritten with an
-	// empty payload (CC-0109, REQ-011, REQ-014).
+	// per-CR bootstrap/{namespace}/{name}/admin OpenBao value is never overwritten
+	// with an empty payload (CC-0109, REQ-011, REQ-014; per-CR path in CC-0112).
 	pushSecretKey := client.ObjectKey{Namespace: ns.Name, Name: "test-keystone-admin-password-backup"}
 	g.Consistently(func() bool {
 		return apierrors.IsNotFound(c.Get(ctx, pushSecretKey, &esov1alpha1.PushSecret{}))
@@ -4656,8 +4798,9 @@ func TestIntegration_PasswordRotation_ApplyCommitsAndPushes(t *testing.T) {
 	eventuallyFindKeystoneEvent(t, ctx, c, ks, "AdminPasswordRotated", corev1.EventTypeNormal)
 
 	// With a valid push-source password, the clobber-safe PushSecret is ensured,
-	// selecting the push-source Secret and targeting the flat single-CR OpenBao
-	// path bootstrap/keystone-admin (CC-0109, REQ-007, REQ-014).
+	// selecting the push-source Secret and targeting the per-CR OpenBao path
+	// bootstrap/{namespace}/{name}/admin (CC-0109, REQ-007, REQ-014; per-CR
+	// scoping added in CC-0112, REQ-002).
 	ps := &esov1alpha1.PushSecret{}
 	g.Eventually(func() error {
 		return c.Get(ctx, pushSecretKey, ps)
@@ -4666,8 +4809,8 @@ func TestIntegration_PasswordRotation_ApplyCommitsAndPushes(t *testing.T) {
 	g.Expect(ps.Spec.Selector.Secret).NotTo(BeNil())
 	g.Expect(ps.Spec.Selector.Secret.Name).To(Equal("test-keystone-admin-password-next"))
 	g.Expect(ps.Spec.Data).To(HaveLen(1))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("bootstrap/keystone-admin"),
-		"RemoteKey must be the flat, single-CR OpenBao path (CC-0109, REQ-014)")
+	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(fmt.Sprintf("bootstrap/%s/%s/admin", ks.Namespace, ks.Name)),
+		"RemoteKey must be the per-CR OpenBao path bootstrap/{namespace}/{name}/admin (CC-0112, REQ-002)")
 }
 
 // TestIntegration_PasswordRotation_DisableTearsDownAllResources verifies the

--- a/operators/keystone/internal/controller/reconcile_credential.go
+++ b/operators/keystone/internal/controller/reconcile_credential.go
@@ -426,14 +426,16 @@ func credentialRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapNam
 
 // credentialKeysPushSecret builds the PushSecret CR that backs up credential keys to OpenBao.
 //
-// The RemoteKey embeds keystone.Name as a path segment
-// (kv-v2/openstack/keystone/{keystone.Name}/credential-keys) so two Keystone
-// CRs in the same namespace never share a backing OpenBao object (CC-0093,
-// REQ-002).
+// The RemoteKey embeds both keystone.Namespace and keystone.Name as path
+// segments (kv-v2/openstack/keystone/{keystone.Namespace}/{keystone.Name}/credential-keys)
+// so two Keystone CRs sharing a Name in different namespaces never share a
+// backing OpenBao object (CC-0093, REQ-002; namespace segment added in CC-0112,
+// REQ-004).
 //
 // DeletionPolicy=Delete wires the backup PushSecret into the OpenBao finalizer
 // flow: when the keystone.openstack.c5c3.io/openbao-finalizer handler deletes
-// this PushSecret, ESO purges the remote kv-v2/openstack/keystone/{keystone.Name}/credential-keys
+// this PushSecret, ESO purges the remote
+// kv-v2/openstack/keystone/{keystone.Namespace}/{keystone.Name}/credential-keys
 // path before letting the PushSecret object be garbage-collected (CC-0079,
 // REQ-008).
 func credentialKeysPushSecret(keystone *keystonev1alpha1.Keystone) *esov1alpha1.PushSecret {
@@ -456,7 +458,10 @@ func credentialKeysPushSecret(keystone *keystonev1alpha1.Keystone) *esov1alpha1.
 			Data: []esov1alpha1.PushSecretData{{
 				Match: esov1alpha1.PushSecretMatch{
 					RemoteRef: esov1alpha1.PushSecretRemoteRef{
-						RemoteKey: "openstack/keystone/" + keystone.Name + "/credential-keys",
+						// DECISION: boundary 4 (CC-0112, REQ-004) — chose option (a), a keystone.Namespace
+						// path segment, so two Keystone CRs with the same Name in different namespaces
+						// resolve to distinct OpenBao leaves. Reviewer: please verify.
+						RemoteKey: "openstack/keystone/" + keystone.Namespace + "/" + keystone.Name + "/credential-keys",
 					},
 				},
 			}},

--- a/operators/keystone/internal/controller/reconcile_credential_test.go
+++ b/operators/keystone/internal/controller/reconcile_credential_test.go
@@ -415,13 +415,13 @@ func TestReconcileCredentialKeys_PushSecretReferencesCorrectSecret(t *testing.T)
 	g.Expect(ps.Spec.SecretStoreRefs[0].Kind).To(Equal("ClusterSecretStore"))
 	g.Expect(ps.Spec.SecretStoreRefs[0].Name).To(Equal("openbao-cluster-store"))
 	g.Expect(ps.Spec.Data).To(HaveLen(1))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/test-keystone/credential-keys"))
+	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/default/test-keystone/credential-keys"))
 }
 
 // TestCredentialKeysPushSecret_RemoteKeyIsCRScoped pins REQ-002 (CC-0093):
-// every Keystone CR must get a RemoteKey containing its own Name as a path
-// segment, so two CRs in the same namespace never collide on one shared KV-v2
-// path.
+// every Keystone CR must get a RemoteKey containing its namespace and Name as
+// path segments (namespace segment added in CC-0112, REQ-004), so two CRs never
+// collide on one shared KV-v2 path.
 func TestCredentialKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -437,8 +437,8 @@ func TestCredentialKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 
 		g.Expect(ps.Spec.Data).To(HaveLen(1))
 		got := ps.Spec.Data[0].Match.RemoteRef.RemoteKey
-		want := "openstack/keystone/" + name + "/credential-keys"
-		g.Expect(got).To(Equal(want), "RemoteKey must embed CR name for %q", name)
+		want := "openstack/keystone/" + ks.Namespace + "/" + name + "/credential-keys"
+		g.Expect(got).To(Equal(want), "RemoteKey must embed CR namespace and name for %q", name)
 		g.Expect(got).NotTo(Equal("openstack/keystone/credential-keys"), "must not fall back to legacy flat path")
 
 		if prev, dup := seen[got]; dup {
@@ -446,6 +446,29 @@ func TestCredentialKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 		}
 		seen[got] = name
 	}
+}
+
+// TestCredentialKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped pins CC-0112
+// (REQ-004): the credential RemoteKey embeds both the CR namespace and name, so
+// two Keystone CRs sharing a Name in different namespaces resolve to distinct
+// OpenBao leaves and never collide on a shared KV-v2 path.
+func TestCredentialKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ksA := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "openstack"},
+	}
+	ksB := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "tenant-b"},
+	}
+
+	keyA := credentialKeysPushSecret(ksA).Spec.Data[0].Match.RemoteRef.RemoteKey
+	keyB := credentialKeysPushSecret(ksB).Spec.Data[0].Match.RemoteRef.RemoteKey
+
+	g.Expect(keyA).To(Equal("openstack/keystone/openstack/keystone/credential-keys"))
+	g.Expect(keyB).To(Equal("openstack/keystone/tenant-b/keystone/credential-keys"))
+	g.Expect(keyA).NotTo(Equal(keyB),
+		"same-named CRs in different namespaces must produce distinct RemoteKeys (CC-0112)")
 }
 
 // TestCredentialKeysPushSecret_PreservesDeletionPolicyAndStoreRef pins that

--- a/operators/keystone/internal/controller/reconcile_fernet.go
+++ b/operators/keystone/internal/controller/reconcile_fernet.go
@@ -422,14 +422,16 @@ func fernetRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapName st
 
 // fernetKeysPushSecret builds the PushSecret CR that backs up Fernet keys to OpenBao.
 //
-// The RemoteKey embeds keystone.Name as a path segment
-// (kv-v2/openstack/keystone/{keystone.Name}/fernet-keys) so two Keystone CRs
-// in the same namespace never share a backing OpenBao object (CC-0093,
-// REQ-001).
+// The RemoteKey embeds both keystone.Namespace and keystone.Name as path
+// segments (kv-v2/openstack/keystone/{keystone.Namespace}/{keystone.Name}/fernet-keys)
+// so two Keystone CRs sharing a Name in different namespaces never share a
+// backing OpenBao object (CC-0093, REQ-001; namespace segment added in CC-0112,
+// REQ-004).
 //
 // DeletionPolicy=Delete wires the backup PushSecret into the OpenBao finalizer
 // flow: when the keystone.openstack.c5c3.io/openbao-finalizer handler deletes
-// this PushSecret, ESO purges the remote kv-v2/openstack/keystone/{keystone.Name}/fernet-keys
+// this PushSecret, ESO purges the remote
+// kv-v2/openstack/keystone/{keystone.Namespace}/{keystone.Name}/fernet-keys
 // path before letting the PushSecret object be garbage-collected (CC-0079,
 // REQ-008).
 func fernetKeysPushSecret(keystone *keystonev1alpha1.Keystone) *esov1alpha1.PushSecret {
@@ -452,7 +454,10 @@ func fernetKeysPushSecret(keystone *keystonev1alpha1.Keystone) *esov1alpha1.Push
 			Data: []esov1alpha1.PushSecretData{{
 				Match: esov1alpha1.PushSecretMatch{
 					RemoteRef: esov1alpha1.PushSecretRemoteRef{
-						RemoteKey: "openstack/keystone/" + keystone.Name + "/fernet-keys",
+						// DECISION: boundary 4 (CC-0112, REQ-004) — chose option (a), a keystone.Namespace
+						// path segment, so two Keystone CRs with the same Name in different namespaces
+						// resolve to distinct OpenBao leaves. Reviewer: please verify.
+						RemoteKey: "openstack/keystone/" + keystone.Namespace + "/" + keystone.Name + "/fernet-keys",
 					},
 				},
 			}},

--- a/operators/keystone/internal/controller/reconcile_fernet_test.go
+++ b/operators/keystone/internal/controller/reconcile_fernet_test.go
@@ -411,12 +411,13 @@ func TestReconcileFernetKeys_PushSecretReferencesCorrectSecret(t *testing.T) {
 	g.Expect(ps.Spec.SecretStoreRefs[0].Kind).To(Equal("ClusterSecretStore"))
 	g.Expect(ps.Spec.SecretStoreRefs[0].Name).To(Equal("openbao-cluster-store"))
 	g.Expect(ps.Spec.Data).To(HaveLen(1))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/test-keystone/fernet-keys"))
+	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("openstack/keystone/default/test-keystone/fernet-keys"))
 }
 
 // TestFernetKeysPushSecret_RemoteKeyIsCRScoped pins REQ-001 (CC-0093): every
-// Keystone CR must get a RemoteKey containing its own Name as a path segment,
-// so two CRs in the same namespace never collide on one shared KV-v2 path.
+// Keystone CR must get a RemoteKey containing its namespace and Name as path
+// segments (namespace segment added in CC-0112, REQ-004), so two CRs never
+// collide on one shared KV-v2 path.
 func TestFernetKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -432,8 +433,8 @@ func TestFernetKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 
 		g.Expect(ps.Spec.Data).To(HaveLen(1))
 		got := ps.Spec.Data[0].Match.RemoteRef.RemoteKey
-		want := "openstack/keystone/" + name + "/fernet-keys"
-		g.Expect(got).To(Equal(want), "RemoteKey must embed CR name for %q", name)
+		want := "openstack/keystone/" + ks.Namespace + "/" + name + "/fernet-keys"
+		g.Expect(got).To(Equal(want), "RemoteKey must embed CR namespace and name for %q", name)
 		g.Expect(got).NotTo(Equal("openstack/keystone/fernet-keys"), "must not fall back to legacy flat path")
 
 		if prev, dup := seen[got]; dup {
@@ -441,6 +442,29 @@ func TestFernetKeysPushSecret_RemoteKeyIsCRScoped(t *testing.T) {
 		}
 		seen[got] = name
 	}
+}
+
+// TestFernetKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped pins CC-0112
+// (REQ-004): the fernet RemoteKey embeds both the CR namespace and name, so two
+// Keystone CRs sharing a Name in different namespaces resolve to distinct
+// OpenBao leaves and never collide on a shared KV-v2 path.
+func TestFernetKeysPushSecret_RemoteKeyIsNamespaceAndNameScoped(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ksA := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "openstack"},
+	}
+	ksB := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "tenant-b"},
+	}
+
+	keyA := fernetKeysPushSecret(ksA).Spec.Data[0].Match.RemoteRef.RemoteKey
+	keyB := fernetKeysPushSecret(ksB).Spec.Data[0].Match.RemoteRef.RemoteKey
+
+	g.Expect(keyA).To(Equal("openstack/keystone/openstack/keystone/fernet-keys"))
+	g.Expect(keyB).To(Equal("openstack/keystone/tenant-b/keystone/fernet-keys"))
+	g.Expect(keyA).NotTo(Equal(keyB),
+		"same-named CRs in different namespaces must produce distinct RemoteKeys (CC-0112)")
 }
 
 // TestFernetKeysPushSecret_PreservesDeletionPolicyAndStoreRef pins that the

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -236,10 +236,10 @@ func (r *KeystoneReconciler) reconcilePasswordRotation(ctx context.Context,
 	}
 
 	// 8. Clobber-safe PushSecret (REQ-007, REQ-011, REQ-014): only mirror the
-	//    push-source Secret to the shared OpenBao path once it actually holds a
+	//    push-source Secret to the per-CR OpenBao path once it actually holds a
 	//    valid password. Before the first rotation completes the push-source
-	//    Secret is empty; pushing it would overwrite the seeded
-	//    bootstrap/keystone-admin value with nothing.
+	//    Secret is empty; pushing it would overwrite the seeded per-CR
+	//    bootstrap/{namespace}/{name}/admin value with nothing (CC-0112).
 	if r.adminPasswordPushSourceReady(ctx, keystone, minLength) {
 		ps := adminPasswordPushSecret(keystone)
 		if err := secrets.EnsurePushSecret(ctx, r.Client, r.Scheme, keystone, ps); err != nil {
@@ -262,7 +262,8 @@ func (r *KeystoneReconciler) reconcilePasswordRotation(ctx context.Context,
 // deletes tolerate NotFound so the teardown is idempotent and safe to run on a
 // CR that never enabled rotation. The PushSecret uses DeletionPolicy=None (see
 // adminPasswordPushSecret), so deleting it here leaves the last-pushed password
-// intact in OpenBao — disabling rotation must never lock the admin out.
+// intact in OpenBao at the per-CR path — disabling rotation must never lock the
+// admin out.
 func (r *KeystoneReconciler) teardownPasswordRotation(ctx context.Context, keystone *keystonev1alpha1.Keystone) error {
 	if err := deleteCronJob(ctx, r.Client, keystone.Namespace, adminPasswordRotateCronJobName(keystone)); err != nil {
 		return fmt.Errorf("deleting admin password rotation CronJob: %w", err)
@@ -550,10 +551,10 @@ func (r *KeystoneReconciler) applyAdminPasswordRotation(
 }
 
 // adminPasswordPushSourceReady reports whether the push-source Secret holds a
-// valid password (CC-0109, REQ-007). Used to gate the PushSecret so the shared
-// OpenBao bootstrap/keystone-admin value is never overwritten with an empty
-// payload before the first rotation completes. Any read error or invalid
-// payload is treated as "not ready" (best-effort gate).
+// valid password (CC-0109, REQ-007). Used to gate the PushSecret so the per-CR
+// OpenBao bootstrap/{namespace}/{name}/admin value is never overwritten with an
+// empty payload before the first rotation completes (CC-0112). Any read error or
+// invalid payload is treated as "not ready" (best-effort gate).
 func (r *KeystoneReconciler) adminPasswordPushSourceReady(ctx context.Context, keystone *keystonev1alpha1.Keystone, minLength int) bool {
 	var pushSource corev1.Secret
 	if err := r.Get(ctx, types.NamespacedName{
@@ -566,16 +567,16 @@ func (r *KeystoneReconciler) adminPasswordPushSourceReady(ctx context.Context, k
 }
 
 // adminPasswordPushSecret builds the PushSecret that mirrors the operator-owned
-// push-source Secret to OpenBao at the flat, single-CR path
-// bootstrap/keystone-admin (CC-0109, REQ-007, REQ-014). The RemoteKey is
-// hardcoded (not CR-scoped): Model B assumes a single Model-B-enabled Keystone
-// CR per cluster sharing the bootstrap/keystone-admin object with the
-// keystone-admin ExternalSecret (REQ-014, boundary 8, option a).
+// push-source Secret to OpenBao at the per-CR path
+// bootstrap/{keystone.Namespace}/{keystone.Name}/admin (CC-0112, REQ-002). The
+// RemoteKey embeds both the CR namespace and name as path segments so two
+// Model-B-enabled Keystone CRs never collide on a shared OpenBao object; the
+// matching keystone-admin ExternalSecret reads the same per-CR path.
 //
 // DECISION: DeletionPolicy=None — unspecified by REQ-007; chose None (not the
-// fernet PushSecret's Delete) because bootstrap/keystone-admin is a shared,
-// persistent bootstrap secret that the keystone-admin ExternalSecret and the
-// OpenBao seed both depend on. Disabling rotation deletes this PushSecret
+// fernet PushSecret's Delete) because the admin bootstrap path is a persistent
+// bootstrap secret that the keystone-admin ExternalSecret and the OpenBao seed
+// both depend on. Disabling rotation deletes this PushSecret
 // (teardownPasswordRotation); DeletionPolicy=None keeps the last-pushed password
 // in OpenBao so the admin is never locked out. Reviewer: please verify this
 // matches intent.
@@ -600,7 +601,7 @@ func adminPasswordPushSecret(keystone *keystonev1alpha1.Keystone) *esov1alpha1.P
 				Match: esov1alpha1.PushSecretMatch{
 					SecretKey: adminPasswordSecretKey,
 					RemoteRef: esov1alpha1.PushSecretRemoteRef{
-						RemoteKey: "bootstrap/keystone-admin",
+						RemoteKey: fmt.Sprintf("bootstrap/%s/%s/admin", keystone.Namespace, keystone.Name),
 						Property:  adminPasswordSecretKey,
 					},
 				},

--- a/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
@@ -7,6 +7,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -443,12 +444,40 @@ func TestAdminPasswordPushSecret_Shape(t *testing.T) {
 	g.Expect(ps.Spec.SecretStoreRefs[0].Kind).To(Equal("ClusterSecretStore"))
 	g.Expect(ps.Spec.SecretStoreRefs[0].Name).To(Equal("openbao-cluster-store"))
 	g.Expect(ps.Spec.Selector.Secret.Name).To(Equal(adminPasswordNextSecretName(ks)))
-	// Shared, persistent bootstrap path: never purge OpenBao on PushSecret delete.
+	// Persistent bootstrap path: never purge OpenBao on PushSecret delete.
 	g.Expect(ps.Spec.DeletionPolicy).To(Equal(esov1alpha1.PushSecretDeletionPolicyNone))
-	// RemoteKey is the flat single-CR path (not CR-scoped).
+	// RemoteKey is the per-CR path bootstrap/{namespace}/{name}/admin (CC-0112, REQ-002).
 	g.Expect(ps.Spec.Data).To(HaveLen(1))
-	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal("bootstrap/keystone-admin"))
+	g.Expect(ps.Spec.Data[0].Match.RemoteRef.RemoteKey).To(Equal(fmt.Sprintf("bootstrap/%s/%s/admin", ks.Namespace, ks.Name)))
 	g.Expect(ps.Spec.Data[0].Match.SecretKey).To(Equal("password"))
+}
+
+// TestAdminPasswordPushSecret_RemoteKeyIsPerCR pins CC-0112 (REQ-002): the
+// admin-password RemoteKey embeds both the CR namespace and name as path
+// segments, so two Keystone CRs sharing a Name in different namespaces resolve
+// to distinct OpenBao leaves and never clobber each other's bootstrap secret.
+func TestAdminPasswordPushSecret_RemoteKeyIsPerCR(t *testing.T) {
+	g := NewWithT(t)
+
+	ksA := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "openstack"},
+	}
+	ksB := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "tenant-b"},
+	}
+
+	psA := adminPasswordPushSecret(ksA)
+	psB := adminPasswordPushSecret(ksB)
+
+	g.Expect(psA.Spec.Data).To(HaveLen(1))
+	g.Expect(psB.Spec.Data).To(HaveLen(1))
+	keyA := psA.Spec.Data[0].Match.RemoteRef.RemoteKey
+	keyB := psB.Spec.Data[0].Match.RemoteRef.RemoteKey
+
+	g.Expect(keyA).To(Equal("bootstrap/openstack/keystone/admin"))
+	g.Expect(keyB).To(Equal("bootstrap/tenant-b/keystone/admin"))
+	g.Expect(keyA).NotTo(Equal(keyB),
+		"same-named CRs in different namespaces must produce distinct RemoteKeys (CC-0112)")
 }
 
 func TestAdminPasswordPushSourceReady_Gating(t *testing.T) {

--- a/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
@@ -230,6 +230,17 @@ spec:
           # CloudCredentialsRef against), not the orc-system copy. Assert the
           # gate-relevant CP_NS ExternalSecret/Secret first, then confirm the
           # orc-system copy K-ORC's globalCloudConfig mounts also materialised.
+          # CC-0112, REQ-013: the minted admin application credential now
+          # round-trips through the PER-CR OpenBao path
+          #   openstack/keystone/openstack/controlplane-keystone/admin/app-credential
+          # (openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential),
+          # not the former cluster-global openstack/keystone/admin/app-credential,
+          # so two ControlPlanes never clobber each other's credential. The
+          # PushSecret-name binding ("${CP_NAME}-admin-app-credential-backup")
+          # is a K8s resource name and is unchanged. The PushSecret/ExternalSecret
+          # Ready conditions below and the `openstack token issue` step in Link 7b
+          # transitively verify the per-CR path: the credential is readable back
+          # from exactly that key and authenticates end-to-end.
           wait_ready_condition pushsecret "${PUSH_SECRET}" "${CP_NS}" 300
           wait_ready_condition externalsecret "${CLOUDS_SECRET}" "${CP_NS}" 300
           kubectl get secret "${CLOUDS_SECRET}" -n "${CP_NS}" >/dev/null

--- a/tests/e2e/c5c3/multi-controlplane/00-tenant-a-controlplane.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/00-tenant-a-controlplane.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Tenant-A ControlPlane CR fixture for the multi-controlplane E2E test
+# (CC-0112, REQ-012). It owns namespace `tenant-a` and the single ControlPlane
+# `controlplane-a` in it.
+#
+# CC-0112 scopes the minted admin application credential per-ControlPlane in the
+# cluster-global OpenBao backend: the c5c3-operator mirrors this CR's admin AC to
+#   openstack/keystone/tenant-a/controlplane-a/admin/app-credential
+# (adminAppCredentialRemoteKeyFor; read back via `bao kv get` as the kv-v2 path
+#   kv-v2/openstack/keystone/tenant-a/controlplane-a/admin/app-credential).
+# Tenant-B (01-tenant-b-controlplane.yaml) lives in a DIFFERENT namespace with a
+# DIFFERENT name so its path can never collide with this one. The two axes are
+# both distinct on purpose, mirroring the completed envtest
+# TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths.
+#
+# DECISION (CC-0112, REQ-012): the validating webhook (CC-0112, task 3.1)
+# enforces ONE ControlPlane per namespace, so the two ControlPlanes MUST live in
+# separate namespaces — hence the bundled Namespace object here.
+#
+# DECISION (CC-0112, REQ-012): the per-namespace prerequisites this CR references
+# — the keystone-admin password Secret and the managed MariaDB/Memcached
+# infrastructure — are provisioned by the deploy stack in ITS namespace, not in
+# tenant-a/tenant-b. Wiring those per-tenant prerequisites into kind CI is the
+# same documented fast-follow as full-controlplane-keystone's chain wiring
+# (CC-0110 GitOps/CI, REQ-022/REQ-023): this test is behind a presence guard and
+# SKIPs cleanly when the c5c3 + K-ORC stack (and these prerequisites) are absent,
+# so it never hard-fails the default kind E2E job. We intentionally do NOT invent
+# unrelated infra here; managed-mode mirrors full-controlplane-keystone's shape so
+# that when the fast-follow lands these CRs reconcile against production-shaped
+# infrastructure. Reviewer: please verify the per-tenant prerequisite wiring.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-a
+---
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: controlplane-a
+  namespace: tenant-a
+spec:
+  openStackRelease: "2025.2"
+  region: RegionOne
+  infrastructure:
+    database:
+      clusterRef:
+        name: openstack-db
+      database: keystone
+      secretRef:
+        name: keystone-db
+    cache:
+      clusterRef:
+        name: openstack-memcached
+      backend: dogpile.cache.pymemcache
+      replicas: 3
+  services:
+    keystone:
+      replicas: 3
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+        secretName: k-orc-clouds-yaml
+      passwordSecretRef:
+        name: keystone-admin
+        key: password
+      applicationCredential:
+        # restricted:true keeps the admin AC least-privilege (REQ-013) and
+        # projects to K-ORC's spec.resource.unrestricted=false.
+        restricted: true
+        rotation:
+          mode: PasswordDriven

--- a/tests/e2e/c5c3/multi-controlplane/01-tenant-b-controlplane.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/01-tenant-b-controlplane.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Tenant-B ControlPlane CR fixture for the multi-controlplane E2E test
+# (CC-0112, REQ-012). It owns namespace `tenant-b` and the single ControlPlane
+# `controlplane-b` in it.
+#
+# CC-0112 scopes the minted admin application credential per-ControlPlane: the
+# c5c3-operator mirrors this CR's admin AC to
+#   openstack/keystone/tenant-b/controlplane-b/admin/app-credential
+# (read back via `bao kv get` as the kv-v2 path
+#   kv-v2/openstack/keystone/tenant-b/controlplane-b/admin/app-credential).
+# It is distinct on BOTH namespace and name from tenant-a's path
+# (00-tenant-a-controlplane.yaml), so neither ControlPlane can clobber the
+# other's admin credential on the cluster-global OpenBao backend. This is the
+# "untouched tenant" in the rotation-isolation assertion: rotating tenant-a's
+# admin AC must leave THIS CR's credential, OpenBao material, and K-ORC AC
+# unchanged.
+#
+# DECISION (CC-0112, REQ-012): one ControlPlane per namespace is enforced by the
+# validating webhook (CC-0112, task 3.1), so this CR carries its own Namespace.
+# The per-tenant prerequisite wiring (admin password Secret + managed infra) is
+# the same documented fast-follow as tenant-a — see the DECISION block in
+# 00-tenant-a-controlplane.yaml. Behind the presence guard this test SKIPs when
+# the stack/prerequisites are absent.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-b
+---
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: controlplane-b
+  namespace: tenant-b
+spec:
+  openStackRelease: "2025.2"
+  region: RegionOne
+  infrastructure:
+    database:
+      clusterRef:
+        name: openstack-db
+      database: keystone
+      secretRef:
+        name: keystone-db
+    cache:
+      clusterRef:
+        name: openstack-memcached
+      backend: dogpile.cache.pymemcache
+      replicas: 3
+  services:
+    keystone:
+      replicas: 3
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+        secretName: k-orc-clouds-yaml
+      passwordSecretRef:
+        name: keystone-admin
+        key: password
+      applicationCredential:
+        # restricted:true keeps the admin AC least-privilege (REQ-013) and
+        # projects to K-ORC's spec.resource.unrestricted=false.
+        restricted: true
+        rotation:
+          mode: PasswordDriven

--- a/tests/e2e/c5c3/multi-controlplane/02-tenant-a-rotation.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/02-tenant-a-rotation.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CredentialRotation fixture that rotates ONLY tenant-a's admin application
+# credential for the multi-controlplane E2E test (CC-0112, REQ-012).
+#
+# The CredentialRotation reconciler resolves its target ControlPlane in its OWN
+# namespace (one-CP-per-namespace; r.List(..., client.InNamespace(cr.Namespace))
+# in reconcile_credentialrotation.go), so this CR — living in `tenant-a` — rotates
+# controlplane-a and CANNOT touch controlplane-b in `tenant-b`. That blast-radius
+# scoping is exactly what the test asserts: tenant-b's credential, OpenBao
+# material, and K-ORC AC must be unaffected by this rotation.
+#
+# reMint:true forces a fresh mint even though the current credential is still
+# valid (the test makes no password change), so the rotation is observable as a
+# change in controlplane-a's status.adminApplicationCredential.id.
+apiVersion: c5c3.io/v1alpha1
+kind: CredentialRotation
+metadata:
+  name: rotate-controlplane-a-admin
+  namespace: tenant-a
+spec:
+  target: adminApplicationCredential
+  reMint: true

--- a/tests/e2e/c5c3/multi-controlplane/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/chainsaw-test.yaml
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for per-ControlPlane admin-credential isolation in the
+# cluster-global OpenBao backend (CC-0112, REQ-012). It brings up TWO
+# ControlPlanes in TWO namespaces and asserts, end-to-end against a live OpenBao,
+# that the c5c3-operator scopes each CR's minted admin application credential to
+# a DISTINCT per-CR path so two ControlPlanes never clobber each other:
+#
+#   Namespace tenant-a / ControlPlane controlplane-a
+#     → kv-v2/openstack/keystone/tenant-a/controlplane-a/admin/app-credential
+#   Namespace tenant-b / ControlPlane controlplane-b
+#     → kv-v2/openstack/keystone/tenant-b/controlplane-b/admin/app-credential
+#
+# These paths are the kv-v2-prefixed read view of adminAppCredentialRemoteKeyFor
+# (operators/c5c3/internal/controller/reconcile_korc.go), which returns
+#   openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential.
+# Both axes (namespace AND name) are distinct on purpose, mirroring the completed
+# envtest TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths.
+#
+# Task 7.1 — distinct ids: both ControlPlanes reach Ready=True and their
+# status.adminApplicationCredential.id values are non-empty and distinct.
+# Task 7.2 — OpenBao isolation + rotation non-interference: both per-CR paths
+# exist with DIFFERENT material; rotating ONLY tenant-a's admin AC leaves
+# tenant-b's status, OpenBao material, and K-ORC AC health unchanged.
+#
+# ── DECISION: belt-and-braces presence guard + single consolidated script ────
+# Mirrors full-controlplane-keystone exactly. The c5c3 + K-ORC + keystone stack
+# is NOT installed by the current kind E2E wiring (hack/deploy-infra.sh +
+# hack/ci-deploy-operator.sh), and the suite runs failFast:true
+# (tests/e2e/chainsaw-config.yaml), so a pure declarative test would HARD-FAIL
+# the whole e2e-operator job on any cluster missing that stack — including the PR
+# that introduces this file. A runtime presence guard probes for the required
+# CRDs + the OpenBao ClusterSecretStore + the openbao-init-keys Secret (needed to
+# read the bao token) and exits 0 with a SKIP line when the stack is absent, so
+# the test is default-safe; when the stack IS present it asserts the full
+# isolation contract. Because chainsaw has no step-level skip, the guard and all
+# assertions live in ONE script step (declarative asserts in sibling steps would
+# time out and fail even after the guard exited 0).
+# Reviewer: please verify, and note the kind E2E wiring to deploy K-ORC + the
+# c5c3-operator AND the per-tenant prerequisites (admin password Secret + managed
+# infra in tenant-a/tenant-b) so this test exercises rather than skips is a
+# documented fast-follow on the CC-0110 GitOps/CI wiring (REQ-022/REQ-023).
+#
+# ── DECISION: "credentials differ" comparison field ──────────────────────────
+# The c5c3-operator pushes the operator-owned admin-credential Secret to OpenBao;
+# its key `clouds.yaml` (appCredCloudsYAMLKey in reconcile_korc.go) is the
+# assembled application-credential clouds.yaml and EMBEDS the per-CR
+# application-credential id and secret. We compare `bao kv get -field=clouds.yaml`
+# between the two paths: it is a single, stable, always-present field whose value
+# differs iff the two ControlPlanes minted distinct credentials — the realistic
+# "the actual secret material differs" signal. We hash it (sha256) before logging
+# so the comparison is deterministic and no credential material is printed.
+#
+# Feature: CC-0112, REQ-012
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: multi-controlplane
+# NOTE: no spec.namespace — the two fixtures declare their own namespaces
+# (tenant-a / tenant-b); the one-CP-per-namespace webhook forces them apart.
+spec:
+  # Two full mint chains (Galera + Keystone bootstrap + two K-ORC mints + the
+  # OpenBao round-trip) plus a rotation are long-running, so the consolidated
+  # script and its diagnostic catch get generous bounds above the suite default.
+  #
+  # Timeout budget (CC-0112, REQ-012): the single consolidated script runs its
+  # polls SEQUENTIALLY, and their own per-poll deadlines sum to a worst case of
+  # 3000s — wait_cp_condition Ready 900 + 900 (both ControlPlanes) +
+  # wait_bao_clouds_sha 300 + 300 (both per-CR paths) + the 600s rotation wait.
+  # exec / script.timeout MUST exceed that sum so that, on a genuine hang, the
+  # offending poll prints its precise "condition/path X not … within Ns" error
+  # rather than chainsaw killing the whole script with a generic timeout that
+  # hides which poll stalled. 55m (3300s) clears the 3000s worst case with margin
+  # for the apply + token-extract overhead.
+  timeouts:
+    assert: 5m
+    exec: 55m
+  steps:
+  # ── Step 1: Presence-gate, apply both ControlPlanes, assert isolation ──────
+  - try:
+    - script:
+        # 55m > the 3000s worst-case sum of the sequential per-poll deadlines
+        # below (see spec.timeouts above) so a hung poll surfaces its own precise
+        # error instead of a generic chainsaw script-timeout kill (CC-0112).
+        timeout: 55m
+        # Chainsaw defaults to `sh`, which rejects `set -o pipefail`; every
+        # infra/keystone e2e script pins bash for the same reason.
+        shell: bash
+        content: |
+          set -euo pipefail
+
+          NS_A=tenant-a
+          NS_B=tenant-b
+          CP_A=controlplane-a
+          CP_B=controlplane-b
+          # AC CR name == {cp.Name}-admin-app-credential (adminAppCredentialName).
+          AC_B="${CP_B}-admin-app-credential"
+          # Per-CR OpenBao read paths (kv-v2 mount prefix added on read).
+          PATH_A="kv-v2/openstack/keystone/${NS_A}/${CP_A}/admin/app-credential"
+          PATH_B="kv-v2/openstack/keystone/${NS_B}/${CP_B}/admin/app-credential"
+
+          # OpenBao server lives in openbao-system (deploy/openbao/bootstrap).
+          BAO_NS="openbao-system"
+          BAO_POD="openbao-0"
+          BAO_SECRET="openbao-init-keys"
+          BAO_ADDR="https://127.0.0.1:8200"
+          VAULT_CACERT="/openbao/tls/ca.crt"
+
+          # ── Presence guard (CC-0112, REQ-012) ──────────────────────────────
+          # Probe every CRD the chain spans plus the OpenBao ClusterSecretStore
+          # and the init-keys Secret (we need its root token to read bao).
+          # Their absence unambiguously means the c5c3-operator + K-ORC +
+          # keystone-operator stack is not deployed here — SKIP cleanly (exit 0).
+          missing=""
+          for crd in \
+            controlplanes.c5c3.io \
+            credentialrotations.c5c3.io \
+            keystones.keystone.openstack.c5c3.io \
+            applicationcredentials.openstack.k-orc.cloud \
+            externalsecrets.external-secrets.io; do
+            if ! kubectl get crd "$crd" >/dev/null 2>&1; then
+              missing="${missing} ${crd}"
+            fi
+          done
+          if [ -n "${missing}" ]; then
+            echo "SKIP: required CRDs not present:${missing}"
+            echo "      The c5c3-operator + K-ORC + keystone-operator stack is"
+            echo "      not deployed on this cluster, so per-ControlPlane admin"
+            echo "      credential isolation cannot be exercised here."
+            exit 0
+          fi
+          if ! kubectl get clustersecretstore openbao-cluster-store >/dev/null 2>&1; then
+            echo "SKIP: openbao-cluster-store ClusterSecretStore not present;"
+            echo "      the admin-credential push chain cannot complete."
+            exit 0
+          fi
+          if ! kubectl get secret "${BAO_SECRET}" -n "${BAO_NS}" >/dev/null 2>&1; then
+            echo "SKIP: ${BAO_NS}/${BAO_SECRET} not present; cannot read the"
+            echo "      OpenBao root token to verify the per-CR paths."
+            exit 0
+          fi
+          echo "OK: c5c3 + K-ORC + keystone CRDs and OpenBao present —"
+          echo "    running the per-ControlPlane admin-credential isolation test."
+
+          # ── Helpers ────────────────────────────────────────────────────────
+          # Poll a ControlPlane status condition to True. Implemented as an
+          # explicit poll (not `kubectl wait`) so a condition that is briefly
+          # absent or False simply retries instead of erroring out, and so the
+          # failure message names the last-observed status for triage.
+          wait_cp_condition() { # <name> <namespace> <conditionType> <timeoutSeconds>
+            local name="$1" ns="$2" ctype="$3" timeout="$4"
+            local deadline status
+            deadline=$(( $(date +%s) + timeout ))
+            while true; do
+              status="$(kubectl get controlplane "${name}" -n "${ns}" \
+                -o "jsonpath={.status.conditions[?(@.type=='${ctype}')].status}" 2>/dev/null || true)"
+              if [ "${status}" = "True" ]; then
+                echo "OK: ControlPlane ${ns}/${name} condition ${ctype}=True"
+                return 0
+              fi
+              if [ "$(date +%s)" -ge "${deadline}" ]; then
+                echo "ERROR: ControlPlane ${ns}/${name} condition ${ctype} not True within ${timeout}s (last: '${status:-<none>}')"
+                return 1
+              fi
+              sleep 5
+            done
+          }
+
+          assert_eq() { # <description> <expected> <actual>
+            if [ "$2" != "$3" ]; then
+              echo "ERROR: $1 — expected '$2', got '$3'"
+              exit 1
+            fi
+            echo "OK: $1 ('$3')"
+          }
+
+          assert_ne() { # <description> <a> <b>  (fails when a == b)
+            if [ "$2" = "$3" ]; then
+              echo "ERROR: $1 — values must differ but both are '$2'"
+              exit 1
+            fi
+            echo "OK: $1 (distinct)"
+          }
+
+          cp_ac_id() { # <name> <namespace>  → status.adminApplicationCredential.id
+            kubectl get controlplane "$1" -n "$2" \
+              -o "jsonpath={.status.adminApplicationCredential.id}" 2>/dev/null || true
+          }
+
+          cp_ac_last_rotation() { # <name> <namespace> → status.…lastRotation
+            kubectl get controlplane "$1" -n "$2" \
+              -o "jsonpath={.status.adminApplicationCredential.lastRotation}" 2>/dev/null || true
+          }
+
+          # Extract the BAO root token once for all `bao kv get` calls below.
+          BAO_TOKEN=$(kubectl get secret "${BAO_SECRET}" -n "${BAO_NS}" \
+            -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')
+          if [ -z "${BAO_TOKEN}" ] || [ "${BAO_TOKEN}" = "null" ]; then
+            echo "ERROR: could not extract root token from ${BAO_NS}/${BAO_SECRET}"
+            exit 1
+          fi
+
+          # sha256 of `bao kv get -field=clouds.yaml <path>`. Returns the hash on
+          # stdout and exit 0 when the path exists; exit 1 (empty stdout) when the
+          # path / field is absent so callers can poll. We hash so no credential
+          # material is ever printed and the comparison is a fixed-width token.
+          bao_clouds_sha() { # <path>
+            local path="$1" field
+            field=$(kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+              env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" \
+                  VAULT_CACERT="${VAULT_CACERT}" \
+                  bao kv get -field=clouds.yaml "${path}" 2>/dev/null) || return 1
+            if [ -z "${field}" ]; then
+              return 1
+            fi
+            printf '%s' "${field}" | sha256sum | awk '{print $1}'
+          }
+
+          # Poll bao_clouds_sha until the path materialises (PushSecret sync is
+          # eventually-consistent). Echoes the sha on success.
+          wait_bao_clouds_sha() { # <path> <timeoutSeconds>
+            local path="$1" timeout="$2" deadline sha
+            deadline=$(( $(date +%s) + timeout ))
+            while true; do
+              if sha=$(bao_clouds_sha "${path}"); then
+                echo "${sha}"
+                return 0
+              fi
+              if [ "$(date +%s)" -ge "${deadline}" ]; then
+                echo "ERROR: ${path} did not materialise in OpenBao within ${timeout}s" >&2
+                return 1
+              fi
+              sleep 5
+            done
+          }
+
+          # Apply both ControlPlane fixtures (each carries its own namespace).
+          # Chainsaw runs scripts with the test directory as CWD.
+          kubectl apply -f 00-tenant-a-controlplane.yaml
+          kubectl apply -f 01-tenant-b-controlplane.yaml
+
+          # ── Task 7.1: both Ready=True with distinct, non-empty AC ids ───────
+          wait_cp_condition "${CP_A}" "${NS_A}" Ready 900
+          wait_cp_condition "${CP_B}" "${NS_B}" Ready 900
+
+          ID_A="$(cp_ac_id "${CP_A}" "${NS_A}")"
+          ID_B="$(cp_ac_id "${CP_B}" "${NS_B}")"
+          if [ -z "${ID_A}" ]; then
+            echo "ERROR: ${NS_A}/${CP_A} status.adminApplicationCredential.id is empty"
+            exit 1
+          fi
+          if [ -z "${ID_B}" ]; then
+            echo "ERROR: ${NS_B}/${CP_B} status.adminApplicationCredential.id is empty"
+            exit 1
+          fi
+          echo "OK: both ControlPlanes report a non-empty admin AC id"
+          assert_ne "admin AC ids of the two ControlPlanes" "${ID_A}" "${ID_B}"
+
+          # ── Task 7.2a: both per-CR OpenBao paths exist with DIFFERENT material ─
+          echo "== bao kv get ${PATH_A} (expect present) =="
+          SHA_A="$(wait_bao_clouds_sha "${PATH_A}" 300)"
+          echo "OK: ${PATH_A} present (clouds.yaml sha256=${SHA_A})"
+          echo "== bao kv get ${PATH_B} (expect present) =="
+          SHA_B="$(wait_bao_clouds_sha "${PATH_B}" 300)"
+          echo "OK: ${PATH_B} present (clouds.yaml sha256=${SHA_B})"
+          assert_ne "OpenBao admin-credential material of the two paths" "${SHA_A}" "${SHA_B}"
+
+          # ── Task 7.2b: record tenant-b's pre-rotation state ─────────────────
+          B_ROT_BEFORE="$(cp_ac_last_rotation "${CP_B}" "${NS_B}")"
+          B_ID_BEFORE="${ID_B}"
+          B_SHA_BEFORE="${SHA_B}"
+          echo "tenant-b before rotation: id='${B_ID_BEFORE}' lastRotation='${B_ROT_BEFORE:-<none>}' sha=${B_SHA_BEFORE}"
+
+          # ── Task 7.2c: rotate ONLY tenant-a's admin AC (reMint) ─────────────
+          # The CredentialRotation reconciler resolves its target in its own
+          # namespace, so this rotates controlplane-a only. We observe the
+          # rotation as a CHANGE in tenant-a's status.adminApplicationCredential.id
+          # (the re-mint produces a fresh OpenStack application-credential id) —
+          # the most robust observable signal, since the CredentialRotation flips
+          # Ready=True the moment it nudges, before the re-mint completes.
+          kubectl apply -f 02-tenant-a-rotation.yaml
+          A_ID_BEFORE="${ID_A}"
+          echo "== waiting for tenant-a admin AC id to change from '${A_ID_BEFORE}' =="
+          rot_deadline=$(( $(date +%s) + 600 ))
+          A_ID_AFTER="${A_ID_BEFORE}"
+          while true; do
+            A_ID_AFTER="$(cp_ac_id "${CP_A}" "${NS_A}")"
+            if [ -n "${A_ID_AFTER}" ] && [ "${A_ID_AFTER}" != "${A_ID_BEFORE}" ]; then
+              echo "OK: tenant-a admin AC id rotated '${A_ID_BEFORE}' → '${A_ID_AFTER}'"
+              break
+            fi
+            if [ "$(date +%s)" -ge "${rot_deadline}" ]; then
+              echo "ERROR: tenant-a admin AC id did not change within 600s (still '${A_ID_AFTER}')"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          # ── Task 7.2d: assert tenant-b is UNAFFECTED by tenant-a's rotation ─
+          # (i) lastRotation unchanged from the recorded pre-rotation value.
+          B_ROT_AFTER="$(cp_ac_last_rotation "${CP_B}" "${NS_B}")"
+          assert_eq "tenant-b admin AC lastRotation unchanged by tenant-a rotation" \
+            "${B_ROT_BEFORE}" "${B_ROT_AFTER}"
+          # (ii) id unchanged (belt-and-braces with lastRotation).
+          B_ID_AFTER="$(cp_ac_id "${CP_B}" "${NS_B}")"
+          assert_eq "tenant-b admin AC id unchanged by tenant-a rotation" \
+            "${B_ID_BEFORE}" "${B_ID_AFTER}"
+          # (iii) tenant-b's K-ORC ApplicationCredential CR still Available=True.
+          B_AC_AVAIL="$(kubectl get applicationcredentials.openstack.k-orc.cloud "${AC_B}" -n "${NS_B}" \
+            -o "jsonpath={.status.conditions[?(@.type=='Available')].status}" 2>/dev/null || true)"
+          assert_eq "tenant-b K-ORC ApplicationCredential ${AC_B} Available" "True" "${B_AC_AVAIL}"
+          # (iv) tenant-b's OpenBao material unchanged from before the rotation.
+          B_SHA_AFTER="$(bao_clouds_sha "${PATH_B}")"
+          assert_eq "tenant-b OpenBao admin-credential material unchanged" \
+            "${B_SHA_BEFORE}" "${B_SHA_AFTER}"
+
+          echo "OK: per-ControlPlane admin-credential isolation verified —"
+          echo "    distinct ids + distinct OpenBao paths/material, and tenant-a's"
+          echo "    rotation left tenant-b's credential, OpenBao material, and"
+          echo "    K-ORC AC untouched (CC-0112, REQ-012)."
+    catch:
+    - script:
+        shell: bash
+        content: |
+          echo "=== ControlPlane controlplane-a (tenant-a) describe ==="
+          kubectl describe controlplane controlplane-a -n tenant-a 2>&1 || true
+          echo "=== ControlPlane controlplane-b (tenant-b) describe ==="
+          kubectl describe controlplane controlplane-b -n tenant-b 2>&1 || true
+          echo "=== ControlPlane conditions (both) ==="
+          for pair in "controlplane-a tenant-a" "controlplane-b tenant-b"; do
+            set -- $pair
+            echo "--- $1/$2 ---"
+            kubectl get controlplane "$1" -n "$2" \
+              -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}: {.message}){"\n"}{end}' 2>&1 || true
+            echo "adminApplicationCredential:"
+            kubectl get controlplane "$1" -n "$2" \
+              -o jsonpath='{.status.adminApplicationCredential}{"\n"}' 2>&1 || true
+          done
+          echo "=== CredentialRotation (tenant-a) ==="
+          kubectl get credentialrotation -n tenant-a -o wide 2>&1 || true
+          kubectl describe credentialrotation rotate-controlplane-a-admin -n tenant-a 2>&1 || true
+          echo "=== K-ORC ApplicationCredentials (both tenants) ==="
+          kubectl get applicationcredentials.openstack.k-orc.cloud -n tenant-a 2>&1 || true
+          kubectl get applicationcredentials.openstack.k-orc.cloud -n tenant-b 2>&1 || true
+          echo "=== c5c3-operator logs (last 200 lines) ==="
+          kubectl logs -n c5c3-system -l app.kubernetes.io/name=c5c3-operator --tail=200 --all-containers 2>&1 || true
+          echo "=== openbao pods ==="
+          kubectl get pods -n openbao-system -l app.kubernetes.io/name=openbao 2>&1 || true
+          echo "=== openbao-0 logs (last 100 lines) ==="
+          kubectl logs -n openbao-system openbao-0 --tail=100 2>&1 || true
+          echo "=== Events (tenant-a / tenant-b, last 30 each) ==="
+          kubectl get events -n tenant-a --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+          kubectl get events -n tenant-b --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    finally:
+    - script:
+        shell: bash
+        content: |
+          # Best-effort cleanup of the CredentialRotation we created (the two
+          # ControlPlanes, their owned children, and the namespaces are GC'd by
+          # chainsaw's namespace teardown).
+          kubectl delete credentialrotation rotate-controlplane-a-admin -n tenant-a --ignore-not-found 2>&1 || true

--- a/tests/e2e/keystone/admin-password-rotation/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/admin-password-rotation/00-keystone-cr.yaml
@@ -20,17 +20,19 @@
 # ExternalSecret never satisfies that gate, so the CR would never reach Ready.
 # The ESO path is therefore the only one that exercises the real contract.
 #
-# Why a DEDICATED OpenBao path (bootstrap/keystone-adminpw) and NOT the shared
-# bootstrap/keystone-admin: every other parallel Keystone CR reads
-# bootstrap/keystone-admin, so rotating that value would re-bootstrap every
-# referencing CR and make concurrent suites observe a mid-flight admin-password
-# change. A per-suite path scopes the rotation to THIS CR only. The
-# eso-management OpenBao policy already grants read on kv-v2/data/bootstrap/*
-# (deploy/openbao/policies/eso-management.hcl), so no new policy is required.
-# The path is seeded with a known initial password by chainsaw-test.yaml step 1
-# (re-seeded every run, so a leftover from a prior run is overwritten); it is
-# treated as a persistent bootstrap secret, mirroring bootstrap/keystone-admin
-# in deploy/openbao/bootstrap/write-bootstrap-secrets.sh.
+# Why a DEDICATED OpenBao path (bootstrap/keystone-adminpw) and NOT a per-CR
+# admin path the deploy-infra seed owns: this suite WRITES its rotation source,
+# so giving it a self-seeded, self-owned path keeps the rotation scoped to THIS
+# CR and avoids racing the deploy-infra seed or any other CR's admin password.
+# (Since CC-0112 every production admin password lives at its own per-CR path
+# bootstrap/{namespace}/{keystone}/admin, so there is no longer a shared admin
+# object to collide on — but a dedicated, test-owned path is still the cleanest
+# rotation source.) The eso-management OpenBao policy already grants read on
+# kv-v2/data/bootstrap/* (deploy/openbao/policies/eso-management.hcl), so no new
+# policy is required. The path is seeded with a known initial password by
+# chainsaw-test.yaml step 1 (re-seeded every run, so a leftover from a prior run
+# is overwritten); it is treated as a persistent bootstrap secret, mirroring how
+# write-bootstrap-secrets.sh seeds the per-CR admin paths.
 #
 # refreshInterval is short so step 3's rotated value reaches the Secret within
 # one ESO tick — ESO does not watch OpenBao for changes, it re-reads the source

--- a/tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml
@@ -15,33 +15,29 @@
 # into the admin Secret; and the bootstrap sub-reconciler re-runs to cut the
 # Keystone admin credential over to the new value (chainsaw-test.yaml step 4).
 #
-# DECISION: [whether this suite reads a DEDICATED OpenBao path (like CC-0108) or
-# the SHARED bootstrap/keystone-admin path] — Chose the SHARED
-# bootstrap/keystone-admin path because the Model B PushSecret hardcodes
-# RemoteKey: bootstrap/keystone-admin (single-CR assumption — REQ-014, boundary
-# 8, option a; see the DECISION comment on adminPasswordPushSecret in
+# DECISION: [which OpenBao path this suite's admin ExternalSecret reads] — read
+# the per-CR path bootstrap/openstack/keystone-adminpw-sched/admin, because since
+# CC-0112 the Model B PushSecret derives its RemoteKey from the CR identity as
+# bootstrap/{namespace}/{name}/admin (see adminPasswordPushSecret in
 # operators/keystone/internal/controller/reconcile_passwordrotation.go). The
 # operator's backup PushSecret therefore writes the rotated password to
-# bootstrap/keystone-admin regardless of CR name, so this suite's dedicated admin
-# ExternalSecret MUST read from that SAME shared path for the evidence chain to
+# bootstrap/openstack/keystone-adminpw-sched/admin for THIS CR, so this suite's
+# admin ExternalSecret MUST read that same per-CR path for the evidence chain to
 # close (OpenBao change → ESO → admin Secret → re-bootstrap). Reviewer: please
-# verify this matches the hardcoded RemoteKey in reconcile_passwordrotation.go.
+# verify this matches the RemoteKey formula in reconcile_passwordrotation.go.
 #
-# Consequence of the shared path: rotating bootstrap/keystone-admin re-bootstraps
-# EVERY Keystone CR that reads it (the production keystone-admin ExternalSecret
-# in deploy/eso/externalsecrets/keystone-admin.yaml reads the same path). This
-# suite must therefore be the SOLE WRITER of that value while it runs:
-# chainsaw-test.yaml sets `concurrent: false` on the Test so it does not run
-# alongside other suites, and re-seeds bootstrap/keystone-admin with a known
-# initial password at the start for cross-run determinism. Unlike CC-0108 — which
-# used a dedicated bootstrap/keystone-adminpw path and so was parallel-safe — this
-# suite cannot be parallel-safe because the rotation target is shared.
+# Consequence of the per-CR path: rotating it re-bootstraps ONLY this CR. No
+# other Keystone CR — nor the production keystone-admin ExternalSecret in
+# deploy/eso/externalsecrets/keystone-admin.yaml (which reads its own per-CR
+# path) — observes the change. The suite is therefore parallel-safe and runs in
+# the execution.parallel:4 pool like its sibling admin-password-rotation suite
+# (CC-0108); chainsaw-test.yaml re-seeds this per-CR path with a known initial
+# password at the start for cross-run determinism.
 #
-# Why a DEDICATED CR/DB/admin Secret despite the shared OpenBao source: the
-# Keystone instance, its database, and the materialised admin Secret are all
-# per-suite so this test owns its own Deployment, bootstrap Job, and rotation
-# resources without colliding on names in the shared `openstack` namespace. Only
-# the OpenBao SOURCE object is shared (it has to be — see DECISION above).
+# Every resource this suite owns is per-CR: the Keystone instance, its database,
+# the materialised admin Secret, AND (since CC-0112) the OpenBao source object.
+# So this test owns its own Deployment, bootstrap Job, rotation resources, and
+# OpenBao path without colliding on names in the shared `openstack` namespace.
 #
 # refreshInterval is short so the rotated value reaches the admin Secret within
 # one ESO tick — ESO does not watch OpenBao for changes, it re-reads the source
@@ -64,10 +60,11 @@ spec:
   data:
     - secretKey: password
       remoteRef:
-        # SHARED path — see the DECISION block above. The Model B backup
-        # PushSecret writes the rotated password here (hardcoded RemoteKey), so
-        # this ExternalSecret must read the same object to observe the rotation.
-        key: bootstrap/keystone-admin
+        # Per-CR path — see the DECISION block above. Since CC-0112 the Model B
+        # backup PushSecret writes the rotated password to
+        # bootstrap/{namespace}/{name}/admin, so this ExternalSecret must read the
+        # same per-CR object to observe the rotation.
+        key: bootstrap/openstack/keystone-adminpw-sched/admin
         property: password
 ---
 apiVersion: keystone.openstack.c5c3.io/v1alpha1

--- a/tests/e2e/keystone/admin-password-scheduled-rotation/chainsaw-test.yaml
+++ b/tests/e2e/keystone/admin-password-scheduled-rotation/chainsaw-test.yaml
@@ -13,34 +13,34 @@
 #     the push-source Secret (<cr>-admin-password-next), deletes staging, and
 #     emits AdminPasswordRotated (REQ-007).
 #   - The backup PushSecret (<cr>-admin-password-backup) mirrors the push-source
-#     Secret to the shared OpenBao path bootstrap/keystone-admin (REQ-007,
-#     REQ-014); ESO (refreshInterval: 10s) projects it back into the admin Secret
-#     (<cr>-admin-password); the operator's secretToKeystoneMapper observes the
-#     change and re-runs the idempotent bootstrap Job with the new
-#     forge.c5c3.io/admin-password-hash; BootstrapReady returns to True and the
-#     new password authenticates (201) while the old one is rejected (401).
+#     Secret to the per-CR OpenBao path bootstrap/<namespace>/<cr>/admin
+#     (REQ-007, REQ-014, CC-0112); ESO (refreshInterval: 10s) projects it back
+#     into the admin Secret (<cr>-admin-password); the operator's
+#     secretToKeystoneMapper observes the change and re-runs the idempotent
+#     bootstrap Job with the new forge.c5c3.io/admin-password-hash; BootstrapReady
+#     returns to True and the new password authenticates (201) while the old one
+#     is rejected (401).
 #   - Disabling rotation tears down every Model B resource and reports
 #     PasswordRotationReady=True / RotationDisabled (REQ-002).
 #
-# SOLE-WRITER / concurrent: false — this suite re-seeds and then rotates the
-# SHARED OpenBao path bootstrap/keystone-admin (the Model B PushSecret hardcodes
-# that RemoteKey; see the DECISION block in 00-keystone-cr.yaml). Rotating it
-# re-bootstraps every Keystone CR that reads it, so this Test must NOT run
-# alongside other suites. `concurrent: false` excludes it from the
-# execution.parallel:4 pool in tests/e2e/chainsaw-config.yaml.
+# Parallel-safe — since CC-0112 the Model B PushSecret writes to the per-CR path
+# bootstrap/{namespace}/{name}/admin (here
+# bootstrap/openstack/keystone-adminpw-sched/admin; see adminPasswordPushSecret
+# in reconcile_passwordrotation.go), so this suite re-seeds and rotates an
+# OpenBao object that no other CR — nor the production keystone-admin
+# ExternalSecret — reads. It therefore runs in the execution.parallel:4 pool like
+# its sibling admin-password-rotation suite (CC-0108); see the DECISION block in
+# 00-keystone-cr.yaml.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: keystone-admin-password-scheduled-rotation
 spec:
   namespace: openstack
-  # REQUIRED — see SOLE-WRITER note above. This suite mutates the shared
-  # bootstrap/keystone-admin OpenBao value, so it cannot run concurrently.
-  concurrent: false
   timeouts:
     assert: 5m
   steps:
-  # ── Step 1: Seed the SHARED OpenBao path, then apply CR + ExternalSecret ─
+  # ── Step 1: Seed the per-CR OpenBao path, then apply CR + ExternalSecret ─
   - name: seed-and-apply
     try:
     - script:
@@ -49,24 +49,26 @@ spec:
         content: |
           set -euo pipefail
 
-          # Seed the SHARED bootstrap/keystone-admin path with a known initial
-          # admin password BEFORE the ExternalSecret is applied, so ESO's first
-          # sync materialises a deterministic value (the bootstrap Job then seeds
-          # the Keystone admin credential with it). Re-seeded unconditionally
-          # every run, so a leftover rotated value from a prior run is
-          # overwritten. OpenBao access mirrors
+          # Seed the per-CR bootstrap/openstack/keystone-adminpw-sched/admin path
+          # with a known initial admin password BEFORE the ExternalSecret is
+          # applied, so ESO's first sync materialises a deterministic value (the
+          # bootstrap Job then seeds the Keystone admin credential with it).
+          # Re-seeded unconditionally every run, so a leftover rotated value from
+          # a prior run is overwritten. OpenBao access mirrors
           # tests/e2e/keystone/admin-password-rotation step 1.
           #
-          # IMPORTANT SIDE-EFFECT: this writes the SHARED bootstrap/keystone-admin
-          # object — the same object the production keystone-admin ExternalSecret
-          # and every Model-B-enabled CR read. That is precisely why this suite is
-          # `concurrent: false` (sole writer). See the DECISION block in
-          # 00-keystone-cr.yaml.
+          # Since CC-0112 the Model B backup PushSecret writes to the per-CR path
+          # bootstrap/{namespace}/{name}/admin (reconcile_passwordrotation.go), so
+          # this object is private to keystone-adminpw-sched — neither another CR
+          # nor the production keystone-admin ExternalSecret reads it. That
+          # isolation is why this suite is parallel-safe; see the DECISION block
+          # in 00-keystone-cr.yaml.
           BAO_NS="openbao-system"
           POD="openbao-0"
           SECRET="openbao-init-keys"
           BAO_ADDR="https://127.0.0.1:8200"
           VAULT_CACERT="/openbao/tls/ca.crt"
+          BAO_PATH="kv-v2/bootstrap/openstack/keystone-adminpw-sched/admin"
 
           BAO_TOKEN=$(kubectl get secret "${SECRET}" -n "${BAO_NS}" \
             -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')
@@ -81,7 +83,7 @@ spec:
           kubectl exec -n "${BAO_NS}" "${POD}" -- \
             env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" \
                 VAULT_CACERT="${VAULT_CACERT}" \
-            bao kv put kv-v2/bootstrap/keystone-admin \
+            bao kv put "${BAO_PATH}" \
               password="initial-admin-password-cc0109"
 
           # Mark the path managed-by=external-secrets so the Model B backup
@@ -100,8 +102,8 @@ spec:
                 VAULT_CACERT="${VAULT_CACERT}" \
             bao kv metadata put \
               -custom-metadata=managed-by=external-secrets \
-              kv-v2/bootstrap/keystone-admin
-          echo "OK: seeded OpenBao bootstrap/keystone-admin with initial password"
+              "${BAO_PATH}"
+          echo "OK: seeded OpenBao bootstrap/openstack/keystone-adminpw-sched/admin with initial password"
     - apply:
         file: 00-keystone-cr.yaml
   # ── Step 2: Wait for Ready=True ────────────────────────────────────────
@@ -252,6 +254,7 @@ spec:
           BAO_SECRET="openbao-init-keys"
           BAO_ADDR="https://127.0.0.1:8200"
           VAULT_CACERT="/openbao/tls/ca.crt"
+          BAO_PATH="kv-v2/bootstrap/openstack/keystone-adminpw-sched/admin"
           BAO_TOKEN=$(kubectl get secret "$BAO_SECRET" -n "$BAO_NS" \
             -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')
           if [ -z "$BAO_TOKEN" ] || [ "$BAO_TOKEN" = "null" ]; then
@@ -262,11 +265,11 @@ spec:
             kubectl exec -n "$BAO_NS" "$BAO_POD" -- \
               env BAO_ADDR="$BAO_ADDR" BAO_TOKEN="$BAO_TOKEN" \
                   VAULT_CACERT="$VAULT_CACERT" \
-              bao kv get -field=password kv-v2/bootstrap/keystone-admin
+              bao kv get -field=password "$BAO_PATH"
           }
           BEFORE_BAO=$(bao_password)
           if [ -z "$BEFORE_BAO" ]; then
-            echo "ERROR: OpenBao bootstrap/keystone-admin has no password value before rotation"
+            echo "ERROR: OpenBao bootstrap/openstack/keystone-adminpw-sched/admin has no password value before rotation"
             exit 1
           fi
           echo "OK: captured pre-rotation OpenBao value"
@@ -310,8 +313,9 @@ spec:
           NEW_HASH=$(printf '%s' "$NEW_PASS" | sha256sum | cut -d' ' -f1)
 
           # The PushSecret mirrors the push-source Secret to OpenBao. Poll until
-          # bootstrap/keystone-admin changes from the seeded initial value —
-          # proves the push-source → PushSecret → OpenBao hop (REQ-007, REQ-014).
+          # bootstrap/openstack/keystone-adminpw-sched/admin changes from the
+          # seeded initial value — proves the push-source → PushSecret → OpenBao
+          # hop (REQ-007, REQ-014).
           AFTER_BAO="$BEFORE_BAO"
           for _ in $(seq 1 60); do
             AFTER_BAO=$(bao_password)
@@ -319,10 +323,10 @@ spec:
             sleep 2
           done
           if [ -z "$AFTER_BAO" ] || [ "$AFTER_BAO" = "$BEFORE_BAO" ]; then
-            echo "ERROR: OpenBao bootstrap/keystone-admin did not change after rotation (PushSecret mirror failed)"
+            echo "ERROR: OpenBao bootstrap/openstack/keystone-adminpw-sched/admin did not change after rotation (PushSecret mirror failed)"
             exit 1
           fi
-          echo "OK: PushSecret mirrored rotated password to OpenBao bootstrap/keystone-admin"
+          echo "OK: PushSecret mirrored rotated password to OpenBao bootstrap/openstack/keystone-adminpw-sched/admin"
 
           # ESO (refreshInterval: 10s) re-reads OpenBao and projects the new value
           # into the admin Secret. Poll until the admin Secret `password` changes
@@ -468,7 +472,8 @@ spec:
           # The operator controller log is the authoritative source for a stuck
           # apply/commit (validateRotationOutput / applyRotationOutput), and the
           # OpenBao log is the authoritative source for a PushSecret 403 against
-          # bootstrap/keystone-admin — neither is captured by the $NAMESPACE pod
+          # bootstrap/openstack/keystone-adminpw-sched/admin — neither is captured
+          # by the $NAMESPACE pod
           # dumps above (CC-0109, CC-0083). The keystone-operator namespace
           # differs between deployment paths: under Flux (CC-0105) it runs in
           # keystone-system, while the CI E2E helm install lands it in

--- a/tests/e2e/keystone/concurrent-cr-conflicts/chainsaw-test.yaml
+++ b/tests/e2e/keystone/concurrent-cr-conflicts/chainsaw-test.yaml
@@ -60,25 +60,41 @@ spec:
           done
           echo "=== Events ==="
           kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
-  # ── Step 3: Assert per-CR OpenBao kv-v2 isolation (CC-0093, REQ-005) ─────
+  # ── Step 3: Assert per-CR OpenBao kv-v2 isolation (CC-0093/REQ-005, CC-0112/REQ-007) ─
   # CC-0093 parameterizes the OpenBao RemoteKey per Keystone CR so that
   # concurrent CRs push their fernet-keys / credential-keys to distinct
-  # kv-v2 paths instead of colliding on a single shared path. This step
-  # exercises that contract end-to-end: after both CRs reach Ready, their
-  # PushSecrets must have synced to the four CR-scoped paths
-  #   kv-v2/openstack/keystone/keystone-concurrent-a/fernet-keys
-  #   kv-v2/openstack/keystone/keystone-concurrent-a/credential-keys
-  #   kv-v2/openstack/keystone/keystone-concurrent-b/fernet-keys
-  #   kv-v2/openstack/keystone/keystone-concurrent-b/credential-keys
+  # kv-v2 paths instead of colliding on a single shared path. CC-0112
+  # (boundary 4, REQ-007) further inserts the Keystone CR's NAMESPACE as a
+  # path segment ahead of the CR name, so the operator RemoteKey is now
+  #   openstack/keystone/{keystone.Namespace}/{keystone.Name}/<material>
+  # (read back through the kv-v2 mount as kv-v2/openstack/keystone/<ns>/<name>/…).
+  # This step exercises that contract end-to-end: after both CRs reach
+  # Ready, their PushSecrets must have synced to the four CR-scoped paths
+  #   kv-v2/openstack/keystone/openstack/keystone-concurrent-a/fernet-keys
+  #   kv-v2/openstack/keystone/openstack/keystone-concurrent-a/credential-keys
+  #   kv-v2/openstack/keystone/openstack/keystone-concurrent-b/fernet-keys
+  #   kv-v2/openstack/keystone/openstack/keystone-concurrent-b/credential-keys
   # proving the RemoteKey templating is actually writing under
-  # <cr-name>/<material>. We additionally assert the legacy flat paths
-  #   kv-v2/openstack/keystone/fernet-keys
-  #   kv-v2/openstack/keystone/credential-keys
-  # do NOT exist. This is a regression guard: if the per-CR RemoteKey
-  # template in the PushSecret is ever reverted to a hard-coded string,
-  # both CRs would race to write the flat paths and silently overwrite
-  # each other's key material. Seeing those paths reappear here fails the
-  # test loudly before the bug ships.
+  # <namespace>/<cr-name>/<material>. We additionally assert these now-absent
+  # paths:
+  #   - the pre-CC-0093 flat paths
+  #       kv-v2/openstack/keystone/fernet-keys
+  #       kv-v2/openstack/keystone/credential-keys
+  #   - the superseded CC-0093 non-namespace per-CR paths
+  #       kv-v2/openstack/keystone/keystone-concurrent-a/fernet-keys
+  #       kv-v2/openstack/keystone/keystone-concurrent-a/credential-keys
+  #       kv-v2/openstack/keystone/keystone-concurrent-b/fernet-keys
+  #       kv-v2/openstack/keystone/keystone-concurrent-b/credential-keys
+  # do NOT exist. This is a regression guard with two failure modes:
+  #   1. A revert of the per-CR RemoteKey template to a hard-coded string
+  #      makes both CRs race to write the flat paths and silently overwrite
+  #      each other's key material (the original CC-0093 hazard).
+  #   2. A revert from the CC-0112 namespace-segmented shape back to the
+  #      CC-0093 non-namespace shape is the exact regression boundary 4 must
+  #      catch; asserting the intermediate non-namespace per-CR paths are
+  #      absent makes the guard precise about which revert occurred.
+  # Seeing any of those superseded paths reappear here fails the test
+  # loudly before the bug ships.
   #
   # PushSecret sync is eventually-consistent; poll every 3 s for up to
   # 60 s (20 iterations) and exit 0 on the first sweep where all four
@@ -119,10 +135,10 @@ spec:
             all_clear=1
             missing=""
             leaked=""
-            for path in "kv-v2/openstack/keystone/keystone-concurrent-a/fernet-keys" \
-                        "kv-v2/openstack/keystone/keystone-concurrent-a/credential-keys" \
-                        "kv-v2/openstack/keystone/keystone-concurrent-b/fernet-keys" \
-                        "kv-v2/openstack/keystone/keystone-concurrent-b/credential-keys"; do
+            for path in "kv-v2/openstack/keystone/openstack/keystone-concurrent-a/fernet-keys" \
+                        "kv-v2/openstack/keystone/openstack/keystone-concurrent-a/credential-keys" \
+                        "kv-v2/openstack/keystone/openstack/keystone-concurrent-b/fernet-keys" \
+                        "kv-v2/openstack/keystone/openstack/keystone-concurrent-b/credential-keys"; do
               echo "=== bao kv get ${path} (expect present) ==="
               out=$(kubectl exec -n "${BAO_NS}" "${POD}" -- \
                 env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" \
@@ -138,8 +154,17 @@ spec:
                 echo "OK: ${path} is present in OpenBao"
               fi
             done
+            # Expect-absent set guards against two regressions (see step header):
+            #   - the pre-CC-0093 flat paths (shared-path collision hazard)
+            #   - the superseded CC-0093 non-namespace per-CR paths, whose
+            #     reappearance means a revert from the CC-0112 namespace-
+            #     segmented shape back to the CC-0093 shape (REQ-007).
             for path in "kv-v2/openstack/keystone/fernet-keys" \
-                        "kv-v2/openstack/keystone/credential-keys"; do
+                        "kv-v2/openstack/keystone/credential-keys" \
+                        "kv-v2/openstack/keystone/keystone-concurrent-a/fernet-keys" \
+                        "kv-v2/openstack/keystone/keystone-concurrent-a/credential-keys" \
+                        "kv-v2/openstack/keystone/keystone-concurrent-b/fernet-keys" \
+                        "kv-v2/openstack/keystone/keystone-concurrent-b/credential-keys"; do
               echo "=== bao kv get ${path} (expect not-found) ==="
               out=$(kubectl exec -n "${BAO_NS}" "${POD}" -- \
                 env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" \
@@ -148,7 +173,7 @@ spec:
               echo "${out}"
               echo "exit=${get_rc}"
               if [ "${get_rc}" -eq 0 ]; then
-                echo "ERROR: ${path} present (legacy flat path leaked — RemoteKey regression)"
+                echo "ERROR: ${path} present (superseded path leaked — RemoteKey regression)"
                 leaked="${leaked} ${path}"
                 all_clear=0
               else
@@ -163,12 +188,12 @@ spec:
 
           # Timeout: name each still-wrong path on stderr so chainsaw's
           # failure surface identifies exactly which kv-v2 path regressed
-          # (CC-0093, REQ-005).
+          # (CC-0093/REQ-005, CC-0112/REQ-007).
           for path in ${missing}; do
             echo "ERROR: ${path} missing after 60s (PushSecret did not sync to per-CR path)" >&2
           done
           for path in ${leaked}; do
-            echo "ERROR: ${path} present after 60s (legacy flat path leaked — RemoteKey regression)" >&2
+            echo "ERROR: ${path} present after 60s (superseded path leaked — RemoteKey regression)" >&2
           done
           exit 1
     catch:

--- a/tests/e2e/keystone/deletion-cleanup/chainsaw-test.yaml
+++ b/tests/e2e/keystone/deletion-cleanup/chainsaw-test.yaml
@@ -203,14 +203,24 @@ spec:
           fi
           echo "OK: No ConfigMap matching keystone-cleanup-config-* found"
   # ── Step 6: Assert OpenBao KV-v2 paths are absent ──────────────────────
-  # REQ-004 (CC-0093): RemoteKey is scoped per Keystone CR as
-  # openstack/keystone/{keystone.Name}/<leaf>, so this step checks the
-  # paths under the keystone-cleanup sub-tree only. Cross-test interference
-  # with other chainsaw suites is no longer structurally possible — each
-  # test's kv-v2 paths live in a disjoint sub-tree.
+  # REQ-004 (CC-0093): RemoteKey is scoped per Keystone CR. REQ-007
+  # (CC-0112, boundary 4) further inserts the Keystone CR's NAMESPACE as a
+  # path segment, so the operator RemoteKey is now
+  # openstack/keystone/{keystone.Namespace}/{keystone.Name}/<leaf>; this step
+  # checks the paths under the openstack/keystone-cleanup sub-tree only.
+  # Cross-test interference with other chainsaw suites is no longer
+  # structurally possible — each test's kv-v2 paths live in a disjoint
+  # sub-tree.
+  #
+  # DECISION: this step is updated under boundary 4 (CC-0112/REQ-007) for
+  # consistency with the operator's actual write path. Before the namespace
+  # segment was added, asserting the non-namespace path returned NotFound;
+  # because the operator never writes that path anymore, the check would be
+  # a vacuous false-positive (NotFound for a path that was never written).
+  # The namespace-segmented path below is the one ESO actually purges.
   #
   # REQ-010 (CC-0079): PushSecret deletion with DeletionPolicy=Delete drives
-  # ESO to purge the remote kv-v2/openstack/keystone/keystone-cleanup/
+  # ESO to purge the remote kv-v2/openstack/keystone/openstack/keystone-cleanup/
   # {fernet-keys,credential-keys} paths. PushSecret NotFound alone does not
   # guarantee the remote purge succeeded, so this step execs bao-cli inside
   # the openbao-0 pod and asserts both paths return a non-zero exit (path
@@ -259,8 +269,8 @@ spec:
           while [ "$(date +%s)" -lt "${deadline}" ]; do
             all_clear=1
             still_present=""
-            for path in "kv-v2/openstack/keystone/keystone-cleanup/fernet-keys" \
-                        "kv-v2/openstack/keystone/keystone-cleanup/credential-keys"; do
+            for path in "kv-v2/openstack/keystone/openstack/keystone-cleanup/fernet-keys" \
+                        "kv-v2/openstack/keystone/openstack/keystone-cleanup/credential-keys"; do
               echo "=== bao kv get ${path} (expect not-found) ==="
               out=$(kubectl exec -n "${BAO_NS}" "${POD}" -- \
                 env BAO_ADDR="${BAO_ADDR}" BAO_TOKEN="${BAO_TOKEN}" \

--- a/tests/e2e/keystone/missing-secret/01-late-secrets.yaml
+++ b/tests/e2e/keystone/missing-secret/01-late-secrets.yaml
@@ -45,5 +45,10 @@ spec:
   data:
   - secretKey: password
     remoteRef:
-      key: bootstrap/keystone-admin
+      # Per-CR admin-password path the deploy-infra seed writes (CC-0112):
+      # bootstrap/{namespace}/{keystone}/admin for ControlPlane "controlplane"
+      # in namespace "openstack". The legacy flat bootstrap/keystone-admin path
+      # is no longer seeded. Read-only here — this fixture only needs a valid
+      # admin password to drive its own CR's recovery to Ready=True.
+      key: bootstrap/openstack/controlplane-keystone/admin
       property: password

--- a/tests/e2e/keystone/pod-security-restricted/00-namespace.yaml
+++ b/tests/e2e/keystone/pod-security-restricted/00-namespace.yaml
@@ -17,12 +17,15 @@
 # Secrets — even with all required keys — leave the CR stuck at
 # SecretsReady=False/WaitingForDBCredentials and never reach Ready=True. The
 # ExternalSecrets pull from the same OpenBao paths the in-cluster
-# `openstack` namespace uses (`bootstrap/keystone-admin` and
-# `openstack/keystone/db`), reusing the canonical `keystone` MariaDB user
-# that brownfield-database (tests/e2e/keystone/brownfield-database) also
-# uses; the `eso-management` policy
-# (deploy/openbao/policies/eso-management.hcl) already grants read access to
-# both paths, so no new OpenBao policy work is required.
+# `openstack` namespace uses: the per-CR admin password at
+# `bootstrap/openstack/controlplane-keystone/admin` (the CC-0112 per-CR path the
+# deploy-infra seed writes; the legacy flat `bootstrap/keystone-admin` is no
+# longer seeded) and the canonical `keystone` MariaDB user at
+# `openstack/keystone/db` that brownfield-database
+# (tests/e2e/keystone/brownfield-database) also uses; the `eso-management` policy
+# (deploy/openbao/policies/eso-management.hcl) grants read access to both paths
+# via its `kv-v2/data/bootstrap/*` and `kv-v2/data/openstack/keystone/*`
+# wildcards, so no new OpenBao policy work is required.
 ---
 apiVersion: v1
 kind: Namespace
@@ -48,7 +51,7 @@ spec:
   data:
   - secretKey: password
     remoteRef:
-      key: bootstrap/keystone-admin
+      key: bootstrap/openstack/controlplane-keystone/admin
       property: password
 ---
 apiVersion: external-secrets.io/v1

--- a/tests/e2e/keystone/pod-security-restricted/chainsaw-test.yaml
+++ b/tests/e2e/keystone/pod-security-restricted/chainsaw-test.yaml
@@ -36,9 +36,11 @@
 #     operators/keystone/internal/controller/reconcile_secrets.go, so
 #     a plain Secret with all required keys still leaves the CR stuck at
 #     SecretsReady=False/WaitingForDBCredentials. The ExternalSecrets pull
-#     from the same OpenBao paths (`bootstrap/keystone-admin`,
-#     `openstack/keystone/db`) the cluster's `openstack` namespace already
-#     uses; the `eso-management` policy
+#     from the same OpenBao paths the cluster's `openstack` namespace already
+#     uses: the per-CR admin password at
+#     `bootstrap/openstack/controlplane-keystone/admin` (CC-0112; the legacy
+#     flat `bootstrap/keystone-admin` is no longer seeded) and the keystone DB
+#     credentials at `openstack/keystone/db`; the `eso-management` policy
 #     (deploy/openbao/policies/eso-management.hcl) covers both paths so no
 #     new OpenBao policy work is required (REQ-003).
 #


### PR DESCRIPTION
# GitHub Issue #414: feat(c5c3-operator): make the admin/K-ORC credential path multi-instance safe (per-ControlPlane OpenBao scoping)

**Description:**

`c5c3-operator` already projects N `ControlPlane` CRs into N namespaces in a way that *creates* them all without name collisions. The Helm chart watches cluster-wide by default (`operators/c5c3/helm/c5c3-operator/values.yaml:24` — `rbac.namespaceScoped: false`) and `bootstrap.Run` leaves `cache.Options.DefaultNamespaces` unset (`internal/common/bootstrap/manager.go:68–78`) so every namespace's `ControlPlane` is reconciled. `childNamespace(cp) = cp.Namespace` (`operators/c5c3/internal/controller/reconcile_infrastructure.go:43–45`) projects every child (`MariaDB`, `Memcached`, `Keystone`, K-ORC `ApplicationCredential`/`User`/`Domain`/`Service`/`Endpoint`, the operator-owned admin Secret and the backup `PushSecret`) into the owning ControlPlane's namespace, and every name is `cp.Name`-prefixed (`adminAppCredentialName`, `adminPasswordCloudSecretName`, `adminAppCredentialSecretName`, `keystoneServiceName`, `keystoneEndpointName`, `adminDomainRef` — all in `reconcile_korc.go:97–113`, `1219–1225`, `683–685`).

The collision is purely on the **remote** identifiers: OpenBao is a single cluster-global backend reached via one `ClusterSecretStore` (`openbao-cluster-store`, `reconcile_korc.go:42`), and four objects on that backend are *not* parameterised per CR.

### Concrete boundaries (already exists ↔ this issue adds)

1. **Admin AC OpenBao path — hardcoded across consumers.**
   - *Exists:* `const adminAppCredentialRemoteKey = "openstack/keystone/admin/app-credential"` (`operators/c5c3/internal/controller/reconcile_korc.go:58`), used by `adminAppCredentialPushSecret` at `reconcile_korc.go:1086`. The matching consumer reads the same key in *both* the control-plane namespace and `orc-system`: `deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml:49,69`. The OpenBao ACL grants this literal leaf and only this leaf — `deploy/openbao/policies/push-app-credentials.hcl:34,38`. The bootstrap seed writes this exact path in `deploy/openbao/bootstrap/write-bootstrap-secrets.sh:131,214`.
   - *Issue adds:* a builder `adminAppCredentialRemoteKeyFor(cp *ControlPlane) string` returning `openstack/keystone/<cp.Namespace>/<cp.Name>/admin/app-credential`. Replace the constant at every write call site (the c5c3 PushSecret builder) and at every read consumer (the operator-owned `k-orc-clouds-yaml` ExternalSecret(s) — see boundary 7). Broaden the policy from one literal leaf to one `+`/`+` two-segment template that *still* excludes the read-only `db` and `+/fernet-keys`/`+/credential-keys` shapes already granted by `push-keystone-keys.hcl`.

2. **Admin-password OpenBao path — hardcoded in `keystone-operator`.**
   - *Exists:* `RemoteKey: "bootstrap/keystone-admin"` (`operators/keystone/internal/controller/reconcile_passwordrotation.go:603`), with the same single-CR assumption documented on the type (`operators/keystone/api/v1alpha1/keystone_types.go:403–407` — *"Model B assumes a single Model-B-enabled Keystone CR per cluster"*) and reiterated in the policy header (`deploy/openbao/policies/push-keystone-admin.hcl:18–29`). The consumer `ExternalSecret` reads this same flat key (`deploy/eso/externalsecrets/keystone-admin.yaml:27`). The bootstrap seed writes it at `write-bootstrap-secrets.sh:192`.
   - *Issue adds:* a builder that returns `bootstrap/<keystone.Namespace>/<keystone.Name>/admin` (or `…/<keystone.Name>/admin`). Repoint the consumer to the matching per-CR key and migrate the bootstrap seed (boundaries 5, 6, 7).

3. **K-ORC `User` import name not CR-scoped.**
   - *Exists:* `adminUserRef(cp)` returns `cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName` (`reconcile_korc.go:666–671`), default `"admin"`. The sibling helper `adminDomainRef` *does* return `cp.Name + "-domain-default"` (`reconcile_korc.go:683–685`), so the inconsistency is local to the `User` import. Two `ControlPlane` CRs in the *same* namespace would `CreateOrUpdate` the same `User` object via `ensureKORCAdminImports` at `reconcile_korc.go:708–723`, flapping `ownerReferences` and spec.
   - *Issue adds:* prefix the import CR's `metadata.name` with `cp.Name` (e.g. `cp.Name + "-user-admin"`), mirroring `adminDomainRef`. Keep `User.Spec.Import.Filter.Name = openstack name "admin"` so the underlying OpenStack user resolved by K-ORC is unchanged — only the Kubernetes object name changes.

4. **Per-CR fernet/credential paths still collide across namespaces on identical CR names.**
   - *Exists:* CC-0093 already moved fernet/credential PushSecrets to `openstack/keystone/{keystone.Name}/{fernet,credential}-keys` (`operators/keystone/internal/controller/reconcile_fernet.go:455`, `reconcile_credential.go:459`) and the policy to the `+` single-segment template `kv-v2/data/openstack/keystone/+/{fernet,credential}-keys` (`deploy/openbao/policies/push-keystone-keys.hcl:73–85`). Two `Keystone` CRs with identical names in different namespaces still resolve to the same OpenBao leaf.
   - *Issue adds:* a per-CR-name **and** per-namespace segment. Decide explicitly: either add a `{keystone.Namespace}` segment (`openstack/keystone/<ns>/<name>/{fernet,credential}-keys`) — robust to name collisions, requires broadening the policy template to `kv-v2/data/openstack/keystone/+/+/{fernet,credential}-keys` — or enforce CR-name uniqueness via the admission guard from boundary 8 so the existing `+` template stays valid. Pick one and record it as a Decision in the source.

5. **Bootstrap seed is single-tenant.**
   - *Exists:* `seed_korc_bootstrap_clouds_yaml()` at `deploy/openbao/bootstrap/write-bootstrap-secrets.sh:130–182` writes exactly one `kv-v2/openstack/keystone/admin/app-credential`. `main()` (`write-bootstrap-secrets.sh:187–217`) seeds exactly one `kv-v2/bootstrap/keystone-admin`. Both paths are then `mark_eso_managed` so ESO can adopt them.
   - *Issue adds:* either (a) make the bootstrap script accept a list of ControlPlane identities (e.g. `KORC_CONTROLPLANES="openstack/controlplane-keystone openstack/controlplane-staging"`) and seed one per-CR path per identity, or (b) move the seed responsibility into the c5c3-operator itself so the first reconcile pass writes the per-CR seed. Option (b) is the natural endpoint when combined with the operator-owned `k-orc-clouds-yaml` ExternalSecret called out in #412 / boundary 7; (a) is the lower-risk interim option that keeps the cluster-bootstrap path unchanged. Pick one explicitly.

6. **No admission guard on `ControlPlane` count per namespace.**
   - *Exists:* `ControlPlaneWebhook.validate()` at `operators/c5c3/api/v1alpha1/controlplane_webhook.go:123–193` enforces release-pattern, database XOR, cache XOR, password-secret-ref required, rotation-interval admissibility — but does *not* count existing CRs in the namespace. The only signal today is `CredentialRotationReconciler.resolveControlPlane` returning Reason `"AmbiguousControlPlane"` (`reconcile_credentialrotation.go:202–230`, documented at `docs/reference/c5c3/controlplane-reconciler.md:589–610`) *after* the clobber has already happened.
   - *Issue adds:* a Decision and the corresponding implementation: either (a) enforce one `ControlPlane` per namespace in `ControlPlaneWebhook.ValidateCreate` (using the injected `Client` to list `ControlPlanes` in the request namespace), and matching the CredentialRotation contract by then dropping the `AmbiguousControlPlane` branch; or (b) make the cluster genuinely multi-instance (boundaries 1–5 already on this issue) and replace the `resolveControlPlane` ambiguity check with a `ControlPlaneRef` field on `CredentialRotation`. Note that path (b) is a CRD schema addition. The issue's title and "multi-instance safe" framing implies (b); (a) is the minimal-change option if multi-instance per namespace is rejected.

7. **K-ORC `clouds.yaml` ExternalSecret is statically named and not per-CR.**
   - *Exists:* `deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml` defines two static `ExternalSecret`s, both named `k-orc-clouds-yaml`, one in `openstack` and one in `orc-system`, both reading the fixed key `openstack/keystone/admin/app-credential`. `reconcileAdminCredential` gates on `secrets.WaitForExternalSecret(childNamespace(cp)/CloudCredentialsRef.SecretName)` (`reconcile_korc.go:880–902`) — `CloudCredentialsRef.SecretName` defaults to `"k-orc-clouds-yaml"` via the CRD default and the webhook (`controlplane_webhook.go:32–33,80–83`).
   - *Issue adds:* the operator owns and templates this ExternalSecret per `ControlPlane` (one per CR in `childNamespace(cp)`, name = `CloudCredentialsRef.SecretName`, key = the per-CR OpenBao path from boundary 1). The `orc-system` global copy is either removed (the AdminCredentialReady gate is already against the CP-namespace ExternalSecret) or also operator-owned and made per-CR. This is the work #412 covers; #414 cannot move the OpenBao path without it because the static `key:` would otherwise drift from the writer.

8. **Existing single-tenant data needs a migration plan.**
   - *Exists:* clusters that already ran the operator hold one `openstack/keystone/admin/app-credential` and one `bootstrap/keystone-admin` object. Pre-existing fernet/credential PushSecrets at `openstack/keystone/{name}/{fernet,credential}-keys` are already per-CR (CC-0093).
   - *Issue adds:* a written one-time migration step (operator runbook): for each ControlPlane, copy the legacy values into the new per-CR paths before bringing the new operator up, then orphan the legacy leaves (the operator does not write them). Boundary 4's decision also implies, in the namespace-segment variant, a one-time copy of fernet/credential leaves into the namespace-prefixed shape.

9. **What this issue does NOT touch.**
   - The K-ORC `Service`/`Endpoint`/`Domain`/`ApplicationCredential` CRs themselves: they already embed `cp.Name` and live in `childNamespace(cp)`. The admin password Secret (`PasswordSecretRef`) and the cleartext-cloudsyaml `<cp.Name>-admin-password-cloud` Secret (`reconcile_korc.go:101–105,216–234`): they are already per-CR. The K-ORC `cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName` value: defaulted today, kept defaulted but documented as the per-CR ExternalSecret name once boundary 7 lands.

**Motivation:**

The current behaviour already provisions N `ControlPlane` CRs in N namespaces without any in-cluster name clash — the operator's own owner-reference and `cp.Name` prefixing discipline is sound. What breaks at *operate* time is purely the four OpenBao identifiers in boundaries 1, 2, 3, and 4: the last writer wins, K-ORC then authenticates with the wrong namespace's credential, and `CredentialRotation` only flags the situation under reason `AmbiguousControlPlane` *after* the clobber. The shape of the bug (the operator advertises namespace-scoped projection but the backing store is cluster-flat) is the same class of issue as CC-0093, which already proved out the per-CR path layout, the `+`-glob policy template, and the migration-note discipline for the fernet/credential leaves; this issue extends the same pattern to the admin AC and admin password.

Closing #414 unblocks two follow-on goals: (a) running a staging and a production `ControlPlane` side-by-side in two namespaces on a single cluster — the documented test setup of `tests/e2e/c5c3/full-controlplane-keystone/` only has one — and (b) the namespace-isolation story the CC-0110 reconciler-reference doc already frames around C1 (`docs/reference/c5c3/controlplane-reconciler.md:507,519`). #412 (operator-owned `k-orc-clouds-yaml` ExternalSecret) is the tightest coupling: that issue cannot land without this one (the read key has to match the per-CR write), and this issue cannot fully land without that one (a per-CR write path with no matching per-CR reader is dead work). They should ship together, with the OpenBao paths and User name landing here and the ExternalSecret templating landing under #412.

The work also pays back debt elsewhere: every "single Model-B-enabled Keystone CR per cluster" sentence in the source (`reconcile_passwordrotation.go:571–574`, `keystone_types.go:403–407`) and policy headers (`push-keystone-admin.hcl:18–29`, `push-app-credentials.hcl:14–22`) becomes deletable.

**Affected Areas:**

- operators/c5c3/internal/controller/reconcile_korc.go (replace the adminAppCredentialRemoteKey constant at line 58 with a builder taking *c5c3v1alpha1.ControlPlane; thread it through adminAppCredentialPushSecret at line 1066–1092; rename adminUserRef at line 666–671 to return cp.Name + "-user-admin" while keeping the OpenStack-name filter inside ensureKORCAdminImports unchanged; reconcileAdminCredential at 854–1045 keeps reading the per-CR ExternalSecret name from CloudCredentialsRef.SecretName)
- operators/c5c3/internal/controller/reconcile_korc_test.go (update every assertion pinning the literal openstack/keystone/admin/app-credential at lines 81, 220, 373, 389, 696, 720, 878, 1012, 1083 and expectations on adminUserRef results to the per-CR builder)
- operators/c5c3/internal/controller/integration_test.go (adjust envtest scenarios to bring up two ControlPlanes; today only one is exercised)
- operators/c5c3/api/v1alpha1/controlplane_webhook.go (Decision-dependent: either add the one-per-namespace admission check using the injected Client at lines 47–49, or leave the webhook untouched per the boundary 6 Decision (b) path)
- operators/c5c3/api/v1alpha1/credentialrotation_types.go (Decision-dependent: if multi-instance per namespace is chosen, add a ControlPlaneRef *corev1.LocalObjectReference to CredentialRotationSpec and document the AmbiguousControlPlane deprecation)
- operators/c5c3/internal/controller/reconcile_credentialrotation.go (keep the resolveControlPlane indirection but switch the body to either "exactly one allowed by admission, never see >1" or "use the explicit ControlPlaneRef")
- operators/c5c3/api/v1alpha1/controlplane_types.go, operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml, operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml (regenerate via make manifests/make sync-crds if the CRD surface changes per boundary 6 path b)
- operators/keystone/internal/controller/reconcile_passwordrotation.go (replace the hardcoded RemoteKey: "bootstrap/keystone-admin" at line 603 with a per-CR builder such as fmt.Sprintf("bootstrap/%s/%s/admin", keystone.Namespace, keystone.Name); update the type comment on PasswordRotationSpec at keystone_types.go:403–407 to drop the single-CR assumption)
- operators/keystone/internal/controller/reconcile_passwordrotation_test.go (update adminPasswordPushSecret test assertions on RemoteKey)
- operators/keystone/internal/controller/reconcile_fernet.go and reconcile_credential.go (Decision-dependent on boundary 4: if the namespace-segment variant is chosen, broaden the RemoteKey builder to include keystone.Namespace)
- operators/keystone/internal/controller/reconcile_fernet_test.go, reconcile_credential_test.go, integration_test.go (matching test updates per the boundary 4 Decision)
- deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml (eliminated or templated by #412; the c5c3 PushSecret writer in this issue and the ExternalSecret reader in #412 must agree on the per-CR key:)
- deploy/eso/externalsecrets/keystone-admin.yaml (eliminated or templated to match the per-CR bootstrap/<ns>/<name>/admin key; if left static, this issue is incomplete)
- deploy/openbao/policies/push-app-credentials.hcl (replace lines 34–40 with a +/+ two-segment template covering kv-v2/{data,metadata}/openstack/keystone/+/+/admin/app-credential; keep the data-only-vs-metadata rationale block)
- deploy/openbao/policies/push-keystone-admin.hcl (replace the two literal leaves at lines 54–60 with kv-v2/{data,metadata}/bootstrap/+/+/admin; rewrite the policy header at lines 18–29 to drop the single-CR justification and document the new two-segment-glob semantics)
- deploy/openbao/policies/push-keystone-keys.hcl (boundary 4 path-dependent: if the namespace-segment variant is chosen, update from kv-v2/data/openstack/keystone/+/{fernet,credential}-keys to kv-v2/data/openstack/keystone/+/+/{fernet,credential}-keys and update the comment on /db exclusion)
- deploy/openbao/policies/eso-management.hcl (verify the trailing wildcard kv-v2/data/openstack/keystone/* at line 34 still covers the new shape for the read side; widen if needed)
- deploy/openbao/bootstrap/write-bootstrap-secrets.sh (boundary 5 path-dependent: if the bootstrap remains responsible for seeding, take a list of <namespace>/<name> ControlPlane identities as env var or CLI and loop the seed + mark_eso_managed calls; update seed_korc_bootstrap_clouds_yaml() at lines 130–182 and main() at lines 187–217 accordingly)
- deploy/kind/controlplane/controlplane.yaml (confirm the example matches the new naming convention; surface that the kind dev cluster still ships one ControlPlane by default)
- tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml (update sub-asserts if the literal openstack/keystone/admin/app-credential path appears, since assertions reference it indirectly through the k-orc-clouds-yaml Secret name)
- tests/e2e/c5c3/multi-controlplane/ (new sibling test directory exercising two ControlPlane CRs in tenant-a and tenant-b namespaces in parallel; covers both CRs reaching Ready=True simultaneously, killing AC-A not disturbing CP-B, and kubectl describe controlplane showing distinct status.adminApplicationCredential.id)
- docs/reference/c5c3/controlplane-reconciler.md (update lines 507, 519, 529, 641 to reference the per-CR remote key; replace the AmbiguousControlPlane row at line 609 per the boundary 6 decision; add a "Multi-instance" section explaining the per-CR path layout, the one-per-namespace contract or its removal, and the migration note)
- docs/reference/c5c3/controlplane-crd.md (update the CloudCredentialsRef.SecretName default doc if anything changes; record the per-CR layout under a Status / Multi-instance section)
- docs/reference/keystone/keystone-reconciler.md (update the admin password rotation PushSecret table at lines 2728–2744 and remove the "single-CR assumption, boundary 8" caveat)
- docs/reference/infrastructure/infrastructure-manifests.md (update lines 687, 699, 704–705 to describe the per-CR template)
- architecture/docs/09-implementation/* (git submodule per .gitmodules; record the architecture-level change as a separate upstream PR — do not modify from this worktree, matching the discipline used in CC-0093 REQ-008)

**Acceptance Criteria:**

- [ ] adminAppCredentialRemoteKey is no longer a package-level constant; in its place a builder adminAppCredentialRemoteKeyFor(cp) returns a path that contains both cp.Namespace and cp.Name as path segments, and every write (the c5c3 PushSecret builder) plus every documented read (the per-CR ExternalSecret materialised by #412) targets it.
- [ ] The keystone-operator's adminPasswordPushSecret RemoteKey is computed per-CR (contains both keystone.Namespace and keystone.Name segments) and the matching ExternalSecret (deploy/eso/externalsecrets/keystone-admin.yaml or its replacement) reads the same key.
- [ ] ensureKORCAdminImports creates a K-ORC User whose Kubernetes metadata.name is cp.Name + "-user-admin" (or equivalent prefix) so two ControlPlanes in the same namespace produce two distinct User objects; the inner Spec.Import.Filter.Name still resolves to OpenStack user admin so the K-ORC import behaviour is unchanged.
- [ ] Boundary 4 is resolved by a documented Decision: either (a) the fernet/credential keys' RemoteKey includes a keystone.Namespace segment and the policy template adopts +/+/{fernet,credential}-keys; or (b) the admission guard from boundary 6 enforces CR-name uniqueness cluster-wide for Keystone CRs. The Decision is recorded as a comment block at the call site (reconcile_fernet.go:455, reconcile_credential.go:459).
- [ ] Boundary 6 is resolved by a documented Decision and matching implementation: either (a) ControlPlaneWebhook.ValidateCreate rejects a ControlPlane when another exists in the same namespace, AND CredentialRotationReconciler keeps AmbiguousControlPlane purely as a defense-in-depth fallback; or (b) CredentialRotationSpec carries an explicit ControlPlaneRef and the AmbiguousControlPlane branch is removed from resolveControlPlane and from the reconciler docs.
- [ ] deploy/openbao/policies/push-app-credentials.hcl and deploy/openbao/policies/push-keystone-admin.hcl grant create/update/read/delete on data-and-metadata paths matching the per-CR templates, still deny anything outside those templates, and carry rationale comments referencing this issue's ID.
- [ ] deploy/openbao/bootstrap/write-bootstrap-secrets.sh either accepts and iterates a list of ControlPlane identities (option a on boundary 5) or has its seed responsibility removed in favour of operator-owned seeding (option b). The script does not silently keep seeding the legacy flat paths on a multi-CR cluster.
- [ ] An E2E suite under tests/e2e/c5c3/multi-controlplane/ (or equivalent) brings up two ControlPlane CRs in two namespaces in the same kind cluster, asserts both reach Ready=True simultaneously with distinct status.adminApplicationCredential.id, rotates the admin AC of one CR via CredentialRotation, and asserts the other CR's AC is unaffected (status.adminApplicationCredential.lastRotation unchanged, AC Available=True throughout).
- [ ] Existing tests/e2e/c5c3/full-controlplane-keystone/ chainsaw test still passes against the per-CR path layout — i.e. the new write/read agreement does not regress the single-CR happy path.
- [ ] docs/reference/c5c3/controlplane-reconciler.md, controlplane-crd.md, docs/reference/keystone/keystone-reconciler.md, and docs/reference/infrastructure/infrastructure-manifests.md describe the per-CR path layout and the multi-instance contract; the "one Model-B-enabled Keystone CR per cluster" and "single admin AC per cluster" wording in source code comments and the policy file headers is removed.
- [ ] A MIGRATION.md (or a "Migration" section in the controlplane-reconciler doc) describes the one-time copy of kv-v2/openstack/keystone/admin/app-credential and kv-v2/bootstrap/keystone-admin (and, on path-(a) of boundary 4, the fernet/credential leaves) into the per-CR layout, including the bao kv put/bao kv list commands and the order with respect to the operator upgrade.

**Non-Goals:**

- Implementing the scheduled rotation loop on CredentialRotation (intervalDays, preRotationDays, gracePeriodDays) — it remains "read-but-ignored" per reconcile_credentialrotation.go:96–110 and credentialrotation_types.go:67–95, out of scope for the multi-instance safety work.
- Adding multi-cluster (Cluster.multitenant style) tenancy — the change is per-namespace within a single cluster, not cross-cluster.
- Re-architecting the cluster-global openbao-cluster-store — the ClusterSecretStore stays cluster-scoped because it has to reach OpenBao from every namespace; only the paths underneath become per-CR.
- Changing the K-ORC CloudCredentialsRef.SecretName default (controlplane_webhook.go:33) or the cloudName default — they continue to default to "k-orc-clouds-yaml" / "admin" so a single-CR cluster's manifests are untouched.
- Modifying the architecture/ submodule from this worktree — architecture-doc updates ship as a separate upstream PR, matching CC-0093 REQ-008 discipline.
- Backfilling per-CR data on the live OpenBao backend automatically — the one-time migration is operator-driven via bao kv put per the migration note; the operator does not read or copy the legacy paths.

**References:**

- operators/c5c3/internal/controller/reconcile_korc.go (admin AC path constant, push-secret builder, User import name)
- operators/c5c3/internal/controller/reconcile_credentialrotation.go (one-per-namespace contract and AmbiguousControlPlane)
- operators/c5c3/internal/controller/controlplane_controller.go (sub-reconciler ordering, cp.Namespace projection model)
- operators/c5c3/internal/controller/reconcile_infrastructure.go:43–45 (childNamespace(cp) = cp.Namespace)
- operators/c5c3/api/v1alpha1/controlplane_webhook.go (defaulting + validation; injected Client)
- operators/c5c3/api/v1alpha1/controlplane_types.go, credentialrotation_types.go
- operators/keystone/internal/controller/reconcile_passwordrotation.go:571–610 (bootstrap/keystone-admin hardcoded)
- operators/keystone/internal/controller/reconcile_fernet.go:455, reconcile_credential.go:459 (existing per-CR pattern from CC-0093)
- deploy/openbao/bootstrap/write-bootstrap-secrets.sh:130–182,187–217
- deploy/eso/externalsecrets/k-orc-clouds-yaml.yaml, keystone-admin.yaml, keystone-db.yaml
- deploy/openbao/policies/push-app-credentials.hcl, push-keystone-admin.hcl, push-keystone-keys.hcl, eso-management.hcl
- internal/common/bootstrap/manager.go:63–78,113–134 (DefaultNamespaces cache scoping)
- tests/e2e/c5c3/full-controlplane-keystone/ (single-CR happy path)
- tests/e2e/keystone/concurrent-cr-conflicts/ (existing pattern for two CRs in one namespace; mirror for two namespaces)
- docs/reference/c5c3/controlplane-reconciler.md (sections reconcileAdminCredential, CredentialRotation reconciler, K-ORC admin credential chain)
- docs/reference/keystone/keystone-reconciler.md:2720–2766 (Model B PushSecret table)
- docs/reference/infrastructure/infrastructure-manifests.md:687–705 (push-app-credentials policy doc)
- Related issue CC-0093 (per-CR RemoteKey for fernet/credential keys; same template-glob pattern this issue extends) — .planwerk/completed/CC-0093-parameterize-openbao-remotekey-per-keystone-cr.json
- Related issue CC-0110 (introduces ControlPlane, reconcileKORC, reconcileAdminCredential) — .planwerk/completed/CC-0110-implement-c5c3-operator-controlplane-for-keystone.json
- Related issue CC-0109 (Model B admin-password rotation, owner of bootstrap/keystone-admin writer) — .planwerk/completed/CC-0109-schedule-keystone-admin-password-rotation-via.json
- Related issue #412 (operator-owned k-orc-clouds-yaml ExternalSecret) — lands together with this for the k-orc-clouds-yaml half
- Review patterns drawn on: Hardcoded sub-resource names prevent multi-instance support, Centralize duplicated status condition strings, Apply security mitigations consistently across all files, Cross-reference access policies against all consumers, Enforce least-privilege on wildcard access paths, Verify migration notes cover brownfield upgrade paths

---

_Elaborated by [planwerk-review](https://github.com/planwerk/planwerk-review) with Claude Code_


**Labels:** enhancement

---
Source: https://github.com/C5C3/forge/issues/414