### PR TITLE
refactor(common): adopt Server-Side Apply for the Ensure* family

### DIFF
--- a/docs/reference/backend/kubernetes-packages.md
+++ b/docs/reference/backend/kubernetes-packages.md
@@ -12,11 +12,16 @@ core Kubernetes resources (Deployments, Services, Jobs, CronJobs, ConfigMaps).
 
 All packages share these conventions:
 
-- **Idempotent create-or-update** — `Ensure*` functions create a resource if it does not
-  exist or update its spec if it already exists. They use `Get` + `Create`/`Update` (not
-  `controllerutil.CreateOrUpdate`) for explicit control.
-- **Owner references** — `controllerutil.SetControllerReference` is called on create so
-  the resource is garbage-collected when the owning CR is deleted.
+- **Idempotent create-or-update via Server-Side Apply** — `Ensure*` functions apply the
+  desired object through the generic `apply.EnsureObject` helper, which uses Server-Side
+  Apply under the fixed field manager `forge-operator`. The field manager owns only the
+  fields the builder sets, so server-defaulted fields the builder omits are never claimed
+  or overwritten and a converged object is applied without a write. The apply is wrapped
+  in `retry.RetryOnConflict`, so a benign field-manager conflict is absorbed as an internal
+  retry rather than surfacing as condition noise.
+- **Owner references** — `controllerutil.SetControllerReference` is called on every apply
+  (not only on create) so the resource is garbage-collected when the owning CR is deleted
+  and the reference is re-enforced if it drifts.
 - **Readiness reporting** — Functions that create resources return `(bool, error)`, where
   `true` means the resource is ready and `false` means it exists but is not yet ready.
 - **Error wrapping** — All errors include context via `fmt.Errorf` with `%w` for
@@ -26,6 +31,7 @@ All packages share these conventions:
 
 | Package | Import Path |
 | --- | --- |
+| `apply` | `github.com/c5c3/forge/internal/common/apply` |
 | `config` | `github.com/c5c3/forge/internal/common/config` |
 | `database` | `github.com/c5c3/forge/internal/common/database` |
 | `deployment` | `github.com/c5c3/forge/internal/common/deployment` |
@@ -46,6 +52,44 @@ These packages import typed Go structs from external operator modules:
 
 > **Note:** The PushSecret API is `v1alpha1` (unstable). Its schema may change in future
 > ESO releases. Pin the ESO module version in `go.mod` to avoid breakage.
+
+---
+
+## Package: `apply`
+
+Provides the generic Server-Side Apply create-or-update primitive that backs the
+`Ensure*` family.
+
+### EnsureObject
+
+```go
+func EnsureObject[T client.Object](
+    ctx context.Context,
+    c client.Client,
+    scheme *runtime.Scheme,
+    owner client.Object,
+    obj T,
+    fieldManager string,
+) error
+```
+
+Creates or updates `obj` via Server-Side Apply under `fieldManager` and sets `owner` as
+the controller reference.
+
+**Behavior:**
+
+- Sets the controller owner reference and stamps the object's GVK (objects built in-code
+  carry an empty `TypeMeta`, which Server-Side Apply requires).
+- Applies the object with `client.FieldOwner(fieldManager)` and `client.ForceOwnership`,
+  wrapped in `retry.RetryOnConflict` so a benign field-manager conflict is retried
+  internally rather than surfaced.
+- The field manager owns only the fields the builder sets, so server-defaulted fields the
+  builder omits are never claimed and a converged object is applied without a write.
+- Decodes the server response back into `obj`, so callers may read fresh status (e.g.
+  readiness) without an extra `Get`.
+
+**Field manager:** the package exports `apply.FieldManager` (`"forge-operator"`), the
+stable field-manager name shared by all `Ensure*` helpers.
 
 ---
 
@@ -224,10 +268,11 @@ Creates or updates a MariaDB Database CR.
 
 **Behavior:**
 
-- On create: sets controller owner reference, creates the resource, returns `(false, nil)`.
-- On update: overwrites `existing.Spec` with the provided spec.
+- Applies the desired Database via `apply.EnsureObject` (Server-Side Apply); the field
+  manager owns only the fields the builder sets, so the server default on
+  `maxUserConnections` is preserved and a converged Database is not rewritten.
 - Readiness is determined by the package-internal `isDatabaseReady` helper on the
-  existing resource.
+  server-fresh apply response.
 
 ### EnsureDatabaseUser
 
@@ -279,9 +324,11 @@ Deployment exists but is not yet ready; `(false, error)` on failure.
 
 **Behavior:**
 
-- On create: sets controller owner reference, creates the resource, returns `(false, nil)`.
-- On update: overwrites `existing.Spec` with the provided spec.
-- Readiness is determined by `IsDeploymentReady` on the existing resource.
+- Applies the desired Deployment via `apply.EnsureObject` (Server-Side Apply); a converged
+  Deployment is not rewritten on every reconcile.
+- Retains a pre-apply `Get` only to delete-and-recreate on an immutable-selector change and
+  to preserve the HPA-owned replica count when `spec.replicas` is left nil.
+- Readiness is determined by `IsDeploymentReady` on the server-fresh apply response.
 
 ### EnsureService
 
@@ -299,10 +346,12 @@ Creates or updates a Service. Does not report readiness (Services are ready imme
 
 **Behavior:**
 
-- On create: sets controller owner reference, creates the resource.
-- On update: preserves the existing `ClusterIP` and `ClusterIPs` values assigned by the
-  API server before overwriting the spec. This prevents accidental ClusterIP reassignment,
-  which would break existing DNS-based service discovery.
+- Applies the desired Service via `apply.EnsureObject` (Server-Side Apply). The builder
+  leaves server-assigned fields (`ClusterIP`, `ClusterIPs`, `IPFamilies`, `NodePort`)
+  unset, so the field manager never owns them and the API server keeps the values it
+  assigned — no hand-rolled preservation is needed.
+- Retains a pre-apply `Get` only to fail fast when the caller explicitly sets one of those
+  immutable fields to a conflicting value.
 
 ### IsDeploymentReady
 
@@ -386,9 +435,8 @@ Creates or updates a CronJob with a controller owner reference.
 
 **Behavior:**
 
-- On create: sets controller owner reference, creates the resource.
-- On update: overwrites `existing.Spec` with the provided spec. CronJob spec updates
-  take effect on the next scheduled run.
+- Applies the desired CronJob via `apply.EnsureObject` (Server-Side Apply); a converged
+  CronJob is not rewritten, and spec changes take effect on the next scheduled run.
 
 The Job completion and permanent-failure checks (`isJobComplete` / `isJobFailed`)
 are package-internal helpers consumed by `RunJob`.
@@ -545,9 +593,10 @@ Creates or updates a PushSecret CR with a controller owner reference.
 
 **Behavior:**
 
-- On create: sets controller owner reference via `SetControllerReference`, creates the
-  resource.
-- On update: overwrites `existing.Spec` with the provided spec.
+- Applies the desired PushSecret via `apply.EnsureObject` (Server-Side Apply). The field
+  manager owns only the fields the builder sets, so the server defaults on `updatePolicy`
+  and `refreshInterval` are preserved and a converged PushSecret is not rewritten — ESO is
+  not woken to re-push an unchanged credential.
 - Uses the ESO `v1alpha1` PushSecret API (unstable — see [External CRD Dependencies](#external-crd-dependencies)).
 
 ---

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -534,6 +534,7 @@ Configures Fernet token key rotation.
 | --- | --- | --- | --- | --- |
 | `rotationSchedule` | `string` | No | `"0 0 * * 0"` | Cron expression (5-field standard format) for key rotation. Validated by `robfig/cron/v3` `ParseStandard`. |
 | `maxActiveKeys` | `int32` | No | `3` | Maximum number of active Fernet keys. Minimum: 3. |
+| `suspend` | `bool` | No | `false` | Suspends the Fernet rotation CronJob without deleting it. Maps to the CronJob `spec.suspend` field. Set `true` to pause key rotation during an incident; the schedule is unchanged so resuming is churn-free. |
 
 ---
 
@@ -551,6 +552,7 @@ ServiceAccount. The Secret is also mirrored to OpenBao through a `PushSecret`.
 | --- | --- | --- | --- | --- |
 | `rotationSchedule` | `string` | No | `"0 0 * * 0"` | Cron expression (5-field standard format). Validated by `robfig/cron/v3` `ParseStandard` in the webhook. |
 | `maxActiveKeys` | `int32` | No | `3` | Maximum number of active credential keys. Minimum: 3. Exposed to `keystone-manage` via the `OS_credential__max_active_keys` environment variable on the rotation CronJob. |
+| `suspend` | `bool` | No | `false` | Suspends the credential rotation CronJob without deleting it. Maps to the CronJob `spec.suspend` field. Set `true` to pause key rotation during an incident; the schedule is unchanged so resuming is churn-free. |
 
 ---
 

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -1553,6 +1553,7 @@ and disaster recovery backup to OpenBao.
 | --- | --- |
 | Name | `{name}-fernet-rotate` |
 | Schedule | `spec.fernet.rotationSchedule` |
+| Suspend | `spec.fernet.suspend` (default `false`); set `true` to pause rotation during an incident without deleting the CronJob or changing its schedule |
 | ServiceAccount | `{name}-fernet-rotate` |
 | Init container | Copies keys from `fernet-keys-src` (Secret) to `fernet-keys` (emptyDir) |
 | Command | `/scripts/fernet_rotate.sh` |
@@ -1724,6 +1725,7 @@ with credential migration, and disaster recovery backup to OpenBao.
 | --- | --- |
 | Name | `{name}-credential-rotate` |
 | Schedule | `spec.credentialKeys.rotationSchedule` |
+| Suspend | `spec.credentialKeys.suspend` (default `false`); set `true` to pause rotation during an incident without deleting the CronJob or changing its schedule |
 | ServiceAccount | `{name}-credential-rotate` |
 | Init container | Copies keys from `credential-keys-src` (Secret) to `credential-keys` (emptyDir) |
 | Command | `/scripts/credential_rotate.sh` |

--- a/internal/common/apply/apply.go
+++ b/internal/common/apply/apply.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// FieldManager is the Server-Side Apply field manager used by EnsureObject. It
+// is a stable, descriptive name so the operator's field ownership is tracked
+// consistently and conflicts (between two managers of the same field) surface
+// reliably.
+const FieldManager = "forge-operator"
+
+// EnsureObject creates or updates obj using Server-Side Apply under fieldManager
+// and sets owner as the controller reference so obj is garbage-collected when
+// owner is deleted.
+//
+// Under SSA the field manager owns only the fields the builder actually sets, so
+// server-defaulted fields the builder omits (e.g. a +kubebuilder:default value
+// on an omitempty field) are never claimed and therefore never overwritten —
+// repeated applies of an unchanged desired object are no-ops and converge,
+// unlike a whole-object Update that rewrites the spec on every pass.
+//
+// The apply is wrapped in retry.RetryOnConflict so a benign FieldManagerConflict
+// is absorbed as an internal retry rather than surfacing as transient condition
+// noise. On success obj is overwritten with the server response, so callers may
+// read fresh status (e.g. readiness) from obj without an extra Get.
+func EnsureObject[T client.Object](ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj T, fieldManager string) error {
+	if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {
+		return fmt.Errorf("setting owner reference on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	// Server-Side Apply requires apiVersion/kind in the request body, but
+	// objects built in-code carry an empty TypeMeta, so resolve and stamp the
+	// GVK before converting to the unstructured apply configuration.
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return fmt.Errorf("resolving GVK for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return fmt.Errorf("converting %s %s/%s to unstructured: %w", gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	u.SetGroupVersionKind(gvk)
+	// Strip server-managed metadata and the status subresource from the apply
+	// body: they are not part of the desired state the operator owns, and a
+	// resourceVersion would impose optimistic concurrency that ForceOwnership is
+	// meant to avoid.
+	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(u.Object, "status")
+
+	ac := client.ApplyConfigurationFromUnstructured(u)
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return c.Apply(ctx, ac, client.FieldOwner(fieldManager), client.ForceOwnership)
+	}); err != nil {
+		return fmt.Errorf("applying %s %s/%s: %w", gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	// The apply response is written back into u; decode it into obj so callers
+	// observe server-fresh state (status, defaulted fields) without a re-Get.
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj); err != nil {
+		return fmt.Errorf("decoding applied %s %s/%s: %w", gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+	return nil
+}

--- a/internal/common/apply/apply_test.go
+++ b/internal/common/apply/apply_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = batchv1.AddToScheme(s)
+	return s
+}
+
+func testOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-owner",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+}
+
+func testConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "applied-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{"key": "value"},
+	}
+}
+
+func TestEnsureObject_createsWithOwnerReference(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+
+	cm := testConfigMap()
+	g.Expect(EnsureObject(context.Background(), c, s, owner, cm, FieldManager)).To(Succeed())
+
+	// The caller's object is overwritten with the server response, so it carries
+	// a resourceVersion after a successful apply.
+	g.Expect(cm.ResourceVersion).NotTo(BeEmpty())
+
+	fetched := &corev1.ConfigMap{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(cm), fetched)).To(Succeed())
+	g.Expect(fetched.Data).To(HaveKeyWithValue("key", "value"))
+	g.Expect(fetched.OwnerReferences).To(HaveLen(1))
+	g.Expect(fetched.OwnerReferences[0].Name).To(Equal("test-owner"))
+	g.Expect(*fetched.OwnerReferences[0].Controller).To(BeTrue())
+}
+
+func TestEnsureObject_usesServerSideApplyOptions(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	var fieldManager string
+	var forced bool
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, cl client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				ao := &client.ApplyOptions{}
+				ao.ApplyOptions(opts)
+				fieldManager = ao.FieldManager
+				forced = ao.Force != nil && *ao.Force
+				return cl.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	g.Expect(EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)).To(Succeed())
+	g.Expect(fieldManager).To(Equal(FieldManager))
+	g.Expect(forced).To(BeTrue(), "apply must set ForceOwnership")
+}
+
+func TestEnsureObject_retriesOnConflict(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	applyCalls := 0
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, cl client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				applyCalls++
+				if applyCalls == 1 {
+					// A benign field-manager conflict must be retried, not surfaced.
+					return apierrors.NewConflict(
+						schema.GroupResource{Resource: "configmaps"}, "applied-cm",
+						apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "applied-cm", nil),
+					)
+				}
+				return cl.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	g.Expect(EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)).To(Succeed())
+	g.Expect(applyCalls).To(Equal(2), "conflict on the first apply must be retried once and then succeed")
+}
+
+func TestEnsureObject_propagatesApplyError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, cl client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				return apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "applied-cm", nil)
+			},
+		}).
+		Build()
+
+	err := EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsForbidden(err)).To(BeTrue())
+}
+
+func TestEnsureObject_errorsWhenGVKUnknown(t *testing.T) {
+	g := NewGomegaWithT(t)
+	// Scheme knows the owner (ConfigMap) but not the applied type (CronJob), so
+	// GVK resolution for the applied object fails before any apply is attempted.
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	owner := testOwner()
+
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(owner).Build()
+
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "cj", Namespace: "default"},
+	}
+	err := EnsureObject(context.Background(), c, s, owner, cronJob, FieldManager)
+	g.Expect(err).To(HaveOccurred())
+}

