### PR TITLE
feat(hack): single-node, configurable ControlPlane backing services

### DIFF
--- a/deploy/kind/controlplane/controlplane.yaml
+++ b/deploy/kind/controlplane/controlplane.yaml
@@ -27,8 +27,15 @@
 #   korc ... cloudCredentialsRef.cloudName  -> admin (secretName k-orc-clouds-yaml)
 #
 # keystone replicas are pinned to 1 to fit the single-node kind cluster; the
-# MariaDB/Memcached topology is operator-derived (not exposed on the ControlPlane
-# spec), so on kind it follows the c5c3-operator defaults.
+# MariaDB and Memcached topology is pinned the same way via
+# spec.infrastructure.{database,cache}.replicas below. The CRD default for both is
+# 3 (a 3-node Galera cluster plus 3 Memcached pods, matching the production
+# baseline), which OOM-kills a laptop-sized single-node kind, so kind pins them to
+# 1: database.replicas:1 yields a single-instance non-Galera MariaDB (the operator
+# derives Galera from replicas>1) and cache.replicas:1 a single Memcached pod.
+# deploy-infra makes these deploy-time configurable via CONTROLPLANE_DB_REPLICAS /
+# CONTROLPLANE_CACHE_REPLICAS (e.g. =3 for a Galera HA cluster on a bigger box; 2 is
+# rejected — Galera needs a quorum). database.replicas is immutable after creation.
 #
 # The projected Keystone is exposed externally via the shared Envoy Gateway
 # (services.keystone.gateway), so it is reachable from the host at
@@ -41,6 +48,17 @@ metadata:
   namespace: openstack
 spec:
   openStackRelease: "2025.2"
+  # Pin the projected backing services to a single instance for the single-node
+  # kind cluster (see the note above). Only replicas is set here; the c5c3-operator
+  # defaulting webhook fills database.clusterRef/database/secretRef and
+  # cache.clusterRef/backend, exactly as it does for the omitted fields listed
+  # above. deploy-infra overrides these from CONTROLPLANE_DB_REPLICAS /
+  # CONTROLPLANE_CACHE_REPLICAS when WITH_CONTROLPLANE_CR=true.
+  infrastructure:
+    database:
+      replicas: 1
+    cache:
+      replicas: 1
   services:
     keystone:
       replicas: 1

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -21,12 +21,19 @@ OpenBao, and register the identity catalog — all reconciled to an aggregate
 ## Prerequisites
 
 Same toolchain as the [Quick Start](./quick-start.md), plus an internet
