### PR TITLE
feat(api): validation-marker wave — image refs, DB endpoints, secret refs, middleware enum, CEL parity, defaulting constants

### DIFF
--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -221,8 +221,8 @@ notes](#infrastructurespec) below.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `database` | [`commonv1.DatabaseSpec`](../keystone/keystone-crd.md#databasespec) | No | managed `clusterRef: openstack-db`, `database: keystone`, `secretRef.name: keystone-db` | MariaDB connection parameters shared by the control plane. Supports managed (`clusterRef`) and brownfield (`host`) modes; exactly one must hold **after defaulting** (enforced by the validating webhook — see [Validation Rules](#validation-rules)). Optional because the defaulting webhook materializes a managed-mode block when omitted. **`database.secretRef` ownership:** in managed mode this reference is **operator-owned** — `reconcileDBCredentials` materialises a per-ControlPlane DB-credential Secret and the reconciler overrides the projected Keystone CR's `spec.database.secretRef` to point at it, so the `keystone-db` default `secretRef.name` is only a managed-mode convenience name (it is **not** what Keystone consumes and no longer resolves to a cluster Secret). A **brownfield** ControlPlane (`database.host` set, no `clusterRef`) **MUST supply** its own `database.secretRef` Secret out-of-band — the operator projects no ExternalSecret in brownfield mode. See [managed-mode provisioning](#infrastructurespec) below. |
-| `cache` | [`commonv1.CacheSpec`](../keystone/keystone-crd.md#cachespec) | No | managed `clusterRef: openstack-memcached`, `backend: dogpile.cache.pymemcache` | Memcached configuration shared by the control plane. Supports managed (`clusterRef`) and brownfield (`servers`) modes; exactly one must hold **after defaulting** (enforced by the validating webhook). Optional because the defaulting webhook materializes a managed-mode block when omitted. |
+| `database` | [`commonv1.DatabaseSpec`](../keystone/keystone-crd.md#databasespec) | No | managed `clusterRef: openstack-db`, `database: keystone`, `secretRef.name: keystone-db` | MariaDB connection parameters shared by the control plane. Supports managed (`clusterRef`) and brownfield (`host`) modes; exactly one must hold **after defaulting** (enforced by the CRD CEL `XValidation` rule and the validating webhook — see [Validation Rules](#validation-rules)). Optional because the defaulting webhook materializes a managed-mode block when omitted. **`database.secretRef` ownership:** in managed mode this reference is **operator-owned** — `reconcileDBCredentials` materialises a per-ControlPlane DB-credential Secret and the reconciler overrides the projected Keystone CR's `spec.database.secretRef` to point at it, so the `keystone-db` default `secretRef.name` is only a managed-mode convenience name (it is **not** what Keystone consumes and no longer resolves to a cluster Secret). A **brownfield** ControlPlane (`database.host` set, no `clusterRef`) **MUST supply** its own `database.secretRef` Secret out-of-band — the operator projects no ExternalSecret in brownfield mode. See [managed-mode provisioning](#infrastructurespec) below. |
+| `cache` | [`commonv1.CacheSpec`](../keystone/keystone-crd.md#cachespec) | No | managed `clusterRef: openstack-memcached`, `backend: dogpile.cache.pymemcache` | Memcached configuration shared by the control plane. Supports managed (`clusterRef`) and brownfield (`servers`) modes; exactly one must hold **after defaulting** (enforced by the CRD CEL `XValidation` rule and the validating webhook). Optional because the defaulting webhook materializes a managed-mode block when omitted. |
 
 <!-- DECISION: `database`/`cache` Required flipped from Yes to No because the
      defaulting webhook now constructs a managed-mode block when the field is omitted.
@@ -300,7 +300,7 @@ Keystone service.
 | `policyOverrides` | [`*commonv1.PolicySpec`](../keystone/keystone-crd.md#policyspec) | No | `nil` | Per-service oslo.policy overrides for Keystone. When set, these take precedence over `spec.global` for the Keystone service. |
 | `rotationInterval` | `*metav1.Duration` | No | `nil` | Overrides the Fernet / credential-key rotation interval the reconciler derives for the projected Keystone CR. When `nil`, the reconciler derives a default schedule. When set, the duration is converted to a cron expression and applied to both `fernet.rotationSchedule` and `credentialKeys.rotationSchedule` on the projected Keystone CR. An unconvertible interval (not a positive whole number of days) is **rejected at admission** by the validating webhook; if the webhook is bypassed, the reconciler surfaces `KeystoneReady=False` with reason `InvalidRotationInterval` and returns the error so the reconcile chain stops and requeues with backoff. |
 | `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Keystone API externally via a Gateway API HTTPRoute. When `nil`, no HTTPRoute is projected and the Keystone API is reachable in-cluster only (its ClusterIP Service). When set, the reconciler projects it onto the Keystone CR's `spec.gateway`, so the Keystone operator attaches an HTTPRoute to the referenced Gateway. When a `gateway` is set its `hostname` must be non-empty — enforced at admission by the validating webhook (see [Validation Rules](#validation-rules)). |
-| `publicEndpoint` | `string` | No | `""` | Externally routable Keystone identity endpoint URL (e.g. `https://keystone.example.com/v3`). Projected into the Keystone bootstrap (`--bootstrap-public-url`) and used for the K-ORC identity catalog Endpoint, so external clients resolve the same URL Keystone advertises. When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}/v3` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
+| `publicEndpoint` | `string` | No | `""` | Externally routable Keystone identity endpoint URL (e.g. `https://keystone.example.com/v3`). Projected into the Keystone bootstrap (`--bootstrap-public-url`) and used for the K-ORC identity catalog Endpoint, so external clients resolve the same URL Keystone advertises. When set, it must be an HTTP(S) URL (`+kubebuilder:validation:Pattern=^https?://`), so a malformed endpoint fails at admission rather than wedging the projected Keystone CR. When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}/v3` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
 
 ---
 
@@ -435,8 +435,8 @@ mirroring the Keystone application-credential access-rule shape.
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `service` | `string` | Yes | — | OpenStack service type the rule applies to (e.g. `"compute"`). The reconciler uses this verbatim as the name of the referenced K-ORC `Service` CR (`serviceRef`). |
-| `method` | `string` | Yes | — | HTTP method the rule allows (e.g. `"GET"`, `"POST"`). Projected onto the K-ORC typed `HTTPMethod` enum. |
-| `path` | `string` | Yes | — | Request path the rule allows (e.g. `"/v2.1/servers"`). |
+| `method` | `string` | No | — | HTTP method the rule allows (e.g. `"GET"`, `"POST"`). Projected onto the K-ORC typed `HTTPMethod` enum; constrained by `+kubebuilder:validation:Enum=CONNECT;DELETE;GET;HEAD;OPTIONS;PATCH;POST;PUT;TRACE` (mirrors that enum). Optional — omitted from the projected rule when empty. |
+| `path` | `string` | No | — | Request path the rule allows (e.g. `"/v2.1/servers"`). When set it must be an absolute path (`+kubebuilder:validation:Pattern=^/`). Optional — omitted from the projected rule when empty. |
 
 ---
 
@@ -469,7 +469,7 @@ the kind/name and applies it.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `kind` | `string` | Yes | — | The K-ORC resource kind to bootstrap (e.g. `"Project"`, `"Role"`). |
+| `kind` | `string` | Yes | — | The K-ORC resource kind to bootstrap. Constrained to the kinds the control plane bootstraps today by `+kubebuilder:validation:Enum=Project;Role`; widen the enum when the reconciler learns to interpret additional kinds. |
 | `name` | `string` | Yes | — | Name of the bootstrapped resource. |
 
 ---
@@ -662,6 +662,10 @@ Keystone discipline:
 | Field | Rule |
 | --- | --- |
 | `spec.openStackRelease` | Pattern `^\d{4}\.\d$` |
+| `spec.services.keystone.publicEndpoint` | Pattern `^https?://` |
+| `spec.korc.adminCredential.applicationCredential.accessRules[].method` | Enum: `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE` |
+| `spec.korc.adminCredential.applicationCredential.accessRules[].path` | Pattern `^/` |
+| `spec.korc.adminCredential.bootstrapResources[].kind` | Enum: `Project`, `Role` |
 | `spec.korc.adminCredential.applicationCredential.rotation.mode` | Enum: `PasswordDriven`, `Scheduled`, `Manual` |
 | `spec.services.keystone.replicas` | Minimum: 1 |
 | `CredentialRotation spec.target` | Enum: `adminApplicationCredential` |

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -209,7 +209,14 @@ validating webhook is unavailable.
 | `spec.policyOverrides.rules` | `!has(self.rules) \|\| self.rules.all(k, size(k) > 0)` | "policy rule name must not be empty" |
 | `spec.policyOverrides.rules` | `!has(self.rules) \|\| self.rules.all(k, size(self.rules[k]) > 0)` | "policy rule value must not be empty" |
 | `spec.autoscaling` | `has(self.targetCPUUtilization) \|\| has(self.targetMemoryUtilization)` | "at least one of targetCPUUtilization or targetMemoryUtilization must be set" |
+| `spec.autoscaling` | `!has(self.minReplicas) \|\| self.minReplicas <= self.maxReplicas` | "minReplicas must not exceed maxReplicas" |
 | `spec.networkPolicy` | `size(self.ingress) > 0` | "at least one ingress source must be specified" |
+| `spec` | drain window: effective `preStopSleepSeconds` (default 5) must be `<` effective `terminationGracePeriodSeconds` (default 30) | "preStopSleepSeconds must be strictly less than terminationGracePeriodSeconds" |
+| `spec.uwsgi` | `!has(self.httpKeepAliveTimeout) \|\| self.httpKeepAlive` | "httpKeepAliveTimeout may only be set when httpKeepAlive is true" |
+| `spec.logging.perLoggerLevels` | `self.all(k, k != '')` | "logger name must not be empty" |
+| `spec.logging.perLoggerLevels` | `self.all(k, self[k] in ['DEBUG','INFO','WARNING','ERROR','CRITICAL'])` | "per-logger level must be one of DEBUG, INFO, WARNING, ERROR, CRITICAL" |
+| `spec.plugins` | list-map keyed by `configSection` (`x-kubernetes-list-type: map`) | "Duplicate value" (a repeated `configSection` is rejected by the API server) |
+| `spec.bootstrap.publicEndpoint` | Pattern: `^https?://` | (non-URL value rejected by API server) |
 | `spec.replicas` | Minimum: 1 | — |
 | `spec.fernet.maxActiveKeys` | Minimum: 3 | — |
 | `spec.credentialKeys.maxActiveKeys` | Minimum: 3 | — |
@@ -506,7 +513,7 @@ full event/condition contract.
 | `format` | `string` | No | `text` | On-wire layout of oslo.log records. `text` emits the standard oslo.log line format; `json` emits one JSON object per record for direct ingest by Loki/OpenSearch. Enforced as `+kubebuilder:validation:Enum=text;json`. |
 | `level` | `string` | No | `INFO` | Root logger level applied to oslo.log. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Enforced as `+kubebuilder:validation:Enum=DEBUG;INFO;WARNING;ERROR;CRITICAL`. |
 | `debug` | `bool` | No | `false` | Toggles oslo.log `[DEFAULT] debug=true`. Independent of `level` because oslo.log gates several extra-verbose code paths on the debug flag specifically (SQL echo, auth-backend tracing). |
-| `perLoggerLevels` | `map[string]string` | No | `nil` | Overrides the level of named loggers, mirroring oslo.log's `default_log_levels`. Each value must be one of `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL` — enforced by the validating webhook (CRD v1 `additionalProperties` does not support enum constraints). Empty-string keys are rejected. Rendered into `[DEFAULT].default_log_levels` in deterministic alphabetical order to keep ConfigMap content-hashes stable across reconciles. |
+| `perLoggerLevels` | `map[string]string` | No | `nil` | Overrides the level of named loggers, mirroring oslo.log's `default_log_levels`. Each value must be one of `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL` and every logger name must be non-empty — enforced by CRD CEL `XValidation` rules (a plain enum on `additionalProperties` is not expressible in CRD v1, so the value constraint is written as an `in [...]` CEL rule) and by the validating webhook. Rendered into `[DEFAULT].default_log_levels` in deterministic alphabetical order to keep ConfigMap content-hashes stable across reconciles. |
 
 ### Example
 
@@ -989,7 +996,7 @@ Configures the initial Keystone bootstrap.
 | `adminUser` | `string` | No | `"admin"` | Admin username for the bootstrap. Immutable after create (CEL transition rule): re-bootstrapping with a different admin user duplicates or strands catalog entries. |
 | `adminPasswordSecretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | — | Secret containing the admin password. |
 | `region` | `string` | No | `"RegionOne"` | Keystone region name. Immutable after create (CEL transition rule): changing the region strands catalog entries under the old region. |
-| `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS. |
+| `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS. When set, it must be an HTTP(S) URL (`+kubebuilder:validation:Pattern=^https?://`), enforced unconditionally by the CRD schema; when `spec.gateway` is also set the webhook additionally requires the host to equal `spec.gateway.hostname`. |
 
 ---
 
@@ -1037,17 +1044,17 @@ operator CRDs.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `repository` | `string` | Yes | Container image repository (e.g., `c5c3/keystone`). |
-| `tag` | `string` | Yes | Image tag (e.g., `2025.1`). |
+| `repository` | `string` | Yes | Container image repository (e.g., `c5c3/keystone`). Must be non-empty (`MinLength=1`) and match a permissive OCI reference `Pattern` (`^[a-z0-9]+([._:/-][a-z0-9]+)*$`) that accepts registry-host and `host:port` forms. |
+| `tag` | `string` | Yes | Image tag (e.g., `2025.1`). Must be non-empty (`MinLength=1`) and match the OCI tag grammar `Pattern` (`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`). |
 
 ### DatabaseSpec
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `clusterRef` | `*corev1.LocalObjectReference` | No | Reference to a MariaDB CR (managed mode). |
-| `host` | `string` | No | Database hostname (brownfield mode). |
-| `port` | `int32` | No | Database port (brownfield mode, default 3306). |
-| `database` | `string` | Yes | Database name. Immutable after create (CEL transition rule): renaming re-points `db_sync` at a fresh, empty schema and silently orphans the existing data. |
+| `host` | `string` | No | Database hostname (brownfield mode). When set, `MinLength=1` plus a permissive host `Pattern` (`^[a-zA-Z0-9._:-]+$`) that accepts DNS names, IPv4, and IPv6 literals. |
+| `port` | `int32` | No | Database port (brownfield mode, default 3306). When set, range `Minimum=1`/`Maximum=65535`; omitted (managed mode) leaves it unset. |
+| `database` | `string` | Yes | Database name. Constrained to the MySQL identifier set and length: `MinLength=1`, `MaxLength=64`, `Pattern=^[A-Za-z0-9_]+$`. Immutable after create (CEL transition rule): renaming re-points `db_sync` at a fresh, empty schema and silently orphans the existing data. |
 | `secretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | Secret with database credentials. |
 | `tls` | [`*DatabaseTLSSpec`](#databasetlsspec) | No | Optional TLS/mTLS configuration. The pointer keeps the field opt-in and non-mutating: a `nil` `tls` means plaintext TCP, preserving the previous behavior for all existing CRs. |
 
@@ -1114,7 +1121,7 @@ condition using these typed reasons:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `name` | `string` | Yes | Name of the Kubernetes Secret. |
+| `name` | `string` | Yes | Name of the Kubernetes Secret. Must be a non-empty DNS-1123 subdomain (`MinLength=1` plus `Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`). Tightening the shared type rejects an empty Secret name on every consumer (database/admin/messaging/TLS refs). |
 | `key` | `string` | No | Key within the Secret's data. |
 
 ### PolicySpec
@@ -1135,7 +1142,7 @@ shared `PolicySpec` type and the validating webhook.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `name` | `string` | Yes | Plugin name (e.g., `keystone-keycloak-backend`). |
-| `configSection` | `string` | Yes | INI section name (e.g., `keycloak`). Must be unique across all plugins. |
+| `configSection` | `string` | Yes | INI section name (e.g., `keycloak`). Must be unique across all plugins — enforced structurally by the CRD (`spec.plugins` is an `x-kubernetes-list-type: map` keyed by `configSection`), so a duplicate is rejected by the API server before the webhook runs. |
 | `config` | `map[string]string` | No | Key-value pairs for the plugin's INI section. |
 
 ### MiddlewareSpec
@@ -1144,7 +1151,7 @@ shared `PolicySpec` type and the validating webhook.
 | --- | --- | --- | --- |
 | `name` | `string` | Yes | Filter name (e.g., `audit`). |
 | `filterFactory` | `string` | Yes | Python entry point (e.g., `audit_middleware:filter_factory`). |
-| `position` | `PipelinePosition` | Yes | Pipeline insertion point: `"before"` or `"after"`. |
+| `position` | `PipelinePosition` | Yes | Pipeline insertion point: `"before"` or `"after"`. Constrained by `+kubebuilder:validation:Enum=before;after` on the shared `PipelinePosition` type, so any other value is rejected at admission. |
 | `config` | `map[string]string` | No | Key-value pairs for the filter section. |
 
 ### GatewaySpec
@@ -1426,6 +1433,14 @@ is pinned by a Chainsaw step.
 | `immutable-database-mode-rejected` | `15-immutable-database-mode.yaml` | `spec.database` mode (clusterRef ↔ host) immutable on UPDATE | Error containing "database mode" and "immutable" |
 | `immutable-adminuser-rejected` | `16-immutable-adminuser.yaml` | `spec.bootstrap.adminUser` immutable on UPDATE | Error containing "adminUser" and "immutable" |
 | `immutable-region-rejected` | `17-immutable-region.yaml` | `spec.bootstrap.region` immutable on UPDATE | Error containing "region" and "immutable" |
+| `image-empty-tag-rejected` | `13-image-empty-tag.yaml` | ImageSpec.Tag MinLength=1 | Error containing "image.tag" |
+| `database-name-invalid-char-rejected` | `14-database-name-invalid-char.yaml` | DatabaseSpec.Database Pattern | Error containing "database.database" |
+| `database-secretref-empty-name-rejected` | `15-database-secretref-empty-name.yaml` | SecretRefSpec.Name MinLength=1 | Error containing "secretRef.name" |
+| `middleware-bad-position-rejected` | `16-middleware-bad-position.yaml` | PipelinePosition Enum=before;after | Error containing "position" and "sideways" |
+| `uwsgi-keepalive-timeout-conflict-rejected` | `17-uwsgi-keepalive-timeout-conflict.yaml` | httpKeepAliveTimeout requires httpKeepAlive (CEL) | Error containing "httpKeepAliveTimeout" |
+| `prestop-not-less-than-grace-rejected` | `18-prestop-not-less-than-grace.yaml` | drain window preStop < TGPS (CEL) | Error containing "preStopSleepSeconds" and "terminationGracePeriodSeconds" |
+| `publicendpoint-not-url-rejected` | `19-publicendpoint-not-url.yaml` | BootstrapSpec.PublicEndpoint Pattern | Error containing "publicEndpoint" |
+| `perloggerlevels-invalid-value-rejected` | `20-perloggerlevels-invalid-value.yaml` | perLoggerLevels value enum (CEL) | Error containing "perLoggerLevels" |
 
 Steps `14`-`17` reuse the `immutable-fields` name from `13-immutable-base.yaml`,
 so each is applied as an UPDATE of the base CR and is rejected by the
@@ -1468,20 +1483,24 @@ the field name, so the loose-substring assertion (`maxActiveKeys`) keeps the tes
 stable regardless of which layer fires first and across upstream Kubernetes
 admission-pipeline changes.
 
-The 16 generated fixtures (`02-…` through `17-…`, with the `08-replicas-zero.yaml`
+The 24 generated fixtures (`02-…` through `20-…`, with the `08-replicas-zero.yaml`
 gap explained above) share an otherwise-identical minimal valid Keystone scaffold.
-The create-rejection fixtures (`02-…` through `12-…`, plus
-`13-policy-overrides-empty-rule-value.yaml`) differ only by the field under test;
-the update-rejection fixtures (`13-immutable-base.yaml` through `17-…`) share the
+The create-rejection fixtures (`02-…` through `12-…`,
+`13-policy-overrides-empty-rule-value.yaml`, and the validation-marker set
+`13-image-empty-tag.yaml` through `20-perloggerlevels-invalid-value.yaml`) differ
+only by the field under test; the update-rejection fixtures
+(`13-immutable-base.yaml` through `17-immutable-region.yaml`) share the
 `immutable-fields` name so `13-immutable-base.yaml` is the base and `14`-`17` are
-applied as UPDATEs.
+applied as UPDATEs. The create-rejection, update-rejection, and validation-marker
+sets deliberately reuse the `13`-`17` numeric prefixes with distinct filenames, so
+those prefixes recur across the suite.
 To prevent that scaffold from drifting across files, the fixtures are generated
 from a single canonical source in `tests/e2e/keystone/invalid-cr/_generate.py`.
 After editing the scaffold or any per-fixture override, regenerate via
 `python3 tests/e2e/keystone/invalid-cr/_generate.py`. The
 `verify-invalid-cr-fixtures` CI job (and the matching
 `make verify-invalid-cr-fixtures` Makefile target) runs `_generate.py --check`
-in drift mode and the `test_generate.py` unit suite (`len(FIXTURES) == 16` plus
+in drift mode and the `test_generate.py` unit suite (`len(FIXTURES) == 24` plus
 a cross-reference assertion that every `Fixture.filename` appears as a
 `file:` step in `chainsaw-test.yaml`), so a hand-edit to any generated fixture
 — or a rename/removal that desynchs `FIXTURES` from `chainsaw-test.yaml` —

--- a/internal/common/types/types.go
+++ b/internal/common/types/types.go
@@ -8,10 +8,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// DefaultCacheBackend is the oslo.cache backend materialized when a Spec leaves
+// CacheSpec.Backend empty. It lives here as the single source of truth shared by
+// the keystone and c5c3 defaulting webhooks so the default cannot drift across
+// operators (kubebuilder markers cannot reference Go constants, so leaf markers
+// keep the literal in sync separately).
+const DefaultCacheBackend = "dogpile.cache.pymemcache"
+
 // ImageSpec defines a container image reference.
 type ImageSpec struct {
+	// Repository is the OCI image repository, optionally including the registry
+	// host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+	// permissive OCI reference — lowercase alphanumeric components separated by
+	// ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
+	// are accepted while an empty string (which "required" alone admits) and
+	// obvious garbage are rejected.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]+([._:/-][a-z0-9]+)*$`
 	Repository string `json:"repository"`
-	Tag        string `json:"tag"`
+	// Tag is the OCI image tag (e.g. "2025.2"). It follows the OCI tag grammar:
+	// up to 128 characters of word characters, dots, and dashes, and must not
+	// begin with a dot or dash.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`
+	Tag string `json:"tag"`
 }
 
 // DatabaseSpec supports managed (ClusterRef) and brownfield (explicit) modes.
@@ -24,13 +44,26 @@ type DatabaseSpec struct {
 	// ClusterRef references a MariaDB CR in the cluster (managed mode).
 	// +optional
 	ClusterRef *corev1.LocalObjectReference `json:"clusterRef,omitempty"`
-	// Host is the database hostname (brownfield mode).
+	// Host is the database hostname (brownfield mode). The pattern is a
+	// permissive host matcher that accepts DNS names, IPv4, and IPv6 literals
+	// while rejecting empty strings and shell/path metacharacters; it is not a
+	// strict RFC-1123 validator, deliberately, so airgapped/mirror endpoints are
+	// not rejected at admission.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._:-]+$`
 	Host string `json:"host,omitempty"`
-	// Port is the database port (brownfield mode, default 3306).
+	// Port is the database port (brownfield mode, default 3306). Omitted (managed
+	// mode) leaves it unset; an explicit value must be a valid TCP port.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
-	// Database is the database name within the cluster.
+	// Database is the database name within the cluster. Constrained to the MySQL
+	// identifier character set and the 64-character identifier limit.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9_]+$`
 	Database string `json:"database"`
 	// SecretRef references the K8s Secret with credentials.
 	SecretRef SecretRefSpec `json:"secretRef"`
@@ -94,6 +127,13 @@ type CacheSpec struct {
 
 // SecretRefSpec references a Kubernetes Secret.
 type SecretRefSpec struct {
+	// Name is the referenced Secret's name. It must be a non-empty DNS-1123
+	// subdomain (the Kubernetes object-name grammar). Tightening the shared type
+	// fixes every consumer at once — keystone adminPasswordSecretRef /
+	// database.secretRef / messaging / TLS cert refs and the c5c3
+	// passwordSecretRef — so an empty name no longer slips through "required".
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	Name string `json:"name"`
 	Key  string `json:"key,omitempty"`
 }
@@ -131,6 +171,7 @@ type PluginSpec struct {
 }
 
 // PipelinePosition defines where middleware is inserted in api-paste.ini.
+// +kubebuilder:validation:Enum=before;after
 type PipelinePosition string
 
 const (

--- a/operators/c5c3/api/v1alpha1/controlplane_types.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_types.go
@@ -83,12 +83,16 @@ type ControlPlaneSpec struct {
 type InfrastructureSpec struct {
 	// Database defines the MariaDB connection parameters shared by the control
 	// plane. Supports managed (clusterRef) and brownfield (host) modes; exactly
-	// one must be set (enforced by the validating webhook, mirroring keystone).
+	// one must be set. That invariant is carried by the embedded commonv1.DatabaseSpec
+	// type-level CEL rule (and the validating webhook), mirroring keystone — no
+	// field-level marker is needed here, and duplicating it would emit the rule twice.
 	Database commonv1.DatabaseSpec `json:"database"`
 
 	// Cache defines the Memcached configuration shared by the control plane.
 	// Supports managed (clusterRef) and brownfield (servers) modes; exactly one
-	// must be set (enforced by the validating webhook, mirroring keystone).
+	// must be set. That invariant is carried by the embedded commonv1.CacheSpec
+	// type-level CEL rule (and the validating webhook), mirroring keystone — no
+	// field-level marker is needed here, and duplicating it would emit the rule twice.
 	Cache commonv1.CacheSpec `json:"cache"`
 }
 
@@ -168,7 +172,11 @@ type ServiceKeystoneSpec struct {
 	// "https://{gateway.hostname}/v3" (the default-443 form); set it explicitly
 	// when the externally reachable port differs (e.g. a kind host-port mapping
 	// like :8443), since the port cannot be derived from the hostname alone.
+	// The pattern enforces an HTTP(S) URL shape so a malformed endpoint is
+	// rejected at admission rather than wedging the projected Keystone CR (the
+	// keystone webhook later rejects a non-URL publicEndpoint post-admission).
 	// +optional
+	// +kubebuilder:validation:Pattern=`^https?://`
 	PublicEndpoint string `json:"publicEndpoint,omitempty"`
 }
 
@@ -255,11 +263,21 @@ type AccessRule struct {
 	// Service is the OpenStack service type the rule applies to (e.g. "compute").
 	Service string `json:"service"`
 
-	// Method is the HTTP method the rule allows (e.g. "GET", "POST").
-	Method string `json:"method"`
+	// Method is the HTTP method the rule allows (e.g. "GET", "POST"). Optional:
+	// projectAccessRules omits it from the projected K-ORC rule when empty. The
+	// enum mirrors K-ORC's HTTPMethod type (the value is cast to it), so a value
+	// the downstream ApplicationCredentialAccessRule would reject is caught at
+	// admission instead.
+	// +optional
+	// +kubebuilder:validation:Enum=CONNECT;DELETE;GET;HEAD;OPTIONS;PATCH;POST;PUT;TRACE
+	Method string `json:"method,omitempty"`
 
-	// Path is the request path the rule allows (e.g. "/v2.1/servers").
-	Path string `json:"path"`
+	// Path is the request path the rule allows (e.g. "/v2.1/servers"). Optional:
+	// projectAccessRules omits it when empty. When set it must be an absolute
+	// path (leading slash).
+	// +optional
+	// +kubebuilder:validation:Pattern=`^/`
+	Path string `json:"path,omitempty"`
 }
 
 // RotationMode selects how the K-ORC admin application credential is rotated
@@ -292,7 +310,10 @@ type RotationSpec struct {
 // the control plane. The shape is intentionally minimal at L1 — the
 // reconciler (L2) interprets the kind/name and applies it.
 type BootstrapResourceSpec struct {
-	// Kind is the K-ORC resource kind to bootstrap (e.g. "Project", "Role").
+	// Kind is the K-ORC resource kind to bootstrap. Constrained to the kinds the
+	// control plane bootstraps today; widen the enum when the L2 reconciler
+	// learns to interpret additional kinds.
+	// +kubebuilder:validation:Enum=Project;Role
 	Kind string `json:"kind"`
 
 	// Name is the name of the bootstrapped resource.

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/c5c3/forge/internal/common/policy"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
 // ControlPlane defaulting constants. These are the single source of
@@ -50,8 +51,10 @@ const (
 	// DefaultDatabaseClusterRefName is the managed MariaDB CR name materialized when
 	// spec.infrastructure.database is in managed mode (host unset).
 	DefaultDatabaseClusterRefName = "openstack-db"
-	// DefaultCacheBackend is materialized when spec.infrastructure.cache.backend is empty.
-	DefaultCacheBackend = "dogpile.cache.pymemcache"
+	// DefaultCacheBackend is materialized when spec.infrastructure.cache.backend
+	// is empty. It aliases commonv1.DefaultCacheBackend so the keystone and c5c3
+	// operators share one source of truth for the cache backend default.
+	DefaultCacheBackend = commonv1.DefaultCacheBackend
 	// DefaultCacheClusterRefName is the managed Memcached CR name materialized when
 	// spec.infrastructure.cache is in managed mode (servers unset).
 	DefaultCacheClusterRefName = "openstack-memcached"

--- a/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
@@ -101,7 +101,9 @@ spec:
                     description: |-
                       Cache defines the Memcached configuration shared by the control plane.
                       Supports managed (clusterRef) and brownfield (servers) modes; exactly one
-                      must be set (enforced by the validating webhook, mirroring keystone).
+                      must be set. That invariant is carried by the embedded commonv1.CacheSpec
+                      type-level CEL rule (and the validating webhook), mirroring keystone — no
+                      field-level marker is needed here, and duplicating it would emit the rule twice.
                     properties:
                       backend:
                         description: Backend is the cache backend (e.g. dogpile.cache.pymemcache).
@@ -147,7 +149,9 @@ spec:
                     description: |-
                       Database defines the MariaDB connection parameters shared by the control
                       plane. Supports managed (clusterRef) and brownfield (host) modes; exactly
-                      one must be set (enforced by the validating webhook, mirroring keystone).
+                      one must be set. That invariant is carried by the embedded commonv1.DatabaseSpec
+                      type-level CEL rule (and the validating webhook), mirroring keystone — no
+                      field-level marker is needed here, and duplicating it would emit the rule twice.
                     properties:
                       clusterRef:
                         description: ClusterRef references a MariaDB CR in the cluster
@@ -165,15 +169,30 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       database:
-                        description: Database is the database name within the cluster.
+                        description: |-
+                          Database is the database name within the cluster. Constrained to the MySQL
+                          identifier character set and the 64-character identifier limit.
+                        maxLength: 64
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9_]+$
                         type: string
                       host:
-                        description: Host is the database hostname (brownfield mode).
+                        description: |-
+                          Host is the database hostname (brownfield mode). The pattern is a
+                          permissive host matcher that accepts DNS names, IPv4, and IPv6 literals
+                          while rejecting empty strings and shell/path metacharacters; it is not a
+                          strict RFC-1123 validator, deliberately, so airgapped/mirror endpoints are
+                          not rejected at admission.
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9._:-]+$
                         type: string
                       port:
-                        description: Port is the database port (brownfield mode, default
-                          3306).
+                        description: |-
+                          Port is the database port (brownfield mode, default 3306). Omitted (managed
+                          mode) leaves it unset; an explicit value must be a valid TCP port.
                         format: int32
+                        maximum: 65535
+                        minimum: 1
                         type: integer
                       secretRef:
                         description: SecretRef references the K8s Secret with credentials.
@@ -181,6 +200,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -199,6 +226,14 @@ spec:
                               key:
                                 type: string
                               name:
+                                description: |-
+                                  Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                                  subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  database.secretRef / messaging / TLS cert refs and the c5c3
+                                  passwordSecretRef — so an empty name no longer slips through "required".
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - name
@@ -211,6 +246,14 @@ spec:
                               key:
                                 type: string
                               name:
+                                description: |-
+                                  Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                                  subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  database.secretRef / messaging / TLS cert refs and the c5c3
+                                  passwordSecretRef — so an empty name no longer slips through "required".
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - name
@@ -281,20 +324,35 @@ spec:
                                 rule shape (service / method / path).
                               properties:
                                 method:
-                                  description: Method is the HTTP method the rule
-                                    allows (e.g. "GET", "POST").
+                                  description: |-
+                                    Method is the HTTP method the rule allows (e.g. "GET", "POST"). Optional:
+                                    projectAccessRules omits it from the projected K-ORC rule when empty. The
+                                    enum mirrors K-ORC's HTTPMethod type (the value is cast to it), so a value
+                                    the downstream ApplicationCredentialAccessRule would reject is caught at
+                                    admission instead.
+                                  enum:
+                                  - CONNECT
+                                  - DELETE
+                                  - GET
+                                  - HEAD
+                                  - OPTIONS
+                                  - PATCH
+                                  - POST
+                                  - PUT
+                                  - TRACE
                                   type: string
                                 path:
-                                  description: Path is the request path the rule allows
-                                    (e.g. "/v2.1/servers").
+                                  description: |-
+                                    Path is the request path the rule allows (e.g. "/v2.1/servers"). Optional:
+                                    projectAccessRules omits it when empty. When set it must be an absolute
+                                    path (leading slash).
+                                  pattern: ^/
                                   type: string
                                 service:
                                   description: Service is the OpenStack service type
                                     the rule applies to (e.g. "compute").
                                   type: string
                               required:
-                              - method
-                              - path
                               - service
                               type: object
                             type: array
@@ -337,8 +395,13 @@ spec:
                             reconciler (L2) interprets the kind/name and applies it.
                           properties:
                             kind:
-                              description: Kind is the K-ORC resource kind to bootstrap
-                                (e.g. "Project", "Role").
+                              description: |-
+                                Kind is the K-ORC resource kind to bootstrap. Constrained to the kinds the
+                                control plane bootstraps today; widen the enum when the L2 reconciler
+                                learns to interpret additional kinds.
+                              enum:
+                              - Project
+                              - Role
                               type: string
                             name:
                               description: Name is the name of the bootstrapped resource.
@@ -381,6 +444,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -484,8 +555,23 @@ spec:
                           reconciler derives the image from spec.openStackRelease.
                         properties:
                           repository:
+                            description: |-
+                              Repository is the OCI image repository, optionally including the registry
+                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              permissive OCI reference — lowercase alphanumeric components separated by
+                              ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
+                              are accepted while an empty string (which "required" alone admits) and
+                              obvious garbage are rejected.
+                            minLength: 1
+                            pattern: ^[a-z0-9]+([._:/-][a-z0-9]+)*$
                             type: string
                           tag:
+                            description: |-
+                              Tag is the OCI image tag (e.g. "2025.2"). It follows the OCI tag grammar:
+                              up to 128 characters of word characters, dots, and dashes, and must not
+                              begin with a dot or dash.
+                            minLength: 1
+                            pattern: ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$
                             type: string
                         required:
                         - repository
@@ -538,6 +624,10 @@ spec:
                           "https://{gateway.hostname}/v3" (the default-443 form); set it explicitly
                           when the externally reachable port differs (e.g. a kind host-port mapping
                           like :8443), since the port cannot be derived from the hostname alone.
+                          The pattern enforces an HTTP(S) URL shape so a malformed endpoint is
+                          rejected at admission rather than wedging the projected Keystone CR (the
+                          keystone webhook later rejects a non-URL publicEndpoint post-admission).
+                        pattern: ^https?://
                         type: string
                       replicas:
                         description: |-

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
@@ -104,7 +104,9 @@ spec:
                     description: |-
                       Cache defines the Memcached configuration shared by the control plane.
                       Supports managed (clusterRef) and brownfield (servers) modes; exactly one
-                      must be set (enforced by the validating webhook, mirroring keystone).
+                      must be set. That invariant is carried by the embedded commonv1.CacheSpec
+                      type-level CEL rule (and the validating webhook), mirroring keystone — no
+                      field-level marker is needed here, and duplicating it would emit the rule twice.
                     properties:
                       backend:
                         description: Backend is the cache backend (e.g. dogpile.cache.pymemcache).
@@ -150,7 +152,9 @@ spec:
                     description: |-
                       Database defines the MariaDB connection parameters shared by the control
                       plane. Supports managed (clusterRef) and brownfield (host) modes; exactly
-                      one must be set (enforced by the validating webhook, mirroring keystone).
+                      one must be set. That invariant is carried by the embedded commonv1.DatabaseSpec
+                      type-level CEL rule (and the validating webhook), mirroring keystone — no
+                      field-level marker is needed here, and duplicating it would emit the rule twice.
                     properties:
                       clusterRef:
                         description: ClusterRef references a MariaDB CR in the cluster
@@ -168,15 +172,30 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       database:
-                        description: Database is the database name within the cluster.
+                        description: |-
+                          Database is the database name within the cluster. Constrained to the MySQL
+                          identifier character set and the 64-character identifier limit.
+                        maxLength: 64
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9_]+$
                         type: string
                       host:
-                        description: Host is the database hostname (brownfield mode).
+                        description: |-
+                          Host is the database hostname (brownfield mode). The pattern is a
+                          permissive host matcher that accepts DNS names, IPv4, and IPv6 literals
+                          while rejecting empty strings and shell/path metacharacters; it is not a
+                          strict RFC-1123 validator, deliberately, so airgapped/mirror endpoints are
+                          not rejected at admission.
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9._:-]+$
                         type: string
                       port:
-                        description: Port is the database port (brownfield mode, default
-                          3306).
+                        description: |-
+                          Port is the database port (brownfield mode, default 3306). Omitted (managed
+                          mode) leaves it unset; an explicit value must be a valid TCP port.
                         format: int32
+                        maximum: 65535
+                        minimum: 1
                         type: integer
                       secretRef:
                         description: SecretRef references the K8s Secret with credentials.
@@ -184,6 +203,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -202,6 +229,14 @@ spec:
                               key:
                                 type: string
                               name:
+                                description: |-
+                                  Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                                  subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  database.secretRef / messaging / TLS cert refs and the c5c3
+                                  passwordSecretRef — so an empty name no longer slips through "required".
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - name
@@ -214,6 +249,14 @@ spec:
                               key:
                                 type: string
                               name:
+                                description: |-
+                                  Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                                  subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  database.secretRef / messaging / TLS cert refs and the c5c3
+                                  passwordSecretRef — so an empty name no longer slips through "required".
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - name
@@ -284,20 +327,35 @@ spec:
                                 rule shape (service / method / path).
                               properties:
                                 method:
-                                  description: Method is the HTTP method the rule
-                                    allows (e.g. "GET", "POST").
+                                  description: |-
+                                    Method is the HTTP method the rule allows (e.g. "GET", "POST"). Optional:
+                                    projectAccessRules omits it from the projected K-ORC rule when empty. The
+                                    enum mirrors K-ORC's HTTPMethod type (the value is cast to it), so a value
+                                    the downstream ApplicationCredentialAccessRule would reject is caught at
+                                    admission instead.
+                                  enum:
+                                  - CONNECT
+                                  - DELETE
+                                  - GET
+                                  - HEAD
+                                  - OPTIONS
+                                  - PATCH
+                                  - POST
+                                  - PUT
+                                  - TRACE
                                   type: string
                                 path:
-                                  description: Path is the request path the rule allows
-                                    (e.g. "/v2.1/servers").
+                                  description: |-
+                                    Path is the request path the rule allows (e.g. "/v2.1/servers"). Optional:
+                                    projectAccessRules omits it when empty. When set it must be an absolute
+                                    path (leading slash).
+                                  pattern: ^/
                                   type: string
                                 service:
                                   description: Service is the OpenStack service type
                                     the rule applies to (e.g. "compute").
                                   type: string
                               required:
-                              - method
-                              - path
                               - service
                               type: object
                             type: array
@@ -340,8 +398,13 @@ spec:
                             reconciler (L2) interprets the kind/name and applies it.
                           properties:
                             kind:
-                              description: Kind is the K-ORC resource kind to bootstrap
-                                (e.g. "Project", "Role").
+                              description: |-
+                                Kind is the K-ORC resource kind to bootstrap. Constrained to the kinds the
+                                control plane bootstraps today; widen the enum when the L2 reconciler
+                                learns to interpret additional kinds.
+                              enum:
+                              - Project
+                              - Role
                               type: string
                             name:
                               description: Name is the name of the bootstrapped resource.
@@ -384,6 +447,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -487,8 +558,23 @@ spec:
                           reconciler derives the image from spec.openStackRelease.
                         properties:
                           repository:
+                            description: |-
+                              Repository is the OCI image repository, optionally including the registry
+                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              permissive OCI reference — lowercase alphanumeric components separated by
+                              ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
+                              are accepted while an empty string (which "required" alone admits) and
+                              obvious garbage are rejected.
+                            minLength: 1
+                            pattern: ^[a-z0-9]+([._:/-][a-z0-9]+)*$
                             type: string
                           tag:
+                            description: |-
+                              Tag is the OCI image tag (e.g. "2025.2"). It follows the OCI tag grammar:
+                              up to 128 characters of word characters, dots, and dashes, and must not
+                              begin with a dot or dash.
+                            minLength: 1
+                            pattern: ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$
                             type: string
                         required:
                         - repository
@@ -541,6 +627,10 @@ spec:
                           "https://{gateway.hostname}/v3" (the default-443 form); set it explicitly
                           when the externally reachable port differs (e.g. a kind host-port mapping
                           like :8443), since the port cannot be derived from the hostname alone.
+                          The pattern enforces an HTTP(S) URL shape so a malformed endpoint is
+                          rejected at admission rather than wedging the projected Keystone CR (the
+                          keystone webhook later rejects a non-URL publicEndpoint post-admission).
+                        pattern: ^https?://
                         type: string
                       replicas:
                         description: |-

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -1366,3 +1366,104 @@ func TestIntegration_ControlPlaneDeletion_SequencesORCTeardown(t *testing.T) {
 	}, itEventuallyTimeout, itPollInterval).Should(BeTrue(),
 		"AC and ControlPlane must be removed once the K-ORC finalizer clears")
 }
+
+// TestIntegration_ControlPlane_ValidationMarkers pins the validation-marker wave
+// on the ControlPlane CRD against the envtest API server (CRD schema + CEL +
+// validating webhook). Each rejection case mutates one field of an otherwise
+// valid managed ControlPlane in its own namespace (the webhook enforces one
+// ControlPlane per namespace); the final case asserts valid non-default
+// accessRules, bootstrapResources, and publicEndpoint are accepted.
+func TestIntegration_ControlPlane_ValidationMarkers(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+
+	c, ctx, _ := setupControlPlaneEnvTest(t)
+
+	cases := []struct {
+		name    string
+		mutate  func(*c5c3v1alpha1.ControlPlane)
+		wantErr bool
+	}{
+		{
+			name:    "database both clusterRef and host",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Infrastructure.Database.Host = "db.example.com"
+			},
+		},
+		{
+			name:    "cache both clusterRef and servers",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Infrastructure.Cache.Servers = []string{"mc:11211"}
+			},
+		},
+		{
+			name:    "non-URL keystone publicEndpoint",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Services.Keystone.PublicEndpoint = "keystone.example.com"
+			},
+		},
+		{
+			name:    "accessRule invalid method",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.KORC.AdminCredential.ApplicationCredential.AccessRules = []c5c3v1alpha1.AccessRule{
+					{Service: "compute", Method: "FETCH", Path: "/v2.1/servers"},
+				}
+			},
+		},
+		{
+			name:    "accessRule non-absolute path",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.KORC.AdminCredential.ApplicationCredential.AccessRules = []c5c3v1alpha1.AccessRule{
+					{Service: "compute", Method: "GET", Path: "v2.1/servers"},
+				}
+			},
+		},
+		{
+			name:    "bootstrapResource invalid kind",
+			wantErr: true,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.KORC.AdminCredential.BootstrapResources = []c5c3v1alpha1.BootstrapResourceSpec{
+					{Kind: "Network", Name: "ext"},
+				}
+			},
+		},
+		{
+			name:    "valid access rules, bootstrap resources, and public endpoint",
+			wantErr: false,
+			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Services.Keystone.PublicEndpoint = "https://keystone.example.com/v3"
+				cp.Spec.KORC.AdminCredential.ApplicationCredential.AccessRules = []c5c3v1alpha1.AccessRule{
+					{Service: "compute", Method: "GET", Path: "/v2.1/servers"},
+				}
+				cp.Spec.KORC.AdminCredential.BootstrapResources = []c5c3v1alpha1.BootstrapResourceSpec{
+					{Kind: "Project", Name: "service"},
+					{Kind: "Role", Name: "admin"},
+				}
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cp-marker-"}}
+			g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+			cp := integrationManagedControlPlane(fmt.Sprintf("cp-marker-%d", i), ns.Name)
+			tc.mutate(cp)
+
+			err := c.Create(ctx, cp)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred(), "admission must reject: %s", tc.name)
+				g.Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
+					fmt.Sprintf("expected Invalid or Forbidden status error for %q, got: %v", tc.name, err))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred(), "admission must accept: %s", tc.name)
+			}
+		})
+	}
+}

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -17,7 +18,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -913,4 +917,178 @@ func TestIntegration_CRDSchemaContainsLoggingSpec(t *testing.T) {
 		"spec.logging.perLoggerLevels.additionalProperties must carry a schema")
 	g.Expect(perLogger.AdditionalProperties.Schema.Type).To(Equal("string"),
 		"spec.logging.perLoggerLevels values must be string-typed")
