### PR TITLE
fix(common): default zap logging to production mode

### DIFF
--- a/docs/reference/backend/helm-values-schema.md
+++ b/docs/reference/backend/helm-values-schema.md
@@ -105,6 +105,21 @@ for the privilege-escalation path this closes. The default stays `false` because
 | --- | --- | --- | --- |
 | `metrics.port` | `integer` | minimum: `1`, maximum: `65535` | `8080` |
 
+### logging
+
+The operator runs the controller-runtime zap logger in the production profile by
+default (`development: false`): JSON encoder, info-level verbosity, and stack traces
+only at error level. Override these for human-readable console output during local
+development. Each value maps to a controller-runtime `--zap-*` flag and is omitted
+from the operator args when left at its default, so the production profile is the
+behaviour unless a field is set explicitly.
+
+| Field | Type | Constraint | Default |
+| --- | --- | --- | --- |
+| `logging.development` | `boolean` | — | `false` |
+| `logging.level` | `string` | pattern: `debug`, `info`, `error`, `panic`, or a positive integer (empty allowed) | `""` |
+| `logging.encoder` | `string` | enum: `json`, `console` (empty allowed) | `""` |
+
 ### serviceAccount
 
 | Field | Type | Constraint | Default |
@@ -166,6 +181,7 @@ Schema validation is tested with helm-unittest in
 | Invalid quantities | `resources.limits.cpu: "not-valid"` |
 | Exponent+suffix | `cpu: "1e3m"`, `memory: "1e3Ki"` |
 | Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=true` |
+| Logging constraints | `logging.development: "yes"`, `logging.encoder: "xml"`, `logging.level: "verbose"` |
 
 ### Positive Tests (acceptance)
 
@@ -177,3 +193,4 @@ Schema validation is tested with helm-unittest in
 | Numeric resource quantities | `cpu: 0.5` |
 | Exponent-only quantities | `cpu: "1e3"` |
 | Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=false` |
+| Logging overrides | `development: true`, `level: debug`, `encoder: console` |

--- a/hack/gen-helm-values-schema.py
+++ b/hack/gen-helm-values-schema.py
@@ -7,7 +7,7 @@
 
 The keystone-operator and c5c3-operator charts share the bulk of their Helm
 values schema: the resourceQuantity definition, the image / replicas /
-resources / rbac / leaderElection / webhook / metrics / monitoring /
+resources / rbac / leaderElection / webhook / metrics / logging / monitoring /
 serviceAccount / name-override properties, the operator-library subchart-values
 property, and the rbac->webhook constraint. This script holds that shared
 schema once and emits each chart's values.schema.json, layering the
@@ -181,6 +181,31 @@ METRICS = {
             "minimum": 1,
             "maximum": 65535,
         }
+    },
+}
+
+LOGGING = {
+    "type": "object",
+    "description": "Operator zap logger configuration. Production defaults (development=false): JSON encoder, info level, error-level stack traces.",
+    "additionalProperties": False,
+    "properties": {
+        "development": {
+            "type": "boolean",
+            "description": "Enable development logging mode (--zap-devel): console encoder, debug verbosity, warn-level stack traces. Leave false for production.",
+            "default": False,
+        },
+        "level": {
+            "type": "string",
+            "description": "Zap log level (--zap-log-level): debug, info, error, panic, or a positive integer for custom verbosity. Empty uses the mode default.",
+            "default": "",
+            "pattern": r"^(|debug|info|error|panic|[1-9][0-9]*)$",
+        },
+        "encoder": {
+            "type": "string",
+            "description": "Zap log encoder (--zap-encoder): json or console. Empty uses the mode default.",
+            "default": "",
+            "enum": ["", "json", "console"],
+        },
     },
 }
 
@@ -397,6 +422,7 @@ def build_schema(chart):
         "leaderElection": LEADER_ELECTION,
         "webhook": webhook_property(chart["webhook_enabled_description"]),
         "metrics": METRICS,
+        "logging": LOGGING,
         "monitoring": MONITORING,
         "serviceAccount": SERVICE_ACCOUNT,
     }

--- a/internal/common/bootstrap/manager.go
+++ b/internal/common/bootstrap/manager.go
@@ -77,6 +77,18 @@ func cacheOptions(syncPeriod time.Duration, namespace string) cache.Options {
 	return opts
 }
 
+// zapOptions returns the base zap logging options shared by all operators.
+// Development is false so the production operator binaries default to the
+// controller-runtime production logging profile: JSON encoder, info-level
+// verbosity, and stacktraces only at error level. A true value would ship a
+// console encoder, debug-level verbosity, and a DPanic that panics — none of
+// which is appropriate for a production binary. Operators opt back into
+// development logging explicitly via the --zap-devel, --zap-log-level, and
+// --zap-encoder flags that BindFlags registers against these options.
+func zapOptions() zap.Options {
+	return zap.Options{Development: false}
+}
+
 // Run bootstraps and starts a controller-runtime manager with standard flag
 // parsing, zap logging, metrics, and health/ready probes. It blocks until the
 // manager stops or an error occurs.
