### PR TITLE
fix(common): re-run permanently failed Jobs after the spec is fixed

### DIFF
--- a/docs/reference/backend/kubernetes-packages.md
+++ b/docs/reference/backend/kubernetes-packages.md
@@ -385,18 +385,26 @@ func RunJob(
 
 Creates a Job if it does not already exist and reports completion status.
 
-**Returns:** `(true, nil)` when the Job has a `Complete` condition with status `True`;
-`(false, nil)` when the Job exists but is still running;
-`(false, error)` when the Job has permanently failed (e.g. exceeded backoffLimit);
+**Returns:** `(true, nil)` when the Job has a `Complete` condition with status `True`
+and its re-run key is unchanged;
+`(false, nil)` when the Job exists but is still running, or was deleted and
+re-created because its re-run key changed;
+`(false, error)` wrapping `ErrJobFailed` when the Job has permanently failed (e.g.
+exceeded backoffLimit) and its re-run key is unchanged;
 `(false, error)` on unexpected API failures.
 
 **Behavior:**
 
 - If the Job does not exist: creates it with a controller owner reference, returns
   `(false, nil)` (newly created Jobs are never immediately complete).
-- If the Job already exists: first checks for permanent failure via `IsJobFailed`
-  (returns an error to prevent infinite requeue loops), then checks completion
-  via `IsJobComplete`. Jobs are immutable after creation — they are not updated.
+- If the Job already exists: checks completion via `IsJobComplete` and permanent
+  failure via `IsJobFailed`. A completed **or permanently failed** Job whose stored
+  re-run key (the `forge.c5c3.io/pod-spec-hash` annotation) no longer matches the
+  desired pod template is deleted (background propagation) and re-created — so a
+  Job that failed under a since-fixed spec (new container image, corrected
+  ConfigMap, rotated password) re-runs instead of wedging. A permanently failed
+  Job whose re-run key is unchanged returns an error wrapping `ErrJobFailed` to
+  prevent infinite requeue loops. Jobs are never updated in place.
 - Reconcilers should call `RunJob` on each reconciliation loop. The function is
   idempotent: calling it when the Job already exists and is complete returns
   `(true, nil)` without side effects.

--- a/internal/common/job/job.go
+++ b/internal/common/job/job.go
@@ -60,22 +60,25 @@ var ErrJobFailed = errors.New("job has permanently failed")
 
 // RunJob creates a Job if it does not already exist and reports whether the
 // Job has completed successfully. It returns (true, nil) when the Job has
-// finished, (false, nil) when the Job exists but is still running,
-// (false, error) when the Job has permanently failed (e.g. exceeded
-// backoffLimit), and (false, error) on unexpected failures (CC-0005).
+// finished, (false, nil) when the Job exists but is still running or was
+// re-created, (false, error) when the Job has permanently failed (e.g. exceeded
+// backoffLimit) and its pod template is unchanged, and (false, error) on
+// unexpected failures (CC-0005).
 //
-// A completed Job is re-run when its full pod template changes — the correct
-// trigger for migration-style Jobs (db-sync, expand/migrate/contract,
-// schema-check) that must re-execute against a new container image on an
-// operator/release upgrade.
+// A completed or permanently failed Job is re-run when its full pod template
+// changes — the correct trigger for migration-style Jobs (db-sync,
+// expand/migrate/contract, schema-check) that must re-execute against a new
+// container image on an operator/release upgrade. Re-running a permanently
+// failed Job once its spec is fixed avoids wedging the Job until a manual
+// `kubectl delete job` (#460).
 func RunJob(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, job *batchv1.Job) (bool, error) {
 	return RunJobWithRerunKey(ctx, c, scheme, owner, job, PodSpecHash(&job.Spec.Template))
 }
 
 // RunJobWithRerunKey behaves like RunJob but uses an explicit rerunKey, rather
-// than the full pod-template hash, to decide whether a *completed* Job must be
-// re-run. The key is stored at creation time and compared on subsequent passes;
-// a completed Job is re-run only when the key changes.
+// than the full pod-template hash, to decide whether a *completed or permanently
+// failed* Job must be re-run. The key is stored at creation time and compared on
+// subsequent passes; a terminal Job is re-run only when the key changes.
 //
 // This lets a Job opt out of image-sensitive re-runs. The keystone bootstrap
 // Job uses the admin-password digest as its key so it re-runs when the password
@@ -83,7 +86,9 @@ func RunJob(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner 
 // upgrade: re-running keystone-manage bootstrap after the cross-version DB
 // migration fails on the already-migrated admin user (oslo_db DBDuplicateEntry
 // 'default-admin'), which would otherwise hold BootstrapReady — and the
-// aggregate Ready — False for the whole upgrade (CC-0113).
+// aggregate Ready — False for the whole upgrade (CC-0113). A failed bootstrap
+// Job follows the same rule: a release-upgrade image change does not re-run it,
+// but a rotated admin password (a new key) does (#460).
 func RunJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, job *batchv1.Job, rerunKey string) (bool, error) {
 	existing := &batchv1.Job{}
 	err := c.Get(ctx, client.ObjectKeyFromObject(job), existing)
@@ -96,6 +101,22 @@ func RunJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Sc
 	}
 
 	if IsJobFailed(existing) {
+		// A permanently failed Job (exceeded backoffLimit) is re-run when its
+		// re-run key changes — the desired spec was fixed since the failure
+		// (e.g. a new container image after a release upgrade, a corrected
+		// policyOverrides ConfigMap, or a rotated admin password for the
+		// bootstrap Job). Without this, the re-run-key gate that exists for the
+		// fixed-spec case would never fire once backoffLimit is exhausted,
+		// wedging the Job until a manual `kubectl delete job` (#460). A failed
+		// Job whose key is unchanged stays failed and returns ErrJobFailed, so a
+		// genuinely-stuck Job does not requeue forever.
+		existingKey := existing.Annotations[PodSpecHashAnnotation]
+		if rerunKey != existingKey {
+			if err := recreateStaleJob(ctx, c, scheme, owner, job, existing, rerunKey); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
 		return false, fmt.Errorf("%w: %s/%s", ErrJobFailed, existing.Namespace, existing.Name)
 	}
 
@@ -108,18 +129,7 @@ func RunJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Sc
 		// (CC-0005, CC-0113).
 		existingKey := existing.Annotations[PodSpecHashAnnotation]
 		if rerunKey != existingKey {
-			// Intentional behavioral alignment: explicitly set Background propagation
-			// policy for both envtest and production consistency. The default on most
-			// API servers is already Background, so this is a no-op in production but
-			// prevents envtest from adding an `orphan` finalizer that would block the
-			// subsequent Create with AlreadyExists. Verified: only the keystone
-			// operator uses RunJob; no other operator in the monorepo is affected
-			// (CC-0056).
-			propagation := metav1.DeletePropagationBackground
-			if err := c.Delete(ctx, existing, &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
-				return false, fmt.Errorf("deleting stale Job %s/%s: %w", existing.Namespace, existing.Name, err)
-			}
-			if err := createJobWithRerunKey(ctx, c, scheme, owner, job, rerunKey); err != nil {
+			if err := recreateStaleJob(ctx, c, scheme, owner, job, existing, rerunKey); err != nil {
 				return false, err
 			}
 			return false, nil
@@ -150,6 +160,25 @@ func createJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime
 		return fmt.Errorf("creating Job %s/%s: %w", job.Namespace, job.Name, err)
 	}
 	return nil
+}
+
+// recreateStaleJob deletes a terminal Job (completed or permanently failed)
+// whose stored re-run key no longer matches the desired template, then creates
+// a replacement carrying the new key. It is the shared delete-and-recreate path
+// for both terminal-state branches of RunJobWithRerunKey (CC-0005).
+//
+// The Background propagation policy is set explicitly for envtest/production
+// consistency: the default on most API servers is already Background, so this is
+// a no-op in production but prevents envtest from adding an `orphan` finalizer
+// that would block the subsequent Create with AlreadyExists. Verified: only the
+// keystone operator uses RunJob; no other operator in the monorepo is affected
+// (CC-0056).
+func recreateStaleJob(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, job, existing *batchv1.Job, rerunKey string) error {
+	propagation := metav1.DeletePropagationBackground
+	if err := c.Delete(ctx, existing, &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
+		return fmt.Errorf("deleting stale Job %s/%s: %w", existing.Namespace, existing.Name, err)
+	}
+	return createJobWithRerunKey(ctx, c, scheme, owner, job, rerunKey)
 }
 
 // EnsureCronJob creates a CronJob if it does not exist or updates its spec if

--- a/internal/common/job/job_test.go
+++ b/internal/common/job/job_test.go
@@ -86,6 +86,31 @@ func testCompletedJobWithHash() *batchv1.Job {
 	return j
 }
 
+// testFailedJobWithHash returns a permanently failed Job that carries the
+// pod-spec-hash annotation matching the testJob() PodSpec, simulating a Job
+// created via RunJob that then exhausted its backoffLimit. As with
+// testCompletedJobWithHash, API-server defaults may be present on the stored
+// spec, but the hash annotation refers to the original desired spec — so a
+// failed Job whose spec is unchanged stays failed (#460).
+func testFailedJobWithHash() *batchv1.Job {
+	desired := testJob()
+	j := testJob()
+	// Simulate API-server defaults on the stored spec.
+	for i := range j.Spec.Template.Spec.Containers {
+		j.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullAlways
+		j.Spec.Template.Spec.Containers[i].TerminationMessagePath = corev1.TerminationMessagePathDefault
+		j.Spec.Template.Spec.Containers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	}
+	j.Annotations = map[string]string{
+		PodSpecHashAnnotation: PodSpecHash(&desired.Spec.Template),
+	}
+	j.Status.Failed = 3
+	j.Status.Conditions = []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+	}
+	return j
+}
+
 func testCronJob() *batchv1.CronJob {
 	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -175,15 +200,10 @@ func TestRunJob_existingFailed(t *testing.T) {
 	s := newScheme()
 	owner := testOwner()
 
-	job := testJob()
-	job.Status.Failed = 3
-	job.Status.Conditions = []batchv1.JobCondition{
-		{
-			Type:   batchv1.JobFailed,
-			Status: corev1.ConditionTrue,
-			Reason: "BackoffLimitExceeded",
-		},
-	}
+	// A permanently failed Job whose stored re-run key still matches the
+	// desired template: the spec has not been fixed, so it stays failed and
+	// returns ErrJobFailed rather than re-running forever (#460).
+	job := testFailedJobWithHash()
 
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -196,6 +216,73 @@ func TestRunJob_existingFailed(t *testing.T) {
 	g.Expect(errors.Is(err, ErrJobFailed)).To(BeTrue(), "error should wrap ErrJobFailed sentinel")
 	g.Expect(err.Error()).To(ContainSubstring("default/test-job"))
 	g.Expect(ready).To(BeFalse())
+}
+
+// TestRunJob_existingFailed_specChanged verifies the #460 fix: a permanently
+// failed Job is deleted and re-created when the desired pod template changes
+// (here a new container image), instead of returning ErrJobFailed forever. This
+// is the failed-then-fixed path shared by the default-hash callers (db-sync,
+// schema-check, expand/migrate/contract, policy validation).
+func TestRunJob_existingFailed_specChanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	// Failed Job whose stored hash matches the OLD template.
+	oldJob := testFailedJobWithHash()
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, oldJob).
+		WithStatusSubresource(oldJob).
+		Build()
+
+	// New desired Job with a different container image (the fixed spec).
+	newJob := testJob()
+	newJob.Spec.Template.Spec.Containers[0].Image = "busybox:v2"
+
+	ready, err := RunJob(context.Background(), c, s, owner, newJob)
+	g.Expect(err).NotTo(HaveOccurred(), "a failed Job must be re-run when the spec is fixed, not return ErrJobFailed")
+	g.Expect(ready).To(BeFalse(), "should recreate the failed Job when the spec changes")
+
+	// Verify the failed Job was replaced with one carrying the new image and hash.
+	fetched := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:v2"))
+	g.Expect(fetched.OwnerReferences).To(HaveLen(1))
+	g.Expect(fetched.Annotations[PodSpecHashAnnotation]).To(Equal(PodSpecHash(&newJob.Spec.Template)),
+		"replacement Job should carry the hash of the new template")
+}
+
+// TestRunJob_existingFailed_noHashAnnotation verifies that a permanently failed
+// Job without a hash annotation (e.g. one that failed before the operator was
+// upgraded to a hash-aware version) is treated as stale and re-created rather
+// than wedged on ErrJobFailed (#460). Mirrors the completed-Job counterpart.
+func TestRunJob_existingFailed_noHashAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	oldJob := testJob()
+	oldJob.Status.Failed = 3
+	oldJob.Status.Conditions = []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+	}
+	// No hash annotation on the old Job.
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, oldJob).
+		WithStatusSubresource(oldJob).
+		Build()
+
+	ready, err := RunJob(context.Background(), c, s, owner, testJob())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "should recreate the failed Job when the hash annotation is missing")
+
+	fetched := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.Annotations[PodSpecHashAnnotation]).NotTo(BeEmpty())
 }
 
 func TestRunJob_existingComplete_specChanged(t *testing.T) {
@@ -266,6 +353,20 @@ func completedJobWithRerunKey(key string) *batchv1.Job {
 	return j
 }
 
+// failedJobWithRerunKey returns a permanently failed Job stamped with an
+// explicit re-run key in the PodSpecHashAnnotation, simulating a Job created via
+// RunJobWithRerunKey that then exhausted its backoffLimit (#460).
+func failedJobWithRerunKey(key string) *batchv1.Job {
+	j := testJob()
+	j.UID = "existing-uid"
+	j.Annotations = map[string]string{PodSpecHashAnnotation: key}
+	j.Status.Failed = 3
+	j.Status.Conditions = []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+	}
+	return j
+}
+
 // TestRunJobWithRerunKey_keyUnchanged_imageChanged locks the CC-0113 behavior:
 // with an explicit re-run key, a completed Job is NOT re-run on a pod-template
 // change (here a new container image) as long as the key is unchanged. The
