### PR TITLE
docs: bring the docs site up to date with the current development state

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: 'Keystone E2E Tests', link: '/reference/testing/keystone-e2e-tests' },
+              { text: 'ControlPlane E2E Tests', link: '/reference/testing/controlplane-e2e-tests' },
               { text: 'Chaos E2E Tests', link: '/reference/testing/chaos-e2e-tests' },
               { text: 'Tempest Test Infrastructure', link: '/reference/testing/tempest-test-infrastructure' },
             ],

--- a/docs/contributing/claude-skills.md
+++ b/docs/contributing/claude-skills.md
@@ -1,3 +1,7 @@
+---
+title: Claude Code Skills
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -1,3 +1,7 @@
+---
+title: Dependency Management
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -29,7 +29,7 @@ regex managers and package rules. The high-level split is:
 | Pins GitHub Actions to commit SHAs (annotated with a `# vX.Y` tag).              | Updating the Go workspace / `go.mod` directives; triaging CVEs. |
 
 Renovate combines the `config:recommended` native managers (Go modules, Dockerfiles,
-GitHub Actions, npm) with **fourteen** custom regex managers that track pins those
+GitHub Actions, npm) with **fifteen** custom regex managers that track pins those
 native managers cannot see. Auto-merge (patch/minor, 3-day cooldown) is wired **only**
 onto the custom-regex managers; native-manager PRs always wait for a human merge
 (`config:recommended` does not auto-merge, and no top-level `automerge` is set).

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -1,3 +1,8 @@
+---
+title: Advanced Configuration
+quadrant: operator
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -137,19 +137,20 @@ spec:
     ingress:
       # Allow the ingress gateway to reach the Keystone API
       - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: envoy-gateway-system
+          kubernetes.io/metadata.name: envoy-gateway-system
       # Allow the monitoring namespace to scrape metrics
       - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: monitoring
+          kubernetes.io/metadata.name: monitoring
 ```
 
-Each list entry supports `namespaceSelector` and/or `podSelector` (label-selector
-semantics) and an optional `ports` list. When the list is non-empty, all other ingress
-is blocked by default — **including kubelet probes from other namespaces, which is
-normally not an issue because probes originate from the node, but verify in your
-cluster topology.**
+Each list entry requires a `namespaceSelector` and may narrow it with an optional
+`podSelector`. Both are plain label maps (`key: value` pairs), **not** full
+Kubernetes label selectors — there is no `matchLabels`/`matchExpressions` nesting.
+Within one entry the two selectors AND together; multiple entries OR. Ingress is
+always restricted to TCP 5000 — there is no per-entry port configuration. When the
+list is non-empty, all other ingress is blocked by default — **including kubelet
+probes from other namespaces, which is normally not an issue because probes
+originate from the node, but verify in your cluster topology.**
 
 For brownfield or external targets that the auto-derivation cannot see (an off-cluster
 MariaDB host, an external IdP), append explicit rules with `spec.networkPolicy.additionalEgress`
@@ -196,7 +197,10 @@ a link to the full reference.
 |---------|-------|--------------|-----------|
 | Credential-key tuning | `spec.credentialKeys` | Credential-key rotation is always on; this field only tunes the rotation schedule and max active keys | [CredentialKeysSpec](../reference/keystone/keystone-crd.md#credentialkeysspec) |
 | Trust flush | `spec.trustFlush` | CronJob running `keystone-manage trust_flush` on a schedule. Default-on (hourly) — to pause without deleting the CronJob, set `spec.trustFlush.suspend: true` rather than removing the field | [TrustFlushSpec](../reference/keystone/keystone-crd.md#trustflushspec) |
-| uWSGI tuning | `spec.uwsgi` | Worker processes, threads, HTTP keep-alive | [UWSGISpec](../reference/keystone/keystone-crd.md#uwsgispec) |
+| uWSGI tuning | `spec.uwsgi` | Worker processes, threads, HTTP keep-alive, plus `harakiri` (per-request kill timer) and `httpKeepAliveTimeout` (idle-socket bound) | [UWSGISpec](../reference/keystone/keystone-crd.md#uwsgispec) |
+| Logging | `spec.logging` | oslo.log output: `format` (text/json), `level`, `debug`, per-logger level overrides | [LoggingSpec](../reference/keystone/keystone-crd.md#loggingspec) |
+| Rollout strategy | `spec.strategy` | Overrides the Deployment rollout strategy; default is `RollingUpdate` with `maxSurge=1`/`maxUnavailable=0` (surge-before-remove) | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
+| Graceful termination | `spec.terminationGracePeriodSeconds`, `spec.preStopSleepSeconds` | SIGTERM→SIGKILL envelope and preStop drain sleep for zero-downtime rolling updates | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
 | Topology spread | `spec.topologySpreadConstraints` | Pod spread across zones/hostnames | [TopologySpreadConstraints](../reference/keystone/keystone-crd.md#topologyspreadconstraints) |
 | Priority class | `spec.priorityClassName` | Scheduling priority and preemption class | [PriorityClassName](../reference/keystone/keystone-crd.md#priorityclassname) |
 | Policy overrides | `spec.policyOverrides` | Custom `oslo.policy` rules (inline or ConfigMap) | [PolicySpec](../reference/keystone/keystone-crd.md#policyspec) |

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -1,3 +1,8 @@
+---
+title: Day 2 Operations
+quadrant: operator
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0
@@ -101,6 +106,9 @@ to restore the database from backup, then patch `spec.image.tag` back. There is 
 The operator ships a `CronJob` that rotates the Fernet keys on the schedule in
 `spec.fernet.rotationSchedule` (default weekly). You can trigger a rotation immediately
 without waiting for the cron job to fire — useful after a suspected key compromise.
+The inverse also works: `spec.fernet.suspend: true` (and
+`spec.credentialKeys.suspend: true`) pauses scheduled rotation during an
+incident without deleting the CronJob.
 
 Rotation uses a split staging→production path: the CronJob writes the new key set to a
 *staging* Secret, and the operator validates it and applies it to the production

--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -55,9 +55,9 @@ and
    Expected: `STATUS=Ready`.
 
 4. **keystone-operator running.** Either via the Helm release in
-   `deploy/flux-system/releases/keystone-operator.yaml` or a local
-   `make deploy-operator`. The operator's RBAC must include the
-   `cert-manager.io/certificates` rule; the chart's
+   `deploy/flux-system/releases/keystone-operator.yaml` or a locally built
+   image deployed with `hack/ci-deploy-operator.sh`. The operator's RBAC must
+   include the `cert-manager.io/certificates` rule; the chart's
    ClusterRole carries it by default.
 
 5. **A `Keystone` CR you control.** New CRs and existing plaintext CRs both

--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -116,7 +116,7 @@ keystone-operator   3s
 ### 2. Import the reference Grafana dashboard
 
 The repository ships a reference dashboard in
-[`operators/keystone/dashboards/keystone-operator.json`](../../operators/keystone/dashboards/keystone-operator.json)
+[`operators/keystone/dashboards/keystone-operator.json`](https://github.com/c5c3/forge/blob/main/operators/keystone/dashboards/keystone-operator.json)
 covering the four core SLIs: reconcile p95 per sub-reconciler, error
 rate per condition type, rotation age per key, and `db_sync` duration
 p95 with failure count.
@@ -275,4 +275,4 @@ ServiceMonitor (and therefore the Prometheus scrape) is removed.
 - [Keystone Operator Prometheus Metrics](../reference/keystone-operator-metrics.md) — authoritative metric catalogue.
 - [Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation) — how sub-reconcilers are instrumented.
 - [Observability & Diagnostics](../guides/observability.md) — conditions, events, and logs.
-- [`operators/keystone/dashboards/keystone-operator.json`](../../operators/keystone/dashboards/keystone-operator.json) — reference Grafana dashboard.
+- [`operators/keystone/dashboards/keystone-operator.json`](https://github.com/c5c3/forge/blob/main/operators/keystone/dashboards/keystone-operator.json) — reference Grafana dashboard.

--- a/docs/guides/keystone-key-rotation.md
+++ b/docs/guides/keystone-key-rotation.md
@@ -54,6 +54,9 @@ Secret.
 
 Rotations run on the `spec.fernet.rotationSchedule` / `spec.credentialKeys.rotationSchedule`
 cron schedule by default (both default to `0 0 * * 0` — weekly, Sunday 00:00 UTC).
+To pause scheduled rotation during an incident without deleting the CronJob or
+any sibling resource, set `spec.fernet.suspend: true` (or
+`spec.credentialKeys.suspend: true`); clearing the flag resumes the schedule.
 To trigger one on demand, create a one-shot Job from the CronJob template:
 
 ```bash

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -184,7 +184,10 @@ are lost:
 
 CRD-level CEL validation rules remain active regardless of webhook status.
 These rules cover structural constraints such as `database` mutual exclusivity,
-`autoscaling` metric requirements, and minimum-value checks.
+`autoscaling` metric requirements, and minimum-value checks, as well as the
+immutability transition rules (`database.name`, the database mode,
+`bootstrap.adminUser`, `bootstrap.region`) — those are enforced by the API
+server itself, so they hold even with the webhook disabled.
 
 ---
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,3 +1,8 @@
+---
+title: Observability & Diagnostics
+quadrant: operator
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -1,3 +1,7 @@
+---
+title: Quick Start (ControlPlane)
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -725,23 +725,27 @@ admission time.
 
 ## Step 8 — Wait for Keystone to become Ready
 
-The operator reconciles the CR through eleven sub-conditions before the aggregate
-`Ready` condition is set — some are only reported when the matching optional spec
-field is configured:
+The operator reconciles the CR through fourteen sub-conditions before the
+aggregate `Ready` condition is set — all are always reported; conditions tied to
+an optional spec field carry a "not required" / "disabled" reason when that
+field is unset:
 
 | Condition | What it waits for |
 |-----------|-------------------|
 | `SecretsReady` | `keystone-db` and `keystone-admin` Secrets are available |
 | `FernetKeysReady` | Fernet key Secret and CronJob created |
-| `CredentialKeysReady` | Credential key Secret and rotation CronJob exist (if `spec.credentialKeys` is set) |
+| `CredentialKeysReady` | Credential key Secret and rotation CronJob exist (`spec.credentialKeys` tunes schedule and max active keys) |
 | `DatabaseReady` | `db_sync` Job completed successfully |
+| `DatabaseTLSReady` | Database TLS client certificate issued, or `NotRequired` when `spec.database.tls` is unset |
 | `PolicyValidReady` | `spec.policyOverrides` validated against `oslo.policy` |
 | `DeploymentReady` | Keystone API Deployment has available replicas |
 | `KeystoneAPIReady` | Keystone API is responding to `/v3` health probes |
 | `HPAReady` | HorizontalPodAutoscaler created (if `spec.autoscaling` is set) |
 | `NetworkPolicyReady` | NetworkPolicy created (if `spec.networkPolicy` is set) |
+| `HTTPRouteReady` | Gateway API HTTPRoute reconciled, or not required when `spec.gateway` is unset |
 | `BootstrapReady` | Bootstrap Job completed (admin user, region, endpoints) |
-| `TrustFlushReady` | Trust-flush CronJob created (if `spec.trustFlush` is set) |
+| `TrustFlushReady` | Trust-flush CronJob created (defaults to hourly) |
+| `PasswordRotationReady` | Scheduled admin-password rotation reconciled, or `RotationDisabled` when `spec.bootstrap.passwordRotation` is unset |
 
 Watch the conditions with:
 
