### PR TITLE
feat(c5c3): make managed MariaDB storage size a spec field

### DIFF
--- a/deploy/kind/controlplane/controlplane.yaml
+++ b/deploy/kind/controlplane/controlplane.yaml
@@ -37,6 +37,13 @@
 # CONTROLPLANE_CACHE_REPLICAS (e.g. =3 for a Galera HA cluster on a bigger box; 2 is
 # rejected — Galera needs a quorum). database.replicas is immutable after creation.
 #
+# database.storageSize is pinned to 512Mi for the same reason: the CRD default is
+# 100Gi (the production volume in deploy/flux-system/infrastructure/mariadb.yaml),
+# which a kind/CI run never fills, so the projected MariaDB requests a test-sized
+# volume instead. deploy-infra makes it configurable via CONTROLPLANE_DB_STORAGE
+# (e.g. =100Gi to mirror production on a bigger box). Like replicas, storageSize is
+# immutable after creation (the mariadb-operator rejects resizing a live volume).
+#
 # The projected Keystone is exposed externally via the shared Envoy Gateway
 # (services.keystone.gateway), so it is reachable from the host at
 # https://keystone.127-0-0-1.nip.io:<KIND_HOST_PORT>/v3 — the same path the
@@ -57,6 +64,7 @@ spec:
   infrastructure:
     database:
       replicas: 1
+      storageSize: 512Mi
     cache:
       replicas: 1
   services:

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -35,6 +35,15 @@ production-shaped topology on a bigger box, set `CONTROLPLANE_DB_REPLICAS=3` and
 Galera needs a quorum). `database.replicas` is immutable after the CR is created,
 so change it on a fresh environment (`make teardown-infra` first).
 