@@ -115,7 +127,7 @@ func Run(cfg ManagerConfig) error {
 			"Used for namespace-scoped deployments (CC-0043). "+
 			"Overrides ManagerConfig.Namespace when provided.")
 
-	opts := zap.Options{Development: true}
+	opts := zapOptions()
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/operators/c5c3/helm/c5c3-operator/Chart.yaml
+++ b/operators/c5c3/helm/c5c3-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: c5c3-operator
 description: A Helm chart for deploying the c5c3 ControlPlane operator
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.0"
 # The shared naming/label helpers and the Deployment skeleton live in the
 # operator-library library chart so they are defined once for both operator
@@ -17,3 +17,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Initial c5c3 ControlPlane operator chart (CC-0110)
+    - kind: added
+      description: Expose operator log level, encoder, and development mode as chart values

--- a/operators/c5c3/helm/c5c3-operator/tests/deployment_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/deployment_test.yaml
@@ -189,3 +189,35 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --health-probe-bind-address=:8081
+
+  # Operator logging (zap) configuration tests.
+  - it: should not render zap flags with default logging values
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true
+
+  - it: should render --zap-devel=true when logging.development is true
+    set:
+      logging:
+        development: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true
+
+  - it: should render --zap-log-level and --zap-encoder when set
+    set:
+      logging:
+        level: debug
+        encoder: console
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-encoder=console
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true

--- a/operators/c5c3/helm/c5c3-operator/tests/schema_validation_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/schema_validation_test.yaml
@@ -349,3 +349,48 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+
+  # ---------------------------------------------------------------------------
+  # logging schema constraints
+  # ---------------------------------------------------------------------------
+  - it: should reject non-boolean logging.development
+    set:
+      logging:
+        development: "yes"
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/development.*want boolean"
+
+  - it: should reject invalid logging.encoder enum value
+    set:
+      logging:
+        encoder: xml
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/encoder.*must be one of"
+
+  - it: should reject invalid logging.level value
+    set:
+      logging:
+        level: verbose
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/level.*does not match pattern"
+
+  - it: should reject unknown property in logging
+    set:
+      logging:
+        timeEncoding: iso8601
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging.*additional properties.*not allowed"
+
+  - it: should accept valid logging overrides
+    set:
+      logging:
+        development: true
+        level: debug
+        encoder: console
+    asserts:
+      - isKind:
+          of: Deployment

--- a/operators/c5c3/helm/c5c3-operator/values.schema.json
+++ b/operators/c5c3/helm/c5c3-operator/values.schema.json
@@ -160,6 +160,34 @@
         }
       }
     },
