### PR TITLE
test(e2e-chaos): make diagnostics.sh CR-kind aware

### DIFF
--- a/tests/e2e-chaos/diagnostics.sh
+++ b/tests/e2e-chaos/diagnostics.sh
@@ -17,6 +17,9 @@
 #             pod status, Chaos Mesh status, pod logs, events.
 #
 # Options:
+#   --cr-kind=KIND        Kind of the CR under test (default: keystone). Set to
+#                         the service kind (e.g. horizon) so the CR status dump
+#                         targets the right resource instead of always keystone.
 #   --dep-label=LABEL     Label selector for dependency pods (chaos mode).
 #   --dep-ns=NAMESPACE    Namespace for dependency pods (default: $NAMESPACE).
 #   --log-label=LABEL     Label selector for log collection. Defaults to
@@ -30,6 +33,7 @@ CR_NAME="${2:?Usage: diagnostics.sh <baseline|chaos> <cr-name> [options]}"
 shift 2
 
 # Parse options.
+CR_KIND="keystone"
 DEP_LABEL=""
 DEP_NS="${NAMESPACE:-openstack}"
 LOG_LABEL=""
@@ -37,6 +41,7 @@ INCLUDE_ESO=false
 
 for arg in "$@"; do
   case "$arg" in
+    --cr-kind=*)   CR_KIND="${arg#--cr-kind=}" ;;
     --dep-label=*) DEP_LABEL="${arg#--dep-label=}" ;;
     --dep-ns=*)    DEP_NS="${arg#--dep-ns=}" ;;
     --log-label=*) LOG_LABEL="${arg#--log-label=}" ;;
@@ -48,9 +53,9 @@ done
 # Default log label to dependency label.
 LOG_LABEL="${LOG_LABEL:-$DEP_LABEL}"
 
-# ── Common: Keystone CR status ──────────────────────────────────────────────
-echo "=== Keystone CR status ==="
-kubectl get keystone "$CR_NAME" -n "$NAMESPACE" -o yaml 2>&1 || true
+# ── Common: CR status ───────────────────────────────────────────────────────
+echo "=== CR status ($CR_KIND/$CR_NAME) ==="
+kubectl get "$CR_KIND" "$CR_NAME" -n "$NAMESPACE" -o yaml 2>&1 || true
 
 case "$MODE" in
   baseline)

--- a/tests/e2e-chaos/horizon-memcached-pod-kill/chainsaw-test.yaml
+++ b/tests/e2e-chaos/horizon-memcached-pod-kill/chainsaw-test.yaml
@@ -39,7 +39,7 @@ spec:
               reason: AllReady
     catch:
     - script:
-        content: ../diagnostics.sh baseline horizon-chaos-mc
+        content: ../diagnostics.sh baseline horizon-chaos-mc --cr-kind=horizon
   # ── Step 3: Inject PodChaos to kill a Memcached pod ────────────────────
   - try:
     - apply:
@@ -104,7 +104,7 @@ spec:
               reason: AllReady
     catch:
     - script:
-        content: ../diagnostics.sh chaos horizon-chaos-mc --dep-label=app.kubernetes.io/name=memcached
+        content: ../diagnostics.sh chaos horizon-chaos-mc --cr-kind=horizon --dep-label=app.kubernetes.io/name=memcached
   # ── Step 5: Delete PodChaos ────────────────────────────────────────────
   - try:
     - delete:
@@ -139,4 +139,4 @@ spec:
           echo "PASS: zero dashboard pod restarts during Memcached loss"
     catch:
     - script:
-        content: ../diagnostics.sh chaos horizon-chaos-mc --dep-label=app.kubernetes.io/name=memcached
+        content: ../diagnostics.sh chaos horizon-chaos-mc --cr-kind=horizon --dep-label=app.kubernetes.io/name=memcached

--- a/tests/e2e-chaos/horizon-operator-pod-kill/chainsaw-test.yaml
+++ b/tests/e2e-chaos/horizon-operator-pod-kill/chainsaw-test.yaml
@@ -37,7 +37,7 @@ spec:
               reason: AllReady
     catch:
     - script:
-        content: ../diagnostics.sh baseline horizon-chaos-op
+        content: ../diagnostics.sh baseline horizon-chaos-op --cr-kind=horizon
   # ── Step 2: Inject chaos and verify one operator pod was replaced ──────
   # Snapshot, apply and poll live in one script so the pre-chaos UID
   # snapshot and the wait share state. mode: one kills exactly one of the
@@ -119,7 +119,7 @@ spec:
           exit 1
     catch:
     - script:
-        content: ../diagnostics.sh chaos horizon-chaos-op --dep-label=app.kubernetes.io/name=horizon-operator --dep-ns=horizon-system
+        content: ../diagnostics.sh chaos horizon-chaos-op --cr-kind=horizon --dep-label=app.kubernetes.io/name=horizon-operator --dep-ns=horizon-system
   # ── Step 3: Delete PodChaos ────────────────────────────────────────────
   - try:
     - delete:
@@ -157,4 +157,4 @@ spec:
               reason: AllReady
     catch:
     - script:
-        content: ../diagnostics.sh chaos horizon-chaos-op --dep-label=app.kubernetes.io/name=horizon-operator --dep-ns=horizon-system
+        content: ../diagnostics.sh chaos horizon-chaos-op --cr-kind=horizon --dep-label=app.kubernetes.io/name=horizon-operator --dep-ns=horizon-system


### PR DESCRIPTION
## Problem

The shared chaos diagnostics helper `tests/e2e-chaos/diagnostics.sh` hardcoded `kubectl get keystone "$CR_NAME"`. It predated the Horizon onboarding (#552), when every chaos suite targeted a Keystone CR.

The two Horizon chaos suites now feed a **Horizon** CR name into the helper, so whenever their `catch` blocks fire they emitted a misleading `NotFound` for the Keystone kind and silently dropped the CR `status.conditions` — the single most useful post-mortem artifact — in exactly the failure path the `catch` block exists to cover.

This is a latent diagnostics gap: it never affects test pass/fail (the bad `kubectl get keystone` runs only inside the `catch` block), so green CI never exercises it. It bites on the *next* Horizon chaos failure.

## Fix

1. Add a `--cr-kind=KIND` option (default `keystone`, so the eight existing Keystone suites are byte-for-byte unchanged).
2. Make the section header generic: `=== CR status (<kind>/<name>) ===`.
3. Pass `--cr-kind=horizon` at the six call sites in the two Horizon suites (`horizon-operator-pod-kill`, `horizon-memcached-pod-kill`).

The helper stays a single service-agnostic script — future services onboarded per the Keystone reference reuse it without another copy-paste fork.

## Verification

Behavioral test with a `kubectl` stub on `PATH`:

- `--cr-kind=horizon` → `kubectl get horizon horizon-chaos-op …` ✅
- default (no flag) → `kubectl get keystone keystone-chaos-api …` ✅ (unchanged)
- unknown option still rejected ✅

Plus `bash -n` clean and `shellcheck` clean.

## Acceptance criteria

- [x] A failing Horizon chaos suite dumps the Horizon CR `status.conditions` in its `catch` output.
- [x] Keystone suites' diagnostic output is unchanged.
- [x] No per-service fork of `diagnostics.sh`.

Closes #568