### PR TITLE
fix(hack): cap containerd RLIMIT_NOFILE so Keystone stops OOM-crashlooping on kind

### DIFF
--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -61,6 +61,19 @@ EXTERNALSECRET_TIMEOUT="${EXTERNALSECRET_TIMEOUT:-120}"
 # suffix. See docs/quick-start.md.
 KIND_HOST_PORT="${KIND_HOST_PORT:-443}"
 
+# Soft/hard RLIMIT_NOFILE applied to every kind node's containerd after cluster
+# creation (see cap_node_nofile). Docker Desktop ships containerd with
+# LimitNOFILE=infinity, so pods inherit ~1e9 open files; uWSGI (the Keystone API
+# server) then allocates memory proportional to the fd count at worker startup
+# and is OOM-killed regardless of its memory limit. 1048576 matches the kind node
+# container's own limit and is ample for every workload in this stack. Set to
+# empty to skip the cap entirely (e.g. on a runtime that already ships a sane
+# limit). See #546.
+#
+# Uses `-` (not `:-`) so an explicitly-empty NODE_NOFILE_LIMIT= opts out, while
+# an unset variable still takes the 1048576 default.
+NODE_NOFILE_LIMIT="${NODE_NOFILE_LIMIT-1048576}"
+
 # Gates the opt-in chaos-mesh kind overlay (deploy/kind/chaos-mesh) and the
 # host-side kernel-module load. Defaults to false so the kind Quick Start
 # stays minimal; set WITH_CHAOS_MESH=true to enable chaos-engineering tests
@@ -938,6 +951,99 @@ render_controlplane_replicas() {
 }
 
 # ---------------------------------------------------------------------------
