### PR TITLE
ci: serialize e2e pipeline so tempest runs after all E2E jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -837,8 +837,11 @@ jobs:
   # the run-chaos PR label is applied), and only after all pre-flight checks
   # have passed or been skipped.
   #
-  # CC-0049, REQ-006: timeout reduced to 45m and e2e-operator dependency
-  # removed so e2e-chaos runs in parallel with e2e-operator.
+  # Chaos tests run only after every e2e-operator matrix leg has finished
+  # without failure: a failed e2e-operator run skips e2e-chaos, a
+  # path-filter-skipped one does not block it (always() + the
+  # failure/cancelled guards below). This supersedes CC-0049 REQ-006,
+  # which had removed the dependency to run both jobs in parallel.
   #
   # CC-0049, REQ-007: run-chaos PR label trigger added for on-demand chaos
   # validation of operator code changes.
@@ -848,7 +851,7 @@ jobs:
   # runs to consider making this job blocking and adding it to publish
   # dependencies.
   e2e-chaos:
-    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
+    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images, e2e-operator]
     # always(): allow the job to run when upstream Go jobs are skipped
     # (e.g. pure E2E test-definition PRs where go=false). The explicit
     # failure/cancelled guard still blocks if any upstream actually failed.
@@ -1044,8 +1047,14 @@ jobs:
   # suite against them.  Currently tests Keystone; designed so additional
   # services can be added to this single job without needing separate runs.
   # CC-0051: Matrix over OpenStack releases to validate each release independently.
+  #
+  # Runs only after every E2E job has finished without failure: a failed
+  # E2E job skips tempest, a path-filter-skipped one does not block it
+  # (always() + the failure/cancelled guards below). e2e-chaos is
+  # continue-on-error, so its result is always 'success' — it merely delays
+  # tempest until it finishes, it cannot block it.
   tempest:
-    needs: [changes, build-e2e-images]
+    needs: [changes, build-e2e-images, e2e-infra, e2e-operator, e2e-chaos, e2e-prometheus]
     if: |
       always() &&
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary

- Gate the `tempest` job on every E2E job (`e2e-infra`, `e2e-operator`, `e2e-chaos`, `e2e-prometheus`) so Tempest API tests only run once the whole E2E suite has finished without failure.
- Gate `e2e-chaos` on `e2e-operator`, superseding the earlier CC-0049 REQ-006 parallelization of the two jobs.

The resulting order is `e2e-operator` → `e2e-chaos` → `tempest`, with `tempest` additionally waiting for `e2e-infra` and `e2e-prometheus`.

## Behavior details

- The existing `always()` + `!contains(needs.*.result, 'failure'/'cancelled')` guards cover the new dependencies: a failed E2E job skips the dependents, while a path-filter-skipped one (e.g. `e2e-infra` on a PR without infrastructure changes, or `e2e-operator` on a pure `tests/e2e-chaos/` PR) does not block them.
- `e2e-operator` runs with `fail-fast: false`, so a single failed matrix leg already reports `failure` and blocks `e2e-chaos` and `tempest`.
- `e2e-chaos` is still `continue-on-error: true` (CC-0054), so its result cannot block `tempest` yet — it only delays it until the chaos suites finish. Once chaos becomes blocking, the gate applies automatically.

## Trade-off

PR CI wall-clock time increases: `tempest` previously ran in parallel with the E2E jobs and now waits for the slowest one. This is the intended cost of serializing the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)