### PR TITLE
feat: roll out Horizon as a standard service in the ControlPlane quick-start

### DIFF
--- a/deploy/kind/base/openstack-gateway.yaml
+++ b/deploy/kind/base/openstack-gateway.yaml
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Gateway API wiring for the kind Quick Start — `GatewayClass/envoy`
-# plus a single-listener HTTPS Gateway at
-# `keystone.127-0-0-1.nip.io:443` terminating TLS with a self-signed
-# certificate issued by the existing `selfsigned-cluster-issuer`
+# plus a two-listener HTTPS Gateway on port 443 (`keystone.127-0-0-1.nip.io`
+# and `horizon.127-0-0-1.nip.io`, routed by SNI) terminating TLS with
+# self-signed certificates issued by the existing `selfsigned-cluster-issuer`
 # ClusterIssuer (the same issuer OpenBao uses; see
 # `deploy/flux-system/infrastructure/cluster-issuer.yaml`).
 #
@@ -61,6 +61,28 @@ spec:
         certificateRefs:
           - kind: Secret
             name: keystone-nip-io-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+    # Second HTTPS listener for the Horizon dashboard the ControlPlane Quick
+    # Start projects (docs/quick-start-controlplane.md). It shares port 443
+    # with the Keystone listener above — Envoy Gateway routes the two by SNI
+    # on the distinct `hostname` values, each terminating with its own
+    # certificate. The Horizon HTTPRoute the horizon-operator projects carries
+    # `hostnames: [horizon.127-0-0-1.nip.io]`, so it attaches to THIS listener
+    # (matching hostname) and not the Keystone one. Adding a second listener on
+    # the same port does not disturb the NodePort pin: `envoy-nodeport.yaml`
+    # keys its StrategicMerge patch by `port: 443`, which selects the single
+    # ServicePort Envoy generates for both listeners.
+    - name: https-horizon
+      protocol: HTTPS
+      port: 443
+      hostname: horizon.127-0-0-1.nip.io
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: horizon-nip-io-tls
       allowedRoutes:
         namespaces:
           from: Same

--- a/deploy/kind/controlplane/controlplane.yaml
+++ b/deploy/kind/controlplane/controlplane.yaml
@@ -10,9 +10,9 @@
 # Managed mode: the c5c3-operator provisions the MariaDB ("openstack-db") and
 # Memcached ("openstack-memcached") itself — which is why deploy-infra does NOT
 # create them when WITH_CONTROLPLANE=true (hack/deploy-infra.sh). The c5c3-operator
-# then projects a {name}-keystone Keystone CR, mints the K-ORC admin Application
-# Credential from the admin password, mirrors it to OpenBao, and registers the
-# identity catalog.
+# then projects a {name}-keystone Keystone CR and a {name}-horizon Horizon CR,
+# mints the K-ORC admin Application Credential from the admin password, mirrors
+# it to OpenBao, and registers the identity catalog.
 #
 # this CR is intentionally minimal. The c5c3-operator defaulting webhook
 # fills the omitted infrastructure/korc references with well-known defaults, so the
@@ -85,3 +85,21 @@ spec:
       # hostname. When KIND_HOST_PORT is overridden (e.g. 8443 on macOS) deploy-infra
       # injects spec.services.keystone.publicEndpoint carrying the host port so
       # Keystone advertises the reachable URL in its catalog.
+    # Horizon: the c5c3-operator projects a Horizon CR once the Keystone child is
+    # Ready (HorizonReady joins the aggregate chain after KeystoneReady). replicas
+    # is pinned to 1 for the single-node kind cluster. The dashboard is exposed
+    # externally through the SAME shared Envoy Gateway as Keystone via a second
+    # HTTPS listener the kind overlay adds for horizon.127-0-0-1.nip.io
+    # (deploy/kind/base/openstack-gateway.yaml); the horizon-operator attaches an
+    # HTTPRoute for that hostname, reachable from the host at
+    # https://horizon.127-0-0-1.nip.io:<KIND_HOST_PORT>/. secretKeyRef is omitted:
+    # this default-identity ControlPlane ("controlplane") inherits the kind shim
+    # Secret "horizon-secret-key" (seeded per the default identity by
+    # deploy/openbao/bootstrap/write-bootstrap-secrets.sh); additional
+    # ControlPlanes MUST set services.horizon.secretKeyRef to their own Secret.
+    horizon:
+      replicas: 1
+      gateway:
+        parentRef:
+          name: openstack-gw
+        hostname: horizon.127-0-0-1.nip.io

--- a/deploy/kind/infrastructure/horizon-nip-io-tls-certificate.yaml
+++ b/deploy/kind/infrastructure/horizon-nip-io-tls-certificate.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# TLS material for the Horizon listener defined in
+# deploy/kind/base/openstack-gateway.yaml. cert-manager issues a
+# self-signed certificate for `horizon.127-0-0-1.nip.io` and writes it
+# to the `horizon-nip-io-tls` Secret in the `openstack` namespace,
+# where the Gateway's `https-horizon` listener `certificateRefs` picks
+# it up. Kept as a sibling of `keystone-nip-io-tls-certificate.yaml`
+# (one Certificate per listener hostname) rather than a shared SAN
+# certificate so each listener terminates with its own key material.
+#
+# Lives in the infrastructure overlay (Phase 2 of hack/deploy-infra.sh)
+# rather than the base overlay because the `cert-manager.io/v1`
+# Certificate CRD is installed by the `cert-manager` HelmRelease in
+# Phase 1; applying this resource before Phase 4 ("wait HelmReleases
+# Ready") would fail with `no matches for kind "Certificate"`.
+# The same reasoning applies to the `selfsigned-cluster-issuer`
+# ClusterIssuer it references (deploy/flux-system/infrastructure/
+# cluster-issuer.yaml) — also a Phase-2 resource.
+#
+# Self-signed is correct for a kind quick-start cluster (single-user
+# localhost-only), matching the Keystone listener certificate above.
+#
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: horizon-nip-io-tls
+  namespace: openstack
+spec:
+  secretName: horizon-nip-io-tls
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - horizon.127-0-0-1.nip.io

