### PR TITLE
fix(c5c3-operator): gate K-ORC catalog/credential readiness on live availability

### DIFF
--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -484,7 +484,7 @@ the kind/name and applies it.
 | `updatePhase` | [`UpdatePhase`](#updatephase) | Current phase of a control-plane release update. Written on every status update; fixed at `Idle` in the current implementation because the release-update state machine is reserved (the other `UpdatePhase` values are not yet set). |
 | `services` | `map[string]ServiceStatus` | Per-service readiness of the projected service CRs, keyed by service name. Written on every status update with a `"keystone"` entry whose `ready` mirrors the `KeystoneReady` condition and whose `release` is `spec.openStackRelease`. See [ServiceStatus](#servicestatus). |
 | `adminApplicationCredential` | [`*AdminApplicationCredentialStatus`](#adminapplicationcredentialstatus) | Observed state of the K-ORC admin application credential. |
-| `catalogReady` | `bool` | Whether the OpenStack service catalog has been observed as fully populated for the control plane. Flipped `true` by the catalog sub-reconciler once the identity `Service` and `Endpoint` are registered. |
+| `catalogReady` | `bool` | Whether the OpenStack service catalog has been observed as fully populated for the control plane. Flipped `true` by the catalog sub-reconciler once the identity `Service` and `Endpoint` are registered **and observed `Available`**, and reset to `false` on any later degradation so it tracks the `CatalogReady` condition. |
 
 ### ServiceStatus
 
@@ -822,7 +822,13 @@ markers' documented values where a marker also exists.
 > these (see the [quick-start](../../quick-start-controlplane.md)). A missing
 > admin password Secret degrades to `KORCReady=False` / `WaitingForAdminPassword`,
 > and a not-yet-synced `clouds.yaml` to `AdminCredentialReady=False` /
-> `WaitingForCloudsYaml` — never a silent authentication.
+> `WaitingForCloudsYaml` — never a silent authentication. A `clouds.yaml` that is
+> synced but stale (a re-mint revoked the old credential while ESO has not yet
+> re-materialised the Secret) degrades to `AdminCredentialReady=False` /
+> `WaitingForCloudsYamlSync`: `reconcileAdminCredential` semantically compares the
+> materialised Secret (by parsed application-credential id+secret) against the
+> freshly assembled credential and forces an ESO re-sync, so the gate never passes
+> against a revoked credential.
 > `TestIntegration_MinimalManagedToReady` encodes this contract by pre-creating
 > those Secrets at the defaulted names.
 
@@ -904,35 +910,46 @@ Set by `reconcileKORC`.
 | --- | --- | --- |
 | `True` | `ApplicationCredentialMinted` | The K-ORC admin `ApplicationCredential` is minted and reports `Available=True`. |
 | `False` | `WaitingForAdminPassword` | The admin password Secret/key is not yet available; minting deferred. |
-| `False` | `WaitingForApplicationCredential` | The `ApplicationCredential` CR is ensured but not yet `Available`. |
+| `False` | `ApplicationCredentialFailed` | The `ApplicationCredential` reports a terminal K-ORC error (`GetTerminalError` — an unrecoverable/invalid-config reason such as K-ORC being unable to authenticate); the message folds in any stuck admin Domain/User import. |
+| `False` | `WaitingForApplicationCredential` | The `ApplicationCredential` CR is ensured but not yet `Available`; the message folds in any stuck admin Domain/User import. |
 | `False` | `AdminPasswordError` | Non-missing error reading the admin password. |
 | `False` | `ApplicationCredentialError` | Error create-or-updating the `ApplicationCredential` CR. |
 
 ### AdminCredentialReady
 
 Set by `reconcileAdminCredential` (gated on `KORCReady`, the OpenBao-backed
-`ClusterSecretStore` being Ready, **and** the K-ORC `clouds.yaml` ExternalSecret
-being Ready).
+`ClusterSecretStore` being Ready, the K-ORC `clouds.yaml` ExternalSecret being
+Ready, **and** the materialised `clouds.yaml` Secret semantically matching (parsed
+application-credential id+secret) the freshly assembled credential).
 
 | Status | Reason | When |
 | --- | --- | --- |
-| `True` | `AdminCredentialReady` | The admin application credential is committed to the owned Secret and mirrored to OpenBao. |
+| `True` | `AdminCredentialReady` | The admin application credential is committed to the owned Secret, mirrored to OpenBao, and the materialised `clouds.yaml` Secret matches the assembled credential. |
 | `False` | `WaitingForKORC` | `KORCReady` is not `True`; credential push deferred. |
 | `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `WaitingForCloudsYaml` | The operator-created per-ControlPlane `k-orc-clouds-yaml` ExternalSecret in the control-plane namespace (co-located with the K-ORC CRs per C1; created and owned by `reconcileKORC`) is not yet Ready. |
-| `False` | `CloudsYamlError` | Error checking the `clouds.yaml` ExternalSecret. |
+| `False` | `WaitingForCloudsYamlSync` | The materialised `k-orc-clouds-yaml` Secret is absent or still holds a stale credential (a re-mint revoked the old one but ESO has not re-synced yet). `reconcileAdminCredential` stamps the `external-secrets.io/force-sync` annotation to force an immediate re-sync and compares the materialised Secret semantically (parsed application-credential id+secret) against the assembled credential before reporting Ready, so the condition never reads `True` against a revoked credential. |
+| `False` | `CloudsYamlSyncStuck` | The materialised `k-orc-clouds-yaml` Secret has failed to match the assembled credential for longer than `cloudsYamlSyncStuckTimeout` (measured from the credential's `LastRotation`); the ESO ExternalSecret or OpenBao backend may be unable to sync. Escalated from `WaitingForCloudsYamlSync` so a never-converging sync is alertable and distinguishable from a transient miss. |
+| `False` | `CloudsYamlError` | Error checking the `clouds.yaml` ExternalSecret, forcing its re-sync, or reading the materialised Secret. |
 | `False` | `SecretError` | Error ensuring the operator-owned application-credential Secret. |
 | `False` | `PushSecretError` | Error ensuring the OpenBao PushSecret. |
 
 ### CatalogReady
 
-Set by `reconcileCatalog` (gated on `AdminCredentialReady`).
-Also flips `status.catalogReady` to `true`.
+Set by `reconcileCatalog` (gated on `AdminCredentialReady`, **and** both the
+identity `Service` and `Endpoint` reporting `Available` for their current
+generation — `korcAvailableUpToDate`, which refuses a stale `Available` condition
+whose `ObservedGeneration` lags the object, so an endpoint/region edit cannot flip
+`CatalogReady` True before K-ORC re-reconciles). Tracks `status.catalogReady`, which
+flips `true` only when both children are Available and is reset to `false` on every
+False branch.
 
 | Status | Reason | When |
 | --- | --- | --- |
-| `True` | `CatalogRegistered` | The Keystone identity `Service` and public `Endpoint` are registered as K-ORC CRs. |
+| `True` | `CatalogRegistered` | The Keystone identity `Service` and public `Endpoint` are registered as K-ORC CRs **and** both report `Available`. |
 | `False` | `WaitingForAdminCredential` | `AdminCredentialReady` is not `True`; catalog registration deferred. |
+| `False` | `WaitingForCatalog` | The identity `Service`/`Endpoint` are registered but not yet `Available` for the current generation (the catalog entries have not landed in Keystone, or a stale `Available` condition whose `ObservedGeneration` lags the object does not yet count). |
+| `False` | `CatalogFailed` | The identity `Service` or `Endpoint` reports a terminal K-ORC error (`GetTerminalError` — e.g. a wrong clouds.yaml endpoint or an import stuck on "created externally"). |
 | `False` | `ServiceError` | Error create-or-updating the identity `Service` CR. |
 | `False` | `EndpointError` | Error create-or-updating the identity `Endpoint` CR. |
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -303,8 +303,8 @@ and the informer cache to that namespace. Keep the default only when
 │           ▼                                                                  │
 │  ┌──────────────────────────┐                                                │
 │  │ reconcileCatalog         │  Register identity Service + public Endpoint   │
-│  │  (gate: AdminCredReady)  │  Sets: CatalogReady                            │
-│  └────────┬─────────────────┘  Requeue: 10s while gated / CRD missing        │
+│  │  (gate: AdminCredReady)  │  Sets: CatalogReady (Service+Endpoint Available)│
+│  └────────┬─────────────────┘  Requeue: 10s gated / not Available / terminal  │
 │           │                                                                  │
 │           ▼                                                                  │
 │  setReadyCondition()  — aggregate Ready = AllTrue(subConditionTypes)         │
@@ -657,8 +657,16 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | Re-mint stuck `Terminating` past `remintStallTimeout` (5m) | False | `ReMintStalled` | requeue 10s; finalizer cannot revoke the old credential |
 | AC create/update/delete/read fails otherwise | False | `ApplicationCredentialError` | returns the error |
 | `value` regeneration fails | False | `SecretError` | returns the error |
+| AC reports a terminal K-ORC error | False | `ApplicationCredentialFailed` | requeue 10s; gated on `orcv1alpha1.GetTerminalError(ac)` (an unrecoverable/invalid-config Progressing reason, e.g. K-ORC cannot authenticate with the clouds.yaml) so a credential that will never converge is not reported as an eternal wait |
 | AC not yet `Available` | False | `WaitingForApplicationCredential` | requeue 10s; gated on `orcv1alpha1.IsAvailable(ac)` (K-ORC uses `Available`, not `Ready`) |
 | AC minted and Available | True | `ApplicationCredentialMinted` | — |
+
+Both the `ApplicationCredentialFailed` and `WaitingForApplicationCredential`
+messages fold in the admin Domain/User import status (`ensureKORCAdminImports`
+returns the first import that is terminally failed or not yet Available), so the
+documented endpoint/clouds.yaml failure class — where K-ORC swallows a list error
+and an import hangs on "created externally" — names the stuck dependency instead of
+surfacing as an opaque wait.
 
 > **Hard CRD dependency.** K-ORC (like Memcached, ESO, MariaDB, and Keystone) is
 > a hard dependency: `SetupWithManager` `Owns`/`Watches` its kinds, so the
@@ -674,9 +682,9 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 | --- | --- |
 | File | `reconcile_korc.go` |
 | Condition | `AdminCredentialReady` |
-| Gate | `KORCReady == True`, the OpenBao-backed `ClusterSecretStore` is Ready, **and** the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready |
+| Gate | `KORCReady == True`, the OpenBao-backed `ClusterSecretStore` is Ready, the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready, **and** the materialised clouds.yaml Secret semantically matches (parsed application-credential id+secret) the freshly assembled credential |
 | Owns | the operator-owned `Secret` `{controlplane.Name}-admin-app-credential` and the `PushSecret` `{controlplane.Name}-admin-app-credential-backup`, both in `childNamespace(cp)` |
-| Requeue | `korcRequeueAfter` = **10s** while either gate is unmet |
+| Requeue | `korcRequeueAfter` = **10s** while any gate is unmet (including a stale/absent materialised clouds.yaml) |
 
 `reconcileAdminCredential` commits the minted credential and mirrors it to
 OpenBao:
@@ -705,26 +713,47 @@ OpenBao:
   the PushSecret on ControlPlane teardown (or when rotation is disabled) leaves the
   last-pushed credential intact in OpenBao at that CR's own path, so re-adoption
   works and the admin is never locked out.
+- **Live clouds.yaml gate (stale-credential window).** A re-mint revokes the old
+  credential immediately, but the `k-orc-clouds-yaml` Secret only refreshes from
+  OpenBao at the ExternalSecret's hourly `refreshInterval`, so the PushSecret-Ready
+  check above can pass while the materialised Secret K-ORC actually authenticates
+  with still holds the revoked credential. After assembling the clouds.yaml,
+  `reconcileAdminCredential` stamps the `external-secrets.io/force-sync` annotation
+  (keyed by the content hash; idempotent, so a steady-state pass does not churn the
+  ExternalSecret) to nudge ESO to re-materialise immediately, then **compares the
+  materialised Secret semantically** — by the parsed application-credential id and
+  secret, not byte-for-byte, so a benign ESO/OpenBao re-serialisation (a stripped
+  trailing newline, reordered keys, requoting) cannot wedge the gate permanently —
+  and only reports `AdminCredentialReady=True` when they match. The semantic
+  compare — not the best-effort force-sync — is the correctness guarantee: the
+  condition never reads True against a stale credential. A sync that never converges
+  is bounded: once the materialised Secret has failed to match for longer than
+  `cloudsYamlSyncStuckTimeout` (measured from the credential's `LastRotation`), the
+  reason escalates from the transient `WaitingForCloudsYamlSync` to the alertable
+  `CloudsYamlSyncStuck`, so a permanently broken sync is distinguishable from a
+  2-second transient miss.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | `KORCReady` not True | False | `WaitingForKORC` | requeue 10s |
 | ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; checked after the `KORCReady` gate so an OpenBao/ESO outage surfaces before the clouds.yaml wait |
-| clouds.yaml ES check errors | False | `CloudsYamlError` | returns the error |
+| clouds.yaml ES check errors | False | `CloudsYamlError` | returns the error (also covers a force-sync/materialised-Secret read error) |
 | clouds.yaml ES not Ready | False | `WaitingForCloudsYaml` | requeue 10s |
 | operator Secret ensure fails | False | `SecretError` | returns the error |
 | PushSecret ensure fails | False | `PushSecretError` | returns the error |
-| committed and mirrored | True | `AdminCredentialReady` | — |
+| materialised clouds.yaml absent or semantically stale | False | `WaitingForCloudsYamlSync` | requeue 10s; force-sync annotation stamped, semantic compare (parsed id+secret) against the assembled document not yet satisfied |
+| materialised clouds.yaml stuck stale past `cloudsYamlSyncStuckTimeout` | False | `CloudsYamlSyncStuck` | requeue 10s; the sync has not converged since `LastRotation` — alertable, distinguishable from a transient miss |
+| committed, mirrored, and materialised | True | `AdminCredentialReady` | — |
 
 ### reconcileCatalog
 
 | Aspect | Value |
 | --- | --- |
 | File | `reconcile_korc.go` |
-| Condition | `CatalogReady` (also sets `cp.Status.CatalogReady = true`) |
-| Gate | `AdminCredentialReady == True` |
+| Condition | `CatalogReady` (also tracks `cp.Status.CatalogReady`, reset to `false` on every False branch) |
+| Gate | `AdminCredentialReady == True`, **and** both the identity `Service` and `Endpoint` report `Available` |
 | Owns | a K-ORC identity `Service` (`{controlplane.Name}-identity-service`) and its public `Endpoint` (`{controlplane.Name}-identity-endpoint`) in `childNamespace(cp)` |
-| Requeue | `korcRequeueAfter` = **10s** while gated |
+| Requeue | `korcRequeueAfter` = **10s** while gated, while the children are not yet Available, or on a terminal K-ORC failure |
 
 `reconcileCatalog` registers the OpenStack service-catalog entries for Keystone
 as owned K-ORC CRs: an `identity`-type `Service` named
@@ -735,12 +764,27 @@ create-or-updates. K-ORC is a hard CRD dependency (see the note above), so a
 missing Service/Endpoint CRD never reaches this path and there is no
 CRD-not-installed condition.
 
+Registering the child CRs only instructs K-ORC to create the catalog entries — it
+does not mean they exist in Keystone — so `CatalogReady` is gated on both children
+reporting `Available` for their current generation (`korcAvailableUpToDate`, which
+refuses a stale `Available` condition whose `ObservedGeneration` lags the object —
+the same generation gate `GetTerminalError` already applies via its `Progressing`
+check — so an endpoint/region edit that moves the catalog URL cannot flip
+`CatalogReady` True before K-ORC re-reconciles the new value), and a terminal K-ORC
+failure (`GetTerminalError`, the documented wrong-endpoint / import-stuck class) is
+surfaced as the distinct `CatalogFailed` reason instead of a false-positive Ready.
+`cp.Status.CatalogReady` tracks the condition: it flips `true` only when both
+children are Available and is reset to `false` on every False branch, so a later
+degradation is never left stale-true.
+
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
-| `AdminCredentialReady` not True | False | `WaitingForAdminCredential` | requeue 10s |
-| Service create/update fails | False | `ServiceError` | returns the error |
-| Endpoint create/update fails | False | `EndpointError` | returns the error |
-| both registered | True | `CatalogRegistered` | also sets `status.catalogReady = true` |
+| `AdminCredentialReady` not True | False | `WaitingForAdminCredential` | requeue 10s; resets `status.catalogReady = false` |
+| Service create/update fails | False | `ServiceError` | returns the error; resets `status.catalogReady = false` |
+| Endpoint create/update fails | False | `EndpointError` | returns the error; resets `status.catalogReady = false` |
+| Service/Endpoint reports a terminal K-ORC error | False | `CatalogFailed` | requeue 10s; resets `status.catalogReady = false` |
+| Service/Endpoint registered but not yet Available | False | `WaitingForCatalog` | requeue 10s; resets `status.catalogReady = false` |
+| both registered and Available | True | `CatalogRegistered` | also sets `status.catalogReady = true` |
 
 ### CredentialRotation reconciler
 

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -392,6 +392,47 @@ func simulateCloudsYamlMaterializedWhenPresent(t testing.TB, ctx context.Context
 	}
 }
 
+// simulateCatalogServiceEndpointAvailableWhenPresent waits for the owned K-ORC
+// identity Service and Endpoint, then sets their Available condition True inline.
+// reconcileCatalog now gates CatalogReady on both child CRs reporting Available
+// (registering them is not enough — the catalog entry must actually land in
+// Keystone), and there is no K-ORC controller in envtest to mark them Available.
+func simulateCatalogServiceEndpointAvailableWhenPresent(t testing.TB, ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	ns := childNamespace(cp)
+
+	svc := &orcv1alpha1.Service{}
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: ns, Name: keystoneServiceName(cp)}, svc)
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "identity Service should be registered")
+	meta.SetStatusCondition(&svc.Status.Conditions, metav1.Condition{
+		Type:   orcv1alpha1.ConditionAvailable,
+		Status: metav1.ConditionTrue,
+		Reason: orcv1alpha1.ConditionReasonSuccess,
+		// reconcileCatalog gates on korcAvailableUpToDate, which requires the
+		// Available condition's ObservedGeneration to match the object's
+		// generation — mirror what the real K-ORC actuator stamps so the gate
+		// flips True (the in-cluster apiserver assigns Generation>=1 on create).
+		ObservedGeneration: svc.Generation,
+		Message:            "simulated available",
+	})
+	g.Expect(c.Status().Update(ctx, svc)).To(Succeed(), "set identity Service Available=True")
+
+	ep := &orcv1alpha1.Endpoint{}
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: ns, Name: keystoneEndpointName(cp)}, ep)
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "identity Endpoint should be registered")
+	meta.SetStatusCondition(&ep.Status.Conditions, metav1.Condition{
+		Type:               orcv1alpha1.ConditionAvailable,
+		Status:             metav1.ConditionTrue,
+		Reason:             orcv1alpha1.ConditionReasonSuccess,
+		ObservedGeneration: ep.Generation,
+		Message:            "simulated available",
+	})
+	g.Expect(c.Status().Update(ctx, ep)).To(Succeed(), "set identity Endpoint Available=True")
+}
+
 // simulateAdminPasswordExternalSecretSyncWhenPresent waits for the operator-created
 // per-ControlPlane admin-password ExternalSecret (named adminPasswordSecretName(cp)
 // in childNamespace(cp)), asserts it reads this CR's keystone-NAME-scoped OpenBao
@@ -536,7 +577,9 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	simulateCloudsYamlMaterializedWhenPresent(t, ctx, c, cp)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
 
-	// --- Phase 5: Catalog (Service + Endpoint). Not status-gated. ---
+	// --- Phase 5: Catalog (Service + Endpoint). Gated on both child CRs reporting
+	// Available, so simulate the K-ORC actuator marking them Available. ---
+	simulateCatalogServiceEndpointAvailableWhenPresent(t, ctx, c, cp)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeCatalogReady, metav1.ConditionTrue, itEventuallyTimeout)
 
 	// --- Aggregate: Ready=True. ---
@@ -727,8 +770,9 @@ func TestIntegration_MinimalManagedToReady(t *testing.T) {
 	driveControlPlaneToAdminCredentialReady(t, ctx, c, cp)
 
 	// --- Phase 5: Catalog. The minimal CR sets no gateway/publicEndpoint, so
-	// keystoneCatalogURL falls back to the in-cluster Service URL — CatalogReady
-	// still flips. ---
+	// keystoneCatalogURL falls back to the in-cluster Service URL. CatalogReady is
+	// gated on both child CRs reporting Available, so simulate the K-ORC actuator. ---
+	simulateCatalogServiceEndpointAvailableWhenPresent(t, ctx, c, cp)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeCatalogReady, metav1.ConditionTrue, itEventuallyTimeout)
 
 	// --- Aggregate: Ready=True. ---

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -16,6 +16,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -338,6 +339,59 @@ func simulatePushSecretSyncedWhenPresent(t testing.TB, ctx context.Context, c cl
 		"admin app-credential PushSecret should be created and synced")
 }
 
+// simulateCloudsYamlMaterializedWhenPresent performs the ESO round-trip envtest has
+// no controller for: it reads the operator-owned app-credential Secret the PushSecret
+// mirrors to OpenBao and writes its assembled clouds.yaml into the k-orc-clouds-yaml
+// Secret K-ORC authenticates with. reconcileAdminCredential now byte-compares the
+// materialized Secret against the freshly assembled clouds.yaml before flipping
+// AdminCredentialReady True (closing the post-re-mint stale-credential window), so
+// without this materialisation the gate would wait forever.
+func simulateCloudsYamlMaterializedWhenPresent(t testing.TB, ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	name := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
+	if name == "" {
+		name = korcCloudsYamlSecretName
+	}
+
+	// Wait for the operator-owned Secret to hold the MINTED application-credential
+	// clouds.yaml, not the password-based bootstrap seed: reconcileKORC creates the
+	// PushSecret (and seeds the password clouds.yaml) before reconcileAdminCredential
+	// overwrites it with the app-credential document, so copying too early would
+	// materialise the wrong bytes and the byte-compare gate would never match.
+	src := &corev1.Secret{}
+	g.Eventually(func() error {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: childNamespace(cp), Name: adminAppCredentialSecretName(cp)}, src); err != nil {
+			return err
+		}
+		if !strings.Contains(string(src.Data[appCredCloudsYAMLKey]), "application_credential_id") {
+			return fmt.Errorf("operator-owned Secret still holds the password seed, not the minted app-credential clouds.yaml")
+		}
+		return nil
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(),
+		"operator must assemble the app-credential clouds.yaml before ESO can materialise it back")
+
+	materialized := &corev1.Secret{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: childNamespace(cp), Name: name}, materialized)
+	switch {
+	case apierrors.IsNotFound(err):
+		materialized = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)},
+			Data:       map[string][]byte{appCredCloudsYAMLKey: src.Data[appCredCloudsYAMLKey]},
+		}
+		g.Expect(c.Create(ctx, materialized)).To(Succeed(), "materialize the k-orc clouds.yaml Secret")
+	case err == nil:
+		if materialized.Data == nil {
+			materialized.Data = map[string][]byte{}
+		}
+		materialized.Data[appCredCloudsYAMLKey] = src.Data[appCredCloudsYAMLKey]
+		g.Expect(c.Update(ctx, materialized)).To(Succeed(), "refresh the materialized k-orc clouds.yaml Secret")
+	default:
+		g.Expect(err).NotTo(HaveOccurred(), "get materialized k-orc clouds.yaml Secret")
+	}
+}
+
 // simulateAdminPasswordExternalSecretSyncWhenPresent waits for the operator-created
 // per-ControlPlane admin-password ExternalSecret (named adminPasswordSecretName(cp)
 // in childNamespace(cp)), asserts it reads this CR's keystone-NAME-scoped OpenBao
@@ -473,11 +527,13 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 		To(Succeed(), "simulate k-orc clouds.yaml ExternalSecret sync")
 
 	// --- Phase 4: AdminCredential push. Gated on the clouds.yaml ES (synced
-	// above) AND on the admin app-credential PushSecret syncing to OpenBao
-	// The latter is status-gated, so simulate the ESO sync —
-	// otherwise AdminCredentialReady never flips in envtest. ---
+	// above), on the admin app-credential PushSecret syncing to OpenBao, AND on the
+	// materialized k-orc-clouds-yaml Secret matching the assembled credential. The
+	// PushSecret sync is status-gated and the materialisation is the ESO round-trip,
+	// so simulate both — otherwise AdminCredentialReady never flips in envtest. ---
 	simulatePushSecretSyncedWhenPresent(t, ctx, c,
 		client.ObjectKey{Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp)})
+	simulateCloudsYamlMaterializedWhenPresent(t, ctx, c, cp)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
 
 	// --- Phase 5: Catalog (Service + Endpoint). Not status-gated. ---
@@ -979,10 +1035,13 @@ func driveControlPlaneToAdminCredentialReady(
 		client.ObjectKey{Namespace: ns, Name: korcCloudsYamlSecretName})).
 		To(Succeed(), "simulate k-orc clouds.yaml ExternalSecret sync")
 
-	// --- Phase 4: AdminCredential push (gated on the synced clouds.yaml ES and the
-	// admin app-credential PushSecret syncing to OpenBao). ---
+	// --- Phase 4: AdminCredential push (gated on the synced clouds.yaml ES, the
+	// admin app-credential PushSecret syncing to OpenBao, AND the materialized
+	// k-orc-clouds-yaml Secret matching the assembled credential — the byte-compare
+	// gate that closes the post-re-mint stale-credential window). ---
 	simulatePushSecretSyncedWhenPresent(t, ctx, c,
 		client.ObjectKey{Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp)})
+	simulateCloudsYamlMaterializedWhenPresent(t, ctx, c, cp)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
 }
 

--- a/operators/c5c3/internal/controller/korc_imports.go
+++ b/operators/c5c3/internal/controller/korc_imports.go
@@ -50,7 +50,14 @@ func adminDomainRef(cp *c5c3v1alpha1.ControlPlane) string {
 // must import — not create — it, otherwise the ApplicationCredential blocks on
 // "Waiting for User/admin to be created". Both CRs are owned by the ControlPlane
 // for GC and reuse the admin clouds.yaml credentials.
-func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) error {
+//
+// It returns a human-readable import-status fragment (empty when both imports are
+// Available with no terminal error) so reconcileKORC can fold the stuck dependency
+// into the KORCReady message — the documented failure class (wrong clouds.yaml
+// endpoint, K-ORC swallowing list errors, an import hanging on "created
+// externally") otherwise surfaces only as an eternal "WaitingForApplicationCredential"
+// with no pointer to the real cause.
+func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) (string, error) {
 	domain := &orcv1alpha1.Domain{
 		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
 	}
@@ -62,7 +69,7 @@ func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp 
 		}
 		return controllerutil.SetControllerReference(cp, domain, r.Scheme)
 	}); err != nil {
-		return fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
+		return "", fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
 	}
 
 	user := &orcv1alpha1.User{
@@ -79,7 +86,26 @@ func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp 
 		}
 		return controllerutil.SetControllerReference(cp, user, r.Scheme)
 	}); err != nil {
-		return fmt.Errorf("admin User import %q: %w", user.Name, err)
+		return "", fmt.Errorf("admin User import %q: %w", user.Name, err)
 	}
-	return nil
+	// Report the first admin import (Domain before User) that is not yet usable —
+	// either a terminal K-ORC error or a not-yet-Available state — or an empty
+	// string when both imports are Available with no terminal error.
+	if frag := korcImportStatusFragment("Domain", domain.Name, domain); frag != "" {
+		return frag, nil
+	}
+	return korcImportStatusFragment("User", user.Name, user), nil
+}
+
+// korcImportStatusFragment reports the import-status fragment for a single K-ORC
+// import resource: a terminal error takes precedence over a not-yet-Available
+// state, and an Available resource with no terminal error yields an empty string.
+func korcImportStatusFragment(kind, name string, obj orcv1alpha1.ObjectWithConditions) string {
+	if termErr := orcv1alpha1.GetTerminalError(obj); termErr != nil {
+		return fmt.Sprintf("admin %s import %q failed terminally: %v", kind, name, termErr)
+	}
+	if !orcv1alpha1.IsAvailable(obj) {
+		return fmt.Sprintf("admin %s import %q is not yet Available", kind, name)
+	}
+	return ""
 }

--- a/operators/c5c3/internal/controller/reconcile_admincredential.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential.go
@@ -7,15 +7,21 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"time"
 
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/secrets"
@@ -173,6 +179,71 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
+	// Close the post-re-mint stale-credential window. A re-mint revokes the old
+	// Keystone credential immediately, but the k-orc-clouds-yaml Secret only
+	// refreshes from OpenBao at the ExternalSecret's hourly refreshInterval, so the
+	// PushSecret-Ready gate above can pass while the materialized Secret K-ORC
+	// actually authenticates with still holds the revoked credential — up to ~2h of
+	// auth against a dead credential while AdminCredentialReady reads True.
+	//
+	// Force an immediate ESO re-sync (a force-sync annotation keyed by the assembled
+	// content hash — idempotent, so a steady-state pass does not churn the
+	// ExternalSecret) and gate AdminCredentialReady on the materialized Secret bytes
+	// actually matching the freshly assembled clouds.yaml. The byte-compare — not the
+	// best-effort force-sync — is the correctness guarantee: it never reports Ready
+	// while the materialized credential is stale.
+	contentSum := sha256.Sum256(cloudsYAML)
+	contentHash := hex.EncodeToString(contentSum[:])
+	if err := r.forceSyncKORCCloudsYAMLExternalSecret(ctx, cp, cloudsYamlName, contentHash); err != nil {
+		fail("CloudsYamlError", fmt.Sprintf("forcing k-orc clouds.yaml ExternalSecret re-sync: %v", err))
+		return ctrl.Result{}, err
+	}
+
+	materialized := &corev1.Secret{}
+	matKey := types.NamespacedName{Namespace: childNamespace(cp), Name: cloudsYamlName}
+	if err := r.Get(ctx, matKey, materialized); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("materialized k-orc clouds.yaml Secret not present yet, requeuing")
+			fail("WaitingForCloudsYamlSync",
+				"k-orc clouds.yaml Secret has not yet materialized the assembled application credential")
+			return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+		}
+		fail("CloudsYamlError", fmt.Sprintf("reading materialized k-orc clouds.yaml Secret: %v", err))
+		return ctrl.Result{}, err
+	}
+	// Compare SEMANTICALLY, not byte-for-byte: a bare bytes.Equal would pin
+	// AdminCredentialReady at False forever if ESO/OpenBao ever re-serialised the
+	// value once (a stripped trailing newline, reordered keys, changed quoting),
+	// even though K-ORC parses the YAML and the credential is functionally
+	// identical. Comparing the parsed application-credential id+secret keeps the
+	// stale-credential guarantee (a revoked credential never reads Ready) without a
+	// brittle byte gate that a benign normalisation could wedge permanently.
+	if !sameAppCredIdentity(materialized.Data[appCredCloudsYAMLKey], cloudsYAML) {
+		// Bound the wait so a never-converging sync is distinguishable from a
+		// 2-second transient miss. LastRotation marks when the current credential id
+		// was (re-)minted, so a materialised Secret that still does not carry it
+		// after cloudsYamlSyncStuckTimeout means ESO/OpenBao is not going to agree on
+		// its own; escalate from the transient WaitingForCloudsYamlSync to the
+		// alertable CloudsYamlSyncStuck so on-call gets a terminal, bounded signal.
+		reason := "WaitingForCloudsYamlSync"
+		message := "materialized k-orc clouds.yaml does not yet match the assembled application credential; awaiting ESO re-sync"
+		var rotatedAt *metav1.Time
+		if cp.Status.AdminApplicationCredential != nil {
+			rotatedAt = cp.Status.AdminApplicationCredential.LastRotation
+		}
+		if rotatedAt != nil && time.Since(rotatedAt.Time) > cloudsYamlSyncStuckTimeout {
+			reason = "CloudsYamlSyncStuck"
+			message = fmt.Sprintf("materialized k-orc clouds.yaml has not matched the assembled application credential "+
+				"for over %s; the ESO ExternalSecret or OpenBao backend may be unable to sync — manual intervention required",
+				cloudsYamlSyncStuckTimeout)
+			logger.Info("materialized k-orc clouds.yaml sync is stuck", "rotatedAt", rotatedAt.Time, "timeout", cloudsYamlSyncStuckTimeout)
+		} else {
+			logger.Info("materialized k-orc clouds.yaml is stale, requeuing for ESO re-sync")
+		}
+		fail(reason, message)
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
 	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 		Type:               conditionTypeAdminCredentialReady,
 		Status:             metav1.ConditionTrue,
@@ -192,4 +263,96 @@ func pushSecretReady(ps *esov1alpha1.PushSecret) bool {
 		}
 	}
 	return false
+}
+
+// appCredIdentity is the credential-identifying subset of an assembled
+// app-credential clouds.yaml: the application credential id and secret. The
+// materialized (ESO) and freshly-assembled documents are compared on these parsed
+// fields rather than byte-for-byte (see reconcileAdminCredential).
+type appCredIdentity struct {
+	id     string
+	secret string
+}
+
+// sameAppCredIdentity reports whether two assembled app-credential clouds.yaml
+// documents carry the same application-credential id and secret. A parse failure
+// or a missing id/secret on either side is treated as NOT matching, so the
+// stale-credential gate never reports a credential fresh against malformed,
+// empty, or password-based (non-app-credential) input.
+func sameAppCredIdentity(materialized, assembled []byte) bool {
+	m, mok := parseAppCredIdentity(materialized)
+	a, aok := parseAppCredIdentity(assembled)
+	if !mok || !aok {
+		return false
+	}
+	return m.id == a.id && m.secret == a.secret
+}
+
+// parseAppCredIdentity extracts the application-credential id and secret from the
+// single cloud entry of an assembled clouds.yaml. ok is false when the document
+// does not parse or no cloud carries both an id and a secret (e.g. a password-based
+// bootstrap document), so callers treat such input as a non-match.
+func parseAppCredIdentity(cloudsYAML []byte) (appCredIdentity, bool) {
+	if len(cloudsYAML) == 0 {
+		return appCredIdentity{}, false
+	}
+	var doc struct {
+		Clouds map[string]struct {
+			Auth struct {
+				ApplicationCredentialID     string `json:"application_credential_id"`
+				ApplicationCredentialSecret string `json:"application_credential_secret"`
+			} `json:"auth"`
+		} `json:"clouds"`
+	}
+	if err := yaml.Unmarshal(cloudsYAML, &doc); err != nil {
+		return appCredIdentity{}, false
+	}
+	for _, cloud := range doc.Clouds {
+		if cloud.Auth.ApplicationCredentialID != "" && cloud.Auth.ApplicationCredentialSecret != "" {
+			return appCredIdentity{id: cloud.Auth.ApplicationCredentialID, secret: cloud.Auth.ApplicationCredentialSecret}, true
+		}
+	}
+	return appCredIdentity{}, false
+}
+
+// forceSyncKORCCloudsYAMLExternalSecret nudges ESO to re-materialise the K-ORC
+// clouds.yaml Secret immediately rather than at the next hourly refresh, by
+// stamping the external-secrets.io/force-sync annotation with the content hash of
+// the freshly assembled clouds.yaml. ESO folds the ExternalSecret's annotations
+// into its sync-decision hash, so a changed value forces a re-sync; an unchanged
+// value is a no-op, so a steady-state pass does not churn the ExternalSecret.
+//
+// A missing ExternalSecret is treated as a no-op nil — reconcileKORC owns its
+// creation (ensureKORCCloudsYAMLExternalSecret), and the byte-compare gate in
+// reconcileAdminCredential, not this nudge, is what guarantees the materialized
+// credential is fresh before AdminCredentialReady flips True.
+func (r *ControlPlaneReconciler) forceSyncKORCCloudsYAMLExternalSecret(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, name, hash string) error {
+	key := types.NamespacedName{Namespace: childNamespace(cp), Name: name}
+	// Read-modify-write the force-sync annotation under RetryOnConflict: ESO mutates
+	// this ExternalSecret's status and its own annotations on every refresh (and on
+	// the force-sync it triggers), so a 409 Conflict between our Get and Update is
+	// expected concurrency — NOT a clouds.yaml fault. Re-reading and retrying keeps a
+	// transient conflict from flipping AdminCredentialReady to False/CloudsYamlError
+	// (and incrementing the sub-reconciler error counter) for what self-heals on the
+	// very next attempt.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		es := &esov1.ExternalSecret{}
+		if err := r.Get(ctx, key, es); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if es.Annotations[esov1.AnnotationForceSync] == hash {
+			return nil
+		}
+		if es.Annotations == nil {
+			es.Annotations = map[string]string{}
+		}
+		es.Annotations[esov1.AnnotationForceSync] = hash
+		return r.Update(ctx, es)
+	}); err != nil {
+		return fmt.Errorf("forcing k-orc clouds.yaml ExternalSecret %q re-sync: %w", name, err)
+	}
+	return nil
 }

--- a/operators/c5c3/internal/controller/reconcile_catalog.go
+++ b/operators/c5c3/internal/controller/reconcile_catalog.go
@@ -36,6 +36,7 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 	// Gate on AdminCredentialReady.
 	if !conditions.AllTrue(cp.Status.Conditions, conditionTypeAdminCredentialReady) {
 		logger.Info("AdminCredential not ready, deferring catalog registration")
+		cp.Status.CatalogReady = false
 		fail("WaitingForAdminCredential", "AdminCredentialReady is not True; catalog registration deferred")
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
@@ -70,6 +71,7 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		service.Spec.Resource.Enabled = ptr.To(true)
 		return controllerutil.SetControllerReference(cp, service, r.Scheme)
 	}); err != nil {
+		cp.Status.CatalogReady = false
 		fail("ServiceError", fmt.Sprintf("create-or-update identity Service: %v", err))
 		return ctrl.Result{}, err
 	}
@@ -100,8 +102,30 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		endpoint.Spec.Resource.Enabled = ptr.To(true)
 		return controllerutil.SetControllerReference(cp, endpoint, r.Scheme)
 	}); err != nil {
+		cp.Status.CatalogReady = false
 		fail("EndpointError", fmt.Sprintf("create-or-update identity Endpoint: %v", err))
 		return ctrl.Result{}, err
+	}
+
+	// Gate CatalogReady on BOTH child CRs reporting Available, and surface a TERMINAL
+	// K-ORC failure distinctly: registering the Service/Endpoint CRs only instructs
+	// K-ORC to create the catalog entries — it does not mean the entries exist in
+	// Keystone. The documented failure class (wrong clouds.yaml endpoint, K-ORC
+	// swallowing list errors, an import hung on "created externally") otherwise lets
+	// CatalogReady (and the aggregate Ready) report True while the catalog is empty.
+	// status.CatalogReady tracks the condition, so it is reset on every False branch
+	// rather than left stale-true after a later degradation.
+	if termErr := orcv1alpha1.GetTerminalError(service); termErr != nil {
+		return r.catalogTerminalError(cp, "identity Service", service.Name, termErr), nil
+	}
+	if termErr := orcv1alpha1.GetTerminalError(endpoint); termErr != nil {
+		return r.catalogTerminalError(cp, "identity Endpoint", endpoint.Name, termErr), nil
+	}
+	if !korcAvailableUpToDate(service) || !korcAvailableUpToDate(endpoint) {
+		logger.Info("catalog Service/Endpoint not yet Available, requeuing")
+		cp.Status.CatalogReady = false
+		fail("WaitingForCatalog", "Keystone identity Service and Endpoint are registered but not yet Available")
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
 	cp.Status.CatalogReady = true
@@ -110,9 +134,43 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: cp.Generation,
 		Reason:             "CatalogRegistered",
-		Message:            "Keystone identity Service and Endpoint are registered",
+		Message:            "Keystone identity Service and Endpoint are registered and Available",
 	})
 	return ctrl.Result{}, nil
+}
+
+// catalogTerminalError records a terminal K-ORC catalog failure: it resets the
+// status bool and sets CatalogReady=False/CatalogFailed naming the failing child
+// CR. It requeues so a fixed configuration (e.g. a corrected clouds.yaml) is
+// re-evaluated rather than leaving the catalog wedged.
+func (r *ControlPlaneReconciler) catalogTerminalError(cp *c5c3v1alpha1.ControlPlane, kind, name string, termErr error) ctrl.Result {
+	cp.Status.CatalogReady = false
+	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeCatalogReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: cp.Generation,
+		Reason:             "CatalogFailed",
+		Message:            fmt.Sprintf("K-ORC reported a terminal error registering the %s %q: %v", kind, name, termErr),
+	})
+	return ctrl.Result{RequeueAfter: korcRequeueAfter}
+}
+
+// korcAvailableUpToDate reports whether a K-ORC resource is Available for its
+// CURRENT generation: the Available condition exists, is True, AND its
+// ObservedGeneration matches the object's generation. Unlike orcv1alpha1.IsAvailable
+// — which is generation-blind — it refuses to treat a stale Available condition
+// (left over from before a spec edit, e.g. a changed publicEndpoint/region that
+// moved keystoneCatalogURL, that K-ORC has not yet re-reconciled) as a live result.
+// This mirrors the generation gate orcv1alpha1.GetTerminalError already applies via
+// its Progressing check, so a gate cannot flip True advertising a value K-ORC has
+// not yet applied.
+func korcAvailableUpToDate(obj orcv1alpha1.ObjectWithConditions) bool {
+	for _, c := range obj.GetConditions() {
+		if c.Type == orcv1alpha1.ConditionAvailable {
+			return c.Status == metav1.ConditionTrue && c.ObservedGeneration == obj.GetGeneration()
+		}
+	}
+	return false
 }
 
 // keystoneServiceName / keystoneEndpointName return the deterministic names of

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -147,7 +147,8 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// Default domain, so import it (and its domain) as UNMANAGED K-ORC resources
 	// before minting — otherwise the AC blocks forever on "Waiting for User/admin
 	// to be created".
-	if err := r.ensureKORCAdminImports(ctx, cp, importCredRef); err != nil {
+	importMsg, err := r.ensureKORCAdminImports(ctx, cp, importCredRef)
+	if err != nil {
 		fail("AdminImportError", fmt.Sprintf("ensuring K-ORC admin User/Domain imports: %v", err))
 		return ctrl.Result{}, err
 	}
@@ -261,12 +262,35 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// value while status is empty). LastRotation is stamped on a fresh mint/re-mint.
 	r.updateAdminApplicationCredentialStatus(cp, ac, restricted)
 
+	// Surface a TERMINAL K-ORC failure distinctly: GetTerminalError is non-nil only
+	// when the AC's Progressing condition reports an unrecoverable/invalid-config
+	// reason (e.g. K-ORC cannot authenticate with the clouds.yaml). Without this the
+	// AC would report KORCReady=False/WaitingForApplicationCredential forever even
+	// though it will never converge — keeping on-call MTTR high. Fold the admin
+	// Domain/User import status into the message so the stuck dependency is named.
+	if termErr := orcv1alpha1.GetTerminalError(ac); termErr != nil {
+		logger.Info("ApplicationCredential reported a terminal error", "name", ac.Name, "error", termErr)
+		message := fmt.Sprintf("ApplicationCredential %q failed terminally: %v", ac.Name, termErr)
+		if importMsg != "" {
+			message += "; " + importMsg
+		}
+		fail("ApplicationCredentialFailed", message)
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+	}
+
 	// Gate KORCReady on the AC CR reporting Available=True. K-ORC uses the
 	// "Available" condition (not "Ready") to signal a usable resource; while it
-	// converges, requeue with KORCReady=False.
+	// converges, requeue with KORCReady=False. Fold the admin Domain/User import
+	// status into the message so an import stuck on "created externally" (the
+	// documented endpoint/clouds.yaml failure class) points at the real dependency
+	// instead of an opaque eternal wait.
 	if !orcv1alpha1.IsAvailable(ac) {
 		logger.Info("ApplicationCredential not yet Available, requeuing", "name", ac.Name)
-		fail("WaitingForApplicationCredential", fmt.Sprintf("ApplicationCredential %q is not yet Available", ac.Name))
+		message := fmt.Sprintf("ApplicationCredential %q is not yet Available", ac.Name)
+		if importMsg != "" {
+			message += "; " + importMsg
+		}
+		fail("WaitingForApplicationCredential", message)
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"testing"
 	"time"
 
@@ -659,8 +660,12 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	cp := korcControlPlane()
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	// The materialized k-orc-clouds-yaml Secret carries the assembled credential the
+	// byte-compare gate checks against (id "test-ac-id", value "generated-app-cred-secret"
+	// from mintedAppCredSecret), so AdminCredentialReady can flip True.
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp),
+			materializedCloudsYamlSecret(cp, "test-ac-id", "generated-app-cred-secret")).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -669,6 +674,16 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+	// The clouds.yaml ExternalSecret carries the force-sync annotation keyed by the
+	// assembled content hash, so ESO re-materialises immediately rather than at the
+	// hourly refresh (closing the stale-credential window after a re-mint).
+	sum := sha256.Sum256([]byte(buildAppCredCloudsYAML(cp, "test-ac-id", "generated-app-cred-secret")))
+	es := &esov1.ExternalSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
+	}, es)).To(Succeed())
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:])))
 
 	// PushSecret created with the right store + remote path.
 	ps := &esov1alpha1.PushSecret{}
@@ -691,6 +706,187 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g.Expect(sec.Data).To(HaveKey("clouds.yaml"))
 	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("application_credential_id"))
 	g.Expect(string(sec.Data["clouds.yaml"])).To(ContainSubstring("test-ac-id"))
+}
+
+// TestReconcileAdminCredential_DefersUntilCloudsYamlMaterialized asserts the
+// stale-credential gate: every other gate (KORCReady, ClusterSecretStore,
+// clouds.yaml ES Ready, PushSecret synced) is satisfied, but the materialized
+// k-orc-clouds-yaml Secret is absent, so AdminCredentialReady must stay False with
+// WaitingForCloudsYamlSync rather than report Ready against a credential K-ORC
+// cannot yet read. The force-sync annotation must still be stamped so the next ESO
+// sync materialises the fresh credential.
+func TestReconcileAdminCredential_DefersUntilCloudsYamlMaterialized(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForCloudsYamlSync"))
+
+	sum := sha256.Sum256([]byte(buildAppCredCloudsYAML(cp, "test-ac-id", "generated-app-cred-secret")))
+	es := &esov1.ExternalSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
+	}, es)).To(Succeed())
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:])),
+		"a deferred sync must still stamp the force-sync annotation so ESO re-materialises")
+}
+
+// TestReconcileAdminCredential_SemanticMatchToleratesNormalizedCloudsYaml asserts
+// the stale gate is SEMANTIC, not byte-strict: a materialized clouds.yaml that
+// ESO/OpenBao re-serialised (reordered keys, requoted, stripped a trailing newline)
+// is byte-different from the freshly assembled document but carries the SAME
+// application credential, so AdminCredentialReady must flip True. A byte-strict gate
+// would pin it at False forever.
+func TestReconcileAdminCredential_SemanticMatchToleratesNormalizedCloudsYaml(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+
+	// Round-trip the assembled clouds.yaml through YAML to simulate an ESO/OpenBao
+	// re-serialisation: byte-different, semantically identical.
+	assembled := []byte(buildAppCredCloudsYAML(cp, "test-ac-id", "generated-app-cred-secret"))
+	var generic map[string]interface{}
+	g.Expect(yaml.Unmarshal(assembled, &generic)).To(Succeed())
+	reserialized, err := yaml.Marshal(generic)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reserialized).NotTo(Equal(assembled),
+		"the round-trip must be byte-different to actually exercise the semantic gate")
+
+	matSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp)},
+		Data:       map[string][]byte{appCredCloudsYAMLKey: reserialized},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp), matSecret).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err = r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue),
+		"a semantically-identical but byte-different materialized clouds.yaml must satisfy the gate")
+}
+
+// TestReconcileAdminCredential_StuckCloudsYamlSyncEscalates asserts the bounded
+// escalation: a materialized clouds.yaml that still carries the OLD (revoked)
+// credential long after the current one was minted (LastRotation past
+// cloudsYamlSyncStuckTimeout) is a never-converging sync, so AdminCredentialReady
+// escalates from the transient WaitingForCloudsYamlSync to the alertable
+// CloudsYamlSyncStuck reason — not an eternal, transient-looking wait.
+func TestReconcileAdminCredential_StuckCloudsYamlSyncEscalates(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	rotatedLongAgo := metav1.NewTime(metav1.Now().Add(-2 * cloudsYamlSyncStuckTimeout))
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{
+		ID: "new-ac-id", LastRotation: &rotatedLongAgo,
+	}
+	// Materialized Secret still holds the OLD credential id — ESO has not (and will
+	// not) re-sync.
+	staleMat := materializedCloudsYamlSecret(cp, "old-revoked-id", "generated-app-cred-secret")
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp), staleMat).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("CloudsYamlSyncStuck"),
+		"a never-converging materialized clouds.yaml past the timeout must escalate to an alertable reason")
+}
+
+// TestReconcileAdminCredential_RecentStaleStaysTransient asserts the escalation is
+// time-bounded, not always-on: a freshly stale materialized clouds.yaml (the current
+// credential was just minted, LastRotation within the timeout) stays on the transient
+// WaitingForCloudsYamlSync reason so a normal ESO sync lag is not mis-reported as stuck.
+func TestReconcileAdminCredential_RecentStaleStaysTransient(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	justRotated := metav1.Now()
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{
+		ID: "new-ac-id", LastRotation: &justRotated,
+	}
+	staleMat := materializedCloudsYamlSecret(cp, "old-revoked-id", "generated-app-cred-secret")
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp), staleMat).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForCloudsYamlSync"),
+		"a freshly stale materialized clouds.yaml within the timeout must stay on the transient reason")
+}
+
+// TestForceSyncKORCCloudsYAMLExternalSecret_RetriesOnConflict asserts that a 409
+// Conflict on the force-sync annotation Update (expected concurrency — ESO mutates
+// the ExternalSecret on every refresh) is retried, not surfaced as a hard error that
+// would flip AdminCredentialReady to False/CloudsYamlError and flap the aggregate.
+func TestForceSyncKORCCloudsYAMLExternalSecret_RetriesOnConflict(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	es := &esov1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp)},
+	}
+	conflicts := 0
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(es).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*esov1.ExternalSecret); ok && conflicts == 0 {
+					conflicts++
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "external-secrets.io", Resource: "externalsecrets"},
+						korcCloudsYamlSecretName, errors.New("the object has been modified"),
+					)
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	err := r.forceSyncKORCCloudsYAMLExternalSecret(context.Background(), cp, korcCloudsYamlSecretName, "hash-1")
+	g.Expect(err).NotTo(HaveOccurred(), "an expected 409 conflict must be retried, not surfaced as a hard error")
+	g.Expect(conflicts).To(Equal(1), "the first Update must have conflicted and been retried")
+
+	got := &esov1.ExternalSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
+	}, got)).To(Succeed())
+	g.Expect(got.Annotations[esov1.AnnotationForceSync]).To(Equal("hash-1"),
+		"the force-sync annotation must be stamped on the retry that succeeds")
 }
 
 // TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName locks in the per-CR
@@ -751,7 +947,8 @@ func TestReconcileAdminCredential_PushSecretClobberSafeNoChurn(t *testing.T) {
 	setKORCReady(cp)
 	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp)).Build()
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), readyAppCredPushSecret(cp),
+			materializedCloudsYamlSecret(cp, "test-ac-id", "generated-app-cred-secret")).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileAdminCredential(context.Background(), cp)
@@ -1308,6 +1505,25 @@ func readyCloudsYamlES(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
 			Conditions: []esov1.ExternalSecretStatusCondition{
 				{Type: esov1.ExternalSecretReady, Status: corev1.ConditionTrue},
 			},
+		},
+	}
+}
+
+// materializedCloudsYamlSecret returns the plain Secret ESO materialises from
+// OpenBao under the spec's CloudCredentialsRef.SecretName — the k-orc-clouds-yaml
+// Secret K-ORC authenticates with — carrying the assembled app-credential
+// clouds.yaml the AdminCredentialReady byte-compare gate checks against. acID and
+// value must match cp.Status.AdminApplicationCredential.ID and the operator-owned
+// Secret's "value" so the bytes equal what reconcileAdminCredential re-assembles.
+func materializedCloudsYamlSecret(cp *c5c3v1alpha1.ControlPlane, acID, value string) *corev1.Secret {
+	name := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
+	if name == "" {
+		name = korcCloudsYamlSecretName
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)},
+		Data: map[string][]byte{
+			appCredCloudsYAMLKey: []byte(buildAppCredCloudsYAML(cp, acID, value)),
 		},
 	}
 }

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -303,6 +303,94 @@ func TestReconcileKORC_KORCReadyFalseWhileACNotAvailable(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"))
 }
 
+// TestReconcileKORC_ApplicationCredentialFailedOnTerminalError asserts that a
+// terminal K-ORC failure on the AC (the documented "K-ORC cannot authenticate /
+// invalid clouds.yaml" class, reported via an unrecoverable Progressing reason) is
+// surfaced as the distinct KORCReady=False/ApplicationCredentialFailed reason —
+// not the eternal WaitingForApplicationCredential — so on-call sees the credential
+// will never converge without intervention.
+func TestReconcileKORC_ApplicationCredentialFailedOnTerminalError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	// AC stamped with the CURRENT hash (so no re-mint) but reporting a terminal
+	// Progressing reason. ObservedGeneration matches the object Generation (both 0
+	// under the fake client) so GetTerminalError treats it as up to date.
+	existing := &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+		},
+		Status: orcv1alpha1.ApplicationCredentialStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionProgressing,
+				Status:             metav1.ConditionFalse,
+				Reason:             orcv1alpha1.ConditionReasonUnrecoverableError,
+				Message:            "cannot authenticate with clouds.yaml",
+				ObservedGeneration: 0,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret(), existing).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("ApplicationCredentialFailed"))
+	g.Expect(cond.Message).To(ContainSubstring("cannot authenticate with clouds.yaml"))
+}
+
+// TestReconcileKORC_FoldsImportStatusIntoMessage asserts that a not-yet-Available
+// admin import is named in the KORCReady=False/WaitingForApplicationCredential
+// message, so the documented "import hangs on created externally" failure points
+// at the stuck dependency rather than producing an opaque eternal wait.
+func TestReconcileKORC_FoldsImportStatusIntoMessage(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	// Domain import Available, User import NOT Available, so korcImportStatusFragment
+	// reports the User as the stuck dependency. No AC is seeded, so it is created
+	// fresh (not Available) and the WaitingForApplicationCredential branch is taken.
+	domain := &orcv1alpha1.Domain{
+		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
+		Status: orcv1alpha1.DomainStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				Message:            "ready",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	user := &orcv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: adminUserRef(cp), Namespace: childNamespace(cp)},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, adminPasswordSecret(), domain, user).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"))
+	g.Expect(cond.Message).To(ContainSubstring(adminUserRef(cp)),
+		"the WaitingForApplicationCredential message must name the stuck admin User import")
+	g.Expect(cond.Message).To(ContainSubstring("not yet Available"))
+}
+
 // HARD CRD DEPENDENCY: K-ORC is a hard dependency (SetupWithManager Owns its
 // kinds, so the manager fails fast at startup if the CRD is absent). The
 // dedicated KORCCRDNotInstalled branch was therefore removed (#476): a no-match
@@ -1277,7 +1365,12 @@ func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	credRef := orcv1alpha1.CloudCredentialsReference{SecretName: "k-orc-clouds-yaml", CloudName: "admin"}
-	g.Expect(r.ensureKORCAdminImports(context.Background(), cp, credRef)).To(Succeed())
+	// Freshly-created imports are not yet Available, so the status fragment names the
+	// first import (Domain) as the stuck dependency.
+	importMsg, err := r.ensureKORCAdminImports(context.Background(), cp, credRef)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(importMsg).To(ContainSubstring("Domain"))
+	g.Expect(importMsg).To(ContainSubstring("not yet Available"))
 
 	var domain orcv1alpha1.Domain
 	g.Expect(c.Get(context.Background(), types.NamespacedName{

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -1306,7 +1306,10 @@ func TestReconcileCatalog_RegistersServiceAndEndpoint(t *testing.T) {
 	s := korcTestScheme(t)
 	cp := korcControlPlane()
 	setAdminCredentialReady(cp)
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	// Pre-create the identity Service and Endpoint reporting Available=True so
+	// CatalogReady can flip True on this pass (registering them is not enough).
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, availableCatalogService(cp), availableCatalogEndpoint(cp)).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
 	_, err := r.reconcileCatalog(context.Background(), cp)
@@ -1335,6 +1338,138 @@ func TestReconcileCatalog_RegistersServiceAndEndpoint(t *testing.T) {
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 	g.Expect(cp.Status.CatalogReady).To(BeTrue())
+}
+
+// TestReconcileCatalog_DefersUntilServiceEndpointAvailable asserts that merely
+// registering the Service/Endpoint CRs is not enough: until BOTH report
+// Available=True, CatalogReady stays False/WaitingForCatalog and status.catalogReady
+// is not set, so the aggregate Ready cannot report True against an empty catalog.
+func TestReconcileCatalog_DefersUntilServiceEndpointAvailable(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setAdminCredentialReady(cp)
+	// No pre-existing Service/Endpoint: they are created fresh (not yet Available).
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileCatalog(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	// Both CRs were registered...
+	svc := &orcv1alpha1.Service{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: keystoneServiceName(cp), Namespace: childNamespace(cp),
+	}, svc)).To(Succeed())
+	ep := &orcv1alpha1.Endpoint{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: keystoneEndpointName(cp), Namespace: childNamespace(cp),
+	}, ep)).To(Succeed())
+
+	// ...but CatalogReady defers because neither is Available yet.
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeCatalogReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForCatalog"))
+	g.Expect(cp.Status.CatalogReady).To(BeFalse())
+}
+
+// TestReconcileCatalog_StaleAvailableGenerationDefers asserts CatalogReady is gated
+// on a GENERATION-aware availability check: a Service/Endpoint whose Available
+// condition is True but whose ObservedGeneration lags the object's generation (K-ORC
+// has not re-reconciled the latest spec, e.g. a publicEndpoint/region edit that moved
+// the catalog URL) must NOT satisfy the gate. A generation-blind IsAvailable would
+// flip CatalogReady True against a stale Available, advertising the new catalog URL
+// as live before K-ORC applied it.
+func TestReconcileCatalog_StaleAvailableGenerationDefers(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setAdminCredentialReady(cp)
+	// Available=True but the condition's ObservedGeneration (0) lags the object's
+	// generation (2): the Available condition reflects a previous spec.
+	service := availableCatalogService(cp)
+	service.Generation = 2
+	endpoint := availableCatalogEndpoint(cp)
+	endpoint.Generation = 2
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, service, endpoint).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileCatalog(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeCatalogReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse),
+		"a stale Available condition (ObservedGeneration < generation) must not satisfy CatalogReady")
+	g.Expect(cond.Reason).To(Equal("WaitingForCatalog"))
+	g.Expect(cp.Status.CatalogReady).To(BeFalse())
+}
+
+// TestReconcileCatalog_TerminalErrorSurfaced asserts that a terminal K-ORC failure
+// on a catalog child (the documented "wrong clouds.yaml endpoint / import stuck on
+// created externally" class) surfaces as CatalogReady=False/CatalogFailed rather
+// than an eternal WaitingForCatalog, and resets the status bool.
+func TestReconcileCatalog_TerminalErrorSurfaced(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setAdminCredentialReady(cp)
+	// Service reports a terminal Progressing reason (ObservedGeneration matches the
+	// object Generation, both 0 under the fake client, so GetTerminalError fires).
+	service := &orcv1alpha1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: keystoneServiceName(cp), Namespace: childNamespace(cp)},
+		Status: orcv1alpha1.ServiceStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionProgressing,
+				Status:             metav1.ConditionFalse,
+				Reason:             orcv1alpha1.ConditionReasonInvalidConfiguration,
+				Message:            "K-ORC cannot reach the identity endpoint",
+				ObservedGeneration: 0,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, service).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileCatalog(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeCatalogReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("CatalogFailed"))
+	g.Expect(cond.Message).To(ContainSubstring("K-ORC cannot reach the identity endpoint"))
+	g.Expect(cp.Status.CatalogReady).To(BeFalse())
+}
+
+// TestReconcileCatalog_ResetsStatusBoolOnDegradation locks in that the
+// status.catalogReady bool is reset to false on a later degradation rather than
+// left stale-true: a control plane that was previously CatalogReady but whose
+// Service/Endpoint are no longer Available must report catalogReady=false.
+func TestReconcileCatalog_ResetsStatusBoolOnDegradation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setAdminCredentialReady(cp)
+	cp.Status.CatalogReady = true // previously registered + Available
+	// On this pass the Service/Endpoint are (re-)created fresh and not Available.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileCatalog(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(cp.Status.CatalogReady).To(BeFalse(),
+		"status.catalogReady must be reset to false when the catalog is no longer Available")
 }
 
 // TestReconcileCatalog_EmptySecretNameFallsBack verifies that when a
@@ -1524,6 +1659,39 @@ func materializedCloudsYamlSecret(cp *c5c3v1alpha1.ControlPlane, acID, value str
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)},
 		Data: map[string][]byte{
 			appCredCloudsYAMLKey: []byte(buildAppCredCloudsYAML(cp, acID, value)),
+		},
+	}
+}
+
+// availableCatalogService returns the identity Service CR reporting Available=True,
+// the state K-ORC would report once the catalog entry actually lands in Keystone.
+func availableCatalogService(cp *c5c3v1alpha1.ControlPlane) *orcv1alpha1.Service {
+	return &orcv1alpha1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: keystoneServiceName(cp), Namespace: childNamespace(cp)},
+		Status: orcv1alpha1.ServiceStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				Message:            "ready",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}
+
+// availableCatalogEndpoint returns the identity Endpoint CR reporting Available=True.
+func availableCatalogEndpoint(cp *c5c3v1alpha1.ControlPlane) *orcv1alpha1.Endpoint {
+	return &orcv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: keystoneEndpointName(cp), Namespace: childNamespace(cp)},
+		Status: orcv1alpha1.EndpointStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonSuccess,
+				Message:            "ready",
+				LastTransitionTime: metav1.Now(),
+			}},
 		},
 	}
 }

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -56,6 +56,16 @@ const (
 	// generous so a slow-but-progressing revoke is not flagged as stalled.
 	remintStallTimeout = 5 * time.Minute
 
+	// cloudsYamlSyncStuckTimeout bounds how long the materialised K-ORC clouds.yaml
+	// Secret may disagree with the freshly assembled admin credential before
+	// reconcileAdminCredential escalates AdminCredentialReady from the transient
+	// "WaitingForCloudsYamlSync" reason to the alertable "CloudsYamlSyncStuck". A
+	// never-converging ESO/OpenBao sync otherwise looks identical to a 2-second
+	// transient miss, so on-call waits forever with no terminal signal. Measured
+	// from the credential's LastRotation (when the current id was minted); the
+	// window is generous so a healthy force-sync is never flagged as stuck.
+	cloudsYamlSyncStuckTimeout = 15 * time.Minute
+
 	// duplicateControlPlaneRequeueAfter is the backoff a parked duplicate
 	// ControlPlane uses while an older ControlPlane owns its namespace
 	// (defense-in-depth). Deleting the incumbent enqueues no


### PR DESCRIPTION
Closes #464

## Summary

The 2026-06 pre-production audit found three ways the ControlPlane reconciler could report `Ready=True` (or an eternal, unactionable `Waiting…`) while the K-ORC-backed catalog was not actually serving. This branch gates each readiness signal on live availability rather than CR existence, surfaces terminal K-ORC failures, and closes the stale-credential window after a re-mint. The three fixes land in `operators/c5c3/internal/controller/reconcile_korc.go` with matching unit/integration tests, followed by a docs refresh.

## Change set (commit order)

**`4247e379` fix(c5c3-operator): surface terminal K-ORC AC errors and import status**
`reconcileKORC` gated `KORCReady` only on `orcv1alpha1.IsAvailable(ac)` and never consulted `GetTerminalError`, so a terminal K-ORC failure (e.g. K-ORC cannot authenticate with the clouds.yaml) reported as an eternal `KORCReady=False` / `WaitingForApplicationCredential` with no pointer to the stuck dependency. This adds a distinct `ApplicationCredentialFailed` reason from `GetTerminalError(ac)`, and has `ensureKORCAdminImports` return a Domain/User import-status fragment that is folded into both the terminal and the `WaitingForApplicationCredential` messages, so an import hung on "created externally" names the dependency that is actually stuck. (Issue problem #2.)

**`a42f93a0` fix(c5c3-operator): gate AdminCredentialReady on live clouds.yaml**
A re-mint revokes the old admin credential immediately, but the `k-orc-clouds-yaml` Secret only refreshes from OpenBao at the ExternalSecret's hourly `refreshInterval`. The old gate trusted the ExternalSecret's `Ready` condition — which stays `True` from the last (now stale) sync — so it could report Ready for up to ~2h while the materialized Secret K-ORC authenticates with still held the revoked credential. This forces an immediate ESO re-sync after assembling a new clouds.yaml (force-sync annotation keyed by the content hash, idempotent so a steady-state pass does not churn the ExternalSecret) **and** gates `AdminCredentialReady` on the materialized Secret bytes actually matching the assembled document. The byte-compare — not the best-effort force-sync — is the correctness guarantee. (Issue problem #3.)

**`e6dc2926` fix(c5c3-operator): gate CatalogReady on Service/Endpoint availability**
`reconcileCatalog` set `CatalogReady=True` immediately after the Service and Endpoint `CreateOrUpdate` calls, with no `orcv1alpha1.IsAvailable` gate. If K-ORC could not authenticate or hit a terminal error, the catalog entries never existed in Keystone while the ControlPlane reported `Ready=True`, and `status.CatalogReady` was never reset to `false` on later degradation. This gates `CatalogReady` on both child CRs reporting `Available`, surfaces a terminal K-ORC failure as a distinct `CatalogFailed` reason, requeues with `WaitingForCatalog` while they converge, and resets `status.CatalogReady` on every `False` branch so the bool tracks the condition rather than going stale-true. (Issue problem #1.)

**`2acf31b8` docs(c5c3): document availability gating and clouds.yaml sync gate**
Updates the ControlPlane reconciler and CRD reference condition tables for the new reasons (`ApplicationCredentialFailed`, `WaitingForCloudsYamlSync`, `WaitingForCatalog`, `CatalogFailed`), the folded import status on `KORCReady`, the force-sync/byte-compare gate on `AdminCredentialReady`, and the Service/Endpoint `Available` gate plus `status.catalogReady` reset on `CatalogReady`. Refreshes the Phase 5 flow-diagram annotation and the status-field / failure-mode notes to match.

## Files

- `operators/c5c3/internal/controller/reconcile_korc.go` — the three gating fixes
- `operators/c5c3/internal/controller/reconcile_korc_test.go`, `integration_test.go` — unit + integration coverage for each gate
- `operators/c5c3/internal/controller/requeue_intervals.go` — requeue interval for the new `Waiting…` branches
- `docs/reference/c5c3/controlplane-crd.md`, `controlplane-reconciler.md` — reference docs

## Notes for the reviewer

- The implementation follows the issue's "Proposed fix" directly. For problem #3 the issue offered two options ("force an ES refresh … **or** drop the refresh interval"); this branch takes the force-sync route and adds the materialized-byte compare as the actual correctness guarantee, leaving the hourly `refreshInterval` untouched.
- No code beyond the three reconcile gates was touched; the docs commit is reference-table sync only.

---

_Implemented by [planwerk-review](https://github.com/planwerk/planwerk-review) fd023aa with Claude:claude-opus-4-8_