@@ -321,6 +422,68 @@ func TestRunJobWithRerunKey_keyChanged(t *testing.T) {
 	fetched := &batchv1.Job{}
 	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, fetched)).To(Succeed())
 	g.Expect(fetched.Annotations[PodSpecHashAnnotation]).To(Equal("rerun-key-2"), "replacement Job must carry the new re-run key")
+}
+
+// TestRunJobWithRerunKey_failed_keyChanged verifies the #460 fix for the
+// explicit-key caller (the keystone bootstrap Job): a permanently failed Job is
+// re-run when the supplied re-run key changes — e.g. a rotated admin password —
+// and the replacement carries the new key.
+func TestRunJobWithRerunKey_failed_keyChanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	existing := failedJobWithRerunKey("rerun-key-1")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, existing).
+		WithStatusSubresource(existing).
+		Build()
+
+	ready, err := RunJobWithRerunKey(context.Background(), c, s, owner, testJob(), "rerun-key-2")
+	g.Expect(err).NotTo(HaveOccurred(), "a changed re-run key must re-run the failed Job, not return ErrJobFailed")
+	g.Expect(ready).To(BeFalse(), "should recreate the failed Job when the re-run key changes")
+
+	fetched := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.Annotations[PodSpecHashAnnotation]).To(Equal("rerun-key-2"), "replacement Job must carry the new re-run key")
+}
+
+// TestRunJobWithRerunKey_failed_keyUnchanged_imageChanged locks the CC-0113
+// behavior for a *failed* Job: with an explicit re-run key, a failed Job is NOT
+// re-run on a pod-template change (here a new container image) as long as the
+// key is unchanged — it returns ErrJobFailed. The keystone bootstrap Job relies
+// on this so a release-upgrade image change does not re-run keystone-manage
+// bootstrap against the already-migrated admin user after a transient failure
+// (#460).
+func TestRunJobWithRerunKey_failed_keyUnchanged_imageChanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	existing := failedJobWithRerunKey("rerun-key-1")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, existing).
+		WithStatusSubresource(existing).
+		Build()
+
+	// Desired Job has a DIFFERENT image but the SAME re-run key.
+	newJob := testJob()
+	newJob.Spec.Template.Spec.Containers[0].Image = "busybox:v2"
+
+	ready, err := RunJobWithRerunKey(context.Background(), c, s, owner, newJob, "rerun-key-1")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(errors.Is(err, ErrJobFailed)).To(BeTrue(), "unchanged re-run key must keep a failed Job failed despite an image change (CC-0113)")
+	g.Expect(ready).To(BeFalse())
+
+	// The original failed Job must be retained unchanged (same UID, original image).
+	fetched := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.UID).To(Equal(existing.UID), "failed Job must be retained, not recreated")
+	g.Expect(fetched.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:latest"))
 }
 
 // TestRunJob_existingComplete_noHashAnnotation verifies that a completed Job