--- a/deploy/kind/infrastructure/kustomization.yaml
+++ b/deploy/kind/infrastructure/kustomization.yaml
@@ -17,6 +17,9 @@ resources:
   # by the cert-manager / envoy-gateway HelmReleases in Phase 1.
   - envoy-nodeport.yaml
   - keystone-nip-io-tls-certificate.yaml
+  # TLS for the second Gateway listener the ControlPlane Quick Start's Horizon
+  # dashboard is exposed through (deploy/kind/base/openstack-gateway.yaml).
+  - horizon-nip-io-tls-certificate.yaml
   # kind-only: standalone Keystone CRs (Quick Start, keystone e2e/tempest/
   # chaos suites) reference the Secret "keystone-db"; ControlPlane-based
   # deployments use the operator-projected per-ControlPlane ExternalSecret

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -12,8 +12,8 @@ SPDX-License-Identifier: Apache-2.0
 The shortest path from `git clone` to an authenticated Keystone API call driven
 by a single **c5c3 ControlPlane** CR. Where the [Quick Start](./quick-start.md)
 stops at a hand-applied `Keystone` CR, here one `ControlPlane` CR makes the
-c5c3-operator provision the `MariaDB`, `Memcached`, and `Keystone` children, mint
-the admin application credential through
+c5c3-operator provision the `MariaDB`, `Memcached`, `Keystone`, and `Horizon`
+children, mint the admin application credential through
 [K-ORC](https://github.com/k-orc/openstack-resource-controller), mirror it to
 OpenBao, and register the identity catalog — all reconciled to an aggregate
 `Ready`.
@@ -63,9 +63,9 @@ KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
 `WITH_CONTROLPLANE=true` brings up the shared infrastructure and then the
-ControlPlane operator stack (keystone-operator, K-ORC, c5c3-operator) from the
-published charts — but **not** the `ControlPlane` CR itself; you create and apply
-that in Step 3. In this mode the ControlPlane provisions its own MariaDB/Memcached
+ControlPlane operator stack (keystone-operator, horizon-operator, K-ORC,
+c5c3-operator) from the published charts — but **not** the `ControlPlane` CR
+itself; you create and apply that in Step 3. In this mode the ControlPlane provisions its own MariaDB/Memcached
 (managed mode), so deploy-infra does not create the shared ones. `KIND_HOST_PORT=8443`
 maps the Gateway to a non-privileged host port for macOS; on Linux with rootful
 Docker drop the override and use port `443`. Expect **5–10 minutes**.
@@ -120,11 +120,29 @@ spec:
           name: openstack-gw
         hostname: keystone.127-0-0-1.nip.io
         path: /
+    horizon:
+      replicas: 1
+      # Exposed through the same shared Envoy Gateway as Keystone, via the
+      # second HTTPS listener the kind overlay adds for horizon.127-0-0-1.nip.io.
+      gateway:
+        parentRef:
+          name: openstack-gw
+        hostname: horizon.127-0-0-1.nip.io
 ```
 
 ```bash
 kubectl apply -f controlplane.yaml
 ```
+
+The `horizon` block makes the reconciler project the OpenStack Dashboard once
+its Keystone child is Ready. Everything else is derived: the image tag from
+`spec.openStackRelease`, the Memcached wiring from `spec.infrastructure.cache`,
+and the Keystone endpoint from the Keystone child's naming convention. The
+Django `SECRET_KEY` defaults to the kind-only `horizon-secret-key` Secret
+(seeded per the default ControlPlane identity); a second ControlPlane must set
+`services.horizon.secretKeyRef` to its own Secret. A `HorizonReady` condition
+joins the chain (after `KeystoneReady`) and `status.services` gains a second
+entry.
 
 ::: tip Dynamic DB credentials (#439)
 A managed-mode ControlPlane defaults to engine-issued (Dynamic) Keystone DB
@@ -179,6 +197,15 @@ spec:
           name: openstack-gw
         hostname: keystone.127-0-0-1.nip.io
         path: /
+    horizon:
+      replicas: 1
+      gateway:
+        parentRef:
+          name: openstack-gw          # same Gateway as Keystone; second listener
+        hostname: horizon.127-0-0-1.nip.io
+      secretKeyRef:
+        name: horizon-secret-key       # default-identity kind shim Secret
+        key: secret-key
   korc:
     adminCredential:
       cloudCredentialsRef:
@@ -196,40 +223,14 @@ spec:
 
 </details>
 
-### Optional — add the Horizon dashboard
-
-Append a `horizon` block under `services` to have the ControlPlane project
-the OpenStack Dashboard once its Keystone child is ready:
-
-```yaml
-  services:
-    keystone:
-      # ... as above ...
-    horizon:
-      replicas: 1
-      gateway:
-        parentRef:
-          name: openstack-gw
-          namespace: envoy-gateway-system
-        hostname: horizon.127-0-0-1.nip.io
-```
-
-The reconciler derives everything else: the image tag from
-`spec.openStackRelease`, the Memcached wiring from
-`spec.infrastructure.cache`, and the Keystone endpoint from the Keystone
-child's naming convention. The Django `SECRET_KEY` defaults to the kind-only
-`horizon-secret-key` Secret (seeded per the default ControlPlane identity);
-additional ControlPlanes must set `services.horizon.secretKeyRef` to their
-own Secret. A `HorizonReady` condition joins the chain (after
-`KeystoneReady`) and `status.services` gains a second entry.
-
 ## Step 4 — Watch the chain reconcile
 
-The aggregate `Ready` flips to `True` once all five sub-conditions are met, in
-dependency order:
+The aggregate `Ready` flips to `True` once all six sub-conditions are met, in
+dependency order (`HorizonReady` gates on `KeystoneReady`; the K-ORC branch runs
+alongside it):
 
 ```
-InfrastructureReady → KeystoneReady → KORCReady → AdminCredentialReady → CatalogReady
+InfrastructureReady → KeystoneReady → HorizonReady → KORCReady → AdminCredentialReady → CatalogReady
 ```
 
 ```bash
@@ -275,17 +276,22 @@ openstack --insecure token issue
 > With the default `KIND_HOST_PORT=443` use `https://keystone.127-0-0-1.nip.io/v3`
 > and drop the `publicEndpoint` line from the CR in Step 3.
 
-### Optional — open the Horizon dashboard
+### Open the Horizon dashboard
 
-If you added the `horizon` block in Step 3, the dashboard is exposed through
-the same shared Envoy Gateway:
+The dashboard is exposed through the same shared Envoy Gateway as Keystone, on
+its own `horizon.127-0-0-1.nip.io` listener:
 
 ```bash
 open https://horizon.127-0-0-1.nip.io:8443/
 ```
 
-Log in with `admin` / the password from the
-`controlplane-keystone-admin-credentials` Secret above (domain `Default`).
+Your browser will warn that the certificate is not trusted — expected for a kind
+cluster (the listener terminates with a self-signed certificate). Log in with
+`admin` / the password from the `controlplane-keystone-admin-credentials` Secret
+above (domain `Default`).
+
+> With the default `KIND_HOST_PORT=443` drop the `:8443` and open
+> `https://horizon.127-0-0-1.nip.io/`.
 
 ## Teardown
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -23,8 +23,8 @@ infrastructure stack (MariaDB, Memcached, K-ORC, OpenBao) the operator targets,
 see [Infrastructure Manifests](../infrastructure/infrastructure-manifests.md).
 
 The c5c3 operator is intentionally a *thin orchestrator*: it provisions and
-owns child CRs (MariaDB, Memcached, Keystone, K-ORC `ApplicationCredential` /
-`Service` / `Endpoint`) and aggregates their readiness. It does **not**
+owns child CRs (MariaDB, Memcached, Keystone, Horizon, K-ORC
+`ApplicationCredential` / `Service` / `Endpoint`) and aggregates their readiness. It does **not**
 re-implement the per-service logic those child operators already own. As a
 consequence the c5c3 API surface is deliberately smaller than the
 [Keystone reconciler](../keystone/keystone-reconciler.md)'s: no parallel
@@ -292,6 +292,12 @@ and the informer cache to that namespace. Keep the default only when
 │           │                                                                  │
 │           ▼                                                                  │
 │  ┌──────────────────────────┐                                                │
+│  │ reconcileHorizon         │  Project the Horizon dashboard child CR        │
+│  │  (gate: KeystoneReady)   │  Sets: HorizonReady (not-managed when unset)   │
+│  └────────┬─────────────────┘  Requeue: 5s gated / 15s child not Ready       │
+│           │                                                                  │
+│           ▼                                                                  │
+│  ┌──────────────────────────┐                                                │
 │  │ reconcileKORC            │  Mint the admin ApplicationCredential          │
 │  │  (gate: none*)           │  Sets: KORCReady                               │
 │  └────────┬─────────────────┘  Requeue: 10s while AC not Available           │
@@ -320,7 +326,7 @@ and the informer cache to that namespace. Keep the default only when
 
 ### Execution Model
 
-All seven sub-reconcilers run **strictly sequentially** — there is no parallel
+All eight sub-reconcilers run **strictly sequentially** — there is no parallel
 group. The chain is a table-driven pipeline over the shared scaffolding in
 `internal/common/reconcile` (the same shape the keystone controller uses):
 each step is a `commonreconcile.Step` wrapped in `instrumentSubReconciler`
@@ -333,7 +339,7 @@ pipeline := []commonreconcile.Step{
     {Name: "Infrastructure", Fn: func(ctx context.Context) (ctrl.Result, error) {
         return r.reconcileInfrastructure(ctx, &cp)
     }},
-    // ... DBCredentials, AdminPassword, Keystone, KORC, AdminCredential, Catalog
+    // ... DBCredentials, AdminPassword, Keystone, Horizon, KORC, AdminCredential, Catalog
 }
 result, err := commonreconcile.RunPipeline(ctx, instrumentSubReconciler, pipeline)
 return r.updateStatus(ctx, &cp, statusBefore, result, err)
@@ -389,11 +395,11 @@ sub-condition type is `True` using `aggregateReady()`, which delegates to
 | Yes | `Status: True` | `AllReady` | `All sub-conditions are ready` |
 | No (any missing or False) | `Status: False` | `NotAllReady` | `One or more sub-conditions are not ready` |
 
-The seven aggregated sub-condition types (the source-of-truth `subConditionTypes`
+The eight aggregated sub-condition types (the source-of-truth `subConditionTypes`
 slice in `controlplane_controller.go`) are:
 
 ```text
-InfrastructureReady, DBCredentialsReady, KeystoneReady, KORCReady, AdminCredentialReady, AdminPasswordReady, CatalogReady
+InfrastructureReady, DBCredentialsReady, KeystoneReady, HorizonReady, KORCReady, AdminCredentialReady, AdminPasswordReady, CatalogReady
 ```
 
 The `Ready` condition carries `ObservedGeneration = cp.Generation` so clients can
@@ -412,7 +418,7 @@ fields that the schema declared but the reconciler previously never wrote:
 | Field | Value |
 | --- | --- |
 | `status.updatePhase` | Fixed at `Idle` — the release-update state machine is not implemented and the other `UpdatePhase` values are reserved, so "no update in progress" is the current state |
-| `status.services` (the `name: keystone` entry) | `ready` mirrors the `KeystoneReady` sub-condition (via `conditions.AllTrue`); `release` is `spec.openStackRelease` |
+| `status.services` | one entry per managed service, in a stable order: `keystone` (present when `spec.services.keystone` is set) then `horizon` (present when `spec.services.horizon` is set). Each entry's `ready` mirrors the matching `KeystoneReady` / `HorizonReady` sub-condition (via `conditions.AllTrue`) and `release` is `spec.openStackRelease`; an unmanaged service is omitted rather than reported |
 
 ---
 
@@ -616,6 +622,60 @@ the ControlPlane provisioned:
 | Keystone create/update fails | False | `KeystoneError` | returns the error |
 | Keystone child not yet Ready | False | `WaitingForKeystone` | requeue 15s |
 | Keystone child Ready | True | `KeystoneReady` | — |
+
+### reconcileHorizon
+
+| Aspect | Value |
+| --- | --- |
+| File | `reconcile_horizon.go` |
+| Condition | `HorizonReady` |
+| Gate | `KeystoneReady == True` |
+| Projects / Owns | one `Horizon` child named `{controlplane.Name}-horizon` (`horizonNameSuffix`) in `childNamespace(cp)` — only when `spec.services.horizon` is set |
+| Requeue | `keystoneInfraGateRequeueAfter` = **5s** while gated; `infraRequeueAfter` = **15s** while the child is not Ready |
+
+`reconcileHorizon` is optional: `spec.services.horizon` unset means this
+ControlPlane manages no dashboard, and the sub-reconciler reports
+`HorizonReady=True` / `HorizonNotManaged` so the aggregate is not blocked (staged
+adoption). A previously-projected child is **preserved** unless the ControlPlane
+opts in with `c5c3.io/allow-horizon-deletion: "true"` (then the orphan is
+deleted) — the same annotation UX as Keystone, though the dashboard is stateless.
+
+When managed, the projection mirrors the Keystone one's *thin* discipline,
+reusing the ControlPlane's own specs so the dashboard points at the same backing
+services:
+
+- **Image:** repository defaults to `ghcr.io/c5c3/horizon` with the tag derived
+  from `spec.openStackRelease`; `spec.services.horizon.image` overrides the whole
+  image reference when set.
+- **Cache:** a DeepCopy of `cp.Spec.Infrastructure.Cache` (same `clusterRef` /
+  servers / replicas), **except** `Backend` is overridden to the Horizon Django
+  default `django.core.cache.backends.memcached.PyMemcacheCache`. The shared
+  `CacheSpec.Backend` carries the oslo.cache dogpile path Keystone consumes
+  (`dogpile.cache.pymemcache`), which Django renders verbatim as a `CACHES`
+  backend and rejects with `InvalidCacheBackendError`, so the dashboard would
+  never go Ready — only the endpoint-bearing fields are reused unchanged.
+- **Keystone endpoint:** derived top-down via `horizonKeystoneEndpoint(cp)` from
+  the Keystone child's naming convention, not read from the Keystone child's
+  status (no machine consumer reads status endpoints, per the settled
+  convention).
+- **SecretKeyRef:** defaults to the kind shim Secret `horizon-secret-key` (key
+  `secret-key`), which is pinned to the **default** ControlPlane identity;
+  `spec.services.horizon.secretKeyRef` overrides it, and a second ControlPlane
+  **must** set its own so each dashboard reads distinct `SECRET_KEY` material.
+- **Gateway:** a DeepCopy of `spec.services.horizon.gateway`; a nil source clears
+  the projected gateway so removing the block tears the HTTPRoute down.
+- **Replicas:** `commonv1.DefaultReplicas`, overridden by
+  `spec.services.horizon.replicas` when set (assigned unconditionally so clearing
+  the field reverts the child to the default instead of pinning a lost update).
+
+| Path | Status | Reason | Notes |
+| --- | --- | --- | --- |
+| `spec.services.horizon` unset | True | `HorizonNotManaged` | staged adoption — does not block the aggregate; a previously-projected child is preserved unless `c5c3.io/allow-horizon-deletion: "true"` is set |
+| `KeystoneReady` not True | False | `WaitingForKeystone` | requeue 5s; no Horizon CR is projected while Keystone is unready |
+| Horizon create/update fails | False | `HorizonError` | returns the error |
+| Projected spec rejected (HTTP 422 Invalid) | False | `HorizonProjectionRejected` | returns the error; the projection violates a Horizon CRD/webhook rule — reconcile the ControlPlane spec to a valid projection to recover |
+| Horizon child not yet Ready | False | `WaitingForHorizon` | requeue 15s |
+| Horizon child Ready | True | `HorizonReady` | — |
 
 ### reconcileKORC
 

--- a/tests/e2e-chaos/horizon-operator-pod-kill/chainsaw-test.yaml
+++ b/tests/e2e-chaos/horizon-operator-pod-kill/chainsaw-test.yaml
@@ -4,10 +4,13 @@
 
 # Chainsaw chaos E2E test for horizon-operator pod kill.
 # Verifies the deployed Horizon workload keeps serving while the operator is
-# down (operational-independence contract), and that the recovered operator
-# resumes reconciliation: a spec change patched after the kill is rolled out
-# by the replacement pod. The old-pod-gone check is UID-based so the
-# recovery poll cannot pass vacuously against the pre-chaos pod.
+# down (operational-independence contract), and that the operator resumes
+# reconciliation after the kill: a spec change patched afterwards is rolled
+# out. Identity-based verification: snapshot ALL pre-chaos pod UIDs, then
+# wait for at least one to disappear. Snapshotting only .items[0] is racy —
+# the operator runs 2 replicas and PodChaos mode: one picks its victim at
+# random, so the recorded pod survives the kill in ~half the runs and the
+# old-pod-gone poll fails spuriously. Mirrors operator-pod-crash.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -35,60 +38,89 @@ spec:
     catch:
     - script:
         content: ../diagnostics.sh baseline horizon-chaos-op
-  # ── Step 2: Record the operator pod UID, then inject the kill ──────────
+  # ── Step 2: Inject chaos and verify one operator pod was replaced ──────
+  # Snapshot, apply and poll live in one script so the pre-chaos UID
+  # snapshot and the wait share state. mode: one kills exactly one of the
+  # two replicas, so "at least one pre-chaos UID gone" proves the kill took
+  # effect regardless of which pod chaos-mesh picked.
   - try:
     - script:
+        # Timeout budget: Phase 1 (60×2s=120s) + Phase 2 (60×2s=120s) = 240s
+        # worst case. 270s gives 30s margin.
+        timeout: 270s
         content: |
-          kubectl get pods -n horizon-system -l app.kubernetes.io/name=horizon-operator \
-            -o jsonpath='{.items[0].metadata.uid}' > /tmp/horizon-operator-pod-uid
-          echo "operator pod UID before chaos: $(cat /tmp/horizon-operator-pod-uid)"
-    - apply:
-        file: 01-podchaos.yaml
-  # ── Step 3: Verify the old pod is gone and a replacement is Ready ──────
-  # UID-based: the pre-chaos pod UID must disappear before the recovery
-  # assertion counts, so a selector mismatch (kill never took effect)
-  # fails loudly instead of passing vacuously.
-  - try:
-    - script:
-        # Timeout budget: Phase 1 (15×2s=30s) + Phase 2 (45×2s=90s) = 120s
-        # worst case; 150s gives 30s margin.
-        timeout: 150s
-        content: |
-          OLD_UID=$(cat /tmp/horizon-operator-pod-uid)
+          # NOTE: set -euo pipefail is intentionally omitted. The polling
+          # loops use ${VAR:-0} defensive defaults that would fail under
+          # set -e when kubectl returns empty output, and loop exit
+          # conditions are checked explicitly rather than via exit codes.
 
-          # Phase 1: poll until the old pod UID is gone (kill took effect).
-          for i in $(seq 1 15); do
-            uids=$(kubectl get pods -n horizon-system -l app.kubernetes.io/name=horizon-operator \
-              -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}')
-            if ! printf '%s\n' "$uids" | grep -qx "$OLD_UID"; then
+          # Read desired replica count from the Deployment so the test stays
+          # valid if the operator replica count changes.
+          DESIRED=$(kubectl get deployment horizon-operator -n horizon-system -o jsonpath='{.spec.replicas}')
+          if [ -z "$DESIRED" ] || [ "$DESIRED" -lt 1 ]; then
+            echo "ERROR: could not determine desired replica count from horizon-operator Deployment"
+            exit 1
+          fi
+          echo "Desired replicas: ${DESIRED}"
+
+          # Snapshot pre-chaos pod UIDs. mode: one must replace at least one
+          # of these; checking that at least one disappears is race-free.
+          OLD_UIDS=$(kubectl get pods -n horizon-system -l app.kubernetes.io/name=horizon-operator -o jsonpath='{.items[*].metadata.uid}')
+          if [ -z "$OLD_UIDS" ]; then
+            echo "ERROR: no operator pods found before chaos injection"
+            exit 1
+          fi
+          echo "Pre-chaos operator pod UIDs: ${OLD_UIDS}"
+
+          # Inject chaos (kill one operator pod).
+          kubectl apply -f 01-podchaos.yaml
+
+          # Phase 1: wait until at least one pre-chaos UID is gone, proving
+          # mode: one replaced a pod. 60 iterations × 2s = 120s max.
+          # Empty CURRENT_UIDS (transient kubectl failure) would spuriously
+          # match "no UIDs present" — skip those iterations instead.
+          for i in $(seq 1 60); do
+            CURRENT_UIDS=$(kubectl get pods -n horizon-system -l app.kubernetes.io/name=horizon-operator -o jsonpath='{.items[*].metadata.uid}')
+            if [ -z "$CURRENT_UIDS" ]; then
+              sleep 2
+              continue
+            fi
+            REPLACED=0
+            for uid in $OLD_UIDS; do
+              case " $CURRENT_UIDS " in
+                *" $uid "*) ;;
+                *) REPLACED=1; break ;;
+              esac
+            done
+            if [ "$REPLACED" -eq 1 ]; then
+              echo "At least one pre-chaos operator pod replaced"
               break
             fi
             sleep 2
           done
