### PR TITLE
fix(images): pin venv-builder base packages with constraints + Renovate

### DIFF
--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -97,18 +97,26 @@ for multi-stage service builds.
 
 **Pre-installed common packages:**
 
-The virtualenv includes four packages shared by all OpenStack services:
+The virtualenv includes five packages shared by all OpenStack services, version-pinned in
+`images/venv-builder/requirements.txt`:
 
 | Package | Purpose |
 | --- | --- |
 | `cryptography` | TLS, token encryption, Fernet keys |
+| `pymemcache` | Memcached client (pure-Python `pymemcache` backend) |
 | `pymysql` | MySQL/MariaDB database driver |
 | `python-memcached` | Memcached client for caching |
 | `uwsgi` | WSGI application server |
 
-These packages are installed **without** the `--constraint` flag. The `venv-builder` image
-is release-independent — version constraints are release-specific and applied only in
-service Dockerfiles when installing the actual service.
+These packages are **version-pinned** in `requirements.txt` so the `venv-builder` image is
+reproducible — without pins they would resolve to whatever is latest on PyPI at build time.
+The image stays release-independent: the pins are deliberately not taken from any single
+release's `upper-constraints.txt`. The OpenStack-dependency subset (`cryptography`,
+`pymemcache`, `pymysql`, `python-memcached`) is authoritatively re-pinned per release by
+service Dockerfiles via `uv pip install --constraint upper-constraints.txt`; `uwsgi` is not
+an OpenStack dependency (it is absent from `upper-constraints.txt`), so its version is fixed
+here. Renovate tracks these pins through its native `pip_requirements` manager — major bumps
+are gated for manual review, minor/patch are automerged after a three-day soak.
 
 **OCI labels:** Same static `LABEL` pattern as `python-base` — title, description,
 licenses, and vendor are embedded in the Dockerfile for local build visibility.

--- a/images/venv-builder/Dockerfile
+++ b/images/venv-builder/Dockerfile
@@ -25,14 +25,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Prepare virtual environment
 RUN python3 -m venv /var/lib/openstack
 
-# Common base packages for all services (no --constraint: venv-builder is
-# release-independent; constraints are applied in service Dockerfiles)
-RUN uv pip install --prefix /var/lib/openstack \
-    cryptography \
-    pymemcache \
-    pymysql \
-    python-memcached \
-    uwsgi
+# Common base packages for all services, version-pinned via requirements.txt
+# for a reproducible venv. venv-builder stays release-independent: the
+# OpenStack-dependency subset is re-pinned per release in service Dockerfiles
+# via --constraint upper-constraints.txt, while uwsgi (not an OpenStack
+# dependency) is fixed here. Renovate tracks the pins (see renovate.json).
+RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    uv pip install --prefix /var/lib/openstack -r /tmp/requirements.txt
 
 # CC-0031: Static OCI Image Spec annotations for local builds.
 # CI-generated labels from docker/metadata-action supplement these at push time.

--- a/images/venv-builder/requirements.txt
+++ b/images/venv-builder/requirements.txt
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Base Python packages pre-installed into the shared virtualenv by the
+# venv-builder image. Pinned so the venv-builder image is reproducible:
+# without pins these resolve to whatever is latest on PyPI at build time.
+#
+# venv-builder is release-independent (one image for every OpenStack release),
+# so these pins are deliberately NOT taken from any single release's
+# upper-constraints.txt. The OpenStack-dependency subset (cryptography,
+# pymemcache, pymysql, python-memcached) is authoritatively re-pinned by each
+# service build via `uv pip install --constraint upper-constraints.txt`; uwsgi
+# is not an OpenStack dependency and is absent from upper-constraints, so its
+# version is fixed here.
+#
+# Renovate keeps these current via the native pip_requirements manager (see
+# renovate.json: minor/patch automerged after 3 days, majors gated for review).
+cryptography==48.0.1
+pymemcache==4.0.0
+pymysql==1.2.0
+python-memcached==1.62
+uwsgi==2.0.31

--- a/renovate.json
+++ b/renovate.json
@@ -315,6 +315,20 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "Go build tooling"
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "matchFileNames": ["images/venv-builder/requirements.txt"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "matchFileNames": ["images/venv-builder/requirements.txt"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "venv-builder base packages"
     }
   ]
 }

