### PR TITLE
fix(c5c3-operator): CredentialRotation reMint loop, K-ORC CEL immutability, lost-rotation race

### DIFF
--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -547,7 +547,7 @@ credential and reports progress via status conditions.
 | --- | --- | --- | --- | --- |
 | `target` | [`RotationTarget`](#rotationtarget) | Yes | — | Which credential to rotate. |
 | `bootstrap` | `bool` | No | `false` | When `true`, requests an initial **mint** of the credential rather than a rotation of an existing one. Idempotent: if the credential already exists it is a no-op. |
-| `reMint` | `bool` | No | `false` | When `true`, forces the reconciler to discard the current credential and mint a fresh one even if the existing credential is still valid. |
+| `reMint` | `bool` | No | `false` | When `true`, forces the reconciler to discard the current credential and mint a fresh one even if the existing credential is still valid. The nudge is **one-shot per spec generation** (latched on `status.lastTriggeredGeneration`), so a `reMint: true` left in the spec does not re-rotate on every resync. |
 | `intervalDays` | `*int32` | No | `nil` | **Deferred** — accepted by the schema but ignored by the L1 reconciler. Rotation cadence in days for scheduled rotation. Minimum: 1. |
 | `preRotationDays` | `*int32` | No | `nil` | **Deferred** — accepted but ignored. Days before expiry a replacement credential is minted (the overlap window). Minimum: 0. |
 | `gracePeriodDays` | `*int32` | No | `nil` | **Deferred** — accepted but ignored. Days the superseded credential remains valid after a rotation before it is revoked. Minimum: 0. |
@@ -575,6 +575,7 @@ credential and reports progress via status conditions.
 | --- | --- | --- |
 | `conditions` | `[]metav1.Condition` | Latest available observations of the rotation state. Upserted via the shared conditions helper. |
 | `observedGeneration` | `int64` | The `.metadata.generation` the controller last reconciled. |
+| `lastTriggeredGeneration` | `int64` | The most recent `.metadata.generation` for which an explicit `reMint` nudge was performed. Latches `reMint` to a single spec generation so a `reMint: true` left in the spec fires once per edit, not on every resync or restart. |
 
 ---
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -635,7 +635,18 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
   password-cloud — and **regenerate** the secret `value`, so the next pass recreates
   the AC for a fresh mint. The hash is computed by the package-level
   `computeAdminPasswordHash`, shared with the CredentialRotation reconciler so both
-  agree on one derivation.
+  agree on one derivation. The annotation is (re-)stamped **only on a fresh mint or
+  when it is absent**, never overwriting a present-but-empty value — that empty value
+  is the CredentialRotation reconciler's nudge marker, so preserving it keeps a
+  concurrently-cleared nudge from being silently lost (`shouldStampPasswordHash`).
+- **Re-mint on immutable resource-block drift.** K-ORC declares the AC's whole
+  `spec.resource` block immutable via CEL (`self == oldSelf`), so a legal, webhook-
+  admitted change to `restricted` or `accessRules` cannot be reconciled by an
+  in-place update — it would be rejected on every pass. `reconcileKORC` detects drift
+  on the operator-managed fields (`Unrestricted`, `UserRef`, `SecretRef`,
+  `AccessRules` — never the whole struct, so a K-ORC/CRD-defaulted sub-field can never
+  read as permanent drift) and routes it through the **same** delete+recreate re-mint
+  (`adminACResourceDrifted`).
 - **Re-mint progress / stall.** While the old AC is `Terminating` the condition is
   `KORCReady=False/ReMinting`; if it stays terminating longer than
   `remintStallTimeout` (**5m**) — a finalizer K-ORC cannot clear, e.g. it cannot
@@ -654,6 +665,7 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | Admin password read fails otherwise | False | `AdminPasswordError` | returns the error |
 | Password-cloud ensure fails | False | `PasswordCloudError` | returns the error |
 | Hash mismatch → AC deleted for re-mint | False | `ReMinting` | requeue 10s; AC deleted + `value` regenerated, recreated next pass |
+| `spec.resource` drift (`restricted`/`accessRules`) → AC deleted for re-mint | False | `ReMinting` | requeue 10s; the block is CEL-immutable, so the change forces a delete+recreate |
 | Re-mint stuck `Terminating` past `remintStallTimeout` (5m) | False | `ReMintStalled` | requeue 10s; finalizer cannot revoke the old credential |
 | AC create/update/delete/read fails otherwise | False | `ApplicationCredentialError` | returns the error |
 | `value` regeneration fails | False | `SecretError` | returns the error |
@@ -807,6 +819,16 @@ mint logic. Its model:
   re-mint, re-stamping the fresh hash. Keeping the AC's resource lifecycle
   (including the delete) owned solely by the ControlPlane reconciler avoids two
   controllers racing on the same object.
+- **`reMint` is one-shot per spec generation.** An explicit `spec.reMint` is
+  **latched** on `status.lastTriggeredGeneration`: the reconciler nudges only while
+  it differs from `metadata.generation`, then records the generation. A `reMint:
+  true` left in the spec therefore fires the nudge **once per edit**, not on every
+  cache resync (~10 min via the shared `SyncPeriod`) or operator restart — without
+  the latch it would revoke + re-mint the admin credential indefinitely, re-opening
+  the stale-credential window each cycle. A pass over an already-latched generation
+  reports `NoRotationNeeded`. The auto-detect (password-hash change) path is **not**
+  latched: it is self-limiting (it stops once the hash matches) and relies on resync
+  to observe an out-of-band password rotation.
 - **ControlPlane resolution (one-per-namespace).** A `CredentialRotation`
   carries no explicit ControlPlane reference, so `resolveControlPlane` lists
   ControlPlanes in the CredentialRotation's **own** namespace and requires
@@ -837,8 +859,8 @@ mint logic. Its model:
 | bootstrap, AC absent | False | `WaitingForBootstrap` | requeue 10s |
 | rotation, AC absent | False | `WaitingForApplicationCredential` | requeue 10s |
 | admin password not yet readable | False | `WaitingForAdminPassword` | requeue 10s |
-| hash unchanged, `reMint` not set | True | `NoRotationNeeded` | nothing to do |
-| nudge performed | True | `RotationTriggered` | emits `RotationNudged` event |
+| hash unchanged, no pending `reMint` (incl. a `reMint` already latched for this generation) | True | `NoRotationNeeded` | nothing to do |
+| nudge performed | True | `RotationTriggered` | emits `RotationNudged` event; an explicit `reMint` latches `status.lastTriggeredGeneration` |
 
 The CredentialRotation reconciler is registered with the manager via a plain
 `For(&CredentialRotation{})` — it owns no children and registers no watches or

--- a/operators/c5c3/api/v1alpha1/credentialrotation_types.go
+++ b/operators/c5c3/api/v1alpha1/credentialrotation_types.go
@@ -107,6 +107,14 @@ type CredentialRotationStatus struct {
 	// reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// LastTriggeredGeneration is the most recent .metadata.generation for which
+	// the reconciler performed an explicit reMint rotation nudge. It latches a
+	// reMint to a single spec generation so a `reMint: true` left in the spec
+	// fires the nudge once per edit, not on every cache resync or operator
+	// restart.
+	// +optional
+	LastTriggeredGeneration int64 `json:"lastTriggeredGeneration,omitempty"`
 }
 
 func init() {

--- a/operators/c5c3/config/crd/bases/c5c3.io_credentialrotations.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_credentialrotations.yaml
@@ -161,6 +161,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastTriggeredGeneration:
+                description: |-
+                  LastTriggeredGeneration is the most recent .metadata.generation for which
+                  the reconciler performed an explicit reMint rotation nudge. It latches a
+                  reMint to a single spec generation so a `reMint: true` left in the spec
+                  fires the nudge once per edit, not on every cache resync or operator
+                  restart.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the .metadata.generation the controller last

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_credentialrotations.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_credentialrotations.yaml
@@ -164,6 +164,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastTriggeredGeneration:
+                description: |-
+                  LastTriggeredGeneration is the most recent .metadata.generation for which
+                  the reconciler performed an explicit reMint rotation nudge. It latches a
+                  reMint to a single spec generation so a `reMint: true` left in the spec
+                  fires the nudge once per edit, not on every cache resync or operator
+                  restart.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the .metadata.generation the controller last

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation.go
@@ -72,6 +72,19 @@ type CredentialRotationReconciler struct {
 // delete+recreate re-mint, re-stamping the fresh hash. Keeping the AC's resource
 // lifecycle (including the delete) owned solely by the ControlPlane reconciler
 // avoids two controllers racing on the same object.
+//
+// DECISION (reMint is one-shot per spec generation): an explicit spec.reMint is
+// LATCHED on status.lastTriggeredGeneration. Without a latch a `reMint: true` left
+// in the spec would re-fire on every cache resync (~10 min via SyncPeriod) and on
+// every operator restart, revoking + re-minting the admin credential indefinitely
+// and re-opening the stale-credential auth window each cycle. The reconciler
+// therefore nudges for an explicit reMint only while
+// status.lastTriggeredGeneration != metadata.generation, and records the
+// generation once it has nudged; a subsequent pass over the same generation
+// reports NoRotationNeeded. The auto-detect path (password-hash change) is NOT
+// latched: it is already self-limiting (it stops nudging once the hash matches
+// again) and relies on resync to observe an out-of-band password rotation, so a
+// generation latch must not gate it.
 func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -147,9 +160,12 @@ func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			"admin application credential does not exist yet; cannot rotate")
 	}
 
-	// Decide whether a re-mint nudge is required: explicit ReMint, or the admin
-	// password hash differs from the annotation last stamped by reconcileKORC.
-	nudge := cr.Spec.ReMint
+	// Decide whether a re-mint nudge is required: explicit ReMint (latched to the
+	// current spec generation so it fires once per edit, not on every resync), or
+	// the admin password hash differs from the annotation last stamped by
+	// reconcileKORC.
+	remintRequested := cr.Spec.ReMint && cr.Status.LastTriggeredGeneration != cr.Generation
+	nudge := remintRequested
 	if !nudge {
 		changed, err := r.passwordHashChanged(ctx, cp, ac)
 		if err != nil {
@@ -164,10 +180,12 @@ func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	if !nudge {
-		// Hash matches and no forced re-mint: nothing to do.
+		// Hash matches and no (un-latched) forced re-mint: nothing to do. A
+		// `reMint: true` left in the spec lands here once it has already fired for
+		// this generation, so it does NOT loop on every resync/restart.
 		return r.finish(ctx, &cr, ctrl.Result{}, metav1.ConditionTrue,
 			"NoRotationNeeded",
-			"admin password unchanged and reMint not requested; no rotation performed")
+			"admin password unchanged and no pending reMint; no rotation performed")
 	}
 
 	// Perform the nudge: clear the password-hash annotation so reconcileKORC
@@ -179,6 +197,15 @@ func (r *CredentialRotationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if r.Recorder != nil {
 		r.Recorder.Event(&cr, "Normal", "RotationNudged",
 			"cleared admin application credential password-hash annotation to trigger a re-mint by the ControlPlane reconciler")
+	}
+
+	// Latch an explicit reMint to this spec generation so it is a one-shot: the
+	// next reconcile of the same generation observes the recorded generation and
+	// reports NoRotationNeeded instead of nudging again. The auto-detect path is
+	// intentionally not latched (it self-limits once the hash matches), so only
+	// stamp when this pass was driven by an explicit reMint.
+	if remintRequested {
+		cr.Status.LastTriggeredGeneration = cr.Generation
 	}
 
 	return r.finish(ctx, &cr, ctrl.Result{}, metav1.ConditionTrue,

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation_test.go
@@ -196,6 +196,59 @@ func TestRotation_ReMintFullCycleReStampsHash(t *testing.T) {
 		"reconcileKORC must recreate the AC and stamp the current password hash (re-mint)")
 }
 
+// TestRotation_ReMintLatchedToGeneration proves the reMint one-shot latch: a
+// `reMint: true` left in the spec must nudge exactly once per spec generation, not
+// on every cache resync or operator restart (the indefinite re-rotation loop this
+// fixes). It runs the reconciler twice against the SAME client with the SAME
+// generation: pass 1 nudges (clears the annotation, records
+// lastTriggeredGeneration), then the annotation is re-stamped to simulate
+// reconcileKORC completing the re-mint, and pass 2 — with reMint STILL true — must
+// observe the latch and report NoRotationNeeded WITHOUT re-clearing the annotation.
+func TestRotation_ReMintLatchedToGeneration(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	cr := credentialRotation()
+	cr.Spec.ReMint = true
+	ac := existingAC(cp, testPasswordHash())
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cp, cr, ac, adminPasswordSecret()).
+		WithStatusSubresource(&c5c3v1alpha1.CredentialRotation{}).
+		Build()
+
+	rotator := &CredentialRotationReconciler{Client: c, Scheme: s}
+	crKey := types.NamespacedName{Namespace: "default", Name: "rotate-admin"}
+
+	// --- Pass 1: reMint fires once, clearing the annotation and latching. ---
+	_, err := rotator.Reconcile(context.Background(), ctrl.Request{NamespacedName: crKey})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &c5c3v1alpha1.CredentialRotation{}
+	g.Expect(c.Get(context.Background(), crKey, got)).To(Succeed())
+	g.Expect(rotationReadyCondition(got).Reason).To(Equal("RotationTriggered"))
+	g.Expect(got.Status.LastTriggeredGeneration).To(Equal(int64(3)),
+		"an explicit reMint must latch on the current spec generation")
+	g.Expect(getAC(t, c, cp).Annotations[adminPasswordHashAnnotation]).To(BeEmpty())
+
+	// Simulate reconcileKORC consuming the nudge and re-stamping the fresh hash.
+	reminted := getAC(t, c, cp)
+	reminted.Annotations[adminPasswordHashAnnotation] = testPasswordHash()
+	g.Expect(c.Update(context.Background(), reminted)).To(Succeed())
+
+	// --- Pass 2: reMint is STILL true but the generation is unchanged. ---
+	_, err = rotator.Reconcile(context.Background(), ctrl.Request{NamespacedName: crKey})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(c.Get(context.Background(), crKey, got)).To(Succeed())
+	g.Expect(rotationReadyCondition(got).Reason).To(Equal("NoRotationNeeded"),
+		"a latched reMint must not re-fire on a subsequent pass of the same generation")
+	g.Expect(getAC(t, c, cp).Annotations[adminPasswordHashAnnotation]).To(Equal(testPasswordHash()),
+		"the latched reMint must leave the re-stamped annotation untouched (no second nudge)")
+}
+
 func TestRotation_PasswordHashChangeTriggersNudge(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -247,14 +247,20 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		ac.Spec.Resource.SecretRef = orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp))
 		ac.Spec.Resource.AccessRules = projectAccessRules(adminCred.ApplicationCredential.AccessRules)
 
-		// Stamp the password hash this credential was minted against. On a later
-		// pass a mismatch (the hash moved because the admin password rotated, or
-		// the CredentialRotation reconciler zeroed the annotation to nudge) is what
-		// the re-mint decision above keys off to delete+recreate the AC.
+		// Stamp the password hash this credential was minted against — but ONLY on a
+		// fresh mint or when the annotation is absent (see shouldStampPasswordHash).
+		// A present-but-empty value is the CredentialRotation reconciler's re-mint
+		// nudge marker; if the top-level re-mint decision above read the matching
+		// hash and fell through while a concurrent nudge zeroed the annotation,
+		// re-stamping pwHash here would silently overwrite the marker without a
+		// re-mint (the lost-rotation race). Preserving the empty marker lets the
+		// NEXT pass's re-mint decision observe the mismatch and re-mint.
 		if ac.Annotations == nil {
 			ac.Annotations = map[string]string{}
 		}
-		ac.Annotations[adminPasswordHashAnnotation] = pwHash
+		if shouldStampPasswordHash(ac) {
+			ac.Annotations[adminPasswordHashAnnotation] = pwHash
+		}
 
 		return controllerutil.SetControllerReference(cp, ac, r.Scheme)
 	})