@@ -926,7 +930,8 @@ The project ships a full [Chainsaw](https://kyverno.github.io/chainsaw/) test su
 all operator behaviour. With the cluster running from the steps above, execute:
 
 ```bash
-# All Keystone test suites (10 suites, up to 4 in parallel)
+# The entire tests/e2e/ tree — 45 suites across keystone, keystone-operator,
+# c5c3 (ControlPlane), and infrastructure — up to 4 in parallel
 make e2e
 
 # Or target a specific suite
@@ -935,7 +940,10 @@ chainsaw test \
   tests/e2e/keystone/basic-deployment/
 ```
 
-Available test suites under `tests/e2e/keystone/`:
+A representative selection of the suites under `tests/e2e/keystone/` (the
+directory itself is the canonical inventory; see the
+[E2E test reference](./reference/testing/keystone-e2e-tests.md) for the full
+catalogue):
 
 | Suite | What it validates |
 |-------|-------------------|

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -1,3 +1,7 @@
+---
+title: Quick Start (Extended)
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,3 +1,7 @@
+---
+title: Quick Start
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
 SPDX-License-Identifier: Apache-2.0

--- a/docs/reference/backend/helm-values-schema.md
+++ b/docs/reference/backend/helm-values-schema.md
@@ -32,7 +32,7 @@ ensuring typos and unsupported keys are caught at deploy time rather than silent
 | Property | Value |
 | --- | --- |
 | JSON Schema Draft | `draft-07` |
-| Chart version | `0.2.0` (bumped from `0.1.0` to signal the schema validation feature) |
+| Chart version | `0.5.0` |
 | `additionalProperties` | `false` at all object levels |
 
 ## Validated Properties
@@ -104,6 +104,27 @@ for the privilege-escalation path this closes. The default stays `false` because
 | Field | Type | Constraint | Default |
 | --- | --- | --- | --- |
 | `metrics.port` | `integer` | minimum: `1`, maximum: `65535` | `8080` |
+
+### monitoring
+
+| Field | Type | Constraint | Default |
+| --- | --- | --- | --- |
+| `monitoring.serviceMonitor.enabled` | `boolean` | requires the `monitoring.coreos.com` CRDs in-cluster when enabled | `false` |
+| `monitoring.serviceMonitor.interval` | `string` | pattern: Go duration (`15s`, `30s`, `1m`) or `0` for the global default | `30s` |
+
+See [How to enable the Keystone operator metrics endpoint](../../guides/enable-keystone-operator-metrics.md).
+
+### networkPolicy
+
+The `networkPolicy` block (default-off operator pod hardening with fail-closed
+render guards) is validated by the schema as well; its fields are documented in
+[Keystone Operator NetworkPolicy](../keystone/keystone-operator-networkpolicy.md).
+
+### operator-library
+
+A reserved, empty values namespace for the `operator-library` library subchart.
+The library carries no configurable values; Helm injects this key during values
+coalescing, so the root-level `additionalProperties: false` must permit it.
 
 ### logging
 

--- a/docs/reference/backend/keystone-operator-packaging.md
+++ b/docs/reference/backend/keystone-operator-packaging.md
@@ -17,7 +17,8 @@ operators/keystone/
 ├── Dockerfile                          Multi-stage operator image build
 ├── helm/
 │   └── keystone-operator/
-│       ├── Chart.yaml                  Helm chart metadata (v0.1.0)
+│       ├── Chart.yaml                  Helm chart metadata (v0.5.0)
+│       ├── Chart.lock                  Pinned operator-library dependency
 │       ├── values.yaml                 Default configuration values
 │       ├── values.schema.json          JSON Schema for values validation
 │       ├── crds/
@@ -25,10 +26,16 @@ operators/keystone/
 │       └── templates/
 │           ├── _helpers.tpl            Template helper functions
 │           ├── serviceaccount.yaml     ServiceAccount (conditional)
-│           ├── clusterrole.yaml        ClusterRole with RBAC rules
-│           ├── clusterrolebinding.yaml ClusterRoleBinding
+│           ├── clusterrole.yaml        ClusterRole (cluster-scoped RBAC, default)
+│           ├── clusterrolebinding.yaml ClusterRoleBinding (default)
+│           ├── role.yaml               Namespace-scoped Role (rbac.namespaceScoped)
+│           ├── rolebinding.yaml        Namespace-scoped RoleBinding (rbac.namespaceScoped)
 │           ├── deployment.yaml         Operator Deployment
 │           ├── service.yaml            ClusterIP Service (webhook + metrics)
+│           ├── pdb.yaml                PodDisruptionBudget (replicas > 1)
+│           ├── certificate.yaml        Self-signed Issuer + webhook Certificate (conditional)
+│           ├── networkpolicy.yaml      Operator pod NetworkPolicy (opt-in)
+│           ├── servicemonitor.yaml     Prometheus ServiceMonitor (opt-in)
 │           └── webhook-configuration.yaml  Mutating + Validating webhooks (conditional)
 deploy/flux-system/
 ├── kustomization.yaml                  Base kustomization (includes keystone-operator release)
@@ -49,7 +56,7 @@ reference sibling modules.
 
 | Stage | Base Image | Purpose |
 | --- | --- | --- |
-| `builder` | `golang:1.25` | Compiles the operator binary with CGO disabled |
+| `builder` | `golang:1.26` (digest-pinned) | Compiles the operator binary with CGO disabled |
 | runtime | `gcr.io/distroless/static:nonroot` | Minimal runtime with no shell or package manager |
 
 ### Image Layers
@@ -206,6 +213,12 @@ All configurable parameters with their types, defaults, and descriptions:
 | `resources.requests.cpu` | `string` | `10m` | CPU request per operator pod |
 | `resources.requests.memory` | `string` | `64Mi` | Memory request per operator pod |
 
+#### RBAC
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `rbac.namespaceScoped` | `boolean` | `false` | When `true`, renders a namespace-scoped Role/RoleBinding instead of the ClusterRole/ClusterRoleBinding, restricting the operator to its release namespace. Requires `webhook.enabled=false` (template renders a hard `fail` otherwise). See the [Multi-Tenant Deployment guide](../../guides/multi-tenant-deployment.md) |
+
 #### Leader Election
 
 | Parameter | Type | Default | Description |
@@ -232,6 +245,39 @@ admission validation — CRs are not validated or defaulted at admission time.
 | --- | --- | --- | --- |
 | `metrics.port` | `integer` | `8080` | Port for the Prometheus metrics endpoint. Exposed via both the container port and the Service |
 
+#### Logging
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `logging.development` | `boolean` | `false` | When `true`, passes `--zap-devel` (console encoder, debug verbosity). Leave `false` for the production profile (JSON encoder, info level) |
+| `logging.level` | `string` | `""` | `--zap-log-level`: `debug`, `info`, `error`, `panic`, or a positive integer. Empty uses the mode default |
+| `logging.encoder` | `string` | `""` | `--zap-encoder`: `json` or `console`. Empty uses the mode default |
+
+Each value maps to a controller-runtime `--zap-*` flag and is omitted from the
+operator args when left at its default.
+
+#### Monitoring
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `monitoring.serviceMonitor.enabled` | `boolean` | `false` | Render a `monitoring.coreos.com/v1` ServiceMonitor targeting the metrics port. Requires prometheus-operator CRDs in the cluster |
+| `monitoring.serviceMonitor.interval` | `string` | `30s` | Scrape interval on the ServiceMonitor endpoint |
+
+See [Enable Keystone Operator Metrics](../../guides/enable-keystone-operator-metrics.md)
+for the end-to-end scraping setup.
+
+#### NetworkPolicy
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `networkPolicy.enabled` | `boolean` | `false` | Opt-in NetworkPolicy that default-denies operator pod traffic and opens explicit rules (kube-apiserver, DNS, webhook, metrics) |
+| `networkPolicy.kubeApiServer.cidrs` / `.ports` | `list` | `[]` | API-server egress targets. Both **must** be non-empty when the policy is enabled (fail-closed template guard) |
+| `networkPolicy.dns.*` | — | kube-dns | DNS egress selectors (UDP/TCP 53) |
+| `networkPolicy.allowMetricsFrom` | `list` | `[]` | Ingress peers allowed to scrape metrics |
+| `networkPolicy.webhookClients.cidrs` | `list` | `[]` | Webhook ingress override; falls back to `kubeApiServer.cidrs` |
+
+Full semantics live in the [Operator NetworkPolicy reference](../keystone/keystone-operator-networkpolicy.md).
+
 #### Service Account
 
 | Parameter | Type | Default | Description |
@@ -246,11 +292,17 @@ The chart renders the following Kubernetes resources with default values:
 | Resource | Kind | Name Pattern | Conditional |
 | --- | --- | --- | --- |
 | ServiceAccount | `v1/ServiceAccount` | `{fullname}` | `serviceAccount.create` |
-| ClusterRole | `rbac.authorization.k8s.io/v1/ClusterRole` | `{fullname}` | Always |
-| ClusterRoleBinding | `rbac.authorization.k8s.io/v1/ClusterRoleBinding` | `{fullname}` | Always |
+| ClusterRole | `rbac.authorization.k8s.io/v1/ClusterRole` | `{fullname}` | `rbac.namespaceScoped=false` (default) |
+| ClusterRoleBinding | `rbac.authorization.k8s.io/v1/ClusterRoleBinding` | `{fullname}` | `rbac.namespaceScoped=false` (default) |
+| Role | `rbac.authorization.k8s.io/v1/Role` | `{fullname}` | `rbac.namespaceScoped=true` |
+| RoleBinding | `rbac.authorization.k8s.io/v1/RoleBinding` | `{fullname}` | `rbac.namespaceScoped=true` |
 | Deployment | `apps/v1/Deployment` | `{fullname}` | Always |
 | Service | `v1/Service` | `{fullname}` | Always |
 | PodDisruptionBudget | `policy/v1/PodDisruptionBudget` | `{fullname}` | `replicas > 1` |
+| Issuer | `cert-manager.io/v1/Issuer` | `{fullname}-selfsigned` | `webhook.enabled` |
+| Certificate | `cert-manager.io/v1/Certificate` | `{fullname}-webhook` | `webhook.enabled` |
+| NetworkPolicy | `networking.k8s.io/v1/NetworkPolicy` | `{fullname}` | `networkPolicy.enabled` |
+| ServiceMonitor | `monitoring.coreos.com/v1/ServiceMonitor` | `{fullname}` | `monitoring.serviceMonitor.enabled` |
 | MutatingWebhookConfiguration | `admissionregistration.k8s.io/v1` | `{fullname}-mutating` | `webhook.enabled` |
 | ValidatingWebhookConfiguration | `admissionregistration.k8s.io/v1` | `{fullname}-validating` | `webhook.enabled` |
 
@@ -348,9 +400,10 @@ The Service is type `ClusterIP` with two ports:
 
 ### RBAC Configuration
 
-The ClusterRole includes permissions derived from kubebuilder RBAC markers in
-`operators/keystone/internal/controller/keystone_controller.go`. These are the minimum
-permissions required for the operator to manage Keystone resources and their dependencies:
+The ClusterRole includes permissions derived from kubebuilder RBAC markers spread
+across the reconciler files in `operators/keystone/internal/controller/`. These are
+the minimum permissions required for the operator to manage Keystone resources and
+their dependencies:
 
 | API Group | Resources | Verbs |
 | --- | --- | --- |
@@ -358,24 +411,40 @@ permissions required for the operator to manage Keystone resources and their dep
 | `keystone.openstack.c5c3.io` | `keystones/status` | get, update, patch |
 | `keystone.openstack.c5c3.io` | `keystones/finalizers` | update |
 | `apps` | `deployments` | get, list, watch, create, update, patch, delete |
+| `autoscaling` | `horizontalpodautoscalers` | get, list, watch, create, update, patch, delete |
 | `""` (core) | `services`, `configmaps`, `secrets`, `serviceaccounts` | get, list, watch, create, update, patch, delete |
 | `""` (core) | `events` | create, patch |
+| `""` (core) | `pods` | get, list |
 | `batch` | `jobs`, `cronjobs` | get, list, watch, create, update, patch, delete |
+| `cert-manager.io` | `certificates` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `databases`, `users`, `grants` | get, list, watch, create, update, patch, delete |
 | `k8s.mariadb.com` | `mariadbs` | get, list, watch |
-| `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch |
+| `external-secrets.io` | `externalsecrets` | get, list, watch, create, update, patch |
+| `external-secrets.io` | `pushsecrets` | get, list, watch, create, update, patch, delete |
+| `external-secrets.io` | `clustersecretstores` | get, list, watch |
+| `gateway.networking.k8s.io` | `httproutes` | get, list, watch, create, update, patch, delete |
+| `gateway.networking.k8s.io` | `httproutes/status` | get |
+| `networking.k8s.io` | `networkpolicies` | get, list, watch, create, update, patch, delete |
+| `policy` | `poddisruptionbudgets` | get, list, watch, create, update, patch, delete |
 | `rbac.authorization.k8s.io` | `roles`, `rolebindings` | get, list, watch, create, update, patch, delete |
+| `scheduling.k8s.io` | `priorityclasses` | get, list, watch |
 
 **Notable verb restrictions:**
 
 - **`events`** has only `create` and `patch` — the operator emits events but never reads
   or deletes them.
-- **`external-secrets.io` resources** have no `delete` verb — the operator creates and
-  updates ExternalSecret/PushSecret CRs but does not delete them (secret lifecycle is
-  managed by the External Secrets Operator).
+- **`externalsecrets`** has no `delete` verb — ExternalSecret cleanup is left to
+  owner-reference garbage collection. **`pushsecrets`** does include `delete`: the
+  OpenBao finalizer deletes the key-backup PushSecrets when a Keystone CR is
+  deleted so ESO stops pushing to OpenBao.
+- **`mariadbs`, `clustersecretstores`, `priorityclasses`, `pods`, and
+  `httproutes/status`** are read-only — the operator observes them but never
+  mutates them.
 
 The ClusterRoleBinding binds the ClusterRole to the operator's ServiceAccount in the
-release namespace only.
+release namespace only. With `rbac.namespaceScoped=true` the identical rule set is
+rendered as a namespaced Role/RoleBinding instead (the templates share the
+`keystone-operator.rbacRules` partial).
 
 ### Webhook Configuration
 
@@ -422,8 +491,10 @@ cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator-li
 :::
 
 This instructs cert-manager to inject the CA bundle from the named Certificate resource
-into the webhook `caBundle` field automatically. The Certificate resource must exist in
-the release namespace with the name `{fullname}-webhook`.
+into the webhook `caBundle` field automatically. The chart renders that Certificate
+itself: `templates/certificate.yaml` creates a self-signed Issuer
+(`{fullname}-selfsigned`) and the `{fullname}-webhook` Certificate in the release
+namespace whenever `webhook.enabled=true`.
 
 ## FluxCD HelmRelease
 
@@ -575,7 +646,9 @@ FluxCD helm-controller
   │
   ├─ 4. Renders templates with merged values (chart defaults + HelmRelease values)
   │     → ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service,
+  │       PodDisruptionBudget, Issuer, Certificate,
   │       MutatingWebhookConfiguration, ValidatingWebhookConfiguration
+  │       (+ opt-in NetworkPolicy / ServiceMonitor when enabled)
   │
   ├─ 5. Applies rendered resources to keystone-system namespace
   │

--- a/docs/reference/backend/kubernetes-packages.md
+++ b/docs/reference/backend/kubernetes-packages.md
@@ -47,7 +47,7 @@ These packages import typed Go structs from external operator modules:
 | Operator | Go Module | API Version | Types Used |
 | --- | --- | --- | --- |
 | mariadb-operator | `github.com/mariadb-operator/mariadb-operator` | `v1alpha1` | `Database`, `User`, `Grant` |
-| External Secrets Operator | `github.com/external-secrets/external-secrets` | `v1beta1` (ExternalSecret), `v1alpha1` (PushSecret) | `ExternalSecret`, `PushSecret` |
+| External Secrets Operator | `github.com/external-secrets/external-secrets` | `v1` (ExternalSecret, ClusterSecretStore), `v1alpha1` (PushSecret) | `ExternalSecret`, `PushSecret` |
 | cert-manager | `github.com/cert-manager/cert-manager` | `v1` | `Certificate` |
 
 > **Note:** The PushSecret API is `v1alpha1` (unstable). Its schema may change in future
@@ -507,19 +507,26 @@ func WaitForExternalSecret(
     ctx context.Context,
     c client.Client,
     key client.ObjectKey,
-) (bool, error)
+) (exists, ready bool, err error)
 ```
 
-Checks whether the ExternalSecret identified by `key` has a `Ready` condition with
-status `True` (the ESO `ExternalSecretReady` condition type).
+Checks whether the ExternalSecret identified by `key` exists and has a `Ready`
+condition with status `True` (the ESO `ExternalSecretReady` condition type).
 
-**Returns:** `(true, nil)` when synced; `(false, nil)` when not yet synced;
-`(false, error)` when the ExternalSecret does not exist or API call fails.
+**Returns (tri-state):**
+
+- `(false, false, nil)` — the ExternalSecret was not found.
+- `(true, false, nil)` — it exists but has not synced yet (no `Ready=True`).
+- `(true, true, nil)` — it exists and is Ready.
+- `(false, false, err)` — an unexpected client failure.
 
 **Behavior:**
 
 - This is a point-in-time check, not a blocking wait. Reconcilers should call it on each
-  reconciliation loop and requeue if it returns `false`.
+  reconciliation loop and requeue while `ready` is `false`.
+- The separate `exists` return lets callers surface a clearer status —
+  "ExternalSecret not found yet" versus "waiting for ESO to sync" — instead of
+  collapsing both into a single not-ready signal.
 - Uses the ESO `ExternalSecretReady` condition type constant, not a raw string.
 
 ### IsSecretReady

--- a/docs/reference/backend/rotation-scripts.md
+++ b/docs/reference/backend/rotation-scripts.md
@@ -30,10 +30,19 @@ see the sub-reconciler sections in
 operators/keystone/internal/controller/
 ├── scripts/
 │   ├── fernet_rotate.sh          # Fernet key rotation
-│   └── credential_rotate.sh      # Credential key rotation
+│   ├── credential_rotate.sh      # Credential key rotation
+│   ├── admin_password_rotate.sh  # Scheduled admin-password rotation (Model B)
+│   └── bootstrap_db_seed.py      # Database seeding helper
 ├── reconcile_fernet.go           # go:embed + ConfigMap creation
 └── reconcile_credential.go       # go:embed + ConfigMap creation
 ```
+
+The embedded `scripts/` directory also carries `admin_password_rotate.sh` and
+`bootstrap_db_seed.py`, which belong to the scheduled admin-password rotation
+and bootstrap sub-reconcilers; they follow the same go:embed/ConfigMap delivery
+pattern but sit outside the Fernet/credential scope of this page. See the
+`reconcilePasswordRotation` section of the reconciler reference and the
+[scheduled rotation guide](../../guides/keystone-admin-password-scheduled-rotation.md).
 
 ## Script Contract
 

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -678,6 +678,8 @@ Keystone discipline:
 | `spec.korc.adminCredential.bootstrapResources[].kind` | Enum: `Project`, `Role` |
 | `spec.korc.adminCredential.applicationCredential.rotation.mode` | Enum: `PasswordDriven`, `Scheduled`, `Manual` |
 | `spec.services.keystone.replicas` | Minimum: 1 |
+| `spec.infrastructure.database.replicas` | Minimum: 1, schema default `3`. The webhook additionally rejects exactly `2` (Galera quorum — see below). |
+| `spec.infrastructure.cache.replicas` | Minimum: 1, schema default `3` |
 | `CredentialRotation spec.target` | Enum: `adminApplicationCredential` |
 | `CredentialRotation spec.intervalDays` | Minimum: 1 |
 | `CredentialRotation spec.preRotationDays` | Minimum: 0 |
@@ -700,6 +702,7 @@ short-circuit on the first error.
 | Release pattern | `spec.openStackRelease` | `field.Invalid` | Value does not match `^\d{4}\.\d$`. Defense-in-depth alongside the CRD `+kubebuilder:validation:Pattern` marker. |
 | Database mutual exclusivity | `spec.infrastructure.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither (`(clusterRef != nil) == (host != "")`). Defense-in-depth alongside the CEL `XValidation` rule on `commonv1.DatabaseSpec`. |
 | Cache mutual exclusivity | `spec.infrastructure.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither (`(clusterRef != nil) == (len(servers) > 0)`). Defense-in-depth alongside the CEL `XValidation` rule on `commonv1.CacheSpec`. |
+| Database replicas quorum | `spec.infrastructure.database.replicas` | `field.Invalid` | Value is exactly `2`. The managed-mode projection turns any `replicas > 1` into a Galera cluster, and a two-node Galera cluster cannot hold a majority — a single pod disruption then loses quorum. Replicas must be 1 (standalone) or >=3. The CRD marker enforces only `Minimum=1` (the shared `commonv1.DatabaseSpec` must not carry a c5c3-specific CEL rule the keystone operator, which ignores `replicas`, would inherit), so this check is **webhook-only**; a zero value (defaulting bypassed) is left to the reconciler's floor. |
 | Admin password Secret required | `spec.korc.adminCredential.passwordSecretRef.name` | `field.Required` | `name` is empty — without it the reconciler cannot (re-)mint the admin application credential. **Webhook-only**. |
 | Gateway hostname required | `spec.services.keystone.gateway.hostname` | `field.Required` | A `gateway` is configured but its `hostname` is empty. Mirrors the `+kubebuilder:validation:MinLength=1` marker on `commonv1.GatewaySpec.Hostname`; without it the reconciler derives an empty `https:///v3` public endpoint. |
 | Empty policy rule name | `spec.global.rules[<key>]`, `spec.services.keystone.policyOverrides.rules[<key>]` | `field.Required` | A rule name (map key) is the empty string. Enforced via the shared `policy.ValidatePolicyRules`, mirrored by the CEL rule on `commonv1.PolicySpec`. |
@@ -733,6 +736,7 @@ an already-migrated schema — an unrecoverable state.
 | Database mode immutable | `spec.infrastructure.database` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
 | Database clusterRef.name immutable | `spec.infrastructure.database.clusterRef.name` | Both managed, but the name changed |
 | Database name immutable | `spec.infrastructure.database.database` | The database name changed |
+| Database replicas immutable | `spec.infrastructure.database.replicas` | The value changed. `replicas` is projected into the managed MariaDB child's replica count and derived Galera topology, so a live edit would drive a destructive Update on the owned cluster (toggling Galera off or scaling a running Galera cluster down); the topology can only be changed safely by recreating the control plane. |
 | Cache mode immutable | `spec.infrastructure.cache` | `clusterRef` nil-ness changed (managed ↔ brownfield) |
 | Cache clusterRef.name immutable | `spec.infrastructure.cache.clusterRef.name` | Both managed, but the name changed |
 | Cloud secretName immutable | `spec.korc.adminCredential.cloudCredentialsRef.secretName` | The value changed |
@@ -892,16 +896,21 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
 
 ## Status Conditions
 
-The ControlPlane status is driven by five sub-reconcilers, each owning one
+The ControlPlane status is driven by seven sub-reconcilers, each owning one
 condition type, plus an aggregate `Ready` condition. The condition-type
 constants in `controlplane_controller.go` are the single source of truth; call
 sites reference the constants rather than inline literals.
 
-The sub-reconcilers run in dependency order, each **gated** on the previous
-one's condition being `True`:
+The sub-reconcilers run in dependency order; a stage that has not converged
+requeues and stops the chain, so later conditions are never computed against a
+half-built earlier stage. Three stages additionally gate **explicitly** on an
+earlier condition being `True` (`reconcileKeystone` on `InfrastructureReady`,
+`reconcileAdminCredential` on `KORCReady`, `reconcileCatalog` on
+`AdminCredentialReady`):
 
 ```
-InfrastructureReady → KeystoneReady → KORCReady → AdminCredentialReady → CatalogReady
+InfrastructureReady → DBCredentialsReady → AdminPasswordReady → KeystoneReady
+  → KORCReady → AdminCredentialReady → CatalogReady
 ```
 
 `Ready` is `True` (reason `AllReady`) **only** when all sub-conditions are
@@ -924,6 +933,43 @@ Set by `reconcileInfrastructure`.
 | `False` | `WaitingForCache` | Managed Memcached is ensured but not yet Ready. |
 | `False` | `MariaDBError` | Error create-or-updating the MariaDB child. |
 | `False` | `MemcachedError` | Error create-or-updating the Memcached child. |
+
+### DBCredentialsReady
+
+Set by `reconcileDBCredentials`. In managed mode (`database.clusterRef` set) it
+create-or-updates the per-ControlPlane DB-credential `ExternalSecret`
+(`{name}-keystone-db-credentials`, reading OpenBao path
+`openstack/keystone/{namespace}/{name}/db`, hourly refresh) and mirrors its
+Ready status. The OpenBao-backed `ClusterSecretStore` is checked first so an
+ESO/OpenBao outage surfaces promptly instead of hiding behind the
+ExternalSecret's stale per-object Ready cache.
+
+| Status | Reason | When |
+| --- | --- | --- |
+| `True` | `DBCredentialsReady` | The DB-credential ExternalSecret is Ready; the materialised Secret exists. |
+| `True` | `BrownfieldUserSuppliedCredential` | Brownfield database (`clusterRef` unset): the user supplies the DB-credential Secret out-of-band, so no ExternalSecret is projected and the chain proceeds immediately. |
+| `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
+| `False` | `ExternalSecretError` | Error ensuring or checking the DB-credential ExternalSecret. |
+| `False` | `WaitingForDBCredentialSecret` | The ExternalSecret is ensured but ESO has not yet synced it to Ready. |
+
+### AdminPasswordReady
+
+Set by `reconcileAdminPassword`. It runs **before** the Keystone stage because
+the keystone-operator's `SecretsReady` gate needs the admin-password
+ExternalSecret to exist before the projected Keystone child references it. In
+managed mode it create-or-updates the per-ControlPlane admin-password
+`ExternalSecret` (`{name}-keystone-admin-credentials`, reading OpenBao path
+`bootstrap/{namespace}/{name}-keystone/admin` — keystone-**name**-scoped so it
+matches the seeder and the keystone-operator rotation PushSecret) and mirrors
+its Ready status.
+
+| Status | Reason | When |
+| --- | --- | --- |
+| `True` | `AdminPasswordReady` | The admin-password ExternalSecret is Ready; the materialised Secret exists. |
+| `True` | `BrownfieldUserSuppliedCredential` | Brownfield database (`clusterRef` unset): the user supplies the admin-password Secret out-of-band, so no ExternalSecret is projected and the chain proceeds immediately. |
+| `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
+| `False` | `ExternalSecretError` | Error ensuring or checking the admin-password ExternalSecret. |
+| `False` | `WaitingForAdminPasswordSecret` | The ExternalSecret is ensured but ESO has not yet synced it to Ready. |
 
 ### KeystoneReady
 
@@ -954,7 +1000,8 @@ Set by `reconcileKORC`.
 
 Set by `reconcileAdminCredential` (gated on `KORCReady`, the OpenBao-backed
 `ClusterSecretStore` being Ready, the K-ORC `clouds.yaml` ExternalSecret being
-Ready, **and** the materialised `clouds.yaml` Secret semantically matching (parsed
+Ready, the admin app-credential `PushSecret` having actually synced to OpenBao,
+**and** the materialised `clouds.yaml` Secret semantically matching (parsed
 application-credential id+secret) the freshly assembled credential).
 
 | Status | Reason | When |
@@ -963,11 +1010,12 @@ application-credential id+secret) the freshly assembled credential).
 | `False` | `WaitingForKORC` | `KORCReady` is not `True`; credential push deferred. |
 | `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `WaitingForCloudsYaml` | The operator-created per-ControlPlane `k-orc-clouds-yaml` ExternalSecret in the control-plane namespace (co-located with the K-ORC CRs per C1; created and owned by `reconcileKORC`) is not yet Ready. |
+| `False` | `WaitingForPushSecret` | The admin app-credential `PushSecret` has not synced the assembled `clouds.yaml` to OpenBao yet. `AdminCredentialReady` is gated on the PushSecret's `Ready` condition — not merely on the CR existing — so a backend permission failure (e.g. the ESO role missing the push policy) cannot yield a false-positive Ready while OpenBao still serves the password-based bootstrap `clouds.yaml`. |
 | `False` | `WaitingForCloudsYamlSync` | The materialised `k-orc-clouds-yaml` Secret is absent or still holds a stale credential (a re-mint revoked the old one but ESO has not re-synced yet). `reconcileAdminCredential` stamps the `external-secrets.io/force-sync` annotation to force an immediate re-sync and compares the materialised Secret semantically (parsed application-credential id+secret) against the assembled credential before reporting Ready, so the condition never reads `True` against a revoked credential. |
 | `False` | `CloudsYamlSyncStuck` | The materialised `k-orc-clouds-yaml` Secret has failed to match the assembled credential for longer than `cloudsYamlSyncStuckTimeout` (measured from the credential's `LastRotation`); the ESO ExternalSecret or OpenBao backend may be unable to sync. Escalated from `WaitingForCloudsYamlSync` so a never-converging sync is alertable and distinguishable from a transient miss. |
 | `False` | `CloudsYamlError` | Error checking the `clouds.yaml` ExternalSecret, forcing its re-sync, or reading the materialised Secret. |
 | `False` | `SecretError` | Error ensuring the operator-owned application-credential Secret. |
-| `False` | `PushSecretError` | Error ensuring the OpenBao PushSecret. |
+| `False` | `PushSecretError` | Error ensuring the OpenBao PushSecret, stamping its content-hash re-push annotation, or reading it back for the sync gate. |
 
 ### CatalogReady
 
@@ -992,7 +1040,7 @@ Set by `setReadyCondition`.
 
 | Status | Reason | When |
 | --- | --- | --- |
-| `True` | `AllReady` | All five sub-conditions above are `True`. |
+| `True` | `AllReady` | All seven sub-conditions above are `True`. |
 | `False` | `NotAllReady` | One or more sub-conditions are not `True`. |
 
 ---

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -694,9 +694,9 @@ surfacing as an opaque wait.
 
 | Aspect | Value |
 | --- | --- |
-| File | `reconcile_korc.go` |
+| File | `reconcile_admincredential.go` |
 | Condition | `AdminCredentialReady` |
-| Gate | `KORCReady == True`, the OpenBao-backed `ClusterSecretStore` is Ready, the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready, **and** the materialised clouds.yaml Secret semantically matches (parsed application-credential id+secret) the freshly assembled credential |
+| Gate | `KORCReady == True`, the OpenBao-backed `ClusterSecretStore` is Ready, the K-ORC clouds.yaml `ExternalSecret` (`{childNamespace(cp)}/{CloudCredentialsRef.SecretName}`, co-located with the K-ORC CRs per C1) is Ready, the admin app-credential `PushSecret` has actually synced to OpenBao (its `Ready` condition is True), **and** the materialised clouds.yaml Secret semantically matches (parsed application-credential id+secret) the freshly assembled credential |
 | Owns | the operator-owned `Secret` `{controlplane.Name}-admin-app-credential` and the `PushSecret` `{controlplane.Name}-admin-app-credential-backup`, both in `childNamespace(cp)` |
 | Requeue | `korcRequeueAfter` = **10s** while any gate is unmet (including a stale/absent materialised clouds.yaml) |
 
@@ -718,8 +718,9 @@ OpenBao:
   OpenBao path, so the operator-created per-CR ExternalSecret can materialise
   before any credential is minted — once the AC is minted the PushSecret carries
   the minted credential-based clouds.yaml instead.
-- **PushSecret to OpenBao.** `secrets.EnsurePushSecret` (idempotent; only Updates
-  on a `DeepEqual` diff so ESO is not woken to re-push an unchanged credential)
+- **PushSecret to OpenBao.** `secrets.EnsurePushSecret` (applied via server-side
+  apply under a fixed field manager that owns only the fields the operator sets,
+  so repeated applies of an unchanged desired spec are no-ops at the API server)
   builds the PushSecret to `openbao-cluster-store` at the per-ControlPlane remote
   key `openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential`
   (`adminAppCredentialRemoteKeyFor`) with **`DeletionPolicy: None`** — the
@@ -727,14 +728,42 @@ OpenBao:
   the PushSecret on ControlPlane teardown (or when rotation is disabled) leaves the
   last-pushed credential intact in OpenBao at that CR's own path, so re-adoption
   works and the admin is never locked out.
+- **Forced re-push on credential change.** ESO's PushSecret controller does
+  **not** watch its source Secret: its refresh gate reacts only to the PushSecret
+  object's own label/annotation hash, so a source-Secret update — e.g. the
+  fresh-create handoff from the password-based bootstrap clouds.yaml to the
+  minted credential — would otherwise not reach OpenBao until the hourly
+  `refreshInterval`, leaving `AdminCredentialReady` stuck False for up to an
+  hour. `forceRepushAdminAppCredential` therefore stamps the assembled
+  clouds.yaml content hash onto the PushSecret (`c5c3.io/push-content-hash`,
+  read-modify-write under `RetryOnConflict`), changing its metadata hash and
+  forcing an immediate re-push. The annotation is keyed by the content hash, so
+  it fires exactly once per credential change and a steady-state pass is a
+  no-op.
+- **PushSecret sync gate.** `AdminCredentialReady` is gated on the PushSecret's
+  `Ready` condition — not merely on the CR existing — so a backend permission
+  failure (e.g. the ESO role missing the push policy) surfaces as
+  `WaitingForPushSecret` instead of a false-positive Ready while OpenBao still
+  serves the password-based bootstrap clouds.yaml.
 - **Live clouds.yaml gate (stale-credential window).** A re-mint revokes the old
   credential immediately, but the `k-orc-clouds-yaml` Secret only refreshes from
   OpenBao at the ExternalSecret's hourly `refreshInterval`, so the PushSecret-Ready
   check above can pass while the materialised Secret K-ORC actually authenticates
   with still holds the revoked credential. After assembling the clouds.yaml,
   `reconcileAdminCredential` stamps the `external-secrets.io/force-sync` annotation
-  (keyed by the content hash; idempotent, so a steady-state pass does not churn the
-  ExternalSecret) to nudge ESO to re-materialise immediately, then **compares the
+  to nudge ESO to re-materialise immediately. The trigger value is
+  `contentHash + "/" + PushSecret.status.syncedResourceVersion`, **not** the
+  content hash alone: both nudges (the PushSecret re-push above and this
+  force-sync) are stamped in the same reconcile pass, but ESO processes the two
+  objects independently — keyed on the content hash alone, the ExternalSecret
+  refresh can read OpenBao *before* the re-push has written it, re-materialise
+  the stale bootstrap document, and (with the annotation already at its final
+  value) never be nudged again, wedging `AdminCredentialReady` at
+  `WaitingForCloudsYamlSync` until the hourly refresh. ESO bumps
+  `syncedResourceVersion` only *after* a completed push, so folding it in
+  re-nudges the ExternalSecret exactly once more as soon as the re-push lands;
+  both inputs are stable once converged, so a steady-state pass still leaves the
+  ExternalSecret untouched. It then **compares the
   materialised Secret semantically** — by the parsed application-credential id and
   secret, not byte-for-byte, so a benign ESO/OpenBao re-serialisation (a stripped
   trailing newline, reordered keys, requoting) cannot wedge the gate permanently —
@@ -754,7 +783,8 @@ OpenBao:
 | clouds.yaml ES check errors | False | `CloudsYamlError` | returns the error (also covers a force-sync/materialised-Secret read error) |
 | clouds.yaml ES not Ready | False | `WaitingForCloudsYaml` | requeue 10s |
 | operator Secret ensure fails | False | `SecretError` | returns the error |
-| PushSecret ensure fails | False | `PushSecretError` | returns the error |
+| PushSecret ensure, re-push stamp, or readback fails | False | `PushSecretError` | returns the error |
+| PushSecret not yet synced to OpenBao | False | `WaitingForPushSecret` | requeue 10s; the PushSecret's `Ready` condition is not True — the assembled credential has not landed in OpenBao yet |
 | materialised clouds.yaml absent or semantically stale | False | `WaitingForCloudsYamlSync` | requeue 10s; force-sync annotation stamped, semantic compare (parsed id+secret) against the assembled document not yet satisfied |
 | materialised clouds.yaml stuck stale past `cloudsYamlSyncStuckTimeout` | False | `CloudsYamlSyncStuck` | requeue 10s; the sync has not converged since `LastRotation` — alertable, distinguishable from a transient miss |
 | committed, mirrored, and materialised | True | `AdminCredentialReady` | — |
@@ -763,7 +793,7 @@ OpenBao:
 
 | Aspect | Value |
 | --- | --- |
-| File | `reconcile_korc.go` |
+| File | `reconcile_catalog.go` |
 | Condition | `CatalogReady` |
 | Gate | `AdminCredentialReady == True`, **and** both the identity `Service` and `Endpoint` report `Available` |
 | Owns | a K-ORC identity `Service` (`{controlplane.Name}-identity-service`) and its public `Endpoint` (`{controlplane.Name}-identity-endpoint`) in `childNamespace(cp)` |
@@ -891,7 +921,10 @@ K-ORC writes the minted credential into the operator-owned Secret
         │
         ▼  (reconcileAdminCredential, gated on KORCReady + clouds.yaml ES)
 PushSecret  →  OpenBao kv  openstack/keystone/{cp.Namespace}/{cp.Name}/admin/app-credential
-   (DeletionPolicy: None — per-ControlPlane bootstrap secret survives teardown)
+   (DeletionPolicy: None — per-ControlPlane bootstrap secret survives teardown;
+    ESO does not watch the source Secret, so a content-hash annotation nudge
+    forces the re-push on credential change, and the clouds.yaml force-sync
+    below is keyed on that hash + the completed push's syncedResourceVersion)
         │
         ▼
 ExternalSecret  →  {control-plane ns}/k-orc-clouds-yaml  (the clouds.yaml gate;
@@ -1206,8 +1239,16 @@ operators/c5c3/
     │   ├── reconcile_adminpassword.go           reconcileAdminPassword (per-CP admin-password ExternalSecret),
     │   │                                        effectiveAdminPasswordSecretRef
     │   ├── reconcile_keystone.go                reconcileKeystone projection
-    │   ├── reconcile_korc.go                    reconcileKORC + reconcileAdminCredential +
-    │   │                                        reconcileCatalog, computeAdminPasswordHash
+    │   ├── reconcile_korc.go                    reconcileKORC (AC mint/re-mint, drift detection)
+    │   ├── reconcile_admincredential.go         reconcileAdminCredential (assemble + push + re-push
+    │   │                                        nudges, semantic clouds.yaml gate)
+    │   ├── reconcile_catalog.go                 reconcileCatalog (identity Service/Endpoint),
+    │   │                                        korcAvailableUpToDate
+    │   ├── reconcile_delete.go                  reconcileDelete (ORC-teardown finalizer sequencing)
+    │   ├── korc_cloudsyaml.go                   clouds.yaml document builders (app-credential + password bootstrap)
+    │   ├── korc_eso.go                          PushSecret + clouds.yaml ExternalSecret builders/ensure
+    │   ├── korc_imports.go                      admin Domain/User import projection
+    │   ├── korc_secrets.go                      app-credential Secret seeding, computeAdminPasswordHash
     │   ├── reconcile_credentialrotation.go      CredentialRotationReconciler (nudge model)
     │   ├── requeue_intervals.go                 infra/dbCredentials/adminPassword/keystone/korc/credentialRotation backoffs
     │   ├── instrumentation.go                   instrumentSubReconciler + drift-guard map
@@ -1218,16 +1259,20 @@ operators/c5c3/
     │   ├── reconcile_adminpassword_test.go      AdminPassword tests
     │   ├── reconcile_keystone_test.go           Keystone projection tests
     │   ├── reconcile_korc_test.go               K-ORC / admin-credential / catalog tests
+    │   ├── reconcile_delete_test.go             Deletion-sequencing (finalizer) tests
     │   ├── reconcile_credentialrotation_test.go CredentialRotation tests
     │   ├── credential_invariant_test.go         Security-invariant tests
     │   ├── instrumentation_test.go              Metrics instrumentation + drift guards
     │   ├── setupwithmanager_test.go             Watch/Owns/indexer wiring tests
     │   ├── helpers_test.go                      helper-function tests
     │   └── integration_test.go                  Envtest integration test (tag: integration)
-    ├── metrics/
-    │   └── collectors.go                        c5c3_operator_* duration/error vectors
     └── testutil/                                c5c3 envtest setup helpers
 ```