-          if printf '%s\n' "$uids" | grep -qx "$OLD_UID"; then
-            echo "ERROR: operator pod $OLD_UID still present — pod kill did not take effect"
+          if [ "$REPLACED" -ne 1 ]; then
+            echo "ERROR: no pre-chaos operator pod was replaced by chaos injection"
+            echo "  pre-chaos UIDs: ${OLD_UIDS}"
+            echo "  current UIDs:   ${CURRENT_UIDS}"
             exit 1
           fi
-          echo "Pod kill confirmed: old UID $OLD_UID gone"
 
-          # Phase 2: poll until the operator Deployment is fully Ready again.
-          for i in $(seq 1 45); do
-            READY=$(kubectl get deployment -n horizon-system -l app.kubernetes.io/name=horizon-operator \
-              -o jsonpath='{.items[0].status.readyReplicas}')
-            DESIRED=$(kubectl get deployment -n horizon-system -l app.kubernetes.io/name=horizon-operator \
-              -o jsonpath='{.items[0].spec.replicas}')
-            if [ -n "$READY" ] && [ "$READY" = "$DESIRED" ]; then
-              echo "Operator recovered: readyReplicas=$READY"
+          # Phase 2: wait until readyReplicas returns to DESIRED (operator
+          # recovered and reconciliation resumed). 60×2s = 120s max.
+          for i in $(seq 1 60); do
+            READY=$(kubectl get deployment horizon-operator -n horizon-system -o jsonpath='{.status.readyReplicas}')
+            if [ "${READY:-0}" -eq "${DESIRED}" ]; then
+              echo "Operator recovered: readyReplicas=${DESIRED}"
               exit 0
             fi
             sleep 2
           done