+The bundled CR also pins the MariaDB volume to a test size
+(`spec.infrastructure.database.storageSize: 512Mi`). The CRD default is `100Gi` —
+the production volume size — which a kind/CI run never fills, so the managed MariaDB
+requests a small volume instead. To mirror the production volume on a bigger box,
+set `CONTROLPLANE_DB_STORAGE=100Gi` for Step 2 (any Kubernetes quantity in
+`Mi`/`Gi`/`Ti` is accepted). Like `database.replicas`, `database.storageSize` is
+immutable after the CR is created — the MariaDB operator refuses to resize a live
+volume — so change it on a fresh environment (`make teardown-infra` first).
+
 ```bash
 make install-test-deps
 export PATH="${HOME}/.local/bin:${PATH}"
@@ -96,7 +105,8 @@ spec:
   # 3-node Galera MariaDB plus three Memcached pods), which OOM-kills a small kind.
   infrastructure:
     database:
-      replicas: 1     # single-instance, non-Galera MariaDB (Galera = replicas > 1)
+      replicas: 1         # single-instance, non-Galera MariaDB (Galera = replicas > 1)
+      storageSize: 512Mi  # test-sized volume; omit to default to 100Gi (production)
     cache:
       replicas: 1     # single Memcached pod
   services:
@@ -138,6 +148,7 @@ spec:
         name: keystone-db         # placeholder default — the operator replaces it
                                   # with {name}-keystone-db-credentials (managed mode)
       replicas: 1                 # single-instance, non-Galera; omit to default to 3 (Galera)
+      storageSize: 512Mi          # test-sized volume; omit to default to 100Gi (production)
     cache:
       clusterRef:
         name: openstack-memcached

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -128,19 +128,25 @@ CONTROLPLANE_OPERATORS="${CONTROLPLANE_OPERATORS:-flux}"
 
 # Single-node footprint of the ControlPlane-projected backing services. On the
 # WITH_CONTROLPLANE path the c5c3-operator provisions MariaDB and Memcached itself
-# from the ControlPlane CR; these two knobs patch spec.infrastructure.{database,
-# cache}.replicas of the bundled CR before it is applied (WITH_CONTROLPLANE_CR=true).
-# Default 1 so a single-node kind gets a single-instance non-Galera MariaDB and a
-# single Memcached pod (the CRD default is 3, which spins up a 3-node Galera cluster
-# plus 3 Memcached pods and OOM-kills a laptop-sized kind).
+# from the ControlPlane CR; these knobs patch spec.infrastructure.{database,cache}
+# of the bundled CR before it is applied (WITH_CONTROLPLANE_CR=true).
+# Default 1 replica so a single-node kind gets a single-instance non-Galera MariaDB
+# and a single Memcached pod (the CRD default is 3, which spins up a 3-node Galera
+# cluster plus 3 Memcached pods and OOM-kills a laptop-sized kind).
 #   CONTROLPLANE_DB_REPLICAS=3     — Galera HA cluster (2 is rejected by the c5c3
 #                                    validating webhook: Galera needs a quorum).
 #   CONTROLPLANE_CACHE_REPLICAS=N  — N Memcached pods.
-# database.replicas is IMMUTABLE after the ControlPlane CR is created, so change it
-# on a fresh environment (teardown-infra first); cache.replicas is reconciled live.
+#   CONTROLPLANE_DB_STORAGE=100Gi  — per-replica MariaDB volume size (default 512Mi,
+#                                    a test-sized volume vs the 100Gi CRD default
+#                                    that a kind/CI run never fills). Must be a
+#                                    Kubernetes quantity in Mi/Gi/Ti.
+# database.replicas AND database.storageSize are IMMUTABLE after the ControlPlane CR
+# is created, so change them on a fresh environment (teardown-infra first);
+# cache.replicas is reconciled live.
 # Ignored unless WITH_CONTROLPLANE=true and WITH_CONTROLPLANE_CR=true.
 CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS:-1}"
 CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS:-1}"
+CONTROLPLANE_DB_STORAGE="${CONTROLPLANE_DB_STORAGE:-512Mi}"
 
 # Gateway API CRD release installed before the keystone-operator HelmRelease so
 # the operator's HTTPRoute watch has a registered kind at startup.
@@ -915,17 +921,20 @@ render_kind_config() {
     "${src}" > "${out_path}"
 }
 
-# render_controlplane_replicas rewrites spec.infrastructure.{database,cache}.replicas
-# of the ControlPlane CR(s) named ${CONTROLPLANE_NAME} in the given manifest file,
-# from CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS. The values are
-# validated first so an invalid footprint is rejected here, before `kubectl apply`,
-# rather than by the c5c3 validating webhook after the CR is sent: both must be a
-# positive integer, and the database count may not be 2 (a two-node Galera cluster
-# cannot hold a quorum — the webhook rejects it). Returns non-zero on an invalid
-# footprint instead of exiting, so the caller decides how to handle it; main() runs
-# under `set -e`, so the bare call there still fails the deploy fast. Name-scoped to
-# the CR we just (possibly) renamed so a growing overlay is not silently rewritten;
-# tonumber keeps the value an integer (the CRD schema types replicas as integer).
+# render_controlplane_replicas rewrites the ControlPlane backing-service knobs —
+# spec.infrastructure.{database,cache}.replicas and database.storageSize — of the
+# CR(s) named ${CONTROLPLANE_NAME} in the given manifest file, from
+# CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS / CONTROLPLANE_DB_STORAGE.
+# The values are validated first so an invalid footprint is rejected here, before
+# `kubectl apply`, rather than by the c5c3 validating webhook after the CR is sent:
+# the replica counts must be a positive integer, the database count may not be 2 (a
+# two-node Galera cluster cannot hold a quorum — the webhook rejects it), and the
+# storage size must match the CRD quantity pattern (digits + Mi/Gi/Ti). Returns
+# non-zero on an invalid footprint instead of exiting, so the caller decides how to
+# handle it; main() runs under `set -e`, so the bare call there still fails the
+# deploy fast. Name-scoped to the CR we just (possibly) renamed so a growing overlay
+# is not silently rewritten; tonumber keeps the replica values integers (the CRD
+# schema types replicas as integer) while storageSize stays a string.
 # Extracted from main() so it is unit-testable
 # (tests/unit/hack/deploy_infra_controlplane_replicas_test.sh).
 render_controlplane_replicas() {
@@ -943,10 +952,28 @@ render_controlplane_replicas() {
     log "ERROR: CONTROLPLANE_DB_REPLICAS=2 is rejected (Galera needs a quorum); use 1 (standalone) or >=3."
     return 1
   fi
+  # Mirror the CRD's storageSize pattern (^[0-9]+(Mi|Gi|Ti)$) so a typo is caught
+  # here rather than surfacing as an admission error from the c5c3 webhook. Keep
+  # this regex in lockstep with the +kubebuilder:validation:Pattern marker on
+  # DatabaseSpec.StorageSize (internal/common/types/types.go) — the CRD field
+  # CONTROLPLANE_DB_STORAGE is projected into; if that pattern changes, change
+  # this one too.
+  if [[ ! "${CONTROLPLANE_DB_STORAGE}" =~ ^[0-9]+(Mi|Gi|Ti)$ ]]; then
+    log "ERROR: CONTROLPLANE_DB_STORAGE='${CONTROLPLANE_DB_STORAGE}' is not a valid quantity (expected digits + Mi/Gi/Ti, e.g. 512Mi)."
+    return 1
+  fi
 
-  CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS}" CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS}" CONTROLPLANE_NAME="${CONTROLPLANE_NAME}" yq -i \
-    '(select(.kind == "ControlPlane" and .metadata.name == strenv(CONTROLPLANE_NAME)) | .spec.infrastructure.database.replicas) = (strenv(CONTROLPLANE_DB_REPLICAS) | tonumber)
-     | (select(.kind == "ControlPlane" and .metadata.name == strenv(CONTROLPLANE_NAME)) | .spec.infrastructure.cache.replicas) = (strenv(CONTROLPLANE_CACHE_REPLICAS) | tonumber)' \
+  # `with(paths; update)` binds the select clause once and runs all three
+  # assignments against each matched node, so the CR-scoping predicate is not
+  # repeated per field (and cannot drift between them). tonumber keeps the
+  # replica values integers (the CRD schema types replicas as integer) while
+  # storageSize stays a string. A select that matches nothing is a no-op, so the
+  # rewrite stays idempotent on an already-scaled or unrelated overlay.
+  CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS}" CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS}" CONTROLPLANE_DB_STORAGE="${CONTROLPLANE_DB_STORAGE}" CONTROLPLANE_NAME="${CONTROLPLANE_NAME}" yq -i \
+    'with(select(.kind == "ControlPlane" and .metadata.name == strenv(CONTROLPLANE_NAME));
+       .spec.infrastructure.database.replicas = (strenv(CONTROLPLANE_DB_REPLICAS) | tonumber)
+       | .spec.infrastructure.cache.replicas = (strenv(CONTROLPLANE_CACHE_REPLICAS) | tonumber)
+       | .spec.infrastructure.database.storageSize = strenv(CONTROLPLANE_DB_STORAGE))' \
     "${manifest}"
 }
 
@@ -1061,7 +1088,7 @@ main() {
   log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
     log "ControlPlane operators : ${CONTROLPLANE_OPERATORS} (flux = published chart + K-ORC Flux source; external = operators deployed out of band)"
-    log "ControlPlane backing   : MariaDB replicas=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera), Memcached replicas=${CONTROLPLANE_CACHE_REPLICAS} (override via CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS)"
+    log "ControlPlane backing   : MariaDB replicas=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera) storage=${CONTROLPLANE_DB_STORAGE}, Memcached replicas=${CONTROLPLANE_CACHE_REPLICAS} (override via CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_DB_STORAGE / CONTROLPLANE_CACHE_REPLICAS)"
   fi
   log ""
 
@@ -1526,11 +1553,12 @@ main() {
       fi
 
       # Project the single-node footprint onto the bundled CR. The bundled CR
-      # already carries replicas: 1 for both backing services; this makes the value
-      # deploy-time configurable (CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS)
-      # without editing the tracked manifest.
+      # already carries replicas: 1 and storageSize: 512Mi for the backing services;
+      # this makes the values deploy-time configurable (CONTROLPLANE_DB_REPLICAS /
+      # CONTROLPLANE_CACHE_REPLICAS / CONTROLPLANE_DB_STORAGE) without editing the
+      # tracked manifest.
       render_controlplane_replicas "${cp_manifest}"
-      log "  Set ControlPlane backing-service replicas: MariaDB=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera), Memcached=${CONTROLPLANE_CACHE_REPLICAS}."
+      log "  Set ControlPlane backing-service footprint: MariaDB replicas=${CONTROLPLANE_DB_REPLICAS} (>1 = Galera) storage=${CONTROLPLANE_DB_STORAGE}, Memcached replicas=${CONTROLPLANE_CACHE_REPLICAS}."
 
       # Apply the ControlPlane CR. Retry briefly: the c5c3-operator validating webhook
       # may need a moment after the chart install before it accepts the CR.

--- a/internal/common/types/types.go
+++ b/internal/common/types/types.go
@@ -15,6 +15,16 @@ import (
 // keep the literal in sync separately).
 const DefaultCacheBackend = "dogpile.cache.pymemcache"
 
+// DatabaseStorageSizeDefault is the per-replica managed-MariaDB volume size
+// materialized when DatabaseSpec.StorageSize is left empty. It is the single Go
+// source of truth shared by the c5c3 fresh-create projection (the fallback in
+// reconcile_infrastructure.go) and the ControlPlane validating webhook (the
+// one-time migration normalization for pre-existing CRs), so the two cannot
+// drift. Keep it in lockstep with the +kubebuilder:default marker on
+// DatabaseSpec.StorageSize below — kubebuilder markers cannot reference Go
+// constants, so the leaf marker keeps the literal in sync separately.
+const DatabaseStorageSizeDefault = "100Gi"
+
 // ImageSpec defines a container image reference.
 type ImageSpec struct {
 	// Repository is the OCI image repository, optionally including the registry
@@ -84,6 +94,23 @@ type DatabaseSpec struct {
 	// +kubebuilder:default=3
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas,omitempty"`
+	// StorageSize is the persistent-volume size requested for each managed
+	// MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
+	// operator's managed-mode projection honours it (it is written to the owned
+	// MariaDB's spec.storage.size); operators that adopt an existing MariaDB
+	// (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+	// mirrors the production baseline (deploy/flux-system/infrastructure/
+	// mariadb.yaml); a constrained cluster such as a single-node kind can pin a
+	// far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
+	// never fills. Immutable after creation: the mariadb-operator rejects
+	// changing spec.storage.size on a live CR, so the ControlPlane validating
+	// webhook freezes it too. Only meaningful when ClusterRef is set. The pattern
+	// admits binary IEC units (Mi/Gi/Ti) matching the Kubernetes quantity grammar
+	// the operator parses with resource.ParseQuantity.
+	// +optional
+	// +kubebuilder:default="100Gi"
+	// +kubebuilder:validation:Pattern=`^[0-9]+(Mi|Gi|Ti)$`
+	StorageSize string `json:"storageSize,omitempty"`
 }
 
 // DatabaseTLSSpec configures opt-in TLS (and mutual TLS) for a database

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -58,6 +58,14 @@ const (
 	// DefaultCacheClusterRefName is the managed Memcached CR name materialized when
 	// spec.infrastructure.cache is in managed mode (servers unset).
 	DefaultCacheClusterRefName = "openstack-memcached"
+	// DefaultDatabaseStorageSize is the effective per-replica MariaDB volume size
+	// when spec.infrastructure.database.storageSize is empty. It aliases
+	// commonv1.DatabaseStorageSizeDefault (also the CRD +kubebuilder:default and
+	// the c5c3 fresh-create fallback) so validateImmutable normalizes an empty
+	// stored value to the exact size the live MariaDB already uses. StorageSize is
+	// defaulted by the CRD marker rather than Default() below, so this constant is
+	// only consulted by the immutability check, not materialized onto the object.
+	DefaultDatabaseStorageSize = commonv1.DatabaseStorageSizeDefault
 	// DefaultAdminPasswordSecretName is materialized when
 	// spec.korc.adminCredential.passwordSecretRef.name is empty.
 	DefaultAdminPasswordSecretName = "keystone-admin" //nolint:gosec // G101 false positive: Secret name, not a credential
@@ -420,6 +428,25 @@ func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
 			newDB.Replicas, "database replicas is immutable after creation "+
 				"(toggling Galera or scaling down a live cluster is destructive)"))
 	}
