### PR TITLE
test(e2e): run the full ControlPlane → Keystone chain in CI on kind

### DIFF
--- a/.github/actions/setup-e2e-infra/action.yaml
+++ b/.github/actions/setup-e2e-infra/action.yaml
@@ -20,6 +20,13 @@
 # resolves to an empty string and hack/deploy-infra.sh's
 # `${WITH_PROMETHEUS:-false}` default keeps the monitoring stack out of
 # the install.
+#
+# WITH_CONTROLPLANE, CONTROLPLANE_OPERATORS, CONTROLPLANE_NAME, and
+# WITH_CONTROLPLANE_CR are threaded the same way so the e2e-controlplane job can
+# provision the shared infra for the c5c3 ControlPlane chain and provide the
+# operator stack out of band (CONTROLPLANE_OPERATORS=external). Unset by every
+# other caller, so deploy-infra.sh's defaults keep the ControlPlane stack out of
+# the install.
 
 name: Setup E2E infrastructure
 description: >
@@ -53,4 +60,10 @@ runs:
         WITH_CHAOS_MESH: ${{ env.WITH_CHAOS_MESH }}
         # opt-in flag — empty when caller does not set it; deploy-infra.sh defaults to false.
         WITH_PROMETHEUS: ${{ env.WITH_PROMETHEUS }}
+        # ControlPlane opt-in flags — empty when caller does not set them;
+        # deploy-infra.sh defaults keep the ControlPlane stack out of the install.
+        WITH_CONTROLPLANE: ${{ env.WITH_CONTROLPLANE }}
+        CONTROLPLANE_OPERATORS: ${{ env.CONTROLPLANE_OPERATORS }}
+        CONTROLPLANE_NAME: ${{ env.CONTROLPLANE_NAME }}
+        WITH_CONTROLPLANE_CR: ${{ env.WITH_CONTROLPLANE_CR }}
       run: make deploy-infra

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
       e2e-infra: ${{ steps.result.outputs.e2e-infra }}
       e2e-chaos: ${{ steps.result.outputs.e2e-chaos }}
       e2e-prometheus: ${{ steps.result.outputs.e2e-prometheus }}
+      e2e-controlplane: ${{ steps.result.outputs.e2e-controlplane }}
       has-e2e-operators: ${{ steps.result.outputs.has-e2e-operators }}
       e2e-operators: ${{ steps.result.outputs.e2e-operators }}
       tempest-releases: ${{ steps.tempest-matrix.outputs.tempest-releases }}
@@ -138,6 +139,19 @@ jobs:
               - '.github/actions/setup-e2e-infra/action.yaml'
               - '.github/workflows/ci.yaml'
               - 'Makefile'
+            # Full ControlPlane -> Keystone chain E2E job — separate filter so
+            # the resource-heavy e2e-controlplane job runs only when the c5c3 or
+            # keystone operator code, the full-chain suite, the deploy stack, the
+            # hack scripts (deploy-infra, ci-deploy-korc, ci-deploy-operator), or
+            # the composite actions it uses actually change.
+            e2e_controlplane:
+              - 'operators/c5c3/**'
+              - 'operators/keystone/**'
+              - 'tests/e2e/c5c3/**'
+              - 'deploy/**'
+              - 'hack/**'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yaml'
             # follow-up: Any E2E test-definition change forces all E2E
             # jobs to run. Kept separate from go_common so pure test edits do
             # not also trigger lint/unit/format/vuln jobs.
@@ -158,6 +172,7 @@ jobs:
           FILTER_e2e_infra: ${{ steps.filter.outputs.e2e_infra }}
           FILTER_e2e_chaos: ${{ steps.filter.outputs.e2e_chaos }}
           FILTER_e2e_prometheus: ${{ steps.filter.outputs.e2e_prometheus }}
+          FILTER_e2e_controlplane: ${{ steps.filter.outputs.e2e_controlplane }}
           FILTER_tests_e2e_operator: ${{ steps.filter.outputs.tests_e2e_operator }}
           FILTER_tests_tempest: ${{ steps.filter.outputs.tests_tempest }}
           FILTER_go_common: ${{ steps.filter.outputs.go_common }}
@@ -599,7 +614,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'pull_request' &&
-      (needs.changes.outputs.has-e2e-operators == 'true' || needs.changes.outputs.e2e-chaos == 'true' || needs.changes.outputs.e2e-prometheus == 'true') &&
+      (needs.changes.outputs.has-e2e-operators == 'true' || needs.changes.outputs.e2e-chaos == 'true' || needs.changes.outputs.e2e-prometheus == 'true' || needs.changes.outputs.e2e-controlplane == 'true') &&
       github.event.pull_request.head.repo.fork != true &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
@@ -630,6 +645,12 @@ jobs:
           ops=$(echo '${{ needs.changes.outputs.e2e-operators }}' | jq -r '.operator[]')
           if ! printf '%s\n' $ops | grep -qx keystone; then
             ops=$(printf '%s\nkeystone' "$ops")