+
+The `c5c3_operator_*` duration/error metric vectors are registered by the shared
+`internal/common/instrumentation` package (the former per-operator
+`internal/metrics` package was folded into it); `instrumentation.go` supplies
+only the `c5c3_operator` prefix and the name → `condition_type` map.
 
 ## Migration: legacy flat paths → per-ControlPlane paths
 

--- a/docs/reference/ci-cd/build-images-workflow.md
+++ b/docs/reference/ci-cd/build-images-workflow.md
@@ -319,7 +319,7 @@ is assembled by the subsequent `merge-base-images` job.
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
 | 1 | Reject fork PRs | Shell (conditional) | Fails fast with `::error::` if the PR originates from a fork |
-| 2 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 2 | Checkout | `actions/checkout@v7` | Checks out the repository |
 | 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value from `${{ github.repository_owner }}` for use in image references |
 | 4 | Prepare platform pair | `.github/actions/platform-pair` | Converts `linux/amd64` → `linux-amd64` for use in artifact names and cache scopes |
 | 5 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login (cosign disabled); replaces inline buildx + login steps |
@@ -352,7 +352,7 @@ on the final manifests.
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository |
 | 2 | Normalize image owner | Shell script | Outputs lowercase `owner` value |
 | 3 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign |
 | 4 | Download python-base digests | `actions/download-artifact@v4` | Downloads all `digests-python-base-*` artifacts, merges into `/tmp/digests/python-base/` |