+	// database.storageSize is create-only for the same reason: it is projected
+	// into the owned MariaDB's spec.storage.size, which the mariadb-operator
+	// rejects changing on a live CR (its webhook forbids resizing/shrinking the
+	// PVC). Freezing it at the ControlPlane layer surfaces the constraint at
+	// admission with a clear message instead of letting the edit reach — and be
+	// rejected by — the child MariaDB. Mirrors the replicas immutability above.
+	//
+	// The comparison is against the DEFAULTED value on both sides: a ControlPlane
+	// created before storageSize existed has "" persisted (and any read/apply
+	// path that bypasses CRD defaulting, e.g. a fake-client test, can surface ""),
+	// yet its live MariaDB was provisioned at the default size. Normalizing ""
+	// to DefaultDatabaseStorageSize lets such a CR migrate once — an update that
+	// pins the field to the default it already runs at is admitted — while any
+	// OTHER value is still rejected as a resize the mariadb-operator would refuse.
+	if effectiveStorageSize(oldDB.StorageSize) != effectiveStorageSize(newDB.StorageSize) {
+		allErrs = append(allErrs, field.Invalid(dbPath.Child("storageSize"),
+			newDB.StorageSize, "database storageSize is immutable after creation "+
+				"(the mariadb-operator rejects resizing a live volume)"))
+	}
 
 	cachePath := field.NewPath("spec", "infrastructure", "cache")
 	oldCache := oldObj.Spec.Infrastructure.Cache
