### PR TITLE
fix(horizon): use cluster-local Keystone endpoints for dashboard logins

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -324,6 +324,14 @@ cluster (the listener terminates with a self-signed certificate). Log in with
 `admin` / the password from the `controlplane-keystone-admin-credentials` Secret
 above (domain `Default`).
 
+After login the dashboard redirects to `/project/`, which reports
+"Unauthorized" — the default landing page needs Compute/Network services this
+control plane does not serve yet. Open the Identity panel instead:
+
+```bash
+open https://horizon.127-0-0-1.nip.io:8443/identity/
+```
+
 > With the default `KIND_HOST_PORT=443` drop the `:8443` and open
 > `https://horizon.127-0-0-1.nip.io/`.
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -657,7 +657,10 @@ services:
 - **Keystone endpoint:** derived top-down via `horizonKeystoneEndpoint(cp)` from
   the Keystone child's naming convention, not read from the Keystone child's
   status (no machine consumer reads status endpoints, per the settled
-  convention).
+  convention). Always the cluster-local Service URL (the same URL K-ORC
+  authenticates against) — never the external `publicEndpoint` or gateway
+  hostname, which the dashboard pods may not be able to reach: the dashboard's
+  Django backend connects to this URL server-side, the browser never does.
 - **SecretKeyRef:** defaults to the kind shim Secret `horizon-secret-key` (key
   `secret-key`), which is pinned to the **default** ControlPlane identity;
   `spec.services.horizon.secretKeyRef` overrides it, and a second ControlPlane

--- a/docs/reference/horizon/horizon-crd.md
+++ b/docs/reference/horizon/horizon-crd.md
@@ -16,7 +16,7 @@ chart ships a synced copy (`make sync-crds` / `make verify-crd-sync`).
 | `deployment` | `DeploymentSpec` | no | Shared pod-level knobs: `replicas` (default 3), `resources` (Burstable defaults), `terminationGracePeriodSeconds`, `preStopSleepSeconds`, `strategy`, `topologySpreadConstraints`, `priorityClassName` |
 | `image` | `ImageSpec` | yes | Container image; exactly one of `tag` or `digest` (shared CEL rule) |
 | `cache` | `CacheSpec` | yes | Memcached backing the Django cache. Exactly one of `clusterRef` (managed) or `servers` (brownfield); `backend` is a Django cache backend path, defaulted to `django.core.cache.backends.memcached.PyMemcacheCache` |
-| `keystoneEndpoint` | `string` | yes | The Keystone public endpoint URL (`OPENSTACK_KEYSTONE_URL`); must match `^https?://` and parse with a host |
+| `keystoneEndpoint` | `string` | yes | The Keystone endpoint URL (`OPENSTACK_KEYSTONE_URL`); must match `^https?://` and parse with a host. Consumed server-side by the dashboard pods, so it must be reachable from inside the cluster — for a colocated control plane use the cluster-local Service URL, not an externally routable address |
 | `secretKeyRef` | `SecretRefSpec` | yes | Secret holding the Django `SECRET_KEY`; `key` defaults to `secret-key`. Injected as the `HORIZON_SECRET_KEY` env var, never into the ConfigMap |
 | `gateway` | `*GatewaySpec` | no | External exposure via a Gateway API HTTPRoute on port 8080; requires `hostname` and `parentRef.name` |
 | `networkPolicy` | `*NetworkPolicySpec` | no | Ingress restricted to TCP 8080 from the listed sources; egress auto-derived (DNS, the Keystone endpoint port, cache ports). At least one ingress source is required (fail-closed) |

--- a/docs/reference/horizon/horizon-reconciler.md
+++ b/docs/reference/horizon/horizon-reconciler.md
@@ -25,7 +25,7 @@ Secrets ──► Config ──► Deployment ──► (prune) ──► ┬─
 | Step | What it does | Condition |
 | --- | --- | --- |
 | Secrets | Gates on the OpenBao ClusterSecretStore and the ESO-synced `SECRET_KEY` Secret; digests the key material for the rollout annotation | `SecretsReady` |