-          echo "ERROR: operator did not recover — readyReplicas=${READY:-0}, expected ${DESIRED:-?}"
+          echo "ERROR: operator did not recover — readyReplicas=${READY:-0}, desired=${DESIRED}"
           exit 1
     catch:
     - script:
         content: ../diagnostics.sh chaos horizon-chaos-op --dep-label=app.kubernetes.io/name=horizon-operator --dep-ns=horizon-system
-  # ── Step 4: Delete PodChaos ────────────────────────────────────────────
+  # ── Step 3: Delete PodChaos ────────────────────────────────────────────
   - try:
     - delete:
         ref:
@@ -96,7 +128,7 @@ spec:
           kind: PodChaos
           name: kill-horizon-operator
           namespace: horizon-system
-  # ── Step 5: Prove the recovered operator reconciles a spec change ──────
+  # ── Step 4: Prove the recovered operator reconciles a spec change ──────
   - try:
     - patch:
         file: 02-patch-scale.yaml

--- a/tests/e2e/horizon/gateway-quick-start-smoke/00-namespace.yaml
+++ b/tests/e2e/horizon/gateway-quick-start-smoke/00-namespace.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Namespace fixture for the Horizon Gateway quick-start smoke test.
+#
+# The `openstack` namespace is already created by the kind overlay
+# (`deploy/kind/base/`) because it holds the Gateway/Certificate objects wired
+# in `openstack-gateway.yaml` (including the second `https-horizon` listener and
+# its `horizon-nip-io-tls` Certificate) and the managed `openstack-memcached`
+# the dashboard caches into. We still apply it here defensively so the suite is
+# self-contained — chainsaw's `apply` is idempotent on an existing Namespace,
+# which makes the test tolerate being invoked against a bare cluster as well.
+#
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack

--- a/tests/e2e/horizon/gateway-quick-start-smoke/01-smoke-horizon-cr.yaml
+++ b/tests/e2e/horizon/gateway-quick-start-smoke/01-smoke-horizon-cr.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal Horizon CR fixture for the Gateway quick-start smoke test — the
+# counterpart to tests/e2e/keystone/gateway-quick-start-smoke for the second
+# Gateway listener the kind overlay adds for the dashboard.
+#
+# This smoke test exercises the end-to-end TLS + Gateway data-plane path the
+# ControlPlane Quick Start documents: `curl -k
+# https://horizon.127-0-0-1.nip.io/auth/login/` must return HTTP 200 with the
+# rendered Django login page. That requires a Horizon CR whose spec.gateway
+# produces an HTTPRoute attaching to the kind overlay's `openstack-gw` Gateway
+# on its `https-horizon` listener (hostname `horizon.127-0-0-1.nip.io`,
+# terminating with `horizon-nip-io-tls`).
+#
+# Name-collision avoidance: chainsaw-config.yaml sets `execution.parallel: 4`,
+# so this fixture uses a unique CR name (`horizon-smoke`) to avoid clashing
+# with the sibling horizon suites on the shared `openstack-memcached` cluster
+# and on HTTPRoute object names inside the `openstack` namespace. No other
+# horizon suite attaches to the nip.io Gateway hostname, so a root-path route
+# does not conflict.
+#
+# The login page renders without a live Keystone (Keystone is only contacted on
+# login submit), so keystoneEndpoint points at the cluster-local convention URL
+# and the smoke needs no running Keystone — exactly like the horizon
+# basic-deployment fixture. The hostname MUST match the Gateway listener
+# hostname AND the dnsName on `Certificate/horizon-nip-io-tls` so the listener's
+# TLS Secret matches the SNI the client presents.
+#
+apiVersion: horizon.openstack.c5c3.io/v1alpha1
+kind: Horizon
+metadata:
+  name: horizon-smoke
+  namespace: openstack
+spec:
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/horizon
+    tag: "2025.2"
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  secretKeyRef:
+    name: horizon-secret-key
+    key: secret-key
+  gateway:
+    parentRef:
+      name: openstack-gw
+    hostname: horizon.127-0-0-1.nip.io
+    path: /