+          fi
+          # The e2e-controlplane job runs the full chain from local dev images, so
+          # both keystone-operator:dev and c5c3-operator:dev must be built when it
+          # runs — even if only the full-chain test definition changed.
+          if [ '${{ needs.changes.outputs.e2e-controlplane }}' = 'true' ] && ! printf '%s\n' $ops | grep -qx c5c3; then
+            ops=$(printf '%s\nc5c3' "$ops")
           fi
           {
             echo "BUILD_OPERATORS<<EOF"
@@ -1074,6 +1095,109 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-prometheus-junit-report
+          path: _output/reports/
+          retention-days: 14
+
+  # Full ControlPlane -> Keystone chain E2E on kind. Deploys keystone-operator +
+  # K-ORC + c5c3-operator as local dev images (the GHCR-published Flux chart path
+  # is bypassed via CONTROLPLANE_OPERATORS=external) and runs the
+  # full-controlplane-keystone Chainsaw suite with the presence guard set to fail
+  # loudly (E2E_REQUIRE_CONTROLPLANE_STACK=true), so broken wiring in the live
+  # chain fails the build instead of SKIPping.
+  #
+  # A real MariaDB + Memcached + Keystone + three operators + OpenBao + ESO +
+  # K-ORC + cert-manager + Envoy on one node is heavy, so this is a dedicated job
+  # with an extended timeout on the larger runner (matching tempest).
+  e2e-controlplane:
+    needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
+    # always(): allow the job to run when upstream Go jobs are skipped
+    # (e.g. pure E2E test-definition PRs where go=false). The explicit
+    # failure/cancelled guard still blocks if any upstream actually failed.
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork != true &&
+      needs.changes.outputs.e2e-controlplane == 'true' &&
+      needs.build-e2e-images.result == 'success' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 60
+    continue-on-error: false
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          config: hack/kind-config.yaml
+          cluster_name: ${{ env.KIND_CLUSTER }}
+      # Pull the pre-built dev operator images plus the Keystone service image
+      # and the OpenStack-client (tempest) image the verify Job uses.
+      - name: Load E2E images
+        uses: ./.github/actions/load-e2e-images
+        with:
+          images: |
+            ${{ env.IMAGE_PREFIX }}/keystone-operator:dev
+            ${{ env.IMAGE_PREFIX }}/c5c3-operator:dev
+            ${{ env.IMAGE_PREFIX }}/keystone:2025.2
+            ${{ env.IMAGE_PREFIX }}/tempest:2025.2
+      - name: Load images into kind
+        run: |
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/c5c3-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone:2025.2 --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/tempest:2025.2 --name ${{ env.KIND_CLUSTER }}
+      # Prepare the shared infra (TLS, OpenBao + per-CR seeding, ESO store) and
+      # suspend the Flux ControlPlane stack; the operators are deployed below.
+      # CONTROLPLANE_NAME must match the fixture CR (controlplane-keystone) so the
+      # OpenBao bootstrap seeds the per-CR admin-password path the chain reads.
+      - name: Setup E2E infrastructure
+        uses: ./.github/actions/setup-e2e-infra
+        env:
+          WITH_CONTROLPLANE: "true"
+          CONTROLPLANE_OPERATORS: external
+          CONTROLPLANE_NAME: controlplane-keystone
+          WITH_CONTROLPLANE_CR: "false"
+      # Deploy K-ORC (CRDs + controller) from the upstream installer at the tag
+      # pinned in deploy/flux-system/sources/k-orc.yaml.
+      - name: Deploy K-ORC
+        run: hack/ci-deploy-korc.sh
+      # keystone-operator first so its CRD exists before c5c3-operator projects
+      # Keystone CRs.
+      - name: Deploy keystone-operator
+        run: hack/ci-deploy-operator.sh
+        env:
+          OPERATOR: keystone
+          IMAGE_REPO: ${{ env.IMAGE_PREFIX }}/keystone-operator
+          NAMESPACE: keystone-system
+      - name: Deploy c5c3-operator
+        run: hack/ci-deploy-operator.sh
+        env:
+          OPERATOR: c5c3
+          IMAGE_REPO: ${{ env.IMAGE_PREFIX }}/c5c3-operator
+          NAMESPACE: c5c3-system
+      # E2E_REQUIRE_CONTROLPLANE_STACK=true flips the suite's presence guard from
+      # SKIP to a hard failure, so missing wiring cannot go green.
+      - name: Run full ControlPlane chain E2E test
+        run: |
+          mkdir -p _output/reports
+          chainsaw test --config tests/e2e/chainsaw-config.yaml \
+            tests/e2e/c5c3/full-controlplane-keystone/
+        env:
+          E2E_REQUIRE_CONTROLPLANE_STACK: "true"
+      - name: Dump diagnostic info
+        if: always()
+        run: hack/ci-dump-diagnostics.sh
+        env:
+          OPERATOR: c5c3
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-controlplane-junit-report
           path: _output/reports/
           retention-days: 14
 

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,26 @@ e2e-prometheus:
 	@kubectl get ns monitoring >/dev/null 2>&1 || { echo 'kube-prometheus-stack is not installed; run `WITH_PROMETHEUS=true make deploy-infra` first' >&2; exit 1; }
 	chainsaw test --config tests/e2e/chainsaw-config.yaml tests/e2e/keystone/prometheus-stack/
 
+.PHONY: e2e-controlplane
+# e2e-controlplane runs the full ControlPlane -> Keystone chain Chainsaw suite
+# against a deployed kind cluster. The full stack (c5c3-operator + K-ORC +
+# keystone-operator, provisioning MariaDB/Memcached in managed mode) is opt-in;
+# fail fast with a clear remediation hint when the ControlPlane CRD is missing
+# instead of letting chainsaw attempt the suite against a cluster that lacks it.
+# The two preflights are kept separate so the kubectl/cluster-reachability
+# failure is not conflated with the stack-not-installed failure — see review
+# pattern
+# .planwerk/review_patterns/distinguish-collapsed-failure-modes-in-preflight-checks.md
+# This Makefile target satisfies the CI-to-Makefile parity expected by
+# .planwerk/review_patterns/maintain-ci-to-makefile-parity-for-new-jobs.md so
+# developers can reproduce the e2e-controlplane CI job locally. Set
+# E2E_REQUIRE_CONTROLPLANE_STACK=true to make the suite's presence guard fail
+# loudly (as the CI job does) rather than SKIP.
+e2e-controlplane:
+	@kubectl version --request-timeout=2s >/dev/null 2>&1 || { echo 'kubectl is not configured or no cluster is reachable' >&2; exit 1; }
+	@kubectl get crd controlplanes.c5c3.io >/dev/null 2>&1 || { echo 'the c5c3 ControlPlane stack is not installed; run `WITH_CONTROLPLANE=true make deploy-infra` (and deploy K-ORC + the operators) first' >&2; exit 1; }
+	chainsaw test --config tests/e2e/chainsaw-config.yaml tests/e2e/c5c3/full-controlplane-keystone/
+
 .PHONY: tempest-test
 # tempest-test runs Tempest API tests against a deployed OpenStack service.
 # Requires a running kind cluster with the service deployed.

--- a/deploy/flux-system/sources/k-orc.yaml
+++ b/deploy/flux-system/sources/k-orc.yaml
@@ -16,8 +16,11 @@
 # The clone is scoped to /dist via spec.ignore so the source artifact stays small
 # (the full upstream repo carries a website/, examples/, tooling, etc.).
 #
-# Renovate: the pinned tag below is tracked by a customManager rule (see the
-# follow-up tracked in the GitHub issue that finalises the c5c3-operator stack).
+# Renovate: the pinned tag below is tracked by a customManager rule in
+# renovate.json (matching this file's ref.tag), so it cannot silently drift from
+# the go.mod k-orc module version the operator compiles against. hack/ci-deploy-
+# korc.sh parses this same tag so the CI installer and the Flux source stay in
+# lockstep.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -39,6 +39,7 @@ The custom managers cover:
 - **OpenStack release refs** — git tags in `releases/*/source-refs.yaml` and PyPI pins in `releases/*/test-refs.yaml`.
 - **Test tooling in `hack/`** — Chainsaw, Flux CLI, kind, and kubectl versions in `hack/install-test-deps.sh`, plus `FLUX_OPERATOR_VERSION` in `hack/deploy-infra.sh`.
 - **kind deploy components** — `flux-web.yaml`, `envoy-gateway.yaml`, and `headlamp.yaml` under `deploy/kind/base/`.
+- **K-ORC Flux source** — the `ref.tag` of the K-ORC `GitRepository` in `deploy/flux-system/sources/k-orc.yaml` (github-releases). This closes a drift gap: without it the Flux-applied K-ORC CRDs could fall behind the Renovate-tracked `k-orc/openstack-resource-controller` Go module the operator compiles against.
 - **Go build tooling in `Makefile` / `.github/workflows/*.yaml`** — `gofumpt`, `controller-gen`, `golangci-lint`, and `yq`.
 
 Major updates are **disabled** for all custom-regex managers — these touch deploy-time

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -18,8 +18,11 @@ OpenBao, and register the identity catalog — all reconciled to an aggregate
 
 Same toolchain as the [Quick Start](./quick-start.md), plus an internet
 connection (K-ORC is cloned from GitHub at a pinned tag). Docker Desktop needs
-ample CPU/memory — the ControlPlane provisions a production-shaped (Galera)
-MariaDB, heavier than the single-replica database the per-service path uses.
+ample CPU/memory — by default the ControlPlane provisions a production-shaped
+(Galera) MariaDB, heavier than the single-replica database the per-service path
+uses. On a constrained cluster set `spec.infrastructure.database.replicas: 1`
+(and `cache.replicas: 1`) in the ControlPlane CR to provision a single-instance,
+non-Galera MariaDB instead.
 
 ```bash
 make install-test-deps

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -236,6 +236,16 @@ the reconciler projects points at the **same** `DatabaseSpec` / `CacheSpec`
 verbatim, so the aggregate and the projected service agree on the backing
 services.
 
+The managed-mode MariaDB topology is derived from
+`spec.infrastructure.database.replicas` (default `3`, minimum `1`): the default
+projects a production-shaped Galera HA cluster (3 replicas, `galera.enabled`,
+`100Gi` storage), while `database.replicas: 1` projects a single-instance,
+non-Galera MariaDB so the fresh-create path schedules on a constrained cluster
+such as a single-node kind. `cache.replicas` (also default `3`) drives the
+Memcached replica count the same way. Both are only honoured in managed mode;
+storage stays at `100Gi` regardless of the replica count, and a ControlPlane
+that adopts a pre-existing MariaDB/Memcached leaves its topology untouched.
+
 > **`database.secretRef` is operator-owned in managed mode.** The
 > `DatabaseSpec` is projected onto the Keystone CR verbatim **except** for its
 > `secretRef`. In managed mode the `reconcileDBCredentials` sub-reconciler

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -113,6 +113,8 @@ E2E Jobs (depends on build-e2e-images):
   e2e-chaos ──────> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
   e2e-prometheus ─> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
                      if: needs.changes.outputs.e2e-prometheus == 'true'
+  e2e-controlplane > needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
+                     if: needs.changes.outputs.e2e-controlplane == 'true'
   tempest ────────> needs: [changes, build-e2e-images]
 
 Publish Jobs (main/tags only, depends on E2E):
@@ -124,9 +126,10 @@ Release Job (v* tags only, depends on publish):
   github-release ──> needs: [changes, merge-operator-images, helm-push], if: v* tag
 ```
 
-The five E2E jobs (`e2e-infra`, `e2e-operator`, `e2e-chaos`, `e2e-prometheus`,
-`tempest`) share infrastructure setup via the `setup-e2e-infra` composite action
-and diagnostic teardown via `hack/ci-dump-diagnostics.sh`.
+The six E2E jobs (`e2e-infra`, `e2e-operator`, `e2e-chaos`, `e2e-prometheus`,
+`e2e-controlplane`, `tempest`) share infrastructure setup via the
+`setup-e2e-infra` composite action and diagnostic teardown via
+`hack/ci-dump-diagnostics.sh`.
 
 ## Jobs
 
@@ -687,6 +690,58 @@ genuine regression of the kind-only Quick Start observability story.
 with `e2e-chaos`, any Go code change (`go_changed`) or any E2E test change
 (`any_e2e_tests`) also triggers the job via `ci-resolve-changes.sh`, since
 the prometheus suite scrapes live operator metrics.
+
+### e2e-controlplane
+
+Runs the full c5c3 `ControlPlane` → Keystone chain on kind. It deploys
+`keystone-operator` + K-ORC + `c5c3-operator` as local dev images (rather than
+the GHCR-published Flux chart) and runs the
+`tests/e2e/c5c3/full-controlplane-keystone/` Chainsaw suite, which asserts the
+whole orchestration link by link: managed MariaDB/Memcached provisioning, the
+projected Keystone CR, the minted restricted K-ORC application credential, the
+OpenBao → ESO credential round-trip, the identity catalog, and finally a live
+`openstack token issue` / `catalog list` against the Keystone `/v3` endpoint.
+
+**Dependencies:** `needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]`
+**Condition:** Runs only when `e2e-controlplane == 'true'`, the upstream
+`build-e2e-images` job succeeded, and no dependency failed or was cancelled.
+
+`setup-e2e-infra` is invoked with `WITH_CONTROLPLANE: "true"`,
+`CONTROLPLANE_OPERATORS: external`, and
+`CONTROLPLANE_NAME: controlplane-keystone`. Under `CONTROLPLANE_OPERATORS=external`
+`hack/deploy-infra.sh` prepares only the shared prerequisites (TLS issuers,
+OpenBao with per-CR admin-password seeding, the ESO ClusterSecretStore) and
+suspends the Flux ControlPlane stack, so the dev-image operators deployed by the
+subsequent steps own the reconcile. K-ORC is applied by `hack/ci-deploy-korc.sh`
+at the tag pinned in `deploy/flux-system/sources/k-orc.yaml`.
+
+The suite runs with `E2E_REQUIRE_CONTROLPLANE_STACK: "true"`, which flips its
+presence guard from a silent SKIP to a hard failure — so a broken operator/CRD
+deployment fails the build instead of going green. Like `e2e-prometheus`, the
+job runs with `continue-on-error: false`, and it uses a 60-minute timeout on the
+larger runner because a real MariaDB + Memcached + Keystone + three operators +
+OpenBao + ESO + K-ORC on one node is resource-heavy.
+
+| Step | Action | Details |
+| --- | --- | --- |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 3 | `load-e2e-images` composite | Restores `keystone-operator:dev`, `c5c3-operator:dev`, `keystone:2025.2`, `tempest:2025.2` from GHCR |
+| 4 | `kind load docker-image` | Loads the four images into kind |
+| 5 | `setup-e2e-infra` composite action | Deploys infra with `WITH_CONTROLPLANE=true CONTROLPLANE_OPERATORS=external CONTROLPLANE_NAME=controlplane-keystone` |
+| 6 | `hack/ci-deploy-korc.sh` | Applies K-ORC CRDs + controller at the pinned tag |
+| 7 | `hack/ci-deploy-operator.sh` (keystone) | Deploys the keystone-operator dev image into `keystone-system` |
+| 8 | `hack/ci-deploy-operator.sh` (c5c3) | Deploys the c5c3-operator dev image into `c5c3-system` |
+| 9 | `chainsaw test` | Runs the full-chain suite with `E2E_REQUIRE_CONTROLPLANE_STACK=true` |
+| 10 | `hack/ci-dump-diagnostics.sh` (always) | Dumps diagnostics with `OPERATOR=c5c3` |
+| 11 | Upload JUnit report | Uploads `_output/reports/` as `e2e-controlplane-junit-report` (14-day retention) |
+
+**Path filter:** `operators/c5c3/**`, `operators/keystone/**`, `tests/e2e/c5c3/**`,
+`deploy/**`, `hack/**`, `.github/actions/**`, `.github/workflows/ci.yaml`. As with
+`e2e-prometheus`, any Go code change (`go_changed`) or any E2E test change
+(`any_e2e_tests`) also triggers the job via `ci-resolve-changes.sh`. When it
+runs, `build-e2e-images` unions `c5c3` into the built operator set so both dev
+images exist even for a full-chain-test-only change.
 
 ### tempest
 

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -214,6 +214,9 @@ The deployment script supports configurable timeouts via environment variables:
 | `SKIP_KIND_CREATE` | `false` | Skip kind cluster creation (CI mode where cluster is pre-created) |
 | `NAMESPACE` | `openbao-system` | OpenBao namespace (propagated to bootstrap scripts) |
 | `INSTALL_DIR` | `~/.local/bin` | Directory for `install-test-deps.sh` to install tools |
+| `WITH_CONTROLPLANE` | `false` | When `true`, the c5c3 `ControlPlane` provisions MariaDB/Memcached in managed mode: deploy-infra skips the shared MariaDB/Memcached CRs and seeds the per-CR OpenBao admin-password paths instead |
+| `CONTROLPLANE_OPERATORS` | `flux` | How the ControlPlane operator stack is provided (only when `WITH_CONTROLPLANE=true`). `flux` deploys the published c5c3-operator chart + K-ORC Flux source and un-suspends keystone-operator; `external` suspends the Flux stack and expects the operators to be deployed out of band (as the `e2e-controlplane` CI job does with local dev images + `hack/ci-deploy-korc.sh`) |
+| `CONTROLPLANE_NAME` | `controlplane` | Name of the ControlPlane CR under `WITH_CONTROLPLANE=true`; the per-CR OpenBao admin-password bootstrap path derives from it, so it must match the applied CR (the `e2e-controlplane` job sets `controlplane-keystone`) |
 
 **Example: override HelmRelease timeout:**
 

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -1057,6 +1057,7 @@ operator CRDs.
 | `database` | `string` | Yes | Database name. Constrained to the MySQL identifier set and length: `MinLength=1`, `MaxLength=64`, `Pattern=^[A-Za-z0-9_]+$`. Immutable after create (CEL transition rule): renaming re-points `db_sync` at a fresh, empty schema and silently orphans the existing data. |
 | `secretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | Secret with database credentials. |
 | `tls` | [`*DatabaseTLSSpec`](#databasetlsspec) | No | Optional TLS/mTLS configuration. The pointer keeps the field opt-in and non-mutating: a `nil` `tls` means plaintext TCP, preserving the previous behavior for all existing CRs. |
+| `replicas` | `int32` | No | Number of managed MariaDB replicas provisioned in fresh-create mode (default `3`, minimum `1`). This field is shared by the c5c3 `ControlPlane`, whose managed-mode projection derives the MariaDB/Galera topology from it. **The keystone operator ignores it**: Keystone adopts an existing MariaDB (managed mode references it via `clusterRef`, brownfield via `host`) and never provisions its own, so `replicas` has no effect on a standalone Keystone CR. |
 
 Exactly one of `clusterRef` or `host` must be set (enforced by CEL validation).
 The database name and the `clusterRef` ↔ `host` mode are immutable after create

--- a/hack/ci-deploy-korc.sh
+++ b/hack/ci-deploy-korc.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# hack/ci-deploy-korc.sh — Deploy K-ORC (OpenStack Resource Controller) into a
+# kind cluster from the upstream released installer manifest.
+#
+# K-ORC does not publish a Helm chart; upstream ships a single flattened
+# installer manifest as a release asset
+# (releases/download/<tag>/install.yaml). This script pins to the SAME tag the
+# Flux GitRepository uses (deploy/flux-system/sources/k-orc.yaml) — parsed at
+# runtime rather than hardcoded so the two never drift — verifies the downloaded
+# bytes against a pinned SHA-256 (release assets are mutable, so an unverified
+# `kubectl apply` would grant cluster-admin to attacker-substituted objects),
+# applies the verified local copy, then waits for the orc-system controller
+# Deployment to become Available.
+#
+# Used by the e2e-controlplane CI job, which deploys the c5c3 + keystone
+# operators as local dev images and needs K-ORC's CRDs + controller alongside
+# them (the Flux ControlPlane stack is suspended on that path).
+#
+# Optional env vars:
+#   KORC_SOURCE  — Path to the Flux GitRepository manifest holding the pinned
+#                  tag (default: deploy/flux-system/sources/k-orc.yaml).
+#   WAIT_TIMEOUT — kubectl wait timeout for the controller Deployment
+#                  (default: 180s).
+#
+# set -euo pipefail, SPDX Apache-2.0 header, shellcheck-clean.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+KORC_SOURCE="${KORC_SOURCE:-deploy/flux-system/sources/k-orc.yaml}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-180s}"
+
+# install.yaml is fetched from a GitHub release asset, which is MUTABLE — an
+# upstream compromise or a re-uploaded asset at the same tag could otherwise run
+# attacker-authored Kubernetes objects when applied with cluster-admin. The
+# downloaded bytes are therefore verified against a pinned SHA-256 before apply.
+# The digest is pinned to KORC_PINNED_TAG; when the tag in ${KORC_SOURCE} is
+# bumped (by Renovate or by hand), re-pin BOTH values below. The e2e-controlplane
+# job re-runs on any deploy/** or hack/** change, so a stale pin fails this step
+# loudly on the bump PR, forcing a human to re-verify the new upstream installer.
+# Recompute with:
+#   curl -fsSL https://github.com/k-orc/openstack-resource-controller/releases/download/<tag>/install.yaml | sha256sum
+KORC_PINNED_TAG="v2.5.0"
+KORC_INSTALL_SHA256="99bf24f0472017585ff1a2df25c1584704fe5503575a711082608517e7fc77f2"
+
+if [[ ! -f "${KORC_SOURCE}" ]]; then
+  echo "::error::K-ORC source manifest not found: ${KORC_SOURCE}"
+  exit 1
+fi
+
+# Parse the pinned tag (e.g. "v2.5.0") from the GitRepository ref.tag line. Use
+# awk (POSIX) so no yq dependency is required on this early CI step.
+KORC_TAG="$(awk '/^[[:space:]]*tag:[[:space:]]*/{print $2; exit}' "${KORC_SOURCE}")"
+if [[ -z "${KORC_TAG}" ]]; then
+  echo "::error::Could not parse a 'tag:' value from ${KORC_SOURCE}"
+  exit 1
+fi
+
+# Guard the pin against a tag bump that forgot to re-pin the checksum, so the
+# failure is an actionable message rather than a raw hash mismatch.
+if [[ "${KORC_TAG}" != "${KORC_PINNED_TAG}" ]]; then
+  echo "::error::K-ORC tag ${KORC_TAG} in ${KORC_SOURCE} does not match the pinned checksum tag ${KORC_PINNED_TAG}; re-pin KORC_PINNED_TAG and KORC_INSTALL_SHA256 in $(basename "${BASH_SOURCE[0]}") to the SHA-256 of the new install.yaml"
+  exit 1
+fi
+
+INSTALL_URL="https://github.com/k-orc/openstack-resource-controller/releases/download/${KORC_TAG}/install.yaml"
+INSTALL_FILE="$(mktemp)"
+trap 'rm -f "${INSTALL_FILE}"' EXIT
+
+echo "Downloading K-ORC ${KORC_TAG} installer from ${INSTALL_URL}"
+curl -fsSL "${INSTALL_URL}" -o "${INSTALL_FILE}"
+
+# Verify the downloaded installer against the pinned digest before it is applied
+# with cluster-admin. Portable across GNU coreutils (sha256sum) and BSD/macOS
+# (shasum -a 256), matching hack/install-test-deps.sh.
+if command -v sha256sum &>/dev/null; then
+  ACTUAL_SHA256="$(sha256sum "${INSTALL_FILE}" | awk '{print $1}')"
+else
+  ACTUAL_SHA256="$(shasum -a 256 "${INSTALL_FILE}" | awk '{print $1}')"
+fi
+if [[ "${ACTUAL_SHA256}" != "${KORC_INSTALL_SHA256}" ]]; then
+  echo "::error::K-ORC installer checksum mismatch for ${INSTALL_URL}: expected ${KORC_INSTALL_SHA256}, got ${ACTUAL_SHA256}; the release asset may have been re-uploaded or tampered with, refusing to apply. If the tag was intentionally bumped, re-pin KORC_INSTALL_SHA256 in $(basename "${BASH_SOURCE[0]}")"
+  exit 1
+fi
+
+echo "Verified K-ORC installer SHA-256 ${ACTUAL_SHA256}; applying ${INSTALL_FILE}"
+kubectl apply --server-side -f "${INSTALL_FILE}"
+
+echo "Waiting for the K-ORC controller Deployment in orc-system to become Available..."
+kubectl wait --for=condition=Available deployment --all \
+  -n orc-system --timeout="${WAIT_TIMEOUT}"
+echo "K-ORC ${KORC_TAG} is deployed and Available."

--- a/hack/ci-resolve-changes.sh
+++ b/hack/ci-resolve-changes.sh
@@ -24,6 +24,7 @@
 #   FILTER_e2e_infra          — paths-filter output for e2e-infra paths
 #   FILTER_e2e_chaos          — paths-filter output for e2e-chaos paths
 #   FILTER_e2e_prometheus     — paths-filter output for e2e-prometheus paths
+#   FILTER_e2e_controlplane   — paths-filter output for e2e-controlplane paths
 #   FILTER_tests_e2e_operator — paths-filter output for tests/e2e/** (follow-up)
 #   FILTER_tests_tempest      — paths-filter output for tests/tempest/** (follow-up)
 #   FILTER_go_common          — paths-filter output for go_common paths
@@ -120,6 +121,17 @@ if [[ "$go_changed" == "true" || "${FILTER_e2e_prometheus:-false}" == "true" || 
   echo "e2e-prometheus=true" >> "$GITHUB_OUTPUT"
 else
   echo "e2e-prometheus=false" >> "$GITHUB_OUTPUT"
+fi
+
+# The full ControlPlane -> Keystone chain E2E job runs when its own paths change
+# (c5c3/keystone operator code, the full-chain suite, the deploy stack, the hack
+# scripts, or the composite actions it uses), when any Go code changes (so the
+# live chain re-validates the current operator code), or when any other E2E test
+# definition changes (so refactoring shared test infra runs the full suite).
+if [[ "$go_changed" == "true" || "${FILTER_e2e_controlplane:-false}" == "true" || "$any_e2e_tests" == "true" ]]; then
+  echo "e2e-controlplane=true" >> "$GITHUB_OUTPUT"
+else
+  echo "e2e-controlplane=false" >> "$GITHUB_OUTPUT"
 fi
 
 # Emit operator matrix — single codepath for both tag and non-tag.

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -98,6 +98,21 @@ WITH_CONTROLPLANE_CR="${WITH_CONTROLPLANE_CR:-false}"
 # to "controlplane". Ignored unless WITH_CONTROLPLANE=true.
 CONTROLPLANE_NAME="${CONTROLPLANE_NAME:-controlplane}"
 
+# Selects HOW the ControlPlane operator stack (keystone-operator, K-ORC,
+# c5c3-operator) is provided under WITH_CONTROLPLANE=true:
+#   flux     — the default: deploy the published c5c3-operator chart and the
+#              K-ORC Flux GitRepository/Kustomization, and un-suspend
+#              keystone-operator so the c5c3-operator dependsOn is satisfied.
+#   external — the operators are deployed OUT OF BAND (e.g. the e2e-controlplane
+#              CI job installs keystone-operator + c5c3-operator as local dev
+#              images via hack/ci-deploy-operator.sh and K-ORC via
+#              hack/ci-deploy-korc.sh). deploy-infra then only prepares the
+#              shared prerequisites (TLS issuers, OpenBao + per-CR seeding, ESO
+#              store) and SUSPENDS the Flux ControlPlane stack so it does not
+#              fight the dev operators or block on the GHCR-published chart.
+# Ignored unless WITH_CONTROLPLANE=true.
+CONTROLPLANE_OPERATORS="${CONTROLPLANE_OPERATORS:-flux}"
+
 # Gateway API CRD release installed before the keystone-operator HelmRelease so
 # the operator's HTTPRoute watch has a registered kind at startup.
 # Keep aligned with sigs.k8s.io/gateway-api in operators/keystone/go.mod.
@@ -886,6 +901,9 @@ main() {
   log "Chaos Mesh         : ${WITH_CHAOS_MESH} (set WITH_CHAOS_MESH=true to install)"
   log "Prometheus stack    : ${WITH_PROMETHEUS} (set WITH_PROMETHEUS=true to install)"
   log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    log "ControlPlane operators : ${CONTROLPLANE_OPERATORS} (flux = published chart + K-ORC Flux source; external = operators deployed out of band)"
+  fi
   log ""
 
   # Pre-flight checks
@@ -1018,7 +1036,7 @@ main() {
   # but running the full chain is opt-in. WITH_CONTROLPLANE=true deploys it; the
   # default leaves it suspended so the bring-up stays light and the keystone E2E
   # path is unchanged.
-  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+  if [[ "${WITH_CONTROLPLANE}" == "true" && "${CONTROLPLANE_OPERATORS}" == "flux" ]]; then
     # Deploy the full ControlPlane stack via Flux from the published c5c3-operator
     # chart and the K-ORC GitRepository/Kustomization. The kind base overlay
     # suspends keystone-operator for the local-build E2E path; un-suspend it here
@@ -1028,6 +1046,23 @@ main() {
     log "WITH_CONTROLPLANE=true: deploying the c5c3 ControlPlane stack (keystone-operator, k-orc, c5c3-operator)."
     kubectl patch helmrelease keystone-operator -n keystone-system \
       --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
+  elif [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    # CONTROLPLANE_OPERATORS=external: the keystone-operator, K-ORC, and
+    # c5c3-operator are deployed out of band (e.g. the e2e-controlplane CI job
+    # uses local dev images). Suspend the Flux ControlPlane stack — including
+    # keystone-operator, which stays suspended so the base HelmRelease does not
+    # fight the dev image deployed via hack/ci-deploy-operator.sh — and let the
+    # rest of this run only prepare the shared prerequisites (TLS, OpenBao +
+    # per-CR seeding, ESO store).
+    log "WITH_CONTROLPLANE=true: ControlPlane operator stack provided externally (dev images); suspending the Flux stack."
+    kubectl patch helmrelease c5c3-operator -n c5c3-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch kustomization k-orc -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch helmrepository c5c3-charts -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
+    kubectl patch gitrepository k-orc -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
   else
     # Suspend the stack (best-effort, not awaited — see helm_releases below) so it
     # does not add idle reconcile churn competing with external-secrets /
@@ -1136,12 +1171,21 @@ main() {
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
     # The c5c3 ControlPlane provisions MariaDB/Memcached itself (managed mode), so
     # render the infrastructure overlay and drop those two CRs before applying —
-    # everything else (TLS issuers, OpenBao certs, ESO ExternalSecrets, Gateway
-    # certs) is still required.
+    # the TLS issuers, OpenBao certs, and Gateway certs are still required.
+    #
+    # Also drop the three standalone-shim ExternalSecrets (keystone-admin,
+    # keystone-db, mariadb-root-password). They are pinned to the DEFAULT
+    # identity's OpenBao paths (openstack/controlplane), but WITH_CONTROLPLANE
+    # seeds per-CR paths for openstack/${CONTROLPLANE_NAME} instead (see the
+    # KORC_CONTROLPLANES export below) — so with a non-default CONTROLPLANE_NAME
+    # the shims have no seeded source and would sit in SecretSyncedError forever.
+    # The ControlPlane path does not use them anyway: the c5c3 operator projects
+    # per-ControlPlane credential ExternalSecrets and the ControlPlane provisions
+    # its own MariaDB root password. Step 8's shim wait is skipped to match.
     kubectl kustomize "${REPO_ROOT}/deploy/kind/infrastructure" \
-      | yq eval 'select(.kind != "MariaDB" and .kind != "Memcached")' - \
+      | yq eval 'select(.kind != "MariaDB" and .kind != "Memcached" and (.kind != "ExternalSecret" or (.metadata.name != "keystone-admin" and .metadata.name != "keystone-db" and .metadata.name != "mariadb-root-password")))' - \
       | kubectl apply -f -
-    log "Infrastructure overlay applied WITHOUT MariaDB/Memcached (WITH_CONTROLPLANE=true; the ControlPlane provisions them)."
+    log "Infrastructure overlay applied WITHOUT MariaDB/Memcached and the standalone-shim ExternalSecrets (WITH_CONTROLPLANE=true; the ControlPlane provisions them)."
   else
     kubectl apply -k "${REPO_ROOT}/deploy/kind/infrastructure"
     log "Infrastructure kustomize overlay applied."
@@ -1182,10 +1226,13 @@ main() {
   # the shell stack no longer seeds it or exports a K-ORC auth_url override.
   # (The admin-password ExternalSecret is now operator-projected per-ControlPlane
   # (reconcileAdminPassword); the kind overlay shim
-  # (deploy/kind/infrastructure/keystone-admin-externalsecret.yaml) pins only the
-  # default identity, so a CONTROLPLANE_NAME override no longer requires editing
-  # that manifest on the ControlPlane path. The K-ORC clouds.yaml ExternalSecret is
-  # likewise created per-CR by the operator and needs no manifest edit.)
+  # (deploy/kind/infrastructure/keystone-admin-externalsecret.yaml) pins the
+  # default identity. A non-default CONTROLPLANE_NAME therefore does NOT seed that
+  # shim's source path, so on the ControlPlane path the three standalone-shim
+  # ExternalSecrets are dropped from the overlay apply and skipped in Step 8
+  # rather than re-pointed — see the overlay-apply and Step 8 blocks below. The
+  # K-ORC clouds.yaml ExternalSecret is likewise created per-CR by the operator
+  # and needs no manifest edit.)
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
     export KORC_CONTROLPLANES="openstack/${CONTROLPLANE_NAME}"
   fi
@@ -1205,20 +1252,33 @@ main() {
   # apply-before-dependency reason as the MariaDB reconcile-trigger below.
   local now
   now=$(date +%s)
-  log "Forcing ESO ClusterSecretStore re-validation and ExternalSecret re-sync..."
+  log "Forcing ESO ClusterSecretStore re-validation..."
   kubectl annotate clustersecretstore/openbao-cluster-store \
     "deploy.c5c3.io/reconcile-trigger=${now}" --overwrite || true
   kubectl wait clustersecretstore/openbao-cluster-store \
     --for=condition=Ready --timeout="${POD_TIMEOUT}s" || true
-  for es in keystone-admin keystone-db mariadb-root-password; do
-    kubectl annotate "externalsecret/${es}" -n openstack \
-      "force-sync=${now}" --overwrite || true
-  done
 
-  # Step 8: Wait for ExternalSecrets to sync
-  log "=== Step 8/8: Wait for ExternalSecrets ==="
-  wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
-    keystone-admin keystone-db mariadb-root-password
+  # The standalone-shim ExternalSecrets (keystone-admin, keystone-db,
+  # mariadb-root-password) are only applied — and only have a seeded OpenBao
+  # source — on the non-ControlPlane path. WITH_CONTROLPLANE drops them from the
+  # overlay apply above and seeds per-CR paths for openstack/${CONTROLPLANE_NAME}
+  # instead, so there is nothing to force-sync or wait for here; the
+  # per-ControlPlane credential ExternalSecrets are projected and verified later
+  # by the c5c3 operator and the chain E2E suite.
+  if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
+    log "=== Step 8/8: Skipping standalone ExternalSecret wait (WITH_CONTROLPLANE=true) ==="
+  else
+    log "Forcing standalone ExternalSecret re-sync..."
+    for es in keystone-admin keystone-db mariadb-root-password; do
+      kubectl annotate "externalsecret/${es}" -n openstack \
+        "force-sync=${now}" --overwrite || true
+    done
+
+    # Step 8: Wait for ExternalSecrets to sync
+    log "=== Step 8/8: Wait for ExternalSecrets ==="
+    wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
+      keystone-admin keystone-db mariadb-root-password
+  fi
 
   if [[ "${WITH_CONTROLPLANE}" != "true" ]]; then
     # Trigger MariaDB operator re-reconciliation.
@@ -1241,22 +1301,33 @@ main() {
     # CR can reconcile; whether that CR is applied here or by hand depends on
     # WITH_CONTROLPLANE_CR (default: by hand — see the ControlPlane Quick Start).
     log "=== WITH_CONTROLPLANE: bringing up the c5c3 ControlPlane stack ==="
-    kubectl wait helmrelease/keystone-operator -n keystone-system \
-      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
-      || log "  keystone-operator not Ready yet (continuing; the ControlPlane tolerates it)."
-    kubectl wait kustomization/k-orc -n flux-system \
-      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
-      || log "  k-orc Kustomization not Ready yet (continuing)."
-    kubectl wait helmrelease/c5c3-operator -n c5c3-system \
-      --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
-      || log "  c5c3-operator not Ready yet (continuing)."
+    if [[ "${CONTROLPLANE_OPERATORS}" == "flux" ]]; then
+      kubectl wait helmrelease/keystone-operator -n keystone-system \
+        --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+        || log "  keystone-operator not Ready yet (continuing; the ControlPlane tolerates it)."
+      kubectl wait kustomization/k-orc -n flux-system \
+        --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+        || log "  k-orc Kustomization not Ready yet (continuing)."
+      kubectl wait helmrelease/c5c3-operator -n c5c3-system \
+        --for=condition=Ready --timeout="${HELMRELEASE_TIMEOUT}s" 2>/dev/null \
+        || log "  c5c3-operator not Ready yet (continuing)."
 
-    # The projected Keystone references ghcr.io/c5c3/keystone:<release>; preload it
-    # so kind need not pull it in-cluster. Best-effort — the image is public on GHCR.
-    local cp_release="2025.2"
-    if docker pull "ghcr.io/c5c3/keystone:${cp_release}" >/dev/null 2>&1; then
-      kind load docker-image "ghcr.io/c5c3/keystone:${cp_release}" --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
-      log "  Preloaded ghcr.io/c5c3/keystone:${cp_release} into kind."
+      # The projected Keystone references ghcr.io/c5c3/keystone:<release>; preload it
+      # so kind need not pull it in-cluster. Best-effort — the image is public on GHCR.
+      local cp_release="2025.2"
+      if docker pull "ghcr.io/c5c3/keystone:${cp_release}" >/dev/null 2>&1; then
+        kind load docker-image "ghcr.io/c5c3/keystone:${cp_release}" --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+        log "  Preloaded ghcr.io/c5c3/keystone:${cp_release} into kind."
+      fi
+    else
+      # CONTROLPLANE_OPERATORS=external: the Flux stack is suspended and the
+      # operators + service/client images are provided by the caller (the
+      # e2e-controlplane CI job deploys keystone-operator + c5c3-operator via
+      # hack/ci-deploy-operator.sh, K-ORC via hack/ci-deploy-korc.sh, and loads
+      # keystone:2025.2 / tempest:2025.2 into kind). Skip the Flux waits and the
+      # published-image preload — the suspended releases would never report Ready.
+      log "  ControlPlane operators provided externally (CONTROLPLANE_OPERATORS=external);"
+      log "  skipping Flux HelmRelease/Kustomization waits and the published-image preload."
     fi
 
     if [[ "${WITH_CONTROLPLANE_CR}" == "true" ]]; then

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -16,11 +16,15 @@ ARG KEYSTONE_TEMPEST_PLUGIN_VERSION=0.19.0
 
 # Install Tempest and plugins into the shared virtualenv.
 # upper-constraints.txt is passed as a named build context from the release dir.
+# python-openstackclient provides the `openstack` CLI used by the
+# full-controlplane-keystone E2E verify Job (token issue / catalog list);
+# its version is pinned by upper-constraints like the other unversioned deps.
 RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \
     uv pip install --prefix /var/lib/openstack \
         --constraint /tmp/upper-constraints.txt \
         tempest==${TEMPEST_VERSION} \
         keystone-tempest-plugin==${KEYSTONE_TEMPEST_PLUGIN_VERSION} \
+        python-openstackclient \
         python-subunit \
         junitxml \
         defusedxml

--- a/internal/common/types/types.go
+++ b/internal/common/types/types.go
@@ -72,6 +72,18 @@ type DatabaseSpec struct {
 	// existing DatabaseSpec consumers.
 	// +optional
 	TLS *DatabaseTLSSpec `json:"tls,omitempty"`
+	// Replicas is the number of managed MariaDB replicas provisioned in
+	// fresh-create mode. It mirrors CacheSpec.Replicas: only the c5c3 operator's
+	// managed-mode projection honours it (a single replica yields a
+	// single-instance non-Galera MariaDB, three or more yield a Galera cluster),
+	// so a constrained cluster such as a single-node kind can schedule the
+	// fresh-create path. Operators that adopt an existing MariaDB (keystone, and
+	// the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+	// set.
+	// +optional
+	// +kubebuilder:default=3
+	// +kubebuilder:validation:Minimum=1
+	Replicas int32 `json:"replicas,omitempty"`
 }
 
 // DatabaseTLSSpec configures opt-in TLS (and mutual TLS) for a database

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -267,6 +267,24 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) field.ErrorList {
 		))
 	}
 
+	// database.replicas must be 1 (standalone) or >=3 (a quorum-safe Galera
+	// cluster). Exactly 2 is rejected because the managed-mode MariaDB projection
+	// (ensureMariaDB) turns any replicas>1 into a Galera cluster, and a two-node
+	// Galera cluster cannot hold a majority — a single pod disruption (restart,
+	// OOM-kill, rolling update, network partition) then loses quorum and takes the
+	// whole database offline. The CRD marker only enforces Minimum=1, so this
+	// webhook is the enforcement point; the shared commonv1.DatabaseSpec must not
+	// carry a c5c3-specific CEL rule the keystone operator (which ignores replicas)
+	// would also inherit. A zero value (CRD/webhook default bypassed) is left to
+	// the reconciler's floor, so only an explicit 2 is rejected here.
+	if db.Replicas == 2 {
+		allErrs = append(allErrs, field.Invalid(
+			specPath.Child("infrastructure", "database", "replicas"),
+			db.Replicas,
+			"database replicas must be 1 (standalone) or >=3 (Galera needs quorum); 2 cannot hold a majority",
+		))
+	}
+
 	// cache must use exactly one of clusterRef or servers (mirrors the
 	// keystone cache XOR check / CEL rule).
 	cache := cp.Spec.Infrastructure.Cache
@@ -389,6 +407,18 @@ func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
 	if oldDB.Database != newDB.Database {
 		allErrs = append(allErrs, field.Invalid(dbPath.Child("database"),
 			newDB.Database, "database name is immutable"))
+	}
+	// database.replicas is create-only. It is projected into the managed MariaDB
+	// child's replica count and the derived Galera topology (ensureMariaDB), so
+	// editing it on a live ControlPlane would drive a destructive Update on the
+	// owned cluster — toggling Galera off (3->1) or scaling a running Galera
+	// cluster down. Freezing it here keeps the CR the single source of truth for a
+	// topology that can only be changed safely by recreating the control plane,
+	// mirroring the database name / region / clusterRef.name immutability above.
+	if oldDB.Replicas != newDB.Replicas {
+		allErrs = append(allErrs, field.Invalid(dbPath.Child("replicas"),
+			newDB.Replicas, "database replicas is immutable after creation "+
+				"(toggling Galera or scaling down a live cluster is destructive)"))
 	}
 
 	cachePath := field.NewPath("spec", "infrastructure", "cache")

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -312,6 +312,40 @@ func TestValidateCreate_RejectsDatabaseNeitherSet(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("database"))
 }
 
+// TestValidateCreate_RejectsDatabaseReplicasTwo verifies that a managed-mode
+// ControlPlane requesting database.replicas: 2 is rejected. The managed MariaDB
+// projection turns any replicas>1 into a Galera cluster, and a two-node Galera
+// cluster cannot hold a quorum majority, so a single pod disruption takes the
+// whole database offline. The CRD marker only enforces Minimum=1, making this
+// webhook the enforcement point.
+func TestValidateCreate_RejectsDatabaseReplicasTwo(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := managedControlPlane()
+	cp.Spec.Infrastructure.Database.Replicas = 2
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("replicas"))
+	g.Expect(err.Error()).To(ContainSubstring("quorum"))
+}
+
+// TestValidateCreate_AcceptsQuorumSafeDatabaseReplicas verifies that the
+// quorum-safe replica counts — 1 (standalone) and 3 (Galera with a majority) —
+// pass validation, so the replicas>1==2 guard does not over-restrict legitimate
+// topologies.
+func TestValidateCreate_AcceptsQuorumSafeDatabaseReplicas(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	for _, replicas := range []int32{1, 3, 5} {
+		cp := managedControlPlane()
+		cp.Spec.Infrastructure.Database.Replicas = replicas
+		_, err := w.ValidateCreate(context.Background(), cp)
+		g.Expect(err).NotTo(HaveOccurred(), "replicas=%d should be accepted", replicas)
+	}
+}
+
 func TestValidateCreate_RejectsCacheBothSet(t *testing.T) {
 	g := NewGomegaWithT(t)
 	w := &ControlPlaneWebhook{}
@@ -666,6 +700,32 @@ func TestValidateUpdate_RejectsDatabaseNameChange(t *testing.T) {
 	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("database name is immutable"))
+}
+
+// TestValidateUpdate_RejectsDatabaseReplicasChange verifies that changing
+// database.replicas is rejected on UPDATE: the count is projected into the owned
+// MariaDB child's replica count and derived Galera topology, so editing it on a
+// live control plane would drive a destructive scale-down or Galera toggle
+// (3->1). Both directions are exercised so neither a scale-up nor a scale-down
+// slips through.
+func TestValidateUpdate_RejectsDatabaseReplicasChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// 3 -> 1 (scale down / Galera toggle off).
+	oldCP := managedControlPlane()
+	oldCP.Spec.Infrastructure.Database.Replicas = 3
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.Replicas = 1
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database replicas is immutable"))
+
+	// 1 -> 3 (the reverse direction).
+	_, err = w.ValidateUpdate(context.Background(), newCP, oldCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database replicas is immutable"))
 }
 
 // TestValidateUpdate_RejectsRegionChange verifies that changing the region is

--- a/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
@@ -194,6 +194,20 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      replicas:
+                        default: 3
+                        description: |-
+                          Replicas is the number of managed MariaDB replicas provisioned in
+                          fresh-create mode. It mirrors CacheSpec.Replicas: only the c5c3 operator's
+                          managed-mode projection honours it (a single replica yields a
+                          single-instance non-Galera MariaDB, three or more yield a Galera cluster),
+                          so a constrained cluster such as a single-node kind can schedule the
+                          fresh-create path. Operators that adopt an existing MariaDB (keystone, and
+                          the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                          set.
+                        format: int32
+                        minimum: 1
+                        type: integer
                       secretRef:
                         description: SecretRef references the K8s Secret with credentials.
                         properties:

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
@@ -197,6 +197,20 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      replicas:
+                        default: 3
+                        description: |-
+                          Replicas is the number of managed MariaDB replicas provisioned in
+                          fresh-create mode. It mirrors CacheSpec.Replicas: only the c5c3 operator's
+                          managed-mode projection honours it (a single replica yields a
+                          single-instance non-Galera MariaDB, three or more yield a Galera cluster),
+                          so a constrained cluster such as a single-node kind can schedule the
+                          fresh-create path. Operators that adopt an existing MariaDB (keystone, and
+                          the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                          set.
+                        format: int32
+                        minimum: 1
+                        type: integer
                       secretRef:
                         description: SecretRef references the K8s Secret with credentials.
                         properties:

--- a/operators/c5c3/internal/controller/reconcile_admincredential.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential.go
@@ -156,14 +156,37 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 		}
 	}
 
+	// Content hash of the assembled clouds.yaml. It keys BOTH the PushSecret
+	// re-push trigger just below and the ExternalSecret force-sync further down, so
+	// each fires exactly once per credential change and a steady-state pass leaves
+	// both untouched.
+	contentSum := sha256.Sum256(cloudsYAML)
+	contentHash := hex.EncodeToString(contentSum[:])
+
 	// CLOBBER-SAFE PushSecret: EnsurePushSecret applies via Server-Side Apply
 	// under a fixed field manager that owns only the fields the operator sets, so
 	// repeated applies of an unchanged desired Spec are no-ops at the API server.
-	// Reconciles therefore do not churn the PushSecret, so ESO is not woken to
-	// re-push an unchanged credential.
 	ps := adminAppCredentialPushSecret(cp)
 	if err := secrets.EnsurePushSecret(ctx, r.Client, r.Scheme, cp, ps); err != nil {
 		fail("PushSecretError", fmt.Sprintf("ensuring admin app-credential PushSecret: %v", err))
+		return ctrl.Result{}, err
+	}
+
+	// Drive an immediate re-push of the (now credential-based) source Secret to
+	// OpenBao. ESO's PushSecret controller does NOT watch its source Secret: its
+	// shouldRefresh gate re-pushes only when the PushSecret object's own
+	// label/annotation hash changes (external-secrets v1.3.2,
+	// pkg/controllers/pushsecret + util.HashMeta), NOT when the referenced Secret's
+	// contents change. On a fresh create the PushSecret first pushes the BOOTSTRAP
+	// clouds.yaml (so K-ORC can authenticate and mint); the credential-based source
+	// update above would then not reach OpenBao until the 1h refreshInterval,
+	// leaving the k-orc-clouds-yaml ExternalSecret materialising the stale bootstrap
+	// credential and AdminCredentialReady stuck False for up to an hour. Stamping a
+	// content-hash annotation changes the PushSecret's metadata hash and forces the
+	// re-push now; it is idempotent (skipped when the hash already matches), so a
+	// converged credential never churns the push.
+	if err := r.forceRepushAdminAppCredential(ctx, cp, ps.Name, contentHash); err != nil {
+		fail("PushSecretError", fmt.Sprintf("forcing admin app-credential PushSecret re-push: %v", err))
 		return ctrl.Result{}, err
 	}
 
@@ -189,14 +212,12 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 	// actually authenticates with still holds the revoked credential — up to ~2h of
 	// auth against a dead credential while AdminCredentialReady reads True.
 	//
-	// Force an immediate ESO re-sync (a force-sync annotation keyed by the assembled
-	// content hash — idempotent, so a steady-state pass does not churn the
+	// Force an immediate ESO re-sync of the materialized Secret (the contentHash
+	// force-sync annotation is idempotent, so a steady-state pass does not churn the
 	// ExternalSecret) and gate AdminCredentialReady on the materialized Secret bytes
 	// actually matching the freshly assembled clouds.yaml. The byte-compare — not the
 	// best-effort force-sync — is the correctness guarantee: it never reports Ready
 	// while the materialized credential is stale.
-	contentSum := sha256.Sum256(cloudsYAML)
-	contentHash := hex.EncodeToString(contentSum[:])
 	if err := r.forceSyncKORCCloudsYAMLExternalSecret(ctx, cp, cloudsYamlName, contentHash); err != nil {
 		fail("CloudsYamlError", fmt.Sprintf("forcing k-orc clouds.yaml ExternalSecret re-sync: %v", err))
 		return ctrl.Result{}, err
@@ -356,6 +377,50 @@ func (r *ControlPlaneReconciler) forceSyncKORCCloudsYAMLExternalSecret(ctx conte
 		return r.Update(ctx, es)
 	}); err != nil {
 		return fmt.Errorf("forcing k-orc clouds.yaml ExternalSecret %q re-sync: %w", name, err)
+	}
+	return nil
+}
+
+// adminAppCredentialPushContentHashAnnotation stamps the assembled clouds.yaml
+// content hash onto the admin app-credential PushSecret. Changing it alters the
+// PushSecret's metadata hash, which is the only input ESO's PushSecret
+// shouldRefresh gate reacts to (it does not watch the source Secret), forcing an
+// immediate re-push of the updated credential.
+const adminAppCredentialPushContentHashAnnotation = "c5c3.io/push-content-hash" //nolint:gosec // G101 false positive: annotation key, not a credential.
+
+// forceRepushAdminAppCredential nudges ESO to re-push the admin app-credential
+// source Secret to OpenBao by stamping a content-hash annotation on the backing
+// PushSecret. ESO's PushSecret controller re-pushes only when the PushSecret
+// object's own metadata hash changes (it does not watch the referenced Secret),
+// so without this stamp a source-Secret update — e.g. the fresh-create handoff
+// from the bootstrap clouds.yaml to the minted credential — would not reach
+// OpenBao until the PushSecret's hourly refreshInterval. The annotation is keyed
+// by the assembled clouds.yaml content hash, so it changes only when the
+// credential changes and a steady-state pass is a no-op.
+func (r *ControlPlaneReconciler) forceRepushAdminAppCredential(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, name, hash string) error {
+	key := types.NamespacedName{Namespace: childNamespace(cp), Name: name}
+	// Read-modify-write under RetryOnConflict: ESO mutates the PushSecret's status
+	// (and re-pushes on the metadata change this triggers), so a 409 Conflict
+	// between our Get and Update is expected concurrency, not a fault — retrying
+	// keeps a transient conflict from surfacing as a PushSecretError.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ps := &esov1alpha1.PushSecret{}
+		if err := r.Get(ctx, key, ps); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if ps.Annotations[adminAppCredentialPushContentHashAnnotation] == hash {
+			return nil
+		}
+		if ps.Annotations == nil {
+			ps.Annotations = map[string]string{}
+		}
+		ps.Annotations[adminAppCredentialPushContentHashAnnotation] = hash
+		return r.Update(ctx, ps)
+	}); err != nil {
+		return fmt.Errorf("forcing admin app-credential PushSecret %q re-push: %w", name, err)
 	}
 	return nil
 }

--- a/operators/c5c3/internal/controller/reconcile_admincredential.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential.go
@@ -212,13 +212,27 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 	// actually authenticates with still holds the revoked credential — up to ~2h of
 	// auth against a dead credential while AdminCredentialReady reads True.
 	//
-	// Force an immediate ESO re-sync of the materialized Secret (the contentHash
-	// force-sync annotation is idempotent, so a steady-state pass does not churn the
+	// Force an immediate ESO re-sync of the materialized Secret (the force-sync
+	// annotation is idempotent, so a steady-state pass does not churn the
 	// ExternalSecret) and gate AdminCredentialReady on the materialized Secret bytes
 	// actually matching the freshly assembled clouds.yaml. The byte-compare — not the
 	// best-effort force-sync — is the correctness guarantee: it never reports Ready
 	// while the materialized credential is stale.
-	if err := r.forceSyncKORCCloudsYAMLExternalSecret(ctx, cp, cloudsYamlName, contentHash); err != nil {
+	//
+	// The trigger is contentHash + the PushSecret's status.syncedResourceVersion,
+	// NOT contentHash alone. Both nudges (re-push above, force-sync here) are
+	// stamped in the same reconcile pass, but ESO processes the PushSecret and the
+	// ExternalSecret independently: keyed on contentHash alone, the ExternalSecret
+	// refresh can read OpenBao BEFORE the re-push has written it, re-materialise
+	// the stale bootstrap document, and — with the annotation already at its final
+	// value — never be nudged again, wedging AdminCredentialReady at
+	// WaitingForCloudsYamlSync until the hourly refresh (lost race observed in the
+	// e2e-controlplane full-chain job). ESO bumps syncedResourceVersion only AFTER
+	// a completed push, so folding it in re-nudges the ExternalSecret exactly once
+	// more as soon as the re-push lands; both inputs are stable once converged, so
+	// a steady-state pass still leaves the ExternalSecret untouched.
+	syncTrigger := contentHash + "/" + pushed.Status.SyncedResourceVersion
+	if err := r.forceSyncKORCCloudsYAMLExternalSecret(ctx, cp, cloudsYamlName, syncTrigger); err != nil {
 		fail("CloudsYamlError", fmt.Sprintf("forcing k-orc clouds.yaml ExternalSecret re-sync: %v", err))
 		return ctrl.Result{}, err
 	}
@@ -341,16 +355,19 @@ func parseAppCredIdentity(cloudsYAML []byte) (appCredIdentity, bool) {
 
 // forceSyncKORCCloudsYAMLExternalSecret nudges ESO to re-materialise the K-ORC
 // clouds.yaml Secret immediately rather than at the next hourly refresh, by
-// stamping the external-secrets.io/force-sync annotation with the content hash of
-// the freshly assembled clouds.yaml. ESO folds the ExternalSecret's annotations
-// into its sync-decision hash, so a changed value forces a re-sync; an unchanged
-// value is a no-op, so a steady-state pass does not churn the ExternalSecret.
+// stamping the external-secrets.io/force-sync annotation with the given trigger
+// (the assembled clouds.yaml content hash combined with the PushSecret's
+// syncedResourceVersion — see the call site in reconcileAdminCredential for why
+// the completed-push marker must be part of it). ESO folds the ExternalSecret's
+// annotations into its sync-decision hash, so a changed value forces a re-sync;
+// an unchanged value is a no-op, so a steady-state pass does not churn the
+// ExternalSecret.
 //
 // A missing ExternalSecret is treated as a no-op nil — reconcileKORC owns its
 // creation (ensureKORCCloudsYAMLExternalSecret), and the byte-compare gate in
 // reconcileAdminCredential, not this nudge, is what guarantees the materialized
 // credential is fresh before AdminCredentialReady flips True.
-func (r *ControlPlaneReconciler) forceSyncKORCCloudsYAMLExternalSecret(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, name, hash string) error {
+func (r *ControlPlaneReconciler) forceSyncKORCCloudsYAMLExternalSecret(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, name, trigger string) error {
 	key := types.NamespacedName{Namespace: childNamespace(cp), Name: name}
 	// Read-modify-write the force-sync annotation under RetryOnConflict: ESO mutates
 	// this ExternalSecret's status and its own annotations on every refresh (and on
@@ -367,13 +384,13 @@ func (r *ControlPlaneReconciler) forceSyncKORCCloudsYAMLExternalSecret(ctx conte
 			}
 			return err
 		}
-		if es.Annotations[esov1.AnnotationForceSync] == hash {
+		if es.Annotations[esov1.AnnotationForceSync] == trigger {
 			return nil
 		}
 		if es.Annotations == nil {
 			es.Annotations = map[string]string{}
 		}
-		es.Annotations[esov1.AnnotationForceSync] = hash
+		es.Annotations[esov1.AnnotationForceSync] = trigger
 		return r.Update(ctx, es)
 	}); err != nil {
 		return fmt.Errorf("forcing k-orc clouds.yaml ExternalSecret %q re-sync: %w", name, err)

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -47,9 +47,13 @@ func childNamespace(cp *c5c3v1alpha1.ControlPlane) string {
 // DECISION the managed-mode MariaDB CR is provisioned with
 // a MINIMAL but VALID spec. The mariadb-operator's webhook requires
 // Storage.Size (or a VolumeClaimTemplate) — see Storage.Validate in the
-// vendored v0.38.1 types — so a 100Gi size and a Galera HA topology are set to
-// mirror the production baseline (deploy/flux-system/infrastructure/mariadb.yaml
-// uses replicas:3 + galera.enabled + storage.size:100Gi). TLS / issuerRefs are
+// vendored v0.38.1 types — so a 100Gi size is set to mirror the production
+// baseline (deploy/flux-system/infrastructure/mariadb.yaml uses
+// storage.size:100Gi). The replica topology is DERIVED from
+// spec.infrastructure.database.replicas: the default (3) yields a Galera HA
+// cluster matching the production baseline, while a single replica yields a
+// single-instance non-Galera MariaDB so the fresh-create path schedules on a
+// constrained cluster such as a single-node kind. TLS / issuerRefs are
 // deliberately NOT set here: the baseline wires those from cluster-specific
 // ClusterIssuers that are an infrastructure concern outside the aggregate's
 // knowledge, and the keystone DB-client baseline reads TLS from
@@ -58,7 +62,11 @@ func childNamespace(cp *c5c3v1alpha1.ControlPlane) string {
 // platform team.
 const (
 	infraMariaDBStorageSize = "100Gi"
-	infraMariaDBReplicas    = int32(3)
+	// infraMariaDBReplicasDefault is the zero-value floor applied when
+	// spec.infrastructure.database.replicas is unset (0). The CRD default is 3,
+	// so this only fires when validation was bypassed; it keeps the projection
+	// admissible (replicas >= 1) rather than creating a zero-replica MariaDB.
+	infraMariaDBReplicasDefault = int32(3)
 )
 
 // memcachedGVK is the GroupVersionKind of the Memcached CR projected in managed
@@ -170,19 +178,31 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 		Name:      cp.Spec.Infrastructure.Database.ClusterRef.Name,
 		Namespace: childNamespace(cp),
 	}
+	// Derive the projected topology from the ControlPlane spec. A single replica
+	// yields a single-instance MariaDB with Galera off, so a single-node kind can
+	// schedule the fresh-create path; any multi-replica count (the default is 3)
+	// enables the Galera clustering the production baseline uses. Floor a
+	// zero/negative value (only reachable when CRD validation was bypassed) to
+	// the default.
+	replicas := cp.Spec.Infrastructure.Database.Replicas
+	if replicas < 1 {
+		replicas = infraMariaDBReplicasDefault
+	}
+	galeraEnabled := replicas > 1
+
 	mariadb := &mariadbv1alpha1.MariaDB{}
 	err := r.Get(ctx, key, mariadb)
 	switch {
 	case apierrors.IsNotFound(err):
-		// Create fresh with the projected, production-shaped spec.
+		// Create fresh with the projected, spec-derived topology.
 		size, perr := resource.ParseQuantity(infraMariaDBStorageSize)
 		if perr != nil {
 			return false, fmt.Errorf("parsing MariaDB storage size %q: %w", infraMariaDBStorageSize, perr)
 		}
 		mariadb.Name = key.Name
 		mariadb.Namespace = key.Namespace
-		mariadb.Spec.Replicas = infraMariaDBReplicas
-		mariadb.Spec.Galera = &mariadbv1alpha1.Galera{Enabled: true}
+		mariadb.Spec.Replicas = replicas
+		mariadb.Spec.Galera = &mariadbv1alpha1.Galera{Enabled: galeraEnabled}
 		mariadb.Spec.Storage = mariadbv1alpha1.Storage{Size: &size}
 		if serr := controllerutil.SetControllerReference(cp, mariadb, r.Scheme); serr != nil {
 			return false, fmt.Errorf("setting owner reference on MariaDB %q: %w", key.Name, serr)
@@ -196,10 +216,13 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 		// A MariaDB with this clusterRef name already exists. Two sub-cases:
 		//
 		//  1. It is OWNED by this ControlPlane (we created it on an earlier pass):
-		//     reconcile the MUTABLE projection — spec.replicas — so a changed
-		//     projection default (infraMariaDBReplicas) takes effect on the cluster
-		//     we own, rather than being frozen at first-creation. spec.storage is
-		//     deliberately NOT re-projected even when owned: the mariadb-operator
+		//     re-assert the spec-derived projection — spec.replicas and the derived
+		//     Galera topology — so external drift on the owned cluster is corrected
+		//     back to the declared topology. spec.infrastructure.database.replicas
+		//     is itself immutable after creation (the ControlPlane validating
+		//     webhook rejects a change), so this never scales down or toggles Galera
+		//     in response to a user edit — only in response to drift. spec.storage
+		//     is deliberately NOT re-projected even when owned: the mariadb-operator
 		//     webhook rejects changing spec.storage.* on an existing CR, so storage
 		//     stays as first created.
 		//
@@ -209,10 +232,14 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 		//     (immutable storage) or needlessly reshape a running database, and we
 		//     never claim GC ownership of a resource we did not create, so deleting
 		//     the ControlPlane never cascades into shared infra.
-		if metav1.IsControlledBy(mariadb, cp) && mariadb.Spec.Replicas != infraMariaDBReplicas {
-			mariadb.Spec.Replicas = infraMariaDBReplicas
-			if uerr := r.Update(ctx, mariadb); uerr != nil {
-				return false, fmt.Errorf("updating owned MariaDB %q replicas: %w", key.Name, uerr)
+		if metav1.IsControlledBy(mariadb, cp) {
+			currentGalera := mariadb.Spec.Galera != nil && mariadb.Spec.Galera.Enabled
+			if mariadb.Spec.Replicas != replicas || currentGalera != galeraEnabled {
+				mariadb.Spec.Replicas = replicas
+				mariadb.Spec.Galera = &mariadbv1alpha1.Galera{Enabled: galeraEnabled}
+				if uerr := r.Update(ctx, mariadb); uerr != nil {
+					return false, fmt.Errorf("updating owned MariaDB %q topology: %w", key.Name, uerr)
+				}
 			}
 		}
 	}

--- a/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
@@ -250,7 +250,7 @@ func TestEnsureMariaDB_OwnedReconcilesReplicas(t *testing.T) {
 	ownedMariaDB := &mariadbv1alpha1.MariaDB{
 		ObjectMeta: metav1.ObjectMeta{Name: "openstack-db", Namespace: childNamespace(cp)},
 		Spec: mariadbv1alpha1.MariaDBSpec{
-			Replicas: 1, // drifted below the projected default (infraMariaDBReplicas)
+			Replicas: 1, // drifted below the projected default (infraMariaDBReplicasDefault)
 			Storage: mariadbv1alpha1.Storage{
 				Size:             &existingSize,
 				StorageClassName: "standard",
@@ -270,10 +270,100 @@ func TestEnsureMariaDB_OwnedReconcilesReplicas(t *testing.T) {
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: "openstack-db", Namespace: childNamespace(cp),
 	}, &mariadb)).To(Succeed())
-	g.Expect(mariadb.Spec.Replicas).To(Equal(infraMariaDBReplicas),
+	g.Expect(mariadb.Spec.Replicas).To(Equal(infraMariaDBReplicasDefault),
 		"an owned MariaDB must have its replicas reconciled to the projected default")
+	g.Expect(mariadb.Spec.Galera).NotTo(BeNil())
+	g.Expect(mariadb.Spec.Galera.Enabled).To(BeTrue(),
+		"the default 3-replica projection re-enables Galera on an owned MariaDB")
 	g.Expect(mariadb.Spec.Storage.StorageClassName).To(Equal("standard"),
 		"storage stays immutable even for an owned MariaDB")
+}
+
+// TestEnsureMariaDB_OwnedReconcilesGaleraState isolates the Galera-only drift
+// case: an owned MariaDB already sits at the projected replica default, but its
+// Galera flag has drifted off. ensureMariaDB must flip Galera back on without
+// touching the (already-correct) replica count or the immutable storage, proving
+// the update triggers on Galera drift alone and not only on a replica mismatch.
+func TestEnsureMariaDB_OwnedReconcilesGaleraState(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := managedInfraControlPlane() // Database.Replicas defaults to infraMariaDBReplicasDefault
+
+	existingSize := resource.MustParse("100Gi")
+	ownedMariaDB := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "openstack-db", Namespace: childNamespace(cp)},
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Replicas: infraMariaDBReplicasDefault,             // already at the projected default
+			Galera:   &mariadbv1alpha1.Galera{Enabled: false}, // only Galera has drifted off
+			Storage: mariadbv1alpha1.Storage{
+				Size:             &existingSize,
+				StorageClassName: "standard",
+			},
+		},
+	}
+	// Mark the MariaDB as owned by this ControlPlane (controller owner reference).
+	g.Expect(controllerutil.SetControllerReference(cp, ownedMariaDB, s)).To(Succeed())
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ownedMariaDB).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.ensureMariaDB(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var mariadb mariadbv1alpha1.MariaDB
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: "openstack-db", Namespace: childNamespace(cp),
+	}, &mariadb)).To(Succeed())
+	g.Expect(mariadb.Spec.Replicas).To(Equal(infraMariaDBReplicasDefault),
+		"replicas already at the default must stay unchanged when only Galera drifted")
+	g.Expect(mariadb.Spec.Galera).NotTo(BeNil())
+	g.Expect(mariadb.Spec.Galera.Enabled).To(BeTrue(),
+		"ensureMariaDB must re-enable Galera when only the Galera flag has drifted on an owned MariaDB")
+	g.Expect(mariadb.Spec.Storage.StorageClassName).To(Equal("standard"),
+		"storage stays immutable while correcting Galera drift")
+}
+
+// TestEnsureMariaDB_ReplicasFromSpec verifies the fresh-create projection honours
+// spec.infrastructure.database.replicas: a single replica yields a non-Galera
+// MariaDB (so it schedules on a single-node kind), three replicas yield a Galera
+// cluster, and a zero value (only reachable when CRD validation is bypassed) is
+// floored to the default with Galera enabled. Storage is always the fixed size.
+func TestEnsureMariaDB_ReplicasFromSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		specReplicas int32
+		wantReplicas int32
+		wantGalera   bool
+	}{
+		{name: "single replica disables Galera", specReplicas: 1, wantReplicas: 1, wantGalera: false},
+		{name: "three replicas enable Galera", specReplicas: 3, wantReplicas: 3, wantGalera: true},
+		{name: "zero replicas floored to default", specReplicas: 0, wantReplicas: infraMariaDBReplicasDefault, wantGalera: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			s := infraTestScheme(t)
+			cp := managedInfraControlPlane()
+			cp.Spec.Infrastructure.Database.Replicas = tc.specReplicas
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+			r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+			_, err := r.ensureMariaDB(context.Background(), cp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var mariadb mariadbv1alpha1.MariaDB
+			g.Expect(c.Get(context.Background(), types.NamespacedName{
+				Name: "openstack-db", Namespace: childNamespace(cp),
+			}, &mariadb)).To(Succeed())
+			g.Expect(mariadb.Spec.Replicas).To(Equal(tc.wantReplicas))
+			g.Expect(mariadb.Spec.Galera).NotTo(BeNil())
+			g.Expect(mariadb.Spec.Galera.Enabled).To(Equal(tc.wantGalera))
+			g.Expect(mariadb.Spec.Storage.Size).NotTo(BeNil(),
+				"storage size is fixed regardless of replica count")
+		})
+	}
 }
 
 // TestEnsureMemcached_OwnedReconcilesReplicas verifies the owner-aware path for

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -676,14 +676,16 @@ func TestReconcileAdminCredential_PushSecretBuiltAndReady(t *testing.T) {
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 
 	// The clouds.yaml ExternalSecret carries the force-sync annotation keyed by the
-	// assembled content hash, so ESO re-materialises immediately rather than at the
-	// hourly refresh (closing the stale-credential window after a re-mint).
+	// assembled content hash AND the PushSecret's completed-push marker
+	// (syncedResourceVersion), so ESO re-materialises immediately rather than at the
+	// hourly refresh (closing the stale-credential window after a re-mint) and gets
+	// re-nudged once more after the re-push actually lands in OpenBao.
 	sum := sha256.Sum256([]byte(buildAppCredCloudsYAML(cp, "test-ac-id", "generated-app-cred-secret")))
 	es := &esov1.ExternalSecret{}
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
 	}, es)).To(Succeed())
-	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:])))
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:]) + "/" + testPushSyncedRV))
 
 	// PushSecret created with the right store + remote path.
 	ps := &esov1alpha1.PushSecret{}
@@ -740,7 +742,7 @@ func TestReconcileAdminCredential_DefersUntilCloudsYamlMaterialized(t *testing.T
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
 	}, es)).To(Succeed())
-	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:])),
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hex.EncodeToString(sum[:])+"/"+testPushSyncedRV),
 		"a deferred sync must still stamp the force-sync annotation so ESO re-materialises")
 }
 
@@ -847,6 +849,72 @@ func TestReconcileAdminCredential_RecentStaleStaysTransient(t *testing.T) {
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).To(Equal("WaitingForCloudsYamlSync"),
 		"a freshly stale materialized clouds.yaml within the timeout must stay on the transient reason")
+}
+
+// TestReconcileAdminCredential_ForceSyncRekeyedAfterRepush locks in the race fix
+// for the fresh-create credential handoff: the re-push nudge (PushSecret) and the
+// force-sync nudge (ExternalSecret) are stamped in the same reconcile pass, but ESO
+// processes them independently — the ExternalSecret refresh can read OpenBao BEFORE
+// the re-push has written it and re-materialise the stale bootstrap document. Keyed
+// on contentHash alone the annotation would then already sit at its final value and
+// ESO would never be nudged again (AdminCredentialReady wedged at
+// WaitingForCloudsYamlSync until the hourly refresh). The trigger must therefore
+// change again once the PushSecret's syncedResourceVersion reports the completed
+// re-push, producing exactly one fresh nudge after the push landed.
+func TestReconcileAdminCredential_ForceSyncRekeyedAfterRepush(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	setKORCReady(cp)
+	cp.Status.AdminApplicationCredential = &c5c3v1alpha1.AdminApplicationCredentialStatus{ID: "test-ac-id"}
+	// The materialized Secret still holds the stale BOOTSTRAP document (no
+	// app-credential identity), simulating an ExternalSecret refresh that lost the
+	// race against the re-push write.
+	staleMat := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp)},
+		Data:       map[string][]byte{appCredCloudsYAMLKey: []byte("clouds:\n  admin:\n    auth:\n      username: admin\n      password: bootstrap\n")},
+	}
+	ps := readyAppCredPushSecret(cp)
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyCloudsYamlES(cp), mintedAppCredSecret(cp), ps, staleMat).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	// Pass 1: the re-push has not completed yet (syncedResourceVersion is the
+	// pre-stamp value) — the trigger carries that marker and the gate stays False.
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+
+	sum := sha256.Sum256([]byte(buildAppCredCloudsYAML(cp, "test-ac-id", "generated-app-cred-secret")))
+	hash := hex.EncodeToString(sum[:])
+	es := &esov1.ExternalSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
+	}, es)).To(Succeed())
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hash + "/" + testPushSyncedRV))
+
+	// ESO completes the re-push: the PushSecret's syncedResourceVersion moves on.
+	got := &esov1alpha1.PushSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: adminAppCredentialPushSecretName(cp), Namespace: childNamespace(cp),
+	}, got)).To(Succeed())
+	got.Status.SyncedResourceVersion = "2-after-repush"
+	g.Expect(c.Update(context.Background(), got)).To(Succeed())
+
+	// Pass 2: the trigger must be re-stamped with the completed-push marker — a
+	// CHANGED annotation value, i.e. a fresh ESO nudge issued after the re-push
+	// actually landed in OpenBao.
+	res, err = r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter),
+		"the materialized document is still stale, so the gate must keep requeuing")
+
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Name: korcCloudsYamlSecretName, Namespace: childNamespace(cp),
+	}, es)).To(Succeed())
+	g.Expect(es.Annotations[esov1.AnnotationForceSync]).To(Equal(hash+"/2-after-repush"),
+		"a completed re-push must produce a fresh force-sync trigger so ESO re-materialises after the write")
 }
 
 // TestForceSyncKORCCloudsYAMLExternalSecret_RetriesOnConflict asserts that a 409
@@ -1868,15 +1936,21 @@ func mintedAppCredSecret(cp *c5c3v1alpha1.ControlPlane) *corev1.Secret {
 	}
 }
 
+// testPushSyncedRV is the syncedResourceVersion readyAppCredPushSecret reports —
+// the completed-push marker the ExternalSecret force-sync trigger folds in.
+const testPushSyncedRV = "1-test-synced-rv"
+
 // readyAppCredPushSecret returns the admin app-credential PushSecret with the exact
 // spec the operator builds (so EnsurePushSecret performs no update) plus a Ready
-// condition — the state after ESO has successfully synced it to OpenBao. The
-// AdminCredentialReady gate requires the PushSecret to be Ready.
+// condition and a syncedResourceVersion — the state after ESO has successfully
+// synced it to OpenBao. The AdminCredentialReady gate requires the PushSecret to be
+// Ready, and the force-sync trigger incorporates the syncedResourceVersion.
 func readyAppCredPushSecret(cp *c5c3v1alpha1.ControlPlane) *esov1alpha1.PushSecret {
 	ps := adminAppCredentialPushSecret(cp)
 	ps.Status.Conditions = []esov1alpha1.PushSecretStatusCondition{
 		{Type: esov1alpha1.PushSecretReady, Status: corev1.ConditionTrue},
 	}
+	ps.Status.SyncedResourceVersion = testPushSyncedRV
 	return ps
 }
 

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -889,6 +889,64 @@ func TestForceSyncKORCCloudsYAMLExternalSecret_RetriesOnConflict(t *testing.T) {
 		"the force-sync annotation must be stamped on the retry that succeeds")
 }
 
+// TestForceRepushAdminAppCredential_StampsHashRetriesAndIdempotent locks in the
+// PushSecret re-push nudge that makes the fresh-create credential handoff reach
+// OpenBao promptly. ESO's PushSecret controller does not watch its source Secret;
+// it re-pushes only when the PushSecret object's own metadata hash changes. The
+// helper must therefore stamp the content-hash annotation (retrying an expected
+// 409), and must be a no-op when the hash already matches so a converged
+// credential never churns the push every reconcile.
+func TestForceRepushAdminAppCredential_StampsHashRetriesAndIdempotent(t *testing.T) {
+	g := NewWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcControlPlane()
+	psName := adminAppCredentialPushSecretName(cp)
+	ps := &esov1alpha1.PushSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: psName, Namespace: childNamespace(cp)},
+	}
+	conflicts, updates := 0, 0
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ps).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*esov1alpha1.PushSecret); ok {
+					if conflicts == 0 {
+						conflicts++
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: "external-secrets.io", Resource: "pushsecrets"},
+							psName, errors.New("the object has been modified"),
+						)
+					}
+					updates++
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	// First stamp: the annotation is set and the 409 is retried, not surfaced.
+	g.Expect(r.forceRepushAdminAppCredential(context.Background(), cp, psName, "hash-1")).To(Succeed(),
+		"an expected 409 conflict must be retried, not surfaced as a hard error")
+	g.Expect(conflicts).To(Equal(1), "the first Update must have conflicted and been retried")
+	g.Expect(updates).To(Equal(1), "exactly one successful Update stamps the hash")
+
+	got := &esov1alpha1.PushSecret{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: psName, Namespace: childNamespace(cp)}, got)).To(Succeed())
+	g.Expect(got.Annotations[adminAppCredentialPushContentHashAnnotation]).To(Equal("hash-1"),
+		"the content-hash annotation must be stamped so ESO's shouldRefresh gate re-pushes the credential")
+
+	// Idempotent: a second call with the SAME hash must not Update the PushSecret,
+	// so a converged credential does not churn the push (and thus OpenBao) each pass.
+	g.Expect(r.forceRepushAdminAppCredential(context.Background(), cp, psName, "hash-1")).To(Succeed())
+	g.Expect(updates).To(Equal(1), "an unchanged hash must be a no-op (no second Update)")
+
+	// A changed hash re-stamps so a rotated credential reaches OpenBao promptly.
+	g.Expect(r.forceRepushAdminAppCredential(context.Background(), cp, psName, "hash-2")).To(Succeed())
+	g.Expect(updates).To(Equal(2), "a changed hash must stamp a fresh re-push trigger")
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: psName, Namespace: childNamespace(cp)}, got)).To(Succeed())
+	g.Expect(got.Annotations[adminAppCredentialPushContentHashAnnotation]).To(Equal("hash-2"))
+}
+
 // TestAdminAppCredentialRemoteKeyFor_EmbedsNamespaceAndName locks in the per-CR
 // OpenBao path the RemoteKey is scoped by both the
 // ControlPlane's Namespace and Name so two ControlPlanes never clobber each

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -333,6 +333,20 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  replicas:
+                    default: 3
+                    description: |-
+                      Replicas is the number of managed MariaDB replicas provisioned in
+                      fresh-create mode. It mirrors CacheSpec.Replicas: only the c5c3 operator's
+                      managed-mode projection honours it (a single replica yields a
+                      single-instance non-Galera MariaDB, three or more yield a Galera cluster),
+                      so a constrained cluster such as a single-node kind can schedule the
+                      fresh-create path. Operators that adopt an existing MariaDB (keystone, and
+                      the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                      set.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   secretRef:
                     description: SecretRef references the K8s Secret with credentials.
                     properties:

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -336,6 +336,20 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  replicas:
+                    default: 3
+                    description: |-
+                      Replicas is the number of managed MariaDB replicas provisioned in
+                      fresh-create mode. It mirrors CacheSpec.Replicas: only the c5c3 operator's
+                      managed-mode projection honours it (a single replica yields a
+                      single-instance non-Galera MariaDB, three or more yield a Galera cluster),
+                      so a constrained cluster such as a single-node kind can schedule the
+                      fresh-create path. Operators that adopt an existing MariaDB (keystone, and
+                      the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                      set.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   secretRef:
                     description: SecretRef references the K8s Secret with credentials.
                     properties:

--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,19 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/deploy/flux-system/sources/k-orc\\.yaml$/"
+      ],
+      "matchStrings": [
+        "tag:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "k-orc/openstack-resource-controller",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "k-orc/openstack-resource-controller",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/Makefile$/",
         "/\\.github/workflows/.*\\.yaml$/"
       ],
@@ -263,6 +276,22 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "headlamp"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/flux-system/sources/k-orc.yaml"],
+      "matchPackageNames": ["k-orc/openstack-resource-controller"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/flux-system/sources/k-orc.yaml"],
+      "matchPackageNames": ["k-orc/openstack-resource-controller"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "k-orc"
     },
     {
       "matchManagers": ["custom.regex"],

--- a/tests/container-images/verify_tempest.sh
+++ b/tests/container-images/verify_tempest.sh
@@ -39,7 +39,18 @@ test_keystone_tempest_plugin_importable() {
   assert_eq "import keystone_tempest_plugin exits 0" "0" "$exit_code"
 }
 
-# --- Test 3: subunit2junitxml is available on PATH ---
+# --- Test 3: openstack CLI is available (used by the E2E verify Job) ---
+test_openstack_cli_available() {
+  echo "Test: openstack --version succeeds"
+  local version exit_code=0
+  version=$(docker run --rm "$IMAGE" openstack --version 2>&1) || exit_code=$?
+
+  assert_eq "openstack --version exits 0" "0" "$exit_code"
+
+  assert_not_empty "openstack version output is non-empty" "$version"
+}
+
+# --- Test 4: subunit2junitxml is available on PATH ---
 test_subunit2junitxml_available() {
   echo "Test: subunit2junitxml is available"
   local path_output exit_code=0
@@ -49,7 +60,7 @@ test_subunit2junitxml_available() {
   assert_not_empty "subunit2junitxml path is non-empty" "$path_output"
 }
 
-# --- Test 4: runs as openstack user ---
+# --- Test 5: runs as openstack user ---
 test_runs_as_openstack_user() {
   echo "Test: container runs as openstack user"
   local whoami_output exit_code=0
@@ -59,7 +70,7 @@ test_runs_as_openstack_user() {
   assert_eq "whoami outputs openstack" "openstack" "$whoami_output"
 }
 
-# --- Test 5: no build tools in final image ---
+# --- Test 6: no build tools in final image ---
 test_no_build_tools_in_final_image() {
   echo "Test: no build tools in final image"
 
@@ -86,6 +97,8 @@ echo ""
 test_tempest_version
 echo ""
 test_keystone_tempest_plugin_importable
+echo ""
+test_openstack_cli_available
 echo ""
 test_subunit2junitxml_available
 echo ""

--- a/tests/e2e/c5c3/full-controlplane-keystone/00-controlplane-cr.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/00-controlplane-cr.yaml
@@ -11,10 +11,16 @@
 # deploy stack provisions (deploy/flux-system/infrastructure/), so the chain
 # reads against the production-shaped infrastructure.
 #
-# The K-ORC admin credential is (re-)minted from the admin password Secret
-# (keystone-admin, materialised by deploy/eso/externalsecrets/keystone-admin.yaml)
-# and the minted application credential is mirrored to OpenBao and back to
-# orc-system/k-orc-clouds-yaml. restricted:true keeps the credential
+# The K-ORC admin credential is (re-)minted from the admin password. In managed
+# mode (this CR sets infrastructure.database.clusterRef) the c5c3-operator
+# projects that password into the per-ControlPlane Secret
+# "controlplane-keystone-keystone-admin-credentials" from the OpenBao bootstrap
+# path bootstrap/openstack/controlplane-keystone-keystone/admin
+# (reconcileAdminPassword); the korc.adminCredential.passwordSecretRef below is a
+# required-but-unused placeholder in managed mode (effectiveAdminPasswordSecretRef
+# overrides it with the projected Secret). The minted application credential is
+# mirrored to OpenBao and read back into the per-CR k-orc-clouds-yaml Secret in
+# this CR's own namespace (openstack). restricted:true keeps the credential
 # least-privilege so a leak is scoped.
 #
 # the FIRST authentication uses a password-based clouds.yaml
@@ -24,8 +30,10 @@
 # never clobbers a minted credential-based clouds.yaml. The per-CR
 # k-orc-clouds-yaml ExternalSecret in this CR's own namespace (openstack) is
 # likewise OPERATOR-CREATED (ensureKORCCloudsYAMLExternalSecret), reading the
-# per-CR OpenBao path; the orc-system/k-orc-clouds-yaml copy is the retained
-# static ExternalSecret that K-ORC's globalCloudConfig mounts.
+# per-CR OpenBao path. There is no orc-system copy and K-ORC has no
+# globalCloudConfig mount: it resolves each CR's cloudCredentialsRef in the CR's
+# own namespace (the C1 co-location), so the openstack-namespace Secret is the
+# only clouds.yaml the chain needs.
 #
 # `global.rules` carries one oslo.policy override so the test can assert that the
 # reconciler merges policy into the projected Keystone CR's spec.policyOverrides
@@ -38,6 +46,11 @@ metadata:
 spec:
   openStackRelease: "2025.2"
   region: RegionOne
+  # Single-replica topology across database, cache, and the Keystone Deployment
+  # so the full fresh-create chain schedules on a single-node kind cluster.
+  # database.replicas:1 drives the operator's fresh-create MariaDB projection to
+  # a single-instance non-Galera MariaDB; cache.replicas:1 to a single Memcached
+  # pod; services.keystone.replicas:1 to a single API pod.
   infrastructure:
     database:
       clusterRef:
@@ -45,14 +58,15 @@ spec:
       database: keystone
       secretRef:
         name: keystone-db
+      replicas: 1
     cache:
       clusterRef:
         name: openstack-memcached
       backend: dogpile.cache.pymemcache
-      replicas: 3
+      replicas: 1
   services:
     keystone:
-      replicas: 3
+      replicas: 1
   global:
     rules:
       "identity:list_users": "role:admin"

--- a/tests/e2e/c5c3/full-controlplane-keystone/01-openstack-verify-job.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/01-openstack-verify-job.yaml
@@ -18,11 +18,13 @@
 # test's `finally` block.
 #
 # DECISION image is the repo's own tempest image, which bundles the
-# OpenStack client. The kind-E2E fast-follow that deploys the c5c3 + K-ORC stack
-# must also load this image (mirroring the tempest job); behind the chainsaw
-# presence guard the verify step never runs on a cluster that lacks it.
-# Reviewer: please verify the image and the `admin` cloud entry name K-ORC
-# writes into the clouds.yaml.
+# OpenStack client. The e2e-controlplane CI job loads ghcr.io/c5c3/tempest:2025.2
+# into kind (the tag CI builds — there is no :latest), so the image is pinned to
+# that tag with imagePullPolicy: IfNotPresent to use the kind-loaded copy rather
+# than pulling from GHCR. Behind the chainsaw presence guard the verify step
+# never runs on a cluster that lacks the stack. The `admin` cloud entry name is
+# the cloudName K-ORC writes into the clouds.yaml (spec.korc.adminCredential in
+# 00-controlplane-cr.yaml).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -35,7 +37,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: osc
-          image: ghcr.io/c5c3/tempest:latest
+          image: ghcr.io/c5c3/tempest:2025.2
+          imagePullPolicy: IfNotPresent
           env:
             - name: OS_CLIENT_CONFIG_FILE
               value: /etc/openstack/clouds.yaml

--- a/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
@@ -61,12 +61,12 @@
 # fast-follow on the GitOps/CI wiring (/).
 #
 # ── DECISION: OpenStack client image for token/catalog verification ──────────
-# `openstack token issue` / `openstack catalog list` need the OpenStack CLI. No
-# such image is loaded into the c5c3 e2e cluster today, so the verify Job uses
-# OPENSTACK_CLIENT_IMAGE (default ghcr.io/c5c3/tempest:latest — the repo's own
-# image that bundles the OpenStack client). The full-chain wiring fast-follow
-# must load it (mirroring the tempest job). Behind the presence guard this never
-# runs on a stack that lacks it. Reviewer: please verify the image/cloud name.
+# `openstack token issue` / `openstack catalog list` need the OpenStack CLI. The
+# verify Job (01-openstack-verify-job.yaml) uses ghcr.io/c5c3/tempest:2025.2 —
+# the repo's own image that bundles the OpenStack client. The e2e-controlplane CI
+# job loads that image into kind (mirroring the tempest job) so it need not be
+# pulled from GHCR. Behind the presence guard this never runs on a stack that
+# lacks it.
 #
 # ── NOTE: operator-owned seed execution ───────────
 # The operator-owned bootstrap clouds.yaml seed (seedBootstrapCloudsYAML) and
@@ -124,9 +124,32 @@ spec:
 
           # ── Presence guard ──────────────────────────────
           # Probe for every CRD the chain spans plus the OpenBao
-          # ClusterSecretStore the credential chain pushes through. Their absence
-          # unambiguously means the c5c3-operator + K-ORC + keystone-operator
-          # stack is not deployed on this cluster — SKIP cleanly (exit 0).
+          # ClusterSecretStore the credential chain pushes through.
+          #
+          # E2E_REQUIRE_CONTROLPLANE_STACK gates the failure mode. The dedicated
+          # e2e-controlplane CI job deploys the full stack and sets it to "true",
+          # so a missing operator / CRD FAILS LOUDLY (exit 1) — broken wiring must
+          # not go green there. Every other context (the c5c3 e2e-operator matrix
+          # leg, a local run against a plain cluster) leaves it unset, so the guard
+          # SKIPs cleanly (exit 0) when the stack is absent, keeping this suite
+          # default-safe. Chainsaw script steps inherit the process environment
+          # (the same way KUBECONFIG reaches them), so the job step's env: block
+          # is enough to set it.
+          REQUIRE_STACK="${E2E_REQUIRE_CONTROLPLANE_STACK:-false}"
+          gate_absent() { # <reason...>
+            if [ "${REQUIRE_STACK}" = "true" ]; then
+              echo "ERROR: $*"
+              echo "       E2E_REQUIRE_CONTROLPLANE_STACK=true — the full ControlPlane"
+              echo "       stack is required on this cluster; failing loudly so broken"
+              echo "       wiring cannot go green."
+              exit 1
+            fi
+            echo "SKIP: $*"
+            echo "      The c5c3-operator + K-ORC + keystone-operator stack is not"
+            echo "      deployed here, so the full ControlPlane chain is not exercised."
+            exit 0
+          }
+
           missing=""
           for crd in \
             controlplanes.c5c3.io \
@@ -140,16 +163,10 @@ spec:
             fi
           done
           if [ -n "${missing}" ]; then
-            echo "SKIP: required CRDs not present:${missing}"
-            echo "      The c5c3-operator + K-ORC + keystone-operator stack is"
-            echo "      not deployed on this cluster, so the full ControlPlane"
-            echo "      chain cannot be exercised here."
-            exit 0
+            gate_absent "required CRDs not present:${missing}"
           fi
           if ! kubectl get clustersecretstore openbao-cluster-store >/dev/null 2>&1; then
-            echo "SKIP: openbao-cluster-store ClusterSecretStore not present;"
-            echo "      the admin-credential push chain cannot complete."
-            exit 0
+            gate_absent "openbao-cluster-store ClusterSecretStore not present; the admin-credential push chain cannot complete."
           fi
           echo "OK: c5c3 + K-ORC + keystone CRDs and OpenBao store present —"
           echo "    running the full ControlPlane → Keystone chain."

--- a/tests/unit/renovate/korc_source_custommanager_test.sh
+++ b/tests/unit/renovate/korc_source_custommanager_test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json has a customManager for the K-ORC GitRepository tag in
+# deploy/flux-system/sources/k-orc.yaml. The manager must:
+#   - target the file, not the broader deploy/flux-system/ dir
+#   - use datasource=github-releases with the k-orc repo package name
+#   - capture the ref.tag value from `tag: vX.Y.Z`
+#   - be paired with a packageRule that disables majors and automerges
+#     minor/patch with minimumReleaseAge=3 days
+# This closes the coverage gap the un-tracked Flux tag left: it and the
+# Renovate-tracked go.mod k-orc module can no longer drift a minor version apart.
+#
+# Usage: bash tests/unit/renovate/korc_source_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+SOURCE_FILE="$PROJECT_ROOT/deploy/flux-system/sources/k-orc.yaml"
+
+test_custom_manager_uses_github_releases() {
+  echo "Test: k-orc customManager uses datasource=github-releases with the k-orc repo"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local entry
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("k-orc"))' \
+    "$RENOVATE_FILE")"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting deploy/flux-system/sources/k-orc.yaml"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  assert_eq "k-orc customManager.datasourceTemplate is github-releases" \
+    "github-releases" \
+    "$(jq -r '.datasourceTemplate' <<<"$entry")"
+  assert_eq "k-orc customManager.depNameTemplate is the k-orc repo" \
+    "k-orc/openstack-resource-controller" \
+    "$(jq -r '.depNameTemplate' <<<"$entry")"
+  assert_eq "k-orc customManager.packageNameTemplate is the k-orc repo" \
+    "k-orc/openstack-resource-controller" \
+    "$(jq -r '.packageNameTemplate' <<<"$entry")"
+}
+
+test_regex_captures_ref_tag() {
+  echo "Test: k-orc customManager regex captures the GitRepository ref.tag"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if [[ ! -f "$SOURCE_FILE" ]]; then
+    echo "  SKIP: $SOURCE_FILE missing"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local entry match_string tag_line captured expected_value
+  entry="$(jq -c '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains("k-orc"))' \
+    "$RENOVATE_FILE")"
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+
+  tag_line="$(grep -E '^[[:space:]]*tag:[[:space:]]*v' "$SOURCE_FILE" | head -1)"
+  assert_not_empty "ref.tag line present in deploy/flux-system/sources/k-orc.yaml" \
+    "$tag_line"
+
+  captured="$(REGEX="$match_string" LINE="$tag_line" perl -e '
+    my $re = $ENV{REGEX};
+    my $line = $ENV{LINE};
+    if ($line =~ /$re/) { print $+{currentValue} // ""; }
+  ')"
+
+  expected_value="$(printf '%s' "$tag_line" \
+    | sed -E 's/.*tag:[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+
+  assert_eq "matchStrings regex captures the k-orc ref.tag version" \
+    "$expected_value" "$captured"
+}
+
+test_package_rules_for_korc() {
+  echo "Test: packageRules disable major k-orc bumps, automerge minor/patch"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c '.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index("k-orc/openstack-resource-controller")) != null
+         or ((.matchFileNames   // []) | index("deploy/flux-system/sources/k-orc.yaml")) != null)
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c '.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index("k-orc/openstack-resource-controller")) != null
+         or ((.matchFileNames   // []) | index("deploy/flux-system/sources/k-orc.yaml")) != null)
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule scoping major updates for k-orc"
+    FAIL=$((FAIL + 2))
+  else
+    assert_eq "major k-orc updates are disabled" \
+      "false" \
+      "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule scoping minor/patch updates for k-orc"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_eq "minor/patch k-orc updates are automerged" \
+    "true" \
+    "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch k-orc rule waits minimumReleaseAge=3 days" \
+    "3 days" \
+    "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+  assert_eq "minor/patch k-orc rule groupName is k-orc" \
+    "k-orc" \
+    "$(jq -r '.groupName' <<<"$minor_rule")"
+}
+
+test_custom_manager_uses_github_releases
+test_regex_captures_ref_tag
+test_package_rules_for_korc
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Makes the full **ControlPlane → Keystone** chain actually run in CI on a single-node kind cluster, instead of SKIPping. Today every green c5c3 test is envtest/simulation: the `e2e-operator` leg deploys only `c5c3-operator` and its own CRDs, so the `full-controlplane-keystone` Chainsaw suite's presence guard exits 0 with a SKIP (Keystone + K-ORC CRDs absent). This branch assembles the whole stack — `keystone-operator` + K-ORC + `c5c3-operator` as local dev images — in a dedicated job, and makes the fixture kind-schedulable so the live chain runs (and fails loudly on broken wiring).

Closes #450

## Change set (in commit order)

1. **`feat(c5c3): make managed MariaDB replicas a spec field`** (`426ae59c`)
   The managed-mode MariaDB projection hardcoded a 3-replica Galera topology, which cannot schedule on single-node kind and left the fresh-create path unexercised e2e. Adds `Replicas` to the shared `commonv1.DatabaseSpec` (default 3, min 1, mirroring `CacheSpec.Replicas`). The c5c3 managed-mode projection derives replica count *and* Galera topology from it: one replica → single-instance non-Galera MariaDB; three or more → the production Galera cluster. A zero value (only reachable if CRD validation is bypassed) floors to the default. The owned-update path reconciles both replicas and derived Galera state. Adopt-existing-MariaDB operators (keystone; c5c3 adopted-infra) ignore the field.

2. **`chore: regenerate CRDs for DatabaseSpec.Replicas`** (`67040c08`)
   Regenerates controller-gen bases + synced Helm chart copies for both operators. The keystone CRD picks up `spec.database.replicas` because it embeds the shared `DatabaseSpec`, even though the keystone operator ignores it.

3. **`test(e2e): make full-chain ControlPlane fixture kind-schedulable`** (`27ced8af`)
   Sets the `full-controlplane-keystone` fixture to single-replica topology (`database.replicas`, `cache.replicas`, `services.keystone.replicas` all `1`) so the fresh-create projection yields a schedulable non-Galera MariaDB. Pins the OpenStack client verify Job to `ghcr.io/c5c3/tempest:2025.2` (the tag CI builds; no `:latest`) with `imagePullPolicy: IfNotPresent` to use the kind-loaded image. Makes the presence guard **fail loudly** (`exit 1`) instead of SKIPping when `E2E_REQUIRE_CONTROLPLANE_STACK=true`, so the dedicated job cannot go green on missing wiring; every other context leaves the var unset and keeps the default-safe SKIP.

4. **`feat(hack): deploy K-ORC + external ControlPlane operators in CI`** (`7d6b8440`)
   Wiring to stand up the chain from local dev images rather than the GHCR-published Flux chart. `hack/ci-deploy-korc.sh` applies the upstream K-ORC installer manifest at the **same tag** the Flux `GitRepository` pins — parsed at runtime from `deploy/flux-system/sources/k-orc.yaml` so the two cannot drift — and waits for the `orc-system` controller. `hack/deploy-infra.sh` gains `CONTROLPLANE_OPERATORS` (`flux|external`): under `external` it suspends the Flux ControlPlane stack (c5c3-operator, k-orc, keystone-operator stay suspended), skips the Flux HelmRelease waits and the published-image preload, and only prepares shared prerequisites (TLS, OpenBao + per-CR seeding, ESO store) while the operators are provided out of band. `setup-e2e-infra` threads `WITH_CONTROLPLANE`, `CONTROLPLANE_OPERATORS`, `CONTROLPLANE_NAME`, `WITH_CONTROLPLANE_CR`.

5. **`ci: add dedicated e2e-controlplane full-chain job`** (`314838f8`)
   Adds an `e2e-controlplane` job deploying keystone-operator + K-ORC + c5c3-operator as local dev images, running the `full-controlplane-keystone` suite with `E2E_REQUIRE_CONTROLPLANE_STACK=true`. Adds an `e2e_controlplane` paths filter threaded through `ci-resolve-changes.sh` (triggers on operator/deploy/hack/test changes, any Go change, or any E2E test-definition change). `build-e2e-images` unions c5c3 into `BUILD_OPERATORS` and gates on the new output so both operator dev images exist even for a full-chain-test-only change. The job (60m timeout, larger runner) loads the four images into kind, runs `deploy-infra` with `WITH_CONTROLPLANE=true CONTROLPLANE_OPERATORS=external CONTROLPLANE_NAME=controlplane-keystone`, deploys K-ORC + both operators, runs the suite, and dumps diagnostics on failure. Adds a `make e2e-controlplane` target for CI-to-Makefile parity.

6. **`build(deps): track K-ORC GitRepository tag with Renovate`** (`539f14f2`)
   The K-ORC Flux `GitRepository` tag had no Renovate coverage while the `go.mod` k-orc module is tracked — so the CRDs Flux applies and the API types the operator compiles against had already drifted a minor apart (Flux `v2.5.0` vs `go.mod` `v2.6.0`). Adds a `customManager` capturing `ref.tag` via `github-releases`, paired `packageRules` (disable majors, automerge minor/patch after 3 days, mirroring envoy-gateway/headlamp), and a jq-based unit test per the per-manager convention. Rewrites the stale comment in `k-orc.yaml`.

7. **`docs: document full-chain e2e job, database.replicas, K-ORC renovate`** (`bb87ddcc`)
   Documents the `e2e-controlplane` job (DAG + job entry) in `ci-workflow.md`; the new `deploy-infra` env vars in `e2e-deployment.md`; how the managed-mode MariaDB/Galera topology derives from `spec.infrastructure.database.replicas` in `controlplane-crd.md`; the shared `database.replicas` field (with the keystone-ignores-it note) in `keystone-crd.md`; the K-ORC Renovate custom manager in `dependency-management.md`; and `database.replicas: 1` for constrained clusters in `quick-start-controlplane.md`.

## Divergences from the issue

The issue's §1 sub-task to *"wait on / force-sync the `k-orc-clouds-yaml` ExternalSecret"* was already flagged obsolete in the issue's own 2026-07-01 status update: that static secret is gone; the operator creates it per-CR and the suite only waits for it. This branch matches that — `CONTROLPLANE_OPERATORS=external` stands up only the shared prerequisites (TLS, OpenBao + per-CR seeding, ESO store) so the operator-created ExternalSecret can resolve, rather than force-syncing anything.

The issue framed CI assembly as either extending the c5c3 `e2e-operator` leg *or* a dedicated full-chain job; this branch takes the **dedicated `e2e-controlplane` job** path, which keeps the existing single-operator `ci-deploy-operator.sh` flow untouched and isolates the heavier full-chain run behind its own paths filter and larger runner.

The missing K-ORC Renovate coverage (§3, the newly-surfaced `v2.5.0` vs `v2.6.0` drift) is addressed here in commit 6 rather than deferred.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 9462322 with Claude:claude-opus-4-8_