-| Config | Renders `local_settings.py` (signed-cookie sessions, `CACHES`, `OPENSTACK_KEYSTONE_URL`, `LOGGING`, offline-compression settings, merged `extraConfig`) into an immutable content-addressed ConfigMap | `ConfigReady` |
+| Config | Renders `local_settings.py` (signed-cookie sessions, `CACHES`, `OPENSTACK_KEYSTONE_URL`, `OPENSTACK_ENDPOINT_TYPE = "internalURL"`, `LOGGING`, offline-compression settings, merged `extraConfig`) into an immutable content-addressed ConfigMap | `ConfigReady` |
 | Deployment | Ensures the uWSGI Deployment (login-page readiness/startup probes, `HORIZON_SECRET_KEY` env var, secret-key-hash pod annotation), the Service (port 8080), and the PDB; sets `status.endpoint` | `DeploymentReady` |
 | (prune) | Uninstrumented retention sweep of historical config ConfigMaps (retain 3 + current); failures flip `ConfigReady` |  |
 | HTTPRoute | Full `spec.gateway` lifecycle; reflects the Gateway's Accepted condition | `HTTPRouteReady` |

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -585,8 +585,8 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 		return c.Get(ctx, horizonKey, projectedHorizon)
 	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "Horizon child should be projected once KeystoneReady")
 	g.Expect(projectedHorizon.Spec.KeystoneEndpoint).To(
-		Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:5000/v3", keystoneName(cp), ns.Name)),
-		"keystoneEndpoint must be derived top-down from the naming convention",
+		Equal(fmt.Sprintf("http://%s.%s.svc:5000/v3", keystoneName(cp), ns.Name)),
+		"keystoneEndpoint must be the cluster-local convention URL (same as the K-ORC auth_url)",
 	)
 	g.Expect(projectedHorizon.Spec.Cache.ClusterRef).NotTo(BeNil())
 	g.Expect(projectedHorizon.Spec.Cache.ClusterRef.Name).To(Equal("openstack-memcached"))

--- a/operators/c5c3/internal/controller/reconcile_horizon.go
+++ b/operators/c5c3/internal/controller/reconcile_horizon.go
@@ -242,17 +242,17 @@ func (r *ControlPlaneReconciler) reconcileHorizon(ctx context.Context, cp *c5c3v
 }
 
 // horizonKeystoneEndpoint returns the Keystone endpoint URL projected into
-// the Horizon child's spec.keystoneEndpoint. When the ControlPlane advertises
-// an externally routable Keystone URL (explicit publicEndpoint or a gateway
-// hostname), that URL wins so browser-visible links resolve; otherwise the
-// cluster-local convention URL of the projected Keystone child is used —
-// derived top-down from the naming convention, never read from the child's
-// status.
+// the Horizon child's spec.keystoneEndpoint. It is ALWAYS the cluster-local
+// convention URL of the projected Keystone child (keystoneEndpointURL, the
+// same URL K-ORC authenticates against) — never the external publicEndpoint
+// or gateway hostname. OPENSTACK_KEYSTONE_URL is consumed server-side by the
+// dashboard's Django backend, not by the browser: an externally routable URL
+// that resolves to a host-only address (a kind port-mapping, an external LB)
+// is unreachable from the dashboard pods and breaks every login with
+// "Unable to establish connection to keystone endpoint". Derived top-down
+// from the naming convention, never read from the child's status.
 func horizonKeystoneEndpoint(cp *c5c3v1alpha1.ControlPlane) string {
-	if public := keystonePublicEndpoint(cp.Spec.Services.Keystone); public != "" {
-		return public
-	}
-	return fmt.Sprintf("http://%s.%s.svc.cluster.local:5000/v3", keystoneName(cp), childNamespace(cp))
+	return keystoneEndpointURL(cp)
 }
 
 // deleteOrphanedHorizon removes a previously-projected Horizon child when