+}
+
+// --- Validation-marker wave (issue #469): CRD-only rejection coverage ---
+
+// TestIntegration_CRD_CELOnly_RejectsValidationMarkers pins the validation-marker
+// wave (image refs, DB endpoints, secret refs, middleware enum, CEL parity)
+// against an envtest API server with NO validating webhook installed, so a
+// dropped marker or CEL rule fails here immediately — the webhook's
+// defense-in-depth checks cannot mask it. Each case mutates exactly one field of
+// an otherwise-valid CR, so the rejection is attributable to that field.
+//
+// The uwsgi httpKeepAlive/timeout cross-field rule is intentionally NOT covered
+// here: a typed Go client drops httpKeepAlive: false via omitempty before the
+// CRD default re-adds it, so the rule cannot fire through this client. The
+// raw-YAML invalid-cr Chainsaw fixture (17-uwsgi-keepalive-timeout-conflict.yaml)
+// is its primary coverage.
+func TestIntegration_CRD_CELOnly_RejectsValidationMarkers(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+
+	c, ctx, _ := setupEnvTestNoWebhook(t)
+
+	cases := []struct {
+		name   string
+		mutate func(*Keystone)
+	}{
+		{"empty image repository", func(k *Keystone) { k.Spec.Image.Repository = "" }},
+		{"empty image tag", func(k *Keystone) { k.Spec.Image.Tag = "" }},
+		{"database port above max", func(k *Keystone) { k.Spec.Database.Port = 70000 }},
+		{"database port negative", func(k *Keystone) { k.Spec.Database.Port = -1 }},
+		{"database name empty", func(k *Keystone) { k.Spec.Database.Database = "" }},
+		{"database name invalid char", func(k *Keystone) { k.Spec.Database.Database = "keystone-prod" }},
+		{"database name too long", func(k *Keystone) { k.Spec.Database.Database = strings.Repeat("a", 65) }},
+		{"empty database secretRef name", func(k *Keystone) { k.Spec.Database.SecretRef.Name = "" }},
+		{"empty admin password secretRef name", func(k *Keystone) {
+			k.Spec.Bootstrap.AdminPasswordSecretRef.Name = ""
+		}},
+		{"middleware bad position", func(k *Keystone) {
+			k.Spec.Middleware = []commonv1.MiddlewareSpec{{
+				Name:          "audit",
+				FilterFactory: "audit:filter_factory",
+				Position:      "sideways",
+			}}
+		}},
+		{"duplicate plugin config section", func(k *Keystone) {
+			k.Spec.Plugins = []commonv1.PluginSpec{
+				{Name: "a", ConfigSection: "dup"},
+				{Name: "b", ConfigSection: "dup"},
+			}
+		}},
+		{"autoscaling min greater than max", func(k *Keystone) {
+			k.Spec.Autoscaling = &AutoscalingSpec{
+				MinReplicas:          ptr.To(int32(10)),
+				MaxReplicas:          5,
+				TargetCPUUtilization: ptr.To(int32(80)),
+			}
+		}},
+		{"prestop not less than grace period", func(k *Keystone) {
+			k.Spec.PreStopSleepSeconds = ptr.To(int64(20))
+			k.Spec.TerminationGracePeriodSeconds = ptr.To(int64(15))
+		}},
+		{"perLoggerLevels invalid value", func(k *Keystone) {
+			k.Spec.Logging = &LoggingSpec{
+				Format:          "text",
+				Level:           "INFO",
+				PerLoggerLevels: map[string]string{"sqlalchemy.engine": "BOGUS"},
+			}
+		}},
+		{"perLoggerLevels empty key", func(k *Keystone) {
+			k.Spec.Logging = &LoggingSpec{
+				Format:          "text",
+				Level:           "INFO",
+				PerLoggerLevels: map[string]string{"": "INFO"},
+			}
+		}},
+		{"non-URL bootstrap publicEndpoint", func(k *Keystone) {
+			k.Spec.Bootstrap.PublicEndpoint = "keystone.example.com"
+		}},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-celonly-marker-"}}
+			g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+			k := validIntegrationKeystone(fmt.Sprintf("marker-reject-%d", i), ns.Name)
+			tc.mutate(k)
+
+			err := c.Create(ctx, k)
+			g.Expect(err).To(HaveOccurred(), "CRD schema alone must reject: %s", tc.name)
+			g.Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
+				fmt.Sprintf("expected Invalid or Forbidden status error for %q, got: %v", tc.name, err))
+		})
+	}
+}
+
+// TestIntegration_CRD_CELOnly_RejectsKeepAliveTimeoutWithoutKeepAlive pins the
+// UWSGISpec cross-field CEL rule against an envtest API server with NO validating
+// webhook installed. The CR is built as an *unstructured.Unstructured so
+// httpKeepAlive: false survives to the API server — a typed Go client drops it
+// via omitempty and the CRD default then re-adds true, which would mask the rule.
+func TestIntegration_CRD_CELOnly_RejectsKeepAliveTimeoutWithoutKeepAlive(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestNoWebhook(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-celonly-keepalive-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(
+		validIntegrationKeystone("keepalive-timeout", ns.Name),
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	u := &unstructured.Unstructured{Object: raw}
+	u.SetGroupVersionKind(GroupVersion.WithKind("Keystone"))
+	g.Expect(unstructured.SetNestedField(u.Object, false, "spec", "uwsgi", "httpKeepAlive")).To(Succeed())
+	g.Expect(unstructured.SetNestedField(u.Object, int64(30), "spec", "uwsgi", "httpKeepAliveTimeout")).To(Succeed())
+
+	err = c.Create(ctx, u)
+	g.Expect(err).To(HaveOccurred(),
+		"httpKeepAliveTimeout set while httpKeepAlive is false must be rejected by the CRD CEL rule")
+	g.Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
+		fmt.Sprintf("expected Invalid or Forbidden status error, got: %v", err))
+	g.Expect(err.Error()).To(ContainSubstring("httpKeepAliveTimeout"))
+}
+
+// TestIntegration_AcceptsValidNonDefaultMarkers verifies the validation-marker
+// wave accepts valid NON-DEFAULT values, so a future over-restrictive marker
+// edit (e.g. a too-narrow pattern) is caught — the positive-coverage counterpart
+// to the rejection table above.
+func TestIntegration_AcceptsValidNonDefaultMarkers(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTest(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-valid-markers-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	k := validIntegrationKeystone("valid-markers", ns.Name)
+	// Non-default image (different repository + tag with separators).
+	k.Spec.Image = commonv1.ImageSpec{Repository: "ghcr.io/c5c3/keystone-operator", Tag: "2025.2-upgraded"}
+	// Brownfield DB with an explicit non-default port and an underscore name.
+	k.Spec.Database.Host = "db.internal.svc.cluster.local"
+	k.Spec.Database.Port = 13306
+	k.Spec.Database.Database = "keystone_prod"
+	// Middleware with a valid position; plugins with distinct config sections.
+	k.Spec.Middleware = []commonv1.MiddlewareSpec{{
+		Name:          "audit",
+		FilterFactory: "audit:filter_factory",
+		Position:      commonv1.PipelinePositionAfter,
+	}}
+	k.Spec.Plugins = []commonv1.PluginSpec{
+		{Name: "ldap", ConfigSection: "ldap"},
+		{Name: "federation", ConfigSection: "federation"},
+	}
+	// Valid HTTP(S) public endpoint (no gateway, so the webhook host check is skipped).
+	k.Spec.Bootstrap.PublicEndpoint = "https://keystone.example.com/v3"
+	// Valid per-logger levels and a valid keepalive+timeout combination.
+	k.Spec.Logging = &LoggingSpec{
+		Format:          "json",
+		Level:           "WARNING",
+		PerLoggerLevels: map[string]string{"sqlalchemy.engine": "WARNING"},
+	}
+	k.Spec.UWSGI = &UWSGISpec{
+		Processes:            4,
+		Threads:              2,
+		HTTPKeepAlive:        true,
+		HTTPKeepAliveTimeout: ptr.To(int32(30)),
+	}
+
+	g.Expect(c.Create(ctx, k)).To(Succeed(),
+		"valid non-default validation-marker values should be accepted")
 }

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -48,6 +48,13 @@ type KeystoneList struct {
 }
 
 // KeystoneSpec defines the desired state of Keystone.
+//
+// The drain-window CEL rule mirrors the validating webhook: when one
+// or both of the nil-preserving pointers is unset, the rule substitutes the same
+// effective defaults the reconciler applies. The literals 5 and 30 must stay in
+// sync with DefaultPreStopSleepSeconds and DefaultTerminationGracePeriodSeconds
+// in keystone_webhook.go — kubebuilder/CEL rules cannot reference Go constants.
+// +kubebuilder:validation:XValidation:rule="(has(self.preStopSleepSeconds) ? self.preStopSleepSeconds : 5) < (has(self.terminationGracePeriodSeconds) ? self.terminationGracePeriodSeconds : 30)",message="preStopSleepSeconds must be strictly less than terminationGracePeriodSeconds"
 type KeystoneSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=3
@@ -128,8 +135,14 @@ type KeystoneSpec struct {
 	// +optional
 	Middleware []commonv1.MiddlewareSpec `json:"middleware,omitempty"`
 
-	// Plugins defines service plugins/drivers to configure.
+	// Plugins defines service plugins/drivers to configure. Modeled as a
+	// list-map keyed by configSection so the API server rejects duplicate
+	// sections structurally (parity with the validating webhook's duplicate
+	// check) and server-side apply merges entries by section instead of
+	// replacing the whole list.
 	// +optional
+	// +listType=map
+	// +listMapKey=configSection
 	Plugins []commonv1.PluginSpec `json:"plugins,omitempty"`
 
 	// PolicyOverrides defines custom oslo.policy rules for the service.
@@ -252,6 +265,7 @@ type KeystoneSpec struct {
 
 // AutoscalingSpec defines the parameters for horizontal pod autoscaling.
 // +kubebuilder:validation:XValidation:rule="has(self.targetCPUUtilization) || has(self.targetMemoryUtilization)",message="at least one of targetCPUUtilization or targetMemoryUtilization must be set"
+// +kubebuilder:validation:XValidation:rule="!has(self.minReplicas) || self.minReplicas <= self.maxReplicas",message="minReplicas must not exceed maxReplicas"
 type AutoscalingSpec struct {
 	// MinReplicas is the lower bound for the number of replicas.
 	// Defaults to the current spec.replicas value if unset.
@@ -314,6 +328,10 @@ type NetworkPolicyIngressSource struct {
 // UWSGISpec defines the uWSGI application server parameters.
 // Exposed as an optional pointer field on KeystoneSpec so that existing CRs
 // without spec.uwsgi continue to work with hardcoded defaults in the reconciler.
+// The cross-field CEL rule mirrors the validating webhook: httpKeepAliveTimeout
+// is only meaningful when httpKeepAlive is true, otherwise the
+// --http-keepalive-timeout flag is never emitted.
+// +kubebuilder:validation:XValidation:rule="!has(self.httpKeepAliveTimeout) || self.httpKeepAlive",message="httpKeepAliveTimeout may only be set when httpKeepAlive is true"
 type UWSGISpec struct {
 	// Processes is the number of uWSGI worker processes.
 	// +kubebuilder:validation:Minimum=1
@@ -495,8 +513,11 @@ type BootstrapSpec struct {
 	// PublicEndpoint is the externally routable Keystone endpoint URL used for
 	// --bootstrap-public-url. When unset, the cluster-local service DNS is used
 	// as a fallback. External clients (CLI users, Horizon, federation partners)
-	// require a routable address here.
+	// require a routable address here. The pattern enforces an HTTP(S)
+	// URL shape unconditionally; the webhook additionally cross-checks the host
+	// against spec.gateway.hostname when a gateway is configured.
 	// +optional
+	// +kubebuilder:validation:Pattern=`^https?://`
 	PublicEndpoint string `json:"publicEndpoint,omitempty"`
 
 	// PasswordRotation optionally enables scheduled rotation of the admin
@@ -586,10 +607,14 @@ type LoggingSpec struct {
 	// PerLoggerLevels overrides the level of named loggers, mirroring
 	// oslo.log's `default_log_levels`. Example:
 	// {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
-	// Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL —
-	// enforced by the validating webhook, not the CRD enum (additionalProperties
-	// does not support enum constraints in CRD v1).
+	// Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
+	// logger name must be non-empty. These are now enforced by the CRD CEL
+	// XValidation rules below as well as by the validating webhook (a plain
+	// enum on additionalProperties is still not expressible in CRD v1, so the
+	// value constraint is written as an `in [...]` CEL rule rather than an enum).
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(k, k != '')",message="logger name must not be empty"
+	// +kubebuilder:validation:XValidation:rule="self.all(k, self[k] in ['DEBUG','INFO','WARNING','ERROR','CRITICAL'])",message="per-logger level must be one of DEBUG, INFO, WARNING, ERROR, CRITICAL"
 	PerLoggerLevels map[string]string `json:"perLoggerLevels,omitempty"`
 }
 

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -334,17 +334,20 @@ type NetworkPolicyIngressSource struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.httpKeepAliveTimeout) || self.httpKeepAlive",message="httpKeepAliveTimeout may only be set when httpKeepAlive is true"
 type UWSGISpec struct {
 	// Processes is the number of uWSGI worker processes.
+	// The default literal mirrors DefaultUWSGIProcesses in keystone_webhook.go.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=2
 	Processes int32 `json:"processes,omitempty"`
 
 	// Threads is the number of threads per uWSGI worker process.
+	// The default literal mirrors DefaultUWSGIThreads in keystone_webhook.go.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=1
 	Threads int32 `json:"threads,omitempty"`
 
 	// HTTPKeepAlive enables the --http-keepalive flag on the uWSGI process.
-	// When false, the flag is omitted from the command.
+	// When false, the flag is omitted from the command. The default literal
+	// mirrors DefaultUWSGIHTTPKeepAlive in keystone_webhook.go.
 	// +kubebuilder:default=true
 	HTTPKeepAlive bool `json:"httpKeepAlive,omitempty"`
 
@@ -480,8 +483,9 @@ type PasswordRotationSpec struct {
 	Suspend bool `json:"suspend,omitempty"`
 
 	// PasswordLength is the length of the generated password. The kubebuilder
-	// default literal below must stay in sync with DefaultPasswordRotationLength
-	// in keystone_webhook.go.
+	// default literal below must stay in sync with DefaultPasswordRotationLength,
+	// and the Minimum literal with DefaultAdminPasswordMinLength, both in
+	// keystone_webhook.go.
 	// +kubebuilder:validation:Minimum=24
 	// +kubebuilder:default=32
 	PasswordLength int32 `json:"passwordLength,omitempty"`

--- a/operators/keystone/api/v1alpha1/keystone_webhook.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/c5c3/forge/internal/common/policy"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
 // Graceful-termination effective defaults.
@@ -71,6 +72,23 @@ const (
 	// into. It is the single source of truth shared by Default() and the
 	// webhook validation enum so the baseline cannot drift across call sites.
 	DefaultDatabaseTLSMode = "require"
+
+	// DefaultUWSGIProcesses / DefaultUWSGIThreads / DefaultUWSGIHTTPKeepAlive are
+	// the uWSGI defaults applied by the defaulting webhook (Processes/Threads)
+	// and the reconciler (uwsgiCommand, when spec.uwsgi is nil). They are the
+	// single source of truth so the webhook and reconcile_deployment.go cannot
+	// drift; the +kubebuilder:default markers on UWSGISpec keep the same literals
+	// in sync separately (markers cannot reference Go constants).
+	DefaultUWSGIProcesses     int32 = 2
+	DefaultUWSGIThreads       int32 = 1
+	DefaultUWSGIHTTPKeepAlive       = true
+
+	// DefaultAdminPasswordMinLength is the floor for the generated admin-password
+	// length. It is the single source of truth shared by the webhook
+	// defense-in-depth check and the reconciler floor (reconcile_passwordrotation.go);
+	// the +kubebuilder:validation:Minimum=24 marker on
+	// PasswordRotationSpec.PasswordLength keeps the same literal in sync.
+	DefaultAdminPasswordMinLength int32 = 24
 )
 
 // Default resource requests and limits for the Keystone API container.
@@ -126,7 +144,7 @@ func (w *KeystoneWebhook) Default(_ context.Context, obj *Keystone) error {
 		obj.Spec.CredentialKeys.MaxActiveKeys = 3
 	}
 	if obj.Spec.Cache.Backend == "" {
-		obj.Spec.Cache.Backend = "dogpile.cache.pymemcache"
+		obj.Spec.Cache.Backend = commonv1.DefaultCacheBackend
 	}
 	if obj.Spec.Bootstrap.AdminUser == "" {
 		obj.Spec.Bootstrap.AdminUser = "admin"
@@ -171,10 +189,10 @@ func (w *KeystoneWebhook) Default(_ context.Context, obj *Keystone) error {
 	// admission path; uwsgiCommand uses the CRD default at runtime.
 	if obj.Spec.UWSGI != nil {
 		if obj.Spec.UWSGI.Processes == 0 {
-			obj.Spec.UWSGI.Processes = 2
+			obj.Spec.UWSGI.Processes = DefaultUWSGIProcesses
 		}
 		if obj.Spec.UWSGI.Threads == 0 {
-			obj.Spec.UWSGI.Threads = 1
+			obj.Spec.UWSGI.Threads = DefaultUWSGIThreads
 		}
 	}
 	// Default zero-valued sub-fields of spec.logging.
@@ -438,15 +456,16 @@ func (w *KeystoneWebhook) validate(ctx context.Context, k *Keystone) error {
 		// out-of-range value if CRD schema admission is bypassed, matching the
 		// defense-in-depth convention every other Minimum-marked field in this
 		// webhook follows (Fernet/CredentialKeys maxActiveKeys, UWSGI harakiri /
-		// httpKeepAliveTimeout, terminationGracePeriodSeconds). The literal 24
-		// mirrors the marker — kubebuilder markers cannot reference Go constants,
-		// and the api package cannot import the controller's adminPasswordMinLength
-		// without a cycle.
-		if pr.PasswordLength != 0 && pr.PasswordLength < 24 {
+		// httpKeepAliveTimeout, terminationGracePeriodSeconds). The check uses
+		// DefaultAdminPasswordMinLength (the single source of truth in this
+		// package, also referenced by the reconciler floor); the
+		// +kubebuilder:validation:Minimum marker keeps the literal in sync,
+		// since markers cannot reference Go constants.
+		if pr.PasswordLength != 0 && pr.PasswordLength < DefaultAdminPasswordMinLength {
 			allErrs = append(allErrs, field.Invalid(
 				prPath.Child("passwordLength"),
 				pr.PasswordLength,
-				"passwordLength must be at least 24",
+				fmt.Sprintf("passwordLength must be at least %d", DefaultAdminPasswordMinLength),
 			))
 		}
 	}

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -50,7 +50,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: KeystoneSpec defines the desired state of Keystone.
+            description: |-
+              KeystoneSpec defines the desired state of Keystone.
+
+              The drain-window CEL rule mirrors the validating webhook: when one
+              or both of the nil-preserving pointers is unset, the rule substitutes the same
+              effective defaults the reconciler applies. The literals 5 and 30 must stay in
+              sync with DefaultPreStopSleepSeconds and DefaultTerminationGracePeriodSeconds
+              in keystone_webhook.go — kubebuilder/CEL rules cannot reference Go constants.
             properties:
               autoscaling:
                 description: |-
@@ -92,6 +99,8 @@ spec:
                 - message: at least one of targetCPUUtilization or targetMemoryUtilization
                     must be set
                   rule: has(self.targetCPUUtilization) || has(self.targetMemoryUtilization)
+                - message: minReplicas must not exceed maxReplicas
+                  rule: '!has(self.minReplicas) || self.minReplicas <= self.maxReplicas'
               bootstrap:
                 description: Bootstrap configures the initial Keystone bootstrap.
                 properties:
@@ -102,6 +111,14 @@ spec:
                       key:
                         type: string
                       name:
+                        description: |-
+                          Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                          subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          database.secretRef / messaging / TLS cert refs and the c5c3
+                          passwordSecretRef — so an empty name no longer slips through "required".
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:
                     - name
@@ -135,8 +152,9 @@ spec:
                         default: 32
                         description: |-
                           PasswordLength is the length of the generated password. The kubebuilder
-                          default literal below must stay in sync with DefaultPasswordRotationLength
-                          in keystone_webhook.go.
+                          default literal below must stay in sync with DefaultPasswordRotationLength,
+                          and the Minimum literal with DefaultAdminPasswordMinLength, both in
+                          keystone_webhook.go.
                         format: int32
                         minimum: 24
                         type: integer
@@ -158,7 +176,10 @@ spec:
                       PublicEndpoint is the externally routable Keystone endpoint URL used for
                       --bootstrap-public-url. When unset, the cluster-local service DNS is used
                       as a fallback. External clients (CLI users, Horizon, federation partners)
-                      require a routable address here.
+                      require a routable address here. The pattern enforces an HTTP(S)
+                      URL shape unconditionally; the webhook additionally cross-checks the host
+                      against spec.gateway.hostname when a gateway is configured.
+                    pattern: ^https?://
                     type: string
                   region:
                     default: RegionOne
@@ -287,15 +308,30 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   database:
-                    description: Database is the database name within the cluster.
+                    description: |-
+                      Database is the database name within the cluster. Constrained to the MySQL
+                      identifier character set and the 64-character identifier limit.
+                    maxLength: 64
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9_]+$
                     type: string
                   host:
-                    description: Host is the database hostname (brownfield mode).
+                    description: |-
+                      Host is the database hostname (brownfield mode). The pattern is a
+                      permissive host matcher that accepts DNS names, IPv4, and IPv6 literals
+                      while rejecting empty strings and shell/path metacharacters; it is not a
+                      strict RFC-1123 validator, deliberately, so airgapped/mirror endpoints are
+                      not rejected at admission.
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9._:-]+$
                     type: string
                   port:
-                    description: Port is the database port (brownfield mode, default
-                      3306).
+                    description: |-
+                      Port is the database port (brownfield mode, default 3306). Omitted (managed
+                      mode) leaves it unset; an explicit value must be a valid TCP port.
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   secretRef:
                     description: SecretRef references the K8s Secret with credentials.
@@ -303,6 +339,14 @@ spec:
                       key:
                         type: string
                       name:
+                        description: |-
+                          Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                          subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          database.secretRef / messaging / TLS cert refs and the c5c3
+                          passwordSecretRef — so an empty name no longer slips through "required".
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:
                     - name
@@ -321,6 +365,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -333,6 +385,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -491,8 +551,23 @@ spec:
                   ControlPlane webhook is bypassed.
                 properties:
                   repository:
+                    description: |-
+                      Repository is the OCI image repository, optionally including the registry
+                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      permissive OCI reference — lowercase alphanumeric components separated by
+                      ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
+                      are accepted while an empty string (which "required" alone admits) and
+                      obvious garbage are rejected.
+                    minLength: 1
+                    pattern: ^[a-z0-9]+([._:/-][a-z0-9]+)*$
                     type: string
                   tag:
+                    description: |-
+                      Tag is the OCI image tag (e.g. "2025.2"). It follows the OCI tag grammar:
+                      up to 128 characters of word characters, dots, and dashes, and must not
+                      begin with a dot or dash.
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$
                     type: string
                 required:
                 - repository
@@ -539,10 +614,18 @@ spec:
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
                       {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
-                      Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL —
-                      enforced by the validating webhook, not the CRD enum (additionalProperties
-                      does not support enum constraints in CRD v1).
+                      Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
+                      logger name must be non-empty. These are now enforced by the CRD CEL
+                      XValidation rules below as well as by the validating webhook (a plain
+                      enum on additionalProperties is still not expressible in CRD v1, so the
+                      value constraint is written as an `in [...]` CEL rule rather than an enum).
                     type: object
+                    x-kubernetes-validations:
+                    - message: logger name must not be empty
+                      rule: self.all(k, k != '')
+                    - message: per-logger level must be one of DEBUG, INFO, WARNING,
+                        ERROR, CRITICAL
+                      rule: self.all(k, self[k] in ['DEBUG','INFO','WARNING','ERROR','CRITICAL'])
                 type: object
               middleware:
                 description: Middleware defines WSGI middleware filters for the api-paste.ini
@@ -567,6 +650,9 @@ spec:
                     position:
                       description: Position defines where in the pipeline this filter
                         is inserted
+                      enum:
+                      - before
+                      - after
                       type: string
                   required:
                   - filterFactory
@@ -812,7 +898,12 @@ spec:
                 - message: at least one ingress source must be specified
                   rule: size(self.ingress) > 0
               plugins:
-                description: Plugins defines service plugins/drivers to configure.
+                description: |-
+                  Plugins defines service plugins/drivers to configure. Modeled as a
+                  list-map keyed by configSection so the API server rejects duplicate
+                  sections structurally (parity with the validating webhook's duplicate
+                  check) and server-side apply merges entries by section instead of
+                  replacing the whole list.
                 items:
                   description: PluginSpec defines a service plugin/driver configuration.
                   properties:
@@ -833,6 +924,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - configSection
+                x-kubernetes-list-type: map
               policyOverrides:
                 description: |-
                   PolicyOverrides defines custom oslo.policy rules for the service.
@@ -1260,7 +1354,8 @@ spec:
                     default: true
                     description: |-
                       HTTPKeepAlive enables the --http-keepalive flag on the uWSGI process.
-                      When false, the flag is omitted from the command.
+                      When false, the flag is omitted from the command. The default literal
+                      mirrors DefaultUWSGIHTTPKeepAlive in keystone_webhook.go.
                     type: boolean
                   httpKeepAliveTimeout:
                     description: |-
@@ -1277,24 +1372,36 @@ spec:
                     type: integer
                   processes:
                     default: 2
-                    description: Processes is the number of uWSGI worker processes.
+                    description: |-
+                      Processes is the number of uWSGI worker processes.
+                      The default literal mirrors DefaultUWSGIProcesses in keystone_webhook.go.
                     format: int32
                     minimum: 1
                     type: integer
                   threads:
                     default: 1
-                    description: Threads is the number of threads per uWSGI worker
-                      process.
+                    description: |-
+                      Threads is the number of threads per uWSGI worker process.
+                      The default literal mirrors DefaultUWSGIThreads in keystone_webhook.go.
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: httpKeepAliveTimeout may only be set when httpKeepAlive
+                    is true
+                  rule: '!has(self.httpKeepAliveTimeout) || self.httpKeepAlive'
             required:
             - bootstrap
             - cache
             - database
             - image
             type: object
+            x-kubernetes-validations:
+            - message: preStopSleepSeconds must be strictly less than terminationGracePeriodSeconds
+              rule: '(has(self.preStopSleepSeconds) ? self.preStopSleepSeconds : 5)
+                < (has(self.terminationGracePeriodSeconds) ? self.terminationGracePeriodSeconds
+                : 30)'
           status:
             description: KeystoneStatus defines the observed state of Keystone.
             properties:

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -53,7 +53,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: KeystoneSpec defines the desired state of Keystone.
+            description: |-
+              KeystoneSpec defines the desired state of Keystone.
+
+              The drain-window CEL rule mirrors the validating webhook: when one
+              or both of the nil-preserving pointers is unset, the rule substitutes the same
+              effective defaults the reconciler applies. The literals 5 and 30 must stay in
+              sync with DefaultPreStopSleepSeconds and DefaultTerminationGracePeriodSeconds
+              in keystone_webhook.go — kubebuilder/CEL rules cannot reference Go constants.
             properties:
               autoscaling:
                 description: |-
@@ -95,6 +102,8 @@ spec:
                 - message: at least one of targetCPUUtilization or targetMemoryUtilization
                     must be set
                   rule: has(self.targetCPUUtilization) || has(self.targetMemoryUtilization)
+                - message: minReplicas must not exceed maxReplicas
+                  rule: '!has(self.minReplicas) || self.minReplicas <= self.maxReplicas'
               bootstrap:
                 description: Bootstrap configures the initial Keystone bootstrap.
                 properties:
@@ -105,6 +114,14 @@ spec:
                       key:
                         type: string
                       name:
+                        description: |-
+                          Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                          subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          database.secretRef / messaging / TLS cert refs and the c5c3
+                          passwordSecretRef — so an empty name no longer slips through "required".
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:
                     - name
@@ -138,8 +155,9 @@ spec:
                         default: 32
                         description: |-
                           PasswordLength is the length of the generated password. The kubebuilder
-                          default literal below must stay in sync with DefaultPasswordRotationLength
-                          in keystone_webhook.go.
+                          default literal below must stay in sync with DefaultPasswordRotationLength,
+                          and the Minimum literal with DefaultAdminPasswordMinLength, both in
+                          keystone_webhook.go.
                         format: int32
                         minimum: 24
                         type: integer
@@ -161,7 +179,10 @@ spec:
                       PublicEndpoint is the externally routable Keystone endpoint URL used for
                       --bootstrap-public-url. When unset, the cluster-local service DNS is used
                       as a fallback. External clients (CLI users, Horizon, federation partners)
-                      require a routable address here.
+                      require a routable address here. The pattern enforces an HTTP(S)
+                      URL shape unconditionally; the webhook additionally cross-checks the host
+                      against spec.gateway.hostname when a gateway is configured.
+                    pattern: ^https?://
                     type: string
                   region:
                     default: RegionOne
@@ -290,15 +311,30 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   database:
-                    description: Database is the database name within the cluster.
+                    description: |-
+                      Database is the database name within the cluster. Constrained to the MySQL
+                      identifier character set and the 64-character identifier limit.
+                    maxLength: 64
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9_]+$
                     type: string
                   host:
-                    description: Host is the database hostname (brownfield mode).
+                    description: |-
+                      Host is the database hostname (brownfield mode). The pattern is a
+                      permissive host matcher that accepts DNS names, IPv4, and IPv6 literals
+                      while rejecting empty strings and shell/path metacharacters; it is not a
+                      strict RFC-1123 validator, deliberately, so airgapped/mirror endpoints are
+                      not rejected at admission.
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9._:-]+$
                     type: string
                   port:
-                    description: Port is the database port (brownfield mode, default
-                      3306).
+                    description: |-
+                      Port is the database port (brownfield mode, default 3306). Omitted (managed
+                      mode) leaves it unset; an explicit value must be a valid TCP port.
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   secretRef:
                     description: SecretRef references the K8s Secret with credentials.
@@ -306,6 +342,14 @@ spec:
                       key:
                         type: string
                       name:
+                        description: |-
+                          Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                          subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          database.secretRef / messaging / TLS cert refs and the c5c3
+                          passwordSecretRef — so an empty name no longer slips through "required".
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:
                     - name
@@ -324,6 +368,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -336,6 +388,14 @@ spec:
                           key:
                             type: string
                           name:
+                            description: |-
+                              Name is the referenced Secret's name. It must be a non-empty DNS-1123
+                              subdomain (the Kubernetes object-name grammar). Tightening the shared type
+                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              database.secretRef / messaging / TLS cert refs and the c5c3
+                              passwordSecretRef — so an empty name no longer slips through "required".
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                         - name
@@ -494,8 +554,23 @@ spec:
                   ControlPlane webhook is bypassed.
                 properties:
                   repository:
+                    description: |-
+                      Repository is the OCI image repository, optionally including the registry
+                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      permissive OCI reference — lowercase alphanumeric components separated by
+                      ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
+                      are accepted while an empty string (which "required" alone admits) and
+                      obvious garbage are rejected.
+                    minLength: 1
+                    pattern: ^[a-z0-9]+([._:/-][a-z0-9]+)*$
                     type: string
                   tag:
+                    description: |-
+                      Tag is the OCI image tag (e.g. "2025.2"). It follows the OCI tag grammar:
+                      up to 128 characters of word characters, dots, and dashes, and must not
+                      begin with a dot or dash.
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$
                     type: string
                 required:
                 - repository
@@ -542,10 +617,18 @@ spec:
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
                       {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
-                      Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL —
-                      enforced by the validating webhook, not the CRD enum (additionalProperties
-                      does not support enum constraints in CRD v1).
+                      Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
+                      logger name must be non-empty. These are now enforced by the CRD CEL
+                      XValidation rules below as well as by the validating webhook (a plain
+                      enum on additionalProperties is still not expressible in CRD v1, so the
+                      value constraint is written as an `in [...]` CEL rule rather than an enum).
                     type: object
+                    x-kubernetes-validations:
+                    - message: logger name must not be empty
+                      rule: self.all(k, k != '')
+                    - message: per-logger level must be one of DEBUG, INFO, WARNING,
+                        ERROR, CRITICAL
+                      rule: self.all(k, self[k] in ['DEBUG','INFO','WARNING','ERROR','CRITICAL'])
                 type: object
               middleware:
                 description: Middleware defines WSGI middleware filters for the api-paste.ini
@@ -570,6 +653,9 @@ spec:
                     position:
                       description: Position defines where in the pipeline this filter
                         is inserted
+                      enum:
+                      - before
+                      - after
                       type: string
                   required:
                   - filterFactory
@@ -815,7 +901,12 @@ spec:
                 - message: at least one ingress source must be specified
                   rule: size(self.ingress) > 0
               plugins:
-                description: Plugins defines service plugins/drivers to configure.
+                description: |-
+                  Plugins defines service plugins/drivers to configure. Modeled as a
+                  list-map keyed by configSection so the API server rejects duplicate
+                  sections structurally (parity with the validating webhook's duplicate
+                  check) and server-side apply merges entries by section instead of
+                  replacing the whole list.
                 items:
                   description: PluginSpec defines a service plugin/driver configuration.
                   properties:
@@ -836,6 +927,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - configSection
+                x-kubernetes-list-type: map
               policyOverrides:
                 description: |-
                   PolicyOverrides defines custom oslo.policy rules for the service.
@@ -1263,7 +1357,8 @@ spec:
                     default: true
                     description: |-
                       HTTPKeepAlive enables the --http-keepalive flag on the uWSGI process.
-                      When false, the flag is omitted from the command.
+                      When false, the flag is omitted from the command. The default literal
+                      mirrors DefaultUWSGIHTTPKeepAlive in keystone_webhook.go.
                     type: boolean
                   httpKeepAliveTimeout:
                     description: |-
@@ -1280,24 +1375,36 @@ spec:
                     type: integer
                   processes:
                     default: 2
-                    description: Processes is the number of uWSGI worker processes.
+                    description: |-
+                      Processes is the number of uWSGI worker processes.
+                      The default literal mirrors DefaultUWSGIProcesses in keystone_webhook.go.
                     format: int32
                     minimum: 1
                     type: integer
                   threads:
                     default: 1
-                    description: Threads is the number of threads per uWSGI worker
-                      process.
+                    description: |-
+                      Threads is the number of threads per uWSGI worker process.
+                      The default literal mirrors DefaultUWSGIThreads in keystone_webhook.go.
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: httpKeepAliveTimeout may only be set when httpKeepAlive
+                    is true
+                  rule: '!has(self.httpKeepAliveTimeout) || self.httpKeepAlive'
             required:
             - bootstrap
             - cache
             - database
             - image
             type: object
+            x-kubernetes-validations:
+            - message: preStopSleepSeconds must be strictly less than terminationGracePeriodSeconds
+              rule: '(has(self.preStopSleepSeconds) ? self.preStopSleepSeconds : 5)
+                < (has(self.terminationGracePeriodSeconds) ? self.terminationGracePeriodSeconds
+                : 30)'
           status:
             description: KeystoneStatus defines the observed state of Keystone.
             properties:

--- a/operators/keystone/internal/controller/reconcile_deployment.go
+++ b/operators/keystone/internal/controller/reconcile_deployment.go
@@ -383,9 +383,9 @@ func buildPodDisruptionBudget(keystone *keystonev1alpha1.Keystone) *policyv1.Pod
 // --http-keepalive[-timeout] block and --wsgi-file so request lines reach
 // stderr in every configuration, including when keep-alive is disabled.
 func uwsgiCommand(uwsgi *keystonev1alpha1.UWSGISpec) []string {
-	processes := int32(2)
-	threads := int32(1)
-	httpKeepAlive := true
+	processes := keystonev1alpha1.DefaultUWSGIProcesses
+	threads := keystonev1alpha1.DefaultUWSGIThreads
+	httpKeepAlive := keystonev1alpha1.DefaultUWSGIHTTPKeepAlive
 
 	if uwsgi != nil {
 		processes = uwsgi.Processes

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -61,8 +61,10 @@ const adminPasswordSecretKey = "password" //nolint:gosec // G101 false positive:
 // password length, mirroring the +kubebuilder:validation:Minimum=24 marker on
 // PasswordRotationSpec.PasswordLength. The webhook defaults PasswordLength to
 // DefaultPasswordRotationLength (32) when rotation is enabled, but this floor
-// protects callers that bypass the webhook (e.g. envtest).
-const adminPasswordMinLength int32 = 24
+// protects callers that bypass the webhook (e.g. envtest). It aliases
+// the api package's DefaultAdminPasswordMinLength so the floor has a single
+// source of truth shared with the validating webhook.
+const adminPasswordMinLength = keystonev1alpha1.DefaultAdminPasswordMinLength
 
 // ErrAdminPasswordMissing is returned when the staged Secret has no non-empty
 // password value.

--- a/tests/e2e/keystone/invalid-cr/13-image-empty-tag.yaml
+++ b/tests/e2e/keystone/invalid-cr/13-image-empty-tag.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR with an empty spec.image.tag. The
+# shared ImageSpec.Tag now carries +kubebuilder:validation:MinLength=1, so
+# an empty tag (which "required" alone admitted) is rejected by the CRD
+# schema. Admission must reject this CR with an $error referencing the
+# substring "image.tag".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-image-empty-tag
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: ""
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/14-database-name-invalid-char.yaml
+++ b/tests/e2e/keystone/invalid-cr/14-database-name-invalid-char.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR whose spec.database.database uses a
+# hyphen, outside the MySQL identifier character set. Rejected by the
+# DatabaseSpec.Database Pattern marker (^[A-Za-z0-9_]+$). Admission must
+# reject this CR with an $error referencing the substring "database".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-database-name-char
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone-prod
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/15-database-secretref-empty-name.yaml
+++ b/tests/e2e/keystone/invalid-cr/15-database-secretref-empty-name.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR whose spec.database.secretRef.name is
+# empty. The shared SecretRefSpec.Name now carries MinLength=1, so an empty
+# Secret name (previously admitted by "required") is rejected at the CRD
+# schema layer. Admission must reject this CR with an $error referencing the
+# substring "secretRef".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-database-secretref-empty-name
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: ""
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/16-middleware-bad-position.yaml
+++ b/tests/e2e/keystone/invalid-cr/16-middleware-bad-position.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR with a spec.middleware[].position
+# value outside the documented enum. The shared PipelinePosition type now
+# carries +kubebuilder:validation:Enum=before;after, so "sideways" — which
+# would corrupt the api-paste.ini pipeline — is rejected at the CRD schema
+# layer. Admission must reject this CR with an $error referencing the
+# substring "position".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-middleware-position
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+  middleware:
+  - name: audit
+    filterFactory: audit:filter_factory
+    position: sideways

--- a/tests/e2e/keystone/invalid-cr/17-uwsgi-keepalive-timeout-conflict.yaml
+++ b/tests/e2e/keystone/invalid-cr/17-uwsgi-keepalive-timeout-conflict.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR that sets spec.uwsgi.httpKeepAliveTimeout
+# while spec.uwsgi.httpKeepAlive is false. The cross-field CEL XValidation
+# rule on UWSGISpec (and the validating webhook) reject the combination
+# because the --http-keepalive-timeout flag is never emitted without
+# keep-alive. Admission must reject this CR with an $error referencing the
+# substring "httpKeepAliveTimeout". This raw-YAML fixture is the primary
+# coverage for the rule: a typed Go client drops httpKeepAlive: false via
+# omitempty before the schema default re-adds it.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-uwsgi-keepalive-timeout
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+  uwsgi:
+    httpKeepAlive: false
+    httpKeepAliveTimeout: 30

--- a/tests/e2e/keystone/invalid-cr/18-prestop-not-less-than-grace.yaml
+++ b/tests/e2e/keystone/invalid-cr/18-prestop-not-less-than-grace.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR with spec.preStopSleepSeconds (20) not
+# strictly less than spec.terminationGracePeriodSeconds (15). The drain-window
+# CEL XValidation rule on KeystoneSpec (and the validating webhook) require a
+# non-zero drain window. Admission must reject this CR with an $error
+# referencing the substring "preStopSleepSeconds".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-prestop-grace-window
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+  preStopSleepSeconds: 20
+  terminationGracePeriodSeconds: 15

--- a/tests/e2e/keystone/invalid-cr/19-publicendpoint-not-url.yaml
+++ b/tests/e2e/keystone/invalid-cr/19-publicendpoint-not-url.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR whose spec.bootstrap.publicEndpoint is
+# not an HTTP(S) URL. The BootstrapSpec.PublicEndpoint Pattern marker
+# (^https?://) now rejects it unconditionally (previously the webhook only
+# checked the URL when spec.gateway was set). Admission must reject this CR
+# with an $error referencing the substring "publicEndpoint".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-publicendpoint-not-url
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+    publicEndpoint: not-a-url

--- a/tests/e2e/keystone/invalid-cr/20-perloggerlevels-invalid-value.yaml
+++ b/tests/e2e/keystone/invalid-cr/20-perloggerlevels-invalid-value.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Validation-marker wave: Keystone CR with a spec.logging.perLoggerLevels
+# value outside DEBUG/INFO/WARNING/ERROR/CRITICAL. The map-value CEL
+# XValidation rule on LoggingSpec.PerLoggerLevels (and the validating
+# webhook) reject it; a plain enum on additionalProperties is not
+# expressible in CRD v1. Admission must reject this CR with an $error
+# referencing the substring "perLoggerLevels".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: invalid-perloggerlevels-value
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+  logging:
+    perLoggerLevels:
+      sqlalchemy.engine: BOGUS

--- a/tests/e2e/keystone/invalid-cr/_generate.py
+++ b/tests/e2e/keystone/invalid-cr/_generate.py
@@ -20,7 +20,7 @@ Two fixture categories share this scaffold:
   rules (``self == oldSelf``, evaluated only on UPDATE) reject the field change.
 
 The reviewer concern this generator addresses (sourcery-ai review #1):
-without a single source of truth the 16 fixtures could drift out of sync with
+without a single source of truth the fixtures could drift out of sync with
 each other and with KeystoneSpec over time. This script enforces a single
 canonical scaffold; per-fixture overrides change only what is necessary to
 trigger the rejection path under test.
@@ -159,6 +159,52 @@ BOOTSTRAP_RENAMED_REGION = """\
     region: RegionTwo
 """
 
+# Default image block used by every fixture whose rejection is unrelated to the
+# image fields. Parameterized (rather than inlined in render) so the
+# validation-marker fixtures can mutate just the image to exercise the
+# ImageSpec MinLength/Pattern markers.
+IMAGE_DEFAULT = """\
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+"""
+
+# Image with an empty tag — rejected by the ImageSpec.Tag MinLength=1 marker.
+IMAGE_EMPTY_TAG = """\
+    repository: ghcr.io/c5c3/keystone
+    tag: ""
+"""
+
+# Database whose name uses a character outside the MySQL identifier set
+# (the hyphen) — rejected by the DatabaseSpec.Database Pattern marker.
+DATABASE_INVALID_NAME = """\
+    host: db.example.com
+    port: 3306
+    database: keystone-prod
+    secretRef:
+      name: keystone-db
+"""
+
+# Database whose secretRef.name is empty — rejected by the shared
+# SecretRefSpec.Name MinLength=1 marker.
+DATABASE_EMPTY_SECRETREF_NAME = """\
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: ""
+"""
+
+# Bootstrap whose publicEndpoint is not an HTTP(S) URL — rejected by the
+# BootstrapSpec.PublicEndpoint Pattern marker.
+BOOTSTRAP_BAD_PUBLIC_ENDPOINT = """\
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+    publicEndpoint: not-a-url
+"""
+
 
 @dataclass(frozen=True)
 class Fixture:
@@ -168,6 +214,7 @@ class Fixture:
     name: str
     comment: str
     replicas: int = 3
+    image: str = IMAGE_DEFAULT
     database: str = DATABASE_HOST_ONLY
     cache: str = CACHE_SERVERS_ONLY
     fernet_max_active_keys: int = 3
@@ -188,8 +235,7 @@ def render(fixture: Fixture) -> str:
         "spec:\n",
         f"  replicas: {fixture.replicas}\n",
         "  image:\n",
-        "    repository: ghcr.io/c5c3/keystone\n",
-        '    tag: "2025.2"\n',
+        fixture.image,
         "  database:\n",
         fixture.database,
         "  cache:\n",
@@ -459,6 +505,114 @@ FIXTURES: list[Fixture] = [
 # rule on BootstrapSpec.Region (self == oldSelf, keystone_types.go) rejects
 # the change on UPDATE. Admission must reject this UPDATE with an $error
 # referencing the substrings "region" and "immutable".""",
+    ),
+    Fixture(
+        filename="13-image-empty-tag.yaml",
+        name="invalid-image-empty-tag",
+        image=IMAGE_EMPTY_TAG,
+        comment="""\
+# Validation-marker wave: Keystone CR with an empty spec.image.tag. The
+# shared ImageSpec.Tag now carries +kubebuilder:validation:MinLength=1, so
+# an empty tag (which "required" alone admitted) is rejected by the CRD
+# schema. Admission must reject this CR with an $error referencing the
+# substring "image.tag".""",
+    ),
+    Fixture(
+        filename="14-database-name-invalid-char.yaml",
+        name="invalid-database-name-char",
+        database=DATABASE_INVALID_NAME,
+        comment="""\
+# Validation-marker wave: Keystone CR whose spec.database.database uses a
+# hyphen, outside the MySQL identifier character set. Rejected by the
+# DatabaseSpec.Database Pattern marker (^[A-Za-z0-9_]+$). Admission must
+# reject this CR with an $error referencing the substring "database".""",
+    ),
+    Fixture(
+        filename="15-database-secretref-empty-name.yaml",
+        name="invalid-database-secretref-empty-name",
+        database=DATABASE_EMPTY_SECRETREF_NAME,
+        comment="""\
+# Validation-marker wave: Keystone CR whose spec.database.secretRef.name is
+# empty. The shared SecretRefSpec.Name now carries MinLength=1, so an empty
+# Secret name (previously admitted by "required") is rejected at the CRD
+# schema layer. Admission must reject this CR with an $error referencing the
+# substring "secretRef".""",
+    ),
+    Fixture(
+        filename="16-middleware-bad-position.yaml",
+        name="invalid-middleware-position",
+        trailing="""\
+  middleware:
+  - name: audit
+    filterFactory: audit:filter_factory
+    position: sideways
+""",
+        comment="""\
+# Validation-marker wave: Keystone CR with a spec.middleware[].position
+# value outside the documented enum. The shared PipelinePosition type now
+# carries +kubebuilder:validation:Enum=before;after, so "sideways" — which
+# would corrupt the api-paste.ini pipeline — is rejected at the CRD schema
+# layer. Admission must reject this CR with an $error referencing the
+# substring "position".""",
+    ),
+    Fixture(
+        filename="17-uwsgi-keepalive-timeout-conflict.yaml",
+        name="invalid-uwsgi-keepalive-timeout",
+        trailing="""\
+  uwsgi:
+    httpKeepAlive: false
+    httpKeepAliveTimeout: 30
+""",
+        comment="""\
+# Validation-marker wave: Keystone CR that sets spec.uwsgi.httpKeepAliveTimeout
+# while spec.uwsgi.httpKeepAlive is false. The cross-field CEL XValidation
+# rule on UWSGISpec (and the validating webhook) reject the combination
+# because the --http-keepalive-timeout flag is never emitted without
+# keep-alive. Admission must reject this CR with an $error referencing the
+# substring "httpKeepAliveTimeout". This raw-YAML fixture is the primary
+# coverage for the rule: a typed Go client drops httpKeepAlive: false via
+# omitempty before the schema default re-adds it.""",
+    ),
+    Fixture(
+        filename="18-prestop-not-less-than-grace.yaml",
+        name="invalid-prestop-grace-window",
+        trailing="""\
+  preStopSleepSeconds: 20
+  terminationGracePeriodSeconds: 15
+""",
+        comment="""\
+# Validation-marker wave: Keystone CR with spec.preStopSleepSeconds (20) not
+# strictly less than spec.terminationGracePeriodSeconds (15). The drain-window
+# CEL XValidation rule on KeystoneSpec (and the validating webhook) require a
+# non-zero drain window. Admission must reject this CR with an $error
+# referencing the substring "preStopSleepSeconds".""",
+    ),
+    Fixture(
+        filename="19-publicendpoint-not-url.yaml",
+        name="invalid-publicendpoint-not-url",
+        bootstrap=BOOTSTRAP_BAD_PUBLIC_ENDPOINT,
+        comment="""\
+# Validation-marker wave: Keystone CR whose spec.bootstrap.publicEndpoint is
+# not an HTTP(S) URL. The BootstrapSpec.PublicEndpoint Pattern marker
+# (^https?://) now rejects it unconditionally (previously the webhook only
+# checked the URL when spec.gateway was set). Admission must reject this CR
+# with an $error referencing the substring "publicEndpoint".""",
+    ),
+    Fixture(
+        filename="20-perloggerlevels-invalid-value.yaml",
+        name="invalid-perloggerlevels-value",
+        trailing="""\
+  logging:
+    perLoggerLevels:
+      sqlalchemy.engine: BOGUS
+""",
+        comment="""\
+# Validation-marker wave: Keystone CR with a spec.logging.perLoggerLevels
+# value outside DEBUG/INFO/WARNING/ERROR/CRITICAL. The map-value CEL
+# XValidation rule on LoggingSpec.PerLoggerLevels (and the validating
+# webhook) reject it; a plain enum on additionalProperties is not
+# expressible in CRD v1. Admission must reject this CR with an $error
+# referencing the substring "perLoggerLevels".""",
     ),
 ]
 

--- a/tests/e2e/keystone/invalid-cr/chainsaw-test.yaml
+++ b/tests/e2e/keystone/invalid-cr/chainsaw-test.yaml
@@ -10,15 +10,17 @@
 # admission $error, and asserts the field-path plus message substring.
 #
 # The create-rejection fixtures (02-…, 03-…, 04-…, 05-…, 06-…, 07-…,
-# 09-…, 10-…, 11-…, 12-…, 13-policy-overrides-empty-rule-value) share the
-# same minimal valid Keystone scaffold and differ only by the field under
-# test. The update-rejection fixtures (13-immutable-base, 14-…, 15-…, 16-…,
-# 17-…, #466) share the name "immutable-fields": 13-immutable-base is the
-# valid base CR applied first, and 14-17 are applied as UPDATEs
-# that the CRD CEL transition rules reject. To prevent scaffold drift
-# across these 16 files (sourcery-ai review #1), they are generated from a
-# single source of truth in `_generate.py`. After editing the canonical
-# scaffold or any per-fixture override, regenerate via:
+# 09-…, 10-…, 11-…, 12-…, 13-policy-overrides-empty-rule-value, and the
+# validation-marker-wave set 13-image-empty-tag through
+# 20-perloggerlevels-invalid-value) share the same minimal valid Keystone
+# scaffold and are each applied once and rejected at admission. The
+# update-rejection fixtures (13-immutable-base, 14-…, 15-…, 16-…, 17-…,
+# #466) share the name "immutable-fields": 13-immutable-base is the valid
+# base CR applied first, and 14-17 are applied as UPDATEs that the CRD CEL
+# transition rules reject. To prevent scaffold drift across these fixtures
+# (sourcery-ai review #1), they are generated from a single source of truth
+# in `_generate.py`. After editing the canonical scaffold or any per-fixture
+# override, regenerate via:
 #   python3 tests/e2e/keystone/invalid-cr/_generate.py
 # CI runs `make verify-invalid-cr-fixtures` (the
 # `verify-invalid-cr-fixtures` job in .github/workflows/ci.yaml), which
@@ -141,14 +143,20 @@ spec:
         - check:
             ($error != null): true
             (contains($error, 'replicas')): true
-  # spec.autoscaling.minReplicas > maxReplicas must be rejected.
+  # spec.autoscaling.minReplicas > maxReplicas must be rejected. The CEL
+  # XValidation rule is declared on AutoscalingSpec, so the apiserver emits the
+  # error at fieldPath spec.autoscaling (the parent), NOT
+  # spec.autoscaling.minReplicas. The validating webhook's deeper-path message
+  # never reaches Chainsaw because CEL fails first and short-circuits the
+  # admission pipeline. The assertion therefore matches only the parent path
+  # so the test is stable across rule-relocation refactors.
   - try:
     - apply:
         file: 10-hpa-min-greater-than-max.yaml
         expect:
         - check:
             ($error != null): true
-            (contains($error, 'spec.autoscaling.minReplicas')): true
+            (contains($error, 'spec.autoscaling')): true
             (contains($error, 'must not exceed maxReplicas')): true
   # spec.fernet.maxActiveKeys below the minimum (3) must
   # be rejected by either CRD schema (Minimum=3) or webhook. The assertion
@@ -231,3 +239,80 @@ spec:
             ($error != null): true
             (contains($error, 'region')): true
             (contains($error, 'immutable')): true
+  # Validation-marker wave: empty spec.image.tag rejected by the ImageSpec.Tag
+  # MinLength=1 marker (CRD schema).
+  - try:
+    - apply:
+        file: 13-image-empty-tag.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'image.tag')): true
+  # Validation-marker wave: spec.database.database with a hyphen rejected by the
+  # DatabaseSpec.Database Pattern marker (CRD schema).
+  - try:
+    - apply:
+        file: 14-database-name-invalid-char.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database.database')): true
+  # Validation-marker wave: empty spec.database.secretRef.name rejected by the
+  # shared SecretRefSpec.Name MinLength=1 marker (CRD schema).
+  - try:
+    - apply:
+        file: 15-database-secretref-empty-name.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'secretRef.name')): true
+  # Validation-marker wave: spec.middleware[].position outside before;after
+  # rejected by the PipelinePosition Enum marker (CRD schema).
+  - try:
+    - apply:
+        file: 16-middleware-bad-position.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'position')): true
+            (contains($error, 'sideways')): true
+  # Validation-marker wave: spec.uwsgi.httpKeepAliveTimeout set while
+  # httpKeepAlive is false rejected by the UWSGISpec cross-field CEL rule. The
+  # CEL rule fires first (CRD validation precedes the validating webhook), so
+  # the assertion matches its message.
+  - try:
+    - apply:
+        file: 17-uwsgi-keepalive-timeout-conflict.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'httpKeepAliveTimeout')): true
+  # Validation-marker wave: spec.preStopSleepSeconds not strictly less than
+  # spec.terminationGracePeriodSeconds rejected by the KeystoneSpec drain-window
+  # CEL rule.
+  - try:
+    - apply:
+        file: 18-prestop-not-less-than-grace.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'preStopSleepSeconds')): true
+            (contains($error, 'terminationGracePeriodSeconds')): true
+  # Validation-marker wave: non-URL spec.bootstrap.publicEndpoint rejected by the
+  # BootstrapSpec.PublicEndpoint Pattern marker (CRD schema).
+  - try:
+    - apply:
+        file: 19-publicendpoint-not-url.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'publicEndpoint')): true
+  # Validation-marker wave: spec.logging.perLoggerLevels with a value outside
+  # the level enum rejected by the LoggingSpec.PerLoggerLevels CEL rule.
+  - try:
+    - apply:
+        file: 20-perloggerlevels-invalid-value.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'perLoggerLevels')): true

