### PR TITLE
fix(operators): drop webhook DELETE interception, add operator PDB/spread, uncached admission checks

### DIFF
--- a/docs/reference/backend/keystone-operator-packaging.md
+++ b/docs/reference/backend/keystone-operator-packaging.md
@@ -149,7 +149,7 @@ docker run --rm keystone-operator:dev --help
 | `name` | `keystone-operator` |
 | `description` | `A Helm chart for deploying the Keystone OpenStack operator` |
 | `type` | `application` |
-| `version` | `0.1.0` |
+| `version` | `0.5.0` |
 | `appVersion` | `0.1.0` |
 
 ### Shared Library Subchart
@@ -250,6 +250,7 @@ The chart renders the following Kubernetes resources with default values:
 | ClusterRoleBinding | `rbac.authorization.k8s.io/v1/ClusterRoleBinding` | `{fullname}` | Always |
 | Deployment | `apps/v1/Deployment` | `{fullname}` | Always |
 | Service | `v1/Service` | `{fullname}` | Always |
+| PodDisruptionBudget | `policy/v1/PodDisruptionBudget` | `{fullname}` | `replicas > 1` |
 | MutatingWebhookConfiguration | `admissionregistration.k8s.io/v1` | `{fullname}-mutating` | `webhook.enabled` |
 | ValidatingWebhookConfiguration | `admissionregistration.k8s.io/v1` | `{fullname}-validating` | `webhook.enabled` |
 
@@ -262,7 +263,7 @@ All resources include standard Helm labels via the `operator-library.labels` hel
 
 | Label | Value |
 | --- | --- |
-| `helm.sh/chart` | `keystone-operator-0.1.0` |
+| `helm.sh/chart` | `keystone-operator-0.5.0` |
 | `app.kubernetes.io/name` | `keystone-operator` |
 | `app.kubernetes.io/instance` | `{release-name}` |
 | `app.kubernetes.io/version` | `0.1.0` |
@@ -323,6 +324,16 @@ configurable via Helm values.
 | `capabilities.drop` | `[ALL]` |
 | `readOnlyRootFilesystem` | `true` |
 | `seccompProfile.type` | `RuntimeDefault` |
+
+**Scheduling and disruption:**
+
+The pod template carries a best-effort topology spread constraint (`maxSkew: 1`,
+`topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`) so
+replicas land on different nodes where possible while single-node clusters
+(kind) stay schedulable. Together with the `PodDisruptionBudget`
+(`minAvailable: 1`, rendered only when `replicas > 1`), a voluntary disruption
+such as a node drain can never evict every replica — and with it the in-process
+admission webhook — at once.
 
 ### Service Configuration
 

--- a/docs/reference/backend/keystone-operator-packaging.md
+++ b/docs/reference/backend/keystone-operator-packaging.md
@@ -390,13 +390,17 @@ Two webhook configurations are rendered when `webhook.enabled=true`:
 | --- | --- |
 | Webhook name | `vkeystone.kb.io` |
 | Path | `/validate-keystone-openstack-c5c3-io-v1alpha1-keystone` |
-| Operations | `CREATE`, `UPDATE`, `DELETE` |
+| Operations | `CREATE`, `UPDATE` |
 | API group | `keystone.openstack.c5c3.io` |
 | API version | `v1alpha1` |
 | Resource | `keystones` |
 | Failure policy | `Fail` |
 | Side effects | `None` |
 | Admission review versions | `v1` |
+
+Neither configuration intercepts `DELETE`: the webhook is served in-process by
+the operator, so with `failurePolicy: Fail` a `DELETE` rule would let a down
+operator block CR — and thereby namespace — deletion.
 
 Both configurations include the annotation:
 

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -692,9 +692,12 @@ admission webhooks for the `ControlPlane` CRD via the typed-generic
 interfaces from controller-runtime. `CredentialRotation` and `SecretAggregate`
 have no webhook at this level.
 
-The struct carries a `Client client.Reader`, injected at startup for any future
-cluster-scoped lookups; it is currently unused by `validate()` but kept to
-mirror the `KeystoneWebhook` shape and avoid a signature change later.
+The struct carries a `Client client.Reader`, injected at startup with the
+manager's **uncached API reader** (`mgr.GetAPIReader()`). `ValidateCreate` uses
+it to enforce one ControlPlane per namespace; reading the API server directly
+ensures concurrent or cache-sync-window CREATEs cannot both pass the check
+against an empty informer cache. The spec-level `validate()` rules do not touch
+the client.
 
 ### Registration
 
