### PR TITLE
ci(renovate): schedule high-churn base images and digest pins weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -329,6 +329,16 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "venv-builder base packages"
+    },
+    {
+      "matchDatasources": ["docker", "go"],
+      "matchPackageNames": [
+        "golang",
+        "ubuntu",
+        "ghcr.io/astral-sh/uv",
+        "github.com/external-secrets/external-secrets/apis"
+      ],
+      "schedule": ["before 6am on monday"]
     }
   ]
 }


### PR DESCRIPTION
## What

Add a Renovate `packageRule` that restricts four high-churn dependencies to a weekly schedule (before 6am on Monday):

- `golang` base-image digest
- `ubuntu` base-image digest
- `ghcr.io/astral-sh/uv` Docker tag
- `github.com/external-secrets/external-secrets/apis` Go-module digest

## Why

These are handled by Renovate's native `docker` and `gomod` managers (not the repo's `customManagers`), so they ran on the default cadence and produced a steady stream of update PRs (#486, #456, #445, #392). Scheduling them weekly cuts the noise without disabling the updates.

## How

The rule matches on `matchDatasources` + `matchPackageNames` rather than file paths, so it covers every Dockerfile using the `golang` base image instead of a single path. Renovate will only create or rebase the corresponding branches/PRs inside the Monday-morning window; manual merges of the existing PRs are unaffected.