--- a/internal/common/apply/doc.go
+++ b/internal/common/apply/doc.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package apply provides a generic Server-Side Apply create-or-update primitive
+// for the Ensure* family of helpers. EnsureObject manages only the fields the
+// operator's builders actually set, so server-defaulted fields stop
+// participating in the diff and reconciliation converges instead of issuing an
+// Update on every pass.
+package apply

--- a/internal/common/apply/integration_test.go
+++ b/internal/common/apply/integration_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apply
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	envtestutil "github.com/c5c3/forge/internal/common/testutil/envtest"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func integrationDeployment(ns string) *appsv1.Deployment {
+	labels := map[string]string{"app": "ssa-demo"}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "ssa-demo", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "busybox:latest"}},
+				},
+			},
+		},
+	}
+}
+
+// TestIntegration_EnsureObject_convergesWithoutRewrite verifies that re-applying
+// an unchanged desired object is a no-op: the API server detects no field-level
+// change under the operator's field manager and leaves the resourceVersion (and
+// thus generation) untouched. This is the convergence guarantee the Update-based
+// helpers lacked.
+func TestIntegration_EnsureObject_convergesWithoutRewrite(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-apply-converge"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	g.Expect(EnsureObject(ctx, c, scheme, owner, integrationDeployment(ns.Name), FieldManager)).To(Succeed())
+
+	first := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, first)).To(Succeed())
+	g.Expect(first.OwnerReferences).To(HaveLen(1))
+
+	// Apply the identical desired object again.
+	g.Expect(EnsureObject(ctx, c, scheme, owner, integrationDeployment(ns.Name), FieldManager)).To(Succeed())
+
+	second := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, second)).To(Succeed())
+	g.Expect(second.ResourceVersion).To(Equal(first.ResourceVersion),
+		"re-applying an unchanged object must not rewrite it")
+	g.Expect(second.Generation).To(Equal(first.Generation))
+}
+
+// TestIntegration_EnsureObject_takesOverFromUpdate verifies that EnsureObject can
+// adopt an object first written with a plain Create/Update (whole-object
+// ownership). ForceOwnership lets the apply field manager take over the fields it
+// sets without surfacing a conflict — the migration path from the old Update
+// helpers to SSA.
+func TestIntegration_EnsureObject_takesOverFromUpdate(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-apply-takeover"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	// Pre-create with a plain client Create (default field manager), mimicking an
+	// object originally written by the Update-based helper.
+	pre := integrationDeployment(ns.Name)
+	g.Expect(c.Create(ctx, pre)).To(Succeed())
+
+	// Now adopt it via SSA: should succeed without a conflict error.
+	desired := integrationDeployment(ns.Name)
+	desired.Spec.Template.Spec.Containers[0].Image = "busybox:1.36"
+	g.Expect(EnsureObject(ctx, c, scheme, owner, desired, FieldManager)).To(Succeed())
+
+	fetched := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, fetched)).To(Succeed())
+	g.Expect(fetched.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:1.36"))
+	g.Expect(fetched.OwnerReferences).To(HaveLen(1))
+}

--- a/internal/common/database/database.go
+++ b/internal/common/database/database.go
@@ -6,52 +6,27 @@ package database
 
 import (
 	"context"
-	"fmt"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 )
 
-// EnsureDatabase creates a MariaDB Database CR if it does not exist or updates
-// its spec if it already exists. It returns (true, nil) when the Database has a
-// Ready condition with status True, (false, nil) when it exists but is not yet
-// ready, and (false, error) on unexpected failures.
+// EnsureDatabase creates a MariaDB Database CR if it does not exist or applies
+// its desired state via Server-Side Apply if it already exists. It returns
+// (true, nil) when the Database has a Ready condition with status True,
+// (false, nil) when it exists but is not yet ready, and (false, error) on
+// unexpected failures. Server-defaulted fields the builder omits are not
+// claimed, so a converged Database is applied without a write; readiness is
+// read from the server-fresh apply response without a re-Get.
 func EnsureDatabase(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, db *mariadbv1alpha1.Database) (bool, error) {
-	existing := &mariadbv1alpha1.Database{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(db), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, db, scheme); err != nil {
-			return false, fmt.Errorf("setting owner reference on Database %s/%s: %w", db.Namespace, db.Name, err)
-		}
-		if err := c.Create(ctx, db); err != nil {
-			return false, fmt.Errorf("creating Database %s/%s: %w", db.Namespace, db.Name, err)
-		}
-		return false, nil
+	if err := apply.EnsureObject(ctx, c, scheme, owner, db, apply.FieldManager); err != nil {
+		return false, err
 	}
-	if err != nil {
-		return false, fmt.Errorf("getting Database %s/%s: %w", db.Namespace, db.Name, err)
-	}
-
-	if !apiequality.Semantic.DeepEqual(existing.Spec, db.Spec) {
-		existing.Spec = db.Spec
-		if err := c.Update(ctx, existing); err != nil {
-			return false, fmt.Errorf("updating Database %s/%s: %w", db.Namespace, db.Name, err)
-		}
-		// Re-fetch to avoid evaluating stale status from before the spec
-		// update.
-		if err := c.Get(ctx, client.ObjectKeyFromObject(db), existing); err != nil {
-			return false, fmt.Errorf("re-fetching Database %s/%s after update: %w", db.Namespace, db.Name, err)
-		}
-	}
-
-	return isDatabaseReady(existing), nil
+	return isDatabaseReady(db), nil
 }
 
 // isDatabaseReady returns true if the Database has a Ready condition with
@@ -80,67 +55,17 @@ func EnsureDatabaseUser(ctx context.Context, c client.Client, scheme *runtime.Sc
 }
 
 func ensureUser(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, user *mariadbv1alpha1.User) (bool, error) {
-	existing := &mariadbv1alpha1.User{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(user), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, user, scheme); err != nil {
-			return false, fmt.Errorf("setting owner reference on User %s/%s: %w", user.Namespace, user.Name, err)
-		}
-		if err := c.Create(ctx, user); err != nil {
-			return false, fmt.Errorf("creating User %s/%s: %w", user.Namespace, user.Name, err)
-		}
-		return false, nil
+	if err := apply.EnsureObject(ctx, c, scheme, owner, user, apply.FieldManager); err != nil {
+		return false, err
 	}
-	if err != nil {
-		return false, fmt.Errorf("getting User %s/%s: %w", user.Namespace, user.Name, err)
-	}
-
-	if !apiequality.Semantic.DeepEqual(existing.Spec, user.Spec) {
-		existing.Spec = user.Spec
-		if err := c.Update(ctx, existing); err != nil {
-			return false, fmt.Errorf("updating User %s/%s: %w", user.Namespace, user.Name, err)
-		}
-		// Re-fetch to avoid evaluating stale status from before the spec
-		// update.
-		if err := c.Get(ctx, client.ObjectKeyFromObject(user), existing); err != nil {
-			return false, fmt.Errorf("re-fetching User %s/%s after update: %w", user.Namespace, user.Name, err)
-		}
-	}
-
-	return isUserReady(existing), nil
+	return isUserReady(user), nil
 }
 
 func ensureGrant(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, grant *mariadbv1alpha1.Grant) (bool, error) {
-	existing := &mariadbv1alpha1.Grant{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(grant), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, grant, scheme); err != nil {
-			return false, fmt.Errorf("setting owner reference on Grant %s/%s: %w", grant.Namespace, grant.Name, err)
-		}
-		if err := c.Create(ctx, grant); err != nil {
-			return false, fmt.Errorf("creating Grant %s/%s: %w", grant.Namespace, grant.Name, err)
-		}
-		return false, nil
+	if err := apply.EnsureObject(ctx, c, scheme, owner, grant, apply.FieldManager); err != nil {
+		return false, err
 	}
-	if err != nil {
-		return false, fmt.Errorf("getting Grant %s/%s: %w", grant.Namespace, grant.Name, err)
-	}
-
-	if !apiequality.Semantic.DeepEqual(existing.Spec, grant.Spec) {
-		existing.Spec = grant.Spec
-		if err := c.Update(ctx, existing); err != nil {
-			return false, fmt.Errorf("updating Grant %s/%s: %w", grant.Namespace, grant.Name, err)
-		}
-		// Re-fetch to avoid evaluating stale status from before the spec
-		// update.
-		if err := c.Get(ctx, client.ObjectKeyFromObject(grant), existing); err != nil {
-			return false, fmt.Errorf("re-fetching Grant %s/%s after update: %w", grant.Namespace, grant.Name, err)
-		}
-	}
-
-	return isGrantReady(existing), nil
+	return isGrantReady(grant), nil
 }
 
 // isUserReady returns true if the User has a Ready condition with status

--- a/internal/common/database/integration_test.go
+++ b/internal/common/database/integration_test.go
@@ -283,3 +283,58 @@ func TestIntegration_EnsureDatabaseUser_idempotent(t *testing.T) {
 	g.Expect(c.List(ctx, grantList, client.InNamespace(ns.Name))).To(Succeed())
 	g.Expect(grantList.Items).To(HaveLen(1))
 }
+
+// TestIntegration_EnsureUser_preservesServerDefault is the canonical issue #474
+// problem #1 regression test: the User builder never sets
+// .spec.maxUserConnections, which the API server defaults to 10. Under the old
+// DeepEqual-then-Update guard the operator re-zeroed it and the server re-applied
+// the default on every reconcile, never converging. With Server-Side Apply the
+// operator's field manager never owns the field, so the default survives and a
+// repeated apply does not rewrite the object.
+func TestIntegration_EnsureUser_preservesServerDefault(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-db-user-default"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "user-owner-default", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	// buildUser-style User: maxUserConnections intentionally left unset.
+	newUser := func() *mariadbv1alpha1.User {
+		return &mariadbv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "default-user", Namespace: ns.Name},
+			Spec: mariadbv1alpha1.UserSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{Name: "mariadb"},
+				},
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{Name: "user-secret"},
+					Key:                  "password",
+				},
+				Name: "appuser",
+				Host: "%",
+			},
+		}
+	}
+
+	_, err := ensureUser(ctx, c, scheme, owner, newUser())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	created := &mariadbv1alpha1.User{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "default-user", Namespace: ns.Name}, created)).To(Succeed())
+	g.Expect(created.Spec.MaxUserConnections).To(Equal(int32(10)), "API server default must be applied")
+
+	// Re-apply the same desired User (still omitting maxUserConnections).
+	_, err = ensureUser(ctx, c, scheme, owner, newUser())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	reapplied := &mariadbv1alpha1.User{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "default-user", Namespace: ns.Name}, reapplied)).To(Succeed())
+	g.Expect(reapplied.Spec.MaxUserConnections).To(Equal(int32(10)), "server default must be preserved, not re-zeroed")
+	g.Expect(reapplied.ResourceVersion).To(Equal(created.ResourceVersion),
+		"a converged User must not be rewritten on the next reconcile (issue #474 problem #1)")
+}

--- a/internal/common/deployment/deployment.go
+++ b/internal/common/deployment/deployment.go
@@ -14,20 +14,23 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/apply"
 )
 