--- a/tests/e2e/horizon/gateway-quick-start-smoke/chainsaw-test.yaml
+++ b/tests/e2e/horizon/gateway-quick-start-smoke/chainsaw-test.yaml
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E smoke test for the Horizon Gateway quick-start path — the
+# dashboard counterpart to tests/e2e/keystone/gateway-quick-start-smoke.
+# Exercises end-to-end:
+#   `curl -k https://horizon.127-0-0-1.nip.io/auth/login/` returns HTTP 200
+#   with the rendered Django login page (containing `csrfmiddlewaretoken`).
+#
+# The full chain under test:
+#   kind host :443 → kindnode :31443 (NodePort) → Envoy Gateway proxy
+#   → the `https-horizon` HTTPS listener on `openstack/openstack-gw`
+#   (self-signed cert `horizon-nip-io-tls`, SNI `horizon.127-0-0-1.nip.io`)
+#   → HTTPRoute managed by the Horizon Operator → Service → Horizon pod.
+# This is the ONLY suite that exercises the second Gateway listener the kind
+# overlay adds for the dashboard (deploy/kind/base/openstack-gateway.yaml);
+# the keystone smoke only proves the `keystone.127-0-0-1.nip.io` listener.
+#
+# Suite location: lives under `tests/e2e/horizon/` (not
+# `tests/e2e/infrastructure/`) so the operator-installed `e2e-operator` matrix
+# job runs it — that job is the only place where the Horizon CRD is registered
+# and the operator can reconcile the smoke Horizon CR into an HTTPRoute. The
+# `e2e-infra` job suspends the horizon-operator HelmRelease, so a smoke suite
+# under `tests/e2e/infrastructure/` could never apply a Horizon CR.
+#
+# ── DECISION: curl from the chainsaw host (Option B) ─────────────────
+# curl runs directly from the chainsaw script step on the CI host, NOT from an
+# ephemeral in-cluster pod: the nip.io → 127.0.0.1 mapping is an external DNS
+# concern, `hack/kind-config.yaml` already bridges host 127.0.0.1:443 to the
+# proxy NodePort 31443, and the point of a quick-start smoke is to prove "the
+# external URL the docs tell the user to open WORKS". Mirrors the sibling
+# keystone gateway-quick-start-smoke.
+#
+# ── DECISION: probe /auth/login/, accept HTTP 200 only ───────────────
+# `/auth/login/` is the Horizon readiness-probe path: the Django login page
+# renders 200 without a live Keystone (Keystone is only contacted on login
+# submit), so the assertion is deterministic. A bare `/` would 302-redirect to
+# it. Accepting only 200 (not 200-or-404/302) proves the HTTPRoute is attached
+# AND the Horizon backend is serving — a 404 would only prove the data-plane is
+# reachable. The self-contained fixture (01-smoke-horizon-cr.yaml) makes the
+# 200 independent of sibling-suite ordering under `parallel: 4`.
+#
+# ── Scope gating — runtime presence checks ──────────────────────────
+# The script probes for `GatewayClass/envoy`, `Gateway/openstack-gw`, and the
+# `horizons.horizon.openstack.c5c3.io` CRD. If any is absent it exits 0 with a
+# SKIP line, so production overlays (no Envoy Gateway, operator suspended)
+# default-skip the test off any non-kind cluster with no `--selector` needed.
+#
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: horizon-gateway-quick-start-smoke
+spec:
+  # Django's dashboard warm-up is slower than Keystone's uWSGI start, so the
+  # envelope is 8m (vs the keystone smoke's 7m). The inner `kubectl wait`
+  # bounds (5m each) stay under this outer cap so their failure mode surfaces
+  # as a targeted `condition X not reached` diagnostic rather than chainsaw's
+  # generic script-timeout kill. The two waits are sequential phases of one
+  # reconcile chain (the Gateway must be Programmed before the HTTPRoute can
+  # attach and Horizon's aggregate Ready — which includes HTTPRouteReady — can
+  # flip True), so both complete well inside 8m on a warm cluster.
+  timeouts:
+    assert: 8m
+    exec: 8m
+  steps:
+  # ── Step 1: Apply namespace ───────────────────────────────────────
+  # The Horizon CR (01-smoke-horizon-cr.yaml) is NOT applied here — its CRD is
+  # registered by the horizon-operator, which is suspended in some overlays.
+  # Applying it unconditionally would abort chainsaw with `no matches for kind
+  # "Horizon"` on those clusters, so the apply lives in the Step 2 script body
+  # behind a CRD presence guard to keep this test default-safe.
+  - try:
+    - apply:
+        file: 00-namespace.yaml
+  # ── Step 2: Smoke-check dashboard reachability ────────────────────
+  - try:
+    - script:
+        timeout: 8m
+        # Chainsaw defaults to `sh`, which rejects `set -o pipefail`; all other
+        # infra/keystone e2e scripts pin bash for the same reason.
+        shell: bash
+        content: |
+          set -euo pipefail
+
+          # ── Presence guard ──────────────────────────────
+          # The kind overlay alone applies
+          # `deploy/kind/base/openstack-gateway.yaml`, which materialises
+          # GatewayClass/envoy and Gateway/openstack-gw (with the
+          # `https-horizon` listener). Their absence unambiguously signals a
+          # non-kind cluster — exit 0 with a SKIP line.
+          if ! kubectl get gatewayclass envoy >/dev/null 2>&1; then
+            echo "SKIP: GatewayClass/envoy not present (non-kind overlay)."
+            exit 0
+          fi
+          if ! kubectl get gateway openstack-gw -n openstack >/dev/null 2>&1; then
+            echo "SKIP: Gateway/openstack-gw not present in openstack namespace"
+            echo "      (non-kind overlay)."
+            exit 0
+          fi
+          # Horizon CRD gate — the `e2e-operator` matrix job installs the
+          # operator so the CRD is present and this guard passes; on infra-only
+          # or production clusters where the operator is suspended/absent, the
+          # guard exits 0 and the suite skips cleanly.
+          if ! kubectl get crd horizons.horizon.openstack.c5c3.io >/dev/null 2>&1; then
+            echo "SKIP: Horizon CRD not present (operator not deployed)."
+            exit 0
+          fi
+          echo "OK: Gateway + Horizon CRD present — running smoke checks"
+
+          # Apply the minimal Horizon CR now that the CRD presence guard has
+          # passed. Chainsaw runs scripts with the test directory as CWD, so
+          # the relative path resolves.
+          kubectl apply -f 01-smoke-horizon-cr.yaml
+
+          # ── Pre-flight: Gateway Programmed ────────────────────────
+          # Envoy Gateway sets `Programmed=True` once the listeners have usable
+          # TLS Secrets and the xDS data-plane is ready. Without this wait an
+          # early curl races kind startup (cert issuance + Envoy roll-out).
+          kubectl wait --for=condition=Programmed \
+            gateway/openstack-gw -n openstack --timeout=5m
+          echo "OK: Gateway/openstack-gw is Programmed"
+
+          # ── Pre-flight: Horizon Ready=True ────────────────────────
+          # Horizon's aggregate Ready condition includes the HTTPRouteReady
+          # sub-condition (only True after Envoy publishes Accepted=True on the
+          # route's parent) AND the deployment/health sub-conditions (pods
+          # serving the login page). Waiting on Ready gates the curl on BOTH
+          # the route being attached AND the backend being up — a stronger
+          # single gate than the keystone smoke's HTTPRouteReady-only wait.
+          # --timeout=5m stays inside the outer 8m script cap.
+          kubectl wait --for=condition=Ready \
+            horizon/horizon-smoke -n openstack --timeout=5m
+          echo "OK: Horizon/horizon-smoke Ready=True"
+
+          # ── HTTP 200 from the CI host ────────────────────
+          # `-k` accepts the self-signed cert issued by
+          # selfsigned-cluster-issuer (expected for a kind cluster). Retry
+          # loop: Envoy's xDS push and the Horizon pod's warm-up can race the
+          # Ready signal by a few seconds — up to 15 attempts, 2s apart — so a
+          # brief 503 from the proxy doesn't fail the whole run.
+          URL="https://horizon.127-0-0-1.nip.io/auth/login/"
+          HTTP_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+            HTTP_CODE="$(curl -sk -o /tmp/body -w '%{http_code}' "$URL" || true)"
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "OK: got HTTP 200 on attempt $attempt"
+              break
+            fi
+            echo "attempt $attempt: HTTP $HTTP_CODE (retrying in 2s)"
+            sleep 2
+          done
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: $URL returned HTTP $HTTP_CODE (expected 200)"
+            echo "--- response body (first 2KB) ---"
+            head -c 2048 /tmp/body 2>/dev/null || true
+            echo
+            exit 1
+          fi
+
+          # Non-empty body assertion: a 200 with an empty body would mean the
+          # HTTPRoute is attached but the Horizon backend returned nothing.
+          if [ ! -s /tmp/body ]; then
+            echo "ERROR: $URL returned HTTP 200 with empty body"
+            exit 1
+          fi
+
+          # Login-page assertion: Horizon's Django login form always embeds a
+          # `csrfmiddlewaretoken` hidden input; the `id_username` field is a
+          # fallback marker. Either proves the Gateway served the rendered
+          # dashboard login page, not a plain-text 200 from the proxy (the
+          # dashboard equivalent of the keystone smoke's JSON `version` check).
+          if grep -qE 'csrfmiddlewaretoken|id_username' /tmp/body; then
+            echo "OK: response body is the Horizon login page (login form marker present)"
+          else
+            echo "ERROR: response body is not the Horizon login page"
+            echo "--- response body (first 2KB) ---"
+            head -c 2048 /tmp/body 2>/dev/null || true
+            echo
+            exit 1
+          fi
+
+          echo "OK: Horizon login page responded 200 on https://horizon.127-0-0-1.nip.io/auth/login/"
+    catch:
+    # On failure, dump post-mortem state to help CI triage. Each resource is
+    # individually scoped so a missing one doesn't short-circuit the dump.
+    - describe:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: Gateway
+        name: openstack-gw
+        namespace: openstack
+    - describe:
+        apiVersion: horizon.openstack.c5c3.io/v1alpha1
+        kind: Horizon
+        name: horizon-smoke
+        namespace: openstack
+    - script:
+        # HTTPRoute and Certificate may not exist on an early failure (the
+        # Horizon CR hasn't reconciled yet), so `|| true` so the dump always
+        # runs to completion. The operator-managed HTTPRoute is listed
+        # generically rather than by a guessed name.
+        shell: bash
+        content: |
+          echo "=== HTTPRoutes in openstack ==="
+          kubectl get httproute -n openstack -o wide 2>&1 || true
+          echo
+          echo "=== Certificate horizon-nip-io-tls ==="
+          kubectl describe certificate horizon-nip-io-tls -n openstack 2>&1 || true
+          echo
+          echo "=== Horizon pods ==="
+          kubectl get pods -n openstack -l app.kubernetes.io/instance=horizon-smoke -o wide 2>&1 || true
+          echo
+          echo "=== events (last 30) ==="
+          kubectl get events -n openstack --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    - podLogs:
+        namespace: envoy-gateway-system
+        selector: app.kubernetes.io/name=gateway-helm
+        tail: 200


