### PR TITLE
fix(c5c3-operator): mode-flip/rename orphans, unreachable missing-CRD handling, missing ESO watches, misc gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,16 @@ CONTROLLER_GEN ?= controller-gen
 # Default resolves via GOPATH so local runs work without manually exporting GOBIN.
 SETUP_ENVTEST ?= $(shell go env GOPATH)/bin/setup-envtest
 
+# Local tool binaries are installed under bin/ (gitignored) so local dev pins
+# the same versions as CI without depending on whatever sits on $PATH.
+LOCALBIN ?= $(CURDIR)/bin
+
 # Pin gofumpt version to match CI (single source of truth for local dev).
 # Must be kept in sync with GOFUMPT_VERSION in .github/workflows/ci.yaml.
+# GOFUMPT resolves to the bin/ copy managed by install-gofumpt at the pinned
+# version, so a stale $PATH gofumpt can never silently format differently.
 GOFUMPT_VERSION ?= v0.10.0
-GOFUMPT ?= gofumpt
+GOFUMPT ?= $(LOCALBIN)/gofumpt
 
 # Kubernetes version for envtest binary downloads.
 # Pin to a specific version for reproducible integration tests across runs.
@@ -186,14 +192,14 @@ test-shell:
 .PHONY: fmt
 # fmt formats all tracked Go files with gofumpt.
 # Only formats git-tracked files to skip generated, vendored, or tooling code.
-fmt:
+fmt: install-gofumpt
 	@echo "Formatting Go files with gofumpt..."
 	@git ls-files '*.go' | xargs $(GOFUMPT) -w
 
 .PHONY: format-check
 # format-check verifies all tracked Go files conform to gofumpt formatting.
 # Mirrors the CI format-check job for local pre-commit validation.
-format-check:
+format-check: install-gofumpt
 	@unformatted=$$(git ls-files '*.go' | xargs $(GOFUMPT) -l); \
 	if [ -n "$$unformatted" ]; then \
 		echo "The following files are not formatted with gofumpt:"; \
@@ -204,10 +210,14 @@ format-check:
 	echo "Format check passed."
 
 .PHONY: install-gofumpt
-# install-gofumpt installs gofumpt at the pinned version.
-# Ensures local development uses the same version as CI.
+# install-gofumpt installs gofumpt at the pinned version into bin/.
+# Re-installs when the binary is missing or its version drifts from the pin so
+# fmt/format-check always run the exact version the CI format-check job uses.
 install-gofumpt:
-	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+	@if ! test -x '$(GOFUMPT)' || ! '$(GOFUMPT)' --version | grep -qF '$(GOFUMPT_VERSION)'; then \
+		echo "Installing gofumpt $(GOFUMPT_VERSION) into $(LOCALBIN)..."; \
+		GOBIN='$(LOCALBIN)' go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION); \
+	fi
 
 # ============================================================================
 # Code Generation Targets

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -299,8 +299,8 @@ Keystone service.
 | `replicas` | `*int32` | No | `nil` (Keystone operator default, 3) | Overrides the number of Keystone API replicas. When `nil`, the reconciler leaves `replicas` unset on the projected Keystone CR, so the Keystone operator applies its own default. Minimum: 1. |
 | `image` | [`*commonv1.ImageSpec`](../keystone/keystone-crd.md#imagespec) | No | `nil` | Overrides the Keystone container image. When `nil`, the reconciler derives the image as `ghcr.io/c5c3/keystone:{spec.openStackRelease}`. When set, the whole image reference is used verbatim. |
 | `policyOverrides` | [`*commonv1.PolicySpec`](../keystone/keystone-crd.md#policyspec) | No | `nil` | Per-service oslo.policy overrides for Keystone. When set, these take precedence over `spec.global` for the Keystone service. |
-| `rotationInterval` | `*metav1.Duration` | No | `nil` | Overrides the Fernet / credential-key rotation interval the reconciler derives for the projected Keystone CR. When `nil`, the reconciler derives a default schedule. When set, the duration is converted to a cron expression and applied to both `fernet.rotationSchedule` and `credentialKeys.rotationSchedule` on the projected Keystone CR; an unconvertible interval surfaces `KeystoneReady=False` with reason `InvalidRotationInterval`. |
-| `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Keystone API externally via a Gateway API HTTPRoute. When `nil`, no HTTPRoute is projected and the Keystone API is reachable in-cluster only (its ClusterIP Service). When set, the reconciler projects it onto the Keystone CR's `spec.gateway`, so the Keystone operator attaches an HTTPRoute to the referenced Gateway. |
+| `rotationInterval` | `*metav1.Duration` | No | `nil` | Overrides the Fernet / credential-key rotation interval the reconciler derives for the projected Keystone CR. When `nil`, the reconciler derives a default schedule. When set, the duration is converted to a cron expression and applied to both `fernet.rotationSchedule` and `credentialKeys.rotationSchedule` on the projected Keystone CR. An unconvertible interval (not a positive whole number of days) is **rejected at admission** by the validating webhook; if the webhook is bypassed, the reconciler surfaces `KeystoneReady=False` with reason `InvalidRotationInterval` and returns the error so the reconcile chain stops and requeues with backoff. |
+| `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Keystone API externally via a Gateway API HTTPRoute. When `nil`, no HTTPRoute is projected and the Keystone API is reachable in-cluster only (its ClusterIP Service). When set, the reconciler projects it onto the Keystone CR's `spec.gateway`, so the Keystone operator attaches an HTTPRoute to the referenced Gateway. When a `gateway` is set its `hostname` must be non-empty — enforced at admission by the validating webhook (see [Validation Rules](#validation-rules)). |
 | `publicEndpoint` | `string` | No | `""` | Externally routable Keystone identity endpoint URL (e.g. `https://keystone.example.com/v3`). Projected into the Keystone bootstrap (`--bootstrap-public-url`) and used for the K-ORC identity catalog Endpoint, so external clients resolve the same URL Keystone advertises. When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}/v3` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
 
 ---
@@ -481,8 +481,8 @@ the kind/name and applies it.
 | --- | --- | --- |
 | `conditions` | `[]metav1.Condition` | Latest available observations of the control-plane state. Each condition carries an `observedGeneration`. See [Status Conditions](#status-conditions). |
 | `observedGeneration` | `int64` | The `.metadata.generation` the controller last reconciled, so a stale status is distinguishable from a current one. |
-| `updatePhase` | [`UpdatePhase`](#updatephase) | Current phase of a control-plane release update. Empty / `Idle` outside an update. |
-| `services` | `map[string]ServiceStatus` | Per-service readiness of the projected service CRs, keyed by service name (e.g. `"keystone"`). See [ServiceStatus](#servicestatus). |
+| `updatePhase` | [`UpdatePhase`](#updatephase) | Current phase of a control-plane release update. Written on every status update; fixed at `Idle` in the current implementation because the release-update state machine is reserved (the other `UpdatePhase` values are not yet set). |
+| `services` | `map[string]ServiceStatus` | Per-service readiness of the projected service CRs, keyed by service name. Written on every status update with a `"keystone"` entry whose `ready` mirrors the `KeystoneReady` condition and whose `release` is `spec.openStackRelease`. See [ServiceStatus](#servicestatus). |
 | `adminApplicationCredential` | [`*AdminApplicationCredentialStatus`](#adminapplicationcredentialstatus) | Observed state of the K-ORC admin application credential. |
 | `catalogReady` | `bool` | Whether the OpenStack service catalog has been observed as fully populated for the control plane. Flipped `true` by the catalog sub-reconciler once the identity `Service` and `Endpoint` are registered. |
 
@@ -681,6 +681,28 @@ short-circuit on the first error.
 | Database mutual exclusivity | `spec.infrastructure.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither (`(clusterRef != nil) == (host != "")`). **Webhook-only** — there is no CEL rule for this on the c5c3 CRD. |
 | Cache mutual exclusivity | `spec.infrastructure.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither (`(clusterRef != nil) == (len(servers) > 0)`). **Webhook-only**. |
 | Admin password Secret required | `spec.korc.adminCredential.passwordSecretRef.name` | `field.Required` | `name` is empty — without it the reconciler cannot (re-)mint the admin application credential. **Webhook-only**. |
+| Gateway hostname required | `spec.services.keystone.gateway.hostname` | `field.Required` | A `gateway` is configured but its `hostname` is empty. Mirrors the `+kubebuilder:validation:MinLength=1` marker on `commonv1.GatewaySpec.Hostname`; without it the reconciler derives an empty `https:///v3` public endpoint. |
+
+### Update-only immutability rules
+
+On **update** the validating webhook additionally rejects changes to the
+create-only fields below, accumulating them into the same `field.ErrorList` as
+the spec checks above. These fields are **webhook-only** (the affected leaves
+live in the shared `commonv1.DatabaseSpec`/`CacheSpec`, which the keystone
+operator reuses and which must not carry c5c3-specific CEL immutability markers).
+Flipping the database/cache mode or renaming a managed `clusterRef` would leave
+the previously-projected MariaDB/Memcached child (and its per-ControlPlane
+credential) orphaned and owned until the ControlPlane is deleted; renaming
+`cloudCredentialsRef.secretName` would leak the previously-projected K-ORC
+clouds.yaml ExternalSecret.
+
+| Rule | Field Path | Condition |
+| --- | --- | --- |
+| Database mode immutable | `spec.infrastructure.database` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
+| Database clusterRef.name immutable | `spec.infrastructure.database.clusterRef.name` | Both managed, but the name changed |
+| Cache mode immutable | `spec.infrastructure.cache` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
+| Cache clusterRef.name immutable | `spec.infrastructure.cache.clusterRef.name` | Both managed, but the name changed |
+| Cloud secretName immutable | `spec.korc.adminCredential.cloudCredentialsRef.secretName` | The value changed |
 
 ---
 
@@ -883,19 +905,20 @@ Set by `reconcileKORC`.
 | `True` | `ApplicationCredentialMinted` | The K-ORC admin `ApplicationCredential` is minted and reports `Available=True`. |
 | `False` | `WaitingForAdminPassword` | The admin password Secret/key is not yet available; minting deferred. |
 | `False` | `WaitingForApplicationCredential` | The `ApplicationCredential` CR is ensured but not yet `Available`. |
-| `False` | `KORCCRDNotInstalled` | The K-ORC `ApplicationCredential` CRD is not installed (no-match error); surfaced cleanly without crash-looping the operator. |
 | `False` | `AdminPasswordError` | Non-missing error reading the admin password. |
 | `False` | `ApplicationCredentialError` | Error create-or-updating the `ApplicationCredential` CR. |
 
 ### AdminCredentialReady
 
-Set by `reconcileAdminCredential` (gated on `KORCReady` **and** the K-ORC
-`clouds.yaml` ExternalSecret being Ready).
+Set by `reconcileAdminCredential` (gated on `KORCReady`, the OpenBao-backed
+`ClusterSecretStore` being Ready, **and** the K-ORC `clouds.yaml` ExternalSecret
+being Ready).
 
 | Status | Reason | When |
 | --- | --- | --- |
 | `True` | `AdminCredentialReady` | The admin application credential is committed to the owned Secret and mirrored to OpenBao. |
 | `False` | `WaitingForKORC` | `KORCReady` is not `True`; credential push deferred. |
+| `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `WaitingForCloudsYaml` | The operator-created per-ControlPlane `k-orc-clouds-yaml` ExternalSecret in the control-plane namespace (co-located with the K-ORC CRs per C1; created and owned by `reconcileKORC`) is not yet Ready. |
 | `False` | `CloudsYamlError` | Error checking the `clouds.yaml` ExternalSecret. |
 | `False` | `SecretError` | Error ensuring the operator-owned application-credential Secret. |
@@ -910,7 +933,6 @@ Also flips `status.catalogReady` to `true`.
 | --- | --- | --- |
 | `True` | `CatalogRegistered` | The Keystone identity `Service` and public `Endpoint` are registered as K-ORC CRs. |
 | `False` | `WaitingForAdminCredential` | `AdminCredentialReady` is not `True`; catalog registration deferred. |
-| `False` | `KORCCRDNotInstalled` | The K-ORC `Service`/`Endpoint` CRD is not installed (no-match error). |
 | `False` | `ServiceError` | Error create-or-updating the identity `Service` CR. |
 | `False` | `EndpointError` | Error create-or-updating the identity `Endpoint` CR. |
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -108,7 +108,9 @@ can interact with the typed child CRDs:
 ### Watches
 
 The controller watches the primary `ControlPlane` CR, every child CR the
-sub-reconcilers project, and the admin-password `Secret`:
+sub-reconcilers project (including the owned ESO `ExternalSecret` and
+`PushSecret`), the admin-password `Secret`, and the OpenBao-backed
+`ClusterSecretStore`:
 
 | Resource | Watch Type | Effect |
 | --- | --- | --- |
@@ -119,7 +121,10 @@ sub-reconcilers project, and the admin-password `Secret`:
 | K-ORC `ApplicationCredential` | `Owns()` | Re-reconciles when the minted admin credential's `Available` condition or `status.id` changes |
 | K-ORC `Service` | `Owns()` | Re-reconciles when the identity catalog Service changes |
 | K-ORC `Endpoint` | `Owns()` | Re-reconciles when the public identity Endpoint changes |
+| `ExternalSecret` | `Owns()` | Re-reconciles when an owned ESO ExternalSecret (DB credential, admin password, K-ORC clouds.yaml) syncs or fails, so the credential conditions track ESO promptly |
+| `PushSecret` | `Owns()` | Re-reconciles when the owned admin-credential PushSecret status changes |
 | `Secret` | `Watches()` | Maps Secret events to referencing ControlPlane CRs via the `ControlPlaneSecretNameIndexKey` field indexer (`secretToControlPlaneMapper`) |
+| `ClusterSecretStore` | `Watches()` | Maps a status change on the OpenBao-backed store (`openbao-cluster-store`) to **every** ControlPlane in the cluster (`clusterSecretStoreToControlPlaneMapper`) |
 
 The `Secret` watch uses `Watches()` with a `MapFunc` rather than `Owns()`
 because the admin-password Secret
@@ -129,6 +134,15 @@ owner-reference filter would never match it. The index-backed namespace List is
 exactly what wakes the ControlPlane when its admin password rotates, so the
 re-mint chain (see [K-ORC admin credential chain](#k-orc-admin-credential-chain))
 converges on watch delivery instead of waiting for the next periodic requeue.
+
+The `ClusterSecretStore` watch is cluster-scoped: the OpenBao-backed store is
+shared across namespaces, so any status transition (for example ESO losing the
+backend connection) enqueues every ControlPlane. This is why the DB-credential,
+admin-password, and admin-credential sub-reconcilers can flip their conditions to
+`SecretStoreNotReady` the moment the backend becomes unreachable instead of
+waiting up to a full ESO refresh interval (default 1h) for the next per-secret
+re-sync. The `ExternalSecret`/`PushSecret` children are owned (controller
+reference), so `Owns()` wires them directly.
 
 #### Secret Field Indexer
 
@@ -332,11 +346,12 @@ ctrl.Result{}, nil)`.
 
 ### Status Update Pattern
 
-`updateStatus()` stamps `cp.Status.ObservedGeneration = cp.Generation`, persists
-all condition changes via `r.Status().Update()`, and returns the provided
-`(result, error)` pair. When both a reconcile error and the status update fail,
-both errors are preserved via `errors.Join` so the original reconcile failure
-remains visible in controller-runtime logs:
+`updateStatus()` stamps `cp.Status.ObservedGeneration = cp.Generation`, records
+the per-service status (`setServicesStatus()`, see below), persists all condition
+changes via `r.Status().Update()`, and returns the provided `(result, error)`
+pair. When both a reconcile error and the status update fail, both errors are
+preserved via `errors.Join` so the original reconcile failure remains visible in
+controller-runtime logs:
 
 | reconcileErr | `Status().Update()` | Returned error |
 | --- | --- | --- |
@@ -373,6 +388,16 @@ One path bypasses the aggregation entirely: a ControlPlane parked by the
 duplicate guard (see [Multi-instance](#multi-instance)) gets `Ready=False` with
 reason `DuplicateControlPlane` written directly — `setReadyCondition()` would
 otherwise overwrite the reason with `NotAllReady` on the next status update.
+
+### Services and Update Phase
+
+`setServicesStatus()` runs on every `updateStatus` call and populates two status
+fields that the schema declared but the reconciler previously never wrote:
+
+| Field | Value |
+| --- | --- |
+| `status.updatePhase` | Fixed at `Idle` — the release-update state machine is not implemented and the other `UpdatePhase` values are reserved, so "no update in progress" is the current state |
+| `status.services["keystone"]` | `ready` mirrors the `KeystoneReady` sub-condition (via `conditions.AllTrue`); `release` is `spec.openStackRelease` |
 
 ---
 
@@ -459,6 +484,7 @@ is set and **brownfield** when the user supplies a `host`-based connection:
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | Brownfield (`clusterRef == nil`) | True | `BrownfieldUserSuppliedCredential` | no ExternalSecret projected; user supplies the DB credential Secret out-of-band |
+| ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; managed mode only, checked before the ExternalSecret is projected so an OpenBao/ESO outage surfaces promptly |
 | ExternalSecret create/update or read fails | False | `ExternalSecretError` | returns the error |
 | ExternalSecret not yet synced | False | `WaitingForDBCredentialSecret` | requeue 10s |
 | ExternalSecret Ready | True | `DBCredentialsReady` | — |
@@ -511,6 +537,7 @@ cp-level spec default for `passwordSecretRef` remains `keystone-admin`.
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | Brownfield (`clusterRef == nil`) | True | `BrownfieldUserSuppliedCredential` | no ExternalSecret projected; user supplies the admin-password Secret out-of-band |
+| ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; managed mode only, checked before the ExternalSecret is projected |
 | ExternalSecret create/update or read fails | False | `ExternalSecretError` | returns the error |
 | ExternalSecret not yet synced | False | `WaitingForAdminPasswordSecret` | requeue 10s |
 | ExternalSecret Ready | True | `AdminPasswordReady` | — |
@@ -556,7 +583,7 @@ the ControlPlane provisioned:
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | `InfrastructureReady` not True | False | `WaitingForInfrastructure` | requeue 5s; no Keystone CR is created while infra is unready |
-| Invalid `rotationInterval` | False | `InvalidRotationInterval` | **no requeue, no error** — a bad interval surfaces a clean condition rather than a partial apply or backoff loop |
+| Invalid `rotationInterval` | False | `InvalidRotationInterval` | **returns the error** so the reconcile chain stops at Keystone and the manager requeues with backoff (the validating webhook already rejects unrepresentable intervals at admission, so this is defense-in-depth) |
 | Keystone create/update fails | False | `KeystoneError` | returns the error |
 | Keystone child not yet Ready | False | `WaitingForKeystone` | requeue 15s |
 | Keystone child Ready | True | `KeystoneReady` | — |
@@ -626,7 +653,6 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | Admin password Secret/key missing | False | `WaitingForAdminPassword` | requeue 10s (via `secrets.IsMissingSecretOrKey`) |
 | Admin password read fails otherwise | False | `AdminPasswordError` | returns the error |
 | Password-cloud ensure fails | False | `PasswordCloudError` | returns the error |
-| K-ORC AC CRD not installed | False | `KORCCRDNotInstalled` | requeue 10s (no hard error) |
 | Hash mismatch → AC deleted for re-mint | False | `ReMinting` | requeue 10s; AC deleted + `value` regenerated, recreated next pass |
 | Re-mint stuck `Terminating` past `remintStallTimeout` (5m) | False | `ReMintStalled` | requeue 10s; finalizer cannot revoke the old credential |
 | AC create/update/delete/read fails otherwise | False | `ApplicationCredentialError` | returns the error |
@@ -634,13 +660,21 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | AC not yet `Available` | False | `WaitingForApplicationCredential` | requeue 10s; gated on `orcv1alpha1.IsAvailable(ac)` (K-ORC uses `Available`, not `Ready`) |
 | AC minted and Available | True | `ApplicationCredentialMinted` | — |
 
+> **Hard CRD dependency.** K-ORC (like Memcached, ESO, MariaDB, and Keystone) is
+> a hard dependency: `SetupWithManager` `Owns`/`Watches` its kinds, so the
+> manager fails fast at startup if any CRD is absent. A missing K-ORC CRD never
+> reaches the reconcile path, so there is no dedicated CRD-not-installed
+> condition; a no-match error that could only occur if a CRD were deleted after
+> startup propagates as a hard error (`ApplicationCredentialError` /
+> `ServiceError`) and the manager requeues with backoff.
+
 ### reconcileAdminCredential
 
 | Aspect | Value |
 | --- | --- |
 | File | `reconcile_korc.go` |
 | Condition | `AdminCredentialReady` |
-| Gate | `KORCReady == True` **and** the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready |
+| Gate | `KORCReady == True`, the OpenBao-backed `ClusterSecretStore` is Ready, **and** the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready |
 | Owns | the operator-owned `Secret` `{controlplane.Name}-admin-app-credential` and the `PushSecret` `{controlplane.Name}-admin-app-credential-backup`, both in `childNamespace(cp)` |
 | Requeue | `korcRequeueAfter` = **10s** while either gate is unmet |
 
@@ -675,6 +709,7 @@ OpenBao:
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | `KORCReady` not True | False | `WaitingForKORC` | requeue 10s |
+| ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; checked after the `KORCReady` gate so an OpenBao/ESO outage surfaces before the clouds.yaml wait |
 | clouds.yaml ES check errors | False | `CloudsYamlError` | returns the error |
 | clouds.yaml ES not Ready | False | `WaitingForCloudsYaml` | requeue 10s |
 | operator Secret ensure fails | False | `SecretError` | returns the error |
@@ -689,20 +724,20 @@ OpenBao:
 | Condition | `CatalogReady` (also sets `cp.Status.CatalogReady = true`) |
 | Gate | `AdminCredentialReady == True` |
 | Owns | a K-ORC identity `Service` (`{controlplane.Name}-identity-service`) and its public `Endpoint` (`{controlplane.Name}-identity-endpoint`) in `childNamespace(cp)` |
-| Requeue | `korcRequeueAfter` = **10s** while gated or while the K-ORC CRD is missing |
+| Requeue | `korcRequeueAfter` = **10s** while gated |
 
 `reconcileCatalog` registers the OpenStack service-catalog entries for Keystone
 as owned K-ORC CRs: an `identity`-type `Service` named
 `keystone`, plus a `public` `Endpoint` whose URL defaults to the conventional
 in-cluster identity URL `http://keystone.<namespace>.svc:5000/v3` and whose
 `serviceRef` points at the identity Service. Both children are idempotent
-create-or-updates; the K-ORC missing-CRD safety mirrors `reconcileKORC` via
-`catalogCRDMissing`.
+create-or-updates. K-ORC is a hard CRD dependency (see the note above), so a
+missing Service/Endpoint CRD never reaches this path and there is no
+CRD-not-installed condition.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | `AdminCredentialReady` not True | False | `WaitingForAdminCredential` | requeue 10s |
-| K-ORC Service/Endpoint CRD missing | False | `KORCCRDNotInstalled` | requeue 10s (no hard error) |
 | Service create/update fails | False | `ServiceError` | returns the error |
 | Endpoint create/update fails | False | `EndpointError` | returns the error |
 | both registered | True | `CatalogRegistered` | also sets `status.catalogReady = true` |

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -191,16 +191,17 @@ mariadb-operator-crds     (no dependencies)
 
 K-ORC is **not** in this graph: it is applied by a Flux `Kustomization`, not a
 HelmRelease, and a HelmRelease `dependsOn` can only reference other HelmReleases. The
-c5c3-operator therefore does **not** `dependsOn` K-ORC — the reconciler tolerates the
-K-ORC CRDs being absent (it surfaces `KORCReady=False` / `KORCCRDNotInstalled` rather
-than crash-looping) and converges once they appear.
+c5c3-operator therefore does **not** `dependsOn` K-ORC even though K-ORC is a **hard
+dependency**: `SetupWithManager` `Owns` the K-ORC kinds, so the manager only starts
+once those CRDs are installed (until then the pod restarts), and converges once they
+appear.
 
 The `c5c3-operator` HelmRelease sits at the top of this graph: it
 `dependsOn` the four operators whose CRs it projects (keystone-operator,
 external-secrets, mariadb-operator, memcached-operator). It also drives K-ORC's
 ApplicationCredential / Service / Endpoint CRDs, but K-ORC is applied by the separate
-Flux `Kustomization` above, so it is not a `dependsOn` edge — the c5c3-operator simply
-waits out `KORCCRDNotInstalled` until those CRDs are present.
+Flux `Kustomization` above, so it cannot be a `dependsOn` edge — the c5c3-operator's
+manager instead requires those CRDs to be present at startup.
 
 FluxCD resolves this dependency graph and installs operators in the correct order.
 If cert-manager is not ready, dependent operators are held in a pending state.
@@ -474,8 +475,9 @@ it projects — `keystone-operator` for the Keystone instance, `external-secrets
 `mariadb-operator` and `memcached-operator` for the supporting platform services. It
 also drives K-ORC's `ApplicationCredential` / `Service` / `Endpoint` CRDs to register
 the catalog and rotate the admin credential, but K-ORC is the separate Flux
-`Kustomization` above, not a `dependsOn` edge (the reconciler tolerates those CRDs being
-absent — `KORCCRDNotInstalled` — until they appear). The operator child CRs are created
+`Kustomization` above, not a `dependsOn` edge (so K-ORC, like the other CRD providers,
+is a hard dependency the manager requires at startup rather than tolerating). The
+operator child CRs are created
 in the `ControlPlane`'s own namespace, not a hard-coded one. For the reconciliation
 contract see the upstream design chapter
 `architecture/docs/09-implementation/08-c5c3-operator.md`.

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -193,15 +193,27 @@ func (w *ControlPlaneWebhook) Default(_ context.Context, obj *ControlPlane) erro
 // The check runs only on CREATE (not UPDATE) so an existing CR stays mutable.
 // Reviewer: please verify boundary 6 = option (a).
 func (w *ControlPlaneWebhook) ValidateCreate(ctx context.Context, obj *ControlPlane) (admission.Warnings, error) {
-	if err := w.validate(obj); err != nil {
+	if err := newInvalidIfErrs(obj, w.validate(obj)); err != nil {
 		return nil, err
 	}
 	return nil, w.validateUniqueInNamespace(ctx, obj)
 }
 
 // ValidateUpdate implements admission.Validator[*ControlPlane].
-func (w *ControlPlaneWebhook) ValidateUpdate(_ context.Context, _, newObj *ControlPlane) (admission.Warnings, error) {
-	return nil, w.validate(newObj)
+// In addition to the spec checks in validate(), it enforces the create-only
+// immutable fields between oldObj and newObj: flipping the database/cache mode
+// or renaming a managed clusterRef would orphan the previously-projected
+// MariaDB/Memcached child (and its credentials), and renaming
+// cloudCredentialsRef.secretName would leak the previously-projected K-ORC
+// clouds.yaml ExternalSecret. Restricting these at admission is the smallest
+// change that prevents every such orphan/leak the sub-reconcilers would
+// otherwise create on the next reconcile (#476). Spec errors and immutability
+// errors are accumulated into a single Invalid response so a reviewer sees all
+// problems at once.
+func (w *ControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, newObj *ControlPlane) (admission.Warnings, error) {
+	allErrs := w.validate(newObj)
+	allErrs = append(allErrs, validateImmutable(oldObj, newObj)...)
+	return nil, newInvalidIfErrs(newObj, allErrs)
 }
 
 // ValidateDelete implements admission.Validator[*ControlPlane]. The method is
@@ -213,11 +225,14 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
 	return nil, nil
 }
 
-// validate runs all validation rules against the ControlPlane spec. The kubebuilder markers / CEL rules on the CRD are the primary
-// enforcement point at admission time; the checks below are defense-in-depth
-// (mirroring the KeystoneWebhook discipline) so callers that bypass CRD schema
-// admission still get field-specific errors.
-func (w *ControlPlaneWebhook) validate(cp *ControlPlane) error {
+// validate accumulates all spec validation errors for cp.
+// The kubebuilder markers / CEL rules on the CRD are the primary enforcement
+// point at admission time; the checks below are defense-in-depth (mirroring the
+// KeystoneWebhook discipline) so callers that bypass CRD schema admission still
+// get field-specific errors. It returns the accumulated field errors; callers
+// wrap them via newInvalidIfErrs so ValidateUpdate can fold in the immutability
+// errors before constructing a single Invalid response.
+func (w *ControlPlaneWebhook) validate(cp *ControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
@@ -279,14 +294,80 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) error {
 		}
 	}
 
-	if len(allErrs) > 0 {
-		return apierrors.NewInvalid(
-			schema.GroupKind{Group: GroupVersion.Group, Kind: "ControlPlane"},
-			cp.Name,
-			allErrs,
-		)
+	return allErrs
+}
+
+// newInvalidIfErrs wraps a non-empty field.ErrorList in an apierrors.NewInvalid
+// for the ControlPlane GroupKind, or returns nil when there are no errors. It is
+// the single point where the validating webhook turns accumulated field errors
+// into the admission response, so ValidateCreate and ValidateUpdate share an
+// identical error shape.
+func newInvalidIfErrs(cp *ControlPlane, allErrs field.ErrorList) error {
+	if len(allErrs) == 0 {
+		return nil
 	}
-	return nil
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: "ControlPlane"},
+		cp.Name,
+		allErrs,
+	)
+}
+
+// validateImmutable accumulates errors for every create-only-immutable field
+// that changed between oldObj and newObj (#476). The validating webhook is the
+// load-bearing mechanism here because the affected leaves live in the shared
+// commonv1.DatabaseSpec/CacheSpec types, which the keystone operator reuses and
+// which therefore must not carry c5c3-specific CEL immutability markers.
+//
+//   - Database/cache MODE (managed clusterRef vs brownfield host/servers):
+//     flipping it leaves the previously-projected MariaDB/Memcached child (and,
+//     in managed mode, its per-ControlPlane credential ExternalSecret) running
+//     and owned until the ControlPlane is deleted.
+//   - A managed clusterRef.NAME change re-points the projection at a new child
+//     and orphans the old one the same way.
+//   - A cloudCredentialsRef.secretName change re-points the K-ORC clouds.yaml
+//     projection and leaks the previously-named ExternalSecret.
+//
+// validate() already enforces the database/cache XOR (exactly one of clusterRef
+// or host/servers), so clusterRef nil-ness is an unambiguous mode discriminator
+// here.
+func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
+	var allErrs field.ErrorList
+
+	dbPath := field.NewPath("spec", "infrastructure", "database")
+	oldDB := oldObj.Spec.Infrastructure.Database
+	newDB := newObj.Spec.Infrastructure.Database
+	switch {
+	case (oldDB.ClusterRef != nil) != (newDB.ClusterRef != nil):
+		allErrs = append(allErrs, field.Invalid(dbPath, newDB,
+			"database mode (managed clusterRef vs brownfield host) is immutable"))
+	case oldDB.ClusterRef != nil && newDB.ClusterRef != nil && oldDB.ClusterRef.Name != newDB.ClusterRef.Name:
+		allErrs = append(allErrs, field.Invalid(dbPath.Child("clusterRef", "name"),
+			newDB.ClusterRef.Name, "managed database clusterRef.name is immutable"))
+	}
+
+	cachePath := field.NewPath("spec", "infrastructure", "cache")
+	oldCache := oldObj.Spec.Infrastructure.Cache
+	newCache := newObj.Spec.Infrastructure.Cache
+	switch {
+	case (oldCache.ClusterRef != nil) != (newCache.ClusterRef != nil):
+		allErrs = append(allErrs, field.Invalid(cachePath, newCache,
+			"cache mode (managed clusterRef vs brownfield servers) is immutable"))
+	case oldCache.ClusterRef != nil && newCache.ClusterRef != nil && oldCache.ClusterRef.Name != newCache.ClusterRef.Name:
+		allErrs = append(allErrs, field.Invalid(cachePath.Child("clusterRef", "name"),
+			newCache.ClusterRef.Name, "managed cache clusterRef.name is immutable"))
+	}
+
+	oldSecretName := oldObj.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
+	newSecretName := newObj.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
+	if oldSecretName != newSecretName {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "korc", "adminCredential", "cloudCredentialsRef", "secretName"),
+			newSecretName, "cloudCredentialsRef.secretName is immutable",
+		))
+	}
+
+	return allErrs
 }
 
 // validateUniqueInNamespace enforces the one-ControlPlane-per-namespace contract

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -294,6 +294,16 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) field.ErrorList {
 		}
 	}
 
+	// When a gateway is configured, its hostname must be set. Mirrors the
+	// +kubebuilder:validation:MinLength=1 marker on commonv1.GatewaySpec.Hostname;
+	// without it the reconciler derives an empty "https:///v3" public endpoint.
+	if g := cp.Spec.Services.Keystone.Gateway; g != nil && g.Hostname == "" {
+		allErrs = append(allErrs, field.Required(
+			specPath.Child("services", "keystone", "gateway", "hostname"),
+			"must be set when a gateway is configured",
+		))
+	}
+
 	return allErrs
 }
 

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -423,6 +423,121 @@ func TestValidateUpdate_AcceptsValidChange(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 }
 
+// managedControlPlane returns a valid managed-mode ControlPlane: database and
+// cache point at managed clusterRefs (not brownfield host/servers). The
+// immutability tests start from this baseline so a clusterRef name or a mode
+// flip is the only delta under test.
+func managedControlPlane() *ControlPlane {
+	cp := validControlPlane()
+	cp.Spec.Infrastructure.Database = commonv1.DatabaseSpec{
+		ClusterRef: &corev1.LocalObjectReference{Name: "openstack-db"},
+		Database:   "openstack",
+		SecretRef:  commonv1.SecretRefSpec{Name: "db-creds"},
+	}
+	cp.Spec.Infrastructure.Cache = commonv1.CacheSpec{
+		ClusterRef: &corev1.LocalObjectReference{Name: "openstack-memcached"},
+		Backend:    "dogpile.cache.pymemcache",
+	}
+	cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName = "k-orc-clouds-yaml"
+	return cp
+}
+
+// TestValidateUpdate_RejectsDatabaseModeFlip verifies that flipping the database
+// between managed (clusterRef) and brownfield (host) mode is rejected on UPDATE,
+// since the previously-projected MariaDB child would otherwise be orphaned (#476).
+func TestValidateUpdate_RejectsDatabaseModeFlip(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// managed -> brownfield.
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database = commonv1.DatabaseSpec{
+		Host: "db.example.com", Database: "openstack", SecretRef: commonv1.SecretRefSpec{Name: "db-creds"},
+	}
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database mode"))
+
+	// brownfield -> managed (the reverse direction).
+	_, err = w.ValidateUpdate(context.Background(), newCP, oldCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database mode"))
+}
+
+// TestValidateUpdate_RejectsDatabaseClusterRefRename verifies that renaming a
+// managed database clusterRef is rejected on UPDATE, since the old MariaDB child
+// would otherwise be orphaned while a new one is provisioned (#476).
+func TestValidateUpdate_RejectsDatabaseClusterRefRename(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.ClusterRef = &corev1.LocalObjectReference{Name: "openstack-db-2"}
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("clusterRef.name"))
+}
+
+// TestValidateUpdate_RejectsCacheModeFlipAndRename verifies the cache mode flip
+// and managed clusterRef rename are both rejected on UPDATE (#476).
+func TestValidateUpdate_RejectsCacheModeFlipAndRename(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// managed -> brownfield (servers) cache mode flip.
+	oldCP := managedControlPlane()
+	flipped := managedControlPlane()
+	flipped.Spec.Infrastructure.Cache = commonv1.CacheSpec{
+		Servers: []string{"mc:11211"}, Backend: "dogpile.cache.pymemcache",
+	}
+	_, err := w.ValidateUpdate(context.Background(), oldCP, flipped)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("cache mode"))
+
+	// managed clusterRef rename.
+	renamed := managedControlPlane()
+	renamed.Spec.Infrastructure.Cache.ClusterRef = &corev1.LocalObjectReference{Name: "openstack-memcached-2"}
+	_, err = w.ValidateUpdate(context.Background(), oldCP, renamed)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("clusterRef.name"))
+}
+
+// TestValidateUpdate_RejectsCloudSecretNameChange verifies that renaming
+// cloudCredentialsRef.secretName is rejected on UPDATE, since the old K-ORC
+// clouds.yaml ExternalSecret would otherwise be leaked (#476).
+func TestValidateUpdate_RejectsCloudSecretNameChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName = "renamed-clouds-yaml"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("secretName"))
+}
+
+// TestValidateUpdate_AllowsMutableFieldChanges verifies that updates which only
+// touch mutable fields (region, replicas, the release) are accepted on an
+// otherwise-unchanged managed ControlPlane, so the immutability guard does not
+// over-restrict legitimate edits (#476).
+func TestValidateUpdate_AllowsMutableFieldChanges(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+
+	newCP := managedControlPlane()
+	newCP.Spec.Region = "EU-West"
+	newCP.Spec.OpenStackRelease = "2026.1"
+	replicas := int32(3)
+	newCP.Spec.Services.Keystone.Replicas = &replicas
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
 func TestValidateDelete_AlwaysAllowed(t *testing.T) {
 	g := NewGomegaWithT(t)
 	w := &ControlPlaneWebhook{}

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -412,6 +412,50 @@ func TestValidateCreate_AcceptsDailyAndWeeklyRotationIntervals(t *testing.T) {
 	}
 }
 
+// TestValidateCreate_RejectsGatewayWithoutHostname verifies that configuring a
+// gateway without a hostname is rejected at admission, so the reconciler never
+// derives an empty "https:///v3" public endpoint (#476).
+func TestValidateCreate_RejectsGatewayWithoutHostname(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane()
+	cp.Spec.Services.Keystone.Gateway = &commonv1.GatewaySpec{
+		ParentRef: commonv1.GatewayParentRefSpec{Name: "openstack-gw"},
+		// Hostname intentionally empty.
+	}
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("hostname"))
+}
+
+// TestValidateCreate_AcceptsGatewayWithHostname verifies a gateway carrying a
+// non-empty hostname passes admission (#476).
+func TestValidateCreate_AcceptsGatewayWithHostname(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane()
+	cp.Spec.Services.Keystone.Gateway = &commonv1.GatewaySpec{
+		ParentRef: commonv1.GatewayParentRefSpec{Name: "openstack-gw"},
+		Hostname:  "keystone.127-0-0-1.nip.io",
+	}
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestValidateCreate_AcceptsNilGateway verifies the gateway hostname check does
+// not fire when no gateway is configured (the field is optional) (#476).
+func TestValidateCreate_AcceptsNilGateway(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane()
+	cp.Spec.Services.Keystone.Gateway = nil
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
 func TestValidateUpdate_AcceptsValidChange(t *testing.T) {
 	g := NewGomegaWithT(t)
 	w := &ControlPlaneWebhook{}

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -365,18 +367,59 @@ func secretToControlPlaneMapper(c client.Reader) handler.MapFunc {
 	}
 }
 
+// clusterSecretStoreToControlPlaneMapper returns a MapFunc that enqueues every
+// ControlPlane in the cluster when the OpenBao-backed ClusterSecretStore
+// changes. The store is cluster-scoped and shared across namespaces, so any
+// status transition (e.g. ESO losing the backend connection) must retrigger
+// reconcile on all ControlPlanes that route credentials through it; otherwise
+// DBCredentialsReady / AdminPasswordReady / AdminCredentialReady would stay
+// stale-True until the next periodic resync. Mirrors the keystone operator's
+// clusterSecretStoreToKeystoneMapper (#476). On a List error the mapper logs and
+// returns nil per the handler.MapFunc contract.
+func clusterSecretStoreToControlPlaneMapper(c client.Reader) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetName() != openBaoClusterStoreName {
+			return nil
+		}
+
+		var cps c5c3v1alpha1.ControlPlaneList
+		if err := c.List(ctx, &cps); err != nil {
+			log.FromContext(ctx).Error(err, "listing ControlPlane CRs for ClusterSecretStore watch")
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(cps.Items))
+		for i := range cps.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&cps.Items[i]),
+			})
+		}
+		return requests
+	}
+}
+
 // SetupWithManager registers the ControlPlaneReconciler with the controller
 // manager. It Owns every child CR the sub-reconcilers project (MariaDB,
-// Keystone, the K-ORC ApplicationCredential/Service/Endpoint, and the Memcached
-// CR) so an upstream child status transition retriggers reconcile, and Watches
-// Secrets so an admin-password rotation wakes the owning ControlPlane via the
-// field indexer.
+// Keystone, the K-ORC ApplicationCredential/Service/Endpoint, the Memcached CR,
+// and the ESO ExternalSecret/PushSecret) so an upstream child status transition
+// retriggers reconcile, Watches Secrets so an admin-password rotation wakes the
+// owning ControlPlane via the field indexer, and Watches the OpenBao-backed
+// ClusterSecretStore so an ESO/OpenBao outage reflects in the credential
+// conditions promptly rather than after the next periodic resync (#476).
 //
 // DECISION (Memcached Owns): memcached.c5c3.io ships no Go module (see
 // memcachedGVK in reconcile_infrastructure.go), so the Memcached child is owned
 // as an *unstructured.Unstructured carrying that shared GVK rather than a typed
 // client object — exactly how ensureMemcached creates it. The same memcachedGVK
 // constant is reused so the watch and the create-or-update agree on the kind.
+//
+// DECISION (ESO Owns): the ExternalSecret and PushSecret children are owned via
+// SetControllerReference by the DB-credential, admin-password and K-ORC
+// sub-reconcilers, so Owns() is the direct wiring (no name-based mapper needed).
+// It wakes the ControlPlane on every ESO status tick, which is acceptable for
+// the goal of reflecting ESO sync/outage transitions in the credential
+// conditions promptly; a relevance predicate could be added later if the
+// reconcile volume becomes a concern.
 func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Register the field indexer before Watches so secretToControlPlaneMapper can
 	// rely on it for its MatchingFields lookup.
@@ -397,8 +440,13 @@ func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&orcv1alpha1.User{}).
 		Owns(&orcv1alpha1.Domain{}).
 		Owns(memcached).
+		Owns(&esov1.ExternalSecret{}).
+		Owns(&esov1alpha1.PushSecret{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
 			secretToControlPlaneMapper(mgr.GetClient()),
+		)).
+		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
+			clusterSecretStoreToControlPlaneMapper(mgr.GetClient()),
 		)).
 		Complete(r)
 }

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -186,6 +186,7 @@ func (r *ControlPlaneReconciler) updateStatus(ctx context.Context, cp *c5c3v1alp
 	// subConditionTypes, not the Ready condition itself, so this is not
 	// self-referential.
 	setReadyCondition(cp)
+	setServicesStatus(cp)
 	cp.Status.ObservedGeneration = cp.Generation
 	if err := r.Status().Update(ctx, cp); err != nil {
 		log.FromContext(ctx).Error(err, "unable to update ControlPlane status")
@@ -270,6 +271,28 @@ func (r *ControlPlaneReconciler) parkDuplicateControlPlane(ctx context.Context, 
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 	return ctrl.Result{RequeueAfter: duplicateControlPlaneRequeueAfter}, nil
+}
+
+// keystoneServiceKey is the key under which status.services reports the
+// projected Keystone service readiness.
+const keystoneServiceKey = "keystone"
+
+// setServicesStatus records status.services and status.updatePhase on every
+// status write (#476). Both fields were declared on ControlPlaneStatus but never
+// written. status.updatePhase is fixed at Idle until the release-update state
+// machine is implemented — the other UpdatePhase values are reserved (see the
+// UpdatePhase DECISION comment), and "no update in progress" is the honest L1
+// state. status.services maps each projected service to its observed readiness,
+// derived from the corresponding sub-condition, with the release the service is
+// being driven to.
+func setServicesStatus(cp *c5c3v1alpha1.ControlPlane) {
+	cp.Status.UpdatePhase = c5c3v1alpha1.UpdatePhaseIdle
+	cp.Status.Services = map[string]c5c3v1alpha1.ServiceStatus{
+		keystoneServiceKey: {
+			Ready:   conditions.AllTrue(cp.Status.Conditions, conditionTypeKeystoneReady),
+			Release: cp.Spec.OpenStackRelease,
+		},
+	}
 }
 
 // controlPlaneSecretNameExtractor is the controller-runtime IndexerFunc registered

--- a/operators/c5c3/internal/controller/controlplane_controller_test.go
+++ b/operators/c5c3/internal/controller/controlplane_controller_test.go
@@ -88,6 +88,33 @@ func TestAggregateReady_OneFalse(t *testing.T) {
 		"aggregate Ready must be false when any sub-condition is False")
 }
 
+// TestSetServicesStatus_WritesPhaseAndKeystoneReadiness verifies that
+// setServicesStatus populates the previously-unwritten status.updatePhase (fixed
+// at Idle) and status.services["keystone"], deriving the service readiness from
+// the KeystoneReady sub-condition and the release from spec (#476).
+func TestSetServicesStatus_WritesPhaseAndKeystoneReadiness(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := &c5c3v1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp", Namespace: "openstack"},
+		Spec:       c5c3v1alpha1.ControlPlaneSpec{OpenStackRelease: "2025.2"},
+	}
+
+	// KeystoneReady absent => service reported not Ready.
+	setServicesStatus(cp)
+	g.Expect(cp.Status.UpdatePhase).To(Equal(c5c3v1alpha1.UpdatePhaseIdle))
+	svc, ok := cp.Status.Services["keystone"]
+	g.Expect(ok).To(BeTrue(), "status.services must report the projected keystone service")
+	g.Expect(svc.Ready).To(BeFalse(), "keystone service must be not Ready while KeystoneReady is absent")
+	g.Expect(svc.Release).To(Equal("2025.2"))
+
+	// KeystoneReady True => service reported Ready.
+	conditions.SetCondition(&cp.Status.Conditions, trueCondition(conditionTypeKeystoneReady))
+	setServicesStatus(cp)
+	g.Expect(cp.Status.Services["keystone"].Ready).To(BeTrue(),
+		"keystone service must be Ready once KeystoneReady is True")
+}
+
 func TestReconcile_NotFound_EarlyReturn(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -191,6 +191,36 @@ func integrationMinimalControlPlane(name, namespace string) *c5c3v1alpha1.Contro
 	}
 }
 
+// ensureReadyClusterSecretStore creates the cluster-scoped OpenBao-backed
+// ClusterSecretStore the DB-credential, admin-password and admin-credential
+// sub-reconcilers gate on (#476) and marks it Ready. It is idempotent across the
+// shared envtest cluster: the store is cluster-scoped, so a second test reuses
+// the existing object and only refreshes its Ready status. Call it before
+// creating a ControlPlane so the first reconcile sees the store Ready and the
+// credential gates open; without it the chain stalls at DBCredentialsReady=False
+// with reason SecretStoreNotReady. Mirrors the keystone operator's helper.
+func ensureReadyClusterSecretStore(t testing.TB, ctx context.Context, c client.Client) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: openBaoClusterStoreName},
+	}
+	err := c.Get(ctx, client.ObjectKeyFromObject(store), store)
+	if apierrors.IsNotFound(err) {
+		g.Expect(c.Create(ctx, store)).To(Succeed(), "create ClusterSecretStore")
+	} else {
+		g.Expect(err).NotTo(HaveOccurred(), "get ClusterSecretStore")
+	}
+
+	store.Status = esov1.SecretStoreStatus{
+		Conditions: []esov1.SecretStoreStatusCondition{
+			{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+		},
+	}
+	g.Expect(c.Status().Update(ctx, store)).To(Succeed(), "update ClusterSecretStore status")
+}
+
 // waitForControlPlaneCondition polls the ControlPlane CR until the named
 // condition reaches the expected status, or the timeout is reached. Returns the
 // observed condition.
@@ -349,6 +379,10 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	// The OpenBao-backed ClusterSecretStore must be Ready before the chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
 
 	// Isolated test namespace per run (namespace-per-test with GenerateName).
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-controlplane-"}}
@@ -584,6 +618,10 @@ func TestIntegration_MinimalManagedToReady(t *testing.T) {
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
 
+	// The OpenBao-backed ClusterSecretStore must be Ready before the chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
+
 	// Isolated test namespace per run (namespace-per-test with GenerateName).
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-minimal-cp-"}}
 	g.Expect(c.Create(ctx, ns)).To(Succeed(), "create test namespace")
@@ -678,6 +716,10 @@ func TestIntegration_DBCredentialsGate_BlocksKeystoneUntilSecretExists(t *testin
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
 
+	// The OpenBao-backed ClusterSecretStore must be Ready before the chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
+
 	// Isolated test namespace per run (namespace-per-test with GenerateName).
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-dbgate-"}}
 	g.Expect(c.Create(ctx, ns)).To(Succeed(), "create test namespace")
@@ -763,6 +805,10 @@ func TestIntegration_AdminPasswordGate_BlocksKeystoneUntilExternalSecretReady(t 
 	g := NewGomegaWithT(t)
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	// The OpenBao-backed ClusterSecretStore must be Ready before the chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
 
 	// Isolated test namespace per run (namespace-per-test with GenerateName).
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-adminpwgate-"}}
@@ -961,6 +1007,10 @@ func TestIntegration_MultiControlPlane_DistinctAdminCredentialPaths(t *testing.T
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
 
+	// The OpenBao-backed ClusterSecretStore must be Ready before either chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
+
 	// Two isolated namespaces (namespace-per-CR with GenerateName).
 	nsA := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcp-a-"}}
 	nsB := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcp-b-"}}
@@ -1036,6 +1086,10 @@ func TestIntegration_MultiControlPlane_DistinctDBCredentialPaths(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	// The OpenBao-backed ClusterSecretStore must be Ready before either chain
+	// reaches the credential gates (#476).
+	ensureReadyClusterSecretStore(t, ctx, c)
 
 	// Two isolated namespaces (namespace-per-CR with GenerateName).
 	nsA := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcpdb-a-"}}

--- a/operators/c5c3/internal/controller/reconcile_adminpassword.go
+++ b/operators/c5c3/internal/controller/reconcile_adminpassword.go
@@ -125,6 +125,27 @@ func (r *ControlPlaneReconciler) reconcileAdminPassword(ctx context.Context, cp 
 		return ctrl.Result{}, nil
 	}
 
+	// Check the OpenBao-backed ClusterSecretStore first so an ESO/OpenBao outage
+	// surfaces as AdminPasswordReady=False even while the per-ExternalSecret cache
+	// still reports Ready=True from its last successful sync (#476). Mirrors
+	// reconcileDBCredentials and the keystone operator's reconcile_secrets.go.
+	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !storeReady {
+		logger.Info("ClusterSecretStore not ready, requeuing admin password projection")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminPasswordReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "SecretStoreNotReady",
+			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
+				openBaoClusterStoreName),
+		})
+		return ctrl.Result{RequeueAfter: adminPasswordRequeueAfter}, nil
+	}
+
 	// Managed mode: create-or-update the per-CP admin-password ExternalSecret,
 	// owner-referencing it to the ControlPlane so it is garbage-collected with the CR.
 	desired := adminPasswordExternalSecret(cp)

--- a/operators/c5c3/internal/controller/reconcile_adminpassword_test.go
+++ b/operators/c5c3/internal/controller/reconcile_adminpassword_test.go
@@ -98,7 +98,7 @@ func TestReconcileAdminPassword_Managed_CreatesExternalSecret(t *testing.T) {
 
 	s := korcTestScheme(t)
 	cp := adminPwManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore()).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	// No Ready status on the freshly-created ES, so the call requeues with
@@ -136,7 +136,7 @@ func TestReconcileAdminPassword_NotReady_SetsConditionFalseAndRequeues(t *testin
 
 	s := korcTestScheme(t)
 	cp := adminPwManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore()).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	result, err := r.reconcileAdminPassword(context.Background(), cp)
@@ -158,7 +158,7 @@ func TestReconcileAdminPassword_Ready_SetsConditionTrue(t *testing.T) {
 
 	s := korcTestScheme(t)
 	cp := adminPwManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyAdminPwES(cp)).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore(), readyAdminPwES(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	result, err := r.reconcileAdminPassword(context.Background(), cp)
@@ -198,6 +198,35 @@ func TestReconcileAdminPassword_Brownfield_NoExternalSecret_ReadyTrue(t *testing
 
 	g.Expect(cp.Spec.KORC.AdminCredential.PasswordSecretRef).To(Equal(userRef),
 		"brownfield must not mutate the user-declared admin PasswordSecretRef")
+}
+
+// TestReconcileAdminPassword_StoreNotReady_SetsConditionFalse (#476): when the
+// OpenBao-backed ClusterSecretStore is not Ready (here: absent), the managed-mode
+// sub-reconciler flips AdminPasswordReady=False with reason SecretStoreNotReady
+// and requeues, instead of leaving a stale Ready=True between resyncs. No
+// ExternalSecret is projected while the store is unreachable.
+func TestReconcileAdminPassword_StoreNotReady_SetsConditionFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := adminPwManagedControlPlane()
+	// No ClusterSecretStore seeded => IsClusterSecretStoreReady reports not ready.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	result, err := r.reconcileAdminPassword(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(adminPasswordRequeueAfter),
+		"must requeue while the store is not ready")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminPasswordReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
+
+	_, getErr := getAdminPwES(t, r, cp)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"no admin-password ExternalSecret may be created while the store is not ready")
 }
 
 // TestAdminPasswordRemoteKeyFor_And_SecretName_DistinctPerControlPlane the OpenBao remote key is scoped by both Namespace and keystoneName,

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials.go
@@ -96,6 +96,30 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 		return ctrl.Result{}, nil
 	}
 
+	// Check the OpenBao-backed ClusterSecretStore first so an ESO/OpenBao outage
+	// surfaces as DBCredentialsReady=False even while the per-ExternalSecret cache
+	// still reports Ready=True from its last successful sync. ESO only re-syncs
+	// ExternalSecrets at their refreshInterval (default 1h), so relying on the
+	// ExternalSecret Ready alone would miss short-lived outages; the
+	// ClusterSecretStore watch wakes the ControlPlane the moment ESO flips the
+	// store condition (#476). Mirrors reconcile_secrets.go in the keystone operator.
+	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !storeReady {
+		logger.Info("ClusterSecretStore not ready, requeuing DB credential projection")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeDBCredentialsReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "SecretStoreNotReady",
+			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
+				openBaoClusterStoreName),
+		})
+		return ctrl.Result{RequeueAfter: dbCredentialsRequeueAfter}, nil
+	}
+
 	// Managed mode: create-or-update the per-CP DB-credential ExternalSecret,
 	// owner-referencing it to the ControlPlane so it is garbage-collected with the CR.
 	desired := dbCredentialExternalSecret(cp)

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
@@ -72,6 +72,21 @@ func getDBCredES(t *testing.T, r *ControlPlaneReconciler, cp *c5c3v1alpha1.Contr
 	return es, err
 }
 
+// readyClusterSecretStore returns the OpenBao-backed ClusterSecretStore with a
+// Ready status condition so IsClusterSecretStoreReady reports the store ready
+// without an ESO controller in the fake client. Seed it whenever a managed-mode
+// sub-reconciler must pass its ClusterSecretStore gate (#476).
+func readyClusterSecretStore() *esov1.ClusterSecretStore {
+	return &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: openBaoClusterStoreName},
+		Status: esov1.SecretStoreStatus{
+			Conditions: []esov1.SecretStoreStatusCondition{
+				{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
 // readyDBCredES builds a Ready DB-credential ExternalSecret at the derived
 // name/namespace, mirroring readyCloudsYamlES so WaitForExternalSecret reports
 // Ready without an ESO controller in the fake client.
@@ -94,7 +109,7 @@ func TestReconcileDBCredentials_Managed_CreatesExternalSecret(t *testing.T) {
 
 	s := korcTestScheme(t)
 	cp := dbCredManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore()).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	// No Ready status on the freshly-created ES, so the call requeues with
@@ -135,7 +150,7 @@ func TestReconcileDBCredentials_NotReady_SetsConditionFalseAndRequeues(t *testin
 
 	s := korcTestScheme(t)
 	cp := dbCredManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore()).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	result, err := r.reconcileDBCredentials(context.Background(), cp)
@@ -156,7 +171,7 @@ func TestReconcileDBCredentials_Ready_SetsConditionTrue(t *testing.T) {
 
 	s := korcTestScheme(t)
 	cp := dbCredManagedControlPlane()
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyDBCredES(cp)).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore(), readyDBCredES(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	result, err := r.reconcileDBCredentials(context.Background(), cp)
@@ -191,6 +206,35 @@ func TestReconcileDBCredentials_Brownfield_NoExternalSecret_ReadyTrue(t *testing
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeDBCredentialsReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+}
+
+// TestReconcileDBCredentials_StoreNotReady_SetsConditionFalse (#476): when the
+// OpenBao-backed ClusterSecretStore is not Ready (here: absent), the managed-mode
+// sub-reconciler flips DBCredentialsReady=False with reason SecretStoreNotReady
+// and requeues, instead of leaving a stale Ready=True between resyncs. No
+// ExternalSecret is projected while the store is unreachable.
+func TestReconcileDBCredentials_StoreNotReady_SetsConditionFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := dbCredManagedControlPlane()
+	// No ClusterSecretStore seeded => IsClusterSecretStoreReady reports not ready.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	result, err := r.reconcileDBCredentials(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(BeNumerically(">", 0), "must requeue while the store is not ready")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeDBCredentialsReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
+
+	// No ExternalSecret may be projected while the store is unreachable.
+	_, getErr := getDBCredES(t, r, cp)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"no DB-credential ExternalSecret may be created while the store is not ready")
 }
 
 // TestDBCredentialRemoteKeyFor_And_SecretName_DistinctPerControlPlane

--- a/operators/c5c3/internal/controller/reconcile_keystone.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone.go
@@ -109,8 +109,13 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 		keystone.Spec.Image = image
 
 		// Point Keystone at the SAME backing services the ControlPlane
-		// provisioned by reusing the infrastructure specs verbatim.
-		keystone.Spec.Database = cp.Spec.Infrastructure.Database
+		// provisioned by reusing the infrastructure specs. DeepCopy (over a plain
+		// struct copy) is required because DatabaseSpec carries pointer fields
+		// (ClusterRef, TLS): a shallow copy would share those pointers with
+		// cp.Spec, so the SecretRef override below — or any later mutation of
+		// either spec — could alias the ControlPlane's own spec, exactly as the
+		// Gateway projection already guards against with DeepCopy (#476).
+		keystone.Spec.Database = *cp.Spec.Infrastructure.Database.DeepCopy()
 
 		// in managed mode the operator OWNS the service DB
 		// credential — reconcileDBCredentials materialises it into a per-ControlPlane
@@ -124,7 +129,10 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 			keystone.Spec.Database.SecretRef = commonv1.SecretRefSpec{Name: dbCredentialSecretName(cp), Key: "password"}
 		}
 
-		keystone.Spec.Cache = cp.Spec.Infrastructure.Cache
+		// DeepCopy for the same reason as Database above: CacheSpec carries a
+		// pointer ClusterRef and a Servers slice, so a shallow copy would alias
+		// cp.Spec (#476).
+		keystone.Spec.Cache = *cp.Spec.Infrastructure.Cache.DeepCopy()
 
 		// in managed mode the operator OWNS the admin password —
 		// reconcileAdminPassword projects it from OpenBao into a per-ControlPlane

--- a/operators/c5c3/internal/controller/reconcile_keystone.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone.go
@@ -98,7 +98,13 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 				Reason:             "InvalidRotationInterval",
 				Message:            fmt.Sprintf("invalid keystone rotation interval: %v", err),
 			})
-			return ctrl.Result{}, nil
+			// Return the error so the reconcile chain stops here (the guard in
+			// Reconcile keys off err != nil) and the manager requeues with
+			// backoff, rather than returning a zero Result that lets the chain
+			// continue past this failed sub-reconciler (#476). The webhook now
+			// rejects unrepresentable intervals at admission, so this path is
+			// defense-in-depth for callers that bypass it.
+			return ctrl.Result{}, fmt.Errorf("invalid keystone rotation interval: %w", err)
 		}
 		rotationSchedule = cron
 	}

--- a/operators/c5c3/internal/controller/reconcile_keystone_test.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone_test.go
@@ -230,7 +230,12 @@ func TestReconcileKeystone_InvalidRotationIntervalSetsFalse(t *testing.T) {
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileKeystone(context.Background(), cp)
-	g.Expect(err).NotTo(HaveOccurred(), "an invalid interval must not crash the reconciler")
+	// The sub-reconciler now RETURNS the error so the Reconcile chain stops here
+	// (the chain guard keys off err != nil) and the manager requeues with
+	// backoff, rather than returning a zero Result that lets the chain continue
+	// past this failed sub-reconciler (#476).
+	g.Expect(err).To(HaveOccurred(), "an invalid rotation interval must surface as an error")
+	g.Expect(err.Error()).To(ContainSubstring("rotation interval"))
 
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKeystoneReady)
 	g.Expect(cond).NotTo(BeNil())
@@ -239,10 +244,10 @@ func TestReconcileKeystone_InvalidRotationIntervalSetsFalse(t *testing.T) {
 
 	// No Keystone CR must be created when the interval is invalid.
 	k := &keystonev1alpha1.Keystone{}
-	err = c.Get(context.Background(), types.NamespacedName{
+	getErr := c.Get(context.Background(), types.NamespacedName{
 		Name: keystoneName(cp), Namespace: childNamespace(cp),
 	}, k)
-	g.Expect(err).To(HaveOccurred(), "no Keystone CR should be created for an invalid rotation interval")
+	g.Expect(getErr).To(HaveOccurred(), "no Keystone CR should be created for an invalid rotation interval")
 }
 
 func TestReconcileKeystone_ReplicasPassthrough(t *testing.T) {

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -14,14 +14,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
-
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -336,10 +333,13 @@ func adminAppCredentialPushSecretName(cp *c5c3v1alpha1.ControlPlane) string {
 // resource K-ORC reacts to; reconcileAdminCredential only commits/pushes the
 // already-(re-)minted secret.
 //
-// MISSING-CRD SAFETY: if the K-ORC CRD is not installed the apiserver / RESTMapper
-// returns a no-match error; this is detected via meta.IsNoMatchError and surfaced
-// as KORCReady=False (Reason "KORCCRDNotInstalled") WITHOUT returning a hard error
-// that would crash-loop the operator.
+// HARD CRD DEPENDENCY: K-ORC (and Memcached, ESO, MariaDB, Keystone) are hard
+// dependencies of the ControlPlane operator. SetupWithManager Owns/Watches their
+// kinds, so the manager fails fast at startup if any CRD is absent — a missing
+// K-ORC CRD never reaches this reconcile path. No-match errors are therefore
+// handled by the generic error returns below (manager backoff requeue) rather
+// than a dedicated KORCReady=False branch that could only fire if a CRD were
+// deleted after the manager had started (#476).
 func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -418,17 +418,6 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// before minting — otherwise the AC blocks forever on "Waiting for User/admin
 	// to be created".
 	if err := r.ensureKORCAdminImports(ctx, cp, importCredRef); err != nil {
-		if meta.IsNoMatchError(err) {
-			logger.Info("K-ORC User/Domain CRD not installed; KORCReady=False")
-			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-				Type:               conditionTypeKORCReady,
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: cp.Generation,
-				Reason:             "KORCCRDNotInstalled",
-				Message:            "K-ORC User/Domain CRD is not installed",
-			})
-			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
-		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeKORCReady,
 			Status:             metav1.ConditionFalse,
@@ -521,16 +510,6 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		// converges the spec without re-minting (no-op when nothing changed).
 	case apierrors.IsNotFound(getErr):
 		// First mint, or the recreate after a re-mint delete: CreateOrUpdate below.
-	case meta.IsNoMatchError(getErr):
-		logger.Info("K-ORC ApplicationCredential CRD not installed; KORCReady=False")
-		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKORCReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: cp.Generation,
-			Reason:             "KORCCRDNotInstalled",
-			Message:            "K-ORC ApplicationCredential CRD is not installed",
-		})
-		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	default:
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeKORCReady,
@@ -575,19 +554,6 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		return controllerutil.SetControllerReference(cp, ac, r.Scheme)
 	})
 	if err != nil {
-		// MISSING-CRD SAFETY: a no-match error means the K-ORC CRD is absent.
-		// Surface a clean condition instead of crash-looping.
-		if meta.IsNoMatchError(err) {
-			logger.Info("K-ORC ApplicationCredential CRD not installed; KORCReady=False")
-			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-				Type:               conditionTypeKORCReady,
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: cp.Generation,
-				Reason:             "KORCCRDNotInstalled",
-				Message:            "K-ORC ApplicationCredential CRD is not installed",
-			})
-			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
-		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeKORCReady,
 			Status:             metav1.ConditionFalse,
@@ -675,17 +641,6 @@ func (r *ControlPlaneReconciler) remintAdminApplicationCredential(
 	// recreated AC mints a fresh credential (a NotFound on delete is benign — the
 	// AC is already gone, the recreate happens next pass).
 	if err := r.Delete(ctx, ac); err != nil && !apierrors.IsNotFound(err) {
-		if meta.IsNoMatchError(err) {
-			logger.Info("K-ORC ApplicationCredential CRD not installed; KORCReady=False")
-			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-				Type:               conditionTypeKORCReady,
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: cp.Generation,
-				Reason:             "KORCCRDNotInstalled",
-				Message:            "K-ORC ApplicationCredential CRD is not installed",
-			})
-			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
-		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeKORCReady,
 			Status:             metav1.ConditionFalse,
@@ -1267,7 +1222,9 @@ func (r *ControlPlaneReconciler) ensureKORCCloudsYAMLExternalSecret(ctx context.
 // It is GATED on AdminCredentialReady: the admin credential must be available
 // before K-ORC can register catalog entries. Both child CRs are create-or-updated
 // idempotently; CatalogReady (and cp.Status.CatalogReady) flip True once both are
-// registered. MISSING-CRD SAFETY mirrors reconcileKORC.
+// registered. K-ORC is a hard CRD dependency (see reconcileKORC), so a missing
+// Service/Endpoint CRD never reaches here — no-match errors fall through to the
+// generic error returns below (#476).
 func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -1314,9 +1271,6 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		service.Spec.Resource.Enabled = ptr.To(true)
 		return controllerutil.SetControllerReference(cp, service, r.Scheme)
 	}); err != nil {
-		if meta.IsNoMatchError(err) {
-			return r.catalogCRDMissing(cp, logger)
-		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCatalogReady,
 			Status:             metav1.ConditionFalse,
@@ -1353,9 +1307,6 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		endpoint.Spec.Resource.Enabled = ptr.To(true)
 		return controllerutil.SetControllerReference(cp, endpoint, r.Scheme)
 	}); err != nil {
-		if meta.IsNoMatchError(err) {
-			return r.catalogCRDMissing(cp, logger)
-		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCatalogReady,
 			Status:             metav1.ConditionFalse,
@@ -1375,20 +1326,6 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		Message:            "Keystone identity Service and Endpoint are registered",
 	})
 	return ctrl.Result{}, nil
-}
-
-// catalogCRDMissing surfaces the MISSING-CRD safety condition for the catalog
-// sub-reconciler (mirrors reconcileKORC's KORCCRDNotInstalled handling).
-func (r *ControlPlaneReconciler) catalogCRDMissing(cp *c5c3v1alpha1.ControlPlane, logger logr.Logger) (ctrl.Result, error) {
-	logger.Info("K-ORC Service/Endpoint CRD not installed; CatalogReady=False")
-	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeCatalogReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: cp.Generation,
-		Reason:             "KORCCRDNotInstalled",
-		Message:            "K-ORC Service/Endpoint CRD is not installed",
-	})
-	return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 }
 
 // keystoneServiceName / keystoneEndpointName return the deterministic names of

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -1262,6 +1262,14 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 	}
 
 	secretName := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
+	// Fall back to the conventional name when SecretName is empty, matching
+	// reconcileAdminCredential and ensureKORCCloudsYAMLExternalSecret so a
+	// webhook-bypass CR resolves to the same clouds.yaml Secret name everywhere
+	// (#476). Without this the catalog Service/Endpoint would reference an empty
+	// CloudCredentialsRef.SecretName.
+	if secretName == "" {
+		secretName = korcCloudsYamlSecretName
+	}
 	cloudName := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.CloudName
 	credRef := orcv1alpha1.CloudCredentialsReference{SecretName: secretName, CloudName: cloudName}
 

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -962,6 +962,29 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
+	// Gate on the OpenBao-backed ClusterSecretStore so an ESO/OpenBao outage
+	// surfaces as AdminCredentialReady=False promptly. The clouds.yaml
+	// ExternalSecret read below would eventually requeue on its own, but ESO only
+	// re-syncs at the refreshInterval (default 1h); the ClusterSecretStore watch
+	// wakes the ControlPlane the moment ESO flips the store condition, so the
+	// credential condition does not stay stale-True through a short outage (#476).
+	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !storeReady {
+		logger.Info("ClusterSecretStore not ready, deferring admin credential push")
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminCredentialReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "SecretStoreNotReady",
+			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
+				openBaoClusterStoreName),
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
 	// Gate on the K-ORC clouds.yaml ExternalSecret being Ready. It MUST materialise
 	// in the SAME namespace as the K-ORC resource CRs (childNamespace) because
 	// K-ORC resolves CloudCredentialsRef in the resource's own namespace (C1). The

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -1021,6 +1021,40 @@ func TestReconcileCatalog_RegistersServiceAndEndpoint(t *testing.T) {
 	g.Expect(cp.Status.CatalogReady).To(BeTrue())
 }
 
+// TestReconcileCatalog_EmptySecretNameFallsBack verifies that when a
+// webhook-bypass CR carries an empty CloudCredentialsRef.SecretName,
+// reconcileCatalog resolves the catalog Service/Endpoint CloudCredentialsRef to
+// the conventional korcCloudsYamlSecretName instead of referencing an empty
+// Secret name — matching the fallback used in reconcileAdminCredential and
+// ensureKORCCloudsYAMLExternalSecret (#476).
+func TestReconcileCatalog_EmptySecretNameFallsBack(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName = ""
+	setAdminCredentialReady(cp)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileCatalog(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	svc := &orcv1alpha1.Service{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: keystoneServiceName(cp), Namespace: childNamespace(cp),
+	}, svc)).To(Succeed())
+	g.Expect(svc.Spec.CloudCredentialsRef.SecretName).To(Equal(korcCloudsYamlSecretName),
+		"empty CloudCredentialsRef.SecretName must fall back to the conventional name")
+
+	ep := &orcv1alpha1.Endpoint{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: keystoneEndpointName(cp), Namespace: childNamespace(cp),
+	}, ep)).To(Succeed())
+	g.Expect(ep.Spec.CloudCredentialsRef.SecretName).To(Equal(korcCloudsYamlSecretName),
+		"empty CloudCredentialsRef.SecretName must fall back to the conventional name")
+}
+
 func TestReconcileCatalog_Idempotent(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -303,8 +303,14 @@ func TestReconcileKORC_KORCReadyFalseWhileACNotAvailable(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"))
 }
 
-// MISSING-CRD: a no-match error on the AC CR must surface KORCReady=False with no panic / no hard error.
-func TestReconcileKORC_MissingCRDNoPanic(t *testing.T) {
+// HARD CRD DEPENDENCY: K-ORC is a hard dependency (SetupWithManager Owns its
+// kinds, so the manager fails fast at startup if the CRD is absent). The
+// dedicated KORCCRDNotInstalled branch was therefore removed (#476): a no-match
+// error reaching reconcileKORC (only possible if the CRD is deleted after start)
+// now propagates as a hard error so the manager requeues with backoff, with
+// KORCReady=False/ApplicationCredentialError on the CR. This test asserts the
+// no-match error is handled without a panic via that generic path.
+func TestReconcileKORC_MissingCRDReturnsError(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	s := korcTestScheme(t)
@@ -320,16 +326,16 @@ func TestReconcileKORC_MissingCRDNoPanic(t *testing.T) {
 		}).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
+	var err error
 	g.Expect(func() {
-		res, err := r.reconcileKORC(context.Background(), cp)
-		g.Expect(err).NotTo(HaveOccurred(), "missing CRD must NOT return a hard error")
-		g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+		_, err = r.reconcileKORC(context.Background(), cp)
 	}).NotTo(Panic())
+	g.Expect(err).To(HaveOccurred(), "a no-match error must propagate so the manager requeues with backoff")
 
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(cond.Reason).To(Equal("KORCCRDNotInstalled"))
+	g.Expect(cond.Reason).To(Equal("ApplicationCredentialError"))
 }
 
 func TestReconcileKORC_WaitsForAdminPassword(t *testing.T) {
@@ -1118,7 +1124,11 @@ func TestReconcileCatalog_Idempotent(t *testing.T) {
 	g.Expect(ep2.ResourceVersion).To(Equal(ep1.ResourceVersion), "Endpoint must not churn on re-reconcile")
 }
 
-func TestReconcileCatalog_MissingCRDNoPanic(t *testing.T) {
+// HARD CRD DEPENDENCY: as for reconcileKORC, the catalog sub-reconciler's
+// dedicated KORCCRDNotInstalled branch was removed (#476). A no-match error on
+// the Service CRD (only possible post-startup) now propagates as a hard error
+// with CatalogReady=False/ServiceError.
+func TestReconcileCatalog_MissingCRDReturnsError(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	s := korcTestScheme(t)
@@ -1135,16 +1145,16 @@ func TestReconcileCatalog_MissingCRDNoPanic(t *testing.T) {
 		}).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
+	var err error
 	g.Expect(func() {
-		res, err := r.reconcileCatalog(context.Background(), cp)
-		g.Expect(err).NotTo(HaveOccurred(), "missing CRD must NOT return a hard error")
-		g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+		_, err = r.reconcileCatalog(context.Background(), cp)
 	}).NotTo(Panic())
+	g.Expect(err).To(HaveOccurred(), "a no-match error must propagate so the manager requeues with backoff")
 
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeCatalogReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(cond.Reason).To(Equal("KORCCRDNotInstalled"))
+	g.Expect(cond.Reason).To(Equal("ServiceError"))
 }
 
 // --- helpers ---

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -394,6 +394,31 @@ func TestReconcileAdminCredential_GatedOnKORC(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal("WaitingForKORC"))
 }
 
+// TestReconcileAdminCredential_StoreNotReady_SetsConditionFalse (#476): once
+// KORCReady is True, reconcileAdminCredential gates on the OpenBao-backed
+// ClusterSecretStore. When the store is not Ready (here: absent) it flips
+// AdminCredentialReady=False with reason SecretStoreNotReady and requeues,
+// instead of leaving a stale Ready=True between resyncs.
+func TestReconcileAdminCredential_StoreNotReady_SetsConditionFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	// No ClusterSecretStore seeded => IsClusterSecretStoreReady reports not ready.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter), "must requeue while the store is not ready")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("SecretStoreNotReady"))
+}
+
 // TestReconcileKORC_FreshClusterSeedsCloudsYamlAndCreatesPushSecretAndExternalSecret
 // is the reworked fresh-cluster bootstrap test. It
 // REPLACES TestReconcileAdminCredential_FreshClusterWithoutCloudsYamlSeedDoesNotPush,
@@ -503,7 +528,7 @@ func TestReconcileAdminCredential_MissingAppCredSecretDefers(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	// clouds.yaml ExternalSecret is Ready, but the app-credential Secret is absent.
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyCloudsYamlES(cp)).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	res, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -541,7 +566,7 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -632,7 +657,7 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -1323,7 +1348,7 @@ func TestReconcileAdminCredential_WaitsForPushSecretSync(t *testing.T) {
 	// No pre-existing Ready PushSecret — EnsurePushSecret creates it, but it has not
 	// synced to the backend yet.
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)

--- a/operators/c5c3/internal/controller/setupwithmanager_test.go
+++ b/operators/c5c3/internal/controller/setupwithmanager_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,4 +157,52 @@ func TestSecretToControlPlaneMapper_ScopedToNamespace(t *testing.T) {
 	g.Expect(reqs).To(HaveLen(1),
 		"only the ControlPlane in the Secret's namespace must be enqueued")
 	g.Expect(reqs[0].NamespacedName).To(Equal(types.NamespacedName{Namespace: "ns-a", Name: "cp-a"}))
+}
+
+// --- clusterSecretStoreToControlPlaneMapper (#476) ---
+
+// TestClusterSecretStoreToControlPlaneMapper_EnqueuesAllControlPlanes verifies
+// that a status change on the OpenBao-backed ClusterSecretStore enqueues every
+// ControlPlane in the cluster (across namespaces), since the cluster-scoped store
+// is shared and an ESO/OpenBao outage affects all of them.
+func TestClusterSecretStoreToControlPlaneMapper_EnqueuesAllControlPlanes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cpA := mapperControlPlane("cp-a", "ns-a", "secret-a")
+	cpB := mapperControlPlane("cp-b", "ns-b", "secret-b")
+	c := newControlPlaneMapperClient(t, cpA, cpB)
+	mapper := clusterSecretStoreToControlPlaneMapper(c)
+
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: openBaoClusterStoreName},
+	}
+	reqs := mapper(context.Background(), store)
+
+	names := make([]types.NamespacedName, 0, len(reqs))
+	for _, r := range reqs {
+		names = append(names, r.NamespacedName)
+	}
+	g.Expect(names).To(ConsistOf(
+		types.NamespacedName{Namespace: "ns-a", Name: "cp-a"},
+		types.NamespacedName{Namespace: "ns-b", Name: "cp-b"},
+	), "a ClusterSecretStore change must enqueue every ControlPlane in the cluster")
+}
+
+// TestClusterSecretStoreToControlPlaneMapper_IgnoresOtherStores verifies the
+// mapper only reacts to the OpenBao-backed store the operator routes credentials
+// through, not to unrelated ClusterSecretStores.
+func TestClusterSecretStoreToControlPlaneMapper_IgnoresOtherStores(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := mapperControlPlane("cp", "default", "secret")
+	c := newControlPlaneMapperClient(t, cp)
+	mapper := clusterSecretStoreToControlPlaneMapper(c)
+
+	other := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-other-store"},
+	}
+	reqs := mapper(context.Background(), other)
+
+	g.Expect(reqs).To(BeEmpty(),
+		"a change to an unrelated ClusterSecretStore must enqueue nothing")
 }


### PR DESCRIPTION
Closes #476

Pre-production hardening pass over the c5c3 (ControlPlane) operator, addressing the four defect classes from the 2026-06 audit. Each problem is its own small, reviewable commit; the destructive Problem-2 deletion is isolated so it can be dropped if the team prefers the RESTMapper-probe alternative.

## Problem 1 — mode-flip / rename orphans

Flipping the database/cache mode (managed `clusterRef` ↔ brownfield `host`/`servers`), renaming a managed `clusterRef.Name`, or renaming `cloudCredentialsRef.secretName` left the previously-projected MariaDB/Memcached child (and its credentials) or the K-ORC clouds.yaml ExternalSecret orphaned and owned until CP deletion.

- **`fix(c5c3): make infra mode, clusterRef and cloud secretName immutable`** — `ValidateUpdate` now rejects changes to those create-only fields. The webhook (not CEL) is load-bearing because the affected leaves live in the shared `commonv1.DatabaseSpec`/`CacheSpec` reused by the keystone operator. `validate()` was refactored to return a `field.ErrorList` so spec + immutability errors fold into one `Invalid` response.

## Problem 2 — unreachable missing-CRD handling

`SetupWithManager` `Owns`/`Watches` every K-ORC, Memcached and ESO kind, so the manager fails fast at startup if any CRD is absent — the in-reconcile `KORCCRDNotInstalled`/`catalogCRDMissing` branches could only fire if a CRD were deleted *after* start.

- **`refactor(c5c3): drop unreachable missing-CRD reconcile branches`** — treat K-ORC (like Memcached/ESO/MariaDB) as a hard dependency and remove the dead branches; no-match errors fall through to the generic error returns. Drops the `catalogCRDMissing` helper and the orphaned `meta`/`logr` imports. **Isolated commit** — drop it to substitute the RESTMapper-probe approach instead.

## Problem 3 — missing ESO watches

`AdminCredentialReady`/`DBCredentialsReady`/`AdminPasswordReady` could stay stale-True between resyncs during an OpenBao/ESO outage.

- **`feat(c5c3): watch ESO objects and gate on ClusterSecretStore`** — `Owns(ExternalSecret)`/`Owns(PushSecret)` + a `ClusterSecretStore` watch (cluster-wide mapper), plus an `IsClusterSecretStoreReady` gate in the three credential sub-reconcilers, mirroring the keystone operator's `reconcile_secrets.go`. RBAC was already granted.

## Problem 4 — misc

- **`fix(c5c3): validate gateway.hostname on the ControlPlane webhook`** — reject a gateway without a hostname (would derive an empty `https:///v3` endpoint).
- **`fix(c5c3): deep-copy projected Keystone database and cache specs`** — `DeepCopy()` the projected `Database`/`Cache` so the child never aliases `cp.Spec`, matching the Gateway projection.
- **`fix(c5c3): error on invalid Keystone rotation interval`** — return the error so the chain stops and requeues instead of `ctrl.Result{}, nil` letting it continue.
- **`fix(c5c3): apply clouds.yaml secretName fallback in reconcileCatalog`** — empty `SecretName` falls back to `korcCloudsYamlSecretName` like the other call sites.
- **`feat(c5c3): populate status.services and status.updatePhase`** — both fields were declared but never written; `updatePhase` is fixed at `Idle`, `services["keystone"]` mirrors `KeystoneReady` + release.

- **`docs(c5c3): refresh ControlPlane reference for #476 changes`** — Watches table, `SecretStoreNotReady` rows, immutability/gateway contract, removed `KORCCRDNotInstalled` rows + hard-dependency note, status-field wiring (reconciler + CRD + infrastructure-manifests docs).

## Tests & verification

- New unit tests: webhook immutability + gateway, catalog secretName fallback, the three store-not-ready gates, the new ClusterSecretStore mapper; updated the rotation-interval and missing-CRD tests to the new behavior.
- Integration tests seed a Ready `ClusterSecretStore` before driving the chain; the full envtest suite passes.
- `go build` / `go vet` / `golangci-lint` (0 issues) / `gofumpt` clean / `make manifests` (no CRD drift) / `make check-docs-ids` clean.

## Notes for the reviewer

- **Problem 1 fork:** implemented as webhook immutability (smallest, single-file). The alternative the issue also sanctions — delete-orphans in each sub-reconciler — would keep post-create mode/name edits allowed at materially more cost.
- **Problem 2 fork:** implemented as drop-dead-branches (commit isolated). The RESTMapper-probe + conditional `Owns()` alternative preserves graceful degradation but yields a split dependency model.
- **DeepCopy (Problem 4):** behavior-preserving and untestable through the fake client (it deep-copies on store), so it relies on the existing projection-value test rather than a vacuous aliasing assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)