--- a/tests/e2e/keystone/invalid-cr/test_generate.py
+++ b/tests/e2e/keystone/invalid-cr/test_generate.py
@@ -12,7 +12,7 @@ instead of waiting for the Chainsaw E2E job to fail at the apply step.
 
 Coverage (each assertion traceable to review-2 finding FC1):
 
-* ``FIXTURES`` lists exactly the 16 fixtures the chainsaw suite expects.
+* ``FIXTURES`` lists exactly the generated fixtures the chainsaw suite expects.
 * Every ``Fixture.filename`` is referenced by an ``apply.file:`` entry in
   ``chainsaw-test.yaml`` — guards against renames or accidental deletions.
 * Filenames are unique within ``FIXTURES`` — guards against copy/paste typos
@@ -38,12 +38,13 @@ _GENERATOR = _HERE / "_generate.py"
 _CHAINSAW_TEST = _HERE / "chainsaw-test.yaml"
 
 # Number of fixtures emitted by _generate.py: eleven create-rejection fixtures
-# (02-12 plus 13-policy-overrides-empty-rule-value) plus five update-rejection
-# fixtures (13-immutable-base and 14-17, #466). The fixtures
-# (00-, 01-) predate and are intentionally NOT generated. Bumping
-# this value requires adding the matching Fixture entry AND the matching
+# (02-12 plus 13-policy-overrides-empty-rule-value), five update-rejection
+# fixtures (13-immutable-base and 14-17, #466), and eight validation-marker
+# fixtures (13-image-empty-tag through 20-perloggerlevels-invalid-value). The
+# fixtures (00-, 01-) predate and are intentionally NOT generated. Bumping this
+# value requires adding the matching Fixture entry AND the matching
 # `file: <name>` line in chainsaw-test.yaml.