### PR DESCRIPTION
Makes the Horizon dashboard a first-class part of the ControlPlane quick-start.
Reviewing the tutorial surfaced that Horizon was only an optional appendix whose
block was broken (wrong Gateway namespace, and external access the
single-listener kind Gateway could never serve), while the operator already
projects a Horizon child and drives a `HorizonReady` condition. This branch
makes the documented external access actually work, brings the docs in sync, and
covers the new data-plane with an e2e smoke.

## Change set (in commit order)

### Enablement (kind overlay)

- **`feat(kind): add a Horizon HTTPS listener to the quick-start Envoy Gateway`** —
  a second HTTPS listener (`https-horizon`) on port 443, routed by SNI to
  `horizon.127-0-0-1.nip.io`, terminating with its own self-signed
  `horizon-nip-io-tls` certificate. Without it a Horizon HTTPRoute is rejected
  with `NoMatchingListenerHostname`. The NodePort pin is keyed by `port: 443`
  (not listener index), so the added listener leaves it untouched.
- **`feat(kind): project Horizon in the bundled ControlPlane quick-start CR`** —
  a `services.horizon` block so `WITH_CONTROLPLANE_CR=true` (and a hand-applied
  CR) rolls out the dashboard exposed through that listener. The default-identity
  ControlPlane inherits the seeded `horizon-secret-key` shim.