-// EnsureDeployment creates a Deployment if it does not exist or updates its
-// spec if it already exists. It returns (true, nil) when all replicas are
-// available, (false, nil) when the Deployment exists but is not yet ready,
-// and (false, error) on unexpected failures.
+// EnsureDeployment creates a Deployment if it does not exist or applies its
+// desired state via Server-Side Apply if it already exists. It returns
+// (true, nil) when all replicas are available, (false, nil) when the Deployment
+// exists but is not yet ready, and (false, error) on unexpected failures.
 func EnsureDeployment(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, deploy *appsv1.Deployment) (bool, error) {
 	existing := &appsv1.Deployment{}
 	err := c.Get(ctx, client.ObjectKeyFromObject(deploy), existing)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("getting Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+	}
 
 	if apierrors.IsNotFound(err) {
 		// Write an explicit replica count on create so the API server does not
@@ -39,317 +42,85 @@ func EnsureDeployment(ctx context.Context, c client.Client, scheme *runtime.Sche
 			replicas := int32(1)
 			deploy.Spec.Replicas = &replicas
 		}
-		if err := controllerutil.SetControllerReference(owner, deploy, scheme); err != nil {
-			return false, fmt.Errorf("setting owner reference on Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+	} else {
+		// If the selector has changed, the Deployment must be deleted and
+		// re-created: Kubernetes rejects .spec.selector mutations as immutable
+		// after creation. Returning (false, nil) causes the reconciler to
+		// requeue; on the next pass the Deployment no longer exists and is
+		// created fresh.
+		if !reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector) {
+			if err := c.Delete(ctx, existing); err != nil {
+				return false, fmt.Errorf("deleting Deployment %s/%s for selector migration: %w", deploy.Namespace, deploy.Name, err)
+			}
+			return false, nil
 		}
-		if err := c.Create(ctx, deploy); err != nil {
-			return false, fmt.Errorf("creating Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
-		}
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("getting Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
-	}
 
-	// If the selector has changed, the Deployment must be deleted and re-created:
-	// Kubernetes rejects .spec.selector mutations as immutable after creation.
-	// Returning (false, nil) causes the reconciler to requeue; on the next pass
-	// the Deployment no longer exists and will be created fresh.
-	if !reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector) {
-		if err := c.Delete(ctx, existing); err != nil {
-			return false, fmt.Errorf("deleting Deployment %s/%s for selector migration: %w", deploy.Namespace, deploy.Name, err)
-		}
-		return false, nil
-	}
-
-	// DECISION: I-001 — Backported metadata reconciliation from EnsurePDB/EnsureHPA
-	// to align sibling Ensure* functions in the same package. DeepEqual spec guard
-	// is NOT added because the mandatory pattern for mutable resources (Deployments)
-	// specifies unconditional spec updates to avoid maintaining a normalization
-	// layer. Reviewer: please verify.
-
-	// Ensure controller owner reference is enforced so garbage collection
-	// behaves correctly even if the ref was removed out-of-band.
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return false, fmt.Errorf("updating owner reference on Deployment %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	// Merge desired labels into existing labels; extra user-added keys are
-	// preserved, keys present on the desired Deployment are authoritative.
-	if deploy.Labels != nil {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(deploy.Labels))
-		}
-		for k, v := range deploy.Labels {
-			existing.Labels[k] = v
+		// Preserve the live replica count when the caller leaves it unset. A nil
+		// desired .spec.replicas signals that an HPA owns the field, so the
+		// operator must not reset it to a static value on every reconcile —
+		// otherwise each write fights the HPA and the resulting watch event
+		// re-triggers reconciliation, producing a scale-up/scale-down loop with
+		// real pod churn (issue #462). Writing back the live value keeps the
+		// Server-Side Apply a no-op while the HPA is in control.
+		if deploy.Spec.Replicas == nil {
+			deploy.Spec.Replicas = existing.Spec.Replicas
 		}
 	}
 
-	// Merge desired annotations into existing annotations.
-	if deploy.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(deploy.Annotations))
-		}
-		for k, v := range deploy.Annotations {
-			existing.Annotations[k] = v
-		}
+	// Server-Side Apply manages only the fields the builder sets, so server
+	// defaults are never clobbered and a converged spec is applied without a
+	// write. The apply response is decoded back into deploy, so readiness is
+	// read from server-fresh state without a re-Get that the reconciler's cache
+	// could answer with a stale (pre-update) object during an upgrade.
+	if err := apply.EnsureObject(ctx, c, scheme, owner, deploy, apply.FieldManager); err != nil {
+		return false, err
 	}
 
-	// Preserve the live replica count when the caller leaves it unset. A nil
-	// desired .spec.replicas signals that an HPA owns the field, so the
-	// operator must not reset it to a static value on every reconcile —
-	// otherwise each write fights the HPA and the resulting watch event
-	// re-triggers reconciliation, producing a scale-up/scale-down loop with
-	// real pod churn (issue #462).
-	if deploy.Spec.Replicas == nil {
-		deploy.Spec.Replicas = existing.Spec.Replicas
-	}
-
-	// Always update the spec to the desired state. This avoids maintaining
-	// a normalization layer to replicate API-server defaulting logic, which
-	// would be an unmanageable maintenance burden.
-	existing.Spec = deploy.Spec
-	if err := c.Update(ctx, existing); err != nil {
-		return false, fmt.Errorf("updating Deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
-	}
-	// c.Update updates `existing` in-place with the server response, so its
-	// .metadata.generation reflects the post-update value. Do NOT re-fetch via
-	// the reconciler's cached client: during an upgrade where Generation has
-	// just been bumped, the cache may still return the pre-update object (with
-	// matching Generation and Status.ObservedGeneration), causing
-	// IsDeploymentReady to incorrectly report Ready=true and the upgrade state
-	// machine to skip the RollingUpdate phase.
-
-	return IsDeploymentReady(existing), nil
+	return IsDeploymentReady(deploy), nil
 }
 
-// EnsureService creates a Service if it does not exist or updates its spec
-// if it already exists. Server-assigned fields (ClusterIP, ClusterIPs,
-// IPFamilies) are preserved on updates. If the desired spec explicitly sets
-// any of these fields to a value that differs from the existing service, an
-// error is returned to signal an API usage problem.
+// EnsureService creates a Service if it does not exist or applies its desired
+// state via Server-Side Apply if it already exists. Server-assigned fields
+// (ClusterIP, ClusterIPs, IPFamilies, NodePort) are left unset by the builder,
+// so the operator's field manager never owns them and the API server keeps the
+// values it assigned. If the desired spec explicitly sets any of these fields
+// to a value that differs from the existing Service, an error is returned to
+// signal an API usage problem before the apply is attempted.
 func EnsureService(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, svc *corev1.Service) error {
 	existing := &corev1.Service{}
 	err := c.Get(ctx, client.ObjectKeyFromObject(svc), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, svc, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on Service %s/%s: %w", svc.Namespace, svc.Name, err)
-		}
-		if err := c.Create(ctx, svc); err != nil {
-			return fmt.Errorf("creating Service %s/%s: %w", svc.Namespace, svc.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("getting Service %s/%s: %w", svc.Namespace, svc.Name, err)
 	}
 
-	// Fail fast if the desired spec explicitly sets immutable/server-assigned
-	// fields to values that conflict with what the API server has already
-	// assigned. This indicates a programming error in the caller.
-	if err := validateImmutableServiceFields(svc, existing); err != nil {
-		return err
-	}
-
-	// DECISION: I-001 — Backported metadata reconciliation from EnsurePDB/EnsureHPA.
-	// DeepEqual spec guard is NOT added — see EnsureDeployment.
-
-	// Ensure controller owner reference is enforced so garbage collection
-	// behaves correctly even if the ref was removed out-of-band.
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return fmt.Errorf("updating owner reference on Service %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	// Merge desired labels into existing labels.
-	if svc.Labels != nil {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(svc.Labels))
-		}
-		for k, v := range svc.Labels {
-			existing.Labels[k] = v
+	if err == nil {
+		// Fail fast if the desired spec explicitly sets immutable/server-assigned
+		// fields to values that conflict with what the API server has already
+		// assigned. This indicates a programming error in the caller.
+		if err := validateImmutableServiceFields(svc, existing); err != nil {
+			return err
 		}
 	}
 
-	// Merge desired annotations into existing annotations.
-	if svc.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(svc.Annotations))
-		}
-		for k, v := range svc.Annotations {
-			existing.Annotations[k] = v
-		}
-	}
-
-	// Work on a copy of the desired spec so the caller's svc is never
-	// mutated — consistent with the other Ensure* functions.
-	newSpec := *svc.Spec.DeepCopy()
-	// Preserve the ClusterIP assigned by the API server.
-	newSpec.ClusterIP = existing.Spec.ClusterIP
-	newSpec.ClusterIPs = existing.Spec.ClusterIPs
-	newSpec.IPFamilies = existing.Spec.IPFamilies // preserve API-server-assigned IP families
-	// Preserve NodePort values assigned by the API server when the desired
-	// spec does not explicitly set them. Matching falls back to Port-only
-	// when Protocol is unset, since the API server defaults it to "TCP"
-	for i := range newSpec.Ports {
-		if newSpec.Ports[i].NodePort != 0 {
-			continue
-		}
-		for _, ep := range existing.Spec.Ports {
-			if newSpec.Ports[i].Port == ep.Port && (newSpec.Ports[i].Protocol == "" || newSpec.Ports[i].Protocol == ep.Protocol) {
-				newSpec.Ports[i].NodePort = ep.NodePort
-				break
-			}
-		}
-	}
-	// Always update the spec to the desired state.
-	existing.Spec = newSpec
-	if err := c.Update(ctx, existing); err != nil {
-		return fmt.Errorf("updating Service %s/%s: %w", svc.Namespace, svc.Name, err)
-	}
-	return nil
+	return apply.EnsureObject(ctx, c, scheme, owner, svc, apply.FieldManager)
 }
 
-// EnsurePDB creates a PodDisruptionBudget if it does not exist or updates its
-// spec and metadata if it already exists. An owner reference is set on the PDB
-// so that it is garbage-collected when the owning resource is deleted. On the
-// update path, owner references, labels, and annotations are reconciled to
-// correct any out-of-band drift.
+// EnsurePDB creates a PodDisruptionBudget if it does not exist or applies its
+// desired state via Server-Side Apply if it already exists. An owner reference
+// is set so the PDB is garbage-collected when the owning resource is deleted,
+// and the reference is re-enforced on every apply so out-of-band drift is
+// corrected.
 func EnsurePDB(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, pdb *policyv1.PodDisruptionBudget) error {
-	existing := &policyv1.PodDisruptionBudget{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(pdb), existing)
-
-	// PDB does not exist yet: set owner reference and create.
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, pdb, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on PodDisruptionBudget %s/%s: %w", pdb.Namespace, pdb.Name, err)
-		}
-		if err := c.Create(ctx, pdb); err != nil {
-			return fmt.Errorf("creating PodDisruptionBudget %s/%s: %w", pdb.Namespace, pdb.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting PodDisruptionBudget %s/%s: %w", pdb.Namespace, pdb.Name, err)
-	}
-
-	// PDB exists: reconcile metadata (ownerRefs/labels/annotations) and spec.
-	// Snapshot before mutations to detect whether an update is necessary.
-	before := existing.DeepCopy()
-
-	// Ensure controller owner reference is enforced so garbage collection
-	// behaves correctly even if the ref was removed out-of-band.
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return fmt.Errorf("updating owner reference on PodDisruptionBudget %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	// Merge desired labels into existing labels; extra user-added keys are
-	// preserved, keys present on the desired PDB are authoritative.
-	if pdb.Labels != nil {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(pdb.Labels))
-		}
-		for k, v := range pdb.Labels {
-			existing.Labels[k] = v
-		}
-	}
-
-	// Merge desired annotations into existing annotations.
-	if pdb.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(pdb.Annotations))
-		}
-		for k, v := range pdb.Annotations {
-			existing.Annotations[k] = v
-		}
-	}
-
-	// Reconcile spec to the desired state.
-	existing.Spec = pdb.Spec
-
-	// Only issue an API update when something actually changed to avoid
-	// unnecessary write load and events.
-	if !apiequality.Semantic.DeepEqual(existing.Spec, before.Spec) ||
-		!apiequality.Semantic.DeepEqual(normalizeMap(existing.Labels), normalizeMap(before.Labels)) ||
-		!apiequality.Semantic.DeepEqual(normalizeMap(existing.Annotations), normalizeMap(before.Annotations)) ||
-		!apiequality.Semantic.DeepEqual(existing.OwnerReferences, before.OwnerReferences) {
-		if err := c.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating PodDisruptionBudget %s/%s: %w", existing.Namespace, existing.Name, err)
-		}
-	}
-
-	return nil
+	return apply.EnsureObject(ctx, c, scheme, owner, pdb, apply.FieldManager)
 }
 
-// EnsureHPA creates a HorizontalPodAutoscaler if it does not exist or updates
-// its spec and metadata if it already exists. An owner reference is set on the
-// HPA so that it is garbage-collected when the owning resource is deleted. On
-// the update path, owner references, labels, and annotations are reconciled to
-// correct any out-of-band drift.
+// EnsureHPA creates a HorizontalPodAutoscaler if it does not exist or applies
+// its desired state via Server-Side Apply if it already exists. An owner
+// reference is set so the HPA is garbage-collected when the owning resource is
+// deleted, and the reference is re-enforced on every apply so out-of-band drift
+// is corrected.
 func EnsureHPA(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, hpa *autoscalingv2.HorizontalPodAutoscaler) error {
-	existing := &autoscalingv2.HorizontalPodAutoscaler{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(hpa), existing)
-
-	// HPA does not exist yet: set owner reference and create.
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, hpa, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on HorizontalPodAutoscaler %s/%s: %w", hpa.Namespace, hpa.Name, err)
-		}
-		if err := c.Create(ctx, hpa); err != nil {
-			return fmt.Errorf("creating HorizontalPodAutoscaler %s/%s: %w", hpa.Namespace, hpa.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting HorizontalPodAutoscaler %s/%s: %w", hpa.Namespace, hpa.Name, err)
-	}
-
-	// HPA exists: reconcile metadata (ownerRefs/labels/annotations) and spec.
-	// Snapshot before mutations to detect whether an update is necessary.
-	before := existing.DeepCopy()
-
-	// Ensure controller owner reference is enforced so garbage collection
-	// behaves correctly even if the ref was removed out-of-band.
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return fmt.Errorf("updating owner reference on HorizontalPodAutoscaler %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	// Merge desired labels into existing labels; extra user-added keys are
-	// preserved, keys present on the desired HPA are authoritative.
-	if hpa.Labels != nil {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(hpa.Labels))
-		}
-		for k, v := range hpa.Labels {
-			existing.Labels[k] = v
-		}
-	}
-
-	// Merge desired annotations into existing annotations.
-	if hpa.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(hpa.Annotations))
-		}
-		for k, v := range hpa.Annotations {
-			existing.Annotations[k] = v
-		}
-	}
-
-	// Reconcile spec to the desired state.
-	existing.Spec = hpa.Spec
-
-	// Only issue an API update when something actually changed to avoid
-	// unnecessary write load and events.
-	if !apiequality.Semantic.DeepEqual(existing.Spec, before.Spec) ||
-		!apiequality.Semantic.DeepEqual(normalizeMap(existing.Labels), normalizeMap(before.Labels)) ||
-		!apiequality.Semantic.DeepEqual(normalizeMap(existing.Annotations), normalizeMap(before.Annotations)) ||
-		!apiequality.Semantic.DeepEqual(existing.OwnerReferences, before.OwnerReferences) {
-		if err := c.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating HorizontalPodAutoscaler %s/%s: %w", existing.Namespace, existing.Name, err)
-		}
-	}
-
-	return nil
+	return apply.EnsureObject(ctx, c, scheme, owner, hpa, apply.FieldManager)
 }
 
 // DeleteHPA deletes the HorizontalPodAutoscaler identified by namespace and
@@ -362,15 +133,6 @@ func DeleteHPA(ctx context.Context, c client.Client, namespace, name string) err
 		return fmt.Errorf("deleting HorizontalPodAutoscaler %s/%s: %w", namespace, name, err)
 	}
 	return nil
-}
-
-// normalizeMap converts empty maps to nil so apiequality.Semantic.DeepEqual
-// does not report spurious diffs between nil and empty maps.
-func normalizeMap(m map[string]string) map[string]string {
-	if len(m) == 0 {
-		return nil
-	}
-	return m
 }
 
 // validateImmutableServiceFields returns an error if the desired Service spec

