### PR TITLE
feat(c5c3-operator): deletion orchestration — sequence ORC teardown before Keystone/infrastructure

### DIFF
--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -27,8 +27,10 @@ owns child CRs (MariaDB, Memcached, Keystone, K-ORC `ApplicationCredential` /
 `Service` / `Endpoint`) and aggregates their readiness. It does **not**
 re-implement the per-service logic those child operators already own. As a
 consequence the c5c3 API surface is deliberately smaller than the
-[Keystone reconciler](../keystone/keystone-reconciler.md)'s: there is no
-finalizer, no parallel sub-reconciler group, and no per-CR metric cardinality.
+[Keystone reconciler](../keystone/keystone-reconciler.md)'s: no parallel
+sub-reconciler group and no per-CR metric cardinality. It does install a single
+finalizer to sequence K-ORC teardown ahead of Keystone/infrastructure teardown
+on deletion — see [Owner-ref / GC model](#owner-ref--gc-model).
 
 ## Controller Registration
 
@@ -974,11 +976,40 @@ ControlPlane CR via `controllerutil.SetControllerReference()`. This enables both
 children) and **watch-based reconciliation** (a child change re-reconciles the
 owner).
 
-> **No finalizer.** Unlike the
-> [Keystone reconciler](../keystone/keystone-reconciler.md#finalizer), the
-> ControlPlane reconciler installs **no finalizer**. Teardown is driven entirely
-> by owner-reference garbage collection — there is no ordered external cleanup
-> the operator must perform before the CR leaves etcd.
+### Deletion ordering — the `c5c3.io/orc-teardown` finalizer
+
+Owner-reference GC alone is **unordered**: deleting the ControlPlane would
+garbage-collect every child at once. That is unsafe for the K-ORC CRs the
+operator owns (`ApplicationCredential`, `Service`, `Endpoint`, `User`,
+`Domain`). Those CRs carry K-ORC finalizers that call the **Keystone API** to
+revoke/delete the credentials and catalog entries they minted; if Keystone (and
+in managed mode its MariaDB) were torn down concurrently, the K-ORC finalizers
+could never complete and the ControlPlane — and its namespace — would hang
+indefinitely on Terminating ORC CRs.
+
+The ControlPlane reconciler therefore installs a single finalizer,
+`c5c3.io/orc-teardown`, added on the first reconcile before any K-ORC CR is
+projected. On deletion it:
+
+1. **Deletes the owned K-ORC CRs first** and holds the ControlPlane CR in etcd.
+   Holding the CR defers the owner-reference GC cascade, so Keystone stays
+   reachable while K-ORC revokes. While ORC CRs are still Terminating the
+   reconciler reports `KORCReady=False` with reason `FinalizingORC` and requeues
+   at the K-ORC cadence.
+2. **Releases the finalizer once the ORC CRs are gone**, letting GC cascade-
+   delete Keystone, the infrastructure, and the remaining children.
+3. **Bounds the wait.** If the ORC CRs stay Terminating longer than the
+   `orcTeardownStallTimeout` (5 minutes) — typically because Keystone is already
+   gone and K-ORC cannot revoke — the reconciler force-removes the stuck
+   `openstack.k-orc.cloud/*` finalizers (preserving any non-K-ORC finalizers),
+   emits a **Warning** `ORCTeardownStalled` event, and releases the ControlPlane
+   finalizer so deletion completes rather than wedging forever.
+
+This mirrors the Keystone reconciler's sequenced-finalizer discipline (MariaDB
+then OpenBao cleanup); see
+[Keystone reconciler — finalizer](../keystone/keystone-reconciler.md#finalizer).
+The `{name}-admin-app-credential-backup` PushSecret is the one child kept on
+`DeletionPolicy: None` so its OpenBao path is not purged on teardown.
 
 > **Children live in the owner's namespace.** Every projected child is created in
 > `childNamespace(cp) = cp.Namespace`, **not** a hardcoded `openstack`. A

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -59,6 +60,16 @@ const (
 	conditionTypeCatalogReady         = "CatalogReady"
 	conditionTypeReady                = "Ready"
 )
+
+// controlPlaneORCFinalizer blocks the ControlPlane CR from leaving etcd until
+// the operator has torn down the K-ORC CRs it owns
+// (ApplicationCredential/Service/Endpoint/User/Domain). Those CRs carry K-ORC
+// finalizers that revoke/delete against the Keystone API; holding the
+// ControlPlane CR in etcd defers the owner-reference GC cascade that would
+// otherwise tear Keystone (and its MariaDB) down concurrently, keeping Keystone
+// reachable so K-ORC can finish. Defined once as the single source of truth for
+// Reconcile, reconcileDelete, tests, and docs.
+const controlPlaneORCFinalizer = "c5c3.io/orc-teardown"
 
 // subConditionTypes lists the condition types set by individual sub-reconcilers.
 // The Ready condition is True only when all of these are True.
@@ -106,6 +117,24 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("fetching ControlPlane: %w", err)
 	}
 
