### PR TITLE
feat(api): enforce field immutability via oldSelf CEL rules; reject openStackRelease downgrades

### DIFF
--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -187,8 +187,8 @@ status:
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.\d$`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. |
-| `region` | `string` | No | `"RegionOne"` | OpenStack region name applied across the control plane. Projected into the Keystone CR's `bootstrap.region`. Defaulted to `RegionOne` by **both** the `+kubebuilder:default` marker (normal admission) and the defaulting webhook (callers that bypass the CRD default). |
+| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.\d$`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. Upgrades are allowed on update, but **downgrades are rejected** (Keystone DB migrations are forward-only). |
+| `region` | `string` | No | `"RegionOne"` | OpenStack region name applied across the control plane. Projected into the Keystone CR's `bootstrap.region`. Defaulted to `RegionOne` by **both** the `+kubebuilder:default` marker (normal admission) and the defaulting webhook (callers that bypass the CRD default). Immutable after create (the projected `bootstrap.region` is itself immutable). |
 | `infrastructure` | [`InfrastructureSpec`](#infrastructurespec) | No | managed-mode defaulted | Shared backing services (database, cache) the control plane's services connect to. Optional — the defaulting webhook materializes a managed-mode `database`/`cache` when omitted; see [InfrastructureSpec](#infrastructurespec). |
 | `services` | [`ServicesSpec`](#servicesspec) | Yes | — | Per-service configuration projected into the individual service CRs. |
 | `global` | [`*commonv1.PolicySpec`](../keystone/keystone-crd.md#policyspec) | No | `nil` | oslo.policy overrides applied across every service in the control plane. Per-service overrides (e.g. `services.keystone.policyOverrides`) take precedence over these global rules when both are set. |
@@ -702,15 +702,28 @@ Flipping the database/cache mode or renaming a managed `clusterRef` would leave
 the previously-projected MariaDB/Memcached child (and its per-ControlPlane
 credential) orphaned and owned until the ControlPlane is deleted; renaming
 `cloudCredentialsRef.secretName` would leak the previously-projected K-ORC
-clouds.yaml ExternalSecret.
+clouds.yaml ExternalSecret. The database **name** and the **region** are also
+immutable: both are projected verbatim into the Keystone child's now-immutable
+`spec.database.database` / `spec.bootstrap.region`, so a rename here would make
+the next reconcile attempt an update the Keystone CEL rule rejects, wedging the
+loop — rejecting it at the ControlPlane layer surfaces a clean error instead.
+
+The webhook additionally rejects an **openStackRelease downgrade**: a monotonic
+upgrade check parses the `YYYY.N` release into `(year, minor)` and rejects a
+lower tuple while allowing upgrades and same-release no-ops. Keystone DB
+migrations are forward-only, so a downgrade would project an older image against
+an already-migrated schema — an unrecoverable state.
 
 | Rule | Field Path | Condition |
 | --- | --- | --- |
 | Database mode immutable | `spec.infrastructure.database` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
 | Database clusterRef.name immutable | `spec.infrastructure.database.clusterRef.name` | Both managed, but the name changed |
+| Database name immutable | `spec.infrastructure.database.database` | The database name changed |
 | Cache mode immutable | `spec.infrastructure.cache` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
 | Cache clusterRef.name immutable | `spec.infrastructure.cache.clusterRef.name` | Both managed, but the name changed |
 | Cloud secretName immutable | `spec.korc.adminCredential.cloudCredentialsRef.secretName` | The value changed |
+| Region immutable | `spec.region` | The region changed |
+| Release downgrade rejected | `spec.openStackRelease` | New release `(year, minor)` is lower than the old (upgrades and same-release updates allowed) |
 
 ---
 

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -190,13 +190,20 @@ status:
 ### CEL Validation Rules
 
 The CRD includes structural validation rules enforced by the API server before
-webhooks are invoked:
+webhooks are invoked. Rules that reference `oldSelf` are transition rules: they
+are evaluated only on UPDATE and enforce field immutability. Because they are
+enforced by the API server itself, they keep protecting the field even when the
+validating webhook is unavailable.
 
 | Field | Rule | Error Message |
 | --- | --- | --- |
 | `spec.database` | `has(self.clusterRef) != has(self.host)` | "exactly one of clusterRef or host must be set" |
 | `spec.database` | `!has(self.tls) \|\| !self.tls.enabled \|\| (self.tls.caBundleSecretRef.name != '' && self.tls.clientCertSecretRef.name != '')` | "when database.tls.enabled is true, both database.tls.caBundleSecretRef.name and database.tls.clientCertSecretRef.name must be set" |
+| `spec.database` | `self.database == oldSelf.database` (UPDATE only) | "database name is immutable" |
+| `spec.database` | `has(self.clusterRef) == has(oldSelf.clusterRef)` (UPDATE only) | "database mode (managed clusterRef vs brownfield host) is immutable" |
 | `spec.database.tls.mode` | Enum: `prefer`, `require`, `verify-ca`, `verify-full` | — |
+| `spec.bootstrap.adminUser` | `self == oldSelf` (UPDATE only) | "bootstrap.adminUser is immutable" |
+| `spec.bootstrap.region` | `self == oldSelf` (UPDATE only) | "bootstrap.region is immutable" |
 | `spec.cache` | `has(self.clusterRef) != (has(self.servers) && size(self.servers) > 0)` | "exactly one of clusterRef or servers must be set" |
 | `spec.policyOverrides` | `(has(self.rules) && size(self.rules) > 0) \|\| self.configMapRef != null` | "at least one of rules or configMapRef must be set" |
 | `spec.policyOverrides.rules` | `!has(self.rules) \|\| self.rules.all(k, size(k) > 0)` | "policy rule name must not be empty" |
@@ -979,9 +986,9 @@ Configures the initial Keystone bootstrap.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `adminUser` | `string` | No | `"admin"` | Admin username for the bootstrap. |
+| `adminUser` | `string` | No | `"admin"` | Admin username for the bootstrap. Immutable after create (CEL transition rule): re-bootstrapping with a different admin user duplicates or strands catalog entries. |
 | `adminPasswordSecretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | — | Secret containing the admin password. |
-| `region` | `string` | No | `"RegionOne"` | Keystone region name. |
+| `region` | `string` | No | `"RegionOne"` | Keystone region name. Immutable after create (CEL transition rule): changing the region strands catalog entries under the old region. |
 | `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS. |
 
 ---
@@ -1039,11 +1046,13 @@ operator CRDs.
 | `clusterRef` | `*corev1.LocalObjectReference` | No | Reference to a MariaDB CR (managed mode). |
 | `host` | `string` | No | Database hostname (brownfield mode). |
 | `port` | `int32` | No | Database port (brownfield mode, default 3306). |
-| `database` | `string` | Yes | Database name. |
+| `database` | `string` | Yes | Database name. Immutable after create (CEL transition rule): renaming re-points `db_sync` at a fresh, empty schema and silently orphans the existing data. |
 | `secretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | Secret with database credentials. |
 | `tls` | [`*DatabaseTLSSpec`](#databasetlsspec) | No | Optional TLS/mTLS configuration. The pointer keeps the field opt-in and non-mutating: a `nil` `tls` means plaintext TCP, preserving the previous behavior for all existing CRs. |
 
 Exactly one of `clusterRef` or `host` must be set (enforced by CEL validation).
+The database name and the `clusterRef` ↔ `host` mode are immutable after create
+(CEL transition rules, evaluated only on UPDATE).
 
 ### DatabaseTLSSpec
 
@@ -1411,6 +1420,18 @@ is pinned by a Chainsaw step.
 | `fernet-maxactivekeys-below-minimum-rejected` | `11-fernet-maxactivekeys-below-minimum.yaml` | Fernet maxActiveKeys Minimum=3 | Error containing "maxActiveKeys" |
 | `credentialkeys-maxactivekeys-below-minimum-rejected` | `12-credentialkeys-maxactivekeys-below-minimum.yaml` | CredentialKeys maxActiveKeys Minimum=3 | Error containing "maxActiveKeys" |
 | `policy-overrides-empty-rule-value-rejected` | `13-policy-overrides-empty-rule-value.yaml` | Non-empty rule values | Error containing "spec.policyOverrides" and "policy rule value must not be empty" |
+| `immutable-base-accepted` | `13-immutable-base.yaml` | Valid base CR for the update-rejection cases (applied first) | None (must succeed) |
+| `immutable-database-name-rejected` | `14-immutable-database-name.yaml` | `spec.database.database` immutable on UPDATE | Error containing "database" and "immutable" |
+| `immutable-database-mode-rejected` | `15-immutable-database-mode.yaml` | `spec.database` mode (clusterRef ↔ host) immutable on UPDATE | Error containing "database mode" and "immutable" |
+| `immutable-adminuser-rejected` | `16-immutable-adminuser.yaml` | `spec.bootstrap.adminUser` immutable on UPDATE | Error containing "adminUser" and "immutable" |
+| `immutable-region-rejected` | `17-immutable-region.yaml` | `spec.bootstrap.region` immutable on UPDATE | Error containing "region" and "immutable" |
+
+Steps `14`-`17` reuse the `immutable-fields` name from `13-immutable-base.yaml`,
+so each is applied as an UPDATE of the base CR and is rejected by the
+corresponding CEL transition rule (`self == oldSelf`, evaluated only on UPDATE).
+The base CR is brownfield (host mode), so the operator creates no MariaDB CRs
+and pushes no OpenBao secrets; its finalizer cleanup is a no-op and the
+ephemeral namespace tears down cleanly.
 
 Each step uses `apply` with `expect` to assert that the `$error` variable is non-null
 and contains the expected field-level error message. Kubernetes admission evaluates
@@ -1446,16 +1467,20 @@ the field name, so the loose-substring assertion (`maxActiveKeys`) keeps the tes
 stable regardless of which layer fires first and across upstream Kubernetes
 admission-pipeline changes.
 
-The 10 generated fixtures (`02-…` through `12-…`, with the `08-replicas-zero.yaml`
-gap explained above) share an otherwise-identical minimal valid Keystone scaffold
-and differ only by the field under test. To prevent that scaffold from drifting
-across files, the fixtures are generated from a
-single canonical source in `tests/e2e/keystone/invalid-cr/_generate.py`. After
-editing the scaffold or any per-fixture override, regenerate via
+The 16 generated fixtures (`02-…` through `17-…`, with the `08-replicas-zero.yaml`
+gap explained above) share an otherwise-identical minimal valid Keystone scaffold.
+The create-rejection fixtures (`02-…` through `12-…`, plus
+`13-policy-overrides-empty-rule-value.yaml`) differ only by the field under test;
+the update-rejection fixtures (`13-immutable-base.yaml` through `17-…`) share the
+`immutable-fields` name so `13-immutable-base.yaml` is the base and `14`-`17` are
+applied as UPDATEs.
+To prevent that scaffold from drifting across files, the fixtures are generated
+from a single canonical source in `tests/e2e/keystone/invalid-cr/_generate.py`.
+After editing the scaffold or any per-fixture override, regenerate via
 `python3 tests/e2e/keystone/invalid-cr/_generate.py`. The
 `verify-invalid-cr-fixtures` CI job (and the matching
 `make verify-invalid-cr-fixtures` Makefile target) runs `_generate.py --check`
-in drift mode and the `test_generate.py` unit suite (`len(FIXTURES) == 10` plus
+in drift mode and the `test_generate.py` unit suite (`len(FIXTURES) == 16` plus
 a cross-reference assertion that every `Fixture.filename` appears as a
 `file:` step in `chainsaw-test.yaml`), so a hand-edit to any generated fixture
 — or a rename/removal that desynchs `FIXTURES` from `chainsaw-test.yaml` —
@@ -1469,7 +1494,7 @@ is tracked as its own feature ticket:
 
 - Empty / malformed `spec.image.tag` (no `MinLength` or pattern on `ImageSpec.Tag`).
 - `topologySpreadConstraints[*].maxSkew: 0` (no CRD-level minimum on the upstream type, no defense-in-depth in the Keystone webhook).
-- Mutation of immutable fields (`spec.database.clusterRef`, `spec.cache.clusterRef`) on `ValidateUpdate` — old-vs-new comparison is not yet implemented.
+- Mutation of `spec.cache` mode (`clusterRef` ↔ `servers`) on UPDATE — no transition rule yet. The `spec.database` name and mode and the `spec.bootstrap.adminUser`/`region` fields are now immutable via CEL transition rules (see [CEL Validation Rules](#cel-validation-rules)).
 
 #### uwsgi Suite
 

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -203,18 +204,21 @@ func (w *ControlPlaneWebhook) ValidateCreate(ctx context.Context, obj *ControlPl
 
 // ValidateUpdate implements admission.Validator[*ControlPlane].
 // In addition to the spec checks in validate(), it enforces the create-only
-// immutable fields between oldObj and newObj: flipping the database/cache mode
-// or renaming a managed clusterRef would orphan the previously-projected
-// MariaDB/Memcached child (and its credentials), and renaming
+// immutable fields between oldObj and newObj (validateImmutable): flipping the
+// database/cache mode or renaming a managed clusterRef would orphan the
+// previously-projected MariaDB/Memcached child (and its credentials), renaming
 // cloudCredentialsRef.secretName would leak the previously-projected K-ORC
-// clouds.yaml ExternalSecret. Restricting these at admission is the smallest
-// change that prevents every such orphan/leak the sub-reconcilers would
-// otherwise create on the next reconcile (#476). Spec errors and immutability
-// errors are accumulated into a single Invalid response so a reviewer sees all
-// problems at once.
+// clouds.yaml ExternalSecret (#476), and renaming the database or changing the
+// region would re-point the projection at the now-immutable Keystone child
+// fields and wedge the reconcile loop (#466). It additionally rejects an
+// openStackRelease downgrade (validateReleaseNotDowngraded), since Keystone DB
+// migrations are forward-only. Spec errors, immutability errors, and the
+// downgrade error are accumulated into a single Invalid response so a reviewer
+// sees all problems at once.
 func (w *ControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, newObj *ControlPlane) (admission.Warnings, error) {
 	allErrs := w.validate(newObj)
 	allErrs = append(allErrs, validateImmutable(oldObj, newObj)...)
+	allErrs = append(allErrs, validateReleaseNotDowngraded(oldObj, newObj)...)
 	return nil, newInvalidIfErrs(newObj, allErrs)
 }
 
@@ -355,6 +359,12 @@ func newInvalidIfErrs(cp *ControlPlane, allErrs field.ErrorList) error {
 //     and orphans the old one the same way.
 //   - A cloudCredentialsRef.secretName change re-points the K-ORC clouds.yaml
 //     projection and leaks the previously-named ExternalSecret.
+//   - The database NAME (spec.infrastructure.database.database) and the region
+//     (spec.region) are projected verbatim into the Keystone child's now-immutable
+//     spec.database.database / spec.bootstrap.region (#466). Renaming either here
+//     would make the next reconcile attempt an update the Keystone CEL rule
+//     rejects, wedging the loop; rejecting the change at the ControlPlane layer
+//     surfaces a clean error instead.
 //
 // validate() already enforces the database/cache XOR (exactly one of clusterRef
 // or host/servers), so clusterRef nil-ness is an unambiguous mode discriminator
@@ -372,6 +382,10 @@ func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
 	case oldDB.ClusterRef != nil && newDB.ClusterRef != nil && oldDB.ClusterRef.Name != newDB.ClusterRef.Name:
 		allErrs = append(allErrs, field.Invalid(dbPath.Child("clusterRef", "name"),
 			newDB.ClusterRef.Name, "managed database clusterRef.name is immutable"))
+	}
+	if oldDB.Database != newDB.Database {
+		allErrs = append(allErrs, field.Invalid(dbPath.Child("database"),
+			newDB.Database, "database name is immutable"))
 	}
 
 	cachePath := field.NewPath("spec", "infrastructure", "cache")
@@ -395,7 +409,54 @@ func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
 		))
 	}
 
+	if oldObj.Spec.Region != newObj.Spec.Region {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "region"),
+			newObj.Spec.Region, "region is immutable",
+		))
+	}
+
 	return allErrs
+}
+
+// validateReleaseNotDowngraded rejects an openStackRelease downgrade on UPDATE.
+// OpenStack/Keystone DB migrations are forward-only (keystone-manage db_sync has
+// no down-migration path), so re-pointing a live control plane at an older
+// release would project an older image whose schema is behind the already-migrated
+// database -- an unrecoverable state. Upgrades and same-release updates are
+// allowed. Both releases are guarded against controlPlaneReleaseRegexp first; a
+// release that does not match the YYYY.N pattern is left to validate()'s pattern
+// check rather than mis-parsed here, so a malformed value yields the pattern
+// error alone instead of a confusing downgrade message.
+func validateReleaseNotDowngraded(oldObj, newObj *ControlPlane) field.ErrorList {
+	oldRel := oldObj.Spec.OpenStackRelease
+	newRel := newObj.Spec.OpenStackRelease
+	if !controlPlaneReleaseRegexp.MatchString(oldRel) || !controlPlaneReleaseRegexp.MatchString(newRel) {
+		return nil
+	}
+	// Compare the (year, minor) integer tuples rather than the raw strings. The
+	// regex re-check above guarantees both values are well-formed (a 4-digit year,
+	// the dot, then an all-digit minor), so the byte offsets are safe and Atoi
+	// cannot fail. Integer comparison keeps this correct even if
+	// controlPlaneReleaseRegexp is ever loosened to admit a multi-digit minor
+	// (e.g. 2025.10), where lexicographic string ordering would silently invert
+	// ("2025.10" < "2025.2" as strings) and reject a real upgrade while admitting
+	// a real downgrade.
+	parse := func(r string) (year, minor int) {
+		year, _ = strconv.Atoi(r[:4])
+		minor, _ = strconv.Atoi(r[5:])
+		return year, minor
+	}
+	oldYear, oldMinor := parse(oldRel)
+	newYear, newMinor := parse(newRel)
+	if newYear < oldYear || (newYear == oldYear && newMinor < oldMinor) {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("spec", "openStackRelease"),
+			newRel,
+			fmt.Sprintf("openStackRelease downgrade from %q to %q is not permitted; Keystone DB migrations are not reversible", oldRel, newRel),
+		)}
+	}
+	return nil
 }
 
 // validateUniqueInNamespace enforces the one-ControlPlane-per-namespace contract

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -633,19 +633,101 @@ func TestValidateUpdate_RejectsCloudSecretNameChange(t *testing.T) {
 }
 
 // TestValidateUpdate_AllowsMutableFieldChanges verifies that updates which only
-// touch mutable fields (region, replicas, the release) are accepted on an
-// otherwise-unchanged managed ControlPlane, so the immutability guard does not
-// over-restrict legitimate edits (#476).
+// touch mutable fields (replicas, an openStackRelease upgrade) are accepted on
+// an otherwise-unchanged managed ControlPlane, so the immutability guard does
+// not over-restrict legitimate edits (#476, #466). Region is now immutable
+// (#466), so it is deliberately left unchanged here.
 func TestValidateUpdate_AllowsMutableFieldChanges(t *testing.T) {
 	g := NewGomegaWithT(t)
 	w := &ControlPlaneWebhook{}
 	oldCP := managedControlPlane()
 
 	newCP := managedControlPlane()
-	newCP.Spec.Region = "EU-West"
 	newCP.Spec.OpenStackRelease = "2026.1"
 	replicas := int32(3)
 	newCP.Spec.Services.Keystone.Replicas = &replicas
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestValidateUpdate_RejectsDatabaseNameChange verifies that renaming the shared
+// database is rejected on UPDATE: the name is projected verbatim into the
+// Keystone child's now-immutable spec.database.database, so a rename here would
+// wedge the reconcile loop (#466). Only the database name changes, so the mode
+// and clusterRef.name immutability checks stay satisfied.
+func TestValidateUpdate_RejectsDatabaseNameChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.Database = "renamed"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database name is immutable"))
+}
+
+// TestValidateUpdate_RejectsRegionChange verifies that changing the region is
+// rejected on UPDATE: the region is projected verbatim into the Keystone child's
+// now-immutable spec.bootstrap.region (#466).
+func TestValidateUpdate_RejectsRegionChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.Region = "EU-West"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("region is immutable"))
+}
+
+// TestValidateUpdate_RejectsOpenStackReleaseDowngrade verifies that lowering the
+// openStackRelease is rejected on UPDATE, because Keystone DB migrations are
+// forward-only (#466). Both a year downgrade and a same-year minor downgrade are
+// exercised.
+func TestValidateUpdate_RejectsOpenStackReleaseDowngrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// Year downgrade: 2025.2 -> 2024.1.
+	oldCP := managedControlPlane()
+	yearDown := managedControlPlane()
+	yearDown.Spec.OpenStackRelease = "2024.1"
+	_, err := w.ValidateUpdate(context.Background(), oldCP, yearDown)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("downgrade"))
+
+	// Same-year minor downgrade: 2025.2 -> 2025.1.
+	minorDown := managedControlPlane()
+	minorDown.Spec.OpenStackRelease = "2025.1"
+	_, err = w.ValidateUpdate(context.Background(), oldCP, minorDown)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("downgrade"))
+}
+
+// TestValidateUpdate_AcceptsOpenStackReleaseUpgrade verifies that raising the
+// openStackRelease is accepted (the monotonic-upgrade happy path) (#466).
+func TestValidateUpdate_AcceptsOpenStackReleaseUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
+	newCP.Spec.OpenStackRelease = "2026.1"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestValidateUpdate_AcceptsSameOpenStackRelease verifies that re-applying the
+// same openStackRelease is accepted, so the downgrade guard does not fire on a
+// no-op update (#466).
+func TestValidateUpdate_AcceptsSameOpenStackRelease(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	oldCP := managedControlPlane()
+	newCP := managedControlPlane()
 
 	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/operators/c5c3/internal/controller/reconcile_keystone.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -179,12 +180,29 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 
 		return controllerutil.SetControllerReference(cp, keystone, r.Scheme)
 	}); err != nil {
+		reason := "KeystoneError"
+		message := fmt.Sprintf("create-or-update Keystone: %v", err)
+		// An Invalid (HTTP 422) rejection from the Keystone API server is almost
+		// always a now-immutable db/bootstrap field whose CEL transition rule
+		// (self == oldSelf) refuses the projected change — e.g. a spec.region or
+		// spec.database.database edit that landed on the ControlPlane before its
+		// own immutability webhook existed, leaving it diverged from the already-
+		// frozen Keystone child (#466). validateImmutable cannot catch that
+		// pre-webhook edit, so this projection loops forever with no self-heal.
+		// Surface a distinct, actionable reason so the wedge is diagnosable from
+		// the condition instead of being buried under a generic KeystoneError.
+		if apierrors.IsInvalid(err) {
+			reason = "KeystoneProjectionRejected"
+			message = fmt.Sprintf("Keystone API server rejected the projected spec (likely an immutable db/bootstrap field "+
+				"diverged from the frozen Keystone child); reconcile the ControlPlane spec back to the child's values or "+
+				"recreate the Keystone child to recover: %v", err)
+		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeKeystoneReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: cp.Generation,
-			Reason:             "KeystoneError",
-			Message:            fmt.Sprintf("create-or-update Keystone: %v", err),
+			Reason:             reason,
+			Message:            message,
 		})
 		return ctrl.Result{}, err
 	}

--- a/operators/c5c3/internal/controller/reconcile_keystone_test.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone_test.go
@@ -12,12 +12,16 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -397,6 +401,61 @@ func TestReconcileKeystone_MirrorsChildReady(t *testing.T) {
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKeystoneReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+}
+
+// TestReconcileKeystone_InvalidRejectionSurfacesDistinctReason is the regression
+// guard for #466: when the projected spec collides with a now-immutable Keystone
+// db/bootstrap field (e.g. a spec.region edit that landed on the ControlPlane
+// before its own immutability webhook existed, diverging it from the already-
+// frozen Keystone child), the Keystone API server rejects the UPDATE with an
+// Invalid (422) error and the loop re-attempts it on every requeue with no
+// self-heal. The sub-reconciler must surface a distinct, actionable KeystoneReady
+// reason rather than the generic KeystoneError so the wedge is diagnosable.
+func TestReconcileKeystone_InvalidRejectionSurfacesDistinctReason(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := keystoneTestScheme(t)
+	cp := keystoneControlPlane()
+
+	// A pre-existing Keystone child whose region differs from the ControlPlane's,
+	// so CreateOrUpdate finds it and takes the UPDATE path (which the interceptor
+	// rejects, standing in for the CEL immutability transition rule).
+	existing := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      keystoneName(cp),
+			Namespace: childNamespace(cp),
+		},
+		Spec: keystonev1alpha1.KeystoneSpec{
+			Bootstrap: keystonev1alpha1.BootstrapSpec{Region: "OldRegion"},
+		},
+	}
+
+	invalidErr := apierrors.NewInvalid(
+		schema.GroupKind{Group: keystonev1alpha1.GroupVersion.Group, Kind: "Keystone"},
+		existing.Name,
+		field.ErrorList{field.Invalid(
+			field.NewPath("spec", "bootstrap", "region"), cp.Spec.Region, "bootstrap.region is immutable",
+		)},
+	)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+				return invalidErr
+			},
+		}).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKeystone(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred(), "the Invalid rejection must propagate so the manager requeues with backoff")
+	g.Expect(apierrors.IsInvalid(err)).To(BeTrue())
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKeystoneReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("KeystoneProjectionRejected"),
+		"an Invalid (422) rejection must surface a distinct, actionable reason, not the generic KeystoneError")
+	g.Expect(cond.Message).To(ContainSubstring("immutable"),
+		"the underlying immutability rejection must be carried into the condition message")
 }
 
 func TestReconcileKeystone_ManagedOverridesDBSecretRef(t *testing.T) {

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -473,38 +473,6 @@ func TestIntegration_CELRejectsDatabaseNameChange(t *testing.T) {
 		"database", "immutable")
 }
 
-// TestIntegration_CELAcceptsUnchangedImmutableFields proves the transition rules
-// do not fire on an identity update: changing only a mutable field (replicas)
-// while leaving every immutable field untouched is accepted, guarding against an
-// over-broad rule that would reject same-value re-applies.
-func TestIntegration_CELAcceptsUnchangedImmutableFields(t *testing.T) {
-	testutil.SkipIfEnvTestUnavailable(t)
-	g := NewGomegaWithT(t)
-
-	c, ctx, _ := setupEnvTestNoWebhook(t)
-
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-celonly-immutable-accept-"}}
-	g.Expect(c.Create(ctx, ns)).To(Succeed())
-
-	k := validIntegrationKeystone("immutable-accept", ns.Name)
-	g.Expect(c.Create(ctx, k)).To(Succeed())
-
-	got := &Keystone{}
-	key := types.NamespacedName{Name: "immutable-accept", Namespace: ns.Name}
-	g.Expect(c.Get(ctx, key, got)).To(Succeed())
-	// Change only a mutable field; immutable fields stay identical.
-	got.Spec.Replicas = 5
-	g.Expect(c.Update(ctx, got)).To(Succeed(),
-		"updating a mutable field must not trip the immutability transition rules")
-
-	final := &Keystone{}
-	g.Expect(c.Get(ctx, key, final)).To(Succeed())
-	g.Expect(final.Spec.Replicas).To(Equal(int32(5)))
-	g.Expect(final.Spec.Database.Database).To(Equal("keystone"))
-	g.Expect(final.Spec.Bootstrap.AdminUser).To(Equal("admin"))
-	g.Expect(final.Spec.Bootstrap.Region).To(Equal("RegionOne"))
-}
-
 // --- Task 2.3: Webhook defaulting tests ---
 
 func TestIntegration_WebhookDefaultsSetsZeroValues(t *testing.T) {

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -380,6 +380,131 @@ func TestIntegration_CRD_CELOnly_RejectsOutOfEnumTLSMode(t *testing.T) {
 	))
 }
 
+// --- Field immutability (CEL transition rules, #466) ---
+
+// updateImmutableFieldRejected is the shared body for the field-immutability
+// rejection tests. It creates a valid Keystone CR, re-reads it, applies the
+// given mutation, and asserts the UPDATE is rejected with every expected
+// message substring. The setup function selects whether the validating webhook
+// is installed: the webhook deliberately discards oldObj and never checks
+// immutability (keystone_webhook.go), so the CRD CEL transition rule is the sole
+// gate. The no-webhook setup pins that the CEL rule rejects the change on its
+// own; a webhook-enabled variant confirms the rule still fires when the webhook
+// is present.
+func updateImmutableFieldRejected(
+	t *testing.T,
+	setup func(testing.TB) (client.Client, context.Context, context.CancelFunc),
+	nsPrefix string,
+	mutate func(*Keystone),
+	wantSubstrings ...string,
+) {
+	t.Helper()
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setup(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: nsPrefix}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	k := validIntegrationKeystone("immutable", ns.Name)
+	g.Expect(c.Create(ctx, k)).To(Succeed(), "valid Keystone CR should be accepted on create")
+
+	got := &Keystone{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "immutable", Namespace: ns.Name}, got)).To(Succeed())
+	mutate(got)
+
+	err := c.Update(ctx, got)
+	g.Expect(err).To(HaveOccurred(), "mutating an immutable field must be rejected on update")
+	g.Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
+		fmt.Sprintf("expected Invalid or Forbidden status error, got: %v", err))
+	for _, want := range wantSubstrings {
+		g.Expect(err.Error()).To(ContainSubstring(want))
+	}
+}
+
+// TestIntegration_CRD_CELOnly_RejectsDatabaseNameChange pins the
+// spec.database.database immutability transition rule against an API server with
+// NO validating webhook installed: renaming the database is rejected by the CEL
+// rule alone.
+func TestIntegration_CRD_CELOnly_RejectsDatabaseNameChange(t *testing.T) {
+	updateImmutableFieldRejected(t, setupEnvTestNoWebhook, "test-celonly-dbname-",
+		func(k *Keystone) { k.Spec.Database.Database = "renamed" },
+		"database", "immutable")
+}
+
+// TestIntegration_CRD_CELOnly_RejectsDatabaseModeFlip pins the database
+// managed-vs-brownfield mode immutability rule: flipping the host-mode base CR
+// to clusterRef mode is rejected by the CEL rule alone. The new object still
+// satisfies the clusterRef/host XOR rule, so only the mode transition rule fires.
+func TestIntegration_CRD_CELOnly_RejectsDatabaseModeFlip(t *testing.T) {
+	updateImmutableFieldRejected(t, setupEnvTestNoWebhook, "test-celonly-dbmode-",
+		func(k *Keystone) {
+			k.Spec.Database.ClusterRef = &corev1.LocalObjectReference{Name: "mariadb"}
+			k.Spec.Database.Host = ""
+		},
+		"database mode", "immutable")
+}
+
+// TestIntegration_CRD_CELOnly_RejectsAdminUserChange pins the
+// spec.bootstrap.adminUser immutability rule against an API server with NO
+// validating webhook installed.
+func TestIntegration_CRD_CELOnly_RejectsAdminUserChange(t *testing.T) {
+	updateImmutableFieldRejected(t, setupEnvTestNoWebhook, "test-celonly-adminuser-",
+		func(k *Keystone) { k.Spec.Bootstrap.AdminUser = "root" },
+		"adminUser", "immutable")
+}
+
+// TestIntegration_CRD_CELOnly_RejectsRegionChange pins the spec.bootstrap.region
+// immutability rule against an API server with NO validating webhook installed.
+func TestIntegration_CRD_CELOnly_RejectsRegionChange(t *testing.T) {
+	updateImmutableFieldRejected(t, setupEnvTestNoWebhook, "test-celonly-region-",
+		func(k *Keystone) { k.Spec.Bootstrap.Region = "RegionTwo" },
+		"region", "immutable")
+}
+
+// TestIntegration_CELRejectsDatabaseNameChange is the webhook-enabled flavour of
+// the database-name immutability test: even with the validating webhook
+// installed (which never checks immutability itself), the CRD CEL transition
+// rule still rejects the rename.
+func TestIntegration_CELRejectsDatabaseNameChange(t *testing.T) {
+	updateImmutableFieldRejected(t, setupEnvTest, "test-cel-dbname-",
+		func(k *Keystone) { k.Spec.Database.Database = "renamed" },
+		"database", "immutable")
+}
+
+// TestIntegration_CELAcceptsUnchangedImmutableFields proves the transition rules
+// do not fire on an identity update: changing only a mutable field (replicas)
+// while leaving every immutable field untouched is accepted, guarding against an
+// over-broad rule that would reject same-value re-applies.
+func TestIntegration_CELAcceptsUnchangedImmutableFields(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupEnvTestNoWebhook(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-celonly-immutable-accept-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	k := validIntegrationKeystone("immutable-accept", ns.Name)
+	g.Expect(c.Create(ctx, k)).To(Succeed())
+
+	got := &Keystone{}
+	key := types.NamespacedName{Name: "immutable-accept", Namespace: ns.Name}
+	g.Expect(c.Get(ctx, key, got)).To(Succeed())
+	// Change only a mutable field; immutable fields stay identical.
+	got.Spec.Replicas = 5
+	g.Expect(c.Update(ctx, got)).To(Succeed(),
+		"updating a mutable field must not trip the immutability transition rules")
+
+	final := &Keystone{}
+	g.Expect(c.Get(ctx, key, final)).To(Succeed())
+	g.Expect(final.Spec.Replicas).To(Equal(int32(5)))
+	g.Expect(final.Spec.Database.Database).To(Equal("keystone"))
+	g.Expect(final.Spec.Bootstrap.AdminUser).To(Equal("admin"))
+	g.Expect(final.Spec.Bootstrap.Region).To(Equal("RegionOne"))
+}
+
 // --- Task 2.3: Webhook defaulting tests ---
 
 func TestIntegration_WebhookDefaultsSetsZeroValues(t *testing.T) {

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -54,6 +54,17 @@ type KeystoneSpec struct {
 	Replicas int32 `json:"replicas,omitempty"`
 
 	// Image defines the Keystone container image reference.
+	//
+	// Unlike the db/bootstrap fields below — whose CEL transition rules
+	// (self == oldSelf) make them immutable even when the validating webhook is
+	// unavailable, because the API server enforces them (#466) — spec.image
+	// carries no immutability rule, since image upgrades are routine and the field
+	// must stay mutable. The ControlPlane operator projects spec.openStackRelease
+	// into this image tag and rejects release downgrades in its validating webhook
+	// (validateReleaseNotDowngraded); that guard is webhook-only and has no
+	// API-server CEL backstop, so a direct edit of this Keystone child's spec.image
+	// can still point an already-migrated deployment at an older release if the
+	// ControlPlane webhook is bypassed.
 	Image commonv1.ImageSpec `json:"image"`
 
 	// Database defines the MariaDB connection parameters.
@@ -71,7 +82,18 @@ type KeystoneSpec struct {
 	// The clusterRef/host mutual-exclusivity rule lives on commonv1.DatabaseSpec
 	// itself, so it is inherited here without per-field duplication. The TLS
 	// rule below stays field-level because it is keystone-specific.
+	//
+	// The database name and the connection mode are immutable after create.
+	// Renaming spec.database.database re-points db_sync at a fresh, empty schema:
+	// Keystone silently "loses" every user/project while the old data is orphaned
+	// (data-loss class). Flipping the managed (clusterRef) ↔ brownfield (host) mode
+	// likewise re-targets the whole connection. The transition rules below
+	// (self == oldSelf, evaluated only on UPDATE) are enforced by the API server
+	// itself, so they keep protecting the field even when the validating webhook
+	// is unavailable (#466).
 	// +kubebuilder:validation:XValidation:rule="!has(self.tls) || !self.tls.enabled || (self.tls.caBundleSecretRef.name != '' && self.tls.clientCertSecretRef.name != '')",message="when database.tls.enabled is true, both database.tls.caBundleSecretRef.name and database.tls.clientCertSecretRef.name must be set"
+	// +kubebuilder:validation:XValidation:rule="self.database == oldSelf.database",message="database name is immutable"
+	// +kubebuilder:validation:XValidation:rule="has(self.clusterRef) == has(oldSelf.clusterRef)",message="database mode (managed clusterRef vs brownfield host) is immutable"
 	Database commonv1.DatabaseSpec `json:"database"`
 
 	// Cache defines the Memcached cache configuration.
@@ -449,15 +471,25 @@ type PasswordRotationSpec struct {
 
 // BootstrapSpec defines Keystone bootstrap parameters.
 type BootstrapSpec struct {
-	// AdminUser is the admin username for the bootstrap.
+	// AdminUser is the admin username for the bootstrap. Immutable after create:
+	// re-bootstrapping against an existing deployment with a different admin user
+	// duplicates or strands catalog entries (known duplicate-admin failure class).
+	// The transition rule (self == oldSelf) is evaluated only on UPDATE and is
+	// enforced by the API server, so it holds even when the webhook is down (#466).
 	// +kubebuilder:default="admin"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="bootstrap.adminUser is immutable"
 	AdminUser string `json:"adminUser,omitempty"`
 
 	// AdminPasswordSecretRef references the Secret containing the admin password.
 	AdminPasswordSecretRef commonv1.SecretRefSpec `json:"adminPasswordSecretRef"`
 
-	// Region is the Keystone region name.
+	// Region is the Keystone region name. Immutable after create: re-bootstrapping
+	// against an existing deployment in a different region strands catalog entries
+	// under the old region. The transition rule (self == oldSelf) is evaluated only
+	// on UPDATE and is enforced by the API server, so it holds even when the webhook
+	// is down (#466).
 	// +kubebuilder:default="RegionOne"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="bootstrap.region is immutable"
 	Region string `json:"region,omitempty"`
 
 	// PublicEndpoint is the externally routable Keystone endpoint URL used for

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -108,8 +108,16 @@ spec:
                     type: object
                   adminUser:
                     default: admin
-                    description: AdminUser is the admin username for the bootstrap.
+                    description: |-
+                      AdminUser is the admin username for the bootstrap. Immutable after create:
+                      re-bootstrapping against an existing deployment with a different admin user
+                      duplicates or strands catalog entries (known duplicate-admin failure class).
+                      The transition rule (self == oldSelf) is evaluated only on UPDATE and is
+                      enforced by the API server, so it holds even when the webhook is down (#466).
                     type: string
+                    x-kubernetes-validations:
+                    - message: bootstrap.adminUser is immutable
+                      rule: self == oldSelf
                   passwordRotation:
                     description: |-
                       PasswordRotation optionally enables scheduled rotation of the admin
@@ -154,8 +162,16 @@ spec:
                     type: string
                   region:
                     default: RegionOne
-                    description: Region is the Keystone region name.
+                    description: |-
+                      Region is the Keystone region name. Immutable after create: re-bootstrapping
+                      against an existing deployment in a different region strands catalog entries
+                      under the old region. The transition rule (self == oldSelf) is evaluated only
+                      on UPDATE and is enforced by the API server, so it holds even when the webhook
+                      is down (#466).
                     type: string
+                    x-kubernetes-validations:
+                    - message: bootstrap.region is immutable
+                      rule: self == oldSelf
                 required:
                 - adminPasswordSecretRef
                 type: object
@@ -245,6 +261,15 @@ spec:
                   The clusterRef/host mutual-exclusivity rule lives on commonv1.DatabaseSpec
                   itself, so it is inherited here without per-field duplication. The TLS
                   rule below stays field-level because it is keystone-specific.
+
+                  The database name and the connection mode are immutable after create.
+                  Renaming spec.database.database re-points db_sync at a fresh, empty schema:
+                  Keystone silently "loses" every user/project while the old data is orphaned
+                  (data-loss class). Flipping the managed (clusterRef) ↔ brownfield (host) mode
+                  likewise re-targets the whole connection. The transition rules below
+                  (self == oldSelf, evaluated only on UPDATE) are enforced by the API server
+                  itself, so they keep protecting the field even when the validating webhook
+                  is unavailable (#466).
                 properties:
                   clusterRef:
                     description: ClusterRef references a MariaDB CR in the cluster
@@ -348,6 +373,11 @@ spec:
                     and database.tls.clientCertSecretRef.name must be set
                   rule: '!has(self.tls) || !self.tls.enabled || (self.tls.caBundleSecretRef.name
                     != '''' && self.tls.clientCertSecretRef.name != '''')'
+                - message: database name is immutable
+                  rule: self.database == oldSelf.database
+                - message: database mode (managed clusterRef vs brownfield host) is
+                    immutable
+                  rule: has(self.clusterRef) == has(oldSelf.clusterRef)
                 - message: exactly one of clusterRef or host must be set
                   rule: has(self.clusterRef) != has(self.host)
               extraConfig:
@@ -446,7 +476,19 @@ spec:
                 - parentRef
                 type: object
               image:
-                description: Image defines the Keystone container image reference.
+                description: |-
+                  Image defines the Keystone container image reference.
+
+                  Unlike the db/bootstrap fields below — whose CEL transition rules
+                  (self == oldSelf) make them immutable even when the validating webhook is
+                  unavailable, because the API server enforces them (#466) — spec.image
+                  carries no immutability rule, since image upgrades are routine and the field
+                  must stay mutable. The ControlPlane operator projects spec.openStackRelease
+                  into this image tag and rejects release downgrades in its validating webhook
+                  (validateReleaseNotDowngraded); that guard is webhook-only and has no
+                  API-server CEL backstop, so a direct edit of this Keystone child's spec.image
+                  can still point an already-migrated deployment at an older release if the
+                  ControlPlane webhook is bypassed.
                 properties:
                   repository:
                     type: string

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -111,8 +111,16 @@ spec:
                     type: object
                   adminUser:
                     default: admin
-                    description: AdminUser is the admin username for the bootstrap.
+                    description: |-
+                      AdminUser is the admin username for the bootstrap. Immutable after create:
+                      re-bootstrapping against an existing deployment with a different admin user
+                      duplicates or strands catalog entries (known duplicate-admin failure class).
+                      The transition rule (self == oldSelf) is evaluated only on UPDATE and is
+                      enforced by the API server, so it holds even when the webhook is down (#466).
                     type: string
+                    x-kubernetes-validations:
+                    - message: bootstrap.adminUser is immutable
+                      rule: self == oldSelf
                   passwordRotation:
                     description: |-
                       PasswordRotation optionally enables scheduled rotation of the admin
@@ -157,8 +165,16 @@ spec:
                     type: string
                   region:
                     default: RegionOne
-                    description: Region is the Keystone region name.
+                    description: |-
+                      Region is the Keystone region name. Immutable after create: re-bootstrapping
+                      against an existing deployment in a different region strands catalog entries
+                      under the old region. The transition rule (self == oldSelf) is evaluated only
+                      on UPDATE and is enforced by the API server, so it holds even when the webhook
+                      is down (#466).
                     type: string
+                    x-kubernetes-validations:
+                    - message: bootstrap.region is immutable
+                      rule: self == oldSelf
                 required:
                 - adminPasswordSecretRef
                 type: object
@@ -248,6 +264,15 @@ spec:
                   The clusterRef/host mutual-exclusivity rule lives on commonv1.DatabaseSpec
                   itself, so it is inherited here without per-field duplication. The TLS
                   rule below stays field-level because it is keystone-specific.
+
+                  The database name and the connection mode are immutable after create.
+                  Renaming spec.database.database re-points db_sync at a fresh, empty schema:
+                  Keystone silently "loses" every user/project while the old data is orphaned
+                  (data-loss class). Flipping the managed (clusterRef) ↔ brownfield (host) mode
+                  likewise re-targets the whole connection. The transition rules below
+                  (self == oldSelf, evaluated only on UPDATE) are enforced by the API server
+                  itself, so they keep protecting the field even when the validating webhook
+                  is unavailable (#466).
                 properties:
                   clusterRef:
                     description: ClusterRef references a MariaDB CR in the cluster
@@ -351,6 +376,11 @@ spec:
                     and database.tls.clientCertSecretRef.name must be set
                   rule: '!has(self.tls) || !self.tls.enabled || (self.tls.caBundleSecretRef.name
                     != '''' && self.tls.clientCertSecretRef.name != '''')'
+                - message: database name is immutable
+                  rule: self.database == oldSelf.database
+                - message: database mode (managed clusterRef vs brownfield host) is
+                    immutable
+                  rule: has(self.clusterRef) == has(oldSelf.clusterRef)
                 - message: exactly one of clusterRef or host must be set
                   rule: has(self.clusterRef) != has(self.host)
               extraConfig:
@@ -449,7 +479,19 @@ spec:
                 - parentRef
                 type: object
               image:
-                description: Image defines the Keystone container image reference.
+                description: |-
+                  Image defines the Keystone container image reference.
+
+                  Unlike the db/bootstrap fields below — whose CEL transition rules
+                  (self == oldSelf) make them immutable even when the validating webhook is
+                  unavailable, because the API server enforces them (#466) — spec.image
+                  carries no immutability rule, since image upgrades are routine and the field
+                  must stay mutable. The ControlPlane operator projects spec.openStackRelease
+                  into this image tag and rejects release downgrades in its validating webhook
+                  (validateReleaseNotDowngraded); that guard is webhook-only and has no
+                  API-server CEL backstop, so a direct edit of this Keystone child's spec.image
+                  can still point an already-migrated deployment at an older release if the
+                  ControlPlane webhook is bypassed.
                 properties:
                   repository:
                     type: string

--- a/tests/e2e/keystone/invalid-cr/13-immutable-base.yaml
+++ b/tests/e2e/keystone/invalid-cr/13-immutable-base.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Valid base Keystone CR for the field-immutability update-rejection
+# fixtures (#466). It is applied FIRST and must SUCCEED. The variants
+# 14-17 reuse this name so each is applied as an UPDATE of this object,
+# exercising the CRD CEL transition rules on spec.database.database, the
+# database mode (clusterRef vs host), spec.bootstrap.adminUser, and
+# spec.bootstrap.region.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: immutable-fields
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/14-immutable-database-name.yaml
+++ b/tests/e2e/keystone/invalid-cr/14-immutable-database-name.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Update of the immutable-fields base CR that renames
+# spec.database.database from "keystone" to "renamed". The CEL transition
+# rule on KeystoneSpec.Database (self.database == oldSelf.database,
+# keystone_types.go) rejects the change on UPDATE. Only the name differs
+# from the base, so the clusterRef/host mode rule stays satisfied.
+# Admission must reject this UPDATE with an $error referencing the
+# substrings "database" and "immutable".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: immutable-fields
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: renamed
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/15-immutable-database-mode.yaml
+++ b/tests/e2e/keystone/invalid-cr/15-immutable-database-mode.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Update of the immutable-fields base CR that flips spec.database from
+# brownfield host mode to managed clusterRef mode. The CEL transition
+# rule on KeystoneSpec.Database (has(self.clusterRef) ==
+# has(oldSelf.clusterRef), keystone_types.go) rejects the mode change on
+# UPDATE. Admission must reject this UPDATE with an $error referencing the
+# substrings "database mode" and "immutable".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: immutable-fields
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/16-immutable-adminuser.yaml
+++ b/tests/e2e/keystone/invalid-cr/16-immutable-adminuser.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Update of the immutable-fields base CR that changes
+# spec.bootstrap.adminUser from "admin" to "root". The CEL transition rule
+# on BootstrapSpec.AdminUser (self == oldSelf, keystone_types.go) rejects
+# the change on UPDATE. Admission must reject this UPDATE with an $error
+# referencing the substrings "adminUser" and "immutable".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: immutable-fields
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: root
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/invalid-cr/17-immutable-region.yaml
+++ b/tests/e2e/keystone/invalid-cr/17-immutable-region.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Update of the immutable-fields base CR that changes
+# spec.bootstrap.region from "RegionOne" to "RegionTwo". The CEL transition
+# rule on BootstrapSpec.Region (self == oldSelf, keystone_types.go) rejects
+# the change on UPDATE. Admission must reject this UPDATE with an $error
+# referencing the substrings "region" and "immutable".
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: immutable-fields
+spec:
+  replicas: 3
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    host: db.example.com
+    port: 3306
+    database: keystone
+    secretRef:
+      name: keystone-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "mc:11211"
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionTwo

--- a/tests/e2e/keystone/invalid-cr/_generate.py
+++ b/tests/e2e/keystone/invalid-cr/_generate.py
@@ -10,8 +10,17 @@ field of the canonical scaffold so the surrounding CR passes schema validation
 for every rule OTHER than the one under test, ensuring the admission error is
 attributable to that single field.
 
+Two fixture categories share this scaffold:
+
+* Create-rejection fixtures are each applied once and rejected at admission by
+  a CEL XValidation or ``webhook.validate()`` rule.
+* Update-rejection fixtures (#466) share the name ``immutable-fields``:
+  ``13-immutable-base`` is the valid base CR applied first, and the ``14``-
+  ``17`` variants are applied as UPDATEs of that base so the CRD CEL transition
+  rules (``self == oldSelf``, evaluated only on UPDATE) reject the field change.
+
 The reviewer concern this generator addresses (sourcery-ai review #1):
-without a single source of truth the 11 fixtures could drift out of sync with
+without a single source of truth the 16 fixtures could drift out of sync with
 each other and with KeystoneSpec over time. This script enforces a single
 canonical scaffold; per-fixture overrides change only what is necessary to
 trigger the rejection path under test.
@@ -82,6 +91,30 @@ DATABASE_BOTH_MODES = """\
       name: keystone-db
 """
 
+# Same brownfield host mode as DATABASE_HOST_ONLY but with the database NAME
+# changed from "keystone" to "renamed". Used by the update-rejection fixture
+# that exercises the database-name immutability transition rule: only the name
+# differs from the base CR, so the clusterRef/host mode rule stays satisfied.
+DATABASE_HOST_RENAMED = """\
+    host: db.example.com
+    port: 3306
+    database: renamed
+    secretRef:
+      name: keystone-db
+"""
+
+# Managed clusterRef mode (no host) with the same database NAME as the base CR.
+# Used by the update-rejection fixture that exercises the database-mode
+# immutability transition rule: flipping the base brownfield host mode to managed
+# clusterRef mode is rejected.
+DATABASE_CLUSTERREF_ONLY = """\
+    clusterRef:
+      name: openstack-db
+    database: keystone
+    secretRef:
+      name: keystone-db
+"""
+
 CACHE_SERVERS_ONLY = """\
     backend: dogpile.cache.pymemcache
     servers:
@@ -104,6 +137,28 @@ BOOTSTRAP = """\
     region: RegionOne
 """
 
+# Same as BOOTSTRAP but with adminUser changed from "admin" to "root". Used by
+# the update-rejection fixture exercising the bootstrap.adminUser immutability
+# transition rule.
+BOOTSTRAP_RENAMED_ADMIN = """\
+  bootstrap:
+    adminUser: root
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne
+"""
+
+# Same as BOOTSTRAP but with region changed from "RegionOne" to "RegionTwo".
+# Used by the update-rejection fixture exercising the bootstrap.region
+# immutability transition rule.
+BOOTSTRAP_RENAMED_REGION = """\
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionTwo
+"""
+
 
 @dataclass(frozen=True)
 class Fixture:
@@ -117,6 +172,7 @@ class Fixture:
     cache: str = CACHE_SERVERS_ONLY
     fernet_max_active_keys: int = 3
     credential_keys: str | None = None
+    bootstrap: str = BOOTSTRAP
     trailing: str | None = None
 
 
@@ -144,7 +200,7 @@ def render(fixture: Fixture) -> str:
     ]
     if fixture.credential_keys is not None:
         parts.append(fixture.credential_keys)
-    parts.append(BOOTSTRAP)
+    parts.append(fixture.bootstrap)
     if fixture.trailing is not None:
         parts.append(fixture.trailing)
     return "".join(parts)
@@ -337,6 +393,72 @@ FIXTURES: list[Fixture] = [
 # policyOverrides field via its PolicySpec type, runs before the validating
 # webhook and emits the error at that field. The key is quoted to keep its
 # embedded colon unambiguous to the YAML parser.""",
+    ),
+    # ── Update-rejection fixtures (#466) ────────────────────────────────
+    # Unlike the create-rejection fixtures above (each applied once and rejected
+    # at admission), these four share name "immutable-fields" with the base CR
+    # below so the chainsaw suite applies the base successfully, then applies each
+    # variant as an UPDATE that the CRD CEL transition rules (self == oldSelf,
+    # evaluated only on UPDATE) reject. The base is brownfield (host mode), so the
+    # operator creates no MariaDB CRs and pushes no OpenBao secrets; its finalizer
+    # cleanup is a no-op and the ephemeral namespace tears down cleanly.
+    Fixture(
+        filename="13-immutable-base.yaml",
+        name="immutable-fields",
+        comment="""\
+# Valid base Keystone CR for the field-immutability update-rejection
+# fixtures (#466). It is applied FIRST and must SUCCEED. The variants
+# 14-17 reuse this name so each is applied as an UPDATE of this object,
+# exercising the CRD CEL transition rules on spec.database.database, the
+# database mode (clusterRef vs host), spec.bootstrap.adminUser, and
+# spec.bootstrap.region.""",
+    ),
+    Fixture(
+        filename="14-immutable-database-name.yaml",
+        name="immutable-fields",
+        database=DATABASE_HOST_RENAMED,
+        comment="""\
+# Update of the immutable-fields base CR that renames
+# spec.database.database from "keystone" to "renamed". The CEL transition
+# rule on KeystoneSpec.Database (self.database == oldSelf.database,
+# keystone_types.go) rejects the change on UPDATE. Only the name differs
+# from the base, so the clusterRef/host mode rule stays satisfied.
+# Admission must reject this UPDATE with an $error referencing the
+# substrings "database" and "immutable".""",
+    ),
+    Fixture(
+        filename="15-immutable-database-mode.yaml",
+        name="immutable-fields",
+        database=DATABASE_CLUSTERREF_ONLY,
+        comment="""\
+# Update of the immutable-fields base CR that flips spec.database from
+# brownfield host mode to managed clusterRef mode. The CEL transition
+# rule on KeystoneSpec.Database (has(self.clusterRef) ==
+# has(oldSelf.clusterRef), keystone_types.go) rejects the mode change on
+# UPDATE. Admission must reject this UPDATE with an $error referencing the
+# substrings "database mode" and "immutable".""",
+    ),
+    Fixture(
+        filename="16-immutable-adminuser.yaml",
+        name="immutable-fields",
+        bootstrap=BOOTSTRAP_RENAMED_ADMIN,
+        comment="""\
+# Update of the immutable-fields base CR that changes
+# spec.bootstrap.adminUser from "admin" to "root". The CEL transition rule
+# on BootstrapSpec.AdminUser (self == oldSelf, keystone_types.go) rejects
+# the change on UPDATE. Admission must reject this UPDATE with an $error
+# referencing the substrings "adminUser" and "immutable".""",
+    ),
+    Fixture(
+        filename="17-immutable-region.yaml",
+        name="immutable-fields",
+        bootstrap=BOOTSTRAP_RENAMED_REGION,
+        comment="""\
+# Update of the immutable-fields base CR that changes
+# spec.bootstrap.region from "RegionOne" to "RegionTwo". The CEL transition
+# rule on BootstrapSpec.Region (self == oldSelf, keystone_types.go) rejects
+# the change on UPDATE. Admission must reject this UPDATE with an $error
+# referencing the substrings "region" and "immutable".""",
     ),
 ]
 

--- a/tests/e2e/keystone/invalid-cr/chainsaw-test.yaml
+++ b/tests/e2e/keystone/invalid-cr/chainsaw-test.yaml
@@ -9,10 +9,14 @@
 # CR with a single field violating the rule under test, captures the
 # admission $error, and asserts the field-path plus message substring.
 #
-# The fixtures (02-…, 03-…, 04-…, 05-…, 06-…, 07-…, 09-…, 10-…,
-# 11-…, 12-…) share the same minimal valid Keystone scaffold and differ
-# only by the field under test. To prevent scaffold drift across these
-# 10 files (sourcery-ai review #1), they are generated from a
+# The create-rejection fixtures (02-…, 03-…, 04-…, 05-…, 06-…, 07-…,
+# 09-…, 10-…, 11-…, 12-…, 13-policy-overrides-empty-rule-value) share the
+# same minimal valid Keystone scaffold and differ only by the field under
+# test. The update-rejection fixtures (13-immutable-base, 14-…, 15-…, 16-…,
+# 17-…, #466) share the name "immutable-fields": 13-immutable-base is the
+# valid base CR applied first, and 14-17 are applied as UPDATEs
+# that the CRD CEL transition rules reject. To prevent scaffold drift
+# across these 16 files (sourcery-ai review #1), they are generated from a
 # single source of truth in `_generate.py`. After editing the canonical
 # scaffold or any per-fixture override, regenerate via:
 #   python3 tests/e2e/keystone/invalid-cr/_generate.py
@@ -182,3 +186,48 @@ spec:
             ($error != null): true
             (contains($error, 'spec.policyOverrides')): true
             (contains($error, 'policy rule value must not be empty')): true
+  # ── Field immutability (CEL transition rules, #466) ───────────────────
+  # The base CR (13) is applied successfully, then four UPDATEs each mutating a
+  # single immutable field (14-17) are rejected by the CRD CEL transition rules
+  # (self == oldSelf, evaluated only on UPDATE). All five fixtures share the
+  # name "immutable-fields", so applying 14-17 after 13 are UPDATEs of the same
+  # object. The base is brownfield (host mode), so the operator creates no
+  # MariaDB CRs and pushes no OpenBao secrets; its finalizer cleanup is a no-op
+  # and the ephemeral namespace tears down cleanly when the test ends.
+  - try:
+    # Base CR must be admitted (no expect → success expected).
+    - apply:
+        file: 13-immutable-base.yaml
+    # Renaming spec.database.database is rejected on UPDATE.
+    - apply:
+        file: 14-immutable-database-name.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database')): true
+            (contains($error, 'immutable')): true
+    # Flipping the database mode (brownfield host → managed clusterRef) is
+    # rejected on UPDATE.
+    - apply:
+        file: 15-immutable-database-mode.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database mode')): true
+            (contains($error, 'immutable')): true
+    # Changing spec.bootstrap.adminUser is rejected on UPDATE.
+    - apply:
+        file: 16-immutable-adminuser.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'adminUser')): true
+            (contains($error, 'immutable')): true
+    # Changing spec.bootstrap.region is rejected on UPDATE.
+    - apply:
+        file: 17-immutable-region.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'region')): true
+            (contains($error, 'immutable')): true

--- a/tests/e2e/keystone/invalid-cr/test_generate.py
+++ b/tests/e2e/keystone/invalid-cr/test_generate.py
@@ -12,7 +12,7 @@ instead of waiting for the Chainsaw E2E job to fail at the apply step.
 
 Coverage (each assertion traceable to review-2 finding FC1):
 
-* ``FIXTURES`` lists exactly the 10 fixtures the chainsaw suite expects.
+* ``FIXTURES`` lists exactly the 16 fixtures the chainsaw suite expects.
 * Every ``Fixture.filename`` is referenced by an ``apply.file:`` entry in
   ``chainsaw-test.yaml`` — guards against renames or accidental deletions.
 * Filenames are unique within ``FIXTURES`` — guards against copy/paste typos
@@ -37,11 +37,13 @@ _HERE = Path(__file__).resolve().parent
 _GENERATOR = _HERE / "_generate.py"
 _CHAINSAW_TEST = _HERE / "chainsaw-test.yaml"
 
-# Number of fixtures emitted by _generate.py. The fixtures
+# Number of fixtures emitted by _generate.py: eleven create-rejection fixtures
+# (02-12 plus 13-policy-overrides-empty-rule-value) plus five update-rejection
+# fixtures (13-immutable-base and 14-17, #466). The fixtures
 # (00-, 01-) predate and are intentionally NOT generated. Bumping
 # this value requires adding the matching Fixture entry AND the matching
 # `file: <name>` line in chainsaw-test.yaml.
-_EXPECTED_FIXTURE_COUNT = 11
+_EXPECTED_FIXTURE_COUNT = 16
 
 
 def _load_generator() -> types.ModuleType:


### PR DESCRIPTION
Closes #466

## What

No field in either CRD was immutable: both `ValidateUpdate` implementations discarded `oldObj` and there were zero `oldSelf` XValidation rules. This let a `spec.database.database` rename re-point `db_sync` at a fresh empty schema (silent data loss), a `clusterRef`↔`host` mode flip re-target the whole connection, a `bootstrap.adminUser`/`bootstrap.region` change re-bootstrap against a live deployment, and an `openStackRelease` *downgrade* run an older image against a forward-only-migrated schema.

This branch enforces immutability on those leaves and rejects release downgrades.

## Change set (in commit order)

1. **`a0367543` feat(api): make keystone db/bootstrap fields immutable via CEL**
   Adds field-level `XValidation` transition rules (`self == oldSelf`, evaluated only on UPDATE) on the Keystone CRD's `spec.database.database`, the managed/brownfield mode (`clusterRef`↔`host`), `spec.bootstrap.adminUser`, and `spec.bootstrap.region`. CEL is enforced by the API server, so the protection holds even when the validating webhook is down — the issue's stated preference. Regenerates `keystone_types.go` markers, the controller-gen CRD base, and the Helm chart copy in lockstep. The c5c3 CRD is unchanged.

2. **`cb2dd715` test(keystone): cover CEL immutability of db/bootstrap fields**
   envtest integration tests pinning each transition rule. CEL-only (no-webhook) variants prove the rule rejects on its own — the Keystone webhook deliberately drops `oldObj` and never checks immutability, so the CRD rule is the sole gate — plus a webhook-enabled variant and a no-op-update test proving identity re-applies (and mutable-only changes) are still accepted.

3. **`b05d8f6b` feat(api): reject controlplane field change and release downgrade**
   The ControlPlane projects `spec.infrastructure.database.database` and `spec.region` verbatim into the now-immutable Keystone child fields, so without matching guards a rename would wedge the reconcile loop on a rejected update. Extends `validateImmutable` to reject database-name and region changes, and adds `validateReleaseNotDowngraded` — a monotonic-upgrade check that lexicographically compares the two regex-validated `YYYY.N` releases (equivalent to ordering the fixed-width `(year, minor)` tuples), rejecting a lower release while allowing upgrades and same-release no-ops. The ControlPlane CRD is unchanged.

4. **`c2332e93` test(e2e): add update-rejection fixtures for immutable keystone fields**
   Extends the invalid-cr generator (previously create-rejection only) with five update-rejection fixtures (13–17) under the shared name `immutable-fields`: 13 applies a valid brownfield base, 14–17 apply UPDATEs the CRD CEL rules reject (database name, database mode, `bootstrap.adminUser`, `bootstrap.region`). Bumps the generator's `Fixture` dataclass with a bootstrap override, the expected fixture count to 15, and the chainsaw suite step. Existing create-rejection fixtures are byte-for-byte unchanged.

5. **`def213a8` docs(api): document field immutability and release-downgrade rejection**
   Records the behavior in both CRD references: the four Keystone transition rules in the CEL Validation Rules table, immutability notes on the `DatabaseSpec`/`BootstrapSpec` descriptions, the extended invalid-cr table (fixtures 13–17, count 15), and corrects the stale note that claimed update-time immutability was unimplemented (cache mode remains the open gap). For ControlPlane: the database-name/region rows and the release-downgrade rule, plus updated `openStackRelease`/`region` descriptions.

## Divergence from the issue

The issue proposed CEL `oldSelf` markers for the immutable leaves on **both** keystone and ControlPlane. On the ControlPlane side these were instead implemented in the **webhook** (commit `b05d8f6b`): the affected leaves live in the shared `commonv1.DatabaseSpec` that the keystone operator also consumes, which must not carry c5c3-specific CEL markers — and this keeps the shared `InfrastructureSpec` clear of the XOR-marker work landing in #469. Net behavior matches the issue's intent (renames/region changes rejected on update; downgrades rejected); only the enforcement layer differs, and with a documented reason. The release-downgrade check lives in `ValidateUpdate` exactly as the issue requested.

## Verification

envtest integration tests (commit 2), webhook unit tests (commit 3, `controlplane_webhook_test.go` +90 / `reconcile_keystone_test.go` +59), and e2e chainsaw update-rejection fixtures (commit 4). CRD base and Helm copy regenerated together.

---

_Implemented by [planwerk-review](https://github.com/planwerk/planwerk-review) b245b5f with Claude:claude-opus-4-8_