@@ -450,6 +477,18 @@ func validateImmutable(oldObj, newObj *ControlPlane) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+// effectiveStorageSize resolves an empty database.storageSize to the default the
+// c5c3 fresh-create projection actually provisions (DefaultDatabaseStorageSize),
+// so validateImmutable compares the sizes the live MariaDB runs at rather than
+// the raw spec strings. This is what lets a pre-existing ControlPlane (stored
+// with "" before the field existed) migrate once to an explicit default.
+func effectiveStorageSize(size string) string {
+	if size == "" {
+		return DefaultDatabaseStorageSize
+	}
+	return size
 }
 
 // validateReleaseNotDowngraded rejects an openStackRelease downgrade on UPDATE.

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -728,6 +728,91 @@ func TestValidateUpdate_RejectsDatabaseReplicasChange(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("database replicas is immutable"))
 }
 
+// TestValidateUpdate_RejectsDatabaseStorageSizeChange verifies that changing
+// database.storageSize is rejected on UPDATE: the size is projected into the owned
+// MariaDB child's spec.storage.size, which the mariadb-operator refuses to resize
+// on a live CR, so freezing it at admission surfaces the constraint with a clear
+// message. Both grow and shrink are exercised so neither slips through.
+func TestValidateUpdate_RejectsDatabaseStorageSizeChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// 512Mi -> 100Gi (grow).
+	oldCP := managedControlPlane()
+	oldCP.Spec.Infrastructure.Database.StorageSize = "512Mi"
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.StorageSize = "100Gi"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database storageSize is immutable"))
+
+	// 100Gi -> 512Mi (shrink, the reverse direction).
+	_, err = w.ValidateUpdate(context.Background(), newCP, oldCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database storageSize is immutable"))
+}
+
+// TestValidateUpdate_AcceptsUnchangedDatabaseStorageSize guards against the
+// immutability check over-firing: an UPDATE that leaves storageSize untouched (here
+// while editing a mutable field) must still be accepted.
+func TestValidateUpdate_AcceptsUnchangedDatabaseStorageSize(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	oldCP := managedControlPlane()
+	oldCP.Spec.Infrastructure.Database.StorageSize = "512Mi"
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.StorageSize = "512Mi"
+	replicas := int32(3)
+	newCP.Spec.Services.Keystone.Replicas = &replicas
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestValidateUpdate_AcceptsStorageSizeMigrationFromEmpty covers a ControlPlane
+// created before storageSize existed: "" is persisted, yet its live MariaDB was
+// provisioned at DefaultDatabaseStorageSize. A first UPDATE that pins the field
+// to that default (the size it already runs at) must be admitted as a one-time
+// migration rather than rejected as a resize. Both the empty->default direction
+// and the (defaulting-bypassed) default->empty direction are exercised.
+func TestValidateUpdate_AcceptsStorageSizeMigrationFromEmpty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	// "" (pre-existing) -> the default it already runs at.
+	oldCP := managedControlPlane()
+	oldCP.Spec.Infrastructure.Database.StorageSize = ""
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.StorageSize = DefaultDatabaseStorageSize
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// The reverse direction (field cleared back to the default) is equally a no-op.
+	_, err = w.ValidateUpdate(context.Background(), newCP, oldCP)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// TestValidateUpdate_RejectsStorageSizeResizeFromEmpty guards the other half of
+// the migration normalization: pinning a pre-existing ("") ControlPlane to a
+// size OTHER than the default it already runs at is a real resize the
+// mariadb-operator would refuse, so it must still be rejected.
+func TestValidateUpdate_RejectsStorageSizeResizeFromEmpty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	oldCP := managedControlPlane()
+	oldCP.Spec.Infrastructure.Database.StorageSize = ""
+	newCP := managedControlPlane()
+	newCP.Spec.Infrastructure.Database.StorageSize = "512Mi"
+
+	_, err := w.ValidateUpdate(context.Background(), oldCP, newCP)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("database storageSize is immutable"))
+}
+
 // TestValidateUpdate_RejectsRegionChange verifies that changing the region is
 // rejected on UPDATE: the region is projected verbatim into the Keystone child's
 // now-immutable spec.bootstrap.region (#466).

--- a/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
@@ -226,6 +226,24 @@ spec:
                         required:
                         - name
                         type: object