### Docs

- **`docs(quick-start): roll out Horizon as a standard ControlPlane service`** —
  Horizon moves from an optional appendix into the standard happy path (intro,
  Step 2 operator stack, Step 3 CRs, the six-condition chain in Step 4, and the
  dashboard-open step in Step 5). Fixes the wrong Gateway namespace and the
  stale "five sub-conditions" count.
- **`docs(c5c3): document the Horizon sub-reconciler in the reconciler reference`** —
  the reference still described a five-step chain / seven sub-conditions,
  omitting the already-shipping Horizon sub-reconciler. Adds the reconcileHorizon
  box (gated on KeystoneReady), corrects the counts, and adds a contract section
  mirroring `reconcile_horizon.go`.

### Test

- **`test(e2e): add a Horizon gateway quick-start smoke test`** — the dashboard
  counterpart to `keystone/gateway-quick-start-smoke`, covering the previously
  unverified second listener. It applies a minimal Horizon CR with a gateway
  block, waits for `Gateway Programmed` + Horizon `Ready` (which aggregates
  `HTTPRouteReady`), then curls `https://horizon.127-0-0-1.nip.io/auth/login/`
  from the CI host and asserts HTTP 200 with the rendered Django login page
  (`/auth/login/` is the readiness-probe path and renders without a live
  Keystone). Presence guards skip it cleanly off any non-kind cluster; it runs
  in the `e2e-operator` horizon leg with no extra matrix wiring.

## Verification

- `kubectl kustomize` of both kind overlays renders the two listeners + certs.
- The Horizon CR validates against the current CRD (`gateway.path` optional,
  `hostname` required); `chainsaw lint` passes on the new suite.
- Docs are free of CC-/REQ-IDs; the reconciliation-flow diagram stays width-aligned.

## Follow-up

- #562 — rename the `full-controlplane-keystone` e2e suite to `full-controlplane`
  now that it projects both Keystone and Horizon (kept separate: the naive CR
  rename to `controlplane` collides with two existing suites under the duplicate
  guard).