+	// Handle deletion via the ORC-teardown finalizer: delete the operator-owned
+	// K-ORC CRs first and hold the ControlPlane CR (which defers the owner-ref GC
+	// cascade so Keystone/MariaDB stay reachable) until they disappear, then
+	// release the finalizer so GC tears down the rest. reconcileDelete requeues
+	// while ORC CRs are still Terminating; route that path through updateStatus so
+	// the KORCReady=False/FinalizingORC condition is persisted. On the terminal
+	// release path it returns a zero result and removes the finalizer, so skip the
+	// status write — the CR is about to be garbage-collected. Deletion is handled
+	// before the duplicate guard so a Terminating ControlPlane that carries the
+	// finalizer always releases it (reconcileDelete is a no-op when the finalizer
+	// is absent), instead of being parked and wedged.
+	if !cp.DeletionTimestamp.IsZero() {
+		if result, err := r.reconcileDelete(ctx, &cp); !result.IsZero() || err != nil {
+			return r.updateStatus(ctx, &cp, result, err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// Defense-in-depth for the one-ControlPlane-per-namespace contract
 	// the validating webhook rejects duplicate CREATEs,
 	// but CRs that predate the guard, raced through the API server, or were
@@ -120,6 +149,21 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	if incumbent != "" {
 		return r.parkDuplicateControlPlane(ctx, &cp, incumbent)
+	}
+
+	// Ensure the ORC-teardown finalizer is installed before any sub-reconciler
+	// projects a K-ORC CR, so a deletion issued between now and the next pass
+	// still funnels through reconcileDelete. Installed after the duplicate guard
+	// so only the active incumbent — the ControlPlane that actually projects K-ORC
+	// CRs — carries the finalizer; parked duplicates return above and never need
+	// it. Returning Requeue=true after the Update guarantees the next reconcile
+	// observes the persisted finalizer.
+	if !controllerutil.ContainsFinalizer(&cp, controlPlaneORCFinalizer) {
+		controllerutil.AddFinalizer(&cp, controlPlaneORCFinalizer)
+		if err := r.Update(ctx, &cp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("adding finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Run sub-reconcilers in dependency order. Every sub-reconciler call is

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/c5c3/forge/internal/common/testutil/simulators"
@@ -1243,4 +1244,125 @@ func TestIntegration_MultiControlPlane_DistinctDBCredentialPaths(t *testing.T) {
 	// materialised Secret in the (separate) namespaces.
 	g.Expect(dbCredentialSecretName(cpA)).NotTo(Equal(dbCredentialSecretName(cpB)),
 		"the two ControlPlanes' DB credential Secret names must be distinct")
+}
+
+// fakeKORCFinalizer mimics the finalizer K-ORC adds to the ApplicationCredential
+// it manages. envtest runs no K-ORC controller, so the test injects this
+// finalizer to hold the AC Terminating exactly as a real revoke-against-Keystone
+// finalizer would, then removes it to let teardown complete.
+const fakeKORCFinalizer = "openstack.k-orc.cloud/applicationcredential"
+
+// TestIntegration_ControlPlaneDeletion_SequencesORCTeardown proves the
+// ORC-teardown finalizer sequences deletion: the operator deletes the owned
+// K-ORC ApplicationCredential FIRST and holds the ControlPlane CR (and thus,
+// via the deferred owner-ref GC cascade, the projected Keystone child) until the
+// AC is gone, then releases the finalizer so the rest can be garbage-collected.
+//
+// envtest runs no garbage collector, so the owner-ref cascade that tears down
+// Keystone/MariaDB once the ControlPlane CR is removed is asserted in the e2e
+// test, not here. What this test pins is the sequencing invariant the finalizer
+// adds on top of GC: while a K-ORC CR is still Terminating, the ControlPlane CR
+// is held and Keystone is NOT yet torn down.
+func TestIntegration_ControlPlaneDeletion_SequencesORCTeardown(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	// The OpenBao-backed ClusterSecretStore must be Ready before the chain
+	// reaches the credential gates (#476); otherwise reconcileDBCredentials
+	// short-circuits at SecretStoreNotReady and never projects the DB-credential
+	// ExternalSecret driveControlPlaneToAdminCredentialReady waits for.
+	ensureReadyClusterSecretStore(t, ctx, c)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cp-deletion-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed(), "create test namespace")
+
+	cp := integrationMinimalControlPlane("cp", ns.Name)
+	g.Expect(c.Create(ctx, cp)).To(Succeed(), "create ControlPlane CR")
+	cpKey := types.NamespacedName{Name: cp.Name, Namespace: ns.Name}
+
+	// Drive the chain until the K-ORC ApplicationCredential and the projected
+	// Keystone child exist.
+	driveControlPlaneToAdminCredentialReady(t, ctx, c, cp)
+
+	acKey := types.NamespacedName{Name: adminAppCredentialName(cp), Namespace: ns.Name}
+	ksKey := types.NamespacedName{Name: keystoneName(cp), Namespace: ns.Name}
+	g.Expect(c.Get(ctx, ksKey, &keystonev1alpha1.Keystone{})).To(Succeed(),
+		"projected Keystone child must exist before deletion")
+
+	// The ControlPlane must carry the ORC-teardown finalizer once reconciled.
+	g.Eventually(func() bool {
+		got := &c5c3v1alpha1.ControlPlane{}
+		if err := c.Get(ctx, cpKey, got); err != nil {
+			return false
+		}
+		return controllerutil.ContainsFinalizer(got, controlPlaneORCFinalizer)
+	}, itEventuallyTimeout, itPollInterval).Should(BeTrue(), "ControlPlane must carry the ORC-teardown finalizer")
+
+	// Inject a fake K-ORC finalizer onto the AC so deleting it leaves it
+	// Terminating (as a real revoke-against-Keystone finalizer would), rather
+	// than removing it outright in the GC-less envtest.
+	g.Eventually(func() error {
+		ac := &orcv1alpha1.ApplicationCredential{}
+		if err := c.Get(ctx, acKey, ac); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(ac, fakeKORCFinalizer) {
+			return nil
+		}
+		controllerutil.AddFinalizer(ac, fakeKORCFinalizer)
+		return c.Update(ctx, ac)
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "inject fake K-ORC finalizer on the AC")
+
+	// Delete the ControlPlane.
+	g.Expect(c.Delete(ctx, cp)).To(Succeed(), "delete ControlPlane CR")
+
+	// Teardown must be initiated: the operator deletes the AC, which is held
+	// Terminating by the fake K-ORC finalizer.
+	g.Eventually(func() bool {
+		ac := &orcv1alpha1.ApplicationCredential{}
+		if err := c.Get(ctx, acKey, ac); err != nil {
+			return false
+		}
+		return !ac.DeletionTimestamp.IsZero()
+	}, itEventuallyTimeout, itPollInterval).Should(BeTrue(), "operator must delete the owned AC first")
+
+	// Sequencing invariant: while the AC is still Terminating, the ControlPlane
+	// CR is HELD (finalizer not released) and the Keystone child is NOT torn down.
+	g.Consistently(func() bool {
+		gotCP := &c5c3v1alpha1.ControlPlane{}
+		if err := c.Get(ctx, cpKey, gotCP); err != nil {
+			return false
+		}
+		if !controllerutil.ContainsFinalizer(gotCP, controlPlaneORCFinalizer) {
+			return false
+		}
+		return c.Get(ctx, ksKey, &keystonev1alpha1.Keystone{}) == nil
+	}, 3*time.Second, itPollInterval).Should(BeTrue(),
+		"ControlPlane finalizer must hold (and Keystone must survive) while the K-ORC CR is Terminating")
+
+	// Release the AC by removing the fake finalizer; the operator then releases
+	// the ControlPlane finalizer.
+	g.Eventually(func() error {
+		ac := &orcv1alpha1.ApplicationCredential{}
+		err := c.Get(ctx, acKey, ac)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		controllerutil.RemoveFinalizer(ac, fakeKORCFinalizer)
+		return c.Update(ctx, ac)
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "remove fake K-ORC finalizer from the AC")
+
+	// Once the AC is gone the operator releases the ControlPlane finalizer, so
+	// both objects disappear.
+	g.Eventually(func() bool {
+		acErr := c.Get(ctx, acKey, &orcv1alpha1.ApplicationCredential{})
+		cpErr := c.Get(ctx, cpKey, &c5c3v1alpha1.ControlPlane{})
+		return apierrors.IsNotFound(acErr) && apierrors.IsNotFound(cpErr)
+	}, itEventuallyTimeout, itPollInterval).Should(BeTrue(),
+		"AC and ControlPlane must be removed once the K-ORC finalizer clears")
 }

--- a/operators/c5c3/internal/controller/reconcile_delete.go
+++ b/operators/c5c3/internal/controller/reconcile_delete.go
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// korcFinalizerPrefix is the common prefix of the finalizers K-ORC adds to the
+// CRs it manages (e.g. "openstack.k-orc.cloud/applicationcredential"). The
+// group prefix is stable across every K-ORC kind, so prefix-matching is what the
+// stall escape uses to strip K-ORC's finalizers without hard-coding a suffix per
+// kind. Non-K-ORC finalizers on the same object are preserved.
+const korcFinalizerPrefix = orcv1alpha1.GroupName + "/"
+
+// orcChildResources is the single source of truth for the K-ORC CRs the
+// ControlPlane owns and must tear down first. Both the deletion sweep
+// (deleteORCResources) and the stall escape (forceRemoveKORCFinalizers, via the
+// objects it returns) iterate this list, so adding a kind only requires one
+// entry here. Each newObj returns a zeroed object for Get/Delete; name derives
+// the deterministic per-ControlPlane CR name (all live in childNamespace(cp)).
+var orcChildResources = []struct {
+	newObj func() client.Object
+	name   func(*c5c3v1alpha1.ControlPlane) string
+}{
+	{func() client.Object { return &orcv1alpha1.ApplicationCredential{} }, adminAppCredentialName},
+	{func() client.Object { return &orcv1alpha1.Service{} }, keystoneServiceName},
+	{func() client.Object { return &orcv1alpha1.Endpoint{} }, keystoneEndpointName},
+	{func() client.Object { return &orcv1alpha1.User{} }, adminUserRef},
+	{func() client.Object { return &orcv1alpha1.Domain{} }, adminDomainRef},
+}
+
+// reconcileDelete drives the ORC-teardown finalizer when the ControlPlane CR is
+// being deleted. It is a no-op if the finalizer is absent.
+//
+// The ControlPlane owns K-ORC CRs whose finalizers revoke/delete against the
+// Keystone API. If the owner-reference GC cascade ran unsequenced, Keystone (and
+// in managed mode its MariaDB) would be torn down at the same time as those ORC
+// CRs, so the K-ORC finalizers could never complete and the ControlPlane /
+// namespace would hang indefinitely on Terminating ORC CRs. Holding the
+// ControlPlane CR in etcd (via this finalizer) defers the GC cascade, keeping
+// Keystone reachable while K-ORC revokes. The flow:
+//
+//  1. Delete every owned K-ORC CR (idempotent; NotFound / CRD-absent tolerated)
+//     and collect those still present (Terminating behind a K-ORC finalizer).
+//  2. When none remain, release the finalizer so GC tears down the rest.
+//  3. While some remain and the bounded orcTeardownStallTimeout has not elapsed,
+//     report KORCReady=False/FinalizingORC and requeue.
+//  4. Once the stall timeout elapses (K-ORC cannot make progress — most likely
+//     Keystone is already gone, so it cannot revoke), force-remove the
+//     openstack.k-orc.cloud/* finalizers, emit a Warning event, and release the
+//     ControlPlane finalizer so deletion can complete.
+func (r *ControlPlaneReconciler) reconcileDelete(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(cp, controlPlaneORCFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	remaining, hasLiveWork, err := r.deleteORCResources(ctx, cp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Announce the teardown once, on the first pass where a live (not-yet-
+	// Terminating) ORC CR is observed. Later requeues see only Terminating CRs
+	// and suppress the event, giving exactly-once semantics per deletion.
+	if hasLiveWork {
+		r.Recorder.Event(cp, "Normal", "FinalizingORC",
+			"Deleting owned K-ORC CRs before releasing the ControlPlane so K-ORC can revoke against a reachable Keystone")
+	}
+
+	if len(remaining) == 0 {
+		// Every owned K-ORC CR is gone (revoked and deleted, or never existed).
+		// Release the finalizer so GC tears down Keystone/MariaDB and the rest.
+		r.Recorder.Event(cp, "Normal", "ORCTeardownComplete",
+			"No remaining K-ORC CRs; releasing the ControlPlane finalizer")
+		controllerutil.RemoveFinalizer(cp, controlPlaneORCFinalizer)
+		if err := r.Update(ctx, cp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Some K-ORC CRs are still present — typically Terminating behind a K-ORC
+	// finalizer that revokes against Keystone. Within the stall window, wait and
+	// requeue; updateStatus persists the FinalizingORC condition so the wait is
+	// operator-visible. The reason matches the FinalizingORC event above.
+	if time.Since(cp.DeletionTimestamp.Time) <= orcTeardownStallTimeout {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKORCReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "FinalizingORC",
+			Message: fmt.Sprintf(
+				"waiting for %d K-ORC CR(s) to be revoked and deleted before releasing the ControlPlane",
+				len(remaining),
+			),
+		})
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
+	// Stall timeout elapsed: the K-ORC finalizers cannot complete (most likely
+	// Keystone is already gone, so K-ORC cannot revoke). Force-remove the
+	// openstack.k-orc.cloud/* finalizers so GC can reclaim the stuck CRs, warn so
+	// the wedge is operator-visible, then release the ControlPlane finalizer.
+	if err := r.forceRemoveKORCFinalizers(ctx, remaining); err != nil {
+		return ctrl.Result{}, err
+	}
+	names := make([]string, 0, len(remaining))
+	for _, obj := range remaining {
+		names = append(names, obj.GetName())
+	}
+	r.Recorder.Event(cp, "Warning", "ORCTeardownStalled", fmt.Sprintf(
+		"K-ORC CRs %v stayed Terminating longer than %s (K-ORC may be unable to reach Keystone to revoke); "+
+			"force-removed their K-ORC finalizers and releasing the ControlPlane",
+		names, orcTeardownStallTimeout,
+	))
+	log.FromContext(ctx).Info("ORC teardown stalled; force-removed K-ORC finalizers",
+		"remaining", names, "stallTimeout", orcTeardownStallTimeout)
+
+	controllerutil.RemoveFinalizer(cp, controlPlaneORCFinalizer)
+	if err := r.Update(ctx, cp); err != nil {
+		return ctrl.Result{}, fmt.Errorf("removing finalizer after force-remove: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// deleteORCResources issues an idempotent Delete on every owned K-ORC CR and
+// returns those still present after the sweep. hasLiveWork reports whether any
+// CR was observed live (present, DeletionTimestamp unset) — that is the one-shot
+// signal for the FinalizingORC event. NotFound and "CRD not installed"
+// (meta.IsNoMatchError) are tolerated as already-gone so the finalizer can still
+// release when the K-ORC stack is absent.
+func (r *ControlPlaneReconciler) deleteORCResources(
+	ctx context.Context, cp *c5c3v1alpha1.ControlPlane,
+) (remaining []client.Object, hasLiveWork bool, err error) {
+	logger := log.FromContext(ctx)
+	ns := childNamespace(cp)
+
+	// Pass 1: classify and delete. A present CR with no DeletionTimestamp is the
+	// live work whose Delete starts the teardown.
+	for _, child := range orcChildResources {
+		obj := child.newObj()
+		key := client.ObjectKey{Name: child.name(cp), Namespace: ns}
+		getErr := r.Get(ctx, key, obj)
+		if apierrors.IsNotFound(getErr) || meta.IsNoMatchError(getErr) {
+			continue
+		}
+		if getErr != nil {
+			return nil, false, fmt.Errorf("getting %T %s: %w", obj, key, getErr)
+		}
+		if obj.GetDeletionTimestamp().IsZero() {
+			hasLiveWork = true
+		}
+		if delErr := r.Delete(ctx, obj); delErr != nil {
+			if apierrors.IsNotFound(delErr) || meta.IsNoMatchError(delErr) {
+				continue
+			}
+			return nil, false, fmt.Errorf("deleting %T %s: %w", obj, key, delErr)
+		}
+	}
+
+	// Pass 2: collect the CRs still present after the deletes. Re-Get so the
+	// returned objects carry current finalizers for a possible force-remove.
+	for _, child := range orcChildResources {
+		obj := child.newObj()
+		key := client.ObjectKey{Name: child.name(cp), Namespace: ns}
+		getErr := r.Get(ctx, key, obj)
+		if apierrors.IsNotFound(getErr) || meta.IsNoMatchError(getErr) {
+			continue
+		}
+		if getErr != nil {
+			return nil, false, fmt.Errorf("re-checking %T %s: %w", obj, key, getErr)
+		}
+		remaining = append(remaining, obj)
+		logger.V(1).Info("K-ORC CR still present during ControlPlane teardown",
+			"resource", fmt.Sprintf("%T", obj), "name", key.Name)
+	}
+
+	return remaining, hasLiveWork, nil
+}
+
+// forceRemoveKORCFinalizers strips every openstack.k-orc.cloud/* finalizer from
+// the given objects, preserving any non-K-ORC finalizers, and persists the
+// change. Removing the last finalizer on an already-Terminating CR lets the API
+// server complete its deletion. NotFound is tolerated (GC won the race).
+func (r *ControlPlaneReconciler) forceRemoveKORCFinalizers(ctx context.Context, remaining []client.Object) error {
+	for _, obj := range remaining {
+		original := obj.GetFinalizers()
+		kept := make([]string, 0, len(original))
+		removed := false
+		for _, f := range original {
+			if strings.HasPrefix(f, korcFinalizerPrefix) {
+				removed = true
+				continue
+			}
+			kept = append(kept, f)
+		}
+		if !removed {
+			continue
+		}
+		obj.SetFinalizers(kept)
+		if err := r.Update(ctx, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("force-removing K-ORC finalizers from %T %s: %w",
+				obj, client.ObjectKeyFromObject(obj), err)
+		}
+	}
+	return nil
+}

--- a/operators/c5c3/internal/controller/reconcile_delete_test.go
+++ b/operators/c5c3/internal/controller/reconcile_delete_test.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the ControlPlane ORC-teardown finalizer (reconcileDelete): the
+// ControlPlane CR is held in etcd until the operator-owned K-ORC CRs are gone,
+// with a bounded stall escape that force-removes their finalizers and releases
+// the ControlPlane anyway.
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// drainEvents returns every event currently buffered on the FakeRecorder. Each
+// entry is "<type> <reason> <message>".
+func drainEvents(rec *record.FakeRecorder) []string {
+	var out []string
+	for {
+		select {
+		case e := <-rec.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// deletingControlPlane returns a ControlPlane being deleted (DeletionTimestamp
+// set deletionAge in the past) carrying the ORC-teardown finalizer, so
+// reconcileDelete drives its teardown.
+func deletingControlPlane(deletionAge time.Duration) *c5c3v1alpha1.ControlPlane {
+	cp := korcControlPlane()
+	ts := metav1.NewTime(metav1.Now().Add(-deletionAge))
+	cp.DeletionTimestamp = &ts
+	cp.Finalizers = []string{controlPlaneORCFinalizer}
+	return cp
+}
+
+// TestReconcile_AddsORCFinalizerOnFirstReconcile asserts that a fresh
+// (non-deleting) ControlPlane gets the ORC-teardown finalizer installed and the
+// reconcile requeues before any sub-reconciler runs.
+func TestReconcile_AddsORCFinalizerOnFirstReconcile(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{Requeue: true}),
+		"first reconcile must requeue after installing the finalizer")
+
+	got := &c5c3v1alpha1.ControlPlane{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(got, controlPlaneORCFinalizer)).To(BeTrue(),
+		"the ORC-teardown finalizer must be installed")
+}
+
+// TestReconcileDelete_NoFinalizer_NoOp asserts reconcileDelete is a no-op when
+// the ControlPlane does not carry the ORC-teardown finalizer: it must not touch
+// any K-ORC CR.
+func TestReconcileDelete_NoFinalizer_NoOp(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	ac := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       adminAppCredentialName(cp),
+			Namespace:  childNamespace(cp),
+			Finalizers: []string{"openstack.k-orc.cloud/applicationcredential"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ac).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	// A deleting ControlPlane that carries only a foreign finalizer.
+	del := metav1.Now()
+	cp.DeletionTimestamp = &del
+	cp.Finalizers = []string{"example.com/other"}
+
+	res, err := r.reconcileDelete(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}), "no-op delete must return a zero result")
+
+	got := &orcv1alpha1.ApplicationCredential{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(ac), got)).To(Succeed())
+	g.Expect(got.DeletionTimestamp.IsZero()).To(BeTrue(),
+		"reconcileDelete must not delete K-ORC CRs when its finalizer is absent")
+	g.Expect(drainEvents(rec)).To(BeEmpty(), "no-op delete must not emit events")
+}
+
+// TestReconcileDelete_NoORCResources_ReleasesFinalizer asserts that when no
+// K-ORC CRs remain, the ControlPlane finalizer is released in one pass (and the
+// CR is then garbage-collected).
+func TestReconcileDelete_NoORCResources_ReleasesFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := deletingControlPlane(0)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	// Refresh from the client so the Update carries the right resourceVersion.
+	key := types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}
+	g.Expect(c.Get(context.Background(), key, cp)).To(Succeed())
+
+	res, err := r.reconcileDelete(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}), "release must return a zero result")
+
+	err = c.Get(context.Background(), key, &c5c3v1alpha1.ControlPlane{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"releasing the last finalizer must let the ControlPlane be garbage-collected")
+	g.Expect(drainEvents(rec)).To(ContainElement(ContainSubstring("ORCTeardownComplete")))
+}
+
+// TestReconcileDelete_WaitsWhileORCTerminating asserts that while an owned K-ORC
+// CR is still present, reconcileDelete holds the ControlPlane finalizer, reports
+// KORCReady=False/FinalizingORC, and requeues. Deleting the live CR marks it
+// Terminating (it carries a K-ORC finalizer) and emits FinalizingORC once.
+func TestReconcileDelete_WaitsWhileORCTerminating(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := deletingControlPlane(0)
+	// A live AC (no DeletionTimestamp) carrying a K-ORC finalizer: deleting it
+	// transitions it to Terminating rather than removing it outright.
+	ac := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       adminAppCredentialName(cp),
+			Namespace:  childNamespace(cp),
+			Finalizers: []string{"openstack.k-orc.cloud/applicationcredential"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ac).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	key := types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}
+	g.Expect(c.Get(context.Background(), key, cp)).To(Succeed())
+
+	res, err := r.reconcileDelete(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter),
+		"a still-Terminating K-ORC CR must requeue at the K-ORC cadence")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("FinalizingORC"))
+
+	g.Expect(controllerutil.ContainsFinalizer(cp, controlPlaneORCFinalizer)).To(BeTrue(),
+		"the ControlPlane finalizer must be held while K-ORC CRs remain")
+
+	gotAC := &orcv1alpha1.ApplicationCredential{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(ac), gotAC)).To(Succeed())
+	g.Expect(gotAC.DeletionTimestamp.IsZero()).To(BeFalse(),
+		"the owned K-ORC CR must have been marked for deletion")
+
+	g.Expect(drainEvents(rec)).To(ContainElement(ContainSubstring("FinalizingORC")))
+}
+
+// TestReconcileDelete_ForceRemovesORCFinalizersAfterStall asserts the stall
+// escape: once the ControlPlane has been Terminating past orcTeardownStallTimeout
+// with K-ORC CRs still stuck, reconcileDelete strips their K-ORC finalizers
+// (preserving non-K-ORC finalizers), emits a Warning, and releases the
+// ControlPlane finalizer.
+func TestReconcileDelete_ForceRemovesORCFinalizersAfterStall(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := deletingControlPlane(2 * orcTeardownStallTimeout)
+	// An AC stuck Terminating behind a K-ORC finalizer AND a foreign finalizer
+	// that must survive the force-remove.
+	acDeletion := metav1.NewTime(metav1.Now().Add(-2 * orcTeardownStallTimeout))
+	ac := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              adminAppCredentialName(cp),
+			Namespace:         childNamespace(cp),
+			Finalizers:        []string{"openstack.k-orc.cloud/applicationcredential", "example.com/keep"},
+			DeletionTimestamp: &acDeletion,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ac).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	key := types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}
+	g.Expect(c.Get(context.Background(), key, cp)).To(Succeed())
+
+	res, err := r.reconcileDelete(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}), "the stall escape must release without requeue")
+
+	// The K-ORC finalizer is stripped; the foreign one survives.
+	gotAC := &orcv1alpha1.ApplicationCredential{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(ac), gotAC)).To(Succeed())
+	g.Expect(gotAC.Finalizers).To(Equal([]string{"example.com/keep"}),
+		"only the openstack.k-orc.cloud/* finalizer must be force-removed")
+
+	// The ControlPlane finalizer is released, so the CR is garbage-collected.
+	err = c.Get(context.Background(), key, &c5c3v1alpha1.ControlPlane{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"the ControlPlane finalizer must be released after the stall escape")
+
+	events := drainEvents(rec)
+	g.Expect(events).To(ContainElement(SatisfyAll(
+		ContainSubstring("Warning"),
+		ContainSubstring("ORCTeardownStalled"),
+	)), "the stall escape must emit a Warning ORCTeardownStalled event")
+}

--- a/operators/c5c3/internal/controller/reconcile_delete_test.go
+++ b/operators/c5c3/internal/controller/reconcile_delete_test.go
@@ -33,10 +33,9 @@ import (
 func drainEvents(rec *record.FakeRecorder) []string {
 	var out []string
 	for {
-		select {
-		case e := <-rec.Events:
-			out = append(out, e)
-		default:
+		if len(rec.Events) > 0 {
+			out = append(out, <-rec.Events)
+		} else {
 			return out
 		}
 	}

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -72,4 +72,17 @@ const (
 	// event for the parked CR, so this periodic requeue is what lets the
 	// parked ControlPlane take over once the incumbent is fully gone.
 	duplicateControlPlaneRequeueAfter = 30 * time.Second
+
+	// orcTeardownStallTimeout bounds how long the ControlPlane finalizer waits for
+	// the operator-owned K-ORC CRs (ApplicationCredential/Service/Endpoint/User/
+	// Domain) to disappear during deletion before force-removing their K-ORC
+	// finalizers and releasing the ControlPlane finalizer anyway. Those K-ORC
+	// finalizers revoke/delete against the Keystone API; if Keystone (and in
+	// managed mode its MariaDB) is already gone, K-ORC can never complete and the
+	// ControlPlane/namespace would otherwise hang indefinitely on Terminating ORC
+	// CRs. After this window reconcileDelete strips the openstack.k-orc.cloud/*
+	// finalizers and emits a Warning event so the wedge is operator-visible. The
+	// window mirrors remintStallTimeout: generous enough that a slow-but-
+	// progressing revoke is not cut short.
+	orcTeardownStallTimeout = 5 * time.Minute
 )

--- a/tests/e2e/c5c3/deletion-orchestration/00-controlplane-cr.yaml
+++ b/tests/e2e/c5c3/deletion-orchestration/00-controlplane-cr.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ControlPlane CR fixture for the deletion-orchestration E2E test.
+#
+# Managed mode: database and cache reference managed clusters by clusterRef, so
+# the c5c3-operator projects an owned MariaDB ("openstack-db") and Memcached
+# ("openstack-memcached") in the ControlPlane's own namespace (openstack) — the
+# same cluster names the deploy stack and the full-controlplane-keystone suite
+# use, so this test exercises the production-shaped infrastructure.
+#
+# This CR exists to be DELETED: the suite drives it far enough to mint the K-ORC
+# admin ApplicationCredential, takes Keystone down to simulate "Keystone already
+# gone", then deletes the ControlPlane and asserts the ORC-teardown finalizer
+# sequences the teardown and ultimately lets deletion COMPLETE (rather than
+# hanging forever on a Terminating ApplicationCredential whose K-ORC finalizer
+# can never revoke against a dead Keystone).
+#
+# The name "deletion-orch" is distinct from the canonical "controlplane" /
+# "controlplane-keystone" CRs so the suite never clobbers them; the c5c3 suite
+# runs serially (one ControlPlane per namespace, enforced by the webhook), and
+# this CR is removed by the test itself.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: deletion-orch
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  region: RegionOne
+  infrastructure:
+    database:
+      clusterRef:
+        name: openstack-db
+      database: keystone
+      secretRef:
+        name: keystone-db
+    cache:
+      clusterRef:
+        name: openstack-memcached
+      backend: dogpile.cache.pymemcache
+      replicas: 3
+  services:
+    keystone:
+      replicas: 1
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+        secretName: k-orc-clouds-yaml
+      passwordSecretRef:
+        name: keystone-admin
+        key: password
+      applicationCredential:
+        restricted: true
+        rotation:
+          mode: PasswordDriven

--- a/tests/e2e/c5c3/deletion-orchestration/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/deletion-orchestration/chainsaw-test.yaml
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for ControlPlane deletion orchestration: the ORC-teardown
+# finalizer (c5c3.io/orc-teardown) must sequence the deletion of the operator-
+# owned K-ORC CRs (ApplicationCredential/Service/Endpoint/User/Domain) and let
+# ControlPlane deletion COMPLETE even when Keystone is already gone — so the
+# managed control plane (and its namespace) never hangs forever on a Terminating
+# ApplicationCredential whose K-ORC finalizer can never revoke against a dead
+# Keystone.
+#
+# Scenario ("Keystone already gone"):
+#   1. Apply a managed ControlPlane and drive it to Ready (infra + Keystone +
+#      minted K-ORC ApplicationCredential + identity catalog).
+#   2. Initiate ControlPlane deletion (async). The operator enters its deletion
+#      branch and stops re-projecting children.
+#   3. Take Keystone down (delete the projected Keystone CR; the c5c3-operator no
+#      longer recreates it while the ControlPlane is Terminating). K-ORC can now
+#      no longer revoke the admin credential against the Keystone API.
+#   4. Assert ControlPlane deletion COMPLETES within a window larger than the
+#      bounded stall timeout (orcTeardownStallTimeout = 5m): the finalizer waits,
+#      then force-removes the stuck openstack.k-orc.cloud/* finalizers and
+#      releases the ControlPlane.
+#   5. Assert the projected Keystone, MariaDB, Memcached, and all five K-ORC CRs
+#      are garbage-collected, and that an ORC-teardown event was emitted.
+#
+# Whether step 3 wins the race against an in-flight revoke or not, the regression
+# guard is identical: deletion must COMPLETE (the happy path emits
+# ORCTeardownComplete; the stalled path emits a Warning ORCTeardownStalled and
+# force-removes). The deterministic stall/force-remove escalation itself is also
+# covered by the fast fake-client unit test
+# (TestReconcileDelete_ForceRemovesORCFinalizersAfterStall).
+#
+# ── DECISION: belt-and-braces presence guard + single consolidated script ────
+# Like tests/e2e/c5c3/full-controlplane-keystone, the full c5c3 + K-ORC +
+# keystone stack is NOT wired into the current kind E2E (hack/deploy-infra.sh +
+# hack/ci-deploy-operator.sh do not install K-ORC or the c5c3-operator), and the
+# suite runs under execution.failFast. So a runtime presence guard probes the
+# required CRDs + the OpenBao ClusterSecretStore and exits 0 with a SKIP line
+# when the stack is absent; chainsaw has no step-level skip, so the guard and all
+# assertions live in ONE script step. Wiring the stack into kind so this suite
+# EXERCISES rather than skips is the documented c5c3 GitOps/CI fast-follow.
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deletion-orchestration
+spec:
+  namespace: openstack
+  # The full chain bring-up plus the bounded stall (5m) and GC cascade is long-
+  # running, so the consolidated script and its diagnostic catch get generous
+  # bounds well above the 120s suite default.
+  timeouts:
+    assert: 5m
+    exec: 30m
+  steps:
+  - try:
+    - script:
+        timeout: 30m
+        # Chainsaw defaults to `sh`, which rejects `set -o pipefail`; every
+        # infra/keystone/c5c3 e2e script pins bash for the same reason.
+        shell: bash
+        content: |
+          set -euo pipefail
+
+          CP_NS=openstack
+          CP_NAME=deletion-orch
+          KEYSTONE_CR="${CP_NAME}-keystone"
+          AC_NAME="${CP_NAME}-admin-app-credential"
+          SVC_CR="${CP_NAME}-identity-service"
+          EP_CR="${CP_NAME}-identity-endpoint"
+          USER_CR="${CP_NAME}-user-admin"
+          DOMAIN_CR="${CP_NAME}-domain-default"
+          FINALIZER="c5c3.io/orc-teardown"
+
+          # ── Presence guard ─────────────────────────────────────────────────
+          missing=""
+          for crd in \
+            controlplanes.c5c3.io \
+            keystones.keystone.openstack.c5c3.io \
+            applicationcredentials.openstack.k-orc.cloud \
+            services.openstack.k-orc.cloud \
+            endpoints.openstack.k-orc.cloud \
+            users.openstack.k-orc.cloud \
+            domains.openstack.k-orc.cloud \
+            externalsecrets.external-secrets.io; do
+            if ! kubectl get crd "$crd" >/dev/null 2>&1; then
+              missing="${missing} ${crd}"
+            fi
+          done
+          if [ -n "${missing}" ]; then
+            echo "SKIP: required CRDs not present:${missing}"
+            echo "      The c5c3-operator + K-ORC + keystone-operator stack is"
+            echo "      not deployed on this cluster, so ControlPlane deletion"
+            echo "      orchestration cannot be exercised here."
+            exit 0
+          fi
+          if ! kubectl get clustersecretstore openbao-cluster-store >/dev/null 2>&1; then
+            echo "SKIP: openbao-cluster-store ClusterSecretStore not present;"
+            echo "      the admin-credential chain cannot complete."
+            exit 0
+          fi
+          echo "OK: stack present — running ControlPlane deletion orchestration."
+
+          # ── Helpers ────────────────────────────────────────────────────────
+          wait_cp_condition() { # <conditionType> <timeoutSeconds>
+            local ctype="$1" timeout="$2" deadline status
+            deadline=$(( $(date +%s) + timeout ))
+            while true; do
+              status="$(kubectl get controlplane "${CP_NAME}" -n "${CP_NS}" \
+                -o "jsonpath={.status.conditions[?(@.type=='${ctype}')].status}" 2>/dev/null || true)"
+              if [ "${status}" = "True" ]; then
+                echo "OK: ControlPlane condition ${ctype}=True"
+                return 0
+              fi
+              if [ "$(date +%s)" -ge "${deadline}" ]; then
+                echo "ERROR: ControlPlane condition ${ctype} not True within ${timeout}s (last: '${status:-<none>}')"
+                return 1
+              fi
+              sleep 5
+            done
+          }
+
+          wait_gone() { # <resource> <name> <timeoutSeconds>
+            local res="$1" name="$2" timeout="$3" deadline
+            deadline=$(( $(date +%s) + timeout ))
+            while kubectl get "${res}" "${name}" -n "${CP_NS}" >/dev/null 2>&1; do
+              if [ "$(date +%s)" -ge "${deadline}" ]; then
+                echo "ERROR: ${res}/${name} still present after ${timeout}s"
+                return 1
+              fi
+              sleep 5
+            done
+            echo "OK: ${res}/${name} is gone"
+          }
+
+          # ── Bring the ControlPlane up to Ready ─────────────────────────────
+          kubectl apply -f 00-controlplane-cr.yaml
+          wait_cp_condition Ready 900
+
+          # The ORC-teardown finalizer must be installed, and the five owned
+          # K-ORC CRs must exist before we tear down.
+          kubectl get controlplane "${CP_NAME}" -n "${CP_NS}" \
+            -o jsonpath='{.metadata.finalizers}' | grep -qF "${FINALIZER}" \
+            || { echo "ERROR: ${FINALIZER} not installed on the ControlPlane"; exit 1; }
+          for kv in \
+            "applicationcredential ${AC_NAME}" \
+            "services.openstack.k-orc.cloud ${SVC_CR}" \
+            "endpoints.openstack.k-orc.cloud ${EP_CR}" \
+            "users.openstack.k-orc.cloud ${USER_CR}" \
+            "domains.openstack.k-orc.cloud ${DOMAIN_CR}"; do
+            set -- $kv
+            kubectl get "$1" "$2" -n "${CP_NS}" >/dev/null \
+              || { echo "ERROR: expected K-ORC CR $1/$2 missing before teardown"; exit 1; }
+          done
+          echo "OK: finalizer installed and all five K-ORC CRs present."
+
+          # ── Simulate "Keystone already gone" during teardown ───────────────
+          # Initiate deletion first (async) so the operator enters its deletion
+          # branch and stops re-projecting the Keystone child, THEN delete the
+          # Keystone CR so K-ORC can no longer revoke against a live Keystone.
+          echo "== deleting ControlPlane (async) and taking Keystone down =="
+          kubectl delete controlplane "${CP_NAME}" -n "${CP_NS}" --wait=false
+          kubectl delete keystone "${KEYSTONE_CR}" -n "${CP_NS}" --ignore-not-found --wait=false
+
+          # ── Deletion must COMPLETE despite Keystone being gone ──────────────
+          # The finalizer waits up to orcTeardownStallTimeout (5m), then force-
+          # removes the stuck openstack.k-orc.cloud/* finalizers and releases the
+          # ControlPlane. 10m bounds that with comfortable headroom.
+          echo "== waiting for ControlPlane deletion to complete (<=10m) =="
+          kubectl wait --for=delete "controlplane/${CP_NAME}" -n "${CP_NS}" --timeout=10m
+          echo "OK: ControlPlane deletion completed — did not hang on Terminating ORC CRs."
+
+          # ── GC cascade: every owned child must be reclaimed ────────────────
+          wait_gone applicationcredential "${AC_NAME}" 300
+          wait_gone services.openstack.k-orc.cloud "${SVC_CR}" 300
+          wait_gone endpoints.openstack.k-orc.cloud "${EP_CR}" 300
+          wait_gone users.openstack.k-orc.cloud "${USER_CR}" 300
+          wait_gone domains.openstack.k-orc.cloud "${DOMAIN_CR}" 300
+          wait_gone keystone "${KEYSTONE_CR}" 300
+          wait_gone mariadb openstack-db 300
+          wait_gone memcacheds.memcached.c5c3.io openstack-memcached 300
+
+          # ── The ORC-teardown finalizer must have run ───────────────────────
+          # Either ORCTeardownComplete (revoke won the race) or ORCTeardownStalled
+          # (Keystone gone first → force-remove) proves the finalizer drove the
+          # sequenced teardown rather than GC tearing everything down at once.
+          echo "== ORC-teardown events =="
+          reasons="$(kubectl get events -n "${CP_NS}" \
+            -o jsonpath='{range .items[*]}{.reason}{"\n"}{end}' 2>/dev/null || true)"
+          echo "${reasons}" | grep -E 'FinalizingORC|ORCTeardown' || true
+          if echo "${reasons}" | grep -qE 'ORCTeardownStalled|ORCTeardownComplete'; then
+            echo "OK: ORC-teardown finalizer ran to completion."
+          else
+            echo "ERROR: no ORCTeardownStalled/ORCTeardownComplete event observed"
+            exit 1
+          fi
+          echo "OK: ControlPlane deletion orchestration verified."
+    catch:
+    - script:
+        shell: bash
+        content: |
+          echo "=== ControlPlane (may be Terminating or gone) ==="
+          kubectl get controlplane deletion-orch -n openstack -o yaml 2>&1 || true
+          echo "=== ControlPlane status.conditions ==="
+          kubectl get controlplane deletion-orch -n openstack \
+            -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}: {.message}){"\n"}{end}' 2>&1 || true
+          echo "=== K-ORC CRs (may be Terminating) ==="
+          kubectl get applicationcredentials.openstack.k-orc.cloud,services.openstack.k-orc.cloud,endpoints.openstack.k-orc.cloud,users.openstack.k-orc.cloud,domains.openstack.k-orc.cloud -n openstack 2>&1 || true
+          echo "=== Projected child CRs ==="
+          kubectl get mariadb,memcacheds.memcached.c5c3.io,keystone -n openstack 2>&1 || true
+          echo "=== c5c3-operator logs (last 200 lines) ==="
+          kubectl logs -n c5c3-system -l app.kubernetes.io/name=c5c3-operator --tail=200 --all-containers 2>&1 || true
+          echo "=== K-ORC controller logs (last 100 lines) ==="
+          kubectl logs -n orc-system -l app.kubernetes.io/name=openstack-resource-controller --tail=100 --all-containers 2>&1 || true
+          echo "=== Events (openstack ns, last 40) ==="
+          kubectl get events -n openstack --sort-by='.lastTimestamp' 2>&1 | tail -40 || true
+    finally:
+    - script:
+        shell: bash
+        content: |
+          # Best-effort cleanup if the test failed mid-flight: force-release the
+          # ControlPlane and Keystone so the shared namespace is not left wedged
+          # for the next suite. Successful runs already deleted everything.
+          kubectl delete controlplane deletion-orch -n openstack --ignore-not-found --wait=false 2>&1 || true
+          kubectl delete keystone deletion-orch-keystone -n openstack --ignore-not-found --wait=false 2>&1 || true


### PR DESCRIPTION
## Summary

The ControlPlane had no finalizer, so on deletion owner-reference GC removed every child concurrently — including the managed K-ORC CRs whose finalizers must call the **Keystone API** to revoke/delete. When Keystone (and in managed mode its MariaDB) was torn down at the same time, those K-ORC finalizers could never complete and the ControlPlane / namespace hung indefinitely on Terminating ORC CRs.

This adds a single finalizer, `c5c3.io/orc-teardown`, that sequences teardown: delete the owned K-ORC CRs first and hold the ControlPlane CR (which defers the GC cascade, keeping Keystone reachable) until they are gone, then release so GC tears down the rest — with a bounded stall escape that force-removes stuck K-ORC finalizers so deletion always completes. It mirrors the keystone operator's sequenced-finalizer discipline. No CRD or RBAC change is required.

Closes #465

## Changes (in commit order)

1. **`feat(c5c3-operator): sequence ORC teardown via ControlPlane finalizer`** — `controlplane_controller.go` (finalizer const + deletion/ensure-finalizer branches in `Reconcile`), new `reconcile_delete.go` (`reconcileDelete`, `deleteORCResources`, `forceRemoveKORCFinalizers`, the `orcChildResources` single source of truth), `requeue_intervals.go` (`orcTeardownStallTimeout = 5m`), and the fake-client unit tests `reconcile_delete_test.go`.
2. **`test(c5c3-operator): integration-test ControlPlane deletion sequencing`** — envtest test proving the AC is deleted first and the ControlPlane (and Keystone child) is held until the K-ORC finalizer clears.
3. **`test(c5c3-operator): add deletion-orchestration e2e scenario`** — presence-guarded Chainsaw test for deletion while Keystone is already gone; asserts deletion completes (the regression guard) and the children are GC'd.
4. **`docs(c5c3): document the ORC-teardown finalizer and deletion order`** — replaces the stale "No finalizer" callout with a "Deletion ordering" subsection.

## Behavior

On deletion, `reconcileDelete`:
- deletes the 5 owned K-ORC CRs (ApplicationCredential/Service/Endpoint/User/Domain), reports `KORCReady=False`/`FinalizingORC`, and requeues while they are Terminating;
- releases the finalizer once they are gone;
- after `orcTeardownStallTimeout` (5m), force-removes the `openstack.k-orc.cloud/*` finalizers (preserving any non-K-ORC finalizers), emits a **Warning** `ORCTeardownStalled` event, and releases anyway.

## Tests

- `make test-operator OPERATOR=c5c3` — pass (fake-client deletion tests incl. the force-remove stall path).
- `make test-integration OPERATOR=c5c3` — pass; new `TestIntegration_ControlPlaneDeletion_SequencesORCTeardown` runs (45.9s) and asserts the sequencing invariant.
- `go test -race -count=1 ./operators/c5c3/internal/controller/...` — pass.
- `golangci-lint run`, `gofumpt`, `make chainsaw-lint`, `make check-docs-ids` — clean.

## Notes / scope

- No API-type, CRD, or RBAC change (existing markers already grant `delete`/`update` on the K-ORC resources and `controlplanes/finalizers`), so no `make manifests`/`make generate`.
- The e2e suite is presence-guarded and SKIPs in current CI (the c5c3 + K-ORC + keystone stack is not yet wired into kind — a documented fast-follow). The deterministic stall/force-remove escalation is covered by the fast fake-client unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)