+# cap_node_nofile — Cap RLIMIT_NOFILE on every kind node's containerd.
+#
+# Docker Desktop ships the containerd service with LimitNOFILE=infinity, so pods
+# inherit an ~1e9 open-file limit even though the node container itself is capped
+# at 1048576. uWSGI (the Keystone API server) allocates a structure proportional
+# to the fd count when a worker loads the app, so it immediately tries to
+# allocate multiple GiB and is OOM-killed within seconds — regardless of the
+# container memory limit (raising it to 512Mi/1Gi/2Gi makes no difference). See
+# #546.
+#
+# We write a systemd drop-in that lowers containerd's LimitNOFILE to
+# NODE_NOFILE_LIMIT and restart containerd. This must run BEFORE any workload is
+# scheduled: a containerd restart does not change the limit of already-running
+# containers, so only pods created afterwards inherit the sane value (the target
+# is the fresh-deploy path). Idempotent — re-writing the same drop-in and
+# restarting again is a no-op — and best-effort per node: a node that cannot be
+# patched logs a warning but does not abort the deploy.
+#
+# No-op when NODE_NOFILE_LIMIT is empty (opt out on a runtime that already ships
+# a sane limit).
+# ---------------------------------------------------------------------------
+cap_node_nofile() {
+  if [[ -z "${NODE_NOFILE_LIMIT}" ]]; then
+    log "NODE_NOFILE_LIMIT is empty — skipping containerd RLIMIT_NOFILE cap."
+    return 0
+  fi
+
+  local nodes
+  nodes=$(kind get nodes --name "${CLUSTER_NAME}" 2>/dev/null) || true
+  if [[ -z "${nodes}" ]]; then
+    log "WARNING: no kind nodes found for cluster '${CLUSTER_NAME}' — skipping RLIMIT_NOFILE cap."
+    return 0
+  fi
+
+  log "Capping containerd RLIMIT_NOFILE to ${NODE_NOFILE_LIMIT} on kind node(s): ${nodes//$'\n'/ }"
+
+  local node
+  for node in ${nodes}; do
+    if docker exec "${node}" sh -c '
+      set -e
+      mkdir -p /etc/systemd/system/containerd.service.d
+      printf "[Service]\nLimitNOFILE='"${NODE_NOFILE_LIMIT}"'\n" \
+        > /etc/systemd/system/containerd.service.d/nofile.conf
+      systemctl daemon-reload
+      systemctl restart containerd
+    ' >/dev/null 2>&1; then
+      log "  ${node}: containerd RLIMIT_NOFILE set to ${NODE_NOFILE_LIMIT}."
+    else
+      log "  WARNING: failed to cap RLIMIT_NOFILE on ${node} — uWSGI workloads (Keystone) may OOM-crashloop."
+    fi
+  done
+
+  # containerd was just restarted; give the node a moment to re-register with the
+  # API server before Step 2 starts issuing kubectl apply against it.
+  wait_for_node_ready "${POD_TIMEOUT}"
+}
+
+# ---------------------------------------------------------------------------
+# wait_for_node_ready — Wait until every kind node reports Ready=True.
+#
+# Called after cap_node_nofile restarts containerd, so the subsequent kubectl
+# apply steps do not race a briefly-NotReady kubelet. Polls every 5s up to the
+# supplied timeout; on timeout it logs the node status and returns 0 anyway. The
+# wait is best-effort — like cap_node_nofile itself, it must never abort the
+# deploy, so callers do not check its status.
+# ---------------------------------------------------------------------------
+wait_for_node_ready() {
+  local timeout="$1"
+  local deadline=$(( $(date +%s) + timeout ))
+
+  log "Waiting up to ${timeout}s for all nodes to be Ready..."
+
+  while true; do
+    local not_ready
+    not_ready=$(kubectl get nodes -o json 2>/dev/null \
+      | jq -r '[.items[] | select((.status.conditions[]? | select(.type == "Ready") | .status) != "True")] | length' 2>/dev/null) || true
+
+    if [[ "${not_ready}" == "0" ]]; then
+      log "All nodes are Ready."
+      return 0
+    fi
+
+    if [[ $(date +%s) -ge ${deadline} ]]; then
+      log "WARNING: not all nodes Ready after ${timeout}s; continuing anyway."
+      kubectl get nodes 2>/dev/null || true
+      return 0
+    fi
+
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
 # main — Orchestrate the 8-step deployment sequence.
 # ---------------------------------------------------------------------------
 main() {
@@ -949,6 +1055,7 @@ main() {
   log "Pod timeout         : ${POD_TIMEOUT}s"
   log "ExternalSecret timeout : ${EXTERNALSECRET_TIMEOUT}s"
   log "Kind host port      : ${KIND_HOST_PORT} → 31443 (override via KIND_HOST_PORT)"
+  log "Node RLIMIT_NOFILE  : ${NODE_NOFILE_LIMIT:-<unset — skip cap>} (override via NODE_NOFILE_LIMIT)"
   log "Chaos Mesh         : ${WITH_CHAOS_MESH} (set WITH_CHAOS_MESH=true to install)"
   log "Prometheus stack    : ${WITH_PROMETHEUS} (set WITH_PROMETHEUS=true to install)"
   log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
@@ -995,6 +1102,13 @@ main() {
     rm -f "${kind_cfg}"
     log "Kind cluster '${CLUSTER_NAME}' created."
   fi
+
+  # Cap containerd's RLIMIT_NOFILE on every node before any workload lands.
+  # Runs on all three Step-1 paths (fresh create, pre-existing cluster,
+  # SKIP_KIND_CREATE) because the fd limit is a property of the node's
+  # containerd, not of how the cluster came to exist, and a uWSGI workload
+  # (Keystone) scheduled later would otherwise OOM-crashloop. See #546.
+  cap_node_nofile
 
   # Step 2: Install flux-operator and apply FluxInstance (/)
   #

--- a/tests/unit/hack/deploy_infra_nofile_test.sh
+++ b/tests/unit/hack/deploy_infra_nofile_test.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify hack/deploy-infra.sh `cap_node_nofile`: it lowers containerd's
+# RLIMIT_NOFILE on every kind node so uWSGI workloads (Keystone) do not
+# OOM-crashloop under Docker Desktop's LimitNOFILE=infinity default (#546).
+#
+# The function is exercised in a subshell with recording stubs for kind/docker/
+# kubectl prepended to PATH, so no real cluster is touched. The docker stub
+# appends its argv to a log file, letting us assert the drop-in content and the
+# containerd restart without a running node.
+#
+# Usage: bash tests/unit/hack/deploy_infra_nofile_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEPLOY_INFRA_SH="$PROJECT_ROOT/hack/deploy-infra.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# make_recording_stubs <dir>
+# Writes kind/docker/kubectl shims into <dir>:
+#   kind    — `kind get nodes --name X` echoes $KIND_NODES (space/newline sep).
+#   docker  — appends its full argv to $DOCKER_LOG and exits $DOCKER_EXIT.
+#   kubectl — `kubectl get nodes -o json` returns one Ready node so
+#             wait_for_node_ready returns on the first poll (no sleep).
+make_recording_stubs() {
+  local dir="$1"
+  mkdir -p "$dir"
+
+  cat >"$dir/kind" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "get" ] && [ "${2:-}" = "nodes" ]; then
+  printf '%s\n' ${KIND_NODES:-}
+fi
+STUB
+
+  cat >"$dir/docker" <<'STUB'
+#!/bin/bash
+echo "docker $*" >> "$DOCKER_LOG"
+exit "${DOCKER_EXIT:-0}"
+STUB
+
+  cat >"$dir/kubectl" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "get" ] && [ "${2:-}" = "nodes" ]; then
+  echo '{"items":[{"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+fi
+STUB
+
+  chmod +x "$dir/kind" "$dir/docker" "$dir/kubectl"
+}
+
+# run_cap <stub_dir>
+# Sources deploy-infra.sh in a subshell with <stub_dir> prepended to PATH and
+# invokes cap_node_nofile. The caller controls behaviour via the exported env:
+# KIND_NODES, DOCKER_LOG, DOCKER_EXIT, and NODE_NOFILE_LIMIT (set/unset).
+# Echoes combined stdout/stderr.
+run_cap() {
+  local stub_dir="$1"
+  (
+    PATH="$stub_dir:$PATH"
+    export PATH
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    cap_node_nofile
+  ) 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: default limit is written and containerd restarted on the one node
+# ---------------------------------------------------------------------------
+test_default_limit_applied() {
+  echo "Test: cap_node_nofile writes the default 1048576 drop-in and restarts containerd"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT   # exercise the built-in 1048576 default
+
+  local output
+  output="$(run_cap "$tmp/bin")"
+
+  local docker_log
+  docker_log="$(cat "$DOCKER_LOG")"
+
+  assert_contains "docker exec targets the node" "$docker_log" "docker exec forge-control-plane"
+  assert_contains "drop-in sets the default LimitNOFILE" "$docker_log" "LimitNOFILE=1048576"
+  assert_contains "drop-in path is the containerd service dir" "$docker_log" "/etc/systemd/system/containerd.service.d/nofile.conf"
+  assert_contains "containerd is restarted" "$docker_log" "systemctl restart containerd"
+  assert_contains "log confirms the applied limit" "$output" "containerd RLIMIT_NOFILE set to 1048576"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: NODE_NOFILE_LIMIT override flows into the drop-in
+# ---------------------------------------------------------------------------
+test_override_limit() {
+  echo "Test: cap_node_nofile honours a NODE_NOFILE_LIMIT override"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  export NODE_NOFILE_LIMIT=524288
+
+  run_cap "$tmp/bin" >/dev/null
+
+  local docker_log
+  docker_log="$(cat "$DOCKER_LOG")"
+  assert_contains "override value lands in the drop-in" "$docker_log" "LimitNOFILE=524288"
+  assert_not_contains "default value is not used" "$docker_log" "LimitNOFILE=1048576"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: empty NODE_NOFILE_LIMIT opts out entirely
+# ---------------------------------------------------------------------------
+test_empty_limit_skips() {
+  echo "Test: an explicitly-empty NODE_NOFILE_LIMIT skips the cap"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  export NODE_NOFILE_LIMIT=""   # explicit opt-out (preserved by `-`, not `:-`)
+
+  local output
+  output="$(run_cap "$tmp/bin")"
+
+  assert_contains "log reports the skip" "$output" "skipping containerd RLIMIT_NOFILE cap"
+  assert_eq "docker is never invoked when opted out" "" "$(cat "$DOCKER_LOG")"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: no kind nodes → warn and return without touching docker
+# ---------------------------------------------------------------------------
+test_no_nodes_warns() {
+  echo "Test: cap_node_nofile warns and no-ops when the cluster has no nodes"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES=""          # kind returns no node names
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT
+
+  local output
+  output="$(run_cap "$tmp/bin")"
+
+  assert_contains "log warns about the missing nodes" "$output" "no kind nodes found"
+  assert_eq "docker is never invoked without nodes" "" "$(cat "$DOCKER_LOG")"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: every node in a multi-node cluster is patched
+# ---------------------------------------------------------------------------
+test_multi_node() {
+  echo "Test: cap_node_nofile patches every node in a multi-node cluster"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES=$'forge-control-plane\nforge-worker'
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT
+
+  run_cap "$tmp/bin" >/dev/null
+
+  local docker_log
+  docker_log="$(cat "$DOCKER_LOG")"
+  assert_contains "control-plane node is patched" "$docker_log" "docker exec forge-control-plane"
+  assert_contains "worker node is patched" "$docker_log" "docker exec forge-worker"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: a docker failure warns but does not abort the deploy
+# ---------------------------------------------------------------------------
+test_docker_failure_is_best_effort() {
+  echo "Test: a failing docker exec warns but cap_node_nofile still returns 0"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=1          # docker exec fails
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT
+
+  local output exit_code
+  output="$(run_cap "$tmp/bin")"
+  exit_code=$?
+
+  assert_eq "cap_node_nofile returns 0 despite the failure" "0" "$exit_code"
+  assert_contains "log warns about the failed node" "$output" "failed to cap RLIMIT_NOFILE on forge-control-plane"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_default_limit_applied
+test_override_limit
+test_empty_limit_skips
+test_no_nodes_warns
+test_multi_node
+test_docker_failure_is_best_effort
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

On a local `kind` cluster (Docker Desktop) the projected Keystone pod
(`controlplane-keystone-*`, `ghcr.io/c5c3/keystone:2025.2`, uWSGI) enters
`CrashLoopBackOff` with `OOMKilled` (exit 137) within seconds of the worker
spawning — **independent of the container memory limit**. It reads like a
laptop-RAM problem but is not: the node had ~2.8 GiB free throughout, so it is a
per-container cgroup OOM, not a node OOM.

## Root cause

`containerd` on the kind node hands pods `RLIMIT_NOFILE = 1073741816` (~1
billion) — Docker Desktop ships the containerd unit with `LimitNOFILE=infinity`,
even though the kind node container itself is capped at `1048576`. uWSGI reports
it at startup (`detected max file descriptor number: 1073741816`) and allocates
a structure proportional to the fd count when the worker loads the app, so it
immediately tries to allocate multiple GiB and is OOM-killed regardless of the
memory limit. OpenBao and the operator pods tolerate the huge limit; uWSGI does
not. Known kind/containerd interaction (kubernetes-sigs/kind#1437 and related).

## Evidence (measured, single-node kind, Apple Silicon)

| Keystone memory limit | uWSGI workers | Result |
|---|---|---|
| 512Mi (default) | 2 | OOMKilled, seconds after worker spawn |
| 1Gi | 1 | OOMKilled, **same speed** |
| 2Gi | 1 | OOMKilled, **same speed** |
| 512Mi + `nofile=1048576` | 2 | **Ready, 222 MiB working set, 0 restarts** |

Capping the fd limit and recreating the pod fixes it with the **original
defaults** — proving the fd limit, not the memory limit, was the cause.

## Change

- **`hack/deploy-infra.sh`** — new `NODE_NOFILE_LIMIT` knob (default `1048576`,
  empty opts out) and `cap_node_nofile` / `wait_for_node_ready`. Right after
  Step 1 (and before any workload is scheduled) it writes a systemd drop-in
  lowering each node's containerd `LimitNOFILE` and restarts containerd, then
  waits for the node to be Ready before Step 2's `kubectl apply`. Idempotent,
  best-effort per node, runs on all three Step-1 paths (fresh create,
  pre-existing cluster, `SKIP_KIND_CREATE`).
- **`tests/unit/hack/deploy_infra_nofile_test.sh`** — 6 tests / 15 assertions
  covering default, override, empty opt-out, no-nodes, multi-node, and
  best-effort-on-docker-failure.

## Testing

- `shellcheck hack/deploy-infra.sh tests/unit/hack/deploy_infra_nofile_test.sh` — clean.
- `bash tests/unit/hack/deploy_infra_nofile_test.sh` — 15 passed, 0 failed.
- Verified end-to-end on a live single-node kind cluster: after the cap,
  Keystone comes up Ready at 222 MiB with the stock 512Mi limit / 2 workers,
  0 restarts.

## Notes

- Independent of #545 (single-node backing-services `replicas: 1`) — that
  addresses MariaDB/Memcached topology, not the Keystone pod's fd limit.
- The manual drop-in is not persistent (lost on `kind delete cluster`), which is
  why it belongs in the deploy path.
- CI runs this on `SKIP_KIND_CREATE=true` too: the only new behaviour on a
  runtime that already ships a sane limit is the single containerd restart,
  guarded by the node-Ready wait.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