--- a/internal/common/deployment/deployment_test.go
+++ b/internal/common/deployment/deployment_test.go
@@ -414,6 +414,10 @@ func TestEnsureService_creates(t *testing.T) {
 	g.Expect(created.Spec.Ports[0].Port).To(Equal(int32(80)))
 }
 
+// TestEnsureService_updatesPreservingClusterIP verifies that the API-server
+// assigned ClusterIP/ClusterIPs survive an apply: the builder never sets these
+// fields, so the operator's field manager never owns them and Server-Side Apply
+// leaves them untouched while still applying an operator-owned change.
 func TestEnsureService_updatesPreservingClusterIP(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := newScheme()
@@ -428,10 +432,9 @@ func TestEnsureService_updatesPreservingClusterIP(t *testing.T) {
 		WithObjects(owner, existing).
 		Build()
 
+	// Change an operator-owned field (the selector) to make this a real update.
 	updated := testService()
-	updated.Spec.Ports = []corev1.ServicePort{
-		{Port: 8080, Protocol: corev1.ProtocolTCP},
-	}
+	updated.Spec.Selector = map[string]string{"app": "test", "tier": "api"}
 
 	err := EnsureService(context.Background(), c, s, owner, updated)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -440,10 +443,14 @@ func TestEnsureService_updatesPreservingClusterIP(t *testing.T) {
 	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(existing), fetched)).To(Succeed())
 	g.Expect(fetched.Spec.ClusterIP).To(Equal("10.0.0.42"))
 	g.Expect(fetched.Spec.ClusterIPs).To(Equal([]string{"10.0.0.42"}))
-	g.Expect(fetched.Spec.Ports[0].Port).To(Equal(int32(8080)))
+	g.Expect(fetched.Spec.Selector).To(HaveKeyWithValue("tier", "api"))
 }
 
-func TestEnsureService_doesNotMutateCallerObject(t *testing.T) {
+// TestEnsureService_decodesServerResponseIntoObject verifies that EnsureService
+// writes the server response back into the caller's object after the apply, so
+// it reflects server-fresh state (e.g. the API-server-assigned ClusterIP and a
+// populated resourceVersion) rather than the pre-apply desired values.
+func TestEnsureService_decodesServerResponseIntoObject(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := newScheme()
 	owner := testOwner()
@@ -451,10 +458,6 @@ func TestEnsureService_doesNotMutateCallerObject(t *testing.T) {
 	existing := testService()
 	existing.Spec.ClusterIP = "10.0.0.42"
 	existing.Spec.ClusterIPs = []string{"10.0.0.42"}
-	existing.Spec.Type = corev1.ServiceTypeNodePort
-	existing.Spec.Ports = []corev1.ServicePort{
-		{Port: 80, Protocol: corev1.ProtocolTCP, NodePort: 30080},
-	}
 
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -462,23 +465,15 @@ func TestEnsureService_doesNotMutateCallerObject(t *testing.T) {
 		Build()
 
 	desired := testService()
-	desired.Spec.Type = corev1.ServiceTypeNodePort
-	desired.Spec.Ports = []corev1.ServicePort{
-		{Port: 80, Protocol: corev1.ProtocolTCP},
-	}
-
-	// Snapshot the desired values before the call.
-	originalClusterIP := desired.Spec.ClusterIP
-	originalClusterIPs := desired.Spec.ClusterIPs
-	originalNodePort := desired.Spec.Ports[0].NodePort
+	g.Expect(desired.Spec.ClusterIP).To(BeEmpty(), "builder leaves ClusterIP unset")
 
 	err := EnsureService(context.Background(), c, s, owner, desired)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// The caller's object must remain unchanged.
-	g.Expect(desired.Spec.ClusterIP).To(Equal(originalClusterIP), "caller's ClusterIP must not be mutated")
-	g.Expect(desired.Spec.ClusterIPs).To(Equal(originalClusterIPs), "caller's ClusterIPs must not be mutated")
-	g.Expect(desired.Spec.Ports[0].NodePort).To(Equal(originalNodePort), "caller's NodePort must not be mutated")
+	// The apply response is decoded back into the caller's object: it now carries
+	// the server-assigned ClusterIP and a resourceVersion.
+	g.Expect(desired.Spec.ClusterIP).To(Equal("10.0.0.42"))
+	g.Expect(desired.ResourceVersion).NotTo(BeEmpty())
 }
 
 func TestEnsureService_updatesPreservingNodePorts(t *testing.T) {
@@ -879,27 +874,33 @@ func TestEnsurePDB_creates(t *testing.T) {
 	g.Expect(created.OwnerReferences[0].Name).To(Equal("test-owner"))
 }
 
+// TestEnsurePDB_updatesExisting verifies that an operator-owned field is removed
+// when the desired object stops setting it. The PDB is first established via
+// EnsurePDB so the operator's field manager owns .spec.minAvailable; applying a
+// desired object that sets .spec.maxUnavailable instead relinquishes
+// minAvailable, and Server-Side Apply removes the now-unowned field.
 func TestEnsurePDB_updatesExisting(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := newScheme()
 	owner := testOwner()
-	existing := testPDB()
 
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(owner, existing).
+		WithObjects(owner).
 		Build()
+
+	ctx := context.Background()
+	g.Expect(EnsurePDB(ctx, c, s, owner, testPDB())).To(Succeed())
 
 	updated := testPDB()
 	maxUnavailable := intstr.FromInt32(1)
 	updated.Spec.MinAvailable = nil
 	updated.Spec.MaxUnavailable = &maxUnavailable
 
-	err := EnsurePDB(context.Background(), c, s, owner, updated)
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(EnsurePDB(ctx, c, s, owner, updated)).To(Succeed())
 
 	fetched := &policyv1.PodDisruptionBudget{}
-	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(existing), fetched)).To(Succeed())
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(updated), fetched)).To(Succeed())
 	g.Expect(fetched.Spec.MinAvailable).To(BeNil())
 	g.Expect(fetched.Spec.MaxUnavailable).NotTo(BeNil())
 	g.Expect(fetched.Spec.MaxUnavailable.IntValue()).To(Equal(1))

--- a/internal/common/deployment/integration_test.go
+++ b/internal/common/deployment/integration_test.go
@@ -178,6 +178,93 @@ func TestIntegration_EnsureService(t *testing.T) {
 	g.Expect(fetched.Spec.Ports[0].Port).To(Equal(int32(8080)))
 }
 
+// TestIntegration_EnsureService_preservesNodePort verifies that a NodePort
+// assigned by the API server survives an apply: the builder leaves NodePort
+// unset, so the operator's field manager never owns it and Server-Side Apply
+// keeps the assigned value.
+func TestIntegration_EnsureService_preservesNodePort(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-svc-nodeport"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "svc-owner-np", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodeport-svc", Namespace: ns.Name},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeNodePort,
+			Selector: map[string]string{"app": "np"},
+			Ports:    []corev1.ServicePort{{Port: 80, Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	g.Expect(EnsureService(ctx, c, scheme, owner, svc)).To(Succeed())
+
+	created := &corev1.Service{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(svc), created)).To(Succeed())
+	assignedNodePort := created.Spec.Ports[0].NodePort
+	g.Expect(assignedNodePort).NotTo(BeZero())
+
+	// Re-apply the builder's view (NodePort still unset) and a selector change.
+	updated := svc.DeepCopy()
+	updated.Spec.Selector = map[string]string{"app": "np", "tier": "api"}
+	g.Expect(EnsureService(ctx, c, scheme, owner, updated)).To(Succeed())
+
+	fetched := &corev1.Service{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(svc), fetched)).To(Succeed())
+	g.Expect(fetched.Spec.Ports[0].NodePort).To(Equal(assignedNodePort), "API-server-assigned NodePort must survive the apply")
+	g.Expect(fetched.Spec.Selector).To(HaveKeyWithValue("tier", "api"))
+}
+
+// TestIntegration_EnsureDeployment_convergedApplyIsNoOp verifies that
+// re-applying an unchanged Deployment does not rewrite it: the resourceVersion
+// is unchanged after the second EnsureDeployment, so the operator no longer
+// issues a write on every reconcile pass.
+func TestIntegration_EnsureDeployment_convergedApplyIsNoOp(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-deploy-noop"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "deploy-owner-noop", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	build := func() *appsv1.Deployment {
+		labels := map[string]string{"app": "noop"}
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "noop-deploy", Namespace: ns.Name},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: intPtr(1),
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox:latest"}}},
+				},
+			},
+		}
+	}
+
+	_, err := EnsureDeployment(ctx, c, scheme, owner, build())
+	g.Expect(err).NotTo(HaveOccurred())
+	first := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "noop-deploy", Namespace: ns.Name}, first)).To(Succeed())
+
+	_, err = EnsureDeployment(ctx, c, scheme, owner, build())
+	g.Expect(err).NotTo(HaveOccurred())
+	second := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "noop-deploy", Namespace: ns.Name}, second)).To(Succeed())
+
+	g.Expect(second.ResourceVersion).To(Equal(first.ResourceVersion),
+		"a converged Deployment must not be rewritten on the next reconcile")
+}
+
 func TestIntegration_EnsureService_idempotent(t *testing.T) {
 	envtestutil.SkipIfEnvTestUnavailable(t)
 	g := NewGomegaWithT(t)

--- a/internal/common/job/job.go
+++ b/internal/common/job/job.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/apply"
 )
 
 // PodSpecHashAnnotation stores a Job's re-run gate value at creation time. By
@@ -177,33 +179,14 @@ func recreateStaleJob(ctx context.Context, c client.Client, scheme *runtime.Sche
 	return createJobWithRerunKey(ctx, c, scheme, owner, job, rerunKey)
 }
 
-// EnsureCronJob creates a CronJob if it does not exist or updates its spec if
-// it already exists. An owner reference is set on the CronJob so that it is
-// garbage-collected when the owning resource is deleted.
+// EnsureCronJob creates a CronJob if it does not exist or applies its desired
+// state via Server-Side Apply if it already exists. An owner reference is set on
+// the CronJob so that it is garbage-collected when the owning resource is
+// deleted. Because the field manager owns only the fields the builder sets,
+// server-defaulted CronJob fields no longer participate in the diff and a
+// converged CronJob is applied without a write.
 func EnsureCronJob(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, cronJob *batchv1.CronJob) error {
-	existing := &batchv1.CronJob{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(cronJob), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, cronJob, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on CronJob %s/%s: %w", cronJob.Namespace, cronJob.Name, err)
-		}
-		if err := c.Create(ctx, cronJob); err != nil {
-			return fmt.Errorf("creating CronJob %s/%s: %w", cronJob.Namespace, cronJob.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting CronJob %s/%s: %w", cronJob.Namespace, cronJob.Name, err)
-	}
-
-	// Always update the spec to the desired state. This avoids maintaining
-	// a normalization layer to replicate API-server defaulting logic
-	existing.Spec = cronJob.Spec
-	if err := c.Update(ctx, existing); err != nil {
-		return fmt.Errorf("updating CronJob %s/%s: %w", cronJob.Namespace, cronJob.Name, err)
-	}
-	return nil
+	return apply.EnsureObject(ctx, c, scheme, owner, cronJob, apply.FieldManager)
 }
 
 // isJobComplete returns true if the given Job has a Complete condition with

--- a/internal/common/secrets/integration_test.go
+++ b/internal/common/secrets/integration_test.go
@@ -137,12 +137,7 @@ func TestIntegration_EnsurePushSecret(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, owner)).To(Succeed())
 
-	ps := &esov1alpha1.PushSecret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "integration-ps",
-			Namespace: ns.Name,
-		},
-	}
+	ps := validPushSecret("integration-ps", ns.Name)
 
 	// Create.
 	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, ps)).To(Succeed())
@@ -151,6 +146,38 @@ func TestIntegration_EnsurePushSecret(t *testing.T) {
 	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(ps), created)).To(Succeed())
 	g.Expect(created.OwnerReferences).To(HaveLen(1))
 	g.Expect(created.OwnerReferences[0].Name).To(Equal("ps-owner"))
+	g.Expect(created.Spec.SecretStoreRefs).To(HaveLen(1))
+
+	// A second apply of the unchanged desired PushSecret must not rewrite it, so
+	// ESO is not woken to re-push an unchanged credential.
+	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, validPushSecret("integration-ps", ns.Name))).To(Succeed())
+	reapplied := &esov1alpha1.PushSecret{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(ps), reapplied)).To(Succeed())
+	g.Expect(reapplied.ResourceVersion).To(Equal(created.ResourceVersion),
+		"converged PushSecret must not be rewritten on a repeated apply")
+}
+
+// validPushSecret returns a schema-valid PushSecret mirroring the production
+// builders (a ClusterSecretStore ref, a source Secret selector, and one data
+// match), so the apply is accepted by the API server.
+func validPushSecret(name, namespace string) *esov1alpha1.PushSecret {
+	return &esov1alpha1.PushSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: esov1alpha1.PushSecretSpec{
+			SecretStoreRefs: []esov1alpha1.PushSecretStoreRef{{
+				Kind: "ClusterSecretStore",
+				Name: "openbao-cluster-store",
+			}},
+			Selector: esov1alpha1.PushSecretSelector{
+				Secret: &esov1alpha1.PushSecretSecret{Name: name + "-source"},
+			},
+			Data: []esov1alpha1.PushSecretData{{
+				Match: esov1alpha1.PushSecretMatch{
+					RemoteRef: esov1alpha1.PushSecretRemoteRef{RemoteKey: "openstack/" + name},
+				},
+			}},
+		},
+	}
 }
 
 func TestIntegration_EnsurePushSecret_idempotent(t *testing.T) {
@@ -168,15 +195,8 @@ func TestIntegration_EnsurePushSecret_idempotent(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, owner)).To(Succeed())
 
-	ps := &esov1alpha1.PushSecret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "idem-ps",
-			Namespace: ns.Name,
-		},
-	}
-
-	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, ps)).To(Succeed())
-	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, ps)).To(Succeed())
+	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, validPushSecret("idem-ps", ns.Name))).To(Succeed())
+	g.Expect(EnsurePushSecret(ctx, c, scheme, owner, validPushSecret("idem-ps", ns.Name))).To(Succeed())
 
 	list := &esov1alpha1.PushSecretList{}
 	g.Expect(c.List(ctx, list, client.InNamespace(ns.Name))).To(Succeed())

--- a/internal/common/secrets/secrets.go
+++ b/internal/common/secrets/secrets.go
@@ -14,11 +14,11 @@ import (
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/apply"
 )
 
 // ErrKeyNotFound is returned (wrapped) by GetSecretValue when the requested