+                      storageSize:
+                        default: 100Gi
+                        description: |-
+                          StorageSize is the persistent-volume size requested for each managed
+                          MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
+                          operator's managed-mode projection honours it (it is written to the owned
+                          MariaDB's spec.storage.size); operators that adopt an existing MariaDB
+                          (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                          mirrors the production baseline (deploy/flux-system/infrastructure/
+                          mariadb.yaml); a constrained cluster such as a single-node kind can pin a
+                          far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
+                          never fills. Immutable after creation: the mariadb-operator rejects
+                          changing spec.storage.size on a live CR, so the ControlPlane validating
+                          webhook freezes it too. Only meaningful when ClusterRef is set. The pattern
+                          admits binary IEC units (Mi/Gi/Ti) matching the Kubernetes quantity grammar
+                          the operator parses with resource.ParseQuantity.
+                        pattern: ^[0-9]+(Mi|Gi|Ti)$
+                        type: string
                       tls:
                         description: |-
                           TLS optionally enables TLS/mTLS for the database connection. The pointer keeps the field opt-in and non-mutating: a nil

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
@@ -229,6 +229,24 @@ spec:
                         required:
                         - name
                         type: object
+                      storageSize:
+                        default: 100Gi
+                        description: |-
+                          StorageSize is the persistent-volume size requested for each managed
+                          MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
+                          operator's managed-mode projection honours it (it is written to the owned
+                          MariaDB's spec.storage.size); operators that adopt an existing MariaDB
+                          (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                          mirrors the production baseline (deploy/flux-system/infrastructure/
+                          mariadb.yaml); a constrained cluster such as a single-node kind can pin a
+                          far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
+                          never fills. Immutable after creation: the mariadb-operator rejects
+                          changing spec.storage.size on a live CR, so the ControlPlane validating
+                          webhook freezes it too. Only meaningful when ClusterRef is set. The pattern
+                          admits binary IEC units (Mi/Gi/Ti) matching the Kubernetes quantity grammar
+                          the operator parses with resource.ParseQuantity.
+                        pattern: ^[0-9]+(Mi|Gi|Ti)$
+                        type: string
                       tls:
                         description: |-
                           TLS optionally enables TLS/mTLS for the database connection. The pointer keeps the field opt-in and non-mutating: a nil

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
 
@@ -47,21 +48,31 @@ func childNamespace(cp *c5c3v1alpha1.ControlPlane) string {
 // DECISION the managed-mode MariaDB CR is provisioned with
 // a MINIMAL but VALID spec. The mariadb-operator's webhook requires
 // Storage.Size (or a VolumeClaimTemplate) — see Storage.Validate in the
-// vendored v0.38.1 types — so a 100Gi size is set to mirror the production
-// baseline (deploy/flux-system/infrastructure/mariadb.yaml uses
-// storage.size:100Gi). The replica topology is DERIVED from
-// spec.infrastructure.database.replicas: the default (3) yields a Galera HA
-// cluster matching the production baseline, while a single replica yields a
-// single-instance non-Galera MariaDB so the fresh-create path schedules on a
-// constrained cluster such as a single-node kind. TLS / issuerRefs are
-// deliberately NOT set here: the baseline wires those from cluster-specific
-// ClusterIssuers that are an infrastructure concern outside the aggregate's
-// knowledge, and the keystone DB-client baseline reads TLS from
-// cp.Spec.Infrastructure.Database.TLS rather than the MariaDB CR. The minimal
-// spec keeps the CR admissible while leaving site-specific hardening to the
-// platform team.
+// vendored v0.38.1 types — so a size is always set. Both the replica topology
+// and the storage size are DERIVED from the ControlPlane spec:
+// spec.infrastructure.database.replicas drives the topology (the default 3
+// yields a Galera HA cluster matching the production baseline, a single replica
+// a single-instance non-Galera MariaDB so the fresh-create path schedules on a
+// constrained cluster such as a single-node kind), and
+// spec.infrastructure.database.storageSize drives the volume size (default
+// 100Gi mirrors deploy/flux-system/infrastructure/mariadb.yaml; kind/CI pins a
+// far smaller value). TLS / issuerRefs are deliberately NOT set here: the
+// baseline wires those from cluster-specific ClusterIssuers that are an
+// infrastructure concern outside the aggregate's knowledge, and the keystone
+// DB-client baseline reads TLS from cp.Spec.Infrastructure.Database.TLS rather
+// than the MariaDB CR. The minimal spec keeps the CR admissible while leaving
+// site-specific hardening to the platform team.
 const (
-	infraMariaDBStorageSize = "100Gi"
+	// infraMariaDBStorageSizeDefault is the zero-value fallback applied when
+	// spec.infrastructure.database.storageSize is unset (""). The CRD default is
+	// 100Gi, so this only fires when validation was bypassed (e.g. a fake-client
+	// unit test that builds the CR directly); it keeps the projection admissible
+	// (the mariadb-operator requires a non-empty size) and matches the production
+	// baseline rather than requesting a zero-sized volume. It shares
+	// commonv1.DatabaseStorageSizeDefault with the ControlPlane webhook's
+	// migration normalization so the fallback and the webhook cannot disagree
+	// on what "" means.
+	infraMariaDBStorageSizeDefault = commonv1.DatabaseStorageSizeDefault
 	// infraMariaDBReplicasDefault is the zero-value floor applied when
 	// spec.infrastructure.database.replicas is unset (0). The CRD default is 3,
 	// so this only fires when validation was bypassed; it keeps the projection
@@ -190,14 +201,23 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 	}
 	galeraEnabled := replicas > 1
 
+	// Derive the projected volume size from the spec, falling back to the
+	// production baseline when the field is empty (only reachable when the CRD
+	// default was bypassed). Storage is immutable on the mariadb-operator CR, so
+	// this value is honoured on fresh create only and never re-projected below.
+	storageSize := cp.Spec.Infrastructure.Database.StorageSize
+	if storageSize == "" {
+		storageSize = infraMariaDBStorageSizeDefault
+	}
+
 	mariadb := &mariadbv1alpha1.MariaDB{}
 	err := r.Get(ctx, key, mariadb)
 	switch {
 	case apierrors.IsNotFound(err):
 		// Create fresh with the projected, spec-derived topology.
-		size, perr := resource.ParseQuantity(infraMariaDBStorageSize)
+		size, perr := resource.ParseQuantity(storageSize)
 		if perr != nil {
-			return false, fmt.Errorf("parsing MariaDB storage size %q: %w", infraMariaDBStorageSize, perr)
+			return false, fmt.Errorf("parsing MariaDB storage size %q: %w", storageSize, perr)
 		}
 		mariadb.Name = key.Name
 		mariadb.Namespace = key.Namespace

--- a/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
@@ -366,6 +366,48 @@ func TestEnsureMariaDB_ReplicasFromSpec(t *testing.T) {
 	}
 }
 
+// TestEnsureMariaDB_StorageSizeFromSpec verifies the fresh-create projection
+// honours spec.infrastructure.database.storageSize: an explicit value is written
+// to the owned MariaDB's spec.storage.size verbatim (so kind/CI can request a
+// small test-sized volume), while an empty value (only reachable when the CRD
+// default is bypassed, e.g. a fake-client build like this one) falls back to the
+// production baseline default rather than a zero-sized volume the mariadb-operator
+// would reject.
+func TestEnsureMariaDB_StorageSizeFromSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		specStorage string
+		wantStorage string
+	}{
+		{name: "explicit small volume projected verbatim", specStorage: "512Mi", wantStorage: "512Mi"},
+		{name: "explicit large volume projected verbatim", specStorage: "100Gi", wantStorage: "100Gi"},
+		{name: "empty falls back to the baseline default", specStorage: "", wantStorage: infraMariaDBStorageSizeDefault},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			s := infraTestScheme(t)
+			cp := managedInfraControlPlane()
+			cp.Spec.Infrastructure.Database.StorageSize = tc.specStorage
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+			r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+			_, err := r.ensureMariaDB(context.Background(), cp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var mariadb mariadbv1alpha1.MariaDB
+			g.Expect(c.Get(context.Background(), types.NamespacedName{
+				Name: "openstack-db", Namespace: childNamespace(cp),
+			}, &mariadb)).To(Succeed())
+			g.Expect(mariadb.Spec.Storage.Size).NotTo(BeNil())
+			want := resource.MustParse(tc.wantStorage)
+			g.Expect(mariadb.Spec.Storage.Size.Equal(want)).To(BeTrue(),
+				"projected storage size %s must equal %s", mariadb.Spec.Storage.Size, tc.wantStorage)
+		})
+	}
+}
+
 // TestEnsureMemcached_OwnedReconcilesReplicas verifies the owner-aware path for
 // Memcached: a Memcached this ControlPlane OWNS has spec.replicas reconciled to
 // cp.Spec.Infrastructure.Cache.Replicas when they differ, so a ControlPlane spec

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -365,6 +365,24 @@ spec:
                     required:
                     - name
                     type: object