@@ -400,7 +400,7 @@ service image builds begin. Runs after `merge-base-images` and blocks
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts) |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository (needed for test scripts) |
 | 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step |
 | 3 | Pull base images | Shell | Pulls both `python-base` and `venv-builder` by digest from `merge-base-images` outputs |
 | 4 | Verify python-base | Shell | Runs `verify_python_base.sh` with the digest-tagged image ref |
@@ -438,7 +438,7 @@ locally for inline verification instead of being pushed to GHCR.
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out this repository |
+| 1 | Checkout | `actions/checkout@v7` | Checks out this repository |
 | 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides |
 | 3 | Resolve extra packages | Shell | Reads `releases/<release>/extra-packages.yaml` via `yq` to extract `pip_extras` (comma-joined), `pip_packages` (space-joined), and `apt_packages` (space-joined). All three fields tolerate empty values — the Dockerfile handles them via conditional guards. |
 | 4 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Computes image name and all tags (see [Tag Schema](#tag-schema)) |
@@ -477,7 +477,7 @@ were computed during the build.
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository |
 | 2 | Install yq | `mikefarah/yq@v4` | Required by the derive-service-tags composite action |
 | 3 | Normalize image owner | Shell script | Outputs lowercase `owner` value |
 | 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | Buildx + GHCR login + cosign |
@@ -551,7 +551,7 @@ This job runs in parallel with `build-service-images` — both depend on
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository |
 | 2 | Checkout service source | `.github/actions/checkout-service-source` | Resolves source ref, clones upstream, applies patches and constraint overrides; eliminates "MUST stay in sync" duplication with `build-service-images` |
 | 3 | Resolve pip extras | Shell | Reads `pip_extras` from `extra-packages.yaml` to construct the install spec (e.g. `.[ldap]` or `.`) |
 | 4 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); authenticates to pull `venv-builder` image |
@@ -634,7 +634,7 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository (needed for test scripts, `source-refs.yaml`, and patch counting) |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository (needed for test scripts, `source-refs.yaml`, and patch counting) |
 | 2 | Setup Docker registry | `.github/actions/setup-docker-registry` | GHCR login (cosign disabled); replaces inline login step |
 | 3 | Derive tags | `.github/actions/derive-service-tags` | Composite action. Reconstructs tags using the same logic as `build-service-images` and `merge-service-images` |
 | 4 | Pull and verify | Shell | `docker pull <image-ref>` then runs `verify_${{ matrix.service }}.sh` with the pulled image ref |
@@ -735,17 +735,20 @@ All actions are pinned to full commit SHAs with version comments, matching the
 convention in `ci.yaml`:
 
 ```yaml
-uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
-uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4
-uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
-uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
-uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0
-uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c  # v7
-uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
-uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818  # v3
+uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6
+uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
+uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
+uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7
+uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4
+uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
 uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4
 ```
+
+(GHCR authentication runs `docker login` via the `registry-login` composite action
+rather than `docker/login-action`; the pinned SHAs above are kept current by
+Renovate, so treat the workflow files as the authoritative source.)
 
 This prevents supply-chain attacks via tag mutation while remaining auditable through
 version comments.
@@ -1340,7 +1343,7 @@ non-zero, the job fails.
 
 | # | Step | Action / Command | Details |
 | --- | --- | --- | --- |
-| 1 | Checkout | `actions/checkout@v6` | Checks out the repository |
+| 1 | Checkout | `actions/checkout@v7` | Checks out the repository |
 | 2 | Install yq | Shell | Downloads `yq` binary from GitHub releases (version-pinned via `YQ_VERSION` env var) |
 | 3 | Verify build-images workflow structure | Shell | Runs `tests/container-images/verify_build_images_workflow.sh` |
 | 4 | Verify deviation comments | Shell | Runs `tests/container-images/verify_deviation_comments.sh` |

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -40,9 +40,14 @@ The workflow triggers on three event types:
 | `push` | `tags: ["v*"]` | Runs on every v-prefixed tag push (triggers publish and release jobs) |
 | `pull_request` | `branches: [main]`, `types: [opened, synchronize, reopened, labeled]` | Runs on every pull request targeting main; includes `labeled` type to support on-demand chaos via `run-chaos` label |
 
-Tag pushes (`v*`) enable the full release pipeline: gate jobs, E2E tests, image/chart
-publishing, and GitHub Release creation. Pull requests and main-branch pushes run only
-gate and E2E jobs (publish jobs are skipped via `if` conditions).
+Gate, test, and E2E jobs run **only on `pull_request` events** — every one of them
+carries a `github.event_name == 'pull_request'` guard. Pushes to `main` and tag pushes
+(`v*`) run only the publish and release jobs (`build-and-push`,
+`merge-operator-images`, `helm-push`, `github-release`): the merged commit's PR was
+already green, so the E2E suite is not re-run on push
+("publish-only-on-merge"). On tag pushes the `changes` job forces all areas and all
+operators active, so every operator's images and charts are published regardless of
+which files the tagged commit touched.
 
 ## Environment Variables
 
@@ -53,17 +58,22 @@ for CI reproducibility:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/c5c3
-  CONTROLLER_GEN_VERSION: v0.20.1
-  GOFUMPT_VERSION: v0.9.2
+  KIND_CLUSTER: forge
+  CONTROLLER_GEN_VERSION: v0.21.0
+  GOFUMPT_VERSION: v0.10.0
+  GOLANGCI_LINT_VERSION: v2.12.2
 ```
 
 `REGISTRY` and `IMAGE_PREFIX` are referenced by the `build-and-push`, `helm-push`,
 `e2e-operator`, and `tempest` jobs to construct image names and registry URLs.
+`KIND_CLUSTER` is the single source of truth for every E2E job's kind cluster name
+(mirroring the `CLUSTER_NAME` default in `hack/deploy-infra.sh`).
 `CONTROLLER_GEN_VERSION` is used by `verify-codegen` to pin controller-gen to a specific
-version. `GOFUMPT_VERSION` is used by `format-check` to pin gofumpt to a specific version; the same version is mirrored in the Makefile (`GOFUMPT_VERSION ?= v0.9.2`) so
+version. `GOFUMPT_VERSION` is used by `format-check` to pin gofumpt to a specific version; the same version is mirrored in the Makefile (`GOFUMPT_VERSION ?= v0.10.0`) so
 that `make fmt` and `make format-check` use a consistent version locally.
-`setup-envtest` is installed via `@release-0.23` because the sub-module does not
-publish its own release tags.
+`GOLANGCI_LINT_VERSION` pins the golangci-lint binary installed by the `lint` job and
+keys its analysis cache. `setup-envtest` is installed via `@release-0.23` because the
+sub-module does not publish its own release tags.
 
 ## Permissions
 
@@ -85,42 +95,47 @@ Jobs that need elevated access declare per-job `permissions:` blocks:
 
 ## Job Dependency DAG
 
-The workflow defines 24 jobs organised in a directed acyclic graph:
+The workflow defines 27 jobs organised in a directed acyclic graph. Every gate, test,
+and E2E job additionally carries a `github.event_name == 'pull_request'` guard; the
+publish and release jobs run only on push events:
 
 ```
-Gate Jobs (always run):
-  lint ────────────────────────┐
-  format-check ────────────────┤
-  shellcheck ──────────────────┤
-  verify-codegen ──────────────┤
-  verify-invalid-cr-fixtures ──┤
-  chainsaw-lint ───────────────┤
+Gate Jobs (pull requests only):
+  lint ────────────────────────┐   (go == 'true')
+  format-check                 │   (go == 'true')
+  shellcheck ──────────────────┤   (always on PRs)
+  feature-ids                  │   (always on PRs)
+  test-shell                   │   (always on PRs)
+  verify-codegen ──────────────┤   (go == 'true')
+  verify-invalid-cr-fixtures ──┤   (always on PRs)
+  chainsaw-lint ───────────────┤   (always on PRs)
   test (matrix) ───────────────┼──> build-e2e-images ──> E2E Jobs
   test-integration ────────────┘
 
-Conditional Jobs (path-filtered via changes job):
+Conditional Jobs (pull requests only, path-filtered via changes job):
   test-race ────> needs: [changes], if: needs.changes.outputs.go == 'true'
   govulncheck ─> needs: [changes], if: needs.changes.outputs.go == 'true'
   helm-validate ──> needs: [changes], if: needs.changes.outputs.helm == 'true'
   docs ──────────> needs: [changes], if: needs.changes.outputs.docs == 'true'
 
-Image Build (depends on gates):
+Image Build (pull requests only, depends on gates):
   build-e2e-images ──> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, verify-invalid-cr-fixtures, chainsaw-lint]
 
-E2E Jobs (depends on build-e2e-images):
+E2E Jobs (pull requests only, depend on build-e2e-images):
   e2e-infra ──────> needs: [changes], if: needs.changes.outputs.e2e-infra == 'true'
   e2e-operator ───> needs: [changes, build-e2e-images]
-  e2e-chaos ──────> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
+  e2e-chaos ──────> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images, e2e-operator]
   e2e-prometheus ─> needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
                      if: needs.changes.outputs.e2e-prometheus == 'true'
   e2e-controlplane > needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]
                      if: needs.changes.outputs.e2e-controlplane == 'true'
-  tempest ────────> needs: [changes, build-e2e-images]
+  tempest ────────> needs: [changes, build-e2e-images, e2e-infra, e2e-operator, e2e-chaos, e2e-prometheus]
+  cleanup-e2e-tags > needs: [build-e2e-images, e2e-operator, e2e-chaos, tempest]
 
-Publish Jobs (main/tags only, depends on E2E):
-  build-and-push (matrix: operator × platform) ──> needs: [changes, e2e-operator], if: push event
+Publish Jobs (push events only — main and v* tags; publish-only-on-merge):
+  build-and-push (matrix: operator × platform) ──> needs: [changes], if: push && has-e2e-operators == 'true'
     └──> merge-operator-images ──> needs: [changes, build-and-push], if: push event
-  helm-push ──> needs: [changes, e2e-operator], if: push event
+  helm-push ──> needs: [changes], if: push && has-e2e-operators == 'true'
 
 Release Job (v* tags only, depends on publish):
   github-release ──> needs: [changes, merge-operator-images, helm-push], if: v* tag
@@ -129,7 +144,9 @@ Release Job (v* tags only, depends on publish):
 The six E2E jobs (`e2e-infra`, `e2e-operator`, `e2e-chaos`, `e2e-prometheus`,
 `e2e-controlplane`, `tempest`) share infrastructure setup via the
 `setup-e2e-infra` composite action and diagnostic teardown via
-`hack/ci-dump-diagnostics.sh`.
+`hack/ci-dump-diagnostics.sh`. They run on `blacksmith-4vcpu-ubuntu-2404` runners
+(as does `test-integration`), except the `e2e-chaos` network suite, which uses a
+GitHub-hosted `ubuntu-24.04` runner for its kernel-module requirements.
 
 ## Jobs
 
@@ -139,10 +156,11 @@ Runs golangci-lint using the project's `.golangci.yml` configuration.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `golangci/golangci-lint-action@v9` | Installs golangci-lint binary (`install-only: true`); version pinned to `v2.11.4` |
-| 4 | `make lint` | Runs golangci-lint per module via the Makefile |
+| 3 | `actions/cache@v5` | Persists the golangci-lint analysis cache, keyed on the Go and golangci-lint versions |
+| 4 | `golangci/golangci-lint-action@v9` | Installs golangci-lint binary (`install-only: true`); version pinned via `GOLANGCI_LINT_VERSION` (`v2.12.2`) |
+| 5 | `make lint` | Runs golangci-lint per module via the Makefile |
 
 The `golangci-lint-action@v9` step is used with `install-only: true`, which installs the
 pinned golangci-lint binary (and caches it) without running lint. The actual linting is
@@ -188,13 +206,13 @@ formatting to all tracked Go files. The Makefile targets use `xargs` without the
 the repository always contains tracked `.go` files.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.go == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'`
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}` | Installs gofumpt at the pinned version (`v0.9.2`) |
+| 3 | `go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}` | Installs gofumpt at the pinned version (`v0.10.0`) |
 | 4 | `git ls-files '*.go' \| xargs -r gofumpt -l` | Lists non-conforming tracked Go files; on failure, prints unified diff and exits 1 |
 
 The check uses `git ls-files '*.go' | xargs -r gofumpt -l` to collect non-conforming files
@@ -211,8 +229,22 @@ The shellcheck binary is pre-installed on `ubuntu-latest` runners.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `shellcheck --severity=warning hack/*.sh` | Lints all shell scripts in `hack/` |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
+| 2 | `make shellcheck` | Runs `shellcheck --severity=warning` over `hack/*.sh` and the operator rotation scripts (`operators/*/internal/controller/scripts/*.sh`) |
+
+Timeout: 5 minutes.
+
+### feature-ids
+
+Verifies the whole tracked tree (code, tests, CI, scripts, docs) is free of internal
+feature/requirement IDs. Runs unconditionally on every pull request — not
+path-filtered — so a stray ID added anywhere is caught. This job folds in the former
+docs-only check.
+
+| Step | Action | Details |
+| --- | --- | --- |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
+| 2 | `make check-feature-ids` | Greps the tracked tree for internal feature/requirement ID patterns and fails on any hit |
 
 Timeout: 5 minutes.
 
@@ -228,7 +260,7 @@ job runs. Always-on because the check is sub-second and `python3` is preinstalle
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `make verify-invalid-cr-fixtures` | Runs `_generate.py --check` and `test_generate.py` |
 
 Timeout: 5 minutes.
@@ -246,7 +278,7 @@ the `setup-test-deps` composite action, the same one consumed internally by
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `./.github/actions/setup-test-deps` | Restores the testdeps cache and runs `make install-test-deps` (puts `chainsaw` on `PATH`) |
 | 3 | `make chainsaw-lint` | Runs `chainsaw lint test -f` and `chainsaw lint configuration -f` over every matching file under `tests/` |
 
@@ -264,7 +296,7 @@ explicitly so the deploy/ overlay assertions run their full check set
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | Install kustomize | Downloads the pinned kustomize binary into `/usr/local/bin` |
 | 3 | `make test-shell` | Iterates every `tests/unit/**/*_test.sh` and aggregates exit status |
 
@@ -278,7 +310,7 @@ a single coverage profile uploaded to Codecov under a dedicated flag.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `make test-common` or `make test-operator` | Runs unit tests for the matrix target |
 | 4 | `codecov/codecov-action@v5` | Uploads coverage profile with target-specific flag |
@@ -315,7 +347,7 @@ download kubebuilder assets (kube-apiserver, etcd) for the test API server.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `go install setup-envtest@release-0.23` | Installs envtest asset downloader (pinned to release branch) |
 | 4 | `make test-integration-common` or `make test-integration` | Runs integration tests for the matrix target |
@@ -347,12 +379,12 @@ caching, since race conditions are non-deterministic and cached results could ma
 races.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.go == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'`
 **Path filter:** Go source files (same filter as `test` and `test-integration`)
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `make test-race RACE_FLAGS="-count=1"` | Delegates to the Makefile so the module list stays in sync |
 