@@ -144,31 +144,13 @@ func GetSecretValue(ctx context.Context, c client.Client, key client.ObjectKey, 
 	return string(val), nil
 }
 
-// EnsurePushSecret creates a PushSecret if it does not exist or updates its
-// spec if it already exists. An owner reference is set on the PushSecret so
-// that it is garbage-collected when the owning resource is deleted.
+// EnsurePushSecret creates a PushSecret if it does not exist or applies its
+// desired state via Server-Side Apply if it already exists. An owner reference
+// is set on the PushSecret so that it is garbage-collected when the owning
+// resource is deleted. Because the field manager owns only the fields the
+// builder sets, server-defaulted fields (updatePolicy, refreshInterval) are
+// never claimed and a converged PushSecret is applied without a write, so ESO
+// is not woken to re-push an unchanged credential.
 func EnsurePushSecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, ps *esov1alpha1.PushSecret) error {
-	existing := &esov1alpha1.PushSecret{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(ps), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, ps, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on PushSecret %s/%s: %w", ps.Namespace, ps.Name, err)
-		}
-		if err := c.Create(ctx, ps); err != nil {
-			return fmt.Errorf("creating PushSecret %s/%s: %w", ps.Namespace, ps.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting PushSecret %s/%s: %w", ps.Namespace, ps.Name, err)
-	}
-
-	if !apiequality.Semantic.DeepEqual(existing.Spec, ps.Spec) {
-		existing.Spec = ps.Spec
-		if err := c.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating PushSecret %s/%s: %w", ps.Namespace, ps.Name, err)
-		}
-	}
-	return nil
+	return apply.EnsureObject(ctx, c, scheme, owner, ps, apply.FieldManager)
 }

--- a/internal/common/testutil/fake_crds/mariadb-operator/database.yaml
+++ b/internal/common/testutil/fake_crds/mariadb-operator/database.yaml
@@ -28,9 +28,14 @@ spec:
           properties:
             spec:
               type: object
+              # Tolerate the non-omitempty struct fields the operator's typed
+              # Server-Side Apply emits without declaring every field of the
+              # production schema.
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 mariaDbRef:
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     name:
                       type: string

--- a/internal/common/testutil/fake_crds/mariadb-operator/grant.yaml
+++ b/internal/common/testutil/fake_crds/mariadb-operator/grant.yaml
@@ -28,9 +28,14 @@ spec:
           properties:
             spec:
               type: object
+              # Tolerate the non-omitempty struct fields the operator's typed
+              # Server-Side Apply emits without declaring every field of the
+              # production schema.
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 mariaDbRef:
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     name:
                       type: string

--- a/internal/common/testutil/fake_crds/mariadb-operator/user.yaml
+++ b/internal/common/testutil/fake_crds/mariadb-operator/user.yaml
@@ -28,9 +28,14 @@ spec:
           properties:
             spec:
               type: object
+              # Tolerate the non-omitempty struct fields the operator's typed
+              # Server-Side Apply emits (e.g. passwordPlugin) without declaring
+              # every field of the production schema.
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 mariaDbRef:
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     name:
                       type: string
@@ -43,6 +48,10 @@ spec:
                       type: string
                 maxUserConnections:
                   type: integer
+                  # Mirrors the real CRD's +kubebuilder:default=10 so envtest
+                  # exercises the server-default convergence the operator relies
+                  # on (the builder never sets maxUserConnections).
+                  default: 10
                 name:
                   type: string
                 host:

--- a/operators/c5c3/internal/controller/reconcile_admincredential.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential.go
@@ -156,10 +156,10 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		}
 	}
 
-	// CLOBBER-SAFE PushSecret: EnsurePushSecret is idempotent — it only Updates
-	// the PushSecret when its desired Spec differs from the stored one
-	// (apiequality.Semantic.DeepEqual guard inside EnsurePushSecret). Repeated
-	// reconciles therefore do not churn the PushSecret, so ESO is not woken to
+	// CLOBBER-SAFE PushSecret: EnsurePushSecret applies via Server-Side Apply
+	// under a fixed field manager that owns only the fields the operator sets, so
+	// repeated applies of an unchanged desired Spec are no-ops at the API server.
+	// Reconciles therefore do not churn the PushSecret, so ESO is not woken to
 	// re-push an unchanged credential.
 	ps := adminAppCredentialPushSecret(cp)
 	if err := secrets.EnsurePushSecret(ctx, r.Client, r.Scheme, cp, ps); err != nil {

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -939,6 +939,15 @@ func TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName(t *testing.T) {
 		"two ControlPlanes must not share a RemoteKey")
 }
 
+// TestReconcileAdminCredential_PushSecretClobberSafeNoChurn verifies that
+// repeated reconciles produce a deterministic admin app-credential PushSecret
+// spec, so EnsurePushSecret's Server-Side Apply is a no-op once converged. The
+// fake client's deduced apply bumps resourceVersion on every apply, so the
+// no-write property itself is asserted against a real API server by
+// internal/common/apply's envtest convergence test
+// (TestIntegration_EnsureObject_convergesWithoutRewrite); here we assert the
+// desired spec is stable across reconciles, which is what makes the apply
+// converge.
 func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -958,9 +967,9 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp),
 	}, ps1)).To(Succeed())
-	rv1 := ps1.ResourceVersion
 
-	// Second reconcile must not churn the PushSecret (same spec => no Update).
+	// Second reconcile must produce an identical desired spec (no drift), so the
+	// Server-Side Apply converges instead of re-pushing the credential.
 	_, err = r.reconcileAdminCredential(context.Background(), cp)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -968,7 +977,7 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp),
 	}, ps2)).To(Succeed())