-connection (K-ORC is cloned from GitHub at a pinned tag). Docker Desktop needs
-ample CPU/memory — by default the ControlPlane provisions a production-shaped
-(Galera) MariaDB, heavier than the single-replica database the per-service path
-uses. On a constrained cluster set `spec.infrastructure.database.replicas: 1`
-(and `cache.replicas: 1`) in the ControlPlane CR to provision a single-instance,
-non-Galera MariaDB instead.
+connection (K-ORC is cloned from GitHub at a pinned tag).
+
+The bundled kind `ControlPlane` CR pins its backing services to a single instance
+(`spec.infrastructure.database.replicas: 1`, `cache.replicas: 1`) so the
+fresh-create chain fits a single-node kind cluster: `database.replicas: 1` yields
+a single-instance, non-Galera MariaDB (the operator derives Galera from
+`replicas > 1`) and `cache.replicas: 1` a single Memcached pod. The CRD default for
+both is `3` — a 3-node Galera cluster plus three Memcached pods, matching the
+production baseline — which OOM-kills a laptop-sized kind. To provision the
+production-shaped topology on a bigger box, set `CONTROLPLANE_DB_REPLICAS=3` and/or
+`CONTROLPLANE_CACHE_REPLICAS=N` for Step 2 (`2` is rejected for the database —
+Galera needs a quorum). `database.replicas` is immutable after the CR is created,
+so change it on a fresh environment (`make teardown-infra` first).
 
 ```bash
 make install-test-deps
@@ -85,6 +92,13 @@ metadata:
   namespace: openstack
 spec:
   openStackRelease: "2025.2"
+  # Single-node backing services for kind. Omit these and both default to 3 (a
+  # 3-node Galera MariaDB plus three Memcached pods), which OOM-kills a small kind.
+  infrastructure:
+    database:
+      replicas: 1     # single-instance, non-Galera MariaDB (Galera = replicas > 1)
+    cache:
+      replicas: 1     # single Memcached pod
   services:
     keystone:
       replicas: 1
@@ -123,10 +137,12 @@ spec:
       secretRef:
         name: keystone-db         # placeholder default — the operator replaces it
                                   # with {name}-keystone-db-credentials (managed mode)
+      replicas: 1                 # single-instance, non-Galera; omit to default to 3 (Galera)
     cache:
       clusterRef:
         name: openstack-memcached
       backend: dogpile.cache.pymemcache
+      replicas: 1                 # single Memcached pod; omit to default to 3
   services:
     keystone:
       replicas: 1

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -113,6 +113,22 @@ CONTROLPLANE_NAME="${CONTROLPLANE_NAME:-controlplane}"
 # Ignored unless WITH_CONTROLPLANE=true.
 CONTROLPLANE_OPERATORS="${CONTROLPLANE_OPERATORS:-flux}"
 
+# Single-node footprint of the ControlPlane-projected backing services. On the
+# WITH_CONTROLPLANE path the c5c3-operator provisions MariaDB and Memcached itself
+# from the ControlPlane CR; these two knobs patch spec.infrastructure.{database,
+# cache}.replicas of the bundled CR before it is applied (WITH_CONTROLPLANE_CR=true).
+# Default 1 so a single-node kind gets a single-instance non-Galera MariaDB and a
+# single Memcached pod (the CRD default is 3, which spins up a 3-node Galera cluster
+# plus 3 Memcached pods and OOM-kills a laptop-sized kind).
+#   CONTROLPLANE_DB_REPLICAS=3     — Galera HA cluster (2 is rejected by the c5c3
+#                                    validating webhook: Galera needs a quorum).
+#   CONTROLPLANE_CACHE_REPLICAS=N  — N Memcached pods.
+# database.replicas is IMMUTABLE after the ControlPlane CR is created, so change it
+# on a fresh environment (teardown-infra first); cache.replicas is reconciled live.
+# Ignored unless WITH_CONTROLPLANE=true and WITH_CONTROLPLANE_CR=true.
+CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS:-1}"
+CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS:-1}"
+
 # Gateway API CRD release installed before the keystone-operator HelmRelease so
 # the operator's HTTPRoute watch has a registered kind at startup.
 # Keep aligned with sigs.k8s.io/gateway-api in operators/keystone/go.mod.
@@ -886,6 +902,41 @@ render_kind_config() {
     "${src}" > "${out_path}"
 }
 
+# render_controlplane_replicas rewrites spec.infrastructure.{database,cache}.replicas
+# of the ControlPlane CR(s) named ${CONTROLPLANE_NAME} in the given manifest file,
+# from CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS. The values are
+# validated first so an invalid footprint is rejected here, before `kubectl apply`,
+# rather than by the c5c3 validating webhook after the CR is sent: both must be a
+# positive integer, and the database count may not be 2 (a two-node Galera cluster
+# cannot hold a quorum — the webhook rejects it). Returns non-zero on an invalid
+# footprint instead of exiting, so the caller decides how to handle it; main() runs
+# under `set -e`, so the bare call there still fails the deploy fast. Name-scoped to
+# the CR we just (possibly) renamed so a growing overlay is not silently rewritten;
+# tonumber keeps the value an integer (the CRD schema types replicas as integer).
+# Extracted from main() so it is unit-testable
+# (tests/unit/hack/deploy_infra_controlplane_replicas_test.sh).
+render_controlplane_replicas() {
+  local manifest="$1"
+
+  local knob val
+  for knob in CONTROLPLANE_DB_REPLICAS CONTROLPLANE_CACHE_REPLICAS; do
+    val="${!knob}"
+    if [[ ! "${val}" =~ ^[0-9]+$ ]] || (( val < 1 )); then
+      log "ERROR: ${knob}='${val}' is not a positive integer."
+      return 1
+    fi
+  done
+  if (( CONTROLPLANE_DB_REPLICAS == 2 )); then
+    log "ERROR: CONTROLPLANE_DB_REPLICAS=2 is rejected (Galera needs a quorum); use 1 (standalone) or >=3."
+    return 1
+  fi
+
+  CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS}" CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS}" CONTROLPLANE_NAME="${CONTROLPLANE_NAME}" yq -i \
+    '(select(.kind == "ControlPlane" and .metadata.name == strenv(CONTROLPLANE_NAME)) | .spec.infrastructure.database.replicas) = (strenv(CONTROLPLANE_DB_REPLICAS) | tonumber)
+     | (select(.kind == "ControlPlane" and .metadata.name == strenv(CONTROLPLANE_NAME)) | .spec.infrastructure.cache.replicas) = (strenv(CONTROLPLANE_CACHE_REPLICAS) | tonumber)' \
+    "${manifest}"
+}
+
 # ---------------------------------------------------------------------------
 # main — Orchestrate the 8-step deployment sequence.
 # ---------------------------------------------------------------------------
@@ -903,6 +954,7 @@ main() {
   log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
     log "ControlPlane operators : ${CONTROLPLANE_OPERATORS} (flux = published chart + K-ORC Flux source; external = operators deployed out of band)"
+    log "ControlPlane backing   : MariaDB replicas=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera), Memcached replicas=${CONTROLPLANE_CACHE_REPLICAS} (override via CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS)"
   fi
   log ""
 
@@ -1358,6 +1410,13 @@ main() {
           "${cp_manifest}"
         log "  Set ControlPlane publicEndpoint to https://keystone.127-0-0-1.nip.io:${KIND_HOST_PORT}/v3 (KIND_HOST_PORT override)."
       fi
+
+      # Project the single-node footprint onto the bundled CR. The bundled CR
+      # already carries replicas: 1 for both backing services; this makes the value
+      # deploy-time configurable (CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS)
+      # without editing the tracked manifest.
+      render_controlplane_replicas "${cp_manifest}"
+      log "  Set ControlPlane backing-service replicas: MariaDB=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera), Memcached=${CONTROLPLANE_CACHE_REPLICAS}."
 
       # Apply the ControlPlane CR. Retry briefly: the c5c3-operator validating webhook
       # may need a moment after the chart install before it accepts the CR.

--- a/tests/unit/hack/deploy_infra_controlplane_replicas_test.sh
+++ b/tests/unit/hack/deploy_infra_controlplane_replicas_test.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify hack/deploy-infra.sh `render_controlplane_replicas` pins the projected
+# backing-service footprint from CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS
+# and rejects an invalid footprint (non-numeric, < 1, or the quorum-unsafe DB=2)
+# before the CR is applied. Also guards that the checked-in bundled kind CR ships a
+# single-node topology (database.replicas=1, cache.replicas=1) so a laptop-sized
+# single-node kind does not spin up a 3-node Galera cluster and OOM.
+#
+# Sources deploy-infra.sh and invokes the function in a subshell so we can assert
+# against a rendered tempfile without spinning up an actual cluster. The yq-backed
+# checks are skipped when `yq` is not installed.
+#
+# Usage: bash tests/unit/hack/deploy_infra_controlplane_replicas_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEPLOY_INFRA_SH="$PROJECT_ROOT/hack/deploy-infra.sh"
+BUNDLED_CR="$PROJECT_ROOT/deploy/kind/controlplane/controlplane.yaml"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# The name of the ControlPlane CR in the bundled fixture. render_controlplane_replicas
+# name-scopes its yq selector to ${CONTROLPLANE_NAME}, so the tests pin this to the
+# fixture's metadata.name explicitly rather than leaning on deploy-infra.sh's default —
+# the tests stay green even if that default is renamed later.
+FIXTURE_CONTROLPLANE_NAME="controlplane"
+
+# Source the script and call render_controlplane_replicas in a subshell with the
+# given DB/cache replica values, mutating <manifest> in place. Echoes combined
+# output and returns the function's exit status. The subshell isolates env
+# mutations and the BASH_SOURCE guard at the bottom of deploy-infra.sh keeps main
+# from running when sourced.
+run_render() {
+  local manifest="$1"
+  local db="$2"
+  local cache="$3"
+  (
+    export CONTROLPLANE_DB_REPLICAS="${db}"
+    export CONTROLPLANE_CACHE_REPLICAS="${cache}"
+    export CONTROLPLANE_NAME="${FIXTURE_CONTROLPLANE_NAME}"
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    render_controlplane_replicas "${manifest}"
+  ) 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: the checked-in bundled CR ships a single-node topology.
+# ---------------------------------------------------------------------------
+test_bundled_cr_is_single_node() {
+  echo "Test: bundled kind ControlPlane CR pins database/cache replicas to 1"
+
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  assert_eq "bundled CR database.replicas is 1" \
+    "1" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas' "$BUNDLED_CR")"
+  assert_eq "bundled CR cache.replicas is 1" \
+    "1" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.cache.replicas' "$BUNDLED_CR")"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: default footprint (both = 1) rewrites to integer 1/1.
+# ---------------------------------------------------------------------------
+test_default_footprint() {
+  echo "Test: render_controlplane_replicas with 1/1 yields integer replicas 1/1"
+
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  local out="$tmp/cr.yaml"
+  cp "$BUNDLED_CR" "$out"
+
+  local exit_code
+  run_render "$out" "1" "1" >/dev/null
+  exit_code=$?
+
+  assert_eq "render exits 0 for 1/1" "0" "$exit_code"
+  assert_eq "database.replicas is 1" \
+    "1" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas' "$out")"
+  # `... | tag` reports the node type; integer keeps the CRD schema happy.
+  assert_eq "database.replicas stays an integer node" \
+    "!!int" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas | tag' "$out")"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: an HA override (DB=3 Galera, cache=2) is projected as integers.
+# ---------------------------------------------------------------------------
+test_ha_override() {
+  echo "Test: render_controlplane_replicas with 3/2 projects a Galera-sized footprint"
+
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  local out="$tmp/cr.yaml"
+  cp "$BUNDLED_CR" "$out"
+
+  local exit_code
+  run_render "$out" "3" "2" >/dev/null
+  exit_code=$?
+
+  assert_eq "render exits 0 for 3/2" "0" "$exit_code"
+  assert_eq "database.replicas is 3 (Galera)" \
+    "3" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas' "$out")"
+  assert_eq "cache.replicas is 2" \
+    "2" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.cache.replicas' "$out")"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: invalid footprints fail fast (before kubectl apply).
+# ---------------------------------------------------------------------------
+test_invalid_footprint_rejected() {
+  echo "Test: render_controlplane_replicas rejects non-numeric, < 1, and DB=2"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  local out="$tmp/cr.yaml"
+  cp "$BUNDLED_CR" "$out"
+
+  local output exit_code
+
+  output="$(run_render "$out" "not-a-number" "1")"
+  exit_code=$?
+  assert_nonzero_exit "non-numeric CONTROLPLANE_DB_REPLICAS exits non-zero" "$exit_code"
+  assert_contains "non-numeric error surfaces the offending value" \
+    "$output" "CONTROLPLANE_DB_REPLICAS='not-a-number'"
+
+  output="$(run_render "$out" "0" "1")"
+  exit_code=$?
+  assert_nonzero_exit "CONTROLPLANE_DB_REPLICAS=0 exits non-zero" "$exit_code"
+
+  output="$(run_render "$out" "1" "0")"
+  exit_code=$?
+  assert_nonzero_exit "CONTROLPLANE_CACHE_REPLICAS=0 exits non-zero" "$exit_code"
+
+  output="$(run_render "$out" "2" "1")"
+  exit_code=$?
+  assert_nonzero_exit "quorum-unsafe CONTROLPLANE_DB_REPLICAS=2 exits non-zero" "$exit_code"
+  assert_contains "DB=2 error explains the Galera quorum constraint" \
+    "$output" "quorum"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: main() wires the knobs — the function is called, the env vars are
+# declared with a single-node default, and they are documented in the preamble.
+# Static text checks keep this independent of stub plumbing.
+# ---------------------------------------------------------------------------
+test_main_wires_knobs() {
+  echo "Test: main() calls render_controlplane_replicas and declares the knobs"
+
+  assert_file_contains "render_controlplane_replicas is called from main()" \
+    "$DEPLOY_INFRA_SH" "render_controlplane_replicas "
+  assert_file_contains "CONTROLPLANE_DB_REPLICAS defaults to 1" \
+    "$DEPLOY_INFRA_SH" 'CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS:-1}"'
+  assert_file_contains "CONTROLPLANE_CACHE_REPLICAS defaults to 1" \
+    "$DEPLOY_INFRA_SH" 'CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS:-1}"'
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_bundled_cr_is_single_node
+test_default_footprint
+test_ha_override
+test_invalid_footprint_rejected
+test_main_wires_knobs
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

On the `WITH_CONTROLPLANE` path the c5c3-operator provisions MariaDB and Memcached from the `ControlPlane` CR. The bundled kind CR left `spec.infrastructure.{database,cache}.replicas` unset, so both defaulted to the CRD value **3** — a 3-node Galera cluster plus three Memcached pods — which OOM-kills a single-node kind cluster.

## Change

- **`deploy/kind/controlplane/controlplane.yaml`** — pin the bundled CR to a single instance: `database.replicas: 1` (single-instance, non-Galera MariaDB; the operator derives Galera from `replicas > 1`) and `cache.replicas: 1` (single Memcached pod).
- **`hack/deploy-infra.sh`** — expose `CONTROLPLANE_DB_REPLICAS` / `CONTROLPLANE_CACHE_REPLICAS` (default `1`) so the footprint can be scaled back up to a Galera-sized topology on a larger host. Logic extracted into a testable `render_controlplane_replicas`, which rejects the quorum-unsafe DB value `2` up front (matching the validating webhook).
- **`docs/quick-start-controlplane.md`** — document the single-node default and the two knobs.
- **`tests/unit/hack/deploy_infra_controlplane_replicas_test.sh`** — unit test for the render + validation (17 checks).

## Usage

```bash
# single-node (new default)
KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_CONTROLPLANE_CR=true make deploy-infra

# Galera-sized on a larger host
CONTROLPLANE_DB_REPLICAS=3 CONTROLPLANE_CACHE_REPLICAS=3 \
  WITH_CONTROLPLANE=true WITH_CONTROLPLANE_CR=true make deploy-infra
```

## Note

`database.replicas` is immutable after the CR is created, so an existing environment must be torn down (`make teardown-infra`) before the smaller footprint takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