+    "logging": {
+      "type": "object",
+      "description": "Operator zap logger configuration. Production defaults (development=false): JSON encoder, info level, error-level stack traces.",
+      "additionalProperties": false,
+      "properties": {
+        "development": {
+          "type": "boolean",
+          "description": "Enable development logging mode (--zap-devel): console encoder, debug verbosity, warn-level stack traces. Leave false for production.",
+          "default": false
+        },
+        "level": {
+          "type": "string",
+          "description": "Zap log level (--zap-log-level): debug, info, error, panic, or a positive integer for custom verbosity. Empty uses the mode default.",
+          "default": "",
+          "pattern": "^(|debug|info|error|panic|[1-9][0-9]*)$"
+        },
+        "encoder": {
+          "type": "string",
+          "description": "Zap log encoder (--zap-encoder): json or console. Empty uses the mode default.",
+          "default": "",
+          "enum": [
+            "",
+            "json",
+            "console"
+          ]
+        }
+      }
+    },
     "monitoring": {
       "type": "object",
       "description": "Observability integration configuration (CC-0089)",

--- a/operators/c5c3/helm/c5c3-operator/values.yaml
+++ b/operators/c5c3/helm/c5c3-operator/values.yaml
@@ -36,6 +36,23 @@ webhook:
 metrics:
   port: 8080
 
+# Operator logging configuration (controller-runtime zap logger). The operator
+# defaults to the production profile (development=false): JSON encoder, info
+# level, and stack traces only at error level — suitable for log aggregation.
+# Override these to restore human-readable console output during local
+# development; each value maps to a controller-runtime --zap-* flag and is
+# omitted from the operator args when left at its default.
+logging:
+  # When true, passes --zap-devel: console encoder, debug verbosity, warn-level
+  # stack traces, and a DPanic that panics. Leave false for production.
+  development: false
+  # --zap-log-level: one of debug, info, error, panic, or a positive integer
+  # for custom verbosity. Empty uses the mode default (info in production).
+  level: ""
+  # --zap-encoder: json or console. Empty uses the mode default (json in
+  # production).
+  encoder: ""
+
 # CC-0089, REQ-006: Prometheus ServiceMonitor integration.
 # When enabled, renders a monitoring.coreos.com/v1 ServiceMonitor targeting the
 # operator's metrics port; prometheus-operator CRDs must be installed in-cluster.

--- a/operators/keystone/helm/keystone-operator/Chart.yaml
+++ b/operators/keystone/helm/keystone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keystone-operator
 description: A Helm chart for deploying the Keystone OpenStack operator
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.1.0"
 # The shared naming/label helpers and the Deployment skeleton live in the
 # operator-library library chart so they are defined once for both operator
@@ -19,3 +19,5 @@ annotations:
       description: JSON Schema validation for chart values (CC-0069)
     - kind: added
       description: Opt-in NetworkPolicy for operator pod egress/ingress restriction (CC-0090)
+    - kind: added
+      description: Expose operator log level, encoder, and development mode as chart values

--- a/operators/keystone/helm/keystone-operator/tests/deployment_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/deployment_test.yaml
@@ -185,3 +185,35 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --health-probe-bind-address=:8081
+
+  # Operator logging (zap) configuration tests.
+  - it: should not render zap flags with default logging values
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true
+
+  - it: should render --zap-devel=true when logging.development is true
+    set:
+      logging:
+        development: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true
+
+  - it: should render --zap-log-level and --zap-encoder when set
+    set:
+      logging:
+        level: debug
+        encoder: console
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-encoder=console
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --zap-devel=true

--- a/operators/keystone/helm/keystone-operator/tests/schema_validation_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/schema_validation_test.yaml
@@ -473,3 +473,48 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+
+  # ---------------------------------------------------------------------------
+  # logging schema constraints
+  # ---------------------------------------------------------------------------
+  - it: should reject non-boolean logging.development
+    set:
+      logging:
+        development: "yes"
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/development.*want boolean"
+
+  - it: should reject invalid logging.encoder enum value
+    set:
+      logging:
+        encoder: xml
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/encoder.*must be one of"
+
+  - it: should reject invalid logging.level value
+    set:
+      logging:
+        level: verbose
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging/level.*does not match pattern"
+
+  - it: should reject unknown property in logging
+    set:
+      logging:
+        timeEncoding: iso8601
+    asserts:
+      - failedTemplate:
+          errorPattern: "/logging.*additional properties.*not allowed"
+
+  - it: should accept valid logging overrides
+    set:
+      logging:
+        development: true
+        level: debug
+        encoder: console
+    asserts:
+      - isKind:
+          of: Deployment

--- a/operators/keystone/helm/keystone-operator/values.schema.json
+++ b/operators/keystone/helm/keystone-operator/values.schema.json
@@ -172,6 +172,34 @@
         }
       }
     },
+    "logging": {
+      "type": "object",
+      "description": "Operator zap logger configuration. Production defaults (development=false): JSON encoder, info level, error-level stack traces.",
+      "additionalProperties": false,
+      "properties": {
+        "development": {
+          "type": "boolean",
+          "description": "Enable development logging mode (--zap-devel): console encoder, debug verbosity, warn-level stack traces. Leave false for production.",
+          "default": false
+        },
+        "level": {
+          "type": "string",
+          "description": "Zap log level (--zap-log-level): debug, info, error, panic, or a positive integer for custom verbosity. Empty uses the mode default.",
+          "default": "",
+          "pattern": "^(|debug|info|error|panic|[1-9][0-9]*)$"
+        },
+        "encoder": {
+          "type": "string",
+          "description": "Zap log encoder (--zap-encoder): json or console. Empty uses the mode default.",
+          "default": "",
+          "enum": [
+            "",
+            "json",
+            "console"
+          ]
+        }
+      }
+    },
     "monitoring": {
       "type": "object",
       "description": "Observability integration configuration (CC-0089)",

--- a/operators/keystone/helm/keystone-operator/values.yaml
+++ b/operators/keystone/helm/keystone-operator/values.yaml
@@ -36,6 +36,23 @@ webhook:
 metrics:
   port: 8080
 
+# Operator logging configuration (controller-runtime zap logger). The operator
+# defaults to the production profile (development=false): JSON encoder, info
+# level, and stack traces only at error level — suitable for log aggregation.
+# Override these to restore human-readable console output during local
+# development; each value maps to a controller-runtime --zap-* flag and is
+# omitted from the operator args when left at its default.
+logging:
+  # When true, passes --zap-devel: console encoder, debug verbosity, warn-level
+  # stack traces, and a DPanic that panics. Leave false for production.
+  development: false
+  # --zap-log-level: one of debug, info, error, panic, or a positive integer
+  # for custom verbosity. Empty uses the mode default (info in production).
+  level: ""
+  # --zap-encoder: json or console. Empty uses the mode default (json in
+  # production).
+  encoder: ""
+
 # CC-0089, REQ-006: Prometheus ServiceMonitor integration.
 # When enabled, renders a monitoring.coreos.com/v1 ServiceMonitor targeting the
 # operator's metrics port; prometheus-operator CRDs must be installed in-cluster.

--- a/operators/shared/helm/operator-library/templates/_deployment.tpl
+++ b/operators/shared/helm/operator-library/templates/_deployment.tpl
@@ -6,7 +6,7 @@ Consuming charts render it with a one-line template that passes the root context
     {{- include "operator-library.deployment" . }}
 
 All settings (image, replicas, resources, webhook, leaderElection, metrics,
-rbac.namespaceScoped) are read from the consuming chart's .Values.
+rbac.namespaceScoped, logging) are read from the consuming chart's .Values.
 */}}
 {{- define "operator-library.deployment" -}}
 apiVersion: apps/v1