-	g.Expect(ps2.ResourceVersion).To(Equal(rv1), "repeated reconcile must not churn the PushSecret")
+	g.Expect(ps2.Spec).To(Equal(ps1.Spec), "repeated reconcile must not change the PushSecret spec")
 }
 
 // --- 2.8: re-mint (hash) ---

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -343,6 +343,12 @@ type FernetSpec struct {
 	// +kubebuilder:validation:Minimum=3
 	// +kubebuilder:default=3
 	MaxActiveKeys int32 `json:"maxActiveKeys,omitempty"`
+
+	// Suspend pauses the Fernet key rotation CronJob without deleting it,
+	// letting an SRE halt rotation during an incident. Matches
+	// TrustFlushSpec.Suspend semantics.
+	// +kubebuilder:default=false
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // CredentialKeysSpec defines credential key rotation configuration.
@@ -355,6 +361,12 @@ type CredentialKeysSpec struct {
 	// +kubebuilder:validation:Minimum=3
 	// +kubebuilder:default=3
 	MaxActiveKeys int32 `json:"maxActiveKeys,omitempty"`
+
+	// Suspend pauses the credential key rotation CronJob without deleting it,
+	// letting an SRE halt rotation during an incident. Matches
+	// TrustFlushSpec.Suspend semantics.
+	// +kubebuilder:default=false
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // TrustFlushSpec configures periodic purging of expired trust delegations

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -220,6 +220,13 @@ spec:
                     description: RotationSchedule is a cron expression for credential
                       key rotation.
                     type: string
+                  suspend:
+                    default: false
+                    description: |-
+                      Suspend pauses the credential key rotation CronJob without deleting it,
+                      letting an SRE halt rotation during an incident. Matches
+                      TrustFlushSpec.Suspend semantics.
+                    type: boolean
                 type: object
               database:
                 description: |-
@@ -375,6 +382,13 @@ spec:
                     default: 0 0 * * 0
                     description: RotationSchedule is a cron expression for key rotation.
                     type: string
+                  suspend:
+                    default: false
+                    description: |-
+                      Suspend pauses the Fernet key rotation CronJob without deleting it,
+                      letting an SRE halt rotation during an incident. Matches
+                      TrustFlushSpec.Suspend semantics.
+                    type: boolean
                 type: object
               gateway:
                 description: |-

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -223,6 +223,13 @@ spec:
                     description: RotationSchedule is a cron expression for credential
                       key rotation.
                     type: string
+                  suspend:
+                    default: false
+                    description: |-
+                      Suspend pauses the credential key rotation CronJob without deleting it,
+                      letting an SRE halt rotation during an incident. Matches
+                      TrustFlushSpec.Suspend semantics.
+                    type: boolean
                 type: object
               database:
                 description: |-
@@ -378,6 +385,13 @@ spec:
                     default: 0 0 * * 0
                     description: RotationSchedule is a cron expression for key rotation.
                     type: string
+                  suspend:
+                    default: false
+                    description: |-
+                      Suspend pauses the Fernet key rotation CronJob without deleting it,
+                      letting an SRE halt rotation during an incident. Matches
+                      TrustFlushSpec.Suspend semantics.
+                    type: boolean
                 type: object
               gateway:
                 description: |-

--- a/operators/keystone/internal/controller/integration_test.go
+++ b/operators/keystone/internal/controller/integration_test.go
@@ -2261,6 +2261,79 @@ func simulateHTTPRouteAccepted(t testing.TB, ctx context.Context, c client.Clien
 	g.Expect(c.Status().Update(ctx, route)).To(Succeed(), "update HTTPRoute status with simulated acceptance")
 }
 
+// TestIntegration_HTTPRoute_PreservesThirdPartyAnnotation verifies the
+// Server-Side Apply merge strategy of ensureHTTPRoute against a real API
+// server: an annotation added by another field manager (e.g. a mesh controller)
+// survives the operator dropping its own annotation, because the operator's
+// field manager only owns the keys it sets. This is the cross-manager guarantee
+// the fake client's deduced converter cannot simulate (it treats the
+// annotations map atomically).
+func TestIntegration_HTTPRoute_PreservesThirdPartyAnnotation(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestWithController(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-httproute-annot-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	createPrerequisites(t, ctx, c, ns.Name)
+
+	ks := integrationKeystoneWithGateway("test-keystone", ns.Name, "keystone.example.com")
+	ks.Spec.Gateway.Annotations = map[string]string{"konghq.com/plugins": "rate-limiting"}
+	g.Expect(c.Create(ctx, ks)).To(Succeed())
+
+	driveReconciliationToDeployment(t, ctx, c, ks.Name, ns.Name)
+
+	routeKey := client.ObjectKey{Namespace: ns.Name, Name: ks.Name}
+	route := &gatewayv1.HTTPRoute{}
+	g.Eventually(func() error {
+		if err := c.Get(ctx, routeKey, route); err != nil {
+			return err
+		}
+		if _, ok := route.Annotations["konghq.com/plugins"]; !ok {
+			return fmt.Errorf("operator annotation not yet present")
+		}
+		return nil
+	}, eventuallyTimeout, pollInterval).Should(Succeed(), "HTTPRoute should carry the operator-managed annotation")
+
+	// A third party (a different field manager) adds an annotation the operator
+	// does not manage.
+	g.Eventually(func() error {
+		if err := c.Get(ctx, routeKey, route); err != nil {
+			return err
+		}
+		if route.Annotations == nil {
+			route.Annotations = map[string]string{}
+		}
+		route.Annotations["sidecar.istio.io/inject"] = "false"
+		return c.Update(ctx, route)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+
+	// Drop the operator-managed annotation from the CR and let the operator
+	// re-reconcile.
+	g.Eventually(func() error {
+		latest := &keystonev1alpha1.Keystone{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(ks), latest); err != nil {
+			return err
+		}
+		latest.Spec.Gateway.Annotations = nil
+		return c.Update(ctx, latest)
+	}, eventuallyTimeout, pollInterval).Should(Succeed())
+
+	// The operator's annotation is removed (it relinquished the key) while the
+	// third party's annotation survives (a different manager owns it).
+	g.Eventually(func() bool {
+		if err := c.Get(ctx, routeKey, route); err != nil {
+			return false
+		}
+		_, operatorKey := route.Annotations["konghq.com/plugins"]
+		_, thirdParty := route.Annotations["sidecar.istio.io/inject"]
+		return !operatorKey && thirdParty
+	}, eventuallyTimeout, pollInterval).Should(BeTrue(),
+		"operator annotation must be removed and third-party annotation preserved")
+}
+
 // TestIntegration_HTTPRoute_CreatedWhenGatewaySet verifies that configuring
 // spec.gateway on a Keystone CR causes the operator to create an HTTPRoute
 // with the correct parentRef/hostname/backendRef, to set HTTPRouteReady

--- a/operators/keystone/internal/controller/reconcile_credential.go
+++ b/operators/keystone/internal/controller/reconcile_credential.go
@@ -309,6 +309,7 @@ func credentialRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapNam
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: keystone.Spec.CredentialKeys.RotationSchedule,
+			Suspend:  ptr.To(keystone.Spec.CredentialKeys.Suspend),
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{

--- a/operators/keystone/internal/controller/reconcile_credential_test.go
+++ b/operators/keystone/internal/controller/reconcile_credential_test.go
@@ -1019,6 +1019,35 @@ func TestCredentialRotationCronJob_PriorityClassNameNil(t *testing.T) {
 	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName).To(BeEmpty())
 }
 
+// TestCredentialRotationCronJob_SuspendDefaultsFalse verifies that when
+// spec.credentialKeys.suspend is unset (false), the rotation CronJob is not
+// suspended.
+func TestCredentialRotationCronJob_SuspendDefaultsFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := credentialTestKeystone()
+
+	cronJob := credentialRotationCronJob(ks, "test-keystone-config-abc123", "test-keystone-credential-rotate-script-abc123")
+
+	g.Expect(cronJob.Spec.Suspend).NotTo(BeNil())
+	g.Expect(*cronJob.Spec.Suspend).To(BeFalse())
+}
+
+// TestCredentialRotationCronJob_SuspendTrue verifies that setting
+// spec.credentialKeys.suspend pauses the rotation CronJob without changing its
+// schedule.
+func TestCredentialRotationCronJob_SuspendTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := credentialTestKeystone()
+	ks.Spec.CredentialKeys.Suspend = true
+
+	cronJob := credentialRotationCronJob(ks, "test-keystone-config-abc123", "test-keystone-credential-rotate-script-abc123")
+
+	g.Expect(cronJob.Spec.Suspend).NotTo(BeNil())
+	g.Expect(*cronJob.Spec.Suspend).To(BeTrue())
+	g.Expect(cronJob.Spec.Schedule).To(Equal(ks.Spec.CredentialKeys.RotationSchedule),
+		"toggling suspend must not change the rotation schedule")
+}
+
 // TestEnsureCredentialRotationRBAC_MainSecretIsReadOnly verifies that the Role
 // created by ensureCredentialRotationRBAC grants only `get` on the production
 // credential keys Secret — no patch, update, create, delete, list, watch, or

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -933,17 +933,17 @@ func TestReconcileDeployment_PDBEnsureError(t *testing.T) {
 	ks := deployTestKeystone()
 	ks.Spec.Replicas = 3 // explicit: PDB expectations depend on this value
 
-	// Use an interceptor to inject an error when creating a PodDisruptionBudget.
+	// Use an interceptor to inject an error when applying a PodDisruptionBudget.
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(ks).
 		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-				if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
-					return fmt.Errorf("simulated PDB creation error")
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if co, ok := obj.(client.Object); ok && co.GetObjectKind().GroupVersionKind().Kind == "PodDisruptionBudget" {
+					return fmt.Errorf("simulated PDB apply error")
 				}
-				return c.Create(ctx, obj, opts...)
+				return c.Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -958,7 +958,7 @@ func TestReconcileDeployment_PDBEnsureError(t *testing.T) {
 
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("ensuring PodDisruptionBudget"))
-	g.Expect(err.Error()).To(ContainSubstring("simulated PDB creation error"))
+	g.Expect(err.Error()).To(ContainSubstring("simulated PDB apply error"))
 }
 
 // TestUWSGICommand_NilUWSGI verifies that uwsgiCommand(nil) returns the command

--- a/operators/keystone/internal/controller/reconcile_fernet.go
+++ b/operators/keystone/internal/controller/reconcile_fernet.go
@@ -306,6 +306,7 @@ func fernetRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapName st
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: keystone.Spec.Fernet.RotationSchedule,
+			Suspend:  ptr.To(keystone.Spec.Fernet.Suspend),
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{

--- a/operators/keystone/internal/controller/reconcile_fernet_test.go
+++ b/operators/keystone/internal/controller/reconcile_fernet_test.go
@@ -994,6 +994,34 @@ func TestFernetRotationCronJob_PriorityClassNameNil(t *testing.T) {
 	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName).To(BeEmpty())
 }
 
+// TestFernetRotationCronJob_SuspendDefaultsFalse verifies that when
+// spec.fernet.suspend is unset (false), the rotation CronJob is not suspended.
+func TestFernetRotationCronJob_SuspendDefaultsFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := fernetTestKeystone()
+
+	cronJob := fernetRotationCronJob(ks, "test-keystone-config-abc123", "test-keystone-fernet-rotate-script-abc123")
+
+	g.Expect(cronJob.Spec.Suspend).NotTo(BeNil())
+	g.Expect(*cronJob.Spec.Suspend).To(BeFalse())
+}
+
+// TestFernetRotationCronJob_SuspendTrue verifies that setting
+// spec.fernet.suspend pauses the rotation CronJob without changing its schedule
+// (the escape hatch must not alter rotation cadence).
+func TestFernetRotationCronJob_SuspendTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := fernetTestKeystone()
+	ks.Spec.Fernet.Suspend = true
+
+	cronJob := fernetRotationCronJob(ks, "test-keystone-config-abc123", "test-keystone-fernet-rotate-script-abc123")
+
+	g.Expect(cronJob.Spec.Suspend).NotTo(BeNil())
+	g.Expect(*cronJob.Spec.Suspend).To(BeTrue())
+	g.Expect(cronJob.Spec.Schedule).To(Equal(ks.Spec.Fernet.RotationSchedule),
+		"toggling suspend must not change the rotation schedule")
+}
+
 // findRuleForResource returns the first PolicyRule whose ResourceNames matches
 // the given resource name exactly. Helper for RBAC split tests.
 func findRuleForResource(rules []rbacv1.PolicyRule, resourceName string) *rbacv1.PolicyRule {

--- a/operators/keystone/internal/controller/reconcile_hpa_test.go
+++ b/operators/keystone/internal/controller/reconcile_hpa_test.go
@@ -282,11 +282,11 @@ func TestReconcileHPA_EnsureError_Propagated(t *testing.T) {
 		WithObjects(ks).
 		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-				if _, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler); ok {
-					return fmt.Errorf("simulated HPA creation error")
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if co, ok := obj.(client.Object); ok && co.GetObjectKind().GroupVersionKind().Kind == "HorizontalPodAutoscaler" {
+					return fmt.Errorf("simulated HPA apply error")
 				}
-				return c.Create(ctx, obj, opts...)
+				return c.Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -300,7 +300,7 @@ func TestReconcileHPA_EnsureError_Propagated(t *testing.T) {
 	_, err := r.reconcileHPA(context.Background(), ks)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("ensuring HorizontalPodAutoscaler"))
-	g.Expect(err.Error()).To(ContainSubstring("simulated HPA creation error"))
+	g.Expect(err.Error()).To(ContainSubstring("simulated HPA apply error"))
 }
 
 func TestReconcileHPA_DeleteError_Propagated(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_httproute.go
+++ b/operators/keystone/internal/controller/reconcile_httproute.go
@@ -7,19 +7,16 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -36,18 +33,6 @@ const (
 // defaultHTTPRoutePath is the URL path prefix applied when spec.gateway.path
 // is empty.
 const defaultHTTPRoutePath = "/"
-
-// managedAnnotationsKey and managedLabelsKey are sentinel annotations that
-// record the operator-managed annotation/label key sets on an HTTPRoute.
-// On each reconcile, keys present in the previous set but absent from the
-// desired set are removed, enabling removal of annotations/labels that
-// disappear from spec.gateway. Stored as a comma-separated,
-// sorted list of key names. The sentinel annotations themselves are never
-// part of the tracked set.
-const (
-	managedAnnotationsKey = "keystone.openstack.c5c3.io/managed-annotations"
-	managedLabelsKey      = "keystone.openstack.c5c3.io/managed-labels"
-)
 
 // keystoneStatusEndpoint returns the externally reachable Keystone API endpoint
 // URL.
@@ -280,161 +265,18 @@ func isHTTPRouteAccepted(route *gatewayv1.HTTPRoute) bool {
 	return false
 }
 
-// ensureHTTPRoute creates an HTTPRoute if it does not exist or updates its
-// spec and metadata if it already exists. An owner reference is set so that
-// the HTTPRoute is garbage-collected when the Keystone CR is deleted
+// ensureHTTPRoute creates or updates the HTTPRoute via Server-Side Apply under
+// a fixed field manager and sets the Keystone CR as its controller owner so it
+// is garbage-collected with the CR.
 //
-// Merge strategy: .Spec is overwritten with the desired state on every
-// reconcile. Labels and annotations use tracked-key merging: operator-managed
-// keys are recorded in sentinel annotations so keys removed from spec.gateway
-// between reconciles are also removed from the live object,
-// while user-added keys not in the managed set are preserved.
+// Merge strategy: the field manager owns exactly the fields the builder sets
+// (the whole Spec and the annotations/labels derived from spec.gateway).
+// Annotations or labels that disappear from spec.gateway between reconciles are
+// relinquished and removed by the API server — no sentinel bookkeeping is
+// needed — while keys owned by other managers are preserved. A converged
+// HTTPRoute is applied without a write.
 func ensureHTTPRoute(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, route *gatewayv1.HTTPRoute) error {
-	existing := &gatewayv1.HTTPRoute{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(route), existing)
-
-	if apierrors.IsNotFound(err) {
-		stampManagedMetadata(route)
-		if err := controllerutil.SetControllerReference(owner, route, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on HTTPRoute %s/%s: %w", route.Namespace, route.Name, err)
-		}
-		if err := c.Create(ctx, route); err != nil {
-			return fmt.Errorf("creating HTTPRoute %s/%s: %w", route.Namespace, route.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting HTTPRoute %s/%s: %w", route.Namespace, route.Name, err)
-	}
-
-	before := existing.DeepCopy()
-
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return fmt.Errorf("updating owner reference on HTTPRoute %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	applyManagedMetadata(existing, route.Annotations, route.Labels)
-
-	existing.Spec = route.Spec
-
-	if !apiequality.Semantic.DeepEqual(existing.Spec, before.Spec) ||
-		!apiequality.Semantic.DeepEqual(hrNormalizeMap(existing.Labels), hrNormalizeMap(before.Labels)) ||
-		!apiequality.Semantic.DeepEqual(hrNormalizeMap(existing.Annotations), hrNormalizeMap(before.Annotations)) ||
-		!apiequality.Semantic.DeepEqual(existing.OwnerReferences, before.OwnerReferences) {
-		if err := c.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating HTTPRoute %s/%s: %w", existing.Namespace, existing.Name, err)
-		}
-	}
-
-	return nil
-}
-
-// stampManagedMetadata records the key sets from route.Annotations and
-// route.Labels in sentinel annotations on the route itself before creation.
-// These sentinels are consulted on subsequent reconciles to remove keys that
-// disappear from the desired set.
-func stampManagedMetadata(route *gatewayv1.HTTPRoute) {
-	annotationKeys := sortedMapKeys(route.Annotations)
-	labelKeys := sortedMapKeys(route.Labels)
-
-	if len(annotationKeys) == 0 && len(labelKeys) == 0 {
-		return
-	}
-	if route.Annotations == nil {
-		route.Annotations = make(map[string]string, 2)
-	}
-	if len(annotationKeys) > 0 {
-		route.Annotations[managedAnnotationsKey] = strings.Join(annotationKeys, ",")
-	}
-	if len(labelKeys) > 0 {
-		route.Annotations[managedLabelsKey] = strings.Join(labelKeys, ",")
-	}
-}
-
-// applyManagedMetadata reconciles the live object's annotations and labels
-// against the desired sets. Keys present in the previously-managed set (read
-// from the sentinel annotations) but absent from the desired set are removed,
-// then desired keys are applied, then the sentinels are updated to reflect the
-// new managed set. This is the removal path that was missing from the naive
-// additive merge.
-func applyManagedMetadata(existing *gatewayv1.HTTPRoute, desiredAnnotations, desiredLabels map[string]string) {
-	prevAnnotationKeys := splitManagedKeys(existing.Annotations[managedAnnotationsKey])
-	prevLabelKeys := splitManagedKeys(existing.Annotations[managedLabelsKey])
-
-	for _, k := range prevAnnotationKeys {
-		if _, stillDesired := desiredAnnotations[k]; !stillDesired {
-			delete(existing.Annotations, k)
-		}
-	}
-	for _, k := range prevLabelKeys {
-		if _, stillDesired := desiredLabels[k]; !stillDesired {
-			delete(existing.Labels, k)
-		}
-	}
-
-	for k, v := range desiredAnnotations {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(desiredAnnotations)+2)
-		}
-		existing.Annotations[k] = v
-	}
-	for k, v := range desiredLabels {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(desiredLabels))
-		}
-		existing.Labels[k] = v
-	}
-
-	annotationKeys := sortedMapKeys(desiredAnnotations)
-	labelKeys := sortedMapKeys(desiredLabels)
-	if len(annotationKeys) > 0 {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, 2)
-		}
-		existing.Annotations[managedAnnotationsKey] = strings.Join(annotationKeys, ",")
-	} else if existing.Annotations != nil {
-		delete(existing.Annotations, managedAnnotationsKey)
-	}
-	if len(labelKeys) > 0 {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, 1)
-		}
-		existing.Annotations[managedLabelsKey] = strings.Join(labelKeys, ",")
-	} else if existing.Annotations != nil {
-		delete(existing.Annotations, managedLabelsKey)
-	}
-}
-
-// splitManagedKeys parses the comma-separated key list stored in a sentinel
-// annotation. An empty or missing value produces a nil slice.
-func splitManagedKeys(v string) []string {
-	if v == "" {
-		return nil
-	}
-	return strings.Split(v, ",")
-}
-
-// sortedMapKeys returns the keys of m in lexicographic order so the sentinel
-// annotation value is deterministic across reconciles.
-func sortedMapKeys(m map[string]string) []string {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-// hrNormalizeMap converts empty maps to nil so apiequality.Semantic.DeepEqual
-// does not report spurious diffs between nil and empty maps.
-func hrNormalizeMap(m map[string]string) map[string]string {
-	if len(m) == 0 {
-		return nil
-	}
-	return m
+	return apply.EnsureObject(ctx, c, scheme, owner, route, apply.FieldManager)
 }
 
 // deleteHTTPRoute deletes the HTTPRoute identified by namespace and name.

--- a/operators/keystone/internal/controller/reconcile_httproute_test.go
+++ b/operators/keystone/internal/controller/reconcile_httproute_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -73,7 +74,14 @@ func hrTestGateway() *keystonev1alpha1.GatewaySpec {
 
 func newHRTestReconciler(s *runtime.Scheme, objs ...client.Object) *KeystoneReconciler {
 	cb := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...)
-	cb = cb.WithStatusSubresource(&keystonev1alpha1.Keystone{})
+	// HTTPRoute carries a status subresource so the operator's main-resource
+	// apply never clobbers the Gateway-controller-written Accepted condition.
+	cb = cb.WithStatusSubresource(&keystonev1alpha1.Keystone{}, &gatewayv1.HTTPRoute{})
+	// The fake client's default typed converter cannot apply an unstructured
+	// HTTPRoute; the deduced converter applies it uniformly. Server-Side Apply
+	// against a real API server is exercised by the internal/common envtest
+	// suites.
+	cb = cb.WithTypeConverters(managedfields.NewDeducedTypeConverter())
 	return &KeystoneReconciler{
 		Client:   cb.Build(),
 		Scheme:   s,
@@ -476,45 +484,28 @@ func TestReconcileHTTPRoute_GatewaySet_HTTPRouteUpdated(t *testing.T) {
 	g.Expect(route.Spec.Hostnames).To(ConsistOf(gatewayv1.Hostname("keystone.new-example.com")))
 }
 
-func TestReconcileHTTPRoute_NoChange_SkipsUpdate(t *testing.T) {
+// TestReconcileHTTPRoute_RepeatedReconcileIsIdempotent verifies that reconciling
+// an unchanged spec twice leaves exactly one HTTPRoute with the desired spec.
+// Server-Side Apply converges without a write on a real API server; that
+// no-write property is exercised by the internal/common envtest convergence
+// suites (the fake client bumps resourceVersion on every apply).
+func TestReconcileHTTPRoute_RepeatedReconcileIsIdempotent(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := hrTestScheme()
 	ks := hrTestKeystone()
 	ks.Spec.Gateway = hrTestGateway()
-
-	updateCount := 0
-	c := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(ks).
-		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				if _, ok := obj.(*gatewayv1.HTTPRoute); ok {
-					updateCount++
-				}
-				return c.Update(ctx, obj, opts...)
-			},
-		}).
-		Build()
-
-	r := &KeystoneReconciler{
-		Client:              c,
-		Scheme:              s,
-		Recorder:            record.NewFakeRecorder(10),
-		gatewayAPIAvailable: true,
-	}
+	r := newHRTestReconciler(s, ks)
 	ctx := context.Background()
 
-	// First reconcile creates the HTTPRoute (no update call expected).
 	_, err := r.reconcileHTTPRoute(ctx, ks)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(updateCount).To(Equal(0), "create path should not trigger update")
-
-	// Second reconcile with identical spec should skip the update.
-	updateCount = 0
 	_, err = r.reconcileHTTPRoute(ctx, ks)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(updateCount).To(Equal(0), "idempotent reconciliation should skip update when spec is unchanged")
+
+	list := &gatewayv1.HTTPRouteList{}
+	g.Expect(r.List(ctx, list, client.InNamespace("default"))).To(Succeed())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].Spec.Hostnames).To(ConsistOf(gatewayv1.Hostname("keystone.example.com")))
 }
 
 // --- Error scenarios ---