@@ -811,8 +814,12 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
 
 - `ValidateCreate` and `ValidateUpdate` both delegate to the internal
   `validate()` method (see [Validating-webhook rules](#validating-webhook-rules)).
-  There are no create-specific or update-specific rules — `ValidateUpdate`
-  validates the new object only.
+  `ValidateCreate` additionally enforces the one-ControlPlane-per-namespace
+  contract: it lists existing ControlPlanes in the new object's namespace
+  through the uncached API reader and rejects the CREATE with a `Forbidden`
+  error naming the incumbent when one already exists. The check runs only on
+  CREATE so an existing CR stays mutable; `ValidateUpdate` validates the new
+  object only.
 - `ValidateDelete` always returns `nil, nil`. It exists only to satisfy the
   `admission.Validator` interface and is **never invoked** — the validating
   webhook does not register the `delete` verb, so **deletion is unconditionally

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -841,9 +841,13 @@ one's condition being `True`:
 InfrastructureReady → KeystoneReady → KORCReady → AdminCredentialReady → CatalogReady
 ```
 
-`Ready` is `True` (reason `AllReady`) **only** when all five sub-conditions are
+`Ready` is `True` (reason `AllReady`) **only** when all sub-conditions are
 `True` (via `conditions.AllTrue`); otherwise it is `False` (reason
-`NotAllReady`). For the full flow, see the
+`NotAllReady`). One exception bypasses the aggregation: when a namespace holds
+more than one ControlPlane (possible only for CRs that predate the
+one-per-namespace webhook guard or bypassed it), every CR except the oldest is
+parked with `Ready=False` reason `DuplicateControlPlane` naming the incumbent,
+and none of its sub-reconcilers run. For the full flow, see the
 [ControlPlane Reconciler reference](./controlplane-reconciler.md).
 
 ### InfrastructureReady

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -706,9 +706,11 @@ Registers both webhooks with the manager using
 `builder.WebhookManagedBy[*ControlPlane]`. The generated webhook paths are
 `/mutate-c5c3-io-v1alpha1-controlplane` (mutating) and
 `/validate-c5c3-io-v1alpha1-controlplane` (validating); both use
-`failurePolicy=fail`, `sideEffects=None`, and `admissionReviewVersions=v1`. The
-mutating webhook fires on `create`/`update`; the validating webhook on
-`create`/`update`/`delete`.
+`failurePolicy=fail`, `sideEffects=None`, and `admissionReviewVersions=v1`.
+Both webhooks fire on `create`/`update` only. `delete` is deliberately **not**
+registered: the webhook is served in-process by the operator, so with
+`failurePolicy=fail` a `delete` rule would let a down operator block CR — and
+thereby namespace — deletion.
 
 ### Defaulting Webhook
 
@@ -811,8 +813,10 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
   `validate()` method (see [Validating-webhook rules](#validating-webhook-rules)).
   There are no create-specific or update-specific rules — `ValidateUpdate`
   validates the new object only.
-- `ValidateDelete` always returns `nil, nil` — **deletion is unconditionally
-  allowed**.
+- `ValidateDelete` always returns `nil, nil`. It exists only to satisfy the
+  `admission.Validator` interface and is **never invoked** — the validating
+  webhook does not register the `delete` verb, so **deletion is unconditionally
+  allowed** even while the operator is down.
 
 ---
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -247,6 +247,10 @@ and the informer cache to that namespace. Keep the default only when
 │  Fetch ControlPlane CR (return empty result if NotFound)                     │
 │         │                                                                    │
 │         ▼                                                                    │
+│  Duplicate guard — park all but the oldest ControlPlane in the namespace     │
+│  (Ready=False / DuplicateControlPlane, requeue 30s; see Multi-instance)      │
+│         │                                                                    │
+│         ▼                                                                    │
 │  ┌──────────────────────────┐                                                │
 │  │ reconcileInfrastructure  │  Ensure managed MariaDB + Memcached children   │
 │  │  (gate: none)            │  Sets: InfrastructureReady                     │
@@ -364,6 +368,11 @@ InfrastructureReady, DBCredentialsReady, KeystoneReady, KORCReady, AdminCredenti
 
 The `Ready` condition carries `ObservedGeneration = cp.Generation` so clients can
 detect a stale aggregate.
+
+One path bypasses the aggregation entirely: a ControlPlane parked by the
+duplicate guard (see [Multi-instance](#multi-instance)) gets `Ready=False` with
+reason `DuplicateControlPlane` written directly — `setReadyCondition()` would
+otherwise overwrite the reason with `NotAllReady` on the next status update.
 
 ---
 
@@ -814,11 +823,22 @@ cluster without sharing OpenBao state.
 - **One ControlPlane per namespace (admission-enforced).** The ControlPlane
   validating webhook's `validateUniqueInNamespace` check runs in
   `ValidateCreate` **only** (not `ValidateUpdate`): it lists ControlPlanes in the
-  object's namespace and returns `field.Forbidden` naming the incumbent if one
-  already exists. The cluster therefore admits **exactly one** ControlPlane per
-  namespace. This is what makes the CredentialRotation reconciler's
-  `AmbiguousControlPlane` branch defense-in-depth (see
+  object's namespace through the uncached API reader and returns
+  `field.Forbidden` naming the incumbent if one already exists. The cluster
+  therefore admits **exactly one** ControlPlane per namespace. This is what
+  makes the CredentialRotation reconciler's `AmbiguousControlPlane` branch
+  defense-in-depth (see
   [CredentialRotation reconciler](#credentialrotation-reconciler)).
+- **Duplicate guard (reconciler-enforced).** As defense-in-depth for CRs that
+  predate the webhook guard, raced through the API server, or were written with
+  the webhook bypassed, `Reconcile` runs `duplicateControlPlaneIncumbent`
+  before the sub-reconciler chain: it lists ControlPlanes in the CR's namespace
+  and parks every CR except the oldest (by `creationTimestamp`, lexically
+  smallest name breaking ties). A parked duplicate gets `Ready=False` with
+  reason `DuplicateControlPlane` naming the incumbent, runs **no**
+  sub-reconcilers, and requeues every 30s — so it takes over automatically once
+  the incumbent is fully deleted (no watch event fires on the duplicate's
+  behalf when that happens).
 - **Per-CR OpenBao path for the admin AC.** The admin application credential is
   pushed to the per-ControlPlane key
   `openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential`

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -937,7 +937,7 @@ spec:
 | --- | --- |
 | `nil` | No priority class is configured; the cluster default applies. |
 | `""` (empty string) | No priority class — explicit opt-out, useful when clearing a previously set value via `kubectl patch`. |
-| Non-empty string | Value is written to the Deployment PodSpec. The webhook performs a cluster-scoped `Get` of the `PriorityClass` at admission time and rejects unknown names with `field.NotFound`. |
+| Non-empty string | Value is written to the Deployment PodSpec. The webhook performs a direct (uncached) cluster-scoped `Get` of the `PriorityClass` at admission time and rejects unknown names with `field.NotFound`. |
 
 The rotation CronJobs (Fernet, credential) reuse the same `priorityClassName`
 to stay co-scheduled with the API pods.
@@ -1242,7 +1242,7 @@ single `apierrors.NewInvalid` error. It does **not** short-circuit on the first 
 | Resource request exceeds limit | `spec.resources.requests.<resource>` | `field.Invalid` | A resource request exceeds its corresponding limit (e.g., CPU request 1000m > limit 500m). Checked per resource type when both requests and limits are set. |
 | Trust flush schedule required | `spec.trustFlush.schedule` | `field.Required` | `trustFlush` is set but `schedule` is empty. Defense-in-depth — the `+kubebuilder:default` marker normally prevents this, but bypass paths (e.g., `kubectl patch`) may produce an empty string. |
 | Trust flush cron expression | `spec.trustFlush.schedule` | `field.Invalid` | `cron.ParseStandard()` fails on `trustFlush.schedule`. Error message includes the parse failure details. |
-| PriorityClass existence | `spec.priorityClassName` | `field.NotFound` / `field.InternalError` | The webhook performs a cluster-scoped `Get` of the referenced `scheduling.k8s.io/v1` `PriorityClass` when the field is non-empty. Missing classes produce `NotFound`; transient API errors produce `InternalError`. |
+| PriorityClass existence | `spec.priorityClassName` | `field.NotFound` / `field.InternalError` | The webhook performs a direct (uncached) cluster-scoped `Get` of the referenced `scheduling.k8s.io/v1` `PriorityClass` when the field is non-empty, so a just-created class is never rejected off a stale cache. Missing classes produce `NotFound`; transient API errors produce `InternalError`. |
 | TopologySpread labelSelector required | `spec.topologySpreadConstraints[i].labelSelector` | `field.Required` | Entry has no `labelSelector`. |
 | TopologySpread matchLabels mismatch | `spec.topologySpreadConstraints[i].labelSelector` | `field.Invalid` | `matchLabels` does not exactly equal `{app.kubernetes.io/name: keystone, app.kubernetes.io/instance: {CR name}}`. |
 | TopologySpread matchExpressions forbidden | `spec.topologySpreadConstraints[i].labelSelector.matchExpressions` | `field.Invalid` | `matchExpressions` is non-empty. Only exact `matchLabels` are allowed. |

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -88,7 +88,7 @@ var (
 )
 
 // +kubebuilder:webhook:path=/mutate-c5c3-io-v1alpha1-controlplane,mutating=true,failurePolicy=fail,sideEffects=None,groups=c5c3.io,resources=controlplanes,verbs=create;update,versions=v1alpha1,name=mcontrolplane.kb.io,admissionReviewVersions=v1
-// +kubebuilder:webhook:path=/validate-c5c3-io-v1alpha1-controlplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=c5c3.io,resources=controlplanes,verbs=create;update;delete,versions=v1alpha1,name=vcontrolplane.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-c5c3-io-v1alpha1-controlplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=c5c3.io,resources=controlplanes,verbs=create;update,versions=v1alpha1,name=vcontrolplane.kb.io,admissionReviewVersions=v1
 
 // SetupWebhookWithManager registers the defaulting and validating webhooks with the manager.
 func (w *ControlPlaneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -202,8 +202,11 @@ func (w *ControlPlaneWebhook) ValidateUpdate(_ context.Context, _, newObj *Contr
 	return nil, w.validate(newObj)
 }
 
-// ValidateDelete implements admission.Validator[*ControlPlane].
-// Deletion is always allowed.
+// ValidateDelete implements admission.Validator[*ControlPlane]. The method is
+// required by the Validator interface but is never invoked: the validating
+// webhook registers only create/update (no delete verb), so with
+// failurePolicy=Fail a down operator can never block ControlPlane CR — and
+// thereby namespace — deletion.
 func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -76,6 +76,9 @@ var controlPlaneReleaseRegexp = regexp.MustCompile(`^\d{4}\.\d$`)
 // ControlPlaneWebhook implements defaulting and validation webhooks for the
 // ControlPlane CRD (CC-0110). Client is injected at startup and used by
 // ValidateCreate to enforce one ControlPlane per namespace (CC-0112, REQ-010).
+// Production wiring injects mgr.GetAPIReader() — a direct, uncached reader —
+// so concurrent or cache-sync-window CREATEs cannot both pass the check
+// against an empty informer cache.
 // +kubebuilder:object:generate=false
 type ControlPlaneWebhook struct {
 	Client client.Reader
@@ -292,13 +295,16 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) error {
 // (CC-0112, REQ-010). It lists existing ControlPlanes in the new object's
 // namespace; any pre-existing CR (len >= 1, since the object under admission is
 // not yet persisted) makes this CREATE a Forbidden error naming the incumbent.
+// The List goes through the injected uncached API reader (mgr.GetAPIReader() in
+// production), so the check cannot admit a second CR off a stale or still-empty
+// informer cache.
 //
 // DECISION: when w.Client is nil (spec-level unit tests that construct a bare
 // &ControlPlaneWebhook{}, or any caller that did not inject a client) the check
 // is skipped rather than panicking. Production and envtest wiring always inject
-// mgr.GetClient() (operators/c5c3/main.go, integration_test.go), so the guard
-// never trips at runtime; it only keeps the spec-validation unit tests
-// client-free. Reviewer: please verify.
+// mgr.GetAPIReader() (operators/c5c3/main.go, integration_test.go), so the
+// guard never trips at runtime; it only keeps the spec-validation unit tests
+// client-free.
 func (w *ControlPlaneWebhook) validateUniqueInNamespace(ctx context.Context, obj *ControlPlane) error {
 	if w.Client == nil {
 		return nil

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -297,7 +297,10 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) error {
 // not yet persisted) makes this CREATE a Forbidden error naming the incumbent.
 // The List goes through the injected uncached API reader (mgr.GetAPIReader() in
 // production), so the check cannot admit a second CR off a stale or still-empty
-// informer cache.
+// informer cache. The reconciler's duplicate-ControlPlane guard
+// (duplicateControlPlaneIncumbent in operators/c5c3/internal/controller) is the
+// defense-in-depth for CREATEs that race within the API server itself or bypass
+// the webhook entirely.
 //
 // DECISION: when w.Client is nil (spec-level unit tests that construct a bare
 // &ControlPlaneWebhook{}, or any caller that did not inject a client) the check

--- a/operators/c5c3/config/webhook/manifests.yaml
+++ b/operators/c5c3/config/webhook/manifests.yaml
@@ -47,7 +47,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - controlplanes
   sideEffects: None

--- a/operators/c5c3/helm/c5c3-operator/Chart.yaml
+++ b/operators/c5c3/helm/c5c3-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: c5c3-operator
 description: A Helm chart for deploying the c5c3 ControlPlane operator
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"
 # The shared naming/label helpers and the Deployment skeleton live in the
 # operator-library library chart so they are defined once for both operator
@@ -19,3 +19,7 @@ annotations:
       description: Initial c5c3 ControlPlane operator chart (CC-0110)
     - kind: added
       description: Expose operator log level, encoder, and development mode as chart values
+    - kind: added
+      description: PodDisruptionBudget (minAvailable 1, replicas > 1) and best-effort node spread for the operator Deployment
+    - kind: changed
+      description: Validating webhook no longer intercepts DELETE, so a down operator cannot block CR or namespace deletion

--- a/operators/c5c3/helm/c5c3-operator/templates/pdb.yaml
+++ b/operators/c5c3/helm/c5c3-operator/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{/*
+  PodDisruptionBudget for the c5c3-operator Deployment.
+
+  Keeps at least one replica — and with it the in-process admission webhook
+  (failurePolicy=Fail) — available during voluntary disruptions such as node
+  drains and cluster upgrades. Rendered only when replicas > 1: with a single
+  replica, minAvailable: 1 would block every voluntary disruption and wedge
+  node drains.
+*/}}
+{{- if gt (int .Values.replicas) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "operator-library.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "operator-library.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "operator-library.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/operators/c5c3/helm/c5c3-operator/templates/webhook-configuration.yaml
+++ b/operators/c5c3/helm/c5c3-operator/templates/webhook-configuration.yaml
@@ -53,10 +53,12 @@ webhooks:
           - c5c3.io
         apiVersions:
           - v1alpha1
+        # No DELETE: the webhook is served in-process by the operator, so with
+        # failurePolicy=Fail a DELETE rule would let a down operator block CR
+        # and namespace deletion. ValidateDelete is a no-op anyway.
         operations:
           - CREATE
           - UPDATE
-          - DELETE
         resources:
           - controlplanes
 {{- end }}

--- a/operators/c5c3/helm/c5c3-operator/tests/deployment_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/deployment_test.yaml
@@ -221,3 +221,22 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --zap-devel=true
+
+  - it: should spread replicas across nodes best-effort
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      # ScheduleAnyway (soft) so single-node clusters (kind) stay schedulable.
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: c5c3-operator
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME

--- a/operators/c5c3/helm/c5c3-operator/tests/pdb_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/pdb_test.yaml
@@ -1,0 +1,44 @@
+# PodDisruptionBudget unit tests. The PDB keeps one replica — and with it the
+# in-process admission webhook — available during voluntary disruptions; it is
+# rendered only when replicas > 1 so a single-replica deployment never wedges
+# node drains.
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: should render a PodDisruptionBudget with minAvailable 1 by default
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-c5c3-operator
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: c5c3-operator
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should not render a PodDisruptionBudget when replicas is 1
+    set:
+      replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should keep minAvailable 1 when replicas is raised
+    set:
+      replicas: 3
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/operators/c5c3/helm/c5c3-operator/tests/webhook_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/webhook_test.yaml
@@ -1,7 +1,8 @@
 # CC-0110: Webhook configuration unit tests.
-# The ControlPlane CR lives in group c5c3.io (DECISION CC-0110 plan #1); the
-# validating webhook additionally intercepts DELETE so deletion invariants can
-# be enforced at admission time.
+# The ControlPlane CR lives in group c5c3.io (DECISION CC-0110 plan #1). The
+# validating webhook intercepts only CREATE/UPDATE — DELETE is deliberately not
+# registered so a down operator (which serves the webhook in-process with
+# failurePolicy=Fail) can never block CR or namespace deletion.
 suite: Webhook Configuration
 templates:
   - templates/webhook-configuration.yaml
@@ -77,7 +78,9 @@ tests:
       - contains:
           path: webhooks[0].rules[0].operations
           content: UPDATE
-      - contains:
+      # DELETE must NOT be intercepted: with failurePolicy=Fail a down operator
+      # would otherwise block CR and namespace deletion.
+      - notContains:
           path: webhooks[0].rules[0].operations
           content: DELETE
 

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -104,6 +104,22 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("fetching ControlPlane: %w", err)
 	}
 
+	// Defense-in-depth for the one-ControlPlane-per-namespace contract
+	// (CC-0112, REQ-010): the validating webhook rejects duplicate CREATEs,
+	// but CRs that predate the guard, raced through the API server, or were
+	// written with the webhook bypassed can still coexist. Park every
+	// ControlPlane except the oldest so two reconcilers never operate on the
+	// namespace's shared credential paths and child resources at once —
+	// mirroring the CredentialRotation reconciler's AmbiguousControlPlane
+	// handling.
+	incumbent, err := r.duplicateControlPlaneIncumbent(ctx, &cp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if incumbent != "" {
+		return r.parkDuplicateControlPlane(ctx, &cp, incumbent)
+	}
+
 	// Run sub-reconcilers in dependency order. Every sub-reconciler call is
 	// routed through instrumentSubReconciler so that duration samples and error
 	// counters are emitted under a stable sub_reconciler label (CC-0110,
@@ -198,6 +214,63 @@ func setReadyCondition(cp *c5c3v1alpha1.ControlPlane) {
 			Message:            "One or more sub-conditions are not ready",
 		})
 	}
+}
+
+// duplicateControlPlaneIncumbent returns the name of the ControlPlane that owns
+// cp's namespace when cp is NOT it — i.e. when cp must be parked. The owner is
+// the oldest ControlPlane in the namespace by CreationTimestamp, with the
+// lexically smallest Name breaking creation-time ties, so every evaluation
+// deterministically picks the same incumbent. An empty string means cp itself
+// is the incumbent (or the only ControlPlane) and reconciliation may proceed.
+// The List goes through the informer cache: unlike the admission-time webhook
+// check this guard runs on every reconcile, so eventual consistency is enough
+// — a briefly stale cache only delays the parking by one requeue.
+func (r *ControlPlaneReconciler) duplicateControlPlaneIncumbent(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (string, error) {
+	var cps c5c3v1alpha1.ControlPlaneList
+	if err := r.List(ctx, &cps, client.InNamespace(cp.Namespace)); err != nil {
+		return "", fmt.Errorf("listing ControlPlanes in namespace %q for the duplicate guard: %w", cp.Namespace, err)
+	}
+	incumbent := cp
+	for i := range cps.Items {
+		other := &cps.Items[i]
+		if other.UID == cp.UID {
+			continue
+		}
+		if other.CreationTimestamp.Before(&incumbent.CreationTimestamp) ||
+			(other.CreationTimestamp.Equal(&incumbent.CreationTimestamp) && other.Name < incumbent.Name) {
+			incumbent = other
+		}
+	}
+	if incumbent.UID == cp.UID {
+		return "", nil
+	}
+	return incumbent.Name, nil
+}
+
+// parkDuplicateControlPlane sets Ready=False with reason DuplicateControlPlane
+// naming the incumbent, persists the status, and requeues. It deliberately
+// bypasses updateStatus: setReadyCondition would recompute Ready from the
+// sub-conditions and overwrite the DuplicateControlPlane reason. The periodic
+// requeue lets the parked CR take over automatically once the incumbent is
+// fully deleted — no watch event fires on the duplicate's behalf when that
+// happens.
+func (r *ControlPlaneReconciler) parkDuplicateControlPlane(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, incumbent string) (ctrl.Result, error) {
+	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: cp.Generation,
+		Reason:             "DuplicateControlPlane",
+		Message: fmt.Sprintf(
+			"parked: ControlPlane %q is older and owns namespace %q; only one ControlPlane is permitted per namespace (CC-0112)",
+			incumbent, cp.Namespace,
+		),
+	})
+	cp.Status.ObservedGeneration = cp.Generation
+	if err := r.Status().Update(ctx, cp); err != nil {
+		log.FromContext(ctx).Error(err, "unable to update ControlPlane status")
+		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+	}
+	return ctrl.Result{RequeueAfter: duplicateControlPlaneRequeueAfter}, nil
 }
 
 // controlPlaneSecretNameExtractor is the controller-runtime IndexerFunc registered

--- a/operators/c5c3/internal/controller/controlplane_controller_test.go
+++ b/operators/c5c3/internal/controller/controlplane_controller_test.go
@@ -8,6 +8,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,4 +104,130 @@ func TestReconcile_NotFound_EarlyReturn(t *testing.T) {
 		"Reconcile on a missing ControlPlane must not error")
 	g.Expect(res).To(Equal(ctrl.Result{}),
 		"Reconcile on a missing ControlPlane must return a zero result")
+}
+
+// --- Duplicate-ControlPlane guard tests (CC-0112, REQ-010 defense-in-depth) ---
+
+// duplicateGuardControlPlane returns a minimal ControlPlane with the given
+// identity and creation time for the duplicate-guard tests. The guard runs
+// before any spec interpretation, so an empty spec is sufficient.
+func duplicateGuardControlPlane(name, namespace, uid string, created time.Time) *c5c3v1alpha1.ControlPlane {
+	return &c5c3v1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(uid),
+			CreationTimestamp: metav1.NewTime(created),
+		},
+	}
+}
+
+func TestReconcile_DuplicateControlPlane_ParksYounger(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := controllerTestScheme(t)
+	now := time.Now()
+	older := duplicateGuardControlPlane("alpha", "default", "uid-alpha", now.Add(-time.Hour))
+	younger := duplicateGuardControlPlane("bravo", "default", "uid-bravo", now)
+	// The scheme deliberately registers no child types (MariaDB, Keystone, ...):
+	// if the guard ever failed to park the duplicate, the sub-reconciler chain
+	// would error on the unregistered kinds and fail this test.
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(older, younger).
+		WithStatusSubresource(&c5c3v1alpha1.ControlPlane{}).
+		Build()
+
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "bravo"},
+	})
+
+	g.Expect(err).NotTo(HaveOccurred(), "parking a duplicate must not error")
+	g.Expect(res.RequeueAfter).To(Equal(duplicateControlPlaneRequeueAfter),
+		"a parked duplicate must requeue so it can take over once the incumbent is gone")
+
+	var parked c5c3v1alpha1.ControlPlane
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "bravo"}, &parked)).To(Succeed())
+	ready := conditions.GetCondition(parked.Status.Conditions, conditionTypeReady)
+	g.Expect(ready).NotTo(BeNil(), "the parked duplicate must carry a Ready condition")
+	g.Expect(ready.Status).To(Equal(metav1.ConditionFalse),
+		"a parked duplicate must report Ready=False")
+	g.Expect(ready.Reason).To(Equal("DuplicateControlPlane"),
+		"a parked duplicate must report reason DuplicateControlPlane")
+	g.Expect(ready.Message).To(ContainSubstring(`"alpha"`),
+		"the Ready message must name the incumbent")
+	g.Expect(parked.Status.ObservedGeneration).To(Equal(parked.Generation),
+		"the parked status must stamp ObservedGeneration")
+}
+
+func TestReconcile_DuplicateControlPlane_TieBreakByName(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := controllerTestScheme(t)
+	created := metav1.Now().Time
+	// Identical creation timestamps: the lexically smallest name wins.
+	first := duplicateGuardControlPlane("alpha", "default", "uid-alpha", created)
+	second := duplicateGuardControlPlane("bravo", "default", "uid-bravo", created)
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(first, second).
+		WithStatusSubresource(&c5c3v1alpha1.ControlPlane{}).
+		Build()
+
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "bravo"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var parked c5c3v1alpha1.ControlPlane
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "bravo"}, &parked)).To(Succeed())
+	ready := conditions.GetCondition(parked.Status.Conditions, conditionTypeReady)
+	g.Expect(ready).NotTo(BeNil())
+	g.Expect(ready.Reason).To(Equal("DuplicateControlPlane"),
+		"on a creation-time tie the lexically larger name must be parked")
+	g.Expect(ready.Message).To(ContainSubstring(`"alpha"`),
+		"the tie-break incumbent must be the lexically smallest name")
+}
+
+func TestDuplicateControlPlaneIncumbent_OldestProceeds(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := controllerTestScheme(t)
+	now := time.Now()
+	older := duplicateGuardControlPlane("alpha", "default", "uid-alpha", now.Add(-time.Hour))
+	younger := duplicateGuardControlPlane("bravo", "default", "uid-bravo", now)
+	// A ControlPlane in another namespace must not influence the guard.
+	unrelated := duplicateGuardControlPlane("older-elsewhere", "other", "uid-other", now.Add(-2*time.Hour))
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(older, younger, unrelated).
+		Build()
+
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	incumbent, err := r.duplicateControlPlaneIncumbent(context.Background(), older)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(incumbent).To(BeEmpty(),
+		"the oldest ControlPlane in the namespace must proceed")
+
+	incumbent, err = r.duplicateControlPlaneIncumbent(context.Background(), younger)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(incumbent).To(Equal("alpha"),
+		"a younger ControlPlane must be parked behind the namespace's oldest")
+}
+
+func TestDuplicateControlPlaneIncumbent_SingleControlPlane(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := controllerTestScheme(t)
+	only := duplicateGuardControlPlane("solo", "default", "uid-solo", time.Now())
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(only).Build()
+
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	incumbent, err := r.duplicateControlPlaneIncumbent(context.Background(), only)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(incumbent).To(BeEmpty(),
+		"a namespace's only ControlPlane must proceed")
 }

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -74,7 +74,9 @@ func setupControlPlaneEnvTest(t testing.TB) (client.Client, context.Context, con
 		t,
 		c5c3v1alpha1.AddToScheme,
 		func(mgr ctrl.Manager) error {
-			return (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr)
+			// mgr.GetAPIReader() mirrors the production wiring in main.go: webhook
+			// admission lookups read the API server directly, never a stale cache.
+			return (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetAPIReader()}).SetupWebhookWithManager(mgr)
 		},
 		func(mgr ctrl.Manager) error {
 			r := &ControlPlaneReconciler{

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -56,4 +56,11 @@ const (
 	// "ReMinting" indefinitely with no operator-visible signal. The window is
 	// generous so a slow-but-progressing revoke is not flagged as stalled.
 	remintStallTimeout = 5 * time.Minute
+
+	// duplicateControlPlaneRequeueAfter is the backoff a parked duplicate
+	// ControlPlane uses while an older ControlPlane owns its namespace
+	// (CC-0112, REQ-010 defense-in-depth). Deleting the incumbent enqueues no
+	// event for the parked CR, so this periodic requeue is what lets the
+	// parked ControlPlane take over once the incumbent is fully gone.
+	duplicateControlPlaneRequeueAfter = 30 * time.Second
 )

--- a/operators/c5c3/main.go
+++ b/operators/c5c3/main.go
@@ -80,9 +80,13 @@ func main() {
 			}
 			if webhooks {
 				// DECISION (CC-0112, REQ-010): Client must be non-nil for the
-				// one-ControlPlane-per-namespace ValidateCreate check; mgr.GetClient()
-				// satisfies it (a client.Reader implementing List).
-				if err := (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
+				// one-ControlPlane-per-namespace ValidateCreate check. It reads
+				// through mgr.GetAPIReader() (direct, uncached) rather than
+				// mgr.GetClient(): two concurrent CREATEs must not both see an
+				// empty informer cache and both be admitted, and even sequential
+				// creates within the cache-sync window would both pass against
+				// the cached client.
+				if err := (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetAPIReader()}).SetupWebhookWithManager(mgr); err != nil {
 					return err
 				}
 			}

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -37,7 +37,9 @@ import (
 func setupEnvTest(t testing.TB) (client.Client, context.Context, context.CancelFunc) {
 	t.Helper()
 	return testutil.SetupKeystoneEnvTest(t, AddToScheme, func(mgr ctrl.Manager) error {
-		return (&KeystoneWebhook{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr)
+		// mgr.GetAPIReader() mirrors the production wiring in main.go: webhook
+		// admission lookups read the API server directly, never a stale cache.
+		return (&KeystoneWebhook{Client: mgr.GetAPIReader()}).SetupWebhookWithManager(mgr)
 	})
 }
 

--- a/operators/keystone/api/v1alpha1/keystone_webhook.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook.go
@@ -84,7 +84,10 @@ var (
 )
 
 // KeystoneWebhook implements defaulting and validation webhooks for the Keystone CRD (CC-0011).
-// Client is injected at startup for cluster-scoped resource lookups (e.g. PriorityClass validation, CC-0075 REQ-006).
+// Client is injected at startup for cluster-scoped resource lookups (e.g. PriorityClass
+// validation, CC-0075 REQ-006). Production wiring injects mgr.GetAPIReader() — a direct,
+// uncached reader — so admission never rejects a just-created object from a stale
+// informer cache and no lazy informer start happens inside the webhook timeout.
 // +kubebuilder:object:generate=false
 type KeystoneWebhook struct {
 	Client client.Reader

--- a/operators/keystone/api/v1alpha1/keystone_webhook.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook.go
@@ -97,7 +97,7 @@ var (
 )
 
 // +kubebuilder:webhook:path=/mutate-keystone-openstack-c5c3-io-v1alpha1-keystone,mutating=true,failurePolicy=fail,sideEffects=None,groups=keystone.openstack.c5c3.io,resources=keystones,verbs=create;update,versions=v1alpha1,name=mkeystone.kb.io,admissionReviewVersions=v1
-// +kubebuilder:webhook:path=/validate-keystone-openstack-c5c3-io-v1alpha1-keystone,mutating=false,failurePolicy=fail,sideEffects=None,groups=keystone.openstack.c5c3.io,resources=keystones,verbs=create;update;delete,versions=v1alpha1,name=vkeystone.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-keystone-openstack-c5c3-io-v1alpha1-keystone,mutating=false,failurePolicy=fail,sideEffects=None,groups=keystone.openstack.c5c3.io,resources=keystones,verbs=create;update,versions=v1alpha1,name=vkeystone.kb.io,admissionReviewVersions=v1
 
 // SetupWebhookWithManager registers the defaulting and validating webhooks with the manager.
 func (w *KeystoneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -237,8 +237,11 @@ func (w *KeystoneWebhook) ValidateUpdate(ctx context.Context, _, newObj *Keyston
 	return nil, w.validate(ctx, newObj)
 }
 
-// ValidateDelete implements admission.Validator[*Keystone].
-// Deletion is always allowed.
+// ValidateDelete implements admission.Validator[*Keystone]. The method is
+// required by the Validator interface but is never invoked: the validating
+// webhook registers only create/update (no delete verb), so with
+// failurePolicy=Fail a down operator can never block Keystone CR — and
+// thereby namespace — deletion.
 func (w *KeystoneWebhook) ValidateDelete(_ context.Context, _ *Keystone) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/operators/keystone/config/webhook/manifests.yaml
+++ b/operators/keystone/config/webhook/manifests.yaml
@@ -47,7 +47,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - keystones
   sideEffects: None

--- a/operators/keystone/helm/keystone-operator/Chart.yaml
+++ b/operators/keystone/helm/keystone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keystone-operator
 description: A Helm chart for deploying the Keystone OpenStack operator
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.1.0"
 # The shared naming/label helpers and the Deployment skeleton live in the
 # operator-library library chart so they are defined once for both operator
@@ -21,3 +21,7 @@ annotations:
       description: Opt-in NetworkPolicy for operator pod egress/ingress restriction (CC-0090)
     - kind: added
       description: Expose operator log level, encoder, and development mode as chart values
+    - kind: added
+      description: PodDisruptionBudget (minAvailable 1, replicas > 1) and best-effort node spread for the operator Deployment
+    - kind: changed
+      description: Validating webhook no longer intercepts DELETE, so a down operator cannot block CR or namespace deletion

--- a/operators/keystone/helm/keystone-operator/templates/pdb.yaml
+++ b/operators/keystone/helm/keystone-operator/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{/*
+  PodDisruptionBudget for the keystone-operator Deployment.
+
+  Keeps at least one replica — and with it the in-process admission webhook
+  (failurePolicy=Fail) — available during voluntary disruptions such as node
+  drains and cluster upgrades. Rendered only when replicas > 1: with a single
+  replica, minAvailable: 1 would block every voluntary disruption and wedge
+  node drains.
+*/}}
+{{- if gt (int .Values.replicas) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "operator-library.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "operator-library.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "operator-library.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/operators/keystone/helm/keystone-operator/templates/webhook-configuration.yaml
+++ b/operators/keystone/helm/keystone-operator/templates/webhook-configuration.yaml
@@ -53,10 +53,12 @@ webhooks:
           - keystone.openstack.c5c3.io
         apiVersions:
           - v1alpha1
+        # No DELETE: the webhook is served in-process by the operator, so with
+        # failurePolicy=Fail a DELETE rule would let a down operator block CR
+        # and namespace deletion. ValidateDelete is a no-op anyway.
         operations:
           - CREATE
           - UPDATE
-          - DELETE
         resources:
           - keystones
 {{- end }}

--- a/operators/keystone/helm/keystone-operator/tests/deployment_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/deployment_test.yaml
@@ -217,3 +217,22 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --zap-devel=true
+
+  - it: should spread replicas across nodes best-effort
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      # ScheduleAnyway (soft) so single-node clusters (kind) stay schedulable.
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: keystone-operator
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME

--- a/operators/keystone/helm/keystone-operator/tests/pdb_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/pdb_test.yaml
@@ -1,0 +1,44 @@
+# PodDisruptionBudget unit tests. The PDB keeps one replica — and with it the
+# in-process admission webhook — available during voluntary disruptions; it is
+# rendered only when replicas > 1 so a single-replica deployment never wedges
+# node drains.
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: should render a PodDisruptionBudget with minAvailable 1 by default
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-keystone-operator
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: keystone-operator
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should not render a PodDisruptionBudget when replicas is 1
+    set:
+      replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should keep minAvailable 1 when replicas is raised
+    set:
+      replicas: 3
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/operators/keystone/helm/keystone-operator/tests/webhook_test.yaml
+++ b/operators/keystone/helm/keystone-operator/tests/webhook_test.yaml
@@ -52,7 +52,9 @@ tests:
       - contains:
           path: webhooks[0].rules[0].operations
           content: UPDATE
-      - contains:
+      # DELETE must NOT be intercepted: with failurePolicy=Fail a down operator
+      # would otherwise block CR and namespace deletion.
+      - notContains:
           path: webhooks[0].rules[0].operations
           content: DELETE
 

--- a/operators/keystone/main.go
+++ b/operators/keystone/main.go
@@ -62,7 +62,12 @@ func main() {
 				return err
 			}
 			if webhooks {
-				if err := (&keystonev1alpha1.KeystoneWebhook{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
+				// DECISION: the webhook reads through mgr.GetAPIReader() (direct,
+				// uncached) rather than mgr.GetClient(). The PriorityClass existence
+				// check must not reject a just-created PriorityClass from a stale
+				// informer cache, and the cached client's lazy informer start would
+				// otherwise happen inside the webhook timeout.
+				if err := (&keystonev1alpha1.KeystoneWebhook{Client: mgr.GetAPIReader()}).SetupWebhookWithManager(mgr); err != nil {
 					return err
 				}
 			}

--- a/operators/shared/helm/operator-library/templates/_deployment.tpl
+++ b/operators/shared/helm/operator-library/templates/_deployment.tpl
@@ -34,6 +34,16 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      # Best-effort spread across nodes so a single node drain cannot evict
+      # every replica — and with it the in-process admission webhook — at once.
+      # ScheduleAnyway keeps single-node (kind) clusters schedulable.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "operator-library.selectorLabels" . | nindent 14 }}
       containers:
         - name: manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
Closes #459.

Remediates the four operator-availability findings from the 2026-06 pre-production audit, in commit order:

1. **fix(operators): stop intercepting DELETE in validating webhooks** — drops the `delete` verb from both validating-webhook markers, the regenerated `config/webhook/manifests.yaml`, and both chart webhook templates. Both `ValidateDelete` implementations were unconditional no-ops, and because the webhook is served in-process with `failurePolicy: Fail`, a down operator made CR — and thereby namespace — deletion impossible. The helm-unittest suites now assert `notContains: DELETE` so a reintroduction fails the chart tests. The no-op `ValidateDelete` methods remain (required by the `admission.Validator` interface) with comments stating they are never invoked.

2. **feat(charts): add PodDisruptionBudget and node spread to operators** — both charts default `replicas: 2` but shipped no PDB and no spread constraint, so a single node drain could evict both replicas at once and take admission down cluster-wide. Adds a `policy/v1` PDB with `minAvailable: 1`, rendered only when `replicas > 1` (a single-replica install must never wedge node drains), plus a soft hostname `topologySpreadConstraint` (`ScheduleAnyway`, so single-node kind clusters stay schedulable). Chart versions bumped (keystone-operator 0.4.0, c5c3-operator 0.2.0) with `artifacthub.io/changes` entries; the FluxCD HelmReleases pin `>=0.1.0 <1.0.0`, so both bumps stay in range. No new values keys, hence no `values.schema.json` change.

3. **fix(operators): read webhook admission lookups through the API reader** — injects `mgr.GetAPIReader()` instead of `mgr.GetClient()` into both webhook structs (they already accept `client.Reader`). The one-ControlPlane-per-namespace List no longer races the informer cache (two concurrent CREATEs both seeing an empty cache), and the Keystone PriorityClass `Get` neither rejects a just-created class off a stale cache nor lazily starts an informer inside the webhook timeout. The envtest wiring mirrors the production wiring.

4. **fix(c5c3): park duplicate ControlPlanes behind the namespace's oldest** — reconciler-side defense-in-depth the issue called out as missing (unlike `CredentialRotation`'s `AmbiguousControlPlane` handling): before the sub-reconciler chain, every ControlPlane except the namespace's oldest (`creationTimestamp`, lexically smallest name breaking ties) is parked with `Ready=False` / `DuplicateControlPlane` naming the incumbent, runs no sub-reconcilers, and requeues every 30s — deleting the incumbent fires no watch event for the duplicate, so the periodic requeue is what lets it take over. The parked status write deliberately bypasses `updateStatus`, which would otherwise overwrite the reason via `setReadyCondition`; rationale is in the method comment.

### Verification

- `make test` — all unit tests pass (internal/common, keystone, c5c3)
- `go test -tags=integration` (envtest, k8s 1.35) for `operators/keystone/api/v1alpha1` and all of `operators/c5c3` — pass, including the multi-ControlPlane suites
- `golangci-lint run` in all three modules — 0 issues; `gofumpt -l` clean
- `helm unittest` both charts (178 + 135 tests) and `helm lint --strict` — pass; all five CI `helm template` scenarios render
- `make manifests` is idempotent (controller-gen v0.20.1); `make verify-crd-sync` and `make check-docs-ids` pass
- `go test -race -count=1` on the changed controller package — pass

### Deviations / notes

- No e2e (Chainsaw) test was added: the four changes are admission wiring, chart resources, and a reconciler pre-flight guard, all covered by unit, helm-unittest, and envtest layers; no existing e2e directory convention covers operator-chart resources.
- Pre-existing doc drift noticed but left untouched (out of scope): `docs/reference/c5c3/controlplane-crd.md` introduces the status-conditions section with "five sub-reconcilers" and a five-element gate diagram while `subConditionTypes` has seven entries. Where my edit touched the adjacent Ready sentence I sidestepped the wrong count ("all sub-conditions") rather than propagating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