--- a/tests/container-images/verify_venv_builder.sh
+++ b/tests/container-images/verify_venv_builder.sh
@@ -26,6 +26,9 @@ if [[ -z "$EXPECTED_UV_VERSION" ]]; then
   echo "ERROR: Could not extract uv version from $SCRIPT_DIR/../../images/venv-builder/Dockerfile" >&2
   exit 1
 fi
+
+# Source of truth for the pinned base-package versions asserted by Test 3.
+REQUIREMENTS="$SCRIPT_DIR/../../images/venv-builder/requirements.txt"
 test_uv_version_is_pinned() {
   echo "Test: uv version is $EXPECTED_UV_VERSION"
   local version exit_code=0
@@ -44,17 +47,55 @@ test_virtualenv_exists() {
   assert_eq "/var/lib/openstack/bin/python3 is executable" "0" "$exit_code"
 }
 
-# --- Test 3: common packages are installed ---
-test_common_packages_installed() {
-  echo "Test: common packages are installed in virtualenv"
-  local pip_list exit_code=0
-  pip_list=$(docker run --rm "$IMAGE" /var/lib/openstack/bin/pip list 2>&1) || exit_code=$?
+# --- Test 3: common packages are installed at their pinned versions ---
+# Asserts every pin in images/venv-builder/requirements.txt is installed at
+# exactly that version, so a drift back to "whatever is latest on PyPI" is
+# caught. Expected values are derived from the requirements file (the source
+# of truth), not hard-coded here.
+test_common_packages_pinned() {
+  echo "Test: common packages are installed at their pinned versions"
 
+  if [[ ! -f "$REQUIREMENTS" ]]; then
+    echo "  FAIL: requirements file not found at $REQUIREMENTS"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local freeze exit_code=0
+  freeze=$(docker run --rm "$IMAGE" /var/lib/openstack/bin/pip list --format=freeze 2>&1) || exit_code=$?
   assert_eq "pip list exits 0" "0" "$exit_code"
-  assert_contains "cryptography installed" "$pip_list" "cryptography"
-  assert_contains "pymysql installed" "$pip_list" "PyMySQL"
-  assert_contains "python-memcached installed" "$pip_list" "python-memcached"
-  assert_contains "uwsgi installed" "$pip_list" "uWSGI"
+
+  # Collect "name==version" pins (skip SPDX header, comments, and blanks).
+  local pins=() line
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[A-Za-z0-9._-]+==[^[:space:]]+$ ]] && pins+=("$line")
+  done < "$REQUIREMENTS"
+
+  if [[ "${#pins[@]}" -eq 0 ]]; then
+    echo "  FAIL: no pins parsed from $REQUIREMENTS"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # Match each pin against a whole freeze line, anchored, so a pin can't match
+  # a substring of another package (e.g. "pymysql==1.2.0" inside
+  # "pymysql==1.2.0.post1", or a different project whose line merely contains
+  # the string). pip canonicalises name casing (PyMySQL, uWSGI), so match
+  # case-insensitively; "." is escaped so it stays literal in the ERE.
+  local pin name version pattern
+  for pin in "${pins[@]}"; do
+    name="${pin%%==*}"
+    version="${pin#*==}"
+    pattern="^${name//./\\.}==${version//./\\.}$"
+    if echo "$freeze" | grep -iqE "$pattern"; then
+      echo "  PASS: $pin installed at pinned version"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: $pin not installed at pinned version"
+      echo "    pip freeze: $freeze"
+      FAIL=$((FAIL + 1))
+    fi
+  done
 }
 
 # --- Run all tests ---
@@ -65,7 +106,7 @@ test_uv_version_is_pinned
 echo ""
 test_virtualenv_exists
 echo ""
