### PR TITLE
fix(openbao): keystone-db token TTL silently capped DB leases at 1h

### DIFF
--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -125,14 +125,25 @@ main() {
   # authenticate; the SA name is fixed and the cross-tenant boundary is enforced by
   # the keystone-db-dynamic policy, which templates the readable creds path to the
   # caller's OWN service_account_namespace (an exact match, so a token minted in
-  # namespace A cannot read namespace B's path). TTLs mirror the eso-<cluster> roles.
+  # namespace A cannot read namespace B's path).
+  #
+  # Token TTLs must cover the DB credential lease, NOT mirror the eso-<cluster>
+  # roles: OpenBao revokes a dynamic-secret lease together with the auth token
+  # that minted it, so the effective credential lifetime is
+  # min(lease TTL, minting token TTL). With the short eso-style 1h token this
+  # role once wore, every issued DB credential silently died after ~1h — 23h
+  # before the ExternalSecret's 24h refresh re-minted — dropping the ephemeral
+  # MySQL user under a running Keystone. Pin both values to DB_CREDS_MAX_TTL
+  # (72h, setup-database-tenant.sh) so the lease TTLs there stay the binding
+  # constraint; the token is read-only-scoped by keystone-db-dynamic, which
+  # bounds the exposure of its longer lifetime.
   log "Writing keystone-db role on kubernetes/management..."
   bao_exec bao write "auth/kubernetes/management/role/keystone-db" \
     bound_service_account_names=keystone-db-creds \
     bound_service_account_namespaces="*" \
     token_policies=keystone-db-dynamic \
-    token_ttl=1h \
-    token_max_ttl=4h
+    token_ttl=72h \
+    token_max_ttl=72h
   log "keystone-db role written."
 
   # AppRole auth

--- a/deploy/openbao/bootstrap/setup-database-tenant.sh
+++ b/deploy/openbao/bootstrap/setup-database-tenant.sh
@@ -60,6 +60,14 @@ BAO_TOKEN="${BAO_TOKEN:?BAO_TOKEN must be set}"
 # loses DB access, instead of silently arming an outage within a couple of hours.
 # max_ttl caps the absolute lifetime of any issued credential. Override via the
 # environment to tune the rotation cadence.
+#
+# INVARIANT: these TTLs only bind while the minting auth token outlives them.
+# OpenBao revokes a dynamic-secret lease together with the token that created
+# it, so the keystone-db auth role (setup-auth.sh) pins its token_ttl/
+# token_max_ttl to DB_CREDS_MAX_TTL. Raising DB_CREDS_* beyond 72h without
+# raising the role's token TTLs silently caps the effective credential
+# lifetime at the token's — the failure mode that once killed running
+# Keystones hourly under a 1h token.
 DB_CREDS_DEFAULT_TTL="${DB_CREDS_DEFAULT_TTL:-48h}"
 DB_CREDS_MAX_TTL="${DB_CREDS_MAX_TTL:-72h}"
 

--- a/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
+++ b/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
@@ -167,6 +167,13 @@ to remove the generator objects.
   Raise `DB_CREDS_DEFAULT_TTL` / `DB_CREDS_MAX_TTL` (and the operator's refresh
   interval) further to trade churn against lease headroom; the PodDisruptionBudget
   and the surge-before-remove rollout strategy keep each roll zero-downtime.
+- **Auth-token TTL bounds the lease:** OpenBao revokes a dynamic-secret lease
+  together with the auth token that minted it, so the effective credential
+  lifetime is `min(lease TTL, minting token TTL)`. The `keystone-db` auth role
+  therefore pins its token TTLs to `DB_CREDS_MAX_TTL` (72h). When raising
+  `DB_CREDS_*` beyond that, raise the role's `token_ttl`/`token_max_ttl` in
+  lockstep — a shorter token silently drops the ephemeral MySQL user under a
+  running Keystone long before the advertised lease end.
 - **Revocation semantics:** revoking a lease runs `DROP USER`, which rejects
   *new* connections. Already-open sessions of a dropped user may persist until
   they disconnect.

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -372,9 +372,18 @@ policy, which templates the readable path to the caller's own
 `service_account_namespace` (an exact match — a token minted in one namespace
 cannot read another namespace's path).
 
+Unlike the `eso-<cluster>` roles, the `keystone-db` token TTLs are pinned to the
+database engine's `max_ttl` (72h): OpenBao revokes a dynamic-secret lease
+together with the auth token that minted it, so a token shorter than the lease
+silently caps the effective credential lifetime at the token's — with an
+eso-style 1h token, every issued DB credential died after ~1h while the
+ExternalSecret refresh only re-mints every 24h, dropping the ephemeral MySQL
+user under a running Keystone. The longer-lived token is bounded by the
+read-only `keystone-db-dynamic` policy.
+
 | Mount Path | Role | Bound SA | Bound NS | Policy | TTL | Max TTL |
 | --- | --- | --- | --- | --- | --- | --- |
-| `kubernetes/management` | `keystone-db` | `keystone-db-creds` | `*` | `keystone-db-dynamic` | 1h | 4h |
+| `kubernetes/management` | `keystone-db` | `keystone-db-creds` | `*` | `keystone-db-dynamic` | 72h | 72h |
 
 **Note:** The management cluster mount is fully configured — the script explicitly writes
 `auth/kubernetes/management/config` with the in-cluster Kubernetes API endpoint and CA


### PR DESCRIPTION
## Problem

A running Keystone loses database access roughly **one hour after every dynamic-credential mint**: MariaDB rejects the ephemeral user with `pymysql 1045 Access denied for user 'v-kubernetes-...'`, `POST /v3/auth/tokens` returns 500, and the stack stays broken for up to 23 hours until the ExternalSecret's 24h refresh (or a manual `force-sync` annotation) re-mints. Observed live on the kind quick-start stack: credential minted at pod start, revoked ~70 minutes later.

## Root cause

The database engine role intends `default_ttl=48h` / `max_ttl=72h`, and the `setup-database-tenant.sh` comment promises a full-day rollout window (48h lease − 24h refresh). But OpenBao revokes a dynamic-secret lease **together with the auth token that minted it**, and the `keystone-db` Kubernetes-auth role — used by the c5c3 operator's `VaultDynamicSecret` generator — carried the eso-style `token_ttl=1h`. The effective credential lifetime was `min(48h, 1h)`: the lease died with the token, and the documented TTL design never took effect.

## Fix

- Pin the `keystone-db` role's `token_ttl`/`token_max_ttl` to the engine's `max_ttl` (72h) so the lease TTLs stay the binding constraint. The longer-lived token is bounded by the read-only, tenant-templated `keystone-db-dynamic` policy.
- Document the `min(lease TTL, minting token TTL)` invariant at the role (`setup-auth.sh`), at the `DB_CREDS_*` knobs that must follow it (`setup-database-tenant.sh`), and in the reference + migration-guide pages — so raising one without the other cannot silently re-arm the outage.

## Applying to existing clusters

The bootstrap scripts are idempotent — re-run `setup-auth.sh` (with `BAO_TOKEN`) against a live OpenBao, then force one ExternalSecret refresh so the next mint inherits the long-lived token:

```bash
kubectl annotate externalsecret <cp>-keystone-db-credentials -n <ns> force-sync=$(date +%s) --overwrite
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)