-_EXPECTED_FIXTURE_COUNT = 16
+_EXPECTED_FIXTURE_COUNT = 24
 
 
 def _load_generator() -> types.ModuleType:


### PR DESCRIPTION
## Summary

Implements the validation-marker wave from #469. Pushes the cheap, declarative half of the operators' admission checks down into the CRD schema (kubebuilder markers + CEL) so malformed specs fail at admission instead of deep in reconcile (Deployment rollout, db-sync Job, paste pipeline) — and even when the validating webhook is bypassed. Parity, not replacement: the webhook defense-in-depth checks stay.

Also closes the ControlPlane↔Keystone admission asymmetry (the CP accepted specs the keystone webhook later rejected, wedging the CP post-admission) and converges duplicated defaulting literals onto shared exported constants.

## Changes

**Shared types (`internal/common`)**
- `ImageSpec.Repository/Tag`: `MinLength=1` + OCI-reference pattern.
- `DatabaseSpec`: `Port` bounded `1..65535`; `Database` `MinLength=1, MaxLength=64, Pattern=^[A-Za-z0-9_]+$`; `Host` hostname pattern.
- `SecretRefSpec.Name`: `MinLength=1` + DNS-1123 pattern (fixes all consumers at once).
- `MiddlewareSpec.Position`: `Enum=before;after`.

**Keystone CRD — CEL parity + markers**
- `bootstrap.publicEndpoint`: `^https?://` pattern, now unconditional (the webhook only checked it when `spec.gateway` was set).
- `plugins`: `listType=map` + `listMapKey=configSection` — structural duplicate rejection + correct SSA merge.
- Autoscaling `minReplicas <= maxReplicas`; uWSGI `httpKeepAliveTimeout` only when `httpKeepAlive` is true; `perLoggerLevels` non-empty keys + value enum; drain-window `preStopSleepSeconds < terminationGracePeriodSeconds`.

**ControlPlane CRD — close the asymmetry**
- `InfrastructureSpec` database/cache XOR CEL (matching `KeystoneSpec`); `services.keystone.publicEndpoint` URL pattern; K-ORC `AccessRule.Method` enum + `Path` `^/` pattern; `BootstrapResourceSpec.Kind` enum.

**Defaulting constants**
- Collapse defaults duplicated as raw literals across markers/webhooks/reconcilers onto exported constants (region, uWSGI processes/threads/keepalive, admin-password min length, cache backend), following the existing TGPS/preStop pattern. Values unchanged.

**Generated + tests + docs**
- Regenerated CRD bases and Helm chart copies (controller-gen v0.21.0); `make verify-crd-sync` clean.
- envtest rejection/acceptance coverage for both CRDs; new invalid-CR Chainsaw fixtures (13–20) + generator parameterization + count guard bump.
- CRD reference docs updated for the new rules.

## Test plan
- [ ] `make verify-crd-sync` (CRD/Helm drift)
- [ ] envtest integration suites (keystone + c5c3)
- [ ] invalid-CR Chainsaw fixtures + generator self-test

Closes #469