-test_common_packages_installed
+test_common_packages_pinned
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/unit/renovate/venv_builder_requirements_test.sh
+++ b/tests/unit/renovate/venv_builder_requirements_test.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the venv-builder base-package pins are covered by Renovate.
+#
+# The pins live in images/venv-builder/requirements.txt and are tracked by
+# Renovate's native pip_requirements manager (no customManager needed). This
+# test guards the coverage the way tests/unit/renovate/*_custommanager_test.sh
+# guard the regex managers: the requirements file must pin every base package,
+# and packageRules must gate major bumps and automerge minor/patch — matching
+# the conservative posture applied to every other tracked pin in the repo.
+#
+# Usage: bash tests/unit/renovate/venv_builder_requirements_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+REQUIREMENTS="$PROJECT_ROOT/images/venv-builder/requirements.txt"
+REQUIREMENTS_GLOB="images/venv-builder/requirements.txt"
+
+test_requirements_file_pins_base_packages() {
+  echo "Test: images/venv-builder/requirements.txt pins every base package"
+
+  if [[ ! -f "$REQUIREMENTS" ]]; then
+    echo "  FAIL: $REQUIREMENTS missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # Every non-comment, non-blank line names a base package and must pin it to
+  # an exact version (name==x.y.z). Parsing the package names from the file
+  # rather than hard-coding them keeps a single source of truth: a new or
+  # removed base package only changes requirements.txt, and an unpinned entry
+  # (e.g. "requests>=2.0" or a bare "requests") fails here.
+  local line name checked=0
+  while IFS= read -r line; do
+    # Strip inline comments and surrounding whitespace, then skip blanks.
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+
+    checked=$((checked + 1))
+    if [[ "$line" =~ ^[A-Za-z0-9._-]+==[0-9] ]]; then
+      name="${line%%==*}"
+      echo "  PASS: ${name} is pinned to an exact version"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: '${line}' is not an exact pin (name==x.y.z) in requirements.txt"
+      FAIL=$((FAIL + 1))
+    fi
+  done < "$REQUIREMENTS"
+
+  if [[ "$checked" -eq 0 ]]; then
+    echo "  FAIL: no base packages found in $REQUIREMENTS"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_package_rule_disables_majors() {
+  echo "Test: packageRule disables majors for the venv-builder requirements file"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local major_rule
+  major_rule="$(jq -c --arg f "$REQUIREMENTS_GLOB" '.packageRules[]
+    | select(
+        ((.matchManagers // []) | index("pip_requirements")) != null
+        and ((.matchFileNames // []) | index($f)) != null
+        and ((.matchUpdateTypes // []) | index("major")) != null
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no pip_requirements packageRule for $REQUIREMENTS_GLOB disables majors"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_eq "major venv-builder base-package updates are disabled" \
+    "false" \
+    "$(jq -r '.enabled' <<<"$major_rule")"
+}
+
+test_package_rule_automerges_minor_patch() {
+  echo "Test: packageRule automerges minor/patch for the venv-builder requirements file"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local minor_rule
+  minor_rule="$(jq -c --arg f "$REQUIREMENTS_GLOB" '.packageRules[]
+    | select(
+        ((.matchManagers // []) | index("pip_requirements")) != null
+        and ((.matchFileNames // []) | index($f)) != null
+        and ((.matchUpdateTypes // []) | index("minor")) != null
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no pip_requirements packageRule for $REQUIREMENTS_GLOB covers minor/patch"
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  assert_eq "minor/patch venv-builder base-package updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+
+  assert_eq "minor/patch venv-builder base-package updates have a release-age gate" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+}
+
+test_requirements_file_pins_base_packages
+test_package_rule_disables_majors
+test_package_rule_automerges_minor_patch
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Implements #473.

## Problem

`images/venv-builder/Dockerfile` installed `cryptography`, `pymemcache`,
`pymysql`, `python-memcached` and `uwsgi` with **no `--constraint` and no
version pin**, so they resolved to whatever was latest on PyPI at build time.
That made the venv-builder image non-reproducible, and the unpinned set
includes the crypto stack and the uWSGI server fronting Keystone. Service
Dockerfiles applied `--constraint upper-constraints.txt` only to the service
package, in a later layer.

## Fix

The venv-builder is built **once, release-independently** (it has no
`upper-constraints` build context, unlike service/tempest images), so it
cannot consume any single release's `upper-constraints.txt`. Instead the base
packages are now pinned in a dedicated, release-independent
`images/venv-builder/requirements.txt` and installed with `uv pip install -r`
via a bind mount. The pins freeze today's resolved versions, so the image is
reproducible; Renovate keeps them current going forward.

Note: the OpenStack-dependency subset (`cryptography`, `pymemcache`, `pymysql`,
`python-memcached`) is authoritatively **re-pinned per release** by service
Dockerfiles via `--constraint upper-constraints.txt`, so final service images
are unaffected by these seed pins. `uwsgi` is *not* an OpenStack dependency
(it is absent from every `upper-constraints.txt`), so its version is fixed
here — this is the one base package whose venv-builder pin is authoritative
for the final image.

## Changes (in commit order)

1. **`fix(images): pin venv-builder base packages for reproducible venv`**
   - New `images/venv-builder/requirements.txt` with exact `==` pins
     (`cryptography==48.0.1`, `pymemcache==4.0.0`, `pymysql==1.2.0`,
     `python-memcached==1.62`, `uwsgi==2.0.31` — current latest = freeze).
   - Dockerfile installs via `uv pip install --prefix /var/lib/openstack -r`
     through a `--mount=type=bind` (no extra image layer).
   - Strengthens `verify_venv_builder.sh` to assert each package is installed
     at its **pinned version** (derived from `requirements.txt`), and adds
     `pymemcache`, which the previous presence-only check omitted.

2. **`ci(renovate): track venv-builder base package pins`**
   - `packageRules` for the file (native `pip_requirements` manager): majors
     gated, minor/patch automerged after a three-day soak, grouped.
   - New `tests/unit/renovate/venv_builder_requirements_test.sh` regression
     guard, mirroring the existing `*_custommanager_test.sh` tests.

3. **`docs(images): document venv-builder base package pinning`**
   - Updates the venv-builder section of the container-images reference and
     fixes the pre-installed package list (it previously omitted `pymemcache`).

## Verification (local)

- `hadolint --config .hadolint.yaml images/venv-builder/Dockerfile` — clean.
- `docker build images/python-base` + `docker build images/venv-builder` —
  build succeeds; install resolves to **exactly** the pinned versions.
- `bash tests/container-images/verify_venv_builder.sh venv-builder` —
  **9 passed, 0 failed** (incl. the new pinned-version assertions).
- `make test-shell` — all shell unit tests pass (incl. the new renovate test,
  8/0).
- `shellcheck --severity=warning` — clean on both touched/new shell scripts.
- `jq empty renovate.json` — valid; `renovate-config-validator` reports the
  **same** pre-existing findings as `main` (zero new). Those findings come
  from npx pulling renovate v37, which predates the `managerFilePatterns`
  option the repo already uses — a tooling-version artifact, not introduced
  here.
- `audit-renovate-coverage.sh` — the 3 `[FAIL]`s are identical on `main`
  (pre-existing `TEMPEST_VERSION`/`KTP_VERSION`/`SERVICE_VERSION` gaps in
  `hack/`); R6 passes with the new test.

## Notes / deviations

- **`--require-hashes` deferred.** The issue lists it as "ideally". It is
  all-or-nothing (every transitive package needs a hash) and the repo's
  `upper-constraints.txt` files carry **zero** hashes — there is no hashing
  mechanism anywhere today. Adding it would require generating and maintaining
  a full, multi-arch hashed lockfile (the venv resolves `cffi`/`pycparser`
  transitively) plus a Renovate strategy for hashed pip files — a substantial
  new mechanism, disproportionate to this audit fix. Pinning + Renovate
  coverage delivers the reproducibility the issue asks for; hashing can be a
  follow-up if desired.
- **Pinned to current PyPI latest** (= freeze current build behaviour) rather
  than to a release's `upper-constraints.txt`, to keep the builder
  release-independent (releases disagree, e.g. `pymysql` 1.1.1 vs 1.1.2) and
  to maximise the security posture of the published, Grype-scanned builder.
- **Out of scope (mentioned, not touched):** the `container-images.md`
  venv-builder property table still lists `uv 0.6.3` while the Dockerfile pins
  `0.11.19` — a pre-existing, unrelated doc drift. The `architecture/`
  submodule (`08-container-images/01-build-pipeline.md`) still carries the old
  "No --constraint here" note; it is a submodule and left unbumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)