### PR TITLE
docs: fix frontmatter rendering broken by leading SPDX header

### DIFF
--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -1,7 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
-SPDX-License-Identifier: Apache-2.0
--->
 ---
 title: Enable Keystone Database TLS/mTLS
 quadrant: operator

--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -1,7 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
-SPDX-License-Identifier: Apache-2.0
--->
 ---
 title: Enable the Keystone Operator Metrics Endpoint
 quadrant: operator

--- a/docs/reference/keystone-operator-metrics.md
+++ b/docs/reference/keystone-operator-metrics.md
@@ -1,7 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
-SPDX-License-Identifier: Apache-2.0
--->
 ---
 title: Keystone Operator Prometheus Metrics
 quadrant: operator


### PR DESCRIPTION
## Summary

VitePress only parses YAML frontmatter when it starts on line 1. An inline SPDX
`<!-- ... -->` comment above the `---` block pushed the frontmatter off line 1, so
`title:` and `quadrant:` rendered as literal body text at the top of the published
page.

Remove the inline SPDX header from the three affected docs so the frontmatter sits
on line 1, matching the other frontmatter docs in the tree. The `docs/` tree carries
no `REUSE.toml` and no `reuse lint` step, so these inline headers were unenforced as
well as breaking the render.

Affected:
- `guides/enable-keystone-operator-metrics.md`
- `guides/enable-keystone-database-tls.md`
- `reference/keystone-operator-metrics.md`

## Verification

- `vitepress build` clean — dead-link checking is on, so every cross-link and anchor resolves.

Split out of #425 so the rendering fix is reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