@@ -529,12 +520,10 @@ func TestReconcileHTTPRoute_EnsureError_Propagated(t *testing.T) {
 		WithScheme(s).
 		WithObjects(ks).
 		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-				if _, ok := obj.(*gatewayv1.HTTPRoute); ok {
-					return fmt.Errorf("simulated HTTPRoute creation error")
-				}
-				return c.Create(ctx, obj, opts...)
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				return fmt.Errorf("simulated HTTPRoute apply error")
 			},
 		}).
 		Build()
@@ -549,7 +538,7 @@ func TestReconcileHTTPRoute_EnsureError_Propagated(t *testing.T) {
 	_, err := r.reconcileHTTPRoute(context.Background(), ks)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("ensuring HTTPRoute"))
-	g.Expect(err.Error()).To(ContainSubstring("simulated HTTPRoute creation error"))
+	g.Expect(err.Error()).To(ContainSubstring("simulated HTTPRoute apply error"))
 }
 
 func TestReconcileHTTPRoute_DeleteError_Propagated(t *testing.T) {
@@ -592,7 +581,7 @@ func TestReconcileHTTPRoute_DeleteError_Propagated(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("simulated HTTPRoute deletion error"))
 }
 
-// --- W-001: annotation/label removal tracking via sentinel annotations ---
+// --- annotation/label removal via Server-Side Apply field ownership ---
 
 func TestReconcileHTTPRoute_AnnotationRemoval_RemovesKeyFromLiveRoute(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -616,10 +605,10 @@ func TestReconcileHTTPRoute_AnnotationRemoval_RemovesKeyFromLiveRoute(t *testing
 	}, &route)).To(Succeed())
 	g.Expect(route.Annotations).To(HaveKeyWithValue("konghq.com/plugins", "rate-limiting"))
 	g.Expect(route.Annotations).To(HaveKeyWithValue("nginx.ingress.k8s.io", "test"))
-	g.Expect(route.Annotations).To(HaveKey(managedAnnotationsKey),
-		"sentinel annotation must be stamped on create so removal is tracked across reconciles")
 
 	// Remove konghq.com/plugins from spec.gateway.annotations and re-reconcile.
+	// Server-Side Apply relinquishes the no-longer-set key, so the API server
+	// removes it without any sentinel bookkeeping.
 	ks.Spec.Gateway.Annotations = map[string]string{
 		"nginx.ingress.k8s.io": "test",
 	}
@@ -634,7 +623,7 @@ func TestReconcileHTTPRoute_AnnotationRemoval_RemovesKeyFromLiveRoute(t *testing
 	g.Expect(route.Annotations).To(HaveKeyWithValue("nginx.ingress.k8s.io", "test"),
 		"annotations still present in spec.gateway.annotations must be preserved")
 
-	// Remove all annotations and re-reconcile — sentinel and all tracked keys must go.
+	// Remove all annotations and re-reconcile — all previously-owned keys go.
 	ks.Spec.Gateway.Annotations = nil
 	_, err = r.reconcileHTTPRoute(ctx, ks)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -644,47 +633,13 @@ func TestReconcileHTTPRoute_AnnotationRemoval_RemovesKeyFromLiveRoute(t *testing
 	}, &route)).To(Succeed())
 	g.Expect(route.Annotations).NotTo(HaveKey("nginx.ingress.k8s.io"),
 		"clearing spec.gateway.annotations must remove all previously-managed annotation keys")
-	g.Expect(route.Annotations).NotTo(HaveKey(managedAnnotationsKey),
-		"sentinel annotation must be cleared when no annotations are desired")
 }
 
-func TestReconcileHTTPRoute_AnnotationRemoval_PreservesUserAddedKey(t *testing.T) {
-	g := NewGomegaWithT(t)
-	s := hrTestScheme()
-	ks := hrTestKeystone()
-	ks.Spec.Gateway = hrTestGateway()
-	ks.Spec.Gateway.Annotations = map[string]string{
-		"konghq.com/plugins": "rate-limiting",
-	}
-	r := newHRTestReconciler(s, ks)
-	ctx := context.Background()
-
-	// Create the HTTPRoute via reconcile.
-	_, err := r.reconcileHTTPRoute(ctx, ks)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	// Simulate a third party (e.g. a mesh controller) adding an annotation
-	// that the operator does not manage.
-	var route gatewayv1.HTTPRoute
-	g.Expect(r.Get(ctx, types.NamespacedName{
-		Name: "test-keystone", Namespace: "default",
-	}, &route)).To(Succeed())
-	route.Annotations["sidecar.istio.io/inject"] = "false"
-	g.Expect(r.Client.Update(ctx, &route)).To(Succeed())
-
-	// Remove konghq.com/plugins and re-reconcile.
-	ks.Spec.Gateway.Annotations = nil
-	_, err = r.reconcileHTTPRoute(ctx, ks)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	g.Expect(r.Get(ctx, types.NamespacedName{
-		Name: "test-keystone", Namespace: "default",
-	}, &route)).To(Succeed())
-	g.Expect(route.Annotations).NotTo(HaveKey("konghq.com/plugins"),
-		"operator-managed annotation must be removed")
-	g.Expect(route.Annotations).To(HaveKeyWithValue("sidecar.istio.io/inject", "false"),
-		"annotations not in the operator-managed set must be preserved across reconciles")
-}
+// Cross-manager annotation preservation (a third party's annotation surviving
+// the operator dropping its own) depends on the API server's granular ownership
+// of the metadata.annotations map, which the fake client's deduced type
+// converter treats atomically. It is therefore covered by the envtest suite:
+// TestIntegration_HTTPRoute_PreservesThirdPartyAnnotation in integration_test.go.
 
 // --- Status tests: Accepted condition tracking ---
 

--- a/operators/keystone/internal/controller/reconcile_networkpolicy.go
+++ b/operators/keystone/internal/controller/reconcile_networkpolicy.go
@@ -12,15 +12,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -318,92 +316,17 @@ func cacheEgressPorts(keystone *keystonev1alpha1.Keystone) []int32 {
 // to the common package is warranted when a second operator needs the same
 // create-or-update logic.
 
-// ensureNetworkPolicy creates a NetworkPolicy if it does not exist or updates
-// its spec and metadata if it already exists. An owner reference is set on the
-// NetworkPolicy so that it is garbage-collected when the owning resource is
-// deleted.
+// ensureNetworkPolicy creates or updates the NetworkPolicy via Server-Side
+// Apply under a fixed field manager and sets the Keystone CR as its controller
+// owner so it is garbage-collected with the CR.
 //
-// Merge strategy: the operator is authoritative over .Spec — the entire Spec
-// is overwritten with the desired state on every reconciliation. For labels and
-// annotations, desired keys are written into the existing map (additive merge);
-// user-added keys that the operator does not manage are preserved. Keys that
-// were previously set by the operator but are no longer in the desired state
-// will remain until manually removed. This is intentional: it avoids
-// accidentally stripping third-party metadata (e.g. Istio sidecar annotations)
-// while still ensuring the operator's own labels stay correct.
+// Merge strategy: the field manager owns exactly the fields the builder sets
+// (the whole Spec and the operator's labels). Labels or annotations the
+// operator no longer sets are relinquished and removed by the API server, while
+// keys owned by other managers (e.g. user- or mesh-added metadata) are
+// preserved. A converged NetworkPolicy is applied without a write.
 func ensureNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, np *networkingv1.NetworkPolicy) error {
-	existing := &networkingv1.NetworkPolicy{}
-	err := c.Get(ctx, client.ObjectKeyFromObject(np), existing)
-
-	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, np, scheme); err != nil {
-			return fmt.Errorf("setting owner reference on NetworkPolicy %s/%s: %w", np.Namespace, np.Name, err)
-		}
-		if err := c.Create(ctx, np); err != nil {
-			return fmt.Errorf("creating NetworkPolicy %s/%s: %w", np.Namespace, np.Name, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting NetworkPolicy %s/%s: %w", np.Namespace, np.Name, err)
-	}
-
-	// NetworkPolicy exists: reconcile metadata (ownerRefs/labels/annotations) and spec.
-	// Snapshot before mutations to detect whether an update is necessary.
-	before := existing.DeepCopy()
-
-	// Ensure controller owner reference is enforced so garbage collection
-	// behaves correctly even if the ref was removed out-of-band.
-	if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
-		return fmt.Errorf("updating owner reference on NetworkPolicy %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-
-	// Merge desired labels into existing labels; extra user-added keys are
-	// preserved, keys present on the desired NetworkPolicy are authoritative.
-	if np.Labels != nil {
-		if existing.Labels == nil {
-			existing.Labels = make(map[string]string, len(np.Labels))
-		}
-		for k, v := range np.Labels {
-			existing.Labels[k] = v
-		}
-	}
-
-	// Merge desired annotations into existing annotations.
-	if np.Annotations != nil {
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string, len(np.Annotations))
-		}
-		for k, v := range np.Annotations {
-			existing.Annotations[k] = v
-		}
-	}
-
-	// Reconcile spec to the desired state.
-	existing.Spec = np.Spec
-
-	// Only issue an API update when something actually changed to avoid
-	// unnecessary write load, spurious watch events, and 409 Conflict
-	// errors.
-	if !apiequality.Semantic.DeepEqual(existing.Spec, before.Spec) ||
-		!apiequality.Semantic.DeepEqual(npNormalizeMap(existing.Labels), npNormalizeMap(before.Labels)) ||
-		!apiequality.Semantic.DeepEqual(npNormalizeMap(existing.Annotations), npNormalizeMap(before.Annotations)) ||
-		!apiequality.Semantic.DeepEqual(existing.OwnerReferences, before.OwnerReferences) {
-		if err := c.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating NetworkPolicy %s/%s: %w", existing.Namespace, existing.Name, err)
-		}
-	}
-
-	return nil
-}
-
-// npNormalizeMap converts empty maps to nil so apiequality.Semantic.DeepEqual
-// does not report spurious diffs between nil and empty maps.
-func npNormalizeMap(m map[string]string) map[string]string {
-	if len(m) == 0 {
-		return nil
-	}
-	return m
+	return apply.EnsureObject(ctx, c, scheme, owner, np, apply.FieldManager)
 }
 
 // deleteNetworkPolicy deletes the NetworkPolicy identified by namespace and

--- a/operators/keystone/internal/controller/reconcile_networkpolicy_test.go
+++ b/operators/keystone/internal/controller/reconcile_networkpolicy_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,6 +67,11 @@ func npTestKeystone() *keystonev1alpha1.Keystone {
 func newNPTestReconciler(s *runtime.Scheme, objs ...client.Object) *KeystoneReconciler {
 	cb := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...)
 	cb = cb.WithStatusSubresource(&keystonev1alpha1.Keystone{})
+	// The fake client's default typed converter cannot apply an unstructured
+	// NetworkPolicy ("expected objects with types from the same schema"); the
+	// deduced converter applies it uniformly. Server-Side Apply against a real
+	// API server is exercised by the internal/common envtest suites.
+	cb = cb.WithTypeConverters(managedfields.NewDeducedTypeConverter())
 	return &KeystoneReconciler{
 		Client:   cb.Build(),
 		Scheme:   s,
@@ -817,7 +823,13 @@ func TestReconcileNetworkPolicy_NetworkPolicyEnabled_NetworkPolicyUpdated(t *tes
 	g.Expect(np.Spec.Ingress[0].From).To(HaveLen(2))
 }
 
-func TestReconcileNetworkPolicy_NetworkPolicyEnabled_NoChange_SkipsUpdate(t *testing.T) {
+// TestReconcileNetworkPolicy_NetworkPolicyEnabled_RepeatedReconcileIsIdempotent
+// verifies that reconciling an unchanged spec twice leaves exactly one
+// NetworkPolicy with the desired spec. Server-Side Apply converges without a
+// write on a real API server; that no-write property is exercised by the
+// internal/common envtest convergence suites (the fake client bumps
+// resourceVersion on every apply and so cannot assert it here).
+func TestReconcileNetworkPolicy_NetworkPolicyEnabled_RepeatedReconcileIsIdempotent(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := npTestScheme()
 	ks := npTestKeystone()
@@ -826,41 +838,18 @@ func TestReconcileNetworkPolicy_NetworkPolicyEnabled_NoChange_SkipsUpdate(t *tes
 			{NamespaceSelector: map[string]string{"kubernetes.io/metadata.name": "openstack"}},
 		},
 	}
-
-	// Track update calls to verify the snapshot-comparison guard skips
-	// no-op updates.
-	updateCount := 0
-	c := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(ks).
-		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
-					updateCount++
-				}
-				return c.Update(ctx, obj, opts...)
-			},
-		}).
-		Build()
-
-	r := &KeystoneReconciler{
-		Client:   c,
-		Scheme:   s,
-		Recorder: record.NewFakeRecorder(10),
-	}
+	r := newNPTestReconciler(s, ks)
 	ctx := context.Background()
 