--- a/operators/c5c3/internal/controller/reconcile_horizon_test.go
+++ b/operators/c5c3/internal/controller/reconcile_horizon_test.go
@@ -261,6 +261,12 @@ func TestReconcileHorizon_CacheDeepCopiedFromInfrastructure(t *testing.T) {
 }
 
 func TestReconcileHorizon_KeystoneEndpointDerivation(t *testing.T) {
+	// The dashboard's Django backend connects to spec.keystoneEndpoint
+	// server-side, so the projection must always use the cluster-local
+	// convention URL. External exposure (gateway hostname, explicit
+	// publicEndpoint) must NOT leak into it: those URLs may only resolve
+	// outside the cluster (a kind port-mapping, an external LB) and would
+	// break every dashboard login.
 	tests := []struct {
 		name   string
 		mutate func(cp *c5c3v1alpha1.ControlPlane)
@@ -269,20 +275,20 @@ func TestReconcileHorizon_KeystoneEndpointDerivation(t *testing.T) {
 		{
 			name:   "convention URL by default",
 			mutate: func(*c5c3v1alpha1.ControlPlane) {},
-			want:   "http://cp-keystone.default.svc.cluster.local:5000/v3",
+			want:   "http://cp-keystone.default.svc:5000/v3",
 		},
 		{
-			name: "gateway hostname wins",
+			name: "gateway hostname does not leak in",
 			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
 				cp.Spec.Services.Keystone.Gateway = &commonv1.GatewaySpec{
 					ParentRef: commonv1.GatewayParentRefSpec{Name: "openstack-gw"},
 					Hostname:  "keystone.example.com",
 				}
 			},
-			want: "https://keystone.example.com/v3",
+			want: "http://cp-keystone.default.svc:5000/v3",
 		},
 		{
-			name: "explicit publicEndpoint wins over gateway",
+			name: "explicit publicEndpoint does not leak in",
 			mutate: func(cp *c5c3v1alpha1.ControlPlane) {
 				cp.Spec.Services.Keystone.Gateway = &commonv1.GatewaySpec{
 					ParentRef: commonv1.GatewayParentRefSpec{Name: "openstack-gw"},
@@ -290,7 +296,7 @@ func TestReconcileHorizon_KeystoneEndpointDerivation(t *testing.T) {
 				}
 				cp.Spec.Services.Keystone.PublicEndpoint = "https://keystone.example.com:8443/v3"
 			},
-			want: "https://keystone.example.com:8443/v3",
+			want: "http://cp-keystone.default.svc:5000/v3",
 		},
 	}
 	for _, tc := range tests {

--- a/operators/horizon/api/v1alpha1/horizon_types.go
+++ b/operators/horizon/api/v1alpha1/horizon_types.go
@@ -83,8 +83,12 @@ type HorizonSpec struct {
 	// not an oslo.cache dogpile path.
 	Cache commonv1.CacheSpec `json:"cache"`
 
-	// KeystoneEndpoint is the Keystone public endpoint URL the dashboard
-	// authenticates against (OPENSTACK_KEYSTONE_URL). A plain URL field keeps
+	// KeystoneEndpoint is the Keystone endpoint URL the dashboard
+	// authenticates against (OPENSTACK_KEYSTONE_URL). The dashboard's Django
+	// backend connects to this URL server-side, so it must be reachable from
+	// the dashboard pods — for a colocated control plane that is the
+	// cluster-local Service URL, never an externally routable address that
+	// only resolves outside the cluster. A plain URL field keeps
 	// the operator decoupled from the keystone-operator; the c5c3 ControlPlane
 	// operator projects it from its Keystone child by naming convention.
 	// +kubebuilder:validation:MinLength=1

--- a/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
@@ -600,8 +600,12 @@ spec:
                   rule: has(self.tag) != has(self.digest)
               keystoneEndpoint:
                 description: |-
-                  KeystoneEndpoint is the Keystone public endpoint URL the dashboard
-                  authenticates against (OPENSTACK_KEYSTONE_URL). A plain URL field keeps
+                  KeystoneEndpoint is the Keystone endpoint URL the dashboard
+                  authenticates against (OPENSTACK_KEYSTONE_URL). The dashboard's Django
+                  backend connects to this URL server-side, so it must be reachable from
+                  the dashboard pods — for a colocated control plane that is the
+                  cluster-local Service URL, never an externally routable address that
+                  only resolves outside the cluster. A plain URL field keeps
                   the operator decoupled from the keystone-operator; the c5c3 ControlPlane
                   operator projects it from its Keystone child by naming convention.
                 minLength: 1

--- a/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
@@ -603,8 +603,12 @@ spec:
                   rule: has(self.tag) != has(self.digest)
               keystoneEndpoint:
                 description: |-
-                  KeystoneEndpoint is the Keystone public endpoint URL the dashboard
-                  authenticates against (OPENSTACK_KEYSTONE_URL). A plain URL field keeps
+                  KeystoneEndpoint is the Keystone endpoint URL the dashboard
+                  authenticates against (OPENSTACK_KEYSTONE_URL). The dashboard's Django
+                  backend connects to this URL server-side, so it must be reachable from
+                  the dashboard pods — for a colocated control plane that is the
+                  cluster-local Service URL, never an externally routable address that
+                  only resolves outside the cluster. A plain URL field keeps
                   the operator decoupled from the keystone-operator; the c5c3 ControlPlane
                   operator projects it from its Keystone child by naming convention.
                 minLength: 1

--- a/operators/horizon/internal/controller/reconcile_config.go
+++ b/operators/horizon/internal/controller/reconcile_config.go
@@ -112,6 +112,19 @@ func defaultSettings(horizon *horizonv1alpha1.Horizon) (map[string]apiextensions
 			},
 		},
 		"OPENSTACK_KEYSTONE_URL": horizon.Spec.KeystoneEndpoint,
+		// The dashboard's server-side clients resolve service URLs from the
+		// Keystone catalog, not from OPENSTACK_KEYSTONE_URL. The upstream
+		// default ("publicURL") selects browser-facing catalog entries, which
+		// a colocated in-cluster dashboard cannot reach when they point at a
+		// host-only address (a kind port-mapping, an external LB). The
+		// dashboard runs next to the services it fronts, so it uses the
+		// internal interface — the same posture kolla-ansible and
+		// openstack-helm ship. Deployments fronting a remote cloud override
+		// this via spec.extraConfig. The legacy "...URL" spelling is
+		// load-bearing: openstack_dashboard's ENDPOINT_TYPE_TO_INTERFACE map
+		// only knows publicURL/internalURL/adminURL, and a bare "internal"
+		// fails every catalog lookup.
+		"OPENSTACK_ENDPOINT_TYPE": "internalURL",
 		// ALLOWED_HOSTS is a closed allow-list of the Hosts the dashboard is
 		// actually reached under (see allowedHosts). Keeping Django's
 		// Host-header validation in force — rather than disabling it with "*"

--- a/operators/horizon/internal/controller/reconcile_config_test.go
+++ b/operators/horizon/internal/controller/reconcile_config_test.go
@@ -46,6 +46,11 @@ func TestReconcileConfig_RendersLocalSettings(t *testing.T) {
 	g.Expect(rendered).To(ContainSubstring(`"LOCATION": ["memcached:11211"]`))
 
 	g.Expect(rendered).To(ContainSubstring(`OPENSTACK_KEYSTONE_URL = "http://keystone.default.svc.cluster.local:5000/v3"`))
+	// The server-side clients must use the internal catalog interface — the
+	// public entries may only resolve outside the cluster. The legacy "...URL"
+	// spelling is required by openstack_dashboard's ENDPOINT_TYPE_TO_INTERFACE
+	// map; a bare "internal" fails every catalog lookup.
+	g.Expect(rendered).To(ContainSubstring(`OPENSTACK_ENDPOINT_TYPE = "internalURL"`))
 	g.Expect(rendered).To(ContainSubstring("COMPRESS_OFFLINE = True"))
 	g.Expect(rendered).To(ContainSubstring(`STATIC_ROOT = "/var/lib/openstack/horizon-static"`))
 	g.Expect(rendered).To(ContainSubstring("DEBUG = False"))

--- a/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
@@ -316,13 +316,73 @@ spec:
             "$(kubectl get horizon "${HORIZON_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.image.tag}')"
           assert_eq "Horizon cache clusterRef wired to infra" "openstack-memcached" \
             "$(kubectl get horizon "${HORIZON_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.cache.clusterRef.name}')"
+          # The cluster-local convention URL (same as K-ORC's auth_url) — the
+          # external gateway hostname must never leak in: OPENSTACK_KEYSTONE_URL
+          # is consumed server-side by the dashboard pods.
           assert_eq "Horizon keystoneEndpoint derived from the naming convention" \
-            "http://${KEYSTONE_CR}.${CP_NS}.svc.cluster.local:5000/v3" \
+            "http://${KEYSTONE_CR}.${CP_NS}.svc:5000/v3" \
             "$(kubectl get horizon "${HORIZON_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.keystoneEndpoint}')"
           assert_eq "Horizon secretKeyRef overridden to the per-CP Secret" \
             "controlplane-keystone-horizon-secret-key" \
             "$(kubectl get horizon "${HORIZON_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.secretKeyRef.name}')"
           assert_eq "Horizon CR owned by ControlPlane" "${CP_NAME}" "$(owner_of horizon "${HORIZON_CR}")"
+
+          # ── Link 2c: Horizon dashboard login round-trip ────────────────────
+          # A real login POST is the only check that exercises the dashboard's
+          # server-side Keystone path end-to-end: Django authenticates against
+          # OPENSTACK_KEYSTONE_URL and then lists the user's projects via the
+          # catalog interface selected by OPENSTACK_ENDPOINT_TYPE. A login-page
+          # GET renders without a live Keystone and misses both (which is how
+          # an unreachable keystoneEndpoint once passed CI). Success is the 302
+          # redirect plus a sessionid cookie; a failed login re-renders the
+          # form with HTTP 200.
+          echo "== Horizon login POST (expect 302 + sessionid) =="
+          ADMIN_PW="$(kubectl get secret "${KEYSTONE_CR}-admin-credentials" -n "${CP_NS}" \
+            -o 'jsonpath={.data.password}' | base64 -d)"
+          kubectl run cp-horizon-login --image=ghcr.io/c5c3/keystone:2025.2 --rm -i --restart=Never \
+            -n "${CP_NS}" \
+            --env "HORIZON_BASE=http://${HORIZON_CR}.${CP_NS}.svc:8080" \
+            --env "OS_PASSWORD=${ADMIN_PW}" \
+            --command -- python3 - <<'PYEOF'
+          import http.cookiejar
+          import os
+          import re
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          class NoRedirect(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, req, fp, code, msg, headers, newurl):
+                  return None
+
+          base = os.environ['HORIZON_BASE']
+          login_url = base + '/auth/login/'
+          jar = http.cookiejar.CookieJar()
+          opener = urllib.request.build_opener(
+              urllib.request.HTTPCookieProcessor(jar), NoRedirect())
+          body = opener.open(login_url).read().decode()
+          token = re.search('name="csrfmiddlewaretoken" value="([^"]+)"', body).group(1)
+          form = urllib.parse.urlencode({
+              'csrfmiddlewaretoken': token,
+              'region': 'default',
+              'domain': 'Default',
+              'username': 'admin',
+              'password': os.environ['OS_PASSWORD'],
+          }).encode()
+          req = urllib.request.Request(login_url, data=form,
+                                       headers={'Referer': login_url})
+          try:
+              status = opener.open(req).status
+          except urllib.error.HTTPError as err:
+              status = err.code
+          assert status == 302, (
+              'login POST returned HTTP %s (expected 302); the dashboard could '
+              'not authenticate against Keystone' % status)
+          assert any(c.name == 'sessionid' for c in jar), \
+              'no sessionid cookie after the login redirect'
+          print('OK: dashboard login round-trip succeeded (302 + sessionid)')
+          PYEOF
+          echo "OK: Horizon authenticated against Keystone through the cluster-local endpoint"
 
           # ── Link 3: K-ORC ApplicationCredential (restricted:true, owned) ───
           wait_cp_condition KORCReady 600


### PR DESCRIPTION
## Problem

Every Horizon login through a gateway-exposed ControlPlane failed with **"Unable to establish connection to keystone endpoint"**, while `openstack token issue` against the same stack worked fine. Reproduced on the kind quick-start stack (`keystone.127-0-0-1.nip.io`).

## Root cause — two layers

1. **`OPENSTACK_KEYSTONE_URL` pointed at the external URL.** The c5c3 projection preferred the `publicEndpoint` / gateway hostname for the Horizon child's `spec.keystoneEndpoint`. But this URL is consumed **server-side** by the Django backend, never by the browser — on kind the nip.io hostname resolves to `127.0.0.1`, which inside the dashboard pod is its own loopback (`[Errno 111] Connection refused`).
2. **Catalog lookups still resolved the public entry.** Even with a reachable auth URL, `openstack_auth` and `openstack_dashboard` resolve all follow-up identity calls (project list at login, panel clients, the session's `region_endpoint`) from the token's service catalog via `OPENSTACK_ENDPOINT_TYPE`, whose upstream default selects the same unreachable public endpoint.

## Fix

- `horizonKeystoneEndpoint()` (c5c3) now always returns the cluster-local convention URL — the same URL K-ORC authenticates against; external exposure never leaks into the child spec.
- The horizon-operator renders `OPENSTACK_ENDPOINT_TYPE = "internalURL"` — Keystone's bootstrap always registers the internal endpoint with the Service DNS. The legacy `...URL` spelling is load-bearing: `openstack_dashboard`'s `ENDPOINT_TYPE_TO_INTERFACE` map only knows `publicURL`/`internalURL`/`adminURL`; a bare `"internal"` fails every catalog lookup. `spec.extraConfig` remains the override for dashboards fronting a remote cloud.

## Testing

- Unit tests updated/extended in both operators (`OPENSTACK_ENDPOINT_TYPE` assertion; endpoint-derivation cases now prove gateway/publicEndpoint do **not** leak in).
- The full-controlplane e2e suite gains a **real login POST round-trip** (CSRF handshake → expect the 302 redirect + `sessionid` cookie). A login-page GET renders without a live Keystone, which is how the broken endpoint passed CI so far.
- Verified end-to-end on a live kind stack with rebuilt operators: login 302, `/identity/` and `/project/api_access/` render 200.

## Docs

- CRD/reconciler reference updated (`keystoneEndpoint` semantics, rendered settings).
- Quick-start now documents that the post-login `/project/` landing page reports "Unauthorized" on a Keystone-only control plane and points at `/identity/` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)