### PR TITLE
docs: recommend namespace-scoped least-privilege RBAC for production

### DIFF
--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -21,6 +21,21 @@ the [ControlPlane Quick Start](../quick-start-controlplane.md); the namespace-sc
 operator RBAC described here is the complementary, lower-level concern.
 :::
 
+::: tip Recommended for single-namespace production
+When a control plane is confined to **one namespace**, deploy the operator
+namespace-scoped (`rbac.namespaceScoped: true`). This replaces the operator's
+cluster-wide `ClusterRole` — which grants read/write on **every** `Secret` in
+**every** namespace — with a `Role` bound to a single namespace, so a
+compromised operator pod can reach only that namespace's Secrets. The
+[Security trade-off](#security-trade-off-the-cluster-wide-rbac-default) below
+explains the privilege-escalation path this closes.
+
+The chart still ships cluster-wide (`rbac.namespaceScoped: false`) by default
+because some capabilities still need cluster scope — see
+[When cluster-wide RBAC is still required](#when-cluster-wide-rbac-is-still-required).
+Adopt namespace-scoped mode when your deployment fits in one namespace.
+:::
+
 ## Prerequisites
 
 Before deploying the operator in namespace-scoped mode, ensure:
@@ -46,6 +61,83 @@ Before deploying the operator in namespace-scoped mode, ensure:
   must not hold cluster-wide permissions.
 - **Multiple operator instances** — you need several independent Keystone
   operators, each managing a different namespace.
+
+---
+
+## When cluster-wide RBAC is still required
+
+Keep the default (`rbac.namespaceScoped: false`) when any of these apply — each
+needs cluster scope, which namespace-scoped mode cannot provide:
+
+- **Cross-namespace CR management** — a single operator instance reconciles
+  `Keystone` (or `ControlPlane`) CRs in more than one namespace. A
+  namespace-scoped operator only watches and reconciles its own namespace.
+- **Admission webhooks** — the defaulting and validating webhooks register
+  through cluster-scoped `ValidatingWebhookConfiguration` /
+  `MutatingWebhookConfiguration` objects, which only a `ClusterRole` can manage
+  (see [Webhook caveat](#webhook-caveat)).
+
+---
+
+## Security trade-off: the cluster-wide RBAC default
+
+The default (`rbac.namespaceScoped: false`) binds the operator's ServiceAccount
+to a **`ClusterRole`**. Among its rules, that ClusterRole grants:
+
+- `get` / `list` / `watch` / `create` / `update` / `patch` / `delete` on
+  **`secrets`** in **every** namespace, and
+- `create` on `serviceaccounts` plus full CRUD on `roles` and `rolebindings` —
+  which the operator needs to mint the per-CronJob rotation RBAC described
+  [below](#contrast-the-per-cronjob-rotation-rbac).
+
+### Privilege-escalation path
+
+A compromised operator pod — or a leaked ServiceAccount token — can therefore:
+
+1. **Read every Secret in the cluster.** Database passwords, TLS keys, service
+   credentials, and the OpenStack admin password, in any namespace.
+2. **Make the compromise durable.** Because the same ClusterRole grants `create`
+   on `rolebindings`, an attacker can bind an existing `Role` (or the operator's
+   own permissions) to a subject they control, turning a transient pod
+   compromise into a standing, cluster-wide secret-read credential that outlives
+   the pod being killed.
+
+The ControlPlane operator widens the blast radius further: it projects the
+OpenStack admin password **in cleartext** into a `clouds.yaml` `Secret` in each
+tenant's child namespace (see
+[ControlPlane Reconciler → RBAC Permissions](../reference/c5c3/controlplane-reconciler.md#rbac-permissions)).
+Cluster-wide Secret read access exposes every one of those projected passwords.
+
+### Contrast: the per-CronJob rotation RBAC
+
+The RBAC the operator *generates* for its rotation CronJobs is the model to
+follow. Each CronJob gets a namespaced `Role` with `get` on exactly the
+push-source `Secret` and `get` + `patch` on exactly the staging `Secret`, both
+pinned by `resourceNames`; the CronJob never holds write access to a Secret a
+privileged workload consumes. Namespace-scoping the operator brings the
+operator's *own* footprint closer to that least-privilege shape.
+
+### Why the cluster-wide Secret rule cannot simply be narrowed
+
+A natural question is whether the cluster-wide `secrets` rule could be pinned to
+specific names or labels instead of switching to namespace scope. For the
+cluster-wide deployment model, it cannot:
+
+- **`resourceNames` does not apply to `list` / `watch`.** The operator's
+  controller-runtime cache `list`s and `watch`es Secrets to stay in sync, and an
+  RBAC rule carrying `resourceNames` does not authorize collection
+  (`list` / `watch`) requests — pinning names would break the cache.
+- **The names are dynamic and per-CR.** Managed Secrets (the Fernet keys, the
+  credential keys, the database-connection Secret, the projected `clouds.yaml`)
+  are named after each CR and spread across namespaces, so there is no static
+  set of names to enumerate.
+- **RBAC has no label or field selectors.** Authorization is all-or-nothing for
+  a resource type within the granted scope. The informer cache *can* be
+  label-filtered, but that reduces memory, not the ServiceAccount's authority.
+
+The supported way to bound the blast radius is therefore to **reduce the
+scope**, not the rule: `rbac.namespaceScoped: true` confines both the RBAC grant
+and the informer cache to a single namespace.
 
 ---
 

--- a/docs/reference/backend/helm-values-schema.md
+++ b/docs/reference/backend/helm-values-schema.md
@@ -79,6 +79,14 @@ rule. Namespace-scoped RBAC cannot coexist with webhooks because
 `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` are cluster-scoped
 resources that require a `ClusterRole` to manage.
 
+**Production recommendation:** For a control plane confined to a single
+namespace, set `rbac.namespaceScoped: true` to bound a compromised operator pod
+to one namespace's Secrets instead of the cluster-wide Secret access the default
+`ClusterRole` grants — see
+[Multi-Tenant Deployment → Security trade-off](../../guides/multi-tenant-deployment.md#security-trade-off-the-cluster-wide-rbac-default)
+for the privilege-escalation path this closes. The default stays `false` because
+[some capabilities still need cluster scope](../../guides/multi-tenant-deployment.md#when-cluster-wide-rbac-is-still-required).
+
 ### leaderElection
 
 | Field | Type | Constraint | Default |

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -211,6 +211,27 @@ holds only `update`/`patch` (not `create`/`delete`) on K-ORC
 | `core` | `secrets` | get, list, watch |
 | `core` | `events` | create, patch |
 
+### Blast radius and namespace scoping
+
+By default the chart binds these markers to a cluster-wide `ClusterRole`, so the
+`secrets` rule lets a compromised operator pod read and write every `Secret` in
+every namespace; the
+[Multi-Tenant Deployment → Security trade-off](../../guides/multi-tenant-deployment.md#security-trade-off-the-cluster-wide-rbac-default)
+details that privilege-escalation path. Two specifics apply to this operator:
+
+- It amplifies the exposure itself: `reconcileAdminPassword` and `reconcileKORC`
+  project the OpenStack admin password **in cleartext** into a `clouds.yaml`
+  `Secret`, so cluster-wide read access exposes every projected admin password.
+- Unlike the keystone operator, this `ClusterRole` holds no `roles` /
+  `rolebindings` verbs, so it lacks the RoleBinding-forgery escalation
+  primitive — the cluster-wide Secret read is the dominant risk.
+
+Because `childNamespace` co-locates every projected resource in the
+ControlPlane's own namespace, a single-namespace deployment can run the operator
+namespace-scoped (`rbac.namespaceScoped: true`), bounding both the RBAC grant
+and the informer cache to that namespace. Keep the default only when
+[cluster-wide RBAC is still required](../../guides/multi-tenant-deployment.md#when-cluster-wide-rbac-is-still-required).
+
 ---
 
 ## Reconciliation Flow

--- a/operators/c5c3/helm/c5c3-operator/values.yaml
+++ b/operators/c5c3/helm/c5c3-operator/values.yaml
@@ -21,6 +21,10 @@ rbac:
   # CC-0043: Set to true to deploy with namespace-scoped Role/RoleBinding
   # instead of ClusterRole/ClusterRoleBinding. Restricts the operator to its
   # release namespace. Requires webhook.enabled=false.
+  # Recommended for single-namespace production deployments: the default
+  # ClusterRole grants cluster-wide Secret CRUD, so namespace scoping bounds a
+  # compromised operator pod to a single namespace. See the Multi-Tenant
+  # Deployment guide for the cluster-wide privilege-escalation trade-off.
   namespaceScoped: false
 
 leaderElection:

--- a/operators/keystone/helm/keystone-operator/values.yaml
+++ b/operators/keystone/helm/keystone-operator/values.yaml
@@ -21,6 +21,10 @@ rbac:
   # CC-0043: Set to true to deploy with namespace-scoped Role/RoleBinding
   # instead of ClusterRole/ClusterRoleBinding. Restricts the operator to its
   # release namespace. Requires webhook.enabled=false.
+  # Recommended for single-namespace production deployments: the default
+  # ClusterRole grants cluster-wide Secret CRUD, so namespace scoping bounds a
+  # compromised operator pod to a single namespace. See the Multi-Tenant
+  # Deployment guide for the cluster-wide privilege-escalation trade-off.
   namespaceScoped: false
 
 leaderElection:


### PR DESCRIPTION
## Summary

Implements #472 (2026-06 pre-production audit): make namespace-scoped
least-privilege RBAC the recommended production posture, document the
privilege-escalation path of the cluster-wide default, and evaluate whether the
cluster-wide Secret rule can be narrowed.

The namespace-scoped mechanism itself already exists — the `rbac.namespaceScoped`
toggle renders a `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding`,
passes `--namespace` to restrict the cache, and requires `--enable-webhooks=false`.
This PR is the documentation/recommendation layer on top. It is **docs-only**
(116 additive lines across three doc pages and two `values.yaml` comments); no
templates, defaults, or generated schema change.

### Decision: recommend, don't flip the default

The issue offers "(or flip the default)". I did **not** flip it, because flipping
`rbac.namespaceScoped` to `true` is not a clean change:

- It would make `helm install` with default values **fail** — the chart guard and
  `values.schema.json` both require `webhook.enabled=false` when namespace-scoped,
  but the default is `webhook.enabled=true`. Flipping would also force the
  admission webhook off by default, losing defaulting + server-side validation.
- It would break the standard topology: the ControlPlane operator projects
  credentials into tenant **child namespaces** and the keystone operator manages
  `Keystone` CRs **across namespaces** — both need cluster scope.

So the supported, non-breaking path is to **recommend** namespace-scoped for
single-namespace production deployments and make the trade-off explicit — the
issue's primary ask. If you would rather actually flip the chart default, that is
a larger breaking change with its own migration story; happy to follow up.

### Changes (commit order)

1. **`docs(multi-tenant): recommend namespace-scoped RBAC for production`** — adds
   to `multi-tenant-deployment.md`: a "Recommended for single-namespace
   production" callout; a "Security trade-off" section documenting the
   privilege-escalation path (cluster-wide Secret read → made durable via
   `rolebindings` create) plus the ControlPlane cleartext-projection amplifier;
   the contrast with the operator's own exemplary per-CronJob rotation RBAC; and
   the evaluation of why the cluster-wide Secret rule cannot be narrowed.
2. **`docs: recommend namespace-scoped RBAC in values reference and comments`** —
   propagates the recommendation to `helm-values-schema.md` and both charts'
   `values.yaml` comments (where the value is actually set).
3. **`docs(c5c3): document the ControlPlane RBAC blast radius`** — adds the
   cluster-wide-Secret blast-radius / namespace-scoping note to
   `controlplane-reconciler.md`, noting the ControlPlane ClusterRole lacks the
   `roles`/`rolebindings` escalation primitive (unlike the keystone operator).

### Acceptance criteria (issue "Proposed fix")

- **Document and recommend `rbac.namespaceScoped=true` as the production posture** —
  guide callout + values reference + both `values.yaml` comments.
- **Evaluate narrowing the cluster-wide Secret rule** — the "Why the cluster-wide
  Secret rule cannot simply be narrowed" section: `resourceNames` do not authorize
  `list`/`watch` (which the informer cache needs), the managed Secret names are
  dynamic/per-CR and span namespaces, and RBAC has no label/field selectors — so
  reducing the *scope* (namespace-scoping), not the rule, is the mitigation.
- **Add a docs/runbook note on the privilege-escalation path** — the
  "Privilege-escalation path" section plus the c5c3 blast-radius note.

### Notes on stale references in the issue

The issue was verified at `0a2f19ba`. The charts have since been refactored onto a
shared `operator-library` (#487), so the cited `_helpers.tpl:NNN` line numbers no
longer hold — the RBAC rules now live in the `{keystone,c5c3}-operator.rbacRules`
named templates. Ground truth was re-confirmed before writing: the keystone
operator still has the full escalation surface (cluster-wide Secret CRUD +
`serviceaccounts`/`roles`/`rolebindings` CRUD), but the c5c3 operator's RBAC
(regenerated from kubebuilder markers) **no longer** carries `roles`/`rolebindings`,
so the issue's `c5c3 _helpers.tpl:221-233` reference is stale. The docs describe the
actual current state.

### Verification

- `make check-docs-ids` → pass (no internal CC-/REQ- IDs in `docs/`).
- `make verify-helm-schema` → pass (the `values.yaml` comment edits do not affect
  the generated `values.schema.json`).
- `helm template` on both charts: default → `ClusterRole`/`ClusterRoleBinding`;
  `namespaceScoped=true webhook.enabled=false` → `Role`/`RoleBinding` +
  `--enable-webhooks=false`; `namespaceScoped=true webhook.enabled=true` → rejected
  (exit 1). The documented behavior matches the chart.