@@ -378,26 +410,32 @@ actually reachable — reducing false positives. Catches supply-chain vulnerabil
 PR stage, before container images are built.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.go == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'`
 **Path filter:** Go source files (same filter as `test`, `test-integration`, and `test-race`)
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `go install golang.org/x/vuln/cmd/govulncheck@latest` | Installs the latest govulncheck binary |
-| 4 | `make govulncheck` | Delegates to the Makefile target, which iterates over `internal/common` and all `$(OPERATORS)` modules |
+| 4 | `make govulncheck` | Delegates to `hack/ci-govulncheck.sh`, which scans `internal/common` and all `$(OPERATORS)` modules with an explicit allowlist |
 
 govulncheck uses `@latest` intentionally — unlike other pinned tools (controller-gen,
 gofumpt), pinning govulncheck to an old version defeats the purpose of vulnerability
 scanning because the vulnerability database is updated frequently. This is a deliberate
 deviation from the general pinning policy, justified by the security tool's nature.
 
-The CI step delegates to `make govulncheck`, which iterates over `internal/common` and
-each operator in the `$(OPERATORS)` Makefile variable. The Makefile target exits on the
-first module with a reachable vulnerability. govulncheck exits non-zero only for reachable
-vulnerabilities — dependencies with known CVEs whose vulnerable functions are not called
-in project code are reported as informational but do not fail the job.
+The CI step delegates to `make govulncheck`, which runs `hack/ci-govulncheck.sh` over
+`internal/common` and each operator in the `$(OPERATORS)` Makefile variable. govulncheck
+has no native suppression flag, so the wrapper runs it in JSON mode per module, keeps
+only the *reachable* symbol-level findings (the ones that fail the default text report),
+and drops any whose advisory ID appears in the script's `ALLOWLIST` map. The build fails
+if, and only if, a reachable finding survives the allowlist — matching govulncheck's
+normal failure semantics while letting the project ride out advisories that have no fix
+and no real exposure. Every allowlist entry carries a one-line justification, and if an
+allowlisted advisory is no longer reported, the wrapper prints a notice so the stale
+entry can be removed. Dependencies with known CVEs whose vulnerable functions are not
+called in project code are reported as informational but do not fail the job.
 
 This job runs independently and does **not** appear in any other job's `needs:` array. It
 is not on the critical path for E2E or publish jobs, matching the `test-race` pattern.
@@ -416,7 +454,7 @@ up-to-date. This is a gate job — it blocks merge alongside `lint`,
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `go install controller-gen@${{ env.CONTROLLER_GEN_VERSION }}` | Installs the pinned code generator |
 | 4 | `make manifests && make generate` | Regenerates CRD manifests and deepcopy functions |
@@ -431,12 +469,12 @@ instructions to run `make manifests && make generate` locally and commit the res
 Builds the VitePress documentation site to catch broken links and build errors.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.docs == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'`
 **Path filter:** `docs/**`, `package.json`, `package-lock.json`
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Full history (`fetch-depth: 0`) for git-based features |
+| 1 | `actions/checkout@v7` | Full history (`fetch-depth: 0`) for git-based features |
 | 2 | `actions/setup-node@v6` | Node.js 24, npm cache enabled |
 | 3 | `npm ci` | Installs dependencies from lockfile |
 | 4 | `npm run docs:build` | Builds the documentation site |
