### PR TITLE
fix(keystone-operator): rotation staging/commit races, ESO finalizer assumptions, DB-TLS Certificate orphan on disable

### DIFF
--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -255,10 +255,11 @@ kubectl -n openstack patch keystone keystone --type json --patch '[
 ```
 
 The `DatabaseTLSReady` condition transitions to `True` with `reason=NotRequired`,
-the `<name>-db-client` Secret is garbage-collected via the cert-manager
-`Certificate` owner reference cascade, and subsequent connections fall back to
-plaintext TCP — but only succeed if MariaDB's `spec.tls.required` is also
-turned off (see warning above).
+the operator deletes the managed `<name>-db-client` `Certificate` (so
+cert-manager stops renewing it), cert-manager then garbage-collects the issued
+Secret via the `Certificate` owner-reference cascade, and subsequent
+connections fall back to plaintext TCP — but only succeed if MariaDB's
+`spec.tls.required` is also turned off (see warning above).
 
 ---
 

--- a/docs/guides/keystone-key-rotation.md
+++ b/docs/guides/keystone-key-rotation.md
@@ -167,8 +167,12 @@ subsequent rotations.
 ## 5. Recover from `RotationRejected`
 
 The operator validates every staged rotation before copying it onto the
-production Secret. On failure it emits a Warning event and **keeps the
-staging Secret in place** so you can inspect what the CronJob produced.
+production Secret. On failure it emits a Warning event and **clears the
+staged payload** — the staging Secret object is kept, but its `.data` and
+the `forge.c5c3.io/rotation-completed-at` annotation are removed so the
+next CronJob run starts from an empty base rather than merging over a
+rejected payload. The Warning event message, not the staging Secret
+contents, is the record of what was rejected.
 
 ### Symptoms
 
@@ -189,13 +193,11 @@ The companion Warning reason `RotationAnnotationInvalid` indicates the
 annotation was present but did not parse as RFC3339; the remediation path
 is the same.
 
-### Inspect the staging Secret
+### Match the rejection reason
 
-```bash
-kubectl -n <ns> get secret <ks>-fernet-keys-rotation -o yaml
-```
-
-Match the event message against the operator's validation contract
+Because the staged `.data` is cleared on rejection, the `RotationRejected`
+event message above — not the staging Secret — is what tells you which
+rule failed. Match it against the operator's validation contract
 (see [Operator validation rules](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split)):
 
 | Event message contains | Likely cause |
@@ -212,16 +214,18 @@ The recovery sequence is always:
 
 1. Fix the cause (CronJob image, script, or CR spec) so the next rotation
    will produce valid output.
-2. Force a fresh rotation:
+2. Force a fresh rotation. The operator already cleared the staged data on
+   rejection, so deleting the staging Secret by hand is optional
+   belt-and-suspenders:
 
    ```bash
-   kubectl -n <ns> delete secret <ks>-fernet-keys-rotation
+   kubectl -n <ns> delete secret <ks>-fernet-keys-rotation   # optional
    kubectl -n <ns> create job --from=cronjob/<ks>-fernet-rotate \
      <ks>-fernet-rotate-recover-$(date +%s)
    ```
 
-   The operator re-creates an empty staging Secret on the next reconcile;
-   the new Job PATCHes it; the operator validates and applies.
+   The new Job PATCHes the (already-empty) staging Secret; the operator
+   validates and applies.
 3. Confirm apply by repeating steps 2-4 above.
 
 > **Production safety note.** The production Secret is never modified

--- a/docs/reference/keystone-operator-metrics.md
+++ b/docs/reference/keystone-operator-metrics.md
@@ -27,7 +27,7 @@ for cluster-side wiring.
 | --- | --- | --- | --- |
 | `keystone_operator_reconcile_duration_seconds` | Histogram | `sub_reconciler` | Latency of each sub-reconciler invocation |
 | `keystone_operator_reconcile_errors_total` | Counter | `sub_reconciler`, `condition_type` | Count of sub-reconciler failures per Ready sub-condition |
-| `keystone_operator_key_rotation_age_seconds` | Gauge | `keystone`, `namespace`, `key_type` | Age of the most recent successful Fernet/credential rotation |
+| `keystone_operator_key_rotation_age_seconds` | Gauge | `keystone`, `namespace`, `key_type` | Age of the most recent successful Fernet/credential/admin-password rotation |
 | `keystone_operator_db_sync_total` | Counter | `keystone`, `namespace`, `result` | Terminal `db_sync` Job outcomes |
 | `keystone_operator_db_sync_duration_seconds` | Histogram | `keystone`, `namespace` | Wall-clock duration of terminated `db_sync` Jobs |
 
@@ -106,9 +106,18 @@ at reconcile time.
 | --- | --- |
 | Type | Gauge |
 | Labels | `keystone`, `namespace`, `key_type` |
-| Call site | `reconcileFernetKeys` / `reconcileCredentialKeys` on every reconcile pass |
+| Call site | `reconcileFernetKeys` / `reconcileCredentialKeys` / `reconcilePasswordRotation` on every reconcile pass |
 
-**`key_type` values.** Exactly `fernet` or `credential`.
+**`key_type` values.** `fernet`, `credential`, or `admin-password`.
+
+**`admin-password` caveat.** For `key_type="admin-password"` the gauge
+measures age since the operator committed the rotated password to its
+push-source Secret — not since the password went live. The new password
+becomes live only after ESO mirrors it to OpenBao, the `keystone-admin`
+ExternalSecret syncs it back, and bootstrap re-runs (~1h+). The gauge
+therefore under-reports time-since-live for `admin-password` relative to
+`fernet` and `credential`, which go live the instant the operator updates
+the keys Secret.
 
 **Annotation source.** The gauge reads the
 `forge.c5c3.io/rotation-completed-at` annotation from the **production**

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -72,6 +72,7 @@ The controller watches the primary Keystone CR and all owned resources:
 | `HorizontalPodAutoscaler` | `Owns()` | Triggers reconciliation when owned HPA changes |
 | `CronJob` | `Owns()` | Triggers reconciliation when owned CronJob changes |
 | `HTTPRoute` | `Owns()` (optional) | Registered only when the `gateway.networking.k8s.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. Triggers reconciliation when owned HTTPRoute changes (only created when `spec.gateway` is set). |
+| `Certificate` | `Owns()` (optional) | Registered only when the `cert-manager.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. Triggers reconciliation when the managed `<name>-db-client` Certificate changes, so later issuance failures surface in `DatabaseTLSReady` (only created when managed DB TLS is enabled). |
 | `Secret` | `Watches()` | Maps Secret events to referencing Keystone CRs via the `KeystoneSecretNameIndexKey` field indexer, with an owner-ref fallback for rotation staging Secrets |
 | `MariaDB` | `Watches()` | Propagates upstream DB cluster health into `DatabaseReady` |
 | `ClusterSecretStore` | `Watches()` | Propagates OpenBao-backend health into `SecretsReady` |

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -1066,6 +1066,11 @@ The deletion handler proceeds as follows:
      ESO had a chance to install `DeletionPolicy=Delete`, orphaning the
      kv-v2 path in OpenBao (see
      [Three-pass lifecycle with two blocked states](#three-pass-lifecycle-with-two-blocked-states)).
+     The wait is **bounded** by `OpenBaoAdoptionWaitTimeout` (10m): once the
+     CR has been deleting longer than that, an unadopted PushSecret stops
+     blocking — the handler emits an `ESOAdoptionTimedOut` Warning event and
+     proceeds to Pass-1's `Delete` — so a renamed or absent ESO finalizer
+     cannot hang CR deletion forever at `WaitingForESOAdoption`.
    - **Pass-1 — parallel Delete.** Issue `Delete` on every backup
      PushSecret (tolerating `NotFound`), so ESO's cleanup finalizers
      fire on all of them in parallel rather than in a serialised
@@ -1154,7 +1159,7 @@ reading controller logs:
 
 | Reason | Pass | When Emitted | Typical Remediation |
 | --- | --- | --- | --- |
-| `WaitingForESOAdoption` | Pre-Delete adoption wait (Pass-0) | A backup PushSecret exists, is not Terminating, and does **not** yet carry ESO's cleanup finalizer. | Resolves itself on ESO workqueue drain. Check `kubectl -n external-secrets logs deploy/external-secrets` for backlog or errors. |
+| `WaitingForESOAdoption` | Pre-Delete adoption wait (Pass-0) | A backup PushSecret exists, is not Terminating, and does **not** yet carry ESO's adoption finalizer (`pushsecret.externalsecrets.io/finalizer`). | Resolves itself on ESO workqueue drain. Check `kubectl -n external-secrets logs deploy/external-secrets` for backlog or errors. The wait is bounded by `OpenBaoAdoptionWaitTimeout` (10m); past that the handler emits an `ESOAdoptionTimedOut` Warning and force-deletes so CR deletion never hangs. |
 | `OpenBaoFinalizerBlocked` | Post-Delete wait-for-gone (Pass-2) | A backup PushSecret is still present in the API server after `Delete` was issued, typically in Terminating state behind ESO's cleanup finalizer. | ESO is running `DeletionPolicy=Delete` against OpenBao. A persistent block here may indicate OpenBao unreachable or ClusterSecretStore auth revoked. |
 
 The three passes execute in strict order:
@@ -1164,7 +1169,14 @@ The three passes execute in strict order:
    `metadata.finalizers` for
    `pushsecret.externalsecrets.io/finalizer`. On the
    first unadopted PushSecret it records `WaitingForESOAdoption` and
-   returns `(done=false, nil)` **without** firing any `Delete`.
+   returns `(done=false, nil)` **without** firing any `Delete`. This wait is
+   bounded by `OpenBaoAdoptionWaitTimeout` (10m): past that deadline the
+   unadopted PushSecret no longer blocks — the handler emits an
+   `ESOAdoptionTimedOut` Warning and breaks to Pass-1's force-`Delete`. The
+   force-delete stays safe when ESO merely renamed its finalizer (the
+   PushSecret carries the renamed finalizer, so `Delete` only marks it
+   Terminating and ESO still purges the kv-v2 path); the path is orphaned
+   only if ESO is genuinely not running during the deletion window.
 2. **Pass-1 — parallel Delete.** Once every still-present PushSecret is
    adopted (ESO finalizer present) or already Terminating, the handler
    issues `Delete` on every name in a single pass so the cleanup

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -2831,8 +2831,10 @@ func TestRotationApplyEndToEnd_EnvTest(t *testing.T) {
 // TestRotationApplyRejectsMalformedKeys_EnvTest verifies that a staging Secret
 // with malformed Fernet keys (32-byte raw strings instead of 44-byte base64url)
 // is rejected by the operator's validation step: production Secret is
-// untouched, staging Secret is retained for inspection, and a
-// RotationRejected Warning event is emitted (CC-0081, Task 4.2, REQ-006).
+// untouched, the staging Secret object is retained but its payload is cleared
+// (Data emptied, completion annotation removed) so the next CronJob
+// strategic-merge PATCH starts from an empty base, and a RotationRejected
+// Warning event is emitted (CC-0081, Task 4.2, REQ-006; issue #475).
 func TestRotationApplyRejectsMalformedKeys_EnvTest(t *testing.T) {
 	g := NewGomegaWithT(t)
 	c, ctx, ks, ns := setupRotationEnvTest(t, "test-rotation-reject-")
@@ -2872,12 +2874,24 @@ func TestRotationApplyRejectsMalformedKeys_EnvTest(t *testing.T) {
 			"production Secret must not be mutated by a rejected rotation (CC-0081)")
 	}, 2*time.Second, pollInterval).Should(Succeed())
 
-	// Staging Secret is retained with the malformed data + annotation (CC-0081).
-	retained := &corev1.Secret{}
-	g.Expect(c.Get(ctx, stagingKey, retained)).To(Succeed(),
-		"staging Secret should be retained after a rejected apply (CC-0081)")
-	g.Expect(retained.Data).To(Equal(malformed))
-	g.Expect(retained.Annotations).To(HaveKey(RotationCompletedAnnotation))
+	// Staging Secret retained but cleared: the operator empties Data and drops
+	// the completion annotation on rejection so the next CronJob strategic-merge
+	// PATCH starts from an empty base rather than accumulating leftover key
+	// indices over the rejected payload (issue #475). The object itself is kept —
+	// the RotationRejected event message, not the now-empty Data, is the
+	// diagnostic of record. Wrapped in Eventually because the clearing Update
+	// lands just after the RotationRejected event the wait above keys on
+	// (CC-0081, issue #475).
+	g.Eventually(func(ig Gomega) {
+		retained := &corev1.Secret{}
+		ig.Expect(c.Get(ctx, stagingKey, retained)).To(Succeed(),
+			"staging Secret should be retained (not deleted) after a rejected apply (issue #475)")
+		ig.Expect(retained.Data).To(BeEmpty(),
+			"rejected staging Data must be cleared (issue #475)")
+		ig.Expect(retained.Annotations).NotTo(HaveKey(RotationCompletedAnnotation),
+			"rejected staging completion annotation must be removed (issue #475)")
+	}, eventuallyTimeout, pollInterval).Should(Succeed(),
+		"staging Secret must be retained but cleared after a rejected apply (issue #475)")
 }
 
 // cronJobStrategicMergePatch emits the exact strategic-merge PATCH shape the

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
@@ -128,6 +129,15 @@ type KeystoneReconciler struct {
 	// reconcileHTTPRoute surfaces a clear HTTPRouteReady=False condition if
 	// the user nonetheless sets spec.gateway (CC-0065).
 	gatewayAPIAvailable bool
+
+	// certManagerAvailable is set during SetupWithManager from the cluster's
+	// RESTMapper and indicates whether the cert-manager.io/v1 Certificate CRD
+	// is installed. When false, the controller skips the Certificate watch and
+	// reconcileDatabaseTLS skips the disable-path Certificate delete (no
+	// Certificate can exist), so the default no-TLS configuration never errors
+	// with "no matches for kind Certificate" on clusters without cert-manager
+	// (issue #475).
+	certManagerAvailable bool
 }
 
 // httpRouteGVK identifies the HTTPRoute kind the operator would watch when
@@ -149,6 +159,30 @@ func isGatewayAPIAvailable(mapper meta.RESTMapper) bool {
 		return false
 	}
 	if _, err := mapper.RESTMapping(httpRouteGVK.GroupKind(), httpRouteGVK.Version); err != nil {
+		return false
+	}
+	return true
+}
+
+// certificateGVK identifies the cert-manager Certificate kind the operator
+// owns when cert-manager is installed.
+var certificateGVK = schema.GroupVersionKind{
+	Group:   certmanagerv1.SchemeGroupVersion.Group,
+	Version: certmanagerv1.SchemeGroupVersion.Version,
+	Kind:    "Certificate",
+}
+
+// isCertManagerAvailable probes the manager's RESTMapper for the Certificate
+// kind, mirroring isGatewayAPIAvailable. Returns false when the mapper has no
+// mapping (CRD not installed); other mapper errors are treated conservatively
+// as "not available" so the operator starts without the Certificate watch and
+// reconcileDatabaseTLS skips the disable-path delete rather than erroring with
+// "no matches for kind Certificate" (issue #475).
+func isCertManagerAvailable(mapper meta.RESTMapper) bool {
+	if mapper == nil {
+		return false
+	}
+	if _, err := mapper.RESTMapping(certificateGVK.GroupKind(), certificateGVK.Version); err != nil {
 		return false
 	}
 	return true
@@ -733,6 +767,18 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		setupLog.Info("Gateway API not installed; HTTPRoute watch disabled, spec.gateway will be rejected via HTTPRouteReady condition")
 	}
 
+	// Detect cert-manager so the operator can Owns(Certificate) — surfacing
+	// later DB-client Certificate issuance failures in DatabaseTLSReady — and
+	// so reconcileDatabaseTLS knows whether a managed Certificate can exist on
+	// the TLS-disable path. spec.database.tls is optional, so the operator must
+	// run on clusters without cert-manager (issue #475).
+	r.certManagerAvailable = isCertManagerAvailable(mgr.GetRESTMapper())
+	if r.certManagerAvailable {
+		setupLog.Info("cert-manager detected; enabling Certificate watch for DatabaseTLSReady")
+	} else {
+		setupLog.Info("cert-manager not installed; Certificate watch disabled, managed DB-TLS Certificates will not be reconciled")
+	}
+
 	// Register the Keystone field indexer before Watches so
 	// secretToKeystoneMapper can rely on it for its MatchingFields lookup
 	// (CC-0087, REQ-001, REQ-006).
@@ -753,6 +799,10 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if r.gatewayAPIAvailable {
 		b = b.Owns(&gatewayv1.HTTPRoute{})
+	}
+
+	if r.certManagerAvailable {
+		b = b.Owns(&certmanagerv1.Certificate{})
 	}
 
 	return b.

--- a/operators/keystone/internal/controller/keystone_controller_test.go
+++ b/operators/keystone/internal/controller/keystone_controller_test.go
@@ -2780,6 +2780,25 @@ func TestIsGatewayAPIAvailable_CRDMissing_ReturnsFalse(t *testing.T) {
 	g.Expect(isGatewayAPIAvailable(m)).To(BeFalse())
 }
 
+// --- isCertManagerAvailable (issue #475, DB-TLS Certificate lifecycle) ---
+
+func TestIsCertManagerAvailable_NilMapper_ReturnsFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	g.Expect(isCertManagerAvailable(nil)).To(BeFalse())
+}
+
+func TestIsCertManagerAvailable_CRDPresent_ReturnsTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m := &fakeRESTMapper{available: map[string]bool{"Certificate.cert-manager.io": true}}
+	g.Expect(isCertManagerAvailable(m)).To(BeTrue())
+}
+
+func TestIsCertManagerAvailable_CRDMissing_ReturnsFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m := &fakeRESTMapper{available: map[string]bool{}}
+	g.Expect(isCertManagerAvailable(m)).To(BeFalse())
+}
+
 // ---------------------------------------------------------------------------
 // reconcileDBConnectionSecret wiring tests (CC-0080, REQ-005, REQ-006)
 // ---------------------------------------------------------------------------

--- a/operators/keystone/internal/controller/reconcile_database.go
+++ b/operators/keystone/internal/controller/reconcile_database.go
@@ -931,9 +931,14 @@ func buildDBSyncJob(keystone *keystonev1alpha1.Keystone, configMapName string) *
 }
 
 // buildUpgradeJob creates a db_sync Job for one of the expand-migrate-contract
-// upgrade phases (CC-0056). The imageTag parameter allows callers to pin the
-// image independently of spec.Image.Tag (expand/migrate use the old release,
-// contract uses the new release).
+// upgrade phases (CC-0056). All three phases run with the NEW release image:
+// reconcileExpand, reconcileMigrate, and reconcileContract each pass
+// keystone.Spec.Image.Tag, per the OpenStack rolling-upgrade procedure where
+// the N+1 alembic tree owns the schema deltas (see reconcileExpand for the
+// full rationale). The imageTag parameter is retained so a caller could pin a
+// phase to a different image, but the upgrade flow always passes the target
+// release to all three — do not read this comment as "expand/migrate use the
+// old release" when triaging a stuck upgrade.
 func buildUpgradeJob(keystone *keystonev1alpha1.Keystone, configMapName, imageTag, phase, flag string) *batchv1.Job {
 	return buildDBJob(keystone, configMapName, imageTag, fmt.Sprintf("db-%s", phase),
 		[]string{"keystone-manage", "--config-dir=/etc/keystone/keystone.conf.d/", "db_sync", flag})

--- a/operators/keystone/internal/controller/reconcile_databasetls.go
+++ b/operators/keystone/internal/controller/reconcile_databasetls.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -60,8 +61,15 @@ func (r *KeystoneReconciler) reconcileDatabaseTLS(ctx context.Context,
 	tlsSpec := keystone.Spec.Database.TLS
 
 	// NotRequired: TLS not requested — preserve pre-CC-0106 plaintext
-	// behavior, create no Certificate (CC-0106, REQ-002).
+	// behavior, create no Certificate (CC-0106, REQ-002). If TLS was
+	// previously Managed, delete the now-orphaned <name>-db-client Certificate
+	// so cert-manager stops renewing it and garbage-collects the issued Secret
+	// via the owner-reference cascade — mirroring HPA/NetworkPolicy/HTTPRoute,
+	// which all delete their managed objects on disable (issue #475).
 	if tlsSpec == nil || !tlsSpec.Enabled {
+		if err := r.deleteManagedDBClientCertificate(ctx, keystone); err != nil {
+			return ctrl.Result{}, err
+		}
 		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeDatabaseTLSReady,
 			Status:             metav1.ConditionTrue,
@@ -75,8 +83,14 @@ func (r *KeystoneReconciler) reconcileDatabaseTLS(ctx context.Context,
 	// ExternallyManaged: TLS enabled but the database is brownfield (no
 	// clusterRef). The operator does not own the external database's trust
 	// domain; the client keypair is supplied out-of-band via
-	// spec.database.tls.clientCertSecretRef (CC-0106, REQ-014).
+	// spec.database.tls.clientCertSecretRef (CC-0106, REQ-014). Delete any
+	// previously-issued managed Certificate — a CR switched from managed to
+	// brownfield must not leave the operator-owned <name>-db-client Certificate
+	// being renewed indefinitely (issue #475).
 	if keystone.Spec.Database.ClusterRef == nil {
+		if err := r.deleteManagedDBClientCertificate(ctx, keystone); err != nil {
+			return ctrl.Result{}, err
+		}
 		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeDatabaseTLSReady,
 			Status:             metav1.ConditionTrue,
@@ -127,6 +141,40 @@ func (r *KeystoneReconciler) reconcileDatabaseTLS(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
+// dbClientCertificateName returns the name of the operator-issued client
+// Certificate (and the Secret cert-manager writes it into):
+// "<keystone.Name>-db-client" (CC-0106, REQ-002).
+func dbClientCertificateName(keystone *keystonev1alpha1.Keystone) string {
+	return fmt.Sprintf("%s-db-client", keystone.Name)
+}
+
+// deleteManagedDBClientCertificate deletes the operator-issued
+// <name>-db-client Certificate when DB TLS is disabled or switched to
+// brownfield mode. It is a no-op when cert-manager is not installed: no
+// Certificate can exist in that case, and an unconditional Delete would fail
+// with "no matches for kind Certificate" — the same CRD-availability gate
+// reconcileHTTPRoute applies before deleting an HTTPRoute (issue #475).
+func (r *KeystoneReconciler) deleteManagedDBClientCertificate(ctx context.Context, keystone *keystonev1alpha1.Keystone) error {
+	if !r.certManagerAvailable {
+		return nil
+	}
+	return deleteDBClientCertificate(ctx, r.Client, keystone.Namespace, dbClientCertificateName(keystone))
+}
+
+// deleteDBClientCertificate deletes the Certificate identified by namespace and
+// name. It tolerates NotFound, mirroring deleteNetworkPolicy / deleteHTTPRoute
+// (issue #475). cert-manager garbage-collects the issued Secret via the
+// Certificate owner-reference cascade once the Certificate is gone.
+func deleteDBClientCertificate(ctx context.Context, c client.Client, namespace, name string) error {
+	cert := &certmanagerv1.Certificate{}
+	cert.SetName(name)
+	cert.SetNamespace(namespace)
+	if err := client.IgnoreNotFound(c.Delete(ctx, cert)); err != nil {
+		return fmt.Errorf("deleting database client Certificate %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
 // dbClientCertificate builds the cert-manager Certificate for the Keystone
 // database client keypair (CC-0106, REQ-002). The Secret it issues is named
 // "<keystone.Name>-db-client" and is mounted into the workloads that open a
@@ -138,7 +186,7 @@ func (r *KeystoneReconciler) reconcileDatabaseTLS(ctx context.Context,
 // include client auth plus digital signature / key encipherment, the
 // standard set for a TLS client keypair.
 func dbClientCertificate(keystone *keystonev1alpha1.Keystone) *certmanagerv1.Certificate {
-	name := fmt.Sprintf("%s-db-client", keystone.Name)
+	name := dbClientCertificateName(keystone)
 	return &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/operators/keystone/internal/controller/reconcile_databasetls_test.go
+++ b/operators/keystone/internal/controller/reconcile_databasetls_test.go
@@ -72,7 +72,10 @@ func dbTLSBaseKeystone() *keystonev1alpha1.Keystone {
 
 func dbTLSReconciler(s *runtime.Scheme, objs ...client.Object) *KeystoneReconciler {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
-	return &KeystoneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	// certManagerAvailable mirrors a cluster with cert-manager installed (the
+	// hard infra dependency for DB TLS); the disable-path Certificate delete is
+	// gated on it (issue #475).
+	return &KeystoneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10), certManagerAvailable: true}
 }
 
 // expectDBTLSProjection asserts that the projected volume sources the
@@ -224,4 +227,103 @@ func TestReconcileDatabaseTLS_BrownfieldExternallyManaged(t *testing.T) {
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 	g.Expect(cond.Reason).To(Equal(reasonExternallyManaged))
+}
+
+// TestReconcileDatabaseTLS_DisabledDeletesManagedCertificate verifies issue
+// #475: disabling spec.database.tls deletes the operator-issued
+// <name>-db-client Certificate (so cert-manager stops renewing it and
+// garbage-collects the issued Secret via the owner-reference cascade) and
+// records NotRequired — matching the HPA/NetworkPolicy/HTTPRoute
+// delete-on-disable behavior rather than leaking the Certificate until CR
+// deletion.
+func TestReconcileDatabaseTLS_DisabledDeletesManagedCertificate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone() // TLS == nil → NotRequired
+
+	// A leftover Certificate from a prior managed configuration.
+	existing := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-db-client", Namespace: "default"},
+	}
+	r := dbTLSReconciler(s, ks, existing)
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	getErr := r.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}, &certmanagerv1.Certificate{})
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"managed Certificate must be deleted when TLS is disabled (issue #475)")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(reasonNotRequired))
+}
+
+// TestReconcileDatabaseTLS_BrownfieldDeletesManagedCertificate verifies issue
+// #475: switching a managed CR to brownfield (TLS enabled, ClusterRef cleared)
+// deletes the operator-issued Certificate and records ExternallyManaged.
+func TestReconcileDatabaseTLS_BrownfieldDeletesManagedCertificate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone()
+	ks.Spec.Database.Host = "db.example.com"
+	ks.Spec.Database.Port = 3306
+	ks.Spec.Database.TLS = &commonv1.DatabaseTLSSpec{
+		Enabled:             true,
+		Mode:                "verify-full",
+		CABundleSecretRef:   commonv1.SecretRefSpec{Name: "db-server-ca"},
+		ClientCertSecretRef: commonv1.SecretRefSpec{Name: "external-db-client"},
+	}
+
+	existing := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-db-client", Namespace: "default"},
+	}
+	r := dbTLSReconciler(s, ks, existing)
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	getErr := r.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}, &certmanagerv1.Certificate{})
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"managed Certificate must be deleted when switched to brownfield mode (issue #475)")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(reasonExternallyManaged))
+}
+
+// TestReconcileDatabaseTLS_DisabledSkipsDeleteWhenCertManagerAbsent verifies
+// the CRD-availability gate (issue #475): on a cluster without cert-manager the
+// disable path must NOT attempt the Certificate delete, since there is no
+// Certificate kind and an unconditional Delete would fail with "no matches for
+// kind Certificate". A seeded Certificate (modeling a stale object) survives
+// because the gate short-circuits before any Delete.
+func TestReconcileDatabaseTLS_DisabledSkipsDeleteWhenCertManagerAbsent(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone() // TLS == nil → NotRequired
+
+	existing := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-db-client", Namespace: "default"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ks, existing).Build()
+	r := &KeystoneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10), certManagerAvailable: false}
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	// Certificate untouched because the cert-manager gate skipped the delete.
+	g.Expect(r.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}, &certmanagerv1.Certificate{})).To(Succeed())
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Reason).To(Equal(reasonNotRequired))
 }

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -472,10 +472,17 @@ func validateAdminPasswordRotationOutput(data map[string][]byte, minLength int) 
 //     staging Secret for operator inspection.
 //  4. GET the push-source Secret, replace its Data with the staged payload,
 //     stamp the rotation-completed annotation, and Update.
-//  5. DELETE the staging Secret (tolerate NotFound).
+//  5. DELETE the staging Secret under client.Preconditions{UID,
+//     ResourceVersion} from the step-1 read; tolerate NotFound and Conflict.
 //  6. Emit AdminPasswordRotated.
 //
 // The password value itself is never logged or echoed in events.
+//
+// NOTE: unlike applyRotationOutput (CC-0081), a validation rejection here does
+// NOT clear staging.Data. The staging Secret carries a single `password` key,
+// not a multi-key map, so the strategic-merge accumulation of stale indices
+// that motivates clearing the fernet/credential staging payload cannot occur;
+// the rejected password is retained verbatim for operator inspection.
 func (r *KeystoneReconciler) applyAdminPasswordRotation(
 	ctx context.Context,
 	keystone *keystonev1alpha1.Keystone,
@@ -538,9 +545,21 @@ func (r *KeystoneReconciler) applyAdminPasswordRotation(
 		return false, fmt.Errorf("updating push-source secret %s: %w", pushSourceSecretName, updateErr)
 	}
 
-	// 5. DELETE staging Secret; tolerate NotFound for races.
-	if delErr := r.Delete(ctx, &staging); delErr != nil && !apierrors.IsNotFound(delErr) {
-		return false, fmt.Errorf("deleting staging secret %s: %w", stagingSecretName, delErr)
+	// 5. DELETE staging Secret under the UID + ResourceVersion observed at the
+	//    step-1 Get, mirroring applyRotationOutput (CC-0081). The preconditions
+	//    make a concurrent CronJob PATCH surface as 409 Conflict instead of
+	//    being silently deleted uncommitted; the newer password then commits on
+	//    the next reconcile. Conflict and NotFound are both tolerated — this
+	//    run's password is already on the push-source Secret.
+	delOpts := client.Preconditions{UID: &staging.UID, ResourceVersion: &staging.ResourceVersion}
+	if delErr := r.Delete(ctx, &staging, delOpts); delErr != nil {
+		if !apierrors.IsNotFound(delErr) && !apierrors.IsConflict(delErr) {
+			return false, fmt.Errorf("deleting staging secret %s: %w", stagingSecretName, delErr)
+		}
+		log.FromContext(ctx).V(1).Info(
+			"staging secret changed since read; newer rotation output applied next reconcile",
+			"staging", stagingSecretName,
+		)
 	}
 
 	// 6. Emit a success event. The password value is intentionally omitted.

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -195,6 +195,15 @@ func (r *KeystoneReconciler) reconcilePasswordRotation(ctx context.Context,
 	//    falls back to staging for the pre-first-apply window. Called before
 	//    applyAdminPasswordRotation so the next reconcile picks up the freshest
 	//    timestamp once the apply re-stamps the push-source annotation.
+	//
+	//    Semantics caveat (issue #475): for key_type="admin-password" this
+	//    timestamp marks the commit-to-push-source instant, NOT the moment the
+	//    password goes live. The new password is live only after ESO mirrors
+	//    the push-source Secret to OpenBao, the keystone-admin ExternalSecret
+	//    syncs it back, and bootstrap re-runs (~1h+). The gauge therefore
+	//    under-reports time-since-live for admin-password compared with fernet
+	//    and credential, which go live the instant the operator updates the
+	//    keys Secret.
 	r.observeRotationAge(ctx, keystone, adminPasswordNextSecretName(keystone),
 		adminPasswordStagingSecretName(keystone), "admin-password")
 
@@ -531,7 +540,10 @@ func (r *KeystoneReconciler) applyAdminPasswordRotation(
 	// 4. GET push-source Secret, replace Data verbatim, stamp the annotation,
 	//    and Update. The push-source Secret is the durable record of the last
 	//    successful rotation timestamp once staging is deleted, so the
-	//    rotation-age gauge can refresh on every reconcile.
+	//    rotation-age gauge can refresh on every reconcile. NOTE (issue #475):
+	//    this annotation marks commit-to-push-source, which precedes the
+	//    password going live by the full ESO round-trip + bootstrap re-run
+	//    (~1h+); the gauge under-reports time-since-live for admin-password.
 	var pushSource corev1.Secret
 	if getErr := r.Get(ctx, types.NamespacedName{Name: pushSourceSecretName, Namespace: keystone.Namespace}, &pushSource); getErr != nil {
 		return false, fmt.Errorf("getting push-source secret %s: %w", pushSourceSecretName, getErr)

--- a/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -339,6 +340,71 @@ func TestApplyAdminPasswordRotation_ValidCommit(t *testing.T) {
 	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue())
 
 	g.Expect(drainEventReasons(rec)).To(ContainElement("AdminPasswordRotated"))
+}
+
+// TestApplyAdminPasswordRotation_ConcurrentStagingPatchTolerated mirrors the
+// fernet/credential staging-delete guard (issue #475, Problem 1a): the step-5
+// Delete carries client.Preconditions{UID, ResourceVersion} from the step-1
+// read, and a 409 Conflict (a CronJob PATCH landing between read and delete) is
+// tolerated as a completed apply with the staging Secret left intact.
+func TestApplyAdminPasswordRotation_ConcurrentStagingPatchTolerated(t *testing.T) {
+	g := NewWithT(t)
+	ks := pwRotationTestKeystone()
+	s := pwRotationTestScheme()
+
+	pushSource := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: adminPasswordNextSecretName(ks), Namespace: ks.Namespace,
+	}}
+	staging := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminPasswordStagingSecretName(ks),
+			Namespace:   ks.Namespace,
+			UID:         "staging-uid",
+			Annotations: validCompletedAnnotation(),
+		},
+		Data: map[string][]byte{"password": []byte(validTestPassword)},
+	}
+
+	var sawPreconditions *metav1.Preconditions
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ks, pushSource, staging).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, wc client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if sec, ok := obj.(*corev1.Secret); ok && sec.Name == adminPasswordStagingSecretName(ks) {
+					do := &client.DeleteOptions{}
+					for _, o := range opts {
+						o.ApplyToDelete(do)
+					}
+					sawPreconditions = do.Preconditions
+					return apierrors.NewConflict(corev1.Resource("secrets"), sec.Name,
+						fmt.Errorf("simulated concurrent rotation PATCH"))
+				}
+				return wc.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &KeystoneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(20)}
+
+	applied, err := r.applyAdminPasswordRotation(context.Background(), ks, 24)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(applied).To(BeTrue(), "a Conflict on the staging Delete must be tolerated as a completed apply")
+
+	g.Expect(sawPreconditions).NotTo(BeNil(), "staging Delete must carry client.Preconditions")
+	g.Expect(sawPreconditions.UID).NotTo(BeNil())
+	g.Expect(*sawPreconditions.UID).To(Equal(types.UID("staging-uid")))
+	g.Expect(sawPreconditions.ResourceVersion).NotTo(BeNil())
+	g.Expect(*sawPreconditions.ResourceVersion).NotTo(BeEmpty())
+
+	// Push-source carries this run's password; staging Secret still present.
+	var committed corev1.Secret
+	g.Expect(r.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordNextSecretName(ks), Namespace: ks.Namespace,
+	}, &committed)).To(Succeed())
+	g.Expect(committed.Data).To(HaveKeyWithValue("password", []byte(validTestPassword)))
+	g.Expect(r.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordStagingSecretName(ks), Namespace: ks.Namespace,
+	}, &corev1.Secret{})).To(Succeed())
 }
 
 func TestApplyAdminPasswordRotation_RejectsShortPassword(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_secrets.go
+++ b/operators/keystone/internal/controller/reconcile_secrets.go
@@ -7,8 +7,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -181,7 +183,11 @@ func openBaoBackupPushSecretNames(keystone *keystonev1alpha1.Keystone) []string 
 //     would never observe a DeletionTimestamp, and the referenced kv-v2 path
 //     in OpenBao would be orphaned. On the first unadopted PushSecret record
 //     WaitingForESOAdoption and return done=false WITHOUT firing any Delete
-//     (CC-0091, REQ-001, REQ-003, REQ-007).
+//     (CC-0091, REQ-001, REQ-003, REQ-007). The wait is bounded by
+//     OpenBaoAdoptionWaitTimeout: past that deadline an unadopted PushSecret no
+//     longer blocks — Pass-1 force-deletes it after an ESOAdoptionTimedOut
+//     Warning — so a renamed/absent ESO finalizer cannot hang CR deletion
+//     forever (issue #475).
 //  1. Issue Delete on every backup PushSecret, tolerating NotFound. Firing all
 //     Deletes up-front lets ESO's cleanup finalizers run in parallel — a
 //     serialised Delete→Get loop doubles the worst-case deletion window when
@@ -212,6 +218,19 @@ func (r *KeystoneReconciler) finalizeOpenBaoSecrets(
 	// any Delete — a racing Delete here would remove the PushSecret object
 	// outright and orphan the kv-v2 path in OpenBao (CC-0091, REQ-001,
 	// REQ-003, REQ-007).
+	//
+	// The wait is bounded by OpenBaoAdoptionWaitTimeout (issue #475): once the
+	// CR has been deleting longer than that, an unadopted PushSecret stops
+	// blocking and Pass-1 force-deletes it (after an ESOAdoptionTimedOut
+	// Warning), so an ESO finalizer rename — or ESO being down — cannot hang CR
+	// deletion forever. The force-delete is still safe when ESO merely renamed
+	// its finalizer: the PushSecret carries that (renamed) finalizer, so Delete
+	// only marks it Terminating and ESO still purges the kv-v2 path via it. The
+	// kv-v2 path is orphaned only if ESO is genuinely not running during the
+	// deletion window — an explicit, event-surfaced trade-off over hanging.
+	adoptionDeadlinePassed := !keystone.DeletionTimestamp.IsZero() &&
+		time.Since(keystone.DeletionTimestamp.Time) > OpenBaoAdoptionWaitTimeout
+
 	for _, name := range names {
 		key := client.ObjectKey{Namespace: keystone.Namespace, Name: name}
 		ps := &esov1alpha1.PushSecret{}
@@ -231,6 +250,17 @@ func (r *KeystoneReconciler) finalizeOpenBaoSecrets(
 			continue
 		}
 		if !hasESOFinalizer(ps) {
+			if adoptionDeadlinePassed {
+				// Bounded wait exceeded — surface the force-delete and break to
+				// Pass-1 rather than blocking forever (issue #475).
+				r.Recorder.Eventf(keystone, corev1.EventTypeWarning, "ESOAdoptionTimedOut",
+					"PushSecret %q not adopted by ESO within %s of deletion; force-deleting "+
+						"to release the openbao-finalizer (the OpenBao kv-v2 path may be "+
+						"orphaned only if ESO is not running)", name, OpenBaoAdoptionWaitTimeout)
+				logger.Info("openbao finalizer adoption wait timed out; proceeding to force-delete",
+					"pushsecret", name, "timeout", OpenBaoAdoptionWaitTimeout)
+				break
+			}
 			setOpenBaoWaitingForESOAdoptionCondition(keystone, name)
 			logger.V(1).Info("openbao finalizer waiting for ESO adoption",
 				"pushsecret", name)

--- a/operators/keystone/internal/controller/reconcile_secrets.go
+++ b/operators/keystone/internal/controller/reconcile_secrets.go
@@ -39,21 +39,26 @@ const openBaoClusterStoreName = "openbao-cluster-store"
 // REQ-005).
 const keystoneOpenBaoFinalizer = "keystone.openstack.c5c3.io/openbao-finalizer"
 
-// esoPushSecretFinalizer is the cleanup finalizer ESO installs on every
-// PushSecret it adopts. The openbao-finalizer handler must observe this
-// finalizer on each backup PushSecret before issuing Delete — otherwise the
-// operator's Delete can race ahead of ESO's first reconcile, remove the
-// PushSecret object outright, and leave the referenced KV-v2 path orphaned
-// in OpenBao (CC-0091, REQ-007). Declared once as the single source of truth
-// for the handler and tests.
+// esoPushSecretFinalizer is the finalizer ESO installs on a PushSecret when it
+// adopts (begins managing) the object. Its presence is the Pass-0 *adoption*
+// signal — NOT a remote-cleanup marker: finalizeOpenBaoSecrets requires it on
+// each backup PushSecret before issuing Delete, because a Delete that races
+// ahead of ESO's first reconcile would remove the PushSecret outright and
+// leave the referenced KV-v2 path orphaned in OpenBao (CC-0091, REQ-007). This
+// is the literal hasESOFinalizer checks and the only ESO finalizer production
+// code branches on. The pinned ESO version's use of this exact string is
+// asserted by the deletion-cleanup e2e suite, so an upstream rename fails CI
+// loudly instead of hanging CR deletion at WaitingForESOAdoption (issue #475).
+// Declared once as the single source of truth for the handler and tests.
 const esoPushSecretFinalizer = "pushsecret.externalsecrets.io/finalizer"
 
-// esoCleanupFinalizer is the cleanup finalizer external-secrets installs on a
-// PushSecret while it purges the remote kv-v2 path (spec.deletionPolicy=Delete).
-// The operator does not add or remove this finalizer itself; it is declared
-// here as the single source of truth so both unit tests (default build) and
-// integration tests (//go:build integration) reference one identical string
-// rather than hard-coding the literal in two places (CC-0092, REQ-004).
+// esoCleanupFinalizer is the *remote-purge* finalizer external-secrets uses
+// while it deletes the kv-v2 path for a PushSecret with
+// spec.deletionPolicy=Delete. Production code never adds, removes, or branches
+// on it; it is declared here only so the tests can simulate ESO holding a
+// PushSecret Terminating during remote cleanup, using one identical string in
+// both unit tests (default build) and integration tests (//go:build
+// integration) rather than hard-coding the literal twice (CC-0092, REQ-004).
 const esoCleanupFinalizer = "external-secrets.io/cleanup"
 
 // reconcileSecrets checks that ESO-provided Kubernetes Secrets exist before

--- a/operators/keystone/internal/controller/reconcile_secrets_test.go
+++ b/operators/keystone/internal/controller/reconcile_secrets_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -1151,6 +1152,87 @@ func TestFinalizeOpenBaoSecrets_BlocksOnMissingESOAdoption(t *testing.T) {
 	// unadopted name encountered is fernet.
 	g.Expect(cond.Message).To(ContainSubstring("test-keystone-fernet-keys-backup"))
 	g.Expect(cond.ObservedGeneration).To(Equal(ks.Generation))
+}
+
+// TestFinalizeOpenBaoSecrets_ProceedsAfterAdoptionTimeout pins the bounded
+// Pass-0 wait (issue #475): once the Keystone CR has been deleting for longer
+// than OpenBaoAdoptionWaitTimeout, an unadopted backup PushSecret no longer
+// blocks — the handler emits an ESOAdoptionTimedOut Warning and force-deletes
+// it via Pass-1 so CR deletion cannot hang forever at WaitingForESOAdoption.
+func TestFinalizeOpenBaoSecrets_ProceedsAfterAdoptionTimeout(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+	ks.DeletionTimestamp = &metav1.Time{
+		Time: time.Now().Add(-(OpenBaoAdoptionWaitTimeout + time.Minute)),
+	}
+
+	fernet := backupPushSecretUnadopted("test-keystone-fernet-keys-backup")
+	credential := backupPushSecretUnadopted("test-keystone-credential-keys-backup")
+
+	var deleteCount int
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(fernet, credential).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCount++
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	rec := record.NewFakeRecorder(10)
+	r := &KeystoneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	done, err := r.finalizeOpenBaoSecrets(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	// Unadopted PushSecrets carry no finalizer, so the force-delete removes
+	// them outright and Pass-2 observes them gone.
+	g.Expect(done).To(BeTrue())
+	g.Expect(deleteCount).To(BeNumerically(">=", 1),
+		"adoption timeout must force at least one Delete instead of blocking forever")
+	g.Expect(drainEventReasons(rec)).To(ContainElement("ESOAdoptionTimedOut"))
+}
+
+// TestFinalizeOpenBaoSecrets_BlocksWithinAdoptionWindow verifies the bounded
+// wait does not fire early: a CR deleting for less than
+// OpenBaoAdoptionWaitTimeout still blocks on an unadopted PushSecret with
+// WaitingForESOAdoption and fires no Delete (issue #475).
+func TestFinalizeOpenBaoSecrets_BlocksWithinAdoptionWindow(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := secretsTestScheme()
+	ks := secretsTestKeystone()
+	ks.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(-time.Second)}
+
+	fernet := backupPushSecretUnadopted("test-keystone-fernet-keys-backup")
+	credential := backupPushSecretUnadopted("test-keystone-credential-keys-backup")
+
+	var deleteCount int
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(fernet, credential).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCount++
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	rec := record.NewFakeRecorder(10)
+	r := &KeystoneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	done, err := r.finalizeOpenBaoSecrets(context.Background(), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(done).To(BeFalse())
+	g.Expect(deleteCount).To(Equal(0),
+		"within the adoption window Pass-0 must still block before any Delete")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, "SecretsReady")
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Reason).To(Equal("WaitingForESOAdoption"))
+	g.Expect(drainEventReasons(rec)).NotTo(ContainElement("ESOAdoptionTimedOut"))
 }
 
 // TestFinalizeOpenBaoSecrets_ProceedsOnceAdopted verifies that once ESO has

--- a/operators/keystone/internal/controller/requeue_intervals.go
+++ b/operators/keystone/internal/controller/requeue_intervals.go
@@ -50,4 +50,14 @@ const (
 	// request. Prevents a hanging Keystone API from blocking the reconcile
 	// loop indefinitely (CC-0067).
 	HealthCheckTimeout = 10 * time.Second
+
+	// OpenBaoAdoptionWaitTimeout bounds how long the OpenBao finalizer's Pass-0
+	// adoption gate blocks Keystone CR deletion while waiting for ESO to stamp
+	// its cleanup finalizer on a backup PushSecret. ESO adoption normally
+	// completes within seconds, so this is generous enough never to trip under
+	// healthy operation; it exists so a renamed or absent ESO finalizer cannot
+	// hang CR deletion forever at WaitingForESOAdoption. Once exceeded, Pass-1
+	// force-deletes the unadopted PushSecret after an ESOAdoptionTimedOut
+	// Warning event (issue #475).
+	OpenBaoAdoptionWaitTimeout = 10 * time.Minute
 )

--- a/operators/keystone/internal/controller/rotation_staging.go
+++ b/operators/keystone/internal/controller/rotation_staging.go
@@ -157,8 +157,11 @@ func (r *KeystoneReconciler) ensureStagingSecret(
 //     RFC3339; a malformed annotation emits a Warning event and is retried on
 //     the next CronJob run (no requeue-with-error).
 //  3. Validate the Secret's Data via validateRotationOutput; a rejection
-//     emits a Warning event and retains the staging Secret for operator
-//     inspection.
+//     emits a Warning event and clears the staged Data and completion
+//     annotation (the staging Secret object is kept) so the next CronJob
+//     strategic-merge PATCH starts from an empty base rather than
+//     accumulating leftover key indices over a rejected payload. The Warning
+//     event message — not the now-empty staging Data — is the diagnostic.
 //  4. GET the main Secret, replace its Data with the staging payload verbatim,
 //     and Update — full-object replacement guarantees the atomic-swap
 //     semantics (stale indices not in the staging payload are removed).
@@ -236,10 +239,32 @@ func (r *KeystoneReconciler) applyRotationOutput(
 		return false, nil
 	}
 
-	// 3. Validate staging payload.
+	// 3. Validate staging payload. On rejection, clear the staged Data and the
+	//    completion annotation before returning. The rotation scripts PATCH the
+	//    staging Secret with strategic-merge semantics over a multi-key `.data`
+	//    map (scripts/fernet_rotate.sh, credential_rotate.sh), so leftover key
+	//    indices from a rejected payload would otherwise survive and merge under
+	//    the next CronJob run — letting validateRotationOutput accept a key set
+	//    keystone-manage never produced together. Clearing makes the next PATCH
+	//    start from an empty base. The RotationRejected event message (not the
+	//    now-empty staging Data) is the diagnostic of record (issue #475).
 	if valErr := validateRotationOutput(staging.Data, minKeys, maxKeys); valErr != nil {
 		r.Recorder.Eventf(keystone, corev1.EventTypeWarning, "RotationRejected",
 			"staging secret %s rejected: %v", stagingSecretName, valErr)
+		staging.Data = nil
+		delete(staging.Annotations, RotationCompletedAnnotation)
+		if updErr := r.Update(ctx, &staging); updErr != nil {
+			if !apierrors.IsConflict(updErr) && !apierrors.IsNotFound(updErr) {
+				return false, fmt.Errorf("clearing rejected staging secret %s: %w", stagingSecretName, updErr)
+			}
+			// A concurrent CronJob PATCH (Conflict) or a manual delete
+			// (NotFound) raced the clear; the next reconcile re-reads and
+			// re-validates, so the stale base cannot survive (issue #475).
+			log.FromContext(ctx).V(1).Info(
+				"rejected staging secret changed since read; clear retried next reconcile",
+				"staging", stagingSecretName,
+			)
+		}
 		return false, nil
 	}
 

--- a/operators/keystone/internal/controller/rotation_staging.go
+++ b/operators/keystone/internal/controller/rotation_staging.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -161,7 +162,8 @@ func (r *KeystoneReconciler) ensureStagingSecret(
 //  4. GET the main Secret, replace its Data with the staging payload verbatim,
 //     and Update — full-object replacement guarantees the atomic-swap
 //     semantics (stale indices not in the staging payload are removed).
-//  5. DELETE the staging Secret (tolerate NotFound for races).
+//  5. DELETE the staging Secret under client.Preconditions{UID,
+//     ResourceVersion} from the step-1 read; tolerate NotFound and Conflict.
 //  6. Emit a Normal event with the given eventReason.
 //
 // DECISION (CC-0081): UPDATE-then-DELETE ordering — if DELETE fails, the
@@ -170,6 +172,16 @@ func (r *KeystoneReconciler) ensureStagingSecret(
 // (and a stale, pre-this-run annotation would fail validation the same way
 // on retry). Tolerating NotFound on DELETE handles the common race where a
 // human operator removed the staging Secret by hand.
+//
+// DECISION (CC-0081): the step-5 DELETE carries client.Preconditions with the
+// UID and ResourceVersion read in step 1. An unconditional DELETE would
+// silently remove a staging Secret the CronJob had PATCHed with fresh rotation
+// output between the step-1 Get and the DELETE, losing that output uncommitted.
+// With the preconditions the API server returns 409 Conflict instead; the
+// newer payload survives on the staging Secret and commits on the next
+// reconcile. Both Conflict (concurrent PATCH) and NotFound (concurrent delete)
+// are therefore tolerated — this run's payload is already on the production
+// Secret, so the apply is complete either way.
 //
 // DECISION (CC-0081): The production Secret's `.data` field is fully
 // replaced under the controller-owned ResourceVersion via a GET+Update
@@ -254,9 +266,22 @@ func (r *KeystoneReconciler) applyRotationOutput(
 		return false, fmt.Errorf("updating main secret %s: %w", mainSecretName, updateErr)
 	}
 
-	// 5. DELETE staging Secret; tolerate NotFound for races.
-	if delErr := r.Delete(ctx, &staging); delErr != nil && !apierrors.IsNotFound(delErr) {
-		return false, fmt.Errorf("deleting staging secret %s: %w", stagingSecretName, delErr)
+	// 5. DELETE staging Secret under the UID + ResourceVersion observed at the
+	//    step-1 Get. The preconditions make a concurrent CronJob PATCH (fresh
+	//    rotation output written between the read and this DELETE) surface as
+	//    409 Conflict rather than being silently deleted uncommitted; the newer
+	//    payload then commits on the next reconcile. Conflict and NotFound are
+	//    both tolerated — this run's payload is already on the production Secret
+	//    (CC-0081).
+	delOpts := client.Preconditions{UID: &staging.UID, ResourceVersion: &staging.ResourceVersion}
+	if delErr := r.Delete(ctx, &staging, delOpts); delErr != nil {
+		if !apierrors.IsNotFound(delErr) && !apierrors.IsConflict(delErr) {
+			return false, fmt.Errorf("deleting staging secret %s: %w", stagingSecretName, delErr)
+		}
+		log.FromContext(ctx).V(1).Info(
+			"staging secret changed since read; newer rotation output applied next reconcile",
+			"staging", stagingSecretName,
+		)
 	}
 
 	// 6. Emit a success event. Count reflects the number of active keys now

--- a/operators/keystone/internal/controller/rotation_staging_apply_test.go
+++ b/operators/keystone/internal/controller/rotation_staging_apply_test.go
@@ -12,6 +12,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -321,6 +323,91 @@ func TestApplyRotationOutput_HappyPath(t *testing.T) {
 	err = r.Get(context.Background(),
 		types.NamespacedName{Name: fernetStagingSecretName(ks), Namespace: "default"}, &gotStaging)
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "staging Secret should be deleted after apply")
+
+	expectEvent(g, r, "Normal FernetKeysRotated")
+}
+
+// TestApplyRotationOutput_ConcurrentStagingPatchTolerated is the regression
+// guard for the staging-delete race (issue #475, Problem 1a): the step-5 Delete
+// must carry client.Preconditions{UID, ResourceVersion} from the step-1 read so
+// that a rotation CronJob PATCHing fresh output between the read and the Delete
+// is rejected with 409 Conflict instead of being silently deleted uncommitted.
+// applyRotationOutput must tolerate that Conflict (this run's payload is already
+// on the production Secret) and leave the staging Secret intact so its newer
+// payload commits on the next reconcile (CC-0081).
+func TestApplyRotationOutput_ConcurrentStagingPatchTolerated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := applyTestKeystone()
+	s := testScheme()
+
+	stagingData := makeValidFernetKeys(t, 3)
+	staging := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fernetStagingSecretName(ks),
+			Namespace: "default",
+			UID:       "staging-uid",
+			Annotations: map[string]string{
+				RotationCompletedAnnotation: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+		Data: stagingData,
+	}
+	prod := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-fernet-keys", Namespace: "default"},
+		Data:       map[string][]byte{"0": []byte("existing")},
+	}
+
+	var sawPreconditions *metav1.Preconditions
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(staging, prod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, wc client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if sec, ok := obj.(*corev1.Secret); ok && sec.Name == fernetStagingSecretName(ks) {
+					do := &client.DeleteOptions{}
+					for _, o := range opts {
+						o.ApplyToDelete(do)
+					}
+					sawPreconditions = do.Preconditions
+					// Simulate a CronJob PATCH landing between the operator's
+					// read and this Delete: the precondition no longer matches,
+					// so the API server rejects the Delete with 409 Conflict.
+					return apierrors.NewConflict(corev1.Resource("secrets"), sec.Name,
+						fmt.Errorf("simulated concurrent rotation PATCH"))
+				}
+				return wc.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &KeystoneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	applied, err := r.applyRotationOutput(
+		context.Background(), ks,
+		fernetStagingSecretName(ks),
+		"test-keystone-fernet-keys",
+		"FernetKeysRotated",
+		1, 10,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(applied).To(BeTrue(), "a Conflict on the staging Delete must be tolerated as a completed apply")
+
+	// The Delete carried the UID + ResourceVersion observed at the step-1 read.
+	g.Expect(sawPreconditions).NotTo(BeNil(), "staging Delete must carry client.Preconditions")
+	g.Expect(sawPreconditions.UID).NotTo(BeNil())
+	g.Expect(*sawPreconditions.UID).To(Equal(types.UID("staging-uid")))
+	g.Expect(sawPreconditions.ResourceVersion).NotTo(BeNil())
+	g.Expect(*sawPreconditions.ResourceVersion).NotTo(BeEmpty())
+
+	// Production carries this run's payload (step 4 completed before the Delete).
+	var gotProd corev1.Secret
+	g.Expect(r.Get(context.Background(),
+		types.NamespacedName{Name: "test-keystone-fernet-keys", Namespace: "default"}, &gotProd)).To(Succeed())
+	g.Expect(gotProd.Data).To(HaveLen(len(stagingData)))
+
+	// Staging Secret still present — its newer payload was NOT deleted, so it
+	// commits on the next reconcile rather than being lost (issue #475).
+	g.Expect(r.Get(context.Background(),
+		types.NamespacedName{Name: fernetStagingSecretName(ks), Namespace: "default"}, &corev1.Secret{})).To(Succeed())
 
 	expectEvent(g, r, "Normal FernetKeysRotated")
 }

--- a/operators/keystone/internal/controller/rotation_staging_apply_test.go
+++ b/operators/keystone/internal/controller/rotation_staging_apply_test.go
@@ -228,10 +228,15 @@ func TestApplyRotationOutput_ValidationFailsWrongLength(t *testing.T) {
 		types.NamespacedName{Name: "test-keystone-fernet-keys", Namespace: "default"}, &gotProd)).To(Succeed())
 	g.Expect(gotProd.Data).To(HaveKeyWithValue("0", []byte("existing")))
 
-	// Staging retained.
+	// Staging Secret retained but cleared: Data emptied and the completion
+	// annotation removed so the next CronJob strategic-merge PATCH starts from
+	// an empty base rather than accumulating over the rejected payload (#475).
 	var gotStaging corev1.Secret
 	g.Expect(r.Get(context.Background(),
 		types.NamespacedName{Name: fernetStagingSecretName(ks), Namespace: "default"}, &gotStaging)).To(Succeed())
+	g.Expect(gotStaging.Data).To(BeEmpty(), "rejected staging Data must be cleared (issue #475)")
+	g.Expect(gotStaging.Annotations).NotTo(HaveKey(RotationCompletedAnnotation),
+		"rejected staging completion annotation must be removed (issue #475)")
 
 	expectEvent(g, r, "Warning RotationRejected")
 }
@@ -272,6 +277,15 @@ func TestApplyRotationOutput_ValidationFailsDuplicates(t *testing.T) {
 	)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(applied).To(BeFalse())
+
+	// Rejected staging payload is cleared (Data emptied, annotation removed)
+	// so a duplicate-key payload cannot persist as a strategic-merge base for
+	// the next CronJob run (issue #475).
+	var gotStaging corev1.Secret
+	g.Expect(r.Get(context.Background(),
+		types.NamespacedName{Name: fernetStagingSecretName(ks), Namespace: "default"}, &gotStaging)).To(Succeed())
+	g.Expect(gotStaging.Data).To(BeEmpty())
+	g.Expect(gotStaging.Annotations).NotTo(HaveKey(RotationCompletedAnnotation))
 
 	expectEvent(g, r, "Warning RotationRejected")
 }

--- a/tests/e2e/keystone/deletion-cleanup/chainsaw-test.yaml
+++ b/tests/e2e/keystone/deletion-cleanup/chainsaw-test.yaml
@@ -52,6 +52,23 @@ spec:
             (conditions[?type == 'Ready']):
             - status: "True"
               reason: AllReady
+    # Pin the ESO adoption-finalizer literal against the deployed ESO version.
+    # The operator's openbao-finalizer Pass-0 adoption gate (and its bounded
+    # adoption-wait timeout) branch on exactly this string; if an ESO upgrade
+    # renames its finalizer, this assertion fails the suite loudly instead of
+    # silently turning CR deletion into a WaitingForESOAdoption hang. Chainsaw
+    # compares the JMESPath result for equality, so contains() (a bool) is
+    # matched against the bool true; the `|| `[]`` fallback lets the assert
+    # retry while the finalizers list is still nil (pre-adoption) rather than
+    # raising a non-retryable type error.
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1alpha1
+          kind: PushSecret
+          metadata:
+            name: keystone-cleanup-fernet-keys-backup
+            namespace: openstack
+            (contains(finalizers || `[]`, 'pushsecret.externalsecrets.io/finalizer')): true
     catch:
     - script:
         content: |


### PR DESCRIPTION
## Summary

Four independent pre-production hardening fixes in the keystone-operator,
each a small, surgical change at the file:line the audit cited. No API-type,
CRD, or RBAC changes were required (the cert-manager `certificates` verbs are
already granted in the marker and Helm `_helpers.tpl`).

Closes #475

## Changes (in commit order)

1. **`fix(keystone-operator): guard rotation staging delete with preconditions`**
   — Problem 1a. The split-compute-write commit deleted the staging Secret with
   an unconditional `Delete`; a rotation CronJob PATCHing fresh output between
   the operator's read and the delete had that output removed uncommitted. Both
   `applyRotationOutput` (fernet/credential) and `applyAdminPasswordRotation`
   now carry `client.Preconditions{UID, ResourceVersion}` on the delete and
   tolerate the resulting 409 Conflict — the newer payload survives and commits
   next reconcile.

2. **`fix(keystone-operator): clear rejected rotation staging payload`**
   — Problem 1b. The rotation scripts PATCH with strategic-merge semantics over
   a multi-key `.data` map, so after a `RotationRejected` the next run merged
   over the stale payload and `validateRotationOutput` could accept a key set
   keystone-manage never produced together. The operator now clears
   `staging.Data` and the completion annotation on rejection (the Secret object
   is kept; the Warning event is the diagnostic). The single-key admin-password
   path is intentionally left as-is.

3. **`fix(keystone-operator): bound the OpenBao finalizer adoption wait`**
   — Problem 2 (mechanism). Pass-0 of `finalizeOpenBaoSecrets` blocked CR
   deletion forever if a backup PushSecret never gained ESO's adoption
   finalizer (e.g. an ESO finalizer rename, or ESO down). A new
   `OpenBaoAdoptionWaitTimeout` (10m) bounds the wait: past it the handler emits
   an `ESOAdoptionTimedOut` Warning and force-deletes via Pass-1. Safe in the
   rename case (ESO still purges via its renamed finalizer); orphans the kv-v2
   path only if ESO is genuinely down — an explicit, event-surfaced trade-off
   over hanging.

4. **`fix(keystone-operator): correct ESO finalizer comments, assert in e2e`**
   — Problem 2 (contract). The two finalizer constants both called themselves
   "the cleanup finalizer". Their comments now distinguish the
   *adoption* finalizer (`pushsecret.externalsecrets.io/finalizer`, the only one
   production branches on) from the test-only *remote-purge* finalizer. The
   `deletion-cleanup` chainsaw suite now asserts the adoption literal against
   the deployed ESO version before deletion, so an upstream rename fails CI
   loudly instead of hanging.

5. **`fix(keystone-operator): delete managed DB-client cert on TLS disable`**
   — Problem 3. Disabling `spec.database.tls` (or switching to brownfield) left
   the managed `<name>-db-client` Certificate being renewed by cert-manager
   until CR deletion. `reconcileDatabaseTLS` now deletes it on both non-managed
   paths (cert-manager GCs the issued Secret via the owner-ref cascade), and a
   cert-manager-CRD-gated `Owns(Certificate)` watch reflects later issuance
   failures in `DatabaseTLSReady`. Both are gated on a `RESTMapper` probe
   mirroring the Gateway-API/HTTPRoute pattern, so the default no-TLS config
   never errors with "no matches for kind Certificate".

6. **`docs(keystone-operator): fix upgrade-job comment and rotation-age note`**
   — Problem 4. `buildUpgradeJob`'s comment claimed expand/migrate use the old
   release; all three phases actually run the new image — corrected so it no
   longer misleads on-call. Documented that `rotation-completed-at` for
   `key_type="admin-password"` marks commit-to-push-source (not time-since-live,
   which lags by the full ESO round-trip + bootstrap re-run, ~1h+), in the
   reconciler comments and the metrics reference.

## Tests

- New unit tests for: precondition-guarded staging delete tolerating Conflict
  (fernet + admin-password); rejected-staging clearing; bounded adoption wait
  (proceeds after timeout / blocks within window); DB-client Certificate delete
  on disable + brownfield + cert-manager-absent skip; `isCertManagerAvailable`.
- Existing rejection tests strengthened to assert the cleared staging payload.
- New e2e assertion pins the ESO adoption-finalizer literal in
  `tests/e2e/keystone/deletion-cleanup/`.

## Local verification

- `make test-operator OPERATOR=keystone` — pass (controller 88.3%)
- `go test -race ./operators/keystone/internal/controller/` — pass
- `golangci-lint run ./...` (keystone module) — 0 issues; `gofmt -l` clean
- `make check-docs-ids` — pass
- `go vet -tags=integration` — compiles. envtest/kind suites (integration, e2e)
  deferred to CI; the bounded-wait change only alters behavior after 10m, which
  no integration test triggers.

## Deviations from the issue

- **Admin-password sibling (1a):** the issue cites only `rotation_staging.go`,
  but `applyAdminPasswordRotation` has the identical delete race, so the
  precondition fix is applied there too (project "apply bug fixes to all
  instances" pattern).
- **Problem 4b** takes the lighter "document" option (proportionate to a
  "Minor" item); stamping `rotation-completed-at` on bootstrap completion would
  require threading the timestamp through the bootstrap re-run path and is left
  for a separate issue.
- Folded the planned dedicated `RejectionClearsStagingData` test into the two
  existing rejection tests (which now assert clearing) to avoid a near-duplicate
  test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