--- a/operators/keystone/internal/controller/reconcile_bootstrap_test.go
+++ b/operators/keystone/internal/controller/reconcile_bootstrap_test.go
@@ -318,6 +318,41 @@ func TestReconcileBootstrap_StaleJobDetection(t *testing.T) {
 	g.Expect(newJob.Annotations[job.PodSpecHashAnnotation]).To(Equal(bootstrapAdminPasswordHash()))
 }
 
+// TestReconcileBootstrap_JobFailed_PasswordRotated_Recreates verifies the #460
+// fix at the bootstrap caller: when the bootstrap Job has permanently failed and
+// the admin password is then rotated (a new re-run key), the failed Job is
+// re-created and BootstrapReady transitions back to False/BootstrapInProgress
+// instead of staying stuck on ErrJobFailed.
+func TestReconcileBootstrap_JobFailed_PasswordRotated_Recreates(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := bootstrapTestScheme()
+	ks := bootstrapKeystone()
+
+	// Failed bootstrap Job stamped with a stale re-run key (the pre-rotation
+	// admin-password digest).
+	failed := failedBootstrapJob(ks)
+	failed.Annotations[job.PodSpecHashAnnotation] = "stale-key-from-previous-password"
+
+	r := newBootstrapTestReconciler(s, ks, failed, bootstrapAdminSecret(ks))
+
+	result, err := r.reconcileBootstrap(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).NotTo(HaveOccurred(), "a rotated admin password must re-run the failed bootstrap Job, not surface ErrJobFailed")
+	g.Expect(result.RequeueAfter).To(Equal(RequeueBootstrapWait))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "BootstrapReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("BootstrapInProgress"))
+
+	// The recreated Job carries the current re-run key (the admin-password digest).
+	var newJob batchv1.Job
+	g.Expect(r.Client.Get(context.Background(), client.ObjectKey{
+		Name:      "test-keystone-bootstrap",
+		Namespace: "default",
+	}, &newJob)).To(Succeed())
+	g.Expect(newJob.Annotations[job.PodSpecHashAnnotation]).To(Equal(bootstrapAdminPasswordHash()))
+}
+
 func TestReconcileBootstrap_JobFailed_ConditionMessage(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := bootstrapTestScheme()

--- a/operators/keystone/internal/controller/reconcile_policyvalidation_test.go
+++ b/operators/keystone/internal/controller/reconcile_policyvalidation_test.go
@@ -325,6 +325,45 @@ func TestReconcilePolicyValidation_JobFailed_ConditionFalse(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal(conditionReasonPolicyValidationFailed))
 }
 
+// TestReconcilePolicyValidation_JobFailed_PolicyFixed_Recreates verifies the
+// #460 fix at the policy-validation caller: when a validation Job has
+// permanently failed and spec.policyOverrides is then fixed (producing a new
+// immutable ConfigMap, hence a new pod-template hash), the failed Job is
+// re-created and PolicyValidReady transitions back to False/InProgress instead
+// of staying stuck on the previous failure (CC-0058).
+func TestReconcilePolicyValidation_JobFailed_PolicyFixed_Recreates(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := policyValidationTestScheme()
+	ks := policyValidationKeystoneWithPolicy()
+
+	// Failed validation Job whose stored hash matches the OLD config
+	// (keystone-config-abc123).
+	r := newPolicyValidationTestReconciler(s, ks, failedPolicyValidationJob(ks))
+
+	// Fixing spec.policyOverrides yields a new immutable ConfigMap name; the
+	// reconciler is called with it, so the desired pod template — and its hash —
+	// differ from the failed Job's stored key.
+	const newConfigMap = "keystone-config-def456"
+	result, err := r.reconcilePolicyValidation(context.Background(), ks, newConfigMap)
+	g.Expect(err).NotTo(HaveOccurred(), "fixing the policy must re-run the failed validation Job, not surface ErrJobFailed")
+	g.Expect(result.RequeueAfter).To(Equal(RequeueValidationWait))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypePolicyValidReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonPolicyValidationInProgress))
+
+	// The recreated Job carries the hash of the new (fixed) template.
+	var recreated batchv1.Job
+	g.Expect(r.Client.Get(context.Background(), client.ObjectKey{
+		Name:      "test-keystone-policy-validation",
+		Namespace: "default",
+	}, &recreated)).To(Succeed())
+	wantHash := job.PodSpecHash(&buildPolicyValidationJob(ks, newConfigMap).Spec.Template)
+	g.Expect(recreated.Annotations[job.PodSpecHashAnnotation]).To(Equal(wantHash),
+		"recreated validation Job should carry the hash of the fixed template")
+}
+
 // --- Descriptive error extraction (REQ-006) ---
 
 // TestReconcilePolicyValidation_JobFailed_DescriptiveErrorMessage verifies that


### PR DESCRIPTION
Closes #460.

## Problem

`RunJobWithRerunKey` checked `IsJobFailed` **before** the re-run-key
comparison, and that comparison only existed in the `IsJobComplete`
branch. Once a Job exhausted its `backoffLimit`, every subsequent
reconcile returned `ErrJobFailed` regardless of how the desired pod
template changed — including the new-image case the re-run-key gate
exists for. The only remediation was a manual `kubectl delete job`.

This wedged every Job-running call site in the keystone operator:

- **db-sync / schema-check** — a failure stuck `DatabaseReady=False`.
- **expand/migrate/contract upgrades** — a transient DB outage exhausting `backoffLimit=4` wedged the upgrade in `ExpandFailed` forever.
- **bootstrap** — a rotated admin password could not re-trigger a failed bootstrap.
- **policy validation** — the expected failure mode is a bad policy; fixing `spec.policyOverrides` produces a new ConfigMap/template that could never be retried.

Found by the 2026-06 pre-production audit.

## Fix

In the `IsJobFailed` branch, compare the re-run key against
`existing.Annotations["forge.c5c3.io/pod-spec-hash"]`:

- **key changed** → delete (background propagation) and recreate with the new template, return `(false, nil)`;
- **key unchanged** → return `ErrJobFailed`, so a genuinely-stuck Job (no spec change) still stops requeueing rather than looping forever.