@@ -451,12 +489,12 @@ value override scenarios, and `helm unittest` for each chart to catch
 regressions at PR time.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.helm == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.helm == 'true'`
 **Path filter:** `operators/keystone/helm/**`, `operators/c5c3/helm/**`, `operators/shared/helm/**`, `hack/gen-helm-values-schema.py`, `Makefile` (forced `true` on `v*` tag pushes)
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `azure/setup-helm@v5` | Installs Helm CLI (SHA-pinned) |
 | 3 | `helm plugin install helm-unittest` | Installs helm-unittest plugin (pinned to `v1.0.3`) |
 | 4 | `make verify-helm-schema` | Fails if either chart's `values.schema.json` has drifted from the shared generator |
@@ -497,11 +535,11 @@ infrastructure stack (Flux, cert-manager, MariaDB, ESO, OpenBao) to a kind clust
 validates health of all operators, CRs, and ExternalSecrets.
 
 **Dependencies:** `needs: [changes]`
-**Condition:** `if: needs.changes.outputs.e2e-infra == 'true'`
+**Condition:** `if: github.event_name == 'pull_request' && needs.changes.outputs.e2e-infra == 'true'`
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
@@ -521,7 +559,8 @@ rebuilding, saving ~5-10 min per CI run.
 
 **Dependencies:** `needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, verify-invalid-cr-fixtures, chainsaw-lint]`
 
-**Condition:** Runs only when `has-e2e-operators == 'true'` (or `e2e-chaos == 'true'`)
+**Condition:** Runs only when any of `has-e2e-operators`, `e2e-chaos`,
+`e2e-prometheus`, or `e2e-controlplane` is `'true'`
 and no gate job failed. Uses `always()` so the job runs when upstream Go jobs are
 skipped (e.g. pure E2E test-definition PRs where `go=false`). Skipped on PRs from
 forks (the workflow's `GITHUB_TOKEN` is read-only on `packages:` for forked
@@ -532,7 +571,7 @@ guard.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `docker/setup-buildx-action@v4` | Sets up BuildKit for `type=gha` cache support |
 | 3 | `docker/login-action@v4` | Authenticates to GHCR with `GITHUB_TOKEN` |
 | 4 | Resolve build operators | Unions `e2e-operators` with a fixed `keystone` entry (required by tempest) |
@@ -567,7 +606,7 @@ Chainsaw E2E test suites.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
@@ -599,18 +638,25 @@ suites (MariaDB pod kill, Memcached pod kill, OpenBao pod kill, MariaDB network
 partition, MariaDB network latency). See
 [Chaos E2E Test Suites](../testing/chaos-e2e-tests.md) for test suite details.
 
-**Dependencies:** `needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images]`
+**Dependencies:** `needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images, e2e-operator]`
 **Condition:** Runs only when `e2e-chaos == 'true'` or the PR has a `run-chaos` label, `build-e2e-images` succeeded, and no dependency failed or was cancelled.
 **Permissions:** `contents: read`, `packages: read` (required for GHCR pull).
 
-The `e2e-chaos` job depends on the standard gate jobs. The `e2e-operator` dependency was
-removed so chaos tests run in parallel with operator E2E tests, reducing
-overall CI wall time. The job uses `continue-on-error: true` while chaos test stability is
+The `e2e-chaos` job depends on the standard gate jobs plus `e2e-operator`, so chaos
+tests run after the happy-path operator E2E suite has passed. The job uses
+`continue-on-error: true` while chaos test stability is
 being proven in CI — failures are visible but do not block merges or the publish pipeline. This will be revisited after 2–4 weeks of successful CI runs.
+
+The job runs as a two-entry matrix split by chaos type: the `pod` suite (PodChaos
+tests) runs on `blacksmith-4vcpu-ubuntu-2404` for speed, while the `network` suite
+(NetworkChaos tests) runs on a GitHub-hosted `ubuntu-24.04` runner, where the
+`linux-modules-extra` kernel modules required by `ip_set`/`sch_netem` are resolvable
+(the Blacksmith Firecracker microVM kernel ships without them). Each matrix entry
+lists its per-suite test directories explicitly.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 3 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 4 | `kind load docker-image` | Loads keystone operator and 2025.2 service images into kind |
@@ -624,12 +670,12 @@ being proven in CI — failures are visible but do not block merges or the publi
 
 | Aspect | `e2e-operator` | `e2e-chaos` |
 | --- | --- | --- |
-| Matrix | Dynamic per-operator | Single job (keystone only) |
+| Matrix | Dynamic per-operator | Two suites (`pod` / `network`) on different runners |
 | Test config | `tests/e2e/chainsaw-config.yaml` | `tests/e2e-chaos/chainsaw-config.yaml` |
-| Test directory | `tests/e2e/<operator>/` | `tests/e2e-chaos/` |
-| Timeout | 45 minutes | 45 minutes |
+| Test directory | `tests/e2e/<operator>/` | per-suite `test_dirs` under `tests/e2e-chaos/` |
+| Timeout | 45 minutes | 60 minutes |
 | Blocking | Yes | No (`continue-on-error: true`) |
-| Dependencies | Gate jobs | Gate jobs |
+| Dependencies | Gate jobs | Gate jobs + `e2e-operator` |
 | Service images | 2025.2 + 2025.2-upgraded + 2026.1 | 2025.2 only |
 
 The chaos test Chainsaw config uses `parallel: 1` (serial execution) because chaos tests
@@ -675,7 +721,7 @@ genuine regression of the kind-only Quick Start observability story.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 3 | `load-e2e-images` composite | Restores prebuilt operator and service images from the build-e2e-images artifact |
 | 4 | `kind load docker-image` | Loads operator and service images into kind |
@@ -750,8 +796,8 @@ cluster and runs the OpenStack Tempest test suite against them. Uses a release m
 configuration, Keystone CRs, and K8s service names. Pulls pre-built images from
 GHCR (run-scoped tag) via the `load-e2e-images` composite action.
 
-**Dependencies:** `needs: [changes, build-e2e-images]`
-**Condition:** Runs only when `has-e2e-operators == 'true'` and `build-e2e-images` succeeded.
+**Dependencies:** `needs: [changes, build-e2e-images, e2e-infra, e2e-operator, e2e-chaos, e2e-prometheus]`
+**Condition:** Runs only when `has-e2e-operators == 'true'`, `build-e2e-images` succeeded, and no other E2E job failed or was cancelled — tempest is the last E2E job in the chain.
 **Permissions:** `contents: read`, `packages: read` (required for GHCR pull).
 
 **Matrix strategy:**
@@ -778,7 +824,7 @@ these via `matrix.release`, `matrix.config-dir`, `matrix.cr-name`, and
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
@@ -796,8 +842,9 @@ Timeout: 45 minutes.
 
 GH-310. Prunes the run-scoped GHCR tags pushed by `build-e2e-images`
 (`e2e-${run_id}-*`) so they don't accumulate on the package page. Runs as a
-matrix over each E2E target package (`keystone-operator`, `keystone`, `tempest`)
-after every consumer that might still pull the images has finished. The
+matrix over each E2E target package (`keystone-operator`, `keystone`,
+`c5c3-operator`, `tempest`) after every consumer that might still pull the images
+has finished. The
 `always() && needs.build-e2e-images.result == 'success'` condition means the
 cleanup runs on success, failure, cancelled, or skipped consumer outcomes — but
 only when `build-e2e-images` actually pushed something.
@@ -818,13 +865,17 @@ single-arch image by digest. Runs only on push events (main branch or
 v* tags) — skipped on pull requests. The multi-arch manifest list and final tags are
 assembled by the subsequent `merge-operator-images` job.
 
-**Dependencies:** `needs: [changes, e2e-operator]`
-**Condition:** `if: github.event_name == 'push' && needs.e2e-operator.result == 'success'`
+Publish-only-on-merge: the merged commit's PR was already green, so the E2E suite is
+not re-run on push. The job depends only on `changes` (for the operator matrix) and
+builds the image from its own cache scope, independent of `build-e2e-images`.
+
+**Dependencies:** `needs: [changes]`
+**Condition:** `if: github.event_name == 'push' && needs.changes.outputs.has-e2e-operators == 'true'`
 **Permissions:** `contents: read`, `packages: write`
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | Prepare platform pair | Shell | Converts `linux/amd64` → `linux-amd64` for artifact names and cache scopes |
 | 3 | `docker/setup-buildx-action@v4` | Sets up Docker Buildx |
 | 4 | `docker/login-action@v4` | Authenticates to GHCR (`github.actor` / `GITHUB_TOKEN`) |
@@ -863,10 +914,10 @@ list, and pushes it with the final tags.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `docker/setup-buildx-action@v4` + `docker/login-action@v4` | Authenticates to GHCR |
 | 3 | `docker/metadata-action@v6` | Generates final image tags |
-| 4 | Download digests | `actions/download-artifact@v4` | Downloads all `digests-operator-<operator>-*` artifacts |
+| 4 | Download digests | `actions/download-artifact@v8` | Downloads all `digests-operator-<operator>-*` artifacts |
 | 5 | Create and push manifest list | Shell | `docker buildx imagetools create` assembles per-platform digests under the final tags from step 3 |
 
 **Matrix strategy:** Same `operator` dimension as `build-and-push` (via `fromJson(needs.changes.outputs.e2e-operators)`).
@@ -884,16 +935,18 @@ Images are published at `ghcr.io/c5c3/<operator>-operator:<tag>`.
 ### helm-push
 
 Packages and pushes operator Helm charts to the GHCR OCI registry.
-Runs only on push events — skipped on pull requests.
+Runs only on push events — skipped on pull requests. Like `build-and-push`, this is
+publish-only-on-merge: the chart is packaged and pushed for every changed operator on
+push without re-running the E2E suite.
 
-**Dependencies:** `needs: [changes, e2e-operator]`
-**Condition:** `if: github.event_name == 'push' && needs.e2e-operator.result == 'success'`
+**Dependencies:** `needs: [changes]`
+**Condition:** `if: github.event_name == 'push' && needs.changes.outputs.has-e2e-operators == 'true'`
 **Permissions:** `contents: read`, `packages: write`
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `azure/setup-helm@v4` | Installs Helm CLI |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
+| 2 | `azure/setup-helm@v5` | Installs Helm CLI |
 | 3 | Helm registry login | Authenticates to GHCR via `helm registry login` |
 | 4 | Package and push | Packages chart and pushes to `oci://ghcr.io/c5c3/charts/` |
 
@@ -904,13 +957,9 @@ Runs only on push events — skipped on pull requests.
 | Push to main | Default version from `Chart.yaml` |
 | Push v* tag | SemVer derived from tag (v prefix stripped, e.g. `v0.1.0` → `0.1.0`) |
 
-**Matrix strategy:**
-
-```yaml
-strategy:
-  matrix:
-    operator: [keystone]
-```
+**Matrix strategy:** Same `operator` dimension as `build-and-push` (via
+`fromJson(needs.changes.outputs.e2e-operators)`), so every changed operator's chart is
+packaged and pushed.
 
 The `make helm-package` target packages `operators/<operator>/helm/<operator>-operator/`.
 When `CHART_VERSION` is set (for tag pushes), it overrides the version in `Chart.yaml`.
@@ -925,10 +974,10 @@ Creates a GitHub Release with auto-generated release notes on v* tag pushes.
 
 | Step | Action | Details |
 | --- | --- | --- |
-| 1 | `actions/checkout@v6` | Checks out the repository (SHA-pinned) |
-| 2 | `azure/setup-helm@v4` | Installs Helm CLI for chart packaging |
+| 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
+| 2 | `azure/setup-helm@v5` | Installs Helm CLI for chart packaging |
 | 3 | Package Helm charts | Packages operator Helm charts with release version |
-| 4 | `softprops/action-gh-release@v2` | Creates release with `generate_release_notes: true` and attaches chart tarballs |
+| 4 | `softprops/action-gh-release@v3` | Creates release with `generate_release_notes: true` and attaches chart tarballs |
 
 This job runs only after both `merge-operator-images` and `helm-push` complete
 successfully, ensuring the final multi-arch manifest list and charts are published before
@@ -1089,7 +1138,7 @@ internally).
 
 | Step | Description |
 | --- | --- |
-| 1 | Installs Flux CLI via `fluxcd/flux2/action@v2.8.3` (SHA-pinned) |
+| 1 | Installs Flux CLI via `fluxcd/flux2/action@v2.9.0` (SHA-pinned) |
 | 2 | Delegates to the `setup-test-deps` composite action (cache restore + `make install-test-deps` + `PATH` wiring) |
 | 3 | Runs `make deploy-infra` with `SKIP_KIND_CREATE=true` |
 
@@ -1175,7 +1224,7 @@ All Go-based jobs use `actions/setup-go@v6` with:
 go-version-file: go.work
 ```
 
-This reads the Go version from `go.work` (currently Go 1.25.0) rather than hardcoding a
+This reads the Go version from `go.work` (currently Go 1.26.4) rather than hardcoding a
 `go-version` value. The repository root contains `go.work` (not `go.mod`) because the
 project uses a Go Workspace with multiple modules (`internal/common`, `operators/keystone`,
 `operators/c5c3`). Module dependency caching is enabled by default in `actions/setup-go@v6`.
@@ -1200,7 +1249,7 @@ branches do not cancel each other's runs.
 All GitHub Actions are referenced by full SHA hash with a trailing version comment:
 
 ```yaml
-- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 ```
 
 This prevents supply chain attacks via mutable tag retargeting and provides audit

--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -80,7 +80,7 @@ for multi-stage service builds.
 | Property | Value |
 | --- | --- |
 | Base image | `python-base` (local) |
-| Package manager | `uv` 0.6.3 (copied from `ghcr.io/astral-sh/uv:0.6.3`) |
+| Package manager | `uv` 0.11.24 (copied from the digest-pinned `ghcr.io/astral-sh/uv:0.11.24`; tracked by Renovate) |
 | Virtualenv path | `/var/lib/openstack` |
 
 **Build-time packages:**

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -226,9 +226,10 @@ HELMRELEASE_TIMEOUT=600 make deploy-infra
 
 ## CI Job
 
-The `e2e-infra` job in `.github/workflows/ci.yaml` runs on every push to `main`
-and on every pull request. It runs independently of the `lint` and `test` jobs
-(no `needs:` dependency).
+The `e2e-infra` job in `.github/workflows/ci.yaml` runs only on pull requests
+(`github.event_name == 'pull_request'`) and only when the `e2e-infra` path filter
+of the `changes` job matches. It depends only on `changes` — not on the `lint` or
+`test` jobs — so it starts as soon as the path filters are resolved.
 
 **Job steps:**
 
@@ -282,10 +283,10 @@ the new release artifacts, compute `sha256sum`, and replace the values in the sc
 
 | Tool | Version | SHA256 Pinning |
 | --- | --- | --- |
-| chainsaw | v0.2.14 | upstream (fetched) |
-| flux | 2.8.6 | pinned |
-| kind | v0.31.0 | pinned |
-| kubectl | v1.36.0 | pinned |
+| chainsaw | v0.2.15 | upstream (fetched) |
+| flux | 2.8.8 | pinned |
+| kind | v0.32.0 | pinned |
+| kubectl | v1.36.1 | pinned |
 
 ## Quick Start
 

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -816,8 +816,9 @@ of scope here. -->
 kubectl apply -k deploy/flux-system/
 ```
 
-This applies 28 resources: 10 namespaces, 1 FluxInstance, 7 HelmRepository
-sources, and 10 HelmRelease operators. FluxCD resolves the dependency graph between
+This applies 28 resources: 10 namespaces, 1 FluxInstance, 7 sources
+(6 HelmRepository + 1 GitRepository for K-ORC), 9 HelmRelease operators, and
+1 Kustomization (K-ORC). FluxCD resolves the dependency graph between
 HelmReleases and installs operators in the correct order. Wait for all operators to
 finish installing before proceeding to step 2.
 
@@ -971,7 +972,7 @@ Quick Start (Step 4a). The `ResourceSet` renders two sibling resources — an
 | Name | `flux-web` |
 | Namespace | `flux-system` |
 | Chart URL | `oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator` |
-| Version pin (input) | `0.47.x` — SemVer range locked to the minor track of `FLUX_OPERATOR_VERSION` in `hack/deploy-infra.sh` |
+| Version pin (input) | `0.52.x` — SemVer range locked to the minor track of `FLUX_OPERATOR_VERSION` in `hack/deploy-infra.sh` |
 
 **Helm values on the nested `HelmRelease`:**
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -384,6 +384,17 @@ path. If the secret already exists, the write is skipped to prevent overwriting
 existing credentials. This is critical — overwriting would create a mismatch between
 the credentials stored in OpenBao and those already provisioned to consuming services.
 
+**ESO PushSecret adoption marker:** After seeding, the script stamps
+`custom_metadata.managed-by=external-secrets` onto the per-ControlPlane admin
+paths via `bao kv metadata put`. ESO refuses to push to a pre-existing secret
+whose metadata lacks this marker (it fails with "secret not managed by
+external-secrets"), so without the stamp the scheduled admin-password rotation
+backup PushSecret (per-CR RemoteKey `bootstrap/{namespace}/{keystone}/admin`)
+could never mirror a rotated password back into OpenBao. The stamp runs
+unconditionally — it also adopts paths a prior deploy created without the
+marker — and `bao kv metadata put` touches only metadata, leaving the stored
+password versions untouched.
+
 ## HCL Access Control Policies
 
 Eight HCL policies enforce least-privilege access for each consumer type. All policy

--- a/docs/reference/keystone-operator-metrics.md
+++ b/docs/reference/keystone-operator-metrics.md
@@ -1,7 +1,6 @@
 ---
 title: Keystone Operator Prometheus Metrics
 quadrant: operator
-
 ---
 
 # Keystone Operator Prometheus Metrics
@@ -56,7 +55,7 @@ Wall-clock duration of a single sub-reconciler invocation in seconds.
 | Call site | `instrumentSubReconciler` in `operators/keystone/internal/controller/instrumentation.go` |
 
 **Label cardinality.** The `sub_reconciler` value is drawn from a closed
-set of 14 strings — the keys of `subReconcilerConditionTypes` — so the
+set of 16 strings — the keys of `subReconcilerConditionTypes` — so the
 series count is bounded regardless of how many Keystone CRs exist. The
 metric deliberately omits a `keystone`/`namespace` label to keep
 cardinality fleet-independent; per-CR attribution is
@@ -86,8 +85,8 @@ and the `status.conditions[]` type it failed to drive to `True`.
 | Labels | `sub_reconciler`, `condition_type` |
 | Call site | `instrumentSubReconciler` (on non-nil error return) |
 
-**Label cardinality.** Both labels are drawn from closed sets: the 14
-sub-reconciler names and the 12 Ready sub-condition types listed in
+**Label cardinality.** Both labels are drawn from closed sets: the 16
+sub-reconciler names and the 14 Ready sub-condition types listed in
 `subConditionTypes`. The `sub_reconciler` → `condition_type` mapping is
 one-to-one for most entries; the exceptions (`Secrets`,
 `DBConnectionSecret`, `Config` all map to `SecretsReady`) collapse into

--- a/docs/reference/keystone/index.md
+++ b/docs/reference/keystone/index.md
@@ -17,10 +17,11 @@ in-depth reference doc for that area.
 ## Lifecycle and Reconciliation
 
 - **Sub-reconciler chain.** A focused pipeline of sub-reconcilers — Secrets →
-  Config → FernetKeys / CredentialKeys / NetworkPolicy → Database →
-  PolicyValidation → Deployment → HTTPRoute → HealthCheck → HPA → Bootstrap →
-  TrustFlush — each emitting a typed sub-condition that aggregates into
-  `Ready`. See [Reconciler Architecture](./keystone-reconciler.md).
+  DatabaseTLS → DBConnectionSecret → Config → FernetKeys / CredentialKeys /
+  NetworkPolicy → Database → PolicyValidation → Deployment → HTTPRoute →
+  HealthCheck → HPA → Bootstrap → TrustFlush → PasswordRotation — each
+  emitting a typed sub-condition that aggregates into `Ready`. See
+  [Reconciler Architecture](./keystone-reconciler.md).
 - **Parallel execution group.** FernetKeys, CredentialKeys and NetworkPolicy
   run concurrently via `errgroup` to cut tail latency on cold reconciles.
 - **Two finalizers.** The standard cleanup finalizer cascades owned resources;
@@ -38,7 +39,7 @@ in-depth reference doc for that area.
   policy overrides, autoscaling, networkPolicy, gateway, resources, uwsgi,
   graceful-termination knobs, topologySpreadConstraints, priorityClassName,
   rollout `strategy`, and free-form `extraConfig`.
-- **Status with sub-conditions.** Eleven typed sub-conditions plus
+- **Status with sub-conditions.** Fourteen typed sub-conditions plus
   `installedRelease`, `targetRelease`, `upgradePhase`, and `endpoint` —
   surfaced via `kubectl get keystones` printer columns.
 - **Validating + Defaulting webhooks.** CEL validation rules enforced by the
@@ -87,6 +88,11 @@ See the [Key Rotation Guide](../../guides/keystone-key-rotation.md).
   knobs are injected via `OS_<GROUP>__<OPTION>` env vars rather than baked
   into the rendered config, so credential rotation does not require a
   ConfigMap re-render.
+- **Optional database TLS.** `spec.database.tls` enables encrypted MariaDB
+  connections up to `verify-full`, with a cert-manager-issued client
+  certificate in managed mode and a dedicated `DatabaseTLSReady`
+  sub-condition. See the
+  [Database TLS guide](../../guides/enable-keystone-database-tls.md).
 
 ## Networking and Exposure
 
@@ -122,6 +128,12 @@ See the [Key Rotation Guide](../../guides/keystone-key-rotation.md).
   admin project/user/role, region and public endpoint.
 - **Trust flush CronJob.** Optional periodic cleanup of expired trust
   delegations.
+- **Admin password rotation.** Manual rotation at the OpenBao source with a
+  digest-gated bootstrap re-run, plus an optional in-cluster scheduled
+  rotation CronJob via `spec.bootstrap.passwordRotation`. See the
+  [rotation](../../guides/keystone-admin-password-rotation.md) and
+  [scheduled rotation](../../guides/keystone-admin-password-scheduled-rotation.md)
+  guides.
 - **Policy validation.** `oslopolicy-validator` Job blocks rollouts on
   invalid policy overrides.
 - **Graceful-termination knobs.** `terminationGracePeriodSeconds`,

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -997,6 +997,26 @@ Configures the initial Keystone bootstrap.
 | `adminPasswordSecretRef` | [`SecretRefSpec`](#secretrefspec) | Yes | — | Secret containing the admin password. |
 | `region` | `string` | No | `"RegionOne"` | Keystone region name. Immutable after create (CEL transition rule): changing the region strands catalog entries under the old region. |
 | `publicEndpoint` | `string` | No | Cluster-local service DNS | Externally routable Keystone endpoint URL. Used for the `--bootstrap-public-url` argument passed to `keystone-manage bootstrap`. Required by external clients (CLI users, Horizon, federation partners) that cannot resolve the cluster-local service DNS. When set, it must be an HTTP(S) URL (`+kubebuilder:validation:Pattern=^https?://`), enforced unconditionally by the CRD schema; when `spec.gateway` is also set the webhook additionally requires the host to equal `spec.gateway.hostname`. |
+| `passwordRotation` | [`PasswordRotationSpec`](#passwordrotationspec) | No | `nil` (feature off) | Optionally enables scheduled rotation of the admin password. Nil leaves the feature off and the PasswordRotation sub-reconciler is a clean no-op. |
+
+### PasswordRotationSpec
+
+Configures scheduled admin-password rotation. Unlike `TrustFlushSpec`, the
+defaulting webhook does **not** materialize this block when it is absent —
+scheduled rotation is strictly opt-in, so upgrading a CR that never set
+`passwordRotation` never silently enables it. The webhook only fills the leaf
+defaults once `enabled` is true; the `+kubebuilder:default` markers below
+remain as defense-in-depth for callers that bypass the webhook. The rotated
+password is pushed to the per-CR OpenBao key
+`bootstrap/{namespace}/{name}/admin`, so enabling rotation on multiple CRs
+does not collide on a shared object.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `enabled` | `bool` | No | `false` | Turns on scheduled admin-password rotation. Disabling it tears down every rotation resource. |
+| `schedule` | `string` | No | `"0 0 1 * *"` | Cron expression controlling when a new admin password is generated (monthly at midnight on the 1st). |
+| `suspend` | `bool` | No | `false` | Pauses the CronJob without deleting it or any sibling resource, matching `TrustFlushSpec.suspend` semantics. |
+| `passwordLength` | `int32` | No | `32` | Length of the generated password. Minimum 24 (`+kubebuilder:validation:Minimum=24`). |
 
 ---
 
@@ -1561,6 +1581,8 @@ Both targets are parameterized by operator directory in the Makefile. Generated
 - `CredentialKeysSpec`
 - `FederationSpec`
 - `BootstrapSpec`
+- `PasswordRotationSpec`
+- `LoggingSpec`
 
 ---
 

--- a/docs/reference/keystone/keystone-events.md
+++ b/docs/reference/keystone/keystone-events.md
@@ -46,6 +46,7 @@ All events follow these conventions:
 | --- | --- | --- | --- |
 | `BootstrapComplete` | Normal | Bootstrap Job completes successfully | `Keystone bootstrap completed successfully` |
 | `BootstrapFailed` | Warning | Bootstrap Job fails | `Keystone bootstrap job failed: <error>` |
+| `AdminSecretInvalid` | Warning | Admin password Secret is missing, unreadable, or has an empty `password` value | `Admin password Secret openstack/keystone-admin is missing, unreadable, or has an empty "password" value` |
 
 **Source:** `reconcileBootstrap` in `reconcile_bootstrap.go`
 
@@ -56,8 +57,9 @@ All events follow these conventions:
 | `DatabaseSynced` | Normal | `db_sync` and `schema-check` Jobs both complete successfully | `Database schema is up to date` |
 | `DBSyncFailed` | Warning | `db_sync` Job fails | `db_sync job failed: <error>` |
 | `SchemaDriftDetected` | Warning | `schema-check` Job fails after `db_sync` succeeds (schema does not match Alembic head) | `schema-check job failed: <error>` |
+| `DBSyncMetricEmissionDeferred` | Warning | Patching the last-observed Job UID annotation fails, deferring `db_sync` metric emission to the next reconcile | `Patching last-observed db-sync Job UID failed; db_sync metric emission deferred to the next reconcile: <error>` |
 
-**Source:** `reconcileDatabase` in `reconcile_database.go`
+**Source:** `reconcileDatabase` in `reconcile_database.go`; `recordDBJobTerminalState` in `db_job_metrics.go`
 
 ### Upgrade Initiation
 
@@ -68,8 +70,9 @@ All events follow these conventions:
 | `DowngradeNotSupported` | Warning | Target release is older than installed release | `Downgrade from 2026.1 to 2025.2 is not supported` |
 | `UpgradePathInvalid` | Warning | Target release skips an intermediate version (non-sequential upgrade) | `Upgrade from 2025.1 to 2026.1 is not sequential` |
 | `UpgradeTargetChanged` | Warning | `spec.image.tag` changed while an upgrade is already in progress | `Image tag changed to 2026.2 during active upgrade 2025.2 → 2026.1` |
+| `UpgradeAborted` | Normal | `spec.image.tag` reverted to the installed release while an upgrade was in progress; upgrade Jobs are deleted and phase/target reset | `Upgrade 2025.2 → 2026.1 aborted: spec.image.tag reverted to installed release 2025.2` |
 
-**Source:** `initiateUpgrade` and `reconcileDatabase` in `reconcile_database.go`
+**Source:** `initiateUpgrade` in `reconcile_upgrade.go`; `UpgradeTargetChanged` and `UpgradeAborted` from `reconcileDatabase`/`abortUpgrade` in `reconcile_database.go`
 
 ### Upgrade Phases
 
@@ -82,7 +85,8 @@ All events follow these conventions:
 | `UpgradeComplete` | Normal | Contract phase Job completes, finishing the entire upgrade | `Upgrade complete: 2025.2 → 2026.1` |
 | `ContractFailed` | Warning | Contract phase Job fails | `Contract job <name> failed: <error>` |
 
-**Source:** `reconcileExpand`, `reconcileMigrate`, `reconcileContract` in `reconcile_database.go`
+**Source:** `reconcileExpand`, `reconcileMigrate`, `reconcileContract`, and the shared
+`runUpgradePhase` step driver in `reconcile_upgrade.go`
 
 ### Encryption Key Generation
 
@@ -94,7 +98,53 @@ All events follow these conventions:
 **Source:** `reconcileFernetKeys` in `reconcile_fernet.go`, `reconcileCredentialKeys` in `reconcile_credential.go`
 
 > **Note:** These events fire only on initial Secret creation. Subsequent key
-> rotations are handled by CronJobs and do not emit controller events.
+> rotations run as CronJobs; when the controller commits a completed rotation
+> from the staging Secret it emits the events in
+> [Rotation Commit (Staged)](#rotation-commit-staged) below.
+
+### Rotation Commit (Staged)
+
+The Fernet, credential-key, and admin-password rotation CronJobs write their
+output to a staging Secret. The controller validates and commits the staged
+payload onto the production Secret and reports the outcome as events:
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `FernetKeysRotated` | Normal | Staged Fernet rotation validated and applied to the main keys Secret | `rotation applied from staging secret keystone-fernet-keys-rotation (3 active keys)` |
+| `CredentialKeysRotated` | Normal | Staged credential-key rotation validated and applied to the main keys Secret | `rotation applied from staging secret keystone-credential-keys-rotation (2 active keys)` |
+| `RotationAnnotationInvalid` | Warning | Staging Secret's `forge.c5c3.io/rotation-completed-at` annotation is not valid RFC3339 (Fernet/credential) | `staging secret <name> has malformed forge.c5c3.io/rotation-completed-at annotation: <error>` |
+| `RotationRejected` | Warning | Staged Fernet/credential key set fails validation (key count outside `[min, max]`); the staged data is cleared | `staging secret <name> rejected: <error>` |
+| `AdminPasswordRotated` | Normal | Staged admin-password rotation validated and applied to the push-source Secret | `admin password rotation applied from staging secret <name>` |
+| `AdminPasswordRotationAnnotationInvalid` | Warning | Admin-password staging Secret's completion annotation is malformed | `staging secret <name> has malformed forge.c5c3.io/rotation-completed-at annotation: <error>` |
+| `AdminPasswordRotationRejected` | Warning | Staged admin password fails validation (e.g. below minimum length); the rejected password is retained for inspection | `staging secret <name> rejected: <error>` |
+
+**Source:** shared `commitStagedRotation` in `rotation_staging.go`, invoked from
+`reconcile_fernet.go`, `reconcile_credential.go`, and `reconcile_passwordrotation.go`
+
+### Trust Flush
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `TrustFlushBypass` | Warning | `spec.trustFlush` is nil on a CR that predates webhook defaulting; the existing trust-flush CronJob is deleted | `Trust flush legacy bypass: spec.trustFlush is nil (webhook defaulting did not run); existing CronJob deleted` |
+
+**Source:** `reconcileTrustFlush` in `reconcile_trustflush.go`
+
+### Finalization
+
+Emitted while the two finalizers tear a deleted Keystone CR down. The
+"Finalizing" events are gated on live cleanup work remaining, so brownfield
+CRs (no MariaDB CRs) and repeated requeue polls do not produce noise:
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `FinalizingDatabase` | Normal | Deletion begins while MariaDB Database/User/Grant CRs are still live | `Cleaning up MariaDB Database, User, and Grant before removing Keystone` |
+| `DatabaseFinalized` | Normal | MariaDB resources marked for deletion; database finalizer released | `MariaDB Database, User, and Grant marked for deletion; releasing finalizer` |
+| `FinalizingOpenBaoSecrets` | Normal | Deletion begins while OpenBao backup PushSecrets are still live | `Cleaning up OpenBao backup PushSecrets before removing Keystone` |
+| `OpenBaoSecretsFinalized` | Normal | Backup PushSecrets deleted; OpenBao finalizer released | `OpenBao backup PushSecrets deleted; releasing openbao-finalizer` |
+| `ESOAdoptionTimedOut` | Warning | A backup PushSecret was not adopted by ESO within the bounded wait after deletion; the controller force-deletes it to release the finalizer | `PushSecret "<name>" not adopted by ESO within <timeout> of deletion; force-deleting to release the openbao-finalizer (the OpenBao kv-v2 path may be orphaned only if ESO is not running)` |
+
+**Source:** finalizer handlers in `keystone_controller.go`; `ESOAdoptionTimedOut`
+from the adoption-wait pass in `reconcile_secrets.go`
 
 ### Deployment Rollout
 
@@ -201,7 +251,15 @@ groups:
 ```text
 KeystoneReconciler.Reconcile()
   │
+  ├── finalizers (deletionTimestamp set)
+  │     ├─ MariaDB CRs still live         → Normal  FinalizingDatabase
+  │     ├─ MariaDB cleanup done           → Normal  DatabaseFinalized
+  │     ├─ Backup PushSecrets still live  → Normal  FinalizingOpenBaoSecrets
+  │     ├─ ESO adoption wait exceeded     → Warning ESOAdoptionTimedOut
+  │     └─ PushSecrets deleted            → Normal  OpenBaoSecretsFinalized
+  │
   ├── reconcileBootstrap()
+  │     ├─ Admin Secret missing/invalid → Warning AdminSecretInvalid
   │     ├─ Job succeeds  → Normal  BootstrapComplete
   │     └─ Job fails     → Warning BootstrapFailed
   │
@@ -209,10 +267,12 @@ KeystoneReconciler.Reconcile()
   │     ├─ Non-upgrade path:
   │     │     ├─ db_sync fails      → Warning DBSyncFailed
   │     │     ├─ schema-check fails → Warning SchemaDriftDetected
-  │     │     └─ Both succeed       → Normal  DatabaseSynced
+  │     │     ├─ Both succeed       → Normal  DatabaseSynced
+  │     │     └─ Job-UID patch fails → Warning DBSyncMetricEmissionDeferred
   │     │
   │     └─ Upgrade path:
   │           ├─ Tag changed mid-upgrade → Warning UpgradeTargetChanged
+  │           ├─ Tag reverted mid-upgrade → Normal UpgradeAborted
   │           ├─ Version parse error     → Warning VersionParseError
   │           ├─ Downgrade attempted     → Warning DowngradeNotSupported
   │           ├─ Non-sequential upgrade  → Warning UpgradePathInvalid
@@ -225,14 +285,28 @@ KeystoneReconciler.Reconcile()
   │           └─ Contract fails          → Warning ContractFailed
   │
   ├── reconcileFernetKeys()
-  │     └─ Initial Secret created → Normal FernetKeysGenerated
+  │     ├─ Initial Secret created → Normal FernetKeysGenerated
+  │     ├─ Staged rotation applied → Normal FernetKeysRotated
+  │     ├─ Malformed completion annotation → Warning RotationAnnotationInvalid
+  │     └─ Staged key set rejected → Warning RotationRejected
   │
   ├── reconcileCredentialKeys()
-  │     └─ Initial Secret created → Normal CredentialKeysGenerated
+  │     ├─ Initial Secret created → Normal CredentialKeysGenerated
+  │     ├─ Staged rotation applied → Normal CredentialKeysRotated
+  │     ├─ Malformed completion annotation → Warning RotationAnnotationInvalid
+  │     └─ Staged key set rejected → Warning RotationRejected
+  │
+  ├── reconcilePasswordRotation()
+  │     ├─ Staged rotation applied → Normal AdminPasswordRotated
+  │     ├─ Malformed completion annotation → Warning AdminPasswordRotationAnnotationInvalid
+  │     └─ Staged password rejected → Warning AdminPasswordRotationRejected
   │
   ├── reconcileConfig()
   │     └─ spec.extraConfig overrides use_stderr → Warning LoggingStderrDisabled
   │       (gated on transition into LoggingHealthy=False, Reason=StderrDisabled)
+  │
+  ├── reconcileTrustFlush()
+  │     └─ Legacy nil spec.trustFlush bypass → Warning TrustFlushBypass
   │
   └── reconcileDeployment()
         └─ Ready during upgrade rollout → Normal DeploymentRolloutComplete

--- a/docs/reference/testing/controlplane-e2e-tests.md
+++ b/docs/reference/testing/controlplane-e2e-tests.md
@@ -1,0 +1,171 @@
+---
+title: ControlPlane E2E Test Suites
+quadrant: operator
+---
+
+# ControlPlane E2E Test Suites
+
+Reference documentation for the Chainsaw E2E test suites covering the
+c5c3-operator's `ControlPlane` orchestration. These suites live in
+`tests/e2e/c5c3/` and exercise the full ControlPlane → Keystone chain:
+infrastructure projection, per-CR credential scoping in OpenBao, the K-ORC
+application-credential handoff, catalog registration, deletion orchestration,
+and multi-tenant isolation.
+
+For the reconciler architecture and sub-reconciler contracts, see
+[ControlPlane Reconciler](../c5c3/controlplane-reconciler.md). For the
+Keystone-level suites, see [Keystone E2E Test Suites](./keystone-e2e-tests.md).
+
+## Overview
+
+`tests/e2e/c5c3/` holds five suites. Each applies one or more `ControlPlane`
+CRs (`c5c3.io/v1alpha1`) and asserts operator behaviour end to end against the
+live cluster. The directory is the canonical inventory.
+
+Unlike the Keystone suites, the ControlPlane chain additionally requires K-ORC
+and the c5c3-operator (on top of the keystone-operator, OpenBao, ESO, MariaDB,
+and Memcached stack). The default kind E2E wiring does not install these, so
+every suite follows the repo's **belt-and-braces presence-guard pattern**: a
+runtime guard probes for the required CRDs and the OpenBao
+`ClusterSecretStore`, and exits with a SKIP line when the stack is absent.
+Because Chainsaw has no step-level skip and the shared config runs with
+`failFast: true`, the guard and all assertions live in a single script step.
+
+Setting `E2E_REQUIRE_CONTROLPLANE_STACK=true` flips the guard from SKIP to a
+hard failure. The dedicated `e2e-controlplane` CI job does exactly that: it
+deploys keystone-operator, c5c3-operator, and K-ORC as local dev images
+(`CONTROLPLANE_OPERATORS=external`), seeds the per-CR OpenBao paths
+(`CONTROLPLANE_NAME=controlplane-keystone`), and runs the
+`full-controlplane-keystone` suite so broken wiring in the live chain fails
+the build instead of skipping. See the
+[CI workflow reference](../ci-cd/ci-workflow.md) for the job definition.
+
+## Running the Tests
+
+```bash
+# Bring up the full stack locally (kind)
+WITH_CONTROLPLANE=true CONTROLPLANE_OPERATORS=external \
+  CONTROLPLANE_NAME=controlplane-keystone make deploy-infra
+hack/ci-deploy-korc.sh
+OPERATOR=keystone IMAGE_REPO=<registry>/keystone-operator NAMESPACE=keystone-system hack/ci-deploy-operator.sh
+OPERATOR=c5c3 IMAGE_REPO=<registry>/c5c3-operator NAMESPACE=c5c3-system hack/ci-deploy-operator.sh
+
+# Run a single suite, failing loudly if the stack is missing
+E2E_REQUIRE_CONTROLPLANE_STACK=true chainsaw test \
+  --config tests/e2e/chainsaw-config.yaml \
+  tests/e2e/c5c3/full-controlplane-keystone/
+```
+
+Without the stack the suites skip cleanly, so `make e2e` (which runs the whole
+`tests/e2e/` tree) stays safe on clusters that only carry the Keystone wiring.
+
+## Test Suite Inventory
+
+| Suite | CR Name(s) | Behaviour Validated |
+| --- | --- | --- |
+| [full-controlplane-keystone](#full-controlplane-keystone) | `controlplane-keystone` | The entire orchestration chain, link by link, through aggregate `Ready` and a live API check |
+| [deletion-orchestration](#deletion-orchestration) | `deletion-orch` | ORC-teardown finalizer sequencing; deletion completes even when Keystone is already gone |
+| [admin-password-scoping](#admin-password-scoping) | `controlplane` | Per-CR OpenBao-backed admin password projection |
+| [db-credential-scoping](#db-credential-scoping) | `controlplane` | Per-CR OpenBao-backed service DB credential projection |
+| [multi-controlplane](#multi-controlplane) | `controlplane-a`, `controlplane-b` | Per-CR admin-credential isolation across two tenants; rotation non-interference |
+
+## Test Suite Details
+
+### full-controlplane-keystone
+
+Applies one `ControlPlane` CR and asserts the whole chain link by link, gating
+each link on the previous one:
+
+1. **Infrastructure** — owned MariaDB (`openstack-db`) and Memcached
+   (`openstack-memcached`) created and owned by the ControlPlane;
+   `InfrastructureReady=True`.
+2. **Keystone** — owned Keystone CR (`controlplane-keystone-keystone`) with
+   the image tag derived from `spec.openStackRelease` and database/cache
+   clusterRefs wired to the infra CRs; `KeystoneReady=True`.
+3. **ApplicationCredential** — owned K-ORC ApplicationCredential minted with
+   `restricted: true`; `KORCReady=True`.
+4. **Credential chain** — minted credential → operator Secret → PushSecret →
+   OpenBao → operator-created per-CR `k-orc-clouds-yaml` ExternalSecret Ready;
+   `AdminCredentialReady=True`.
+5. **Catalog** — owned K-ORC Service and Endpoint; `CatalogReady=True`.
+6. **Aggregate** — `Ready=True` with reason `AllReady`.
+7. **API reachable** — Keystone `/v3` returns HTTP 200, and a verify Job runs
+   `openstack token issue` and `openstack catalog list` (using the `openstack`
+   CLI bundled in the tempest image) against the materialised admin
+   clouds.yaml, proving the minted, pushed, re-materialised application
+   credential actually authenticates.
+
+### deletion-orchestration
+
+Covers the `c5c3.io/orc-teardown` finalizer. Drives a ControlPlane to Ready,
+initiates deletion, then deletes the projected Keystone CR so K-ORC can no
+longer revoke the admin credential against a live API. Asserts that
+ControlPlane deletion still **completes** within a window larger than the
+bounded stall timeout (`orcTeardownStallTimeout`, 5m): the finalizer waits,
+then force-removes the stuck `openstack.k-orc.cloud/*` finalizers. Also
+asserts the projected Keystone, MariaDB, Memcached, and all five K-ORC CRs are
+garbage-collected and an ORC-teardown event (`ORCTeardownComplete`, or the
+Warning `ORCTeardownStalled` on the stalled path) was emitted.
+
+### admin-password-scoping
+
+Asserts that `reconcileAdminPassword` projects a per-ControlPlane,
+OpenBao-backed admin password: an owned ExternalSecret
+`controlplane-keystone-admin-credentials` whose `password` remoteRef reads the
+per-CR OpenBao key `bootstrap/{namespace}/{keystoneName}/admin`, plus the
+materialised Secret of the same name. The path is keystone-name scoped so it
+matches the keystone-operator's scheduled admin-password rotation PushSecret,
+which reads and writes the same key.
+
+### db-credential-scoping
+
+Asserts that `reconcileDBCredentials` projects a per-ControlPlane,
+OpenBao-backed DB credential: an owned ExternalSecret
+`controlplane-keystone-db-credentials` whose `username` and `password`
+remoteRefs read the per-CR OpenBao key
+`openstack/keystone/{namespace}/{name}/db`, plus the materialised Secret. The
+legacy flat shared-key DB ExternalSecret is gone.
+
+### multi-controlplane
+
+Brings up two ControlPlanes in two namespaces (`tenant-a/controlplane-a`,
+`tenant-b/controlplane-b`) and asserts, against a live OpenBao, that each CR's
+minted admin application credential lands on a distinct per-CR path
+(`openstack/keystone/{namespace}/{name}/admin/app-credential`) with different
+material, that both `status.adminApplicationCredential.id` values are
+non-empty and distinct, and that rotating only tenant-a's credential leaves
+tenant-b's status, OpenBao material, and K-ORC ApplicationCredential health
+unchanged. Also asserts the operator-created per-CR `k-orc-clouds-yaml`
+ExternalSecret (ownership and per-CR `remoteRef.key`) for both tenants.
+
+## File Layout
+
+```text
+tests/e2e/c5c3/
+├── admin-password-scoping/
+│   ├── chainsaw-test.yaml              Per-CR admin-password projection
+│   └── 00-controlplane-cr.yaml         Canonical ControlPlane CR
+├── db-credential-scoping/
+│   ├── chainsaw-test.yaml              Per-CR DB-credential projection
+│   └── 00-controlplane-cr.yaml         Canonical ControlPlane CR
+├── deletion-orchestration/
+│   ├── chainsaw-test.yaml              ORC-teardown finalizer sequencing
+│   └── 00-controlplane-cr.yaml         ControlPlane CR (deletion-orch)
+├── full-controlplane-keystone/
+│   ├── chainsaw-test.yaml              Full chain, link by link
+│   ├── 00-controlplane-cr.yaml         ControlPlane CR (controlplane-keystone)
+│   └── 01-openstack-verify-job.yaml    openstack CLI verify Job
+└── multi-controlplane/
+    ├── chainsaw-test.yaml              Two-tenant isolation contract
+    ├── 00-tenant-a-controlplane.yaml   ControlPlane CR controlplane-a
+    ├── 01-tenant-b-controlplane.yaml   ControlPlane CR controlplane-b
+    └── 02-tenant-a-rotation.yaml       Rotation trigger for tenant-a only
+```
+
+## Related Resources
+
+- [ControlPlane CRD API Reference](../c5c3/controlplane-crd.md) — CRD types, webhooks, validation rules
+- [ControlPlane Reconciler](../c5c3/controlplane-reconciler.md) — Sub-reconciler contracts, finalizer, credential re-push
+- [CI Workflow](../ci-cd/ci-workflow.md) — The dedicated `e2e-controlplane` job
+- [Infrastructure E2E Deployment](../infrastructure/e2e-deployment.md) — `WITH_CONTROLPLANE` deployment wiring
+- `tests/e2e/chainsaw-config.yaml` — Shared Chainsaw configuration

--- a/docs/reference/testing/keystone-e2e-tests.md
+++ b/docs/reference/testing/keystone-e2e-tests.md
@@ -21,62 +21,18 @@ deployment automation, see
 The test suites cover the full reconciler lifecycle — from initial deployment through
 scaling, key rotation, image upgrades, cross-release upgrades, and deletion cleanup. Each
 suite is independent and creates its own Keystone CR with a unique name in the `openstack`
-namespace, enabling parallel execution.
+namespace, enabling parallel execution (Chainsaw runs up to 4 suites concurrently).
 
-```text
-┌────────────────────────────────────────────────────────────────────────────┐
-│  Chainsaw E2E Runner (parallel: 4)                                         │
-│                                                                            │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ autoscaling       │  │ basic-deployment  │  │ basic-deployment-     │   │
-│  │                   │  │                   │  │  2026-1               │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ brownfield-       │  │ concurrent-cr-    │  │ config-pruning        │   │
-│  │  database         │  │  conflicts        │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ credential-       │  │ deletion-cleanup  │  │ events                │   │
-│  │  rotation         │  │                   │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ fernet-rotation   │  │ graceful-shutdown │  │ healthcheck           │   │
-│  │                   │  │                   │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ image-upgrade     │  │ invalid-cr        │  │ middleware-config     │   │
-│  │                   │  │                   │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ missing-secret    │  │ namespace-scoped- │  │ network-policy        │   │
-│  │                   │  │  rbac             │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ pod-security-     │  │ policy-overrides  │  │ policy-validation     │   │
-│  │  restricted       │  │                   │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ priority-class    │  │ release-upgrade   │  │ resources             │   │
-│  │                   │  │                   │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ scale             │  │ schema-drift-     │  │ topology-spread       │   │
-│  │                   │  │  detection        │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────────┐   │
-│  │ trust-flush       │  │ trust-flush-      │  │ upgrade-abort         │   │
-│  │                   │  │  default          │  │                       │   │
-│  └───────────────────┘  └───────────────────┘  └───────────────────────┘   │
-│  ┌───────────────────┐  ┌───────────────────┐                              │
-│  │ upgrade-flow      │  │ uwsgi             │                              │
-│  │                   │  │                   │                              │
-│  └───────────────────┘  └───────────────────┘                              │
-│                                                                            │
-│  Most tests run in: namespace openstack                                    │
-│  pod-security-restricted: own namespace keystone-pss-restricted-test       │
-│  Infrastructure: MariaDB, Memcached, ESO, OpenBao (pre-deployed)           │
-└────────────────────────────────────────────────────────────────────────────┘
-```
+`tests/e2e/keystone/` currently holds **45 suites** and is the canonical
+inventory — the [Test Suite Inventory](#test-suite-inventory) below lists all of
+them, and the [Test Suite Details](#test-suite-details) sections walk through a
+representative subset step by step.
+
+Most suites run in the `openstack` namespace; `pod-security-restricted` creates
+its own `keystone-pss-restricted-test` namespace, and the operator-level suites
+(`metrics`, `prometheus-stack`, `namespace-scoped-rbac`) exercise the
+keystone-operator Helm deployment in `keystone-system`. All suites assume the
+pre-deployed infrastructure stack (MariaDB, Memcached, ESO, OpenBao).
 
 ## Prerequisites
 
@@ -150,6 +106,30 @@ Deployment rollout, bootstrap Job).
 | [semantic-invariants](#semantic-invariants) | `keystone-invariants` | `status.endpoint` URL format, `ownerReferences` fan-out, `observedGeneration` tracking, `lastTransitionTime` monotonicity, ConfigMap immutability |
 | [topology-spread](#topology-spread) | `keystone-tsc` | `spec.topologySpreadConstraints`: `nil` injects 2 defaults; non-empty slice passes through verbatim; `[]` disables all constraints |
 | [pod-security-restricted](#pod-security-restricted) | `keystone-pss-restricted` | Reconciliation reaches Ready=True/AllReady inside a `pod-security.kubernetes.io/enforce=restricted` namespace; every Pod the reconciler creates (API Deployment, bootstrap Job, db-sync Job, policy-validation Job, manually-triggered fernet-rotation Job) admits under PSS Restricted; zero `FailedCreate` events carry the literal violation `violates PodSecurity "restricted:latest"` |
+| admin-password-rotation | `keystone-adminpw` | Re-bootstrap on admin-password Secret change: stale bootstrap Job replaced, new password authenticates against `/v3` |
+| admin-password-scheduled-rotation | `keystone-adminpw-sched` | Model B scheduled rotation: rotation CronJob rendered from `spec.bootstrap.passwordRotation`, full OpenBao/ESO evidence chain |
+| autoscaling | `keystone-autoscaling` | HPA create/update/delete driven by `spec.autoscaling` (CPU and memory targets) |
+| basic-deployment-2026-1 | `keystone-basic-2026-1` | Happy-path deployment pinned to the 2026.1 release image |
+| configmap-no-secrets | `keystone-cc0080` | No secrets leak into the ConfigMap: placeholder URL in `keystone.conf`, real DSN only in the derived `<name>-db-connection` Secret |
+| credential-rotation | `keystone-credential` | Credential-key CronJob schedule, manual rotation changes Secret data, `credential_migrate` step |
+| database-tls | `keystone-dbtls` | `spec.database.tls` up to `verify-full`: `DatabaseTLSReady=True`, cert-manager client cert, encrypted MariaDB connection |
+| gateway-quick-start | `keystone-gateway-qs` | Envoy Gateway quick-start wiring: GatewayClass/Gateway Programmed, HTTPRoute attached, endpoint reachable |
+| gateway-quick-start-smoke | `keystone-smoke` | `curl https://keystone.127-0-0-1.nip.io/v3` returns HTTP 200 with a Keystone v3 JSON body |
+| httproute | `keystone-httproute` | `spec.gateway` lifecycle: HTTPRoute created, updated, and removed with the spec block |
+| invalid-cr | multiple (rejected) | Every CEL XValidation and webhook rejection path pinned to a deterministic admission failure |
+| key-repository-mode | `keystone-keymode` | Fernet/credential key volumes are not world-readable (no `key_repository is world readable` startup warning) |
+| logging | `keystone-logging` | `spec.logging` propagation to oslo.log: defaults, level/format overrides, per-logger levels |
+| metrics | — (operator-level) | keystone-operator chart renders and removes the ServiceMonitor; metrics endpoint scrapeable |
+| namespace-scoped-rbac | `keystone-ns-scoped` | Operator deployed with `rbac.namespaceScoped=true` + `webhook.enabled=false` still reconciles to Ready |
+| network-policy | `keystone-netpol` | Per-CR NetworkPolicy create/update/delete driven by `spec.networkPolicy` ingress sources |
+| prometheus-stack | — (operator-level) | `WITH_PROMETHEUS=true` opt-in addon: kube-prometheus-stack scrapes the operator end to end |
+| resources | `keystone-resources` | `spec.resources` webhook defaulting and propagation to the Deployment |
+| rolling-update-zero-downtime | `keystone-rolling-update` | Full graceful-termination chain keeps the API serving during an image-tag rolling update |
+| trust-flush | `keystone-trust-flush` | Trust-flush CronJob creation, schedule and suspend tracking `spec.trustFlush` |
+| trust-flush-default | `keystone-trust-flush-default` | Default-on posture: omitted `spec.trustFlush` materializes the hourly CronJob |
+| upgrade-abort | `keystone-upgrade-abort` | In-flight upgrade abort by reverting the image tag; wedge in `Expanding` recovers cleanly |
+| upgrade-flow | `keystone-upgrade-flow` | Expand-migrate-contract phase progression with `installedRelease`/`targetRelease` bookkeeping |
+| uwsgi | `keystone-uwsgi` | `spec.uwsgi` defaulting and propagation into the uWSGI command line |
 
 ---
 
@@ -884,6 +864,12 @@ single assert step, validating the full progression.
 
 ```text
 tests/e2e/keystone/
+├── admin-password-rotation/
+│   ├── chainsaw-test.yaml              Re-bootstrap on admin-password change
+│   └── 00-keystone-cr.yaml             Keystone CR for rotation test
+├── admin-password-scheduled-rotation/
+│   ├── chainsaw-test.yaml              Model B scheduled rotation chain
+│   └── 00-keystone-cr.yaml             Keystone CR with passwordRotation
 ├── autoscaling/
 │   ├── chainsaw-test.yaml              HPA reconciliation
 │   ├── 00-keystone-cr.yaml             Keystone CR with CPU autoscaling
@@ -906,9 +892,15 @@ tests/e2e/keystone/
 ├── config-pruning/
 │   ├── chainsaw-test.yaml              Immutable ConfigMap pruning
 │   └── 00-keystone-cr.yaml             Keystone CR for pruning test
+├── configmap-no-secrets/
+│   ├── chainsaw-test.yaml              No secrets leak into the ConfigMap
+│   └── 00-keystone-cr.yaml             Keystone CR for env-override split
 ├── credential-rotation/
 │   ├── chainsaw-test.yaml              Credential key rotation
 │   └── 00-keystone-cr.yaml             Keystone CR with rotation schedule
+├── database-tls/
+│   ├── chainsaw-test.yaml              Keystone ↔ MariaDB TLS (verify-full)
+│   └── 00-keystone-cr.yaml             Keystone CR with database.tls
 ├── deletion-cleanup/
 │   ├── chainsaw-test.yaml              Garbage collection
 │   └── 00-keystone-cr.yaml             Keystone CR for cleanup test
@@ -918,12 +910,25 @@ tests/e2e/keystone/
 ├── fernet-rotation/
 │   ├── chainsaw-test.yaml              Fernet key rotation
 │   └── 00-keystone-cr.yaml             Keystone CR with rotation schedule
+├── gateway-quick-start/
+│   ├── chainsaw-test.yaml              Envoy Gateway quick-start wiring
+│   ├── 00-namespace.yaml               Test namespace
+│   └── 01-keystone-cr.yaml             Keystone CR with spec.gateway
+├── gateway-quick-start-smoke/
+│   ├── chainsaw-test.yaml              nip.io HTTPS smoke test
+│   ├── 00-namespace.yaml               Test namespace
+│   └── 01-smoke-keystone-cr.yaml       Keystone CR for smoke test
 ├── graceful-shutdown/
 │   ├── chainsaw-test.yaml              Graceful shutdown
 │   └── 00-keystone-cr.yaml             Keystone CR for graceful shutdown
 ├── healthcheck/
 │   ├── chainsaw-test.yaml              Post-Deployment API health check
 │   └── 00-keystone-cr.yaml             Keystone CR for healthcheck test
+├── httproute/
+│   ├── chainsaw-test.yaml              spec.gateway HTTPRoute lifecycle
+│   ├── 00-httproute-crd.yaml           HTTPRoute CRD install
+│   ├── 01-keystone-cr.yaml             Keystone CR with spec.gateway
+│   └── 02-patch-remove-gateway.yaml    Patch removing spec.gateway
 ├── image-upgrade/
 │   ├── chainsaw-test.yaml              Rolling image upgrade
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial image tag
@@ -944,6 +949,17 @@ tests/e2e/keystone/
 │   ├── 10-hpa-min-greater-than-max.yaml                    HPA minReplicas > maxReplicas (generated)
 │   ├── 11-fernet-maxactivekeys-below-minimum.yaml          Fernet maxActiveKeys < 3 (generated)
 │   └── 12-credentialkeys-maxactivekeys-below-minimum.yaml  CredentialKeys maxActiveKeys < 3 (generated)
+├── key-repository-mode/
+│   ├── chainsaw-test.yaml              Key volumes not world-readable
+│   └── 00-keystone-cr.yaml             Keystone CR for key-mode test
+├── logging/
+│   ├── chainsaw-test.yaml              spec.logging → oslo.log propagation
+│   ├── 00-keystone-cr.yaml             Keystone CR without spec.logging
+│   ├── 01-patch-debug-true.yaml        Patch enabling debug
+│   ├── 02-patch-format-json.yaml       Patch switching to JSON format
+│   └── 03-patch-invalid-perloggerlevel.yaml Invalid per-logger level (rejected)
+├── metrics/
+│   └── chainsaw-test.yaml              Operator ServiceMonitor render/remove
 ├── middleware-config/
 │   ├── chainsaw-test.yaml              Middleware pipeline
 │   └── 00-keystone-cr.yaml             Keystone CR with custom middleware
@@ -979,6 +995,8 @@ tests/e2e/keystone/
 │   ├── 01-keystone-cr.yaml             Keystone CR without priorityClassName
 │   ├── 02-patch-priority-class.yaml    Patch to set priorityClassName
 │   └── 03-patch-empty-priority-class.yaml Patch to clear priorityClassName
+├── prometheus-stack/
+│   └── chainsaw-test.yaml              WITH_PROMETHEUS opt-in addon path
 ├── release-upgrade/
 │   ├── chainsaw-test.yaml              Cross-release upgrade 2025.2→2026.1
 │   ├── 00-keystone-cr.yaml             Keystone CR with initial tag 2025.2
@@ -987,6 +1005,10 @@ tests/e2e/keystone/
 │   ├── chainsaw-test.yaml              Resource defaults and propagation
 │   ├── 00-keystone-cr.yaml             Keystone CR without explicit resources
 │   └── 01-patch-custom-resources.yaml  Patch with custom resource limits
+├── rolling-update-zero-downtime/
+│   ├── chainsaw-test.yaml              Zero-downtime rolling update
+│   ├── 00-keystone-cr.yaml             Keystone CR with initial image tag
+│   └── 01-patch-image.yaml             Patch spec.image.tag
 ├── scale/
 │   ├── chainsaw-test.yaml              Replica scaling and PDB
 │   ├── 00-keystone-cr.yaml             Keystone CR with replicas: 3

--- a/docs/reference/testing/tempest-test-infrastructure.md
+++ b/docs/reference/testing/tempest-test-infrastructure.md
@@ -104,14 +104,16 @@ in three ways: (1) it installs from PyPI instead of mounting a git source tree,
 - Declares `ARG TEMPEST_VERSION` and `ARG KEYSTONE_TEMPEST_PLUGIN_VERSION` for
   build-time version injection (resolved from `test-refs.yaml` by CI)
 - Mounts `upper-constraints.txt` from the release directory via named build context
-- Installs four packages into the shared virtualenv via `uv pip install --constraint`:
+- Installs six packages into the shared virtualenv via `uv pip install --constraint`:
 
 | Package | Purpose |
 | --- | --- |
 | `tempest` | OpenStack Tempest testing framework |
 | `keystone-tempest-plugin` | Keystone-specific Tempest test plugins |
+| `python-openstackclient` | `openstack` CLI, used by the full-chain ControlPlane E2E verify Job (`token issue` / `catalog list`); version pinned by `upper-constraints.txt` |
 | `python-subunit` | Subunit test result streaming protocol |
 | `junitxml` | Subunit-to-JUnit XML conversion (`subunit2junitxml`) |
+| `defusedxml` | Hardened XML parsing for the result-processing tooling |
 
 **Stage 2 (runtime)** — extends `python-base`:
 
@@ -126,6 +128,7 @@ in three ways: (1) it installs from PyPI instead of mounting a git source tree,
 | --- | --- |
 | User | `openstack` (UID 42424) |
 | `tempest` CLI | Available via `PATH` (`/var/lib/openstack/bin/tempest`) |
+| `openstack` CLI | Available via `PATH`; verified by `verify_tempest.sh` (`openstack --version`) |
 | `subunit2junitxml` | Available via `PATH` |
 | Build tools | Absent (`gcc`, `python3-dev`, `uv` are not in the final image) |
 


### PR DESCRIPTION
## Summary

Full staleness audit and refresh of `docs/` (excluding `architecture/`). Every page was verified against the current code, charts, workflows, and manifests; roughly a third carried verified drift. Five commits, grouped by theme:

- **CI reference** (`ac737e7e`): rewritten around the current publish-only-on-merge model — all gate/test/E2E jobs are `pull_request`-only, `build-and-push`/`helm-push` hang off the `changes` path filter instead of `e2e-operator`, 27 jobs documented including the previously missing `feature-ids` gate and the govulncheck allowlist wrapper, version pins refreshed (Go 1.26.4, checkout@v7, controller-gen v0.21.0, golangci-lint v2.12.2, chainsaw v0.2.15, kind v0.32.0, …).
- **Wrong/invalid claims** (`e71eae15`): the NetworkPolicy example in the advanced-configuration guide was invalid against the CRD schema (`matchLabels` nesting on `map[string]string` fields); the packaging RBAC table was missing 8 rule groups and misstated pushsecrets delete; ~15 emitted event reasons were uncatalogued; ESO ExternalSecret is v1 (not v1beta1); `make deploy-operator` does not exist.
- **c5c3 references** (`7ed55765`): seven-stage sub-reconciler chain (new `DBCredentialsReady`/`AdminPasswordReady` sections), `database.replicas` validation rules, and the admin-credential re-push mechanics (`WaitingForPushSecret`, content-hash nudge, `syncedResourceVersion`-keyed force-sync).
- **Mechanical drift** (`afe2fcb1`): condition counts 11→14, metric cardinalities 16/14, `PasswordRotationSpec` added to the CRD reference, chart 0.5.0, flux-web 0.52.x, uv 0.11.24, tempest package list, E2E inventory completed to all 45 suites, OpenBao seed-time `managed-by` stamping.
- **New content & consistency** (`98ebd9e7`): new `reference/testing/controlplane-e2e-tests.md` for the five `tests/e2e/c5c3/` suites (presence-guard pattern, `e2e-controlplane` job); fernet/credential `suspend` escape hatch documented; frontmatter standardized on the eight pages that led with a bare SPDX comment.

## Verification

- `make check-feature-ids` passes (no CC-/REQ- identifiers).
- `npm run docs:build` passes; all sidebar entries resolve.
- The two remaining `audit-doc-drift.sh` findings are pre-existing and out of scope (Makefile `OPERATORS` default vs filesystem; an `architecture/` page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)