@@ -454,6 +460,23 @@ func accessRulesDrifted(existing, desired []orcv1alpha1.ApplicationCredentialAcc
 		}
 	}
 	return false
+}
+
+// shouldStampPasswordHash reports whether reconcileKORC's CreateOrUpdate may
+// (re-)stamp the password-hash annotation on the AC. It stamps on a fresh mint
+// (zero CreationTimestamp) or when the annotation key is absent, but NEVER when the
+// key is present — even with an empty value. A present-but-empty value is the
+// CredentialRotation reconciler's re-mint nudge marker; overwriting it would
+// silently consume the nudge without a re-mint (the lost-rotation race). A present
+// non-empty value can only equal the current hash on this path (a stale hash would
+// have been caught by the re-mint decision before CreateOrUpdate runs), so leaving
+// it untouched is also a no-op for the steady state.
+func shouldStampPasswordHash(ac *orcv1alpha1.ApplicationCredential) bool {
+	if ac.CreationTimestamp.IsZero() {
+		return true
+	}
+	_, present := ac.Annotations[adminPasswordHashAnnotation]
+	return !present
 }
 
 // updateAdminApplicationCredentialStatus reflects the observed AC CR into

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -7,6 +7,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
@@ -207,8 +208,17 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		if existing.Annotations[adminPasswordHashAnnotation] != pwHash {
 			return r.remintAdminApplicationCredential(ctx, cp, existing)
 		}
-		// Hash matches: fall through to the idempotent CreateOrUpdate below, which
-		// converges the spec without re-minting (no-op when nothing changed).
+		// K-ORC declares spec.resource immutable (CEL self == oldSelf), so an
+		// in-place CreateOrUpdate of a changed restricted/accessRules block is
+		// rejected on every pass — a permanent KORCReady=False loop that only a
+		// manual AC deletion clears. Route a legal, webhook-admitted change to those
+		// fields through the same delete+recreate re-mint instead of the update.
+		if adminACResourceDrifted(existing, cp, restricted) {
+			return r.remintAdminApplicationCredential(ctx, cp, existing)
+		}
+		// Hash matches and the resource block is unchanged: fall through to the
+		// idempotent CreateOrUpdate below, which converges the spec without
+		// re-minting (no-op when nothing changed).
 	case apierrors.IsNotFound(getErr):
 		// First mint, or the recreate after a re-mint delete: CreateOrUpdate below.
 	default:
@@ -395,6 +405,55 @@ func projectAccessRules(rules []c5c3v1alpha1.AccessRule) []orcv1alpha1.Applicati
 		out = append(out, projected)
 	}
 	return out
+}
+
+// adminACResourceDrifted reports whether the immutable K-ORC spec.resource block on
+// the existing admin ApplicationCredential differs from what reconcileKORC would
+// project for the current ControlPlane spec. K-ORC declares the whole resource block
+// immutable (CEL self == oldSelf), so any drift in the operator-managed fields
+// cannot be reconciled by an in-place update — it must be a delete+recreate re-mint.
+//
+// It compares ONLY the fields reconcileKORC sets (Unrestricted, UserRef, SecretRef,
+// AccessRules), never the whole struct: K-ORC and CRD defaulting may populate other
+// sub-fields (Name, RoleRefs, …) that a whole-struct compare would read as permanent
+// drift, which would itself become the re-mint loop this issue fixes. A nil resource
+// block is NOT drift — the CEL self==oldSelf rule does not fire on the initial
+// unset→set transition, so the idempotent CreateOrUpdate is free to populate it
+// (this is also the never-minted fixture state).
+func adminACResourceDrifted(existing *orcv1alpha1.ApplicationCredential, cp *c5c3v1alpha1.ControlPlane, restricted bool) bool {
+	res := existing.Spec.Resource
+	if res == nil {
+		return false
+	}
+	if res.Unrestricted == nil || *res.Unrestricted != !restricted {
+		return true
+	}
+	if res.UserRef != orcv1alpha1.KubernetesNameRef(adminUserRef(cp)) {
+		return true
+	}
+	if res.SecretRef != orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp)) {
+		return true
+	}
+	return accessRulesDrifted(res.AccessRules,
+		projectAccessRules(cp.Spec.KORC.AdminCredential.ApplicationCredential.AccessRules))
+}
+
+// accessRulesDrifted reports whether two projected access-rule lists differ on the
+// operator-managed sub-fields only (Path, Method, ServiceRef). It deliberately does
+// NOT whole-struct DeepEqual the rules so a K-ORC/CRD-defaulted sub-field can never
+// register as permanent drift.
+func accessRulesDrifted(existing, desired []orcv1alpha1.ApplicationCredentialAccessRule) bool {
+	if len(existing) != len(desired) {
+		return true
+	}
+	for i := range desired {
+		if !reflect.DeepEqual(existing[i].Path, desired[i].Path) ||
+			!reflect.DeepEqual(existing[i].Method, desired[i].Method) ||
+			!reflect.DeepEqual(existing[i].ServiceRef, desired[i].ServiceRef) {
+			return true
+		}
+	}
+	return false
 }
 
 // updateAdminApplicationCredentialStatus reflects the observed AC CR into

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -1123,6 +1123,140 @@ func TestReconcileKORC_AccessRulesDriftDeletesACForRemint(t *testing.T) {
 	assertACRemintedForDrift(t, cp, existing)
 }
 
+// TestShouldStampPasswordHash exercises the stamp guard that closes the
+// lost-rotation race: the hash is stamped on a fresh mint or when the annotation is
+// absent, but a present value (even empty) is left untouched so the
+// CredentialRotation reconciler's empty nudge marker is never silently overwritten.
+func TestShouldStampPasswordHash(t *testing.T) {
+	g := NewGomegaWithT(t)
+	nonZero := metav1.Now()
+
+	cases := []struct {
+		name string
+		ac   *orcv1alpha1.ApplicationCredential
+		want bool
+	}{
+		{
+			name: "fresh mint, no annotations",
+			ac:   &orcv1alpha1.ApplicationCredential{},
+			want: true,
+		},
+		{
+			name: "fresh mint, empty marker preset (zero timestamp wins)",
+			ac: &orcv1alpha1.ApplicationCredential{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{adminPasswordHashAnnotation: ""},
+			}},
+			want: true,
+		},
+		{
+			name: "existing, annotation absent",
+			ac: &orcv1alpha1.ApplicationCredential{ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: nonZero,
+				Annotations:       map[string]string{"other": "x"},
+			}},
+			want: true,
+		},
+		{
+			name: "existing, present empty nudge marker -> preserve",
+			ac: &orcv1alpha1.ApplicationCredential{ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: nonZero,
+				Annotations:       map[string]string{adminPasswordHashAnnotation: ""},
+			}},
+			want: false,
+		},
+		{
+			name: "existing, present non-empty hash -> no churn",
+			ac: &orcv1alpha1.ApplicationCredential{ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: nonZero,
+				Annotations:       map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+			}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g.Expect(shouldStampPasswordHash(tc.ac)).To(Equal(tc.want))
+		})
+	}
+}
+
+// TestReconcileKORC_DoesNotOverwriteClearedNudgeMarker reproduces the lost-rotation
+// race end-to-end: the top-level re-mint decision reads a MATCHING hash and falls
+// through, but a concurrent CredentialRotation nudge has zeroed the annotation by the
+// time the CreateOrUpdate mutate runs. The stamp guard must preserve the empty marker
+// (rather than re-stamp pwHash) so the NEXT pass observes the mismatch and re-mints.
+// The race is staged with an interceptor that returns the matching hash on the FIRST
+// AC Get (the top-level read) and the real, zeroed stored AC on the CreateOrUpdate
+// read.
+func TestReconcileKORC_DoesNotOverwriteClearedNudgeMarker(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	acKey := types.NamespacedName{Name: adminAppCredentialName(cp), Namespace: childNamespace(cp)}
+
+	// A matching resource block so the top-level read sees no drift and falls through
+	// to CreateOrUpdate (isolating the annotation-stamp path under test).
+	resource := &orcv1alpha1.ApplicationCredentialResourceSpec{
+		Unrestricted: ptr.To(false),
+		UserRef:      orcv1alpha1.KubernetesNameRef(adminUserRef(cp)),
+		SecretRef:    orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp)),
+	}
+	// The STORED AC carries the empty nudge marker (a concurrent rotation cleared it)
+	// and a non-zero CreationTimestamp so the guard's fresh-mint branch does not fire.
+	stored := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              adminAppCredentialName(cp),
+			Namespace:         childNamespace(cp),
+			CreationTimestamp: metav1.Now(),
+			Annotations:       map[string]string{adminPasswordHashAnnotation: ""},
+		},
+		Spec: orcv1alpha1.ApplicationCredentialSpec{Resource: resource.DeepCopy()},
+		Status: orcv1alpha1.ApplicationCredentialStatus{
+			ID: ptr.To("ac-id-current"),
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	// firstView is what the top-level read observes BEFORE the concurrent nudge: the
+	// matching hash, so the re-mint decision falls through to CreateOrUpdate.
+	firstView := stored.DeepCopy()
+	firstView.Annotations[adminPasswordHashAnnotation] = testPasswordHash()
+
+	var acGets int
+	ic := interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if target, ok := obj.(*orcv1alpha1.ApplicationCredential); ok && key == acKey {
+				acGets++
+				if acGets == 1 {
+					firstView.DeepCopyInto(target)
+					return nil
+				}
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), stored, mintedAppCredSecret(cp)).
+		WithInterceptorFuncs(ic).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(acGets).To(BeNumerically(">=", 2),
+		"the test must exercise both the top-level read and the CreateOrUpdate read")
+
+	// The AC must NOT have been deleted this pass, and the empty nudge marker must
+	// survive so the next pass re-mints (overwriting it with pwHash would lose it).
+	reloaded := getAC(t, c, cp)
+	g.Expect(reloaded.Annotations).To(HaveKeyWithValue(adminPasswordHashAnnotation, ""),
+		"a present-but-empty nudge marker must not be overwritten by the hash re-stamp")
+}
+
 // TestReconcileKORC_RemintStalledAfterTimeout asserts the ReMintStalled escape: an
 // AC stuck Terminating longer than remintStallTimeout (a finalizer K-ORC cannot
 // clear because it cannot revoke the old credential) escalates KORCReady from the

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -1032,6 +1032,97 @@ func TestReconcileKORC_HashMismatchDeletesACForRemint(t *testing.T) {
 		"the app-credential secret value must be regenerated on re-mint")
 }
 
+// availableACWithResource builds an Available admin ApplicationCredential whose
+// password-hash annotation already MATCHES the current admin password — so the hash
+// check passes and only a drift in the immutable spec.resource block can drive a
+// re-mint — carrying the given resource spec.
+func availableACWithResource(cp *c5c3v1alpha1.ControlPlane, resource *orcv1alpha1.ApplicationCredentialResourceSpec) *orcv1alpha1.ApplicationCredential {
+	return &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+		},
+		Spec: orcv1alpha1.ApplicationCredentialSpec{Resource: resource},
+		Status: orcv1alpha1.ApplicationCredentialStatus{
+			ID: ptr.To("ac-id-current"),
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}
+
+// assertACRemintedForDrift runs reconcileKORC and asserts the existing AC was
+// deleted (the re-mint trigger) with KORCReady=False/ReMinting — the recovery path
+// for a change to the CEL-immutable spec.resource block that an in-place update
+// would otherwise reject forever.
+func assertACRemintedForDrift(t *testing.T, cp *c5c3v1alpha1.ControlPlane, existing *orcv1alpha1.ApplicationCredential) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), existing, mintedAppCredSecret(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	deleted := &orcv1alpha1.ApplicationCredential{}
+	getErr := c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialName(cp), Namespace: childNamespace(cp),
+	}, deleted)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"a spec.resource drift must delete the AC to trigger a re-mint (CEL forbids in-place update)")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ReMinting"))
+}
+
+// TestReconcileKORC_RestrictedDriftDeletesACForRemint proves that a change to the
+// restricted flag (which flips the immutable spec.resource.unrestricted field) is
+// routed through delete+recreate rather than an in-place update that K-ORC's CEL
+// self==oldSelf rule rejects. The stamped hash MATCHES, so only the resource drift
+// can be the re-mint trigger.
+func TestReconcileKORC_RestrictedDriftDeletesACForRemint(t *testing.T) {
+	cp := korcControlPlane()
+	cp.Spec.KORC.AdminCredential.ApplicationCredential.Restricted = ptr.To(false) // desired Unrestricted=true
+	// Existing AC is restricted (Unrestricted=false) — every other managed field
+	// matches the desired projection, isolating the restricted/unrestricted drift.
+	existing := availableACWithResource(cp, &orcv1alpha1.ApplicationCredentialResourceSpec{
+		Unrestricted: ptr.To(false),
+		UserRef:      orcv1alpha1.KubernetesNameRef(adminUserRef(cp)),
+		SecretRef:    orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp)),
+	})
+	assertACRemintedForDrift(t, cp, existing)
+}
+
+// TestReconcileKORC_AccessRulesDriftDeletesACForRemint proves the same delete+recreate
+// routing for a change to the immutable spec.resource.accessRules list: the spec adds
+// a rule the existing AC does not carry, every other managed field matches, and the
+// stamped hash matches — so only the accessRules drift triggers the re-mint.
+func TestReconcileKORC_AccessRulesDriftDeletesACForRemint(t *testing.T) {
+	cp := korcControlPlane()
+	cp.Spec.KORC.AdminCredential.ApplicationCredential.AccessRules = []c5c3v1alpha1.AccessRule{
+		{Service: "identity", Method: "GET", Path: "/v3/users"},
+	}
+	// Existing AC has the matching Unrestricted/UserRef/SecretRef but NO access rules,
+	// so the new rule is pure accessRules drift.
+	existing := availableACWithResource(cp, &orcv1alpha1.ApplicationCredentialResourceSpec{
+		Unrestricted: ptr.To(false), // restricted defaults to true => Unrestricted=false
+		UserRef:      orcv1alpha1.KubernetesNameRef(adminUserRef(cp)),
+		SecretRef:    orcv1alpha1.KubernetesNameRef(adminAppCredentialSecretName(cp)),
+	})
+	assertACRemintedForDrift(t, cp, existing)
+}
+
 // TestReconcileKORC_RemintStalledAfterTimeout asserts the ReMintStalled escape: an
 // AC stuck Terminating longer than remintStallTimeout (a finalizer K-ORC cannot
 // clear because it cannot revoke the old credential) escalates KORCReady from the


### PR DESCRIPTION
## Summary

Fixes the three K-ORC admin-credential rotation bugs from the 2026-06
pre-production audit (#463). All three share one root: the password-hash
annotation is used as an unguarded re-mint nudge.

Closes #463

## Problems & fixes (in commit order)

1. **`fix(c5c3-operator): latch CredentialRotation reMint to generation`**
   — `reMint: true` left in a `CredentialRotation` re-rotated the admin
   credential forever: `nudge := cr.Spec.ReMint` was evaluated with no
   completion latch, so every cache resync (~10 min via the shared
   `SyncPeriod`) and every operator restart cleared the hash annotation and
   triggered another delete+revoke+re-mint, re-opening the stale-credential
   window each cycle. An explicit `reMint` is now **latched** on a new
   `status.lastTriggeredGeneration` field — one nudge per spec edit. The
   auto-detect (password-hash change) path stays unlatched (it is
   self-limiting and relies on resync to observe an out-of-band rotation).

2. **`fix(c5c3-operator): re-mint AC on immutable resource-block drift`**
   — K-ORC declares the whole `spec.resource` block immutable via CEL
   (`self == oldSelf`, confirmed in `applicationcredential_types.go@v2.6.0`).
   The `CreateOrUpdate` mutate re-projected `ac.Spec.Resource.*`
   unconditionally, so a legal change to `restricted`/`accessRules` was
   rejected by CEL on every pass → permanent
   `KORCReady=False/ApplicationCredentialError` loop. Drift on the
   operator-managed fields (`Unrestricted`, `UserRef`, `SecretRef`,
   `AccessRules`) is now routed through the existing
   `remintAdminApplicationCredential` delete+recreate path. The comparison is
   restricted to managed fields (not whole-struct `DeepEqual`) so a
   K-ORC/CRD-defaulted sub-field can never read as permanent drift and become
   its own loop.

3. **`fix(c5c3-operator): preserve re-mint nudge marker on hash re-stamp`**
   — the mutate re-stamped the hash annotation unconditionally; interleaved
   with the rotation reconciler clearing it, a concurrent nudge could be
   silently overwritten (lost-rotation race) while the rotation CR already
   reported `RotationTriggered`. The hash is now stamped only on a fresh mint
   or when the annotation is absent, never overwriting a present-but-empty
   value (the nudge marker) — extracted as `shouldStampPasswordHash`.

4. **`docs(c5c3): document reMint latch and resource-drift re-mint`** —
   updates the ControlPlane reconciler and CRD references.

## Tests

- `TestRotation_ReMintLatchedToGeneration` — two passes, same generation:
  reMint fires once then reports `NoRotationNeeded` without re-clearing.
- `TestReconcileKORC_RestrictedDriftDeletesACForRemint` /
  `TestReconcileKORC_AccessRulesDriftDeletesACForRemint` — a matching hash
  but drifted resource block deletes the AC for re-mint.
- `TestShouldStampPasswordHash` (table) + `TestReconcileKORC_DoesNotOverwriteClearedNudgeMarker`
  (interceptor-staged race) — the empty nudge marker survives the re-stamp.
  The race test was confirmed to fail without the guard (negative control).

All new tests exercise the regression each fix targets and fail on the
pre-fix code. Existing re-mint / no-churn / `KORCReadyTrue` tests still pass.

## Verification

- `make test-operator OPERATOR=c5c3` — pass
- `make test-race OPERATOR=c5c3 RACE_FLAGS="-count=1"` — pass
- `go vet ./operators/c5c3/...` — pass
- `golangci-lint run` (c5c3 controller + api) — 0 issues
- `make generate && make manifests && make sync-crds && make verify-crd-sync` — no drift

## Notes / deviations

- **K-ORC CEL rule verified** (the plan flagged it as unverifiable from the
  sandbox): `ApplicationCredentialResourceSpec` carries
  `XValidation:rule="self == oldSelf"` at v2.6.0 — Problem 2's premise holds.
- **Nil `spec.resource` is not treated as drift.** The CEL immutability rule
  does not fire on the initial unset→set transition, so `CreateOrUpdate` is
  free to populate a nil block; treating nil as drift would wrongly re-mint
  the minimal never-minted fixture (`TestReconcileKORC_KORCReadyTrueWhenACAvailable`).
- **`GenerationChangedPredicate` deliberately not added** to `For()`: the
  reconciler relies on resync to run the auto-detect path, which that
  predicate would filter out. The generation latch alone fixes the loop.
- **Optional webhook-warn deferred** (it needs `oldObj` plumbing owned by
  #466); out of scope here.
- The `architecture/` submodule docs are in a separate repo and are not
  bumped here.

---

_Implemented by [planwerk-review](https://github.com/planwerk/planwerk-review) d0b3e45 with Claude:claude-opus-4-8_