-	// First reconcile creates the NetworkPolicy (no update call expected).
 	_, err := r.reconcileNetworkPolicy(ctx, ks)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(updateCount).To(Equal(0), "create path should not trigger update")
-
-	// Second reconcile with identical spec should skip the update.
-	updateCount = 0
 	_, err = r.reconcileNetworkPolicy(ctx, ks)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(updateCount).To(Equal(0), "idempotent reconciliation should skip update when spec is unchanged")
+
+	list := &networkingv1.NetworkPolicyList{}
+	g.Expect(r.List(ctx, list, client.InNamespace("default"))).To(Succeed())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].Spec.Ingress[0].From).To(HaveLen(1))
 }
 
 // --- Path 2: networkPolicy disabled — delete NetworkPolicy ---
@@ -965,12 +954,10 @@ func TestReconcileNetworkPolicy_EnsureError_Propagated(t *testing.T) {
 		WithScheme(s).
 		WithObjects(ks).
 		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
-					return fmt.Errorf("simulated NetworkPolicy creation error")
-				}
-				return c.Create(ctx, obj, opts...)
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				return fmt.Errorf("simulated NetworkPolicy apply error")
 			},
 		}).
 		Build()
@@ -984,7 +971,7 @@ func TestReconcileNetworkPolicy_EnsureError_Propagated(t *testing.T) {
 	_, err := r.reconcileNetworkPolicy(context.Background(), ks)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("ensuring NetworkPolicy"))
-	g.Expect(err.Error()).To(ContainSubstring("simulated NetworkPolicy creation error"))
+	g.Expect(err.Error()).To(ContainSubstring("simulated NetworkPolicy apply error"))
 }
 
 func TestReconcileNetworkPolicy_DeleteError_Propagated(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_trustflush_test.go
+++ b/operators/keystone/internal/controller/reconcile_trustflush_test.go
@@ -268,11 +268,11 @@ func TestReconcileTrustFlush_EnsureError_Propagated(t *testing.T) {
 		WithObjects(ks).
 		WithStatusSubresource(&keystonev1alpha1.Keystone{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-				if _, ok := obj.(*batchv1.CronJob); ok {
-					return fmt.Errorf("simulated CronJob creation error")
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if co, ok := obj.(client.Object); ok && co.GetObjectKind().GroupVersionKind().Kind == "CronJob" {
+					return fmt.Errorf("simulated CronJob apply error")
 				}
-				return c.Create(ctx, obj, opts...)
+				return c.Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -286,7 +286,7 @@ func TestReconcileTrustFlush_EnsureError_Propagated(t *testing.T) {
 	_, err := r.reconcileTrustFlush(context.Background(), ks, "test-keystone-config-abc123")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("ensuring trust flush CronJob"))
-	g.Expect(err.Error()).To(ContainSubstring("simulated CronJob creation error"))
+	g.Expect(err.Error()).To(ContainSubstring("simulated CronJob apply error"))
 }
 
 // TestReconcileTrustFlush_DeleteError_Propagated exercises the legacy bypass error path

--- a/tests/e2e/keystone/credential-rotation/01-patch-suspend-credential.yaml
+++ b/tests/e2e/keystone/credential-rotation/01-patch-suspend-credential.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch to pause credential key rotation via spec.credentialKeys.suspend: true.
+# This is the incident escape hatch: it suspends the rotation CronJob without
+# deleting it or changing its schedule, so an SRE can resume rotation without
+# churn.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-credential
+  namespace: openstack
+spec:
+  credentialKeys:
+    suspend: true

--- a/tests/e2e/keystone/credential-rotation/chainsaw-test.yaml
+++ b/tests/e2e/keystone/credential-rotation/chainsaw-test.yaml
@@ -63,7 +63,7 @@ spec:
           done
           echo "=== Events ==="
           kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
-  # ── Step 3: Assert CronJob schedule matches spec ───────────────────────
+  # ── Step 3: Assert CronJob schedule matches spec; not suspended by default ─
   - try:
     - assert:
         resource:
@@ -74,6 +74,7 @@ spec:
             namespace: openstack
           spec:
             schedule: "0 0 * * 0"
+            suspend: false
   # ── Step 4: Trigger rotation, verify no rollout ─────────────────────────
   - try:
     - script:
@@ -207,3 +208,21 @@ spec:
             (conditions[?type == 'Ready']):
             - status: "True"
               reason: AllReady
+  # ── Step 6: Pause rotation via spec.credentialKeys.suspend: true ────────
+  - try:
+    - patch:
+        file: 01-patch-suspend-credential.yaml
+  # ── Step 7: Assert CronJob preserved, suspended, schedule unchanged ─────
+  # suspend pauses rotation without deleting the CronJob and without changing
+  # the rotation cadence, so an SRE can resume without churn.
+  - try:
+    - assert:
+        resource:
+          apiVersion: batch/v1
+          kind: CronJob
+          metadata:
+            name: keystone-credential-credential-rotate
+            namespace: openstack
+          spec:
+            schedule: "0 0 * * 0"
+            suspend: true

--- a/tests/e2e/keystone/fernet-rotation/01-patch-suspend-fernet.yaml
+++ b/tests/e2e/keystone/fernet-rotation/01-patch-suspend-fernet.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch to pause Fernet key rotation via spec.fernet.suspend: true. This is the
+# incident escape hatch: it suspends the rotation CronJob without deleting it or
+# changing its schedule, so an SRE can resume rotation without churn.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-fernet
+  namespace: openstack
+spec:
+  fernet:
+    suspend: true

--- a/tests/e2e/keystone/fernet-rotation/chainsaw-test.yaml
+++ b/tests/e2e/keystone/fernet-rotation/chainsaw-test.yaml
@@ -63,7 +63,7 @@ spec:
           done
           echo "=== Events ==="
           kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
-  # ── Step 3: Assert CronJob schedule matches spec ───────────────────────
+  # ── Step 3: Assert CronJob schedule matches spec; not suspended by default ─
   - try:
     - assert:
         resource:
@@ -74,6 +74,7 @@ spec:
             namespace: openstack
           spec:
             schedule: "0 0 * * 0"
+            suspend: false
   # ── Step 4: Trigger rotation, verify no rollout, validate token ─────────
   - try:
     - script:
@@ -251,3 +252,21 @@ spec:
             (conditions[?type == 'Ready']):
             - status: "True"
               reason: AllReady
+  # ── Step 6: Pause rotation via spec.fernet.suspend: true (escape hatch) ──
+  - try:
+    - patch:
+        file: 01-patch-suspend-fernet.yaml
+  # ── Step 7: Assert CronJob preserved, suspended, schedule unchanged ─────
+  # suspend pauses rotation without deleting the CronJob and without changing
+  # the rotation cadence, so an SRE can resume without churn.
+  - try:
+    - assert:
+        resource:
+          apiVersion: batch/v1
+          kind: CronJob
+          metadata:
+            name: keystone-fernet-fernet-rotate
+            namespace: openstack
+          spec:
+            schedule: "0 0 * * 0"
+            suspend: true

--- a/tests/e2e/keystone/httproute/chainsaw-test.yaml
+++ b/tests/e2e/keystone/httproute/chainsaw-test.yaml
@@ -50,7 +50,6 @@ spec:
               app.kubernetes.io/managed-by: keystone-operator
             annotations:
               example.com/test-annotation: initial
-              keystone.openstack.c5c3.io/managed-annotations: example.com/test-annotation
           spec:
             parentRefs:
             # Deliberately non-existent: keeps the real Envoy Gateway

--- a/tests/e2e/keystone/upgrade-abort/chainsaw-test.yaml
+++ b/tests/e2e/keystone/upgrade-abort/chainsaw-test.yaml
@@ -78,17 +78,19 @@ spec:
             (conditions[?type == 'DatabaseReady']):
             - status: "False"
               reason: ExpandInProgress
-    # Proof the expand phase actually started: the db-expand Job exists.
-    - script:
-        content: |
-          set -eu
-          JOB="keystone-upgrade-abort-db-expand"
-          if kubectl get job "$JOB" -n $NAMESPACE >/dev/null 2>&1; then
-            echo "OK: Job $JOB exists (expand phase started)"
-          else
-            echo "ERROR: Job $JOB not found"
-            exit 1
-          fi
+    # Proof the expand phase actually started: the db-expand Job exists. The
+    # detection reconcile sets upgradePhase=Expanding and requeues; the
+    # db-expand Job is created on the following reconcile pass, so the status
+    # flip above can be observed before the Job exists. Assert on the Job
+    # (which polls up to the assert timeout) rather than a single-shot
+    # `kubectl get job`, which races the controller's create.
+    - assert:
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: keystone-upgrade-abort-db-expand
+            namespace: openstack
     catch:
     - script:
         content: |


### PR DESCRIPTION
## Summary

Adopts Server-Side Apply (SSA) as the single create-or-update primitive for the
`Ensure*` family, replacing both the non-converging `DeepEqual`-then-`Update`
guards and the unconditional `Update` writes. A new generic
`apply.EnsureObject[T client.Object]` applies the desired object under a fixed
field manager (`forge-operator`) with `ForceOwnership`, wrapped in
`retry.RetryOnConflict`. Because the field manager owns only the fields the
builder sets, server-defaulted fields stop participating in the diff and
reconciliation converges; the hand-rolled snapshot/DeepEqual + sentinel-metadata
machinery in the keystone reconcilers collapses to a single call. Also adds a
declarative `suspend` escape hatch to the fernet/credential rotation CronJobs.

Closes #474

## What changed (in commit order)

1. **`refactor(common): add generic server-side apply EnsureObject`** — new
   `internal/common/apply` package. `EnsureObject` sets the owner reference,
   stamps the GVK, and applies via the non-deprecated `client.Client.Apply`
   using `ApplyConfigurationFromUnstructured`, wrapped in `RetryOnConflict`
   (the issue's "treat `IsConflict` as benign requeue"). Unit + envtest tests
   cover the apply shape, conflict retry, GVK-unknown error path, no-op
   convergence, and Update→Apply takeover.
2. **`refactor(common): apply Deployment/Service/PDB/HPA via SSA`** — removes the
   unconditional `Update` (problem #2) and the snapshot-diff in PDB/HPA; deletes
   DECISION I-001 and `normalizeMap`. Keeps the pre-apply `Get` only for the
   immutable-selector delete+recreate, the issue #462 nil-replicas handling, and
   the immutable-Service-field fail-fast.
3. **`refactor(common): apply CronJob via server-side apply`** — `EnsureCronJob`
   only; the immutable-Job `RunJob*` paths are unchanged.
4. **`refactor(common): apply PushSecret via server-side apply`** — fixes the
   `updatePolicy`/`refreshInterval` every-pass rewrite (problem #1) and updates
   the c5c3 `reconcile_korc.go` comment that described the removed guard.
5. **`refactor(common): apply MariaDB Database/User/Grant via SSA`** — fixes the
   `User.maxUserConnections` non-convergence (problem #1), proven by a new
   envtest test that the server default survives and a repeated apply does not
   rewrite.
6. **`refactor(keystone): apply NetworkPolicy/HTTPRoute via SSA helper`** —
   deletes the hand-rolled snapshot-diff and the entire HTTPRoute
   sentinel-annotation bookkeeping (~130 lines, problem #4); SSA field ownership
   removes dropped keys natively and preserves third-party keys.
7. **`feat(keystone): add suspend escape hatch to fernet/credential rotation`** —
   adds `spec.fernet.suspend` / `spec.credentialKeys.suspend` (default `false`,
   mirroring `trustFlush.suspend`) so an SRE can pause key rotation during an
   incident (problem #3). CRDs regenerated with controller-gen v0.21.0.
8. **`docs(keystone): document server-side apply and rotation suspend`** —
   shared-library + Keystone CRD/reconciler reference docs.
9. **`test(c5c3): assert PushSecret spec idempotency under SSA`** — adjusts the
   c5c3 no-churn unit test for fake-client SSA semantics (see Notes).

## Notes for reviewers

- **SSA API choice (deviation from the plan):** `client.Apply` (the patch var)
  is deprecated in controller-runtime v0.24.1 and would fail `staticcheck`
  (SA1019). `EnsureObject` therefore uses the non-deprecated
  `client.Client.Apply` with `ApplyConfigurationFromUnstructured`. Same SSA
  mechanism, non-deprecated API. `ToUnstructured` respects `omitempty`, so the
  problem #1 fix (omitted defaults not owned) holds — verified by envtest.
- **Fake-client SSA fidelity:** the controller-runtime fake client cannot apply
  an unstructured NetworkPolicy/HTTPRoute with its default typed converter and
  bumps `resourceVersion` on every apply (no no-op detection). So the keystone
  NP/HTTPRoute unit tests use the deduced type converter and assert
  *idempotency*; the *no-write convergence* and *cross-manager annotation
  preservation* guarantees are asserted against a real API server in envtest
  (`internal/common/apply`, `internal/common/deployment`, `internal/common/database`,
  `internal/common/secrets`, and a new
  `TestIntegration_HTTPRoute_PreservesThirdPartyAnnotation`).
- **envtest fake CRDs:** the minimal MariaDB fake CRDs now mirror the real
  `maxUserConnections` default and tolerate the non-omitempty struct fields a
  typed apply emits (`mariaDbRef`, `passwordPlugin`) via
  `x-kubernetes-preserve-unknown-fields`.
- **Out of scope:** `tls.EnsureCertificate` (no documented problem) and the
  `helm upgrade` Update→Apply migration e2e (sibling #480).
- **Architecture submodule:** `architecture/docs/09-implementation/02-shared-library.md`
  lives in a git submodule and is not updated here; the in-repo `docs/`
  reference is updated. A submodule doc update can follow separately.

## Verification

- `make lint` — clean (all three modules)
- gofumpt format-check — clean
- `go test ./...` unit — `internal/common`, `operators/keystone`,
  `operators/c5c3` all pass
- envtest integration — `internal/common` (apply/deployment/database/secrets/job)
  and the full `operators/keystone` controller suite pass; `operators/c5c3`
  controller suite pass
- `make verify-crd-sync` — passes
- The fernet/credential rotation Chainsaw suites validate with `chainsaw lint`
  (not run against a cluster in this branch)

---

_Implemented by [planwerk-review](https://github.com/planwerk/planwerk-review) e9105cf with Claude:claude-opus-4-8_