+                  storageSize:
+                    default: 100Gi
+                    description: |-
+                      StorageSize is the persistent-volume size requested for each managed
+                      MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
+                      operator's managed-mode projection honours it (it is written to the owned
+                      MariaDB's spec.storage.size); operators that adopt an existing MariaDB
+                      (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                      mirrors the production baseline (deploy/flux-system/infrastructure/
+                      mariadb.yaml); a constrained cluster such as a single-node kind can pin a
+                      far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
+                      never fills. Immutable after creation: the mariadb-operator rejects
+                      changing spec.storage.size on a live CR, so the ControlPlane validating
+                      webhook freezes it too. Only meaningful when ClusterRef is set. The pattern
+                      admits binary IEC units (Mi/Gi/Ti) matching the Kubernetes quantity grammar
+                      the operator parses with resource.ParseQuantity.
+                    pattern: ^[0-9]+(Mi|Gi|Ti)$
+                    type: string
                   tls:
                     description: |-
                       TLS optionally enables TLS/mTLS for the database connection. The pointer keeps the field opt-in and non-mutating: a nil

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -368,6 +368,24 @@ spec:
                     required:
                     - name
                     type: object
+                  storageSize:
+                    default: 100Gi
+                    description: |-
+                      StorageSize is the persistent-volume size requested for each managed
+                      MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
+                      operator's managed-mode projection honours it (it is written to the owned
+                      MariaDB's spec.storage.size); operators that adopt an existing MariaDB
+                      (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                      mirrors the production baseline (deploy/flux-system/infrastructure/
+                      mariadb.yaml); a constrained cluster such as a single-node kind can pin a
+                      far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
+                      never fills. Immutable after creation: the mariadb-operator rejects
+                      changing spec.storage.size on a live CR, so the ControlPlane validating
+                      webhook freezes it too. Only meaningful when ClusterRef is set. The pattern
+                      admits binary IEC units (Mi/Gi/Ti) matching the Kubernetes quantity grammar
+                      the operator parses with resource.ParseQuantity.
+                    pattern: ^[0-9]+(Mi|Gi|Ti)$
+                    type: string
                   tls:
                     description: |-
                       TLS optionally enables TLS/mTLS for the database connection. The pointer keeps the field opt-in and non-mutating: a nil

--- a/tests/e2e/c5c3/deletion-orchestration/00-controlplane-cr.yaml
+++ b/tests/e2e/c5c3/deletion-orchestration/00-controlplane-cr.yaml
@@ -36,6 +36,8 @@ spec:
       database: keystone
       secretRef:
         name: keystone-db
+      # Pin a test-sized volume instead of the 100Gi CRD default.
+      storageSize: 512Mi
     cache:
       clusterRef:
         name: openstack-memcached

--- a/tests/e2e/c5c3/full-controlplane-keystone/00-controlplane-cr.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/00-controlplane-cr.yaml
@@ -50,7 +50,9 @@ spec:
   # so the full fresh-create chain schedules on a single-node kind cluster.
   # database.replicas:1 drives the operator's fresh-create MariaDB projection to
   # a single-instance non-Galera MariaDB; cache.replicas:1 to a single Memcached
-  # pod; services.keystone.replicas:1 to a single API pod.
+  # pod; services.keystone.replicas:1 to a single API pod. database.storageSize is
+  # pinned to 512Mi so the projected MariaDB requests a test-sized volume instead
+  # of the 100Gi CRD default (the production baseline) that CI never fills.
   infrastructure:
     database:
       clusterRef:
@@ -59,6 +61,7 @@ spec:
       secretRef:
         name: keystone-db
       replicas: 1
+      storageSize: 512Mi
     cache:
       clusterRef:
         name: openstack-memcached

--- a/tests/e2e/c5c3/multi-controlplane/00-tenant-a-controlplane.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/00-tenant-a-controlplane.yaml
@@ -55,6 +55,8 @@ spec:
       database: keystone
       secretRef:
         name: keystone-db
+      # Pin a test-sized volume instead of the 100Gi CRD default.
+      storageSize: 512Mi
     cache:
       clusterRef:
         name: openstack-memcached

--- a/tests/e2e/c5c3/multi-controlplane/01-tenant-b-controlplane.yaml
+++ b/tests/e2e/c5c3/multi-controlplane/01-tenant-b-controlplane.yaml
@@ -48,6 +48,8 @@ spec:
       database: keystone
       secretRef:
         name: keystone-db
+      # Pin a test-sized volume instead of the 100Gi CRD default.
+      storageSize: 512Mi
     cache:
       clusterRef:
         name: openstack-memcached

--- a/tests/unit/hack/deploy_infra_controlplane_replicas_test.sh
+++ b/tests/unit/hack/deploy_infra_controlplane_replicas_test.sh
@@ -5,10 +5,12 @@
 
 # Verify hack/deploy-infra.sh `render_controlplane_replicas` pins the projected
 # backing-service footprint from CONTROLPLANE_DB_REPLICAS / CONTROLPLANE_CACHE_REPLICAS
-# and rejects an invalid footprint (non-numeric, < 1, or the quorum-unsafe DB=2)
-# before the CR is applied. Also guards that the checked-in bundled kind CR ships a
-# single-node topology (database.replicas=1, cache.replicas=1) so a laptop-sized
-# single-node kind does not spin up a 3-node Galera cluster and OOM.
+# / CONTROLPLANE_DB_STORAGE and rejects an invalid footprint (non-numeric or < 1
+# replicas, the quorum-unsafe DB=2, or a malformed storage quantity) before the CR
+# is applied. Also guards that the checked-in bundled kind CR ships a single-node
+# topology (database.replicas=1, cache.replicas=1) with a test-sized volume
+# (database.storageSize=512Mi) so a laptop-sized single-node kind does not spin up a
+# 3-node Galera cluster or request a 100Gi volume it never fills.
 #
 # Sources deploy-infra.sh and invokes the function in a subshell so we can assert
 # against a rendered tempfile without spinning up an actual cluster. The yq-backed
@@ -37,17 +39,20 @@ source "$PROJECT_ROOT/tests/lib/assertions.sh"
 FIXTURE_CONTROLPLANE_NAME="controlplane"
 
 # Source the script and call render_controlplane_replicas in a subshell with the
-# given DB/cache replica values, mutating <manifest> in place. Echoes combined
-# output and returns the function's exit status. The subshell isolates env
-# mutations and the BASH_SOURCE guard at the bottom of deploy-infra.sh keeps main
-# from running when sourced.
+# given DB/cache replica values and DB storage size, mutating <manifest> in place.
+# The storage arg is optional (defaults to the single-node 512Mi) so the replica-only
+# call sites stay unchanged. Echoes combined output and returns the function's exit
+# status. The subshell isolates env mutations and the BASH_SOURCE guard at the bottom
+# of deploy-infra.sh keeps main from running when sourced.
 run_render() {
   local manifest="$1"
   local db="$2"
   local cache="$3"
+  local storage="${4:-512Mi}"
   (
     export CONTROLPLANE_DB_REPLICAS="${db}"
     export CONTROLPLANE_CACHE_REPLICAS="${cache}"
+    export CONTROLPLANE_DB_STORAGE="${storage}"
     export CONTROLPLANE_NAME="${FIXTURE_CONTROLPLANE_NAME}"
     # shellcheck source=/dev/null
     source "$DEPLOY_INFRA_SH"
@@ -59,11 +64,11 @@ run_render() {
 # Test 1: the checked-in bundled CR ships a single-node topology.
 # ---------------------------------------------------------------------------
 test_bundled_cr_is_single_node() {
-  echo "Test: bundled kind ControlPlane CR pins database/cache replicas to 1"
+  echo "Test: bundled kind ControlPlane CR pins database/cache replicas to 1 and storage to 512Mi"
 
   if ! command -v yq >/dev/null 2>&1; then
-    echo "  SKIP: yq not installed (2 checks skipped)"
-    SKIP=$((SKIP + 2))
+    echo "  SKIP: yq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
     return
   fi
 
@@ -73,17 +78,20 @@ test_bundled_cr_is_single_node() {
   assert_eq "bundled CR cache.replicas is 1" \
     "1" \
     "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.cache.replicas' "$BUNDLED_CR")"
+  assert_eq "bundled CR database.storageSize is 512Mi" \
+    "512Mi" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.storageSize' "$BUNDLED_CR")"
 }
 
 # ---------------------------------------------------------------------------
 # Test 2: default footprint (both = 1) rewrites to integer 1/1.
 # ---------------------------------------------------------------------------
 test_default_footprint() {
-  echo "Test: render_controlplane_replicas with 1/1 yields integer replicas 1/1"
+  echo "Test: render_controlplane_replicas with 1/1/512Mi yields replicas 1/1 and storage 512Mi"
 
   if ! command -v yq >/dev/null 2>&1; then
-    echo "  SKIP: yq not installed (3 checks skipped)"
-    SKIP=$((SKIP + 3))
+    echo "  SKIP: yq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
     return
   fi
 
@@ -94,10 +102,10 @@ test_default_footprint() {
   cp "$BUNDLED_CR" "$out"
 
   local exit_code
-  run_render "$out" "1" "1" >/dev/null
+  run_render "$out" "1" "1" "512Mi" >/dev/null
   exit_code=$?
 
-  assert_eq "render exits 0 for 1/1" "0" "$exit_code"
+  assert_eq "render exits 0 for 1/1/512Mi" "0" "$exit_code"
   assert_eq "database.replicas is 1" \
     "1" \
     "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas' "$out")"
@@ -105,17 +113,25 @@ test_default_footprint() {
   assert_eq "database.replicas stays an integer node" \
     "!!int" \
     "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas | tag' "$out")"
+  assert_eq "database.storageSize is 512Mi" \
+    "512Mi" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.storageSize' "$out")"
+  # storageSize must stay a string node — an unquoted 512Mi is fine, but the CRD
+  # types it as string, so guard the node kind explicitly.
+  assert_eq "database.storageSize stays a string node" \
+    "!!str" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.storageSize | tag' "$out")"
 }
 
 # ---------------------------------------------------------------------------
 # Test 3: an HA override (DB=3 Galera, cache=2) is projected as integers.
 # ---------------------------------------------------------------------------
 test_ha_override() {
-  echo "Test: render_controlplane_replicas with 3/2 projects a Galera-sized footprint"
+  echo "Test: render_controlplane_replicas with 3/2/100Gi projects a Galera-sized footprint"
 
   if ! command -v yq >/dev/null 2>&1; then
-    echo "  SKIP: yq not installed (3 checks skipped)"
-    SKIP=$((SKIP + 3))
+    echo "  SKIP: yq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
     return
   fi
 
@@ -126,23 +142,26 @@ test_ha_override() {
   cp "$BUNDLED_CR" "$out"
 
   local exit_code
-  run_render "$out" "3" "2" >/dev/null
+  run_render "$out" "3" "2" "100Gi" >/dev/null
   exit_code=$?
 
-  assert_eq "render exits 0 for 3/2" "0" "$exit_code"
+  assert_eq "render exits 0 for 3/2/100Gi" "0" "$exit_code"
   assert_eq "database.replicas is 3 (Galera)" \
     "3" \
     "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.replicas' "$out")"
   assert_eq "cache.replicas is 2" \
     "2" \
     "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.cache.replicas' "$out")"
+  assert_eq "database.storageSize is 100Gi (production-sized override)" \
+    "100Gi" \
+    "$(yq -r 'select(.kind == "ControlPlane") | .spec.infrastructure.database.storageSize' "$out")"
 }
 
 # ---------------------------------------------------------------------------
 # Test 4: invalid footprints fail fast (before kubectl apply).
 # ---------------------------------------------------------------------------
 test_invalid_footprint_rejected() {
-  echo "Test: render_controlplane_replicas rejects non-numeric, < 1, and DB=2"
+  echo "Test: render_controlplane_replicas rejects non-numeric, < 1, DB=2, and malformed storage"
 
   local tmp
   tmp="$(mktemp -d)"
@@ -171,6 +190,18 @@ test_invalid_footprint_rejected() {
   assert_nonzero_exit "quorum-unsafe CONTROLPLANE_DB_REPLICAS=2 exits non-zero" "$exit_code"
   assert_contains "DB=2 error explains the Galera quorum constraint" \
     "$output" "quorum"
+
+  # Malformed storage quantities: an SI unit (MB, not the CRD's IEC Mi) and a
+  # bare number with no unit both fail the ^[0-9]+(Mi|Gi|Ti)$ pattern.
+  output="$(run_render "$out" "1" "1" "512MB")"
+  exit_code=$?
+  assert_nonzero_exit "SI-unit CONTROLPLANE_DB_STORAGE=512MB exits non-zero" "$exit_code"
+  assert_contains "malformed storage error surfaces the offending value" \
+    "$output" "CONTROLPLANE_DB_STORAGE='512MB'"
+
+  output="$(run_render "$out" "1" "1" "512")"
+  exit_code=$?
+  assert_nonzero_exit "unit-less CONTROLPLANE_DB_STORAGE=512 exits non-zero" "$exit_code"
 }
 
 # ---------------------------------------------------------------------------
@@ -187,6 +218,8 @@ test_main_wires_knobs() {
     "$DEPLOY_INFRA_SH" 'CONTROLPLANE_DB_REPLICAS="${CONTROLPLANE_DB_REPLICAS:-1}"'
   assert_file_contains "CONTROLPLANE_CACHE_REPLICAS defaults to 1" \
     "$DEPLOY_INFRA_SH" 'CONTROLPLANE_CACHE_REPLICAS="${CONTROLPLANE_CACHE_REPLICAS:-1}"'
+  assert_file_contains "CONTROLPLANE_DB_STORAGE defaults to 512Mi" \
+    "$DEPLOY_INFRA_SH" 'CONTROLPLANE_DB_STORAGE="${CONTROLPLANE_DB_STORAGE:-512Mi}"'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On the `WITH_CONTROLPLANE` path the c5c3-operator provisions MariaDB from the ControlPlane CR. `ensureMariaDB` requested a **hardcoded 100Gi** volume (the production baseline) for every fresh create, so a kind/CI run — which never fills it — still asked for a 100Gi PVC. The standalone kind overlay already patches its MariaDB down to 1Gi, but the managed path (which CI's `full-controlplane-keystone` job exercises via `WITH_CONTROLPLANE=true`) had no knob at all.

## Change

Add `spec.infrastructure.database.storageSize` to the shared `DatabaseSpec`, mirroring the existing `Replicas` field:

- Only the c5c3 managed-mode projection honours it (written to the owned MariaDB's `spec.storage.size`); the adopt paths (keystone, adopted-infra) ignore it.
- **Defaults to `100Gi`** so greenfield managed mode keeps the production volume; kind/CI pin a test-sized **`512Mi`**.
- **Create-only**: the mariadb-operator refuses to resize a live volume, so the validating webhook freezes it and surfaces the constraint at admission (mirrors `replicas` immutability).
- `deploy-infra` exposes `CONTROLPLANE_DB_STORAGE` (default `512Mi`) to scale back up to the production volume on a bigger box, alongside the existing replica knobs.

### Files
- `internal/common/types`: `DatabaseSpec.StorageSize` (default `100Gi`, pattern `Mi/Gi/Ti`)
- `operators/c5c3`: honour `storageSize` on fresh create; create-only webhook guard
- Regenerated CRDs (ControlPlane + Keystone) and synced the Helm copies
- `deploy/kind` + `tests/e2e/c5c3`: pin `storageSize: 512Mi` on the projected CRs
- `hack/deploy-infra.sh`: `CONTROLPLANE_DB_STORAGE` knob + render/validation
- Unit tests: reconcile projection + fallback, webhook immutability, hack render
- `docs/quick-start-controlplane.md`: single-node storage default and knob

## Testing
- `go build` + `go test` (c5c3 controller + api/v1alpha1) green; keystone + common build clean
- `tests/unit/hack/deploy_infra_controlplane_replicas_test.sh`: 25/25 passed
- `make verify-crd-sync` passed; gofumpt clean

## Production safety
Default stays `100Gi` (production baseline) — greenfield managed mode is unchanged. Only kind/CI and the e2e fixtures pin `512Mi`. `storageSize` is immutable after create, so an existing environment must be torn down (`make teardown-infra`) before a smaller footprint takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)