### PR TITLE
feat(keystone-operator): allow aborting an in-flight upgrade by reverting spec.image.tag

### DIFF
--- a/docs/reference/keystone/keystone-upgrade-flow.md
+++ b/docs/reference/keystone/keystone-upgrade-flow.md
@@ -97,9 +97,10 @@ Set after the first successful `db_sync` Job completion. For fresh deployments
 ### targetRelease
 
 Set to `spec.image.tag` when an upgrade is initiated. Cleared (set to `""`) when
-the upgrade completes successfully. During an active upgrade, if `spec.image.tag`
-is changed to a value that differs from both `installedRelease` and `targetRelease`,
-the operator blocks with an `UpgradeTargetChanged` condition.
+the upgrade completes successfully or is aborted. During an active upgrade,
+reverting `spec.image.tag` to `installedRelease` aborts the upgrade (see
+[Aborting an Upgrade](#aborting-an-upgrade)); changing it to any other value that
+differs from `targetRelease` blocks with an `UpgradeTargetChanged` condition.
 
 ### upgradePhase
 
@@ -245,7 +246,8 @@ in the main reconcile loop:
 reconcileDatabase (called first in reconciler chain)
   |
   +- Active upgrade? (upgradePhase != "")
-  |  +- Tag changed during upgrade? -> block with UpgradeTargetChanged
+  |  +- Tag reverted to installedRelease? -> abort: delete phase Jobs, clear state, requeue
+  |  +- Tag changed to another value? -> block with UpgradeTargetChanged
   |  +- Delegate to reconcileUpgrade() -> dispatch by phase
   |
   +- isUpgrade()? (installedRelease != "" && tag != installedRelease && !patchOnly)
@@ -324,6 +326,46 @@ because all state is persisted in the Keystone CR status:
 | Operator restarts after expand Job completed | Reconciler detects completion, transitions to Migrating |
 | Operator restarts during RollingUpdate | Reconciler checks Deployment readiness, transitions to Contracting when ready |
 | Operator restarts during Contracting, contract Job completed | Reconciler detects completion, finalizes upgrade |
+
+---
+
+## Aborting an Upgrade
+
+A sequential upgrade can be aborted before it completes by reverting
+`spec.image.tag` to the value in `status.installedRelease`. This is the
+supported escape hatch when an upgrade is wedged — for example, an expand or
+migrate Job that fails permanently (exceeds its backoff limit) or whose Pod
+cannot pull the target image.
+
+When the operator observes `spec.image.tag == status.installedRelease` while an
+upgrade is active (`status.upgradePhase` is set), it:
+
+1. Deletes the `<cr-name>-db-expand`, `<cr-name>-db-migrate`, and
+   `<cr-name>-db-contract` Jobs (with background propagation, so their Pods are
+   removed too).
+2. Clears `status.upgradePhase` and `status.targetRelease`.
+3. Emits an `UpgradeAborted` event on the Keystone CR.
+4. Requeues, so the next reconcile takes the steady-state `db_sync` path and
+   restores `DatabaseReady` against the installed release.
+
+```bash
+# Abort an in-flight upgrade by reverting the tag to the installed release.
+kubectl patch keystone <name> --type=merge \
+  -p '{"spec":{"image":{"tag":"<installed-release>"}}}'
+```
+
+::: warning Abort is only safe before the contract phase
+Expand and migrate are **additive** by design: they add the new columns and
+tables and backfill data without dropping anything the installed release still
+reads, so the pre-contract schema is a superset both releases run against.
+Aborting during **Expanding**, **Migrating**, or **RollingUpdate** is therefore
+safe. The **contract** phase drops the columns the new release no longer needs;
+aborting during **Contracting** can leave the installed release pointed at a
+schema missing fields it expects. The operator clears the upgrade state from any
+active phase, so validate the database before relying on a Contracting-phase
+abort. Once contract completes, the upgrade is finished and reverting the tag is
+a downgrade, which the operator rejects.
+:::
 
 ---
 
@@ -541,9 +583,16 @@ below).
 **Cause:** `spec.image.tag` was changed during an active upgrade to a value
 different from the current `targetRelease`.
 
-**Resolution:** Either revert `spec.image.tag` to match `status.targetRelease` to
-continue the current upgrade, or wait for the current upgrade to complete before
-changing the tag again. The operator does not support changing the upgrade target
+**Resolution:** Choose one of:
+
+- Revert `spec.image.tag` to `status.targetRelease` to continue the current
+  upgrade.
+- Revert `spec.image.tag` to `status.installedRelease` to abort the upgrade and
+  return to the installed release (see
+  [Aborting an Upgrade](#aborting-an-upgrade)).
+- Wait for the current upgrade to complete before changing the tag again.
+
+The operator does not support retargeting an upgrade to a third release
 mid-flight.
 
 #### ExpandFailed / MigrateFailed / ContractFailed
@@ -716,7 +765,10 @@ subsequent reconciles.
    Each intermediate release must be applied in order.
 
 2. **No automatic rollback.** If an upgrade fails, manual intervention is required.
-   The operator does not automatically revert to the previous release.
+   The operator does not automatically revert to the previous release, but an
+   in-flight upgrade can be aborted before the contract phase by reverting
+   `spec.image.tag` to `status.installedRelease` (see
+   [Aborting an Upgrade](#aborting-an-upgrade)).
 
 3. **Single-service scope.** This feature covers only the Keystone operator's
    internal upgrade flow. Cross-service upgrade orchestration is handled by the

--- a/docs/reference/testing/keystone-e2e-tests.md
+++ b/docs/reference/testing/keystone-e2e-tests.md
@@ -64,13 +64,13 @@ namespace, enabling parallel execution.
 │  │                   │  │  detection        │  │                       │   │
 │  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
 │  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ trust-flush       │  │ trust-flush-      │  │ upgrade-flow          │   │
+│  │ trust-flush       │  │ trust-flush-      │  │ upgrade-abort         │   │
 │  │                   │  │  default          │  │                       │   │
 │  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐                                                     │
-│  │ uwsgi             │                                                     │
-│  │                   │                                                     │
-│  └───────────────────┘                                                     │
+│  ┌───────────────────┐  ┌───────────────────┐                              │
+│  │ upgrade-flow      │  │ uwsgi             │                              │
+│  │                   │  │                   │                              │
+│  └───────────────────┘  └───────────────────┘                              │
 │                                                                            │
 │  Most tests run in: namespace openstack                                    │
 │  pod-security-restricted: own namespace keystone-pss-restricted-test       │
@@ -1011,6 +1011,11 @@ tests/e2e/keystone/
 ├── trust-flush-default/
 │   ├── chainsaw-test.yaml              Default-on trust flush via webhook materialization
 │   └── 00-keystone-cr.yaml             Keystone CR omitting trustFlush — webhook injects hourly schedule
+├── upgrade-abort/
+│   ├── chainsaw-test.yaml              Abort an in-flight upgrade by reverting the image tag
+│   ├── 00-keystone-cr.yaml             Keystone CR at release 2026.1
+│   ├── 01-patch-stuck-upgrade.yaml     Patch to 2026.2 (no image — wedges in Expanding)
+│   └── 02-patch-abort.yaml             Patch back to 2026.1 to abort
 ├── upgrade-flow/
 │   ├── chainsaw-test.yaml              Expand-migrate-contract upgrade
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial release

--- a/operators/keystone/internal/controller/reconcile_database.go
+++ b/operators/keystone/internal/controller/reconcile_database.go
@@ -97,7 +97,14 @@ const (
 	conditionReasonExpandComplete        = "ExpandComplete"
 	conditionReasonMigrateComplete       = "MigrateComplete"
 	conditionReasonUpgradeComplete       = "UpgradeComplete"
+	conditionReasonUpgradeAborted        = "UpgradeAborted"
 )
+
+// upgradeJobSuffixes lists the buildDBJob nameSuffixes for the Jobs created
+// during the expand-migrate-contract upgrade flow. abortUpgrade deletes exactly
+// these (and not db-sync or schema-check, which belong to the steady-state path)
+// so reverting an in-flight upgrade leaves no stale phase Jobs behind (#468).
+var upgradeJobSuffixes = []string{"db-expand", "db-migrate", "db-contract"}
 
 // recordDBJobTerminalState observes the named DB-related Job's terminal
 // condition and emits keystone_operator_db_sync_total /
@@ -311,6 +318,14 @@ func (r *KeystoneReconciler) reconcileDatabase(ctx context.Context, keystone *ke
 
 	// Active upgrade: delegate to phase-specific handling (CC-0056).
 	if keystone.Status.UpgradePhase != "" {
+		// Abort path: reverting spec.image.tag back to the installed release
+		// cancels the in-flight upgrade and unblocks a stuck or permanently
+		// failed expand/migrate phase (#468). Checked before the
+		// target-changed guard below because a revert also satisfies
+		// tag != targetRelease and would otherwise return a hard error.
+		if keystone.Spec.Image.Tag == keystone.Status.InstalledRelease {
+			return r.abortUpgrade(ctx, keystone)
+		}
 		// Detect tag change during an active upgrade (CC-0056, REQ-009).
 		if keystone.Spec.Image.Tag != keystone.Status.TargetRelease {
 			logger.Info("Image tag changed during active upgrade",
@@ -503,6 +518,73 @@ func (r *KeystoneReconciler) initiateUpgrade(ctx context.Context, keystone *keys
 	logger.Info("Upgrade detected", "from", from.Raw, "to", to.Raw, "phase", keystonev1alpha1.UpgradePhaseExpanding)
 	r.Recorder.Eventf(keystone, corev1.EventTypeNormal, conditionReasonUpgradeInitiated, "Upgrade initiated: %s \u2192 %s", from.Raw, to.Raw)
 	return ctrl.Result{Requeue: true}, nil
+}
+
+// abortUpgrade cancels an in-flight upgrade when spec.image.tag is reverted to
+// status.installedRelease. It deletes the expand/migrate/contract Jobs, clears
+// status.upgradePhase/targetRelease, emits an UpgradeAborted event, and requeues
+// so the steady-state db_sync path takes over and re-derives DatabaseReady on
+// the next pass. This is the only escape from an upgrade wedged on a stuck or
+// permanently failed expand/migrate Job (#468).
+//
+// Aborting is only safe before the contract phase has run. Expand and migrate
+// are additive by design: they create the new columns/tables and backfill data
+// without dropping anything the installed release still reads, so the
+// pre-contract schema is a superset both releases run against. Contract drops
+// the now-unused columns; once it has started, the installed release would be
+// pointed at a schema missing fields it expects, so a post-contract revert is
+// not a safe rollback. The reverted release is the operator's responsibility to
+// validate. The controller does not gate the abort on the current phase.
+func (r *KeystoneReconciler) abortUpgrade(ctx context.Context, keystone *keystonev1alpha1.Keystone) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	abortedTarget := keystone.Status.TargetRelease
+	abortedPhase := keystone.Status.UpgradePhase
+
+	// Delete the phase Jobs before clearing status so a transient delete error
+	// leaves the upgrade state intact and the next reconcile retries the abort
+	// rather than dropping into the steady-state path with orphaned Jobs (#468).
+	if err := r.deleteUpgradeJobs(ctx, keystone); err != nil {
+		return ctrl.Result{}, fmt.Errorf("deleting upgrade jobs during abort: %w", err)
+	}
+
+	keystone.Status.UpgradePhase = ""
+	keystone.Status.TargetRelease = ""
+
+	logger.Info("Upgrade aborted: spec.image.tag reverted to installed release",
+		"installedRelease", keystone.Status.InstalledRelease,
+		"abortedTarget", abortedTarget,
+		"abortedPhase", abortedPhase)
+	r.Recorder.Eventf(keystone, corev1.EventTypeNormal, conditionReasonUpgradeAborted,
+		"Upgrade %s \u2192 %s aborted: spec.image.tag reverted to installed release %s",
+		keystone.Status.InstalledRelease, abortedTarget, keystone.Status.InstalledRelease)
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// deleteUpgradeJobs deletes the expand/migrate/contract Jobs owned by keystone.
+// NotFound is tolerated so the call is idempotent across requeues, and
+// Background propagation removes each Job's owned Pods too rather than orphaning
+// them (CC-0058, #468).
+func (r *KeystoneReconciler) deleteUpgradeJobs(ctx context.Context, keystone *keystonev1alpha1.Keystone) error {
+	logger := log.FromContext(ctx)
+	for _, suffix := range upgradeJobSuffixes {
+		jobName := fmt.Sprintf("%s-%s", keystone.Name, suffix)
+		j := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: keystone.Namespace,
+			},
+		}
+		err := r.Delete(ctx, j, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		switch {
+		case apierrors.IsNotFound(err):
+			logger.V(1).Info("upgrade phase job already absent during abort", "job", jobName)
+		case err != nil:
+			return fmt.Errorf("deleting %s: %w", jobName, err)
+		default:
+			logger.V(1).Info("deleted upgrade phase job during abort", "job", jobName)
+		}
+	}
+	return nil
 }
 
 // setUpgradePhaseRunning sets DatabaseReady=False with reason "{phase}InProgress"

--- a/operators/keystone/internal/controller/reconcile_database_test.go
+++ b/operators/keystone/internal/controller/reconcile_database_test.go
@@ -1503,6 +1503,127 @@ func TestReconcileDatabase_TagChangedDuringUpgrade_Blocks(t *testing.T) {
 	expectEvent(g, r, "Warning UpgradeTargetChanged")
 }
 
+// --- Upgrade abort tests (#468) ---
+
+// TestReconcileDatabase_RevertToInstalledRelease_AbortsDuringExpand verifies that
+// reverting spec.image.tag to status.installedRelease during the Expanding phase
+// aborts the upgrade: the expand/migrate/contract Jobs are deleted, upgradePhase
+// and targetRelease are cleared, installedRelease is left untouched, an
+// UpgradeAborted event is emitted, and the reconcile requeues so the steady-state
+// db_sync path takes over (#468).
+func TestReconcileDatabase_RevertToInstalledRelease_AbortsDuringExpand(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTestScheme()
+	ks := upgradingKeystone(keystonev1alpha1.UpgradePhaseExpanding)
+	// Operator reverts the tag from the in-flight target (2026.1) back to the
+	// installed release (2025.2) to abort.
+	ks.Spec.Image.Tag = "2025.2"
+
+	// Pre-create the expand and migrate phase Jobs so the abort has something to
+	// clean up (the contract Job is never created during Expanding).
+	expandJob := buildExpandJob(ks, "keystone-config-abc123", "2026.1")
+	migrateJob := buildMigrateJob(ks, "keystone-config-abc123", "2026.1")
+
+	r := newDBTestReconciler(s, ks, expandJob, migrateJob)
+
+	result, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+	// Upgrade state cleared; installed release untouched.
+	g.Expect(ks.Status.UpgradePhase).To(BeEmpty())
+	g.Expect(ks.Status.TargetRelease).To(BeEmpty())
+	g.Expect(ks.Status.InstalledRelease).To(Equal("2025.2"))
+
+	// Assert absence of old state: every upgrade phase Job is gone.
+	for _, suffix := range []string{"db-expand", "db-migrate", "db-contract"} {
+		var jb batchv1.Job
+		getErr := r.Get(context.Background(), client.ObjectKey{
+			Name:      "test-keystone-" + suffix,
+			Namespace: "default",
+		}, &jb)
+		g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+			"%s Job must be absent after abort", suffix)
+	}
+
+	expectEvent(g, r, "Normal UpgradeAborted")
+}
+
+// TestReconcileDatabase_RevertToInstalledRelease_AbortsFromAnyPhase verifies the
+// abort path fires from every active upgrade phase — not just Expanding — and
+// that reverting to the installed release never returns the UpgradeTargetChanged
+// hard error a revert would otherwise trip (the reverted tag also differs from
+// targetRelease). No phase Jobs are pre-created, so this also covers the
+// idempotent NotFound delete path (#468).
+func TestReconcileDatabase_RevertToInstalledRelease_AbortsFromAnyPhase(t *testing.T) {
+	phases := []keystonev1alpha1.UpgradePhase{
+		keystonev1alpha1.UpgradePhaseExpanding,
+		keystonev1alpha1.UpgradePhaseMigrating,
+		keystonev1alpha1.UpgradePhaseRollingUpdate,
+		keystonev1alpha1.UpgradePhaseContracting,
+	}
+	for _, phase := range phases {
+		t.Run(string(phase), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			s := dbTestScheme()
+			ks := upgradingKeystone(phase)
+			ks.Spec.Image.Tag = ks.Status.InstalledRelease
+
+			r := newDBTestReconciler(s, ks)
+
+			result, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+			g.Expect(ks.Status.UpgradePhase).To(BeEmpty())
+			g.Expect(ks.Status.TargetRelease).To(BeEmpty())
+			g.Expect(ks.Status.InstalledRelease).To(Equal("2025.2"))
+
+			expectEvent(g, r, "Normal UpgradeAborted")
+		})
+	}
+}
+
+// TestReconcileDatabase_AbortUpgrade_DeleteErrorRetainsState verifies that when
+// deleting an upgrade phase Job fails with a non-NotFound error, the abort
+// surfaces the error and leaves status.upgradePhase/targetRelease intact so the
+// next reconcile retries the abort rather than dropping into the steady-state
+// path with orphaned phase Jobs (#468).
+func TestReconcileDatabase_AbortUpgrade_DeleteErrorRetainsState(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTestScheme()
+	ks := upgradingKeystone(keystonev1alpha1.UpgradePhaseExpanding)
+	ks.Spec.Image.Tag = "2025.2"
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ks).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*batchv1.Job); ok {
+					return fmt.Errorf("simulated API server error")
+				}
+				return cl.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &KeystoneReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.reconcileDatabase(context.Background(), ks, "keystone-config-abc123")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("simulated API server error"))
+
+	// Upgrade state must survive a failed abort so the retry can complete it.
+	g.Expect(ks.Status.UpgradePhase).To(Equal(keystonev1alpha1.UpgradePhaseExpanding))
+	g.Expect(ks.Status.TargetRelease).To(Equal("2026.1"))
+
+	expectNoEvent(g, r)
+}
+
 // --- Schema check tests (CC-0064) ---
 
 // TestBuildSchemaCheckJob_Name verifies that the schema-check Job has the correct

--- a/tests/e2e/keystone/upgrade-abort/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/upgrade-abort/00-keystone-cr.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Keystone CR fixture for the upgrade-abort E2E test.
+# Managed mode with initial image tag 2026.1. The next sequential release
+# (2026.2) has no pre-loaded image, so an upgrade to it wedges in the Expanding
+# phase — the deterministic stuck-upgrade the abort path must rescue.
+# Unique name and database name keep this suite isolated under parallel runs.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-upgrade-abort
+  namespace: openstack
+spec:
+  replicas: 1
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2026.1"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: keystone_upgrade_abort
+    secretRef:
+      name: keystone-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+    backend: dogpile.cache.pymemcache
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/upgrade-abort/01-patch-stuck-upgrade.yaml
+++ b/tests/e2e/keystone/upgrade-abort/01-patch-stuck-upgrade.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch to start a sequential upgrade from 2026.1 to 2026.2. 2026.2 is a valid
+# sequential target (same year, minor 1 -> 2) but no image for it is pre-loaded
+# into kind, so the db-expand Job pod stays in ImagePullBackOff and the upgrade
+# wedges in the Expanding phase — a deterministic in-flight upgrade to abort.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-upgrade-abort
+  namespace: openstack
+spec:
+  image:
+    tag: "2026.2"

--- a/tests/e2e/keystone/upgrade-abort/02-patch-abort.yaml
+++ b/tests/e2e/keystone/upgrade-abort/02-patch-abort.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch to abort the in-flight upgrade by reverting spec.image.tag back to the
+# installed release (2026.1). The operator clears upgradePhase/targetRelease,
+# deletes the db-expand/db-migrate/db-contract Jobs, emits an UpgradeAborted
+# event, and returns to the steady-state db_sync path.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-upgrade-abort
+  namespace: openstack
+spec:
+  image:
+    tag: "2026.1"

--- a/tests/e2e/keystone/upgrade-abort/chainsaw-test.yaml
+++ b/tests/e2e/keystone/upgrade-abort/chainsaw-test.yaml
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for aborting an in-flight upgrade by reverting the image tag.
+# Verifies:
+#   (1) Fresh deployment at 2026.1 reaches Ready with installedRelease=2026.1
+#   (2) Upgrading to 2026.1 -> 2026.2 wedges in the Expanding phase, because the
+#       2026.2 image is not pre-loaded into kind (db-expand Pod ImagePullBackOff)
+#   (3) Reverting spec.image.tag to 2026.1 aborts the upgrade: upgradePhase and
+#       targetRelease clear, the db-expand/db-migrate/db-contract Jobs are
+#       deleted, an UpgradeAborted event fires, and the CR returns to Ready
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: keystone-upgrade-abort
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply Keystone CR at release 2026.1 ───────────────────────
+  - try:
+    - apply:
+        file: 00-keystone-cr.yaml
+  # ── Step 2: Assert Ready and installedRelease set ─────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: keystone.openstack.c5c3.io/v1alpha1
+          kind: Keystone
+          metadata:
+            name: keystone-upgrade-abort
+            namespace: openstack
+          status:
+            installedRelease: "2026.1"
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Keystone status ==="
+          kubectl get keystone keystone-upgrade-abort -n $NAMESPACE -o yaml 2>&1 | tail -60 || true
+          echo "=== Pods (workload + jobs) ==="
+          kubectl get pods -n $NAMESPACE -o wide 2>&1 | tail -30 || true
+          for pod in $(kubectl get pods -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Job status ==="
+          kubectl get jobs -n $NAMESPACE -o wide 2>&1 || true
+          echo "=== keystone-operator logs (current + previous) ==="
+          for ns in keystone-system default openstack; do
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 2>&1 || true
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -40 || true
+  # ── Step 3: Patch image tag to 2026.2 to start the upgrade ────────────
+  - try:
+    - patch:
+        file: 01-patch-stuck-upgrade.yaml
+  # ── Step 4: Assert the upgrade wedges in the Expanding phase ──────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: keystone.openstack.c5c3.io/v1alpha1
+          kind: Keystone
+          metadata:
+            name: keystone-upgrade-abort
+            namespace: openstack
+          status:
+            installedRelease: "2026.1"
+            targetRelease: "2026.2"
+            upgradePhase: Expanding
+            (conditions[?type == 'DatabaseReady']):
+            - status: "False"
+              reason: ExpandInProgress
+    # Proof the expand phase actually started: the db-expand Job exists.
+    - script:
+        content: |
+          set -eu
+          JOB="keystone-upgrade-abort-db-expand"
+          if kubectl get job "$JOB" -n $NAMESPACE >/dev/null 2>&1; then
+            echo "OK: Job $JOB exists (expand phase started)"
+          else
+            echo "ERROR: Job $JOB not found"
+            exit 1
+          fi
+    catch:
+    - script:
+        content: |
+          echo "=== Keystone status ==="
+          kubectl get keystone keystone-upgrade-abort -n $NAMESPACE -o yaml 2>&1 | tail -60 || true
+          echo "=== Pods (workload + jobs) ==="
+          kubectl get pods -n $NAMESPACE -o wide 2>&1 | tail -30 || true
+          for pod in $(kubectl get pods -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Job status ==="
+          kubectl get jobs -n $NAMESPACE -o wide 2>&1 || true
+          echo "=== keystone-operator logs (current + previous) ==="
+          for ns in keystone-system default openstack; do
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 2>&1 || true
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -40 || true
+  # ── Step 5: Revert image tag to 2026.1 to abort the upgrade ───────────
+  - try:
+    - patch:
+        file: 02-patch-abort.yaml
+  # ── Step 6: Assert the upgrade aborted and the CR is Ready again ──────
+  - try:
+    - assert:
+        resource:
+          apiVersion: keystone.openstack.c5c3.io/v1alpha1
+          kind: Keystone
+          metadata:
+            name: keystone-upgrade-abort
+            namespace: openstack
+          status:
+            installedRelease: "2026.1"
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    # Verify the abort mechanics directly: state cleared, phase Jobs gone, event
+    # emitted. The old state (db-expand Job) is asserted absent before trusting
+    # the recovered Ready state.
+    - script:
+        content: |
+          set -eu
+          echo "=== Verify upgrade state cleared ==="
+          PHASE="$(kubectl get keystone keystone-upgrade-abort -n $NAMESPACE -o jsonpath='{.status.upgradePhase}')"
+          if [ -n "$PHASE" ]; then
+            echo "ERROR: upgradePhase still set to '$PHASE' after abort"
+            exit 1
+          fi
+          TARGET="$(kubectl get keystone keystone-upgrade-abort -n $NAMESPACE -o jsonpath='{.status.targetRelease}')"
+          if [ -n "$TARGET" ]; then
+            echo "ERROR: targetRelease still set to '$TARGET' after abort"
+            exit 1
+          fi
+          echo "OK: upgradePhase and targetRelease cleared"
+          echo "=== Verify upgrade phase Jobs deleted ==="
+          for phase in expand migrate contract; do
+            JOB="keystone-upgrade-abort-db-${phase}"
+            if kubectl get job "$JOB" -n $NAMESPACE >/dev/null 2>&1; then
+              echo "ERROR: Job $JOB still exists after abort"
+              exit 1
+            fi
+            echo "OK: Job $JOB deleted"
+          done
+          echo "=== Verify UpgradeAborted event emitted ==="
+          if ! kubectl get events -n $NAMESPACE \
+               --field-selector reason=UpgradeAborted,involvedObject.name=keystone-upgrade-abort \
+               -o name 2>/dev/null | grep -q .; then
+            echo "ERROR: no UpgradeAborted event found"
+            exit 1
+          fi
+          echo "OK: UpgradeAborted event present"
+    catch:
+    - script:
+        content: |
+          echo "=== Keystone status ==="
+          kubectl get keystone keystone-upgrade-abort -n $NAMESPACE -o yaml 2>&1 | tail -60 || true
+          echo "=== Pods (workload + jobs) ==="
+          kubectl get pods -n $NAMESPACE -o wide 2>&1 | tail -30 || true
+          for pod in $(kubectl get pods -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Job status ==="
+          kubectl get jobs -n $NAMESPACE -o wide 2>&1 || true
+          echo "=== keystone-operator logs (current + previous) ==="
+          for ns in keystone-system default openstack; do
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 2>&1 || true
+            kubectl logs -n "$ns" -l app.kubernetes.io/name=keystone-operator --all-containers --tail=200 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -40 || true


### PR DESCRIPTION
Closes #468.

## Problem

During an active upgrade, **any** `spec.image.tag != status.targetRelease` — including a revert to `status.installedRelease` — returned a hard `UpgradeTargetChanged` error on every reconcile (`reconcile_database.go`). Nothing cleared `status.upgradePhase`/`targetRelease` except contract completion, so an upgrade wedged on a stuck or permanently failed expand/migrate Job could only be escaped through manual status-subresource surgery.

## Change (in commit order)

1. **`feat(keystone-operator): abort in-flight upgrade by reverting tag`**
   - In `reconcileDatabase`, special-case `spec.image.tag == status.installedRelease` while `upgradePhase != ""` as an abort path. It is checked **before** the `UpgradeTargetChanged` guard, because a revert also satisfies `tag != targetRelease`.
   - `abortUpgrade` deletes the `db-expand`/`db-migrate`/`db-contract` Jobs (via `deleteUpgradeJobs`, `DeletePropagationBackground` so owned Pods go too), clears `upgradePhase`/`targetRelease`, emits an `UpgradeAborted` event, and returns `ctrl.Result{Requeue: true}, nil` so the steady-state `db_sync` path re-derives `DatabaseReady`.
   - Jobs are deleted **before** status is cleared, so a transient delete error retains the upgrade state and the next reconcile retries the abort.
   - Unit tests: abort during expand (state cleared, phase Jobs deleted, event, requeue); abort from every active phase (also proves no `UpgradeTargetChanged` hard error on revert); delete-error retains state for retry.

2. **`test(keystone-operator): cover upgrade abort during expand (e2e)`**
   - New `tests/e2e/keystone/upgrade-abort/` Chainsaw suite. Installs at `2026.1`, then upgrades to `2026.2` — a valid sequential target whose image is never pre-loaded into kind, so the `db-expand` Pod stays in `ImagePullBackOff` and the upgrade wedges **deterministically** in `Expanding`. Reverting to `2026.1` must clear the upgrade, delete the phase Jobs, emit `UpgradeAborted`, and return to `Ready`. Unique CR + database name for the parallel runner.

3. **`docs(keystone): document aborting an in-flight upgrade`**
   - New "Aborting an Upgrade" section in the upgrade-flow reference, plus updates to the `targetRelease` note, the decision tree, the `UpgradeTargetChanged` troubleshooting resolution, and the "No automatic rollback" limitation. New suite added to the e2e-tests reference overview + directory tree.

## Semantics / safety note (documented)

Abort is only safe **before** the contract phase has run: expand and migrate are additive, so the pre-contract schema is a superset both releases run against. Contract drops the now-unused columns. The controller does **not** gate the abort on the current phase (matching the issue's proposed fix); the caveat is documented for operators.

## Local verification

- `gofmt -l` (changed Go files) — clean
- `go vet ./internal/controller/` — clean
- `go test ./internal/controller/ -count=1` — pass
- `golangci-lint run ./internal/controller/...` — 0 issues
- `make check-docs-ids` — pass
- New e2e suite YAML parses; full run is CI's job (needs a kind cluster + loaded images).

## Notes for the reviewer

- No CC-ID is assigned to #468 in `.planwerk/`, so code comments reference the GitHub issue (`#468`), mirroring the existing `(CC-NNNN, #issue)` convention; docs stay free of CC/REQ/issue IDs.
- The summary table and per-suite detail sections in `keystone-e2e-tests.md` are a curated subset (the sibling `upgrade-flow` suite is absent from both), so `upgrade-abort` was added only to the completeness enumerations (overview grid + directory tree) for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