@@ -50,6 +50,15 @@ spec:
             {{- end }}
             - --metrics-bind-address=:{{ .Values.metrics.port }}
             - --health-probe-bind-address=:8081
+            {{- if .Values.logging.development }}
+            - --zap-devel=true
+            {{- end }}
+            {{- with .Values.logging.level }}
+            - --zap-log-level={{ . }}
+            {{- end }}
+            {{- with .Values.logging.encoder }}
+            - --zap-encoder={{ . }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}


### PR DESCRIPTION
Closes #458

## Problem

`internal/common/bootstrap/manager.go` hardcoded `zap.Options{Development: true}`, and neither operator Helm chart passed any zap flags. Both production operator binaries (keystone, c5c3) therefore ran with the controller-runtime **development** logging profile: DebugLevel verbosity, a console encoder instead of JSON, stacktraces on warnings, and a `DPanic` that actually panics.

## Change set (commit order)

1. **`fix(common): default zap logging to production mode`**
   Extract a `zapOptions()` helper (mirroring the existing `cacheOptions()` helper) returning `zap.Options{Development: false}`, so both binaries default to the production profile — JSON encoder, info level, error-level stacktraces. Runtime opt-in to development logging stays available through the `--zap-devel` / `--zap-log-level` / `--zap-encoder` flags that `BindFlags` already registers. Adds `TestZapOptions_productionDefault`.

2. **`feat(helm): expose operator log level and encoder as chart values`**
   Adds an opt-in `logging` block (`development`, `level`, `encoder`) to both the keystone-operator and c5c3-operator charts so dev setups can restore verbose/console logging explicitly:
   - `values.yaml`: the three values default to `false`/`""`.
   - `deployment.yaml`: each `--zap-*` flag is rendered only when its value is set, so the default args list (and the existing exact-match deployment test) is unchanged and production stays on the JSON/info profile.
   - `values.schema.json`: validates the block — boolean `development`, a `level` pattern (`debug|info|error|panic|<positive int>`), and a `json|console` `encoder` enum — matching the controller-runtime flag grammar so typos fail at `helm template` time.
   - helm-unittest: deployment + schema tests for the default (no zap flags), the `development` toggle, `level`/`encoder` rendering, and rejection of invalid values.
   - `Chart.yaml`: keystone-operator `0.3.0 → 0.4.0`, c5c3-operator `0.1.0 → 0.2.0`, with `artifacthub.io/changes` entries.

3. **`docs(backend): document operator logging chart values`**
   Adds a `logging` section (and test-coverage rows) to the Helm values schema reference.

## Verification

| Command | Result |
| --- | --- |
| `go test ./internal/common/...` | pass |
| `go vet ./internal/common/...` | pass |
| `make format-check` (gofumpt v0.9.2) | pass |
| `golangci-lint run ./...` (internal/common) | 0 issues |
| `go build ./...` (keystone, c5c3) | pass |
| `helm lint` (both charts) | 0 failed |
| `helm unittest` keystone-operator | 182 passed |
| `helm unittest` c5c3-operator | 139 passed |
| `make check-docs-ids` | clean |

`helm template` confirmed: default values render no `--zap-*` flags; `--set logging.development=true --set logging.level=debug --set logging.encoder=console` renders all three flags.

## Notes / out of scope

- No internal feature ID is assigned to this change (none in the issue title; following the precedent of the issue-#457 implementation, which used descriptive conventional-commit scopes rather than a CC-ID).
- The c5c3-operator chart is updated symmetrically and its helm-unittest suite passes locally, but CI's `helm-validate` job only runs helm-unittest against the keystone-operator chart — a pre-existing gap, left untouched.
- The schema reference's "Chart version" line still reads `0.2.0` (already stale against `main`'s `0.3.0`, independent of this change); left as-is to keep the change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