The delete-and-recreate logic is now shared with the existing
`IsJobComplete` branch via a small `recreateStaleJob` helper, keeping the
background-propagation policy and its rationale in one place.

The change is intentionally caller-agnostic: every site funnels through
`RunJobWithRerunKey` (directly, via `RunJob`, or via
`database.RunDBSyncJob`), so this single change covers all five call
sites. The `CC-0113` contract is preserved — the bootstrap Job keys on
the admin-password digest, so a release-upgrade image change still does
**not** re-run a failed bootstrap, but a password rotation does.

## Commits

1. **`fix(common): re-run permanently failed Jobs after the spec is fixed`** — the core gate change in `internal/common/job`, the shared `recreateStaleJob` helper, and unit tests for the failed-then-fixed path on both the default-hash (`RunJob`) and explicit-key (`RunJobWithRerunKey`) callers, including the `CC-0113` unchanged-key case.
2. **`test(keystone): cover failed Job re-run for bootstrap and policy`** — caller-level regression tests asserting the user-visible condition transition (Failed → InProgress) when a failed policy-validation Job sees a corrected ConfigMap and a failed bootstrap Job sees a rotated password.
3. **`docs(backend): document failed-Job re-run on a fixed spec`** — updates the `RunJob` Returns/Behavior reference in `kubernetes-packages.md`.

## Notes

- The existing `TestRunJob_existingFailed` modeled a failed Job with **no** hash annotation, which under the fix is correctly treated as a key mismatch and recreated. It was updated to stamp a matching key so it still asserts the intended "unchanged key → `ErrJobFailed`" path. Every pre-existing keystone failed-Job test already stamps a matching key, so they exercise the unchanged-key path and stayed green without changes.
- The fix does **not** auto-retry a failed Job whose spec is unchanged (e.g. a pure transient DB outage with no template change) — that still returns `ErrJobFailed` by design to prevent infinite requeue loops, so the manual `kubectl delete job` remediation in the upgrade / schema-drift runbooks remains correct for those cases.

## Verification

- `go test ./...` in `internal/common` and `operators/keystone`, plus `operators/c5c3` build — all green.
- `go vet`, `gofumpt -l` (pinned v0.9.2) on changed files, and `make check-docs-ids` — clean.
