### PR TITLE
feat(c5c3): short-circuit the reconciler chain in External keystone mode

### DIFF
--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -355,12 +355,17 @@ identity against that endpoint rather than deploying a Keystone workload.
 | `endpointType` | `string` (`public` \| `internal` \| `admin`) | No | `public` | Which Keystone catalog interface to authenticate against. Defaulted to `public` by both the `+kubebuilder:default` marker and the defaulting webhook. Named `endpointType` (not `interface`) because it maps to the clouds.yaml `endpoint_type` key — K-ORC drops gophercloud's `Interface` field and only honours `endpoint_type` (the authoritative note lives on `buildAppCredCloudsYAML` in the reconciler's `korc_cloudsyaml.go`). |
 | `caBundleSecretRef` | [`*commonv1.SecretRefSpec`](../keystone/keystone-crd.md#secretrefspec) | No | `nil` | References a Secret carrying a private CA bundle the client trusts when verifying the external endpoint. The referenced bundle is projected verbatim into the generated K-ORC credentials Secret (K-ORC reads an inline `cacert` PEM key from the same Secret that carries `clouds.yaml` — no mount, no upstream change). `key` defaults to `ca.crt`; this default is **webhook-only** because the shared `SecretRefSpec` carries no c5c3-specific marker (the same discipline as `passwordSecretRef.key`). When the ref is set its `name` must be non-empty (CRD `MinLength` marker + webhook). |
 
-> **Consumption is deferred.** This block is pure API surface here. The
-> clouds.yaml builders and admin import filters that consume `authURL`,
-> `endpointType`, and `caBundleSecretRef` land with the External-mode
-> reconciler work; until then an External-mode ControlPlane is accepted at
-> admission but halts at `InfrastructureReady=False`, reason
-> `ExternalModeNotImplemented` (see [Status Conditions](#status-conditions)).
+> **Partial consumption.** The reconciler chain understands External mode: the
+> Infrastructure, DBCredentials, AdminPassword and Keystone sub-reconcilers skip
+> their projection with reason `ExternallyManaged`, and `reconcileKORC`
+> classifies failures against the external endpoint onto `KORCReady` (see
+> [Status Conditions](#status-conditions) and the
+> [reconciler reference](./controlplane-reconciler.md#external-keystone-mode-and-the-chain)).
+> `authURL` currently names the endpoint in conditions, events, and the
+> `ImportStalled` detector's guidance. The clouds.yaml builders and admin import
+> filters that consume `authURL`, `endpointType`, and `caBundleSecretRef` to
+> actually *dial* the external Keystone land with the K-ORC clouds.yaml work; the
+> identity catalog stays managed until the import-first catalog work lands.
 
 ---
 
@@ -1049,7 +1054,8 @@ Set by `reconcileInfrastructure`.
 | `False` | `WaitingForCache` | Managed Memcached is ensured but not yet Ready. |
 | `False` | `MariaDBError` | Error create-or-updating the MariaDB child. |
 | `False` | `MemcachedError` | Error create-or-updating the Memcached child. |
-| `False` | `ExternalModeNotImplemented` | `spec.infrastructure` is unset (External keystone mode). The ControlPlane is accepted at admission but halts here with a gentle requeue — External-mode reconciliation (managing identity against `services.keystone.external.authURL` with no backing services) is not yet implemented. This interim reason is replaced wholesale when the External-mode reconciliation lands. |
+| `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: identity is managed against `services.keystone.external.authURL`, so no MariaDB/Memcached is provisioned. |
+| `False` | `InfrastructureNotConfigured` | `spec.infrastructure` is unset on a **non**-External ControlPlane. The validating webhook requires the block outside External mode, so this only fires for a webhook-bypassed CR; it fails closed rather than dereferencing the nil block. |
 
 ### DBCredentialsReady
 
@@ -1065,6 +1071,7 @@ ExternalSecret's stale per-object Ready cache.
 | --- | --- | --- |
 | `True` | `DBCredentialsReady` | The DB-credential ExternalSecret is Ready; the materialised Secret exists. |
 | `True` | `BrownfieldUserSuppliedCredential` | Brownfield database (`clusterRef` unset): the user supplies the DB-credential Secret out-of-band, so no ExternalSecret is projected and the chain proceeds immediately. |
+| `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: the ControlPlane manages no database at all, so nothing is projected and neither OpenBao nor the `ClusterSecretStore` is consulted. |
 | `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `ExternalSecretError` | Error ensuring or checking the DB-credential ExternalSecret. |
 | `False` | `WaitingForDBCredentialSecret` | The ExternalSecret is ensured but ESO has not yet synced it to Ready. |
@@ -1084,6 +1091,7 @@ its Ready status.
 | --- | --- | --- |
 | `True` | `AdminPasswordReady` | The admin-password ExternalSecret is Ready; the materialised Secret exists. |
 | `True` | `BrownfieldUserSuppliedCredential` | Brownfield database (`clusterRef` unset): the user supplies the admin-password Secret out-of-band, so no ExternalSecret is projected and the chain proceeds immediately. |
+| `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: the admin password is read from the user-supplied `korc.adminCredential.passwordSecretRef` Secret; no ExternalSecret is projected and no OpenBao bootstrap path is seeded. Updating that Secret is what drives a hash-driven re-mint of the admin application credential. |
 | `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `ExternalSecretError` | Error ensuring or checking the admin-password ExternalSecret. |
 | `False` | `WaitingForAdminPasswordSecret` | The ExternalSecret is ensured but ESO has not yet synced it to Ready. |
@@ -1095,6 +1103,8 @@ Set by `reconcileKeystone` (gated on `InfrastructureReady`).
 | Status | Reason | When |
 | --- | --- | --- |
 | `True` | `KeystoneReady` | The projected Keystone CR reports Ready. |
+| `True` | `KeystoneNotManaged` | `services.keystone` is unset: this ControlPlane manages no identity plane. |
+| `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: identity is managed against `services.keystone.external.authURL`; no Keystone child is projected and none is deleted. |
 | `False` | `WaitingForInfrastructure` | `InfrastructureReady` is not `True`; Keystone projection deferred. |
 | `False` | `WaitingForKeystone` | The Keystone CR is ensured but not yet Ready. |
 | `False` | `InvalidRotationInterval` | `services.keystone.rotationInterval` could not be converted to a cron schedule. |
@@ -1112,6 +1122,12 @@ Set by `reconcileKORC`.
 | `False` | `WaitingForApplicationCredential` | The `ApplicationCredential` CR is ensured but not yet `Available`; the message folds in any stuck admin Domain/User import. |
 | `False` | `AdminPasswordError` | Non-missing error reading the admin password. |
 | `False` | `ApplicationCredentialError` | Error create-or-updating the `ApplicationCredential` CR. |
+| `False` | `AuthenticationFailed` | **External mode only.** The external Keystone rejected the admin credential (HTTP 401) — typically the password was rotated out-of-band and `passwordSecretRef` is stale. K-ORC's message is relayed verbatim. |
+| `False` | `EndpointUnreachable` | **External mode only.** `services.keystone.external.authURL` could not be dialled (DNS failure, connection refused, timeout). |
+| `False` | `TLSVerificationFailed` | **External mode only.** The external endpoint's certificate did not verify; supply the private CA via `external.caBundleSecretRef`. |
+| `False` | `CatalogEndpointMismatch` | **External mode only.** Authentication succeeded but the requested interface/region is absent from the external service catalog — a wrong `external.endpointType` or `spec.region`. |
+| `False` | `CredentialDrift` | **External mode only.** An application-credential create against a stale resolve-once import id yielded a Keystone 403 (`identity:create_application_credential`). Drift is surfaced, never remediated. |
+| `False` | `ImportStalled` | **External mode only.** An admin Domain/User import has been waiting to be "created externally" for longer than `externalImportStallGrace` (2m). In External mode the import target already exists, so this is a misconfiguration. |
 
 ### AdminCredentialReady
 
@@ -1125,6 +1141,7 @@ application-credential id+secret) the freshly assembled credential).
 | --- | --- | --- |
 | `True` | `AdminCredentialReady` | The admin application credential is committed to the owned Secret, mirrored to OpenBao, and the materialised `clouds.yaml` Secret matches the assembled credential. |
 | `False` | `WaitingForKORC` | `KORCReady` is not `True`; credential push deferred. |
+| `False` | `CredentialDrift` | **External mode only.** `KORCReady` reports drift in the external installation (`AuthenticationFailed` or `CredentialDrift`). The operator never remediates the external Keystone; update the `passwordSecretRef` Secret to drive a re-mint. |
 | `False` | `SecretStoreNotReady` | The OpenBao-backed `ClusterSecretStore` is not Ready; the secret backend is unreachable. |
 | `False` | `WaitingForCloudsYaml` | The operator-created per-ControlPlane `k-orc-clouds-yaml` ExternalSecret in the control-plane namespace (co-located with the K-ORC CRs per C1; created and owned by `reconcileKORC`) is not yet Ready. |
 | `False` | `WaitingForPushSecret` | The admin app-credential `PushSecret` has not synced the assembled `clouds.yaml` to OpenBao yet. `AdminCredentialReady` is gated on the PushSecret's `Ready` condition — not merely on the CR existing — so a backend permission failure (e.g. the ESO role missing the push policy) cannot yield a false-positive Ready while OpenBao still serves the password-based bootstrap `clouds.yaml`. |

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -434,6 +434,36 @@ and is caught by the no-inline-literals drift guard.
 Every condition is stamped with `ObservedGeneration = cp.Generation` on every
 path.
 
+### External keystone mode and the chain
+
+When `spec.services.keystone.mode` is `External`, the ControlPlane manages
+identity against a pre-existing, externally-operated Keystone. The chain keeps
+its order; External mode changes what each link does. Four sub-reconcilers
+short-circuit — `reconcileInfrastructure`, `reconcileDBCredentials`,
+`reconcileAdminPassword` and `reconcileKeystone` — each reporting its own
+condition with `Status=True` and reason `ExternallyManaged`, and a message naming
+`spec.services.keystone.external.authURL`.
+
+Skipped sub-reconcilers **keep their condition types**. The condition schema is
+therefore identical across modes, so `subConditionTypes`, `setReadyCondition` and
+the `condition_type` drift guard need no mode awareness.
+
+Every skip is keyed on the mode discriminator `cp.IsExternalKeystone()`, never on
+the database shape: an External-mode ControlPlane has no `spec.infrastructure`
+block at all, so "no *managed* database" and "no database" are different states.
+The vocabulary keeps three "nothing was projected" reasons deliberately apart:
+
+| Reason | Meaning |
+| --- | --- |
+| `ExternallyManaged` | identity is managed against a pre-existing Keystone; this sub-reconciler has nothing to project |
+| `KeystoneNotManaged` | `spec.services.keystone` is unset: there is no identity plane at all (staged adoption) |
+| `BrownfieldUserSuppliedCredential` | the ControlPlane owns a Keystone, but the *database* is brownfield, so the user supplies its credential Secret |
+
+`services.horizon` is forbidden in External mode, so `reconcileHorizon` always
+takes its `HorizonNotManaged` early-exit. The duplicate-ControlPlane parking
+guard is mode-agnostic and applies unchanged — External-mode ControlPlanes count
+towards the one-per-namespace contract.
+
 ### reconcileInfrastructure
 
 | Aspect | Value |
@@ -451,19 +481,23 @@ instead. Both managed children are ensured in a single pass *before* readiness i
 gated, so a half-provisioned control plane (DB created but cache missing) never
 occurs; readiness is evaluated collectively afterwards.
 
-`spec.infrastructure` is optional now: an **External**-mode Keystone ControlPlane
+`spec.infrastructure` is optional: an **External**-mode Keystone ControlPlane
 omits it (the validating webhook forbids it in External mode and requires it
-otherwise). When the block is unset the sub-reconciler halts the pipeline with
-`InfrastructureReady=False`, reason `ExternalModeNotImplemented`, and a gentle
-requeue — an interim state until the External-mode reconciliation lands.
+otherwise). In External mode the sub-reconciler provisions nothing and reports
+`InfrastructureReady=True` / `ExternallyManaged` immediately. A **non**-External
+ControlPlane that nevertheless reaches this point with the block unset is a
+webhook-bypass shape (direct etcd write, admission misconfigured); it fails
+closed with `InfrastructureNotConfigured` rather than dereferencing the nil
+pointer.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
+| External keystone mode | True | `ExternallyManaged` | no MariaDB/Memcached is provisioned; the message names `external.authURL` |
 | MariaDB create/update fails | False | `MariaDBError` | returns the error (controller-runtime backoff) |
 | Memcached create/update fails | False | `MemcachedError` | returns the error |
 | MariaDB not yet Ready | False | `WaitingForDatabase` | requeue 15s |
 | Memcached not yet Ready | False | `WaitingForCache` | requeue 15s |
-| `spec.infrastructure` unset (External keystone mode) | False | `ExternalModeNotImplemented` | requeue 15s — interim halt; the CR is accepted but External-mode reconciliation is not yet implemented. Replaced when that work lands. |
+| `spec.infrastructure` unset, not External | False | `InfrastructureNotConfigured` | requeue 15s; unreachable on the admission path — fails closed for a webhook-bypassed CR |
 | All managed children Ready (or pure brownfield) | True | `InfrastructureReady` | — |
 
 > The managed MariaDB child is provisioned with a minimal-but-valid spec —
@@ -521,8 +555,13 @@ is set and **brownfield** when the user supplies a `host`-based connection:
 `spec.database.credentialsMode`, so the Keystone operator consumes the matching
 credential shape.
 
+In **External** keystone mode the ControlPlane manages no database at all —
+neither a managed one to issue credentials for, nor a brownfield connection to
+reference — so neither OpenBao nor the `ClusterSecretStore` is consulted.
+
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
+| External keystone mode | True | `ExternallyManaged` | no database is managed; nothing is projected and the ClusterSecretStore is never read |
 | Brownfield (`clusterRef == nil`) | True | `BrownfieldUserSuppliedCredential` | no ExternalSecret projected; user supplies the DB credential Secret out-of-band |
 | ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; managed mode only, checked before projection so an OpenBao/ESO outage surfaces promptly |
 | Dynamic generator/SA/Certificate/ExternalSecret create/update fails | False | `GeneratorError` | returns the error |
@@ -576,8 +615,20 @@ this materialised Secret's `password` key
 the user-declared `spec.korc.adminCredential.passwordSecretRef` verbatim. The
 cp-level spec default for `passwordSecretRef` remains `keystone-admin`.
 
+`effectiveAdminPasswordSecretRef` keys its External branch on
+`spec.services.keystone.mode`, not on the database shape, and returns
+`spec.korc.adminCredential.passwordSecretRef` verbatim. That Secret is the admin
+password source: the operator only ever **reads** it, because the external
+Keystone's admin password is owned out-of-band. Its SHA-256 feeds
+`adminPasswordHashAnnotation`, so **updating that Secret is what drives a
+hash-driven re-mint** of the admin application credential — the only supported
+rotation path in External mode. The field indexer
+(`controlPlaneSecretNameExtractor`) follows the same ref, so an edit to the
+user's Secret wakes the ControlPlane immediately.
+
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
+| External keystone mode | True | `ExternallyManaged` | the admin password is read from the user-supplied `passwordSecretRef` Secret; no ExternalSecret is projected and no OpenBao bootstrap path is seeded |
 | Brownfield (`clusterRef == nil`) | True | `BrownfieldUserSuppliedCredential` | no ExternalSecret projected; user supplies the admin-password Secret out-of-band |
 | ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; managed mode only, checked before the ExternalSecret is projected |
 | ExternalSecret create/update or read fails | False | `ExternalSecretError` | returns the error |
@@ -622,8 +673,17 @@ the ControlPlane provisioned:
   (weekly, `0 0 * * 0`) and positive whole-day multiples (daily, `0 0 * * *`)
   are supported.
 
+In **External** keystone mode no child is projected — and none is deleted. A
+`Managed -> External` flip is rejected at admission (adopting an existing
+installation must be a fresh External-mode ControlPlane), so no child can exist;
+were one to appear anyway, the fail-safe that preserves a child unless
+`c5c3.io/allow-keystone-deletion: "true"` opts in is the only sanctioned teardown
+path, because the child's credential/fernet keys are irreplaceable.
+
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
+| `spec.services.keystone` unset | True | `KeystoneNotManaged` | no identity plane at all; a previously-projected child is preserved by default |
+| External keystone mode | True | `ExternallyManaged` | identity is managed against `external.authURL`; no child is projected and none is deleted |
 | `InfrastructureReady` not True | False | `WaitingForInfrastructure` | requeue 5s; no Keystone CR is created while infra is unready |
 | Invalid `rotationInterval` | False | `InvalidRotationInterval` | **returns the error** so the reconcile chain stops at Keystone and the manager requeues with backoff (the validating webhook already rejects unrepresentable intervals at admission, so this is defense-in-depth) |
 | Keystone create/update fails | False | `KeystoneError` | returns the error |
@@ -774,10 +834,67 @@ that instructs K-ORC to mint the admin application credential, and drives re-min
 
 Both the `ApplicationCredentialFailed` and `WaitingForApplicationCredential`
 messages fold in the admin Domain/User import status (`ensureKORCAdminImports`
-returns the first import that is terminally failed or not yet Available), so the
+returns the admin Domain/User imports, and `korcAdminImports.statusFragment()`
+names the first that is terminally failed or not yet Available), so the
 documented endpoint/clouds.yaml failure class — where K-ORC swallows a list error
 and an import hangs on "created externally" — names the stuck dependency instead of
 surfacing as an opaque wait.
+
+#### External-mode failure classification
+
+K-ORC collapses **every** hard failure against a pre-existing Keystone — a wrong
+admin password (401), an unresolvable `authURL`, an untrusted private CA, a
+region/`endpointType` absent from the catalog — into the same **non-terminal**
+`Progressing` condition with `reason=TransientError`. Nothing in the observed
+inventory is terminal, so neither `GetTerminalError` nor the reason
+discriminates: the failure class survives only in the free-text message.
+
+In External mode the ControlPlane therefore classifies on message substrings and
+relays K-ORC's message **verbatim** alongside the reason. Classification walks
+the admin Domain, then the admin User, then the ApplicationCredential, so the
+*root* stuck dependency is reported rather than the resource that merely blocked
+on it. Precedence, most specific first: catalog mismatch, credential drift, TLS,
+authentication, reachability.
+
+It is gated on External mode — a managed ControlPlane's `KORCReady` reasons are
+byte-identical to before — and never runs against an `Available` credential: K-ORC
+leaves the message of the last transient attempt on the `Progressing` condition,
+and re-classifying it would flip a converged ControlPlane back to
+`AuthenticationFailed` on a failure it has already recovered from.
+
+| Path (External mode only) | Status | Reason | Notes |
+| --- | --- | --- | --- |
+| message contains `401` / `Unauthorized` | False | `AuthenticationFailed` | the external Keystone rejected the admin credential — typically the password was rotated out-of-band and `passwordSecretRef` is stale |
+| message contains `no such host` / `connection refused` / `dial tcp` / `i/o timeout` | False | `EndpointUnreachable` | `external.authURL` could not be dialled |
+| message contains `x509` | False | `TLSVerificationFailed` | supply the private CA via `external.caBundleSecretRef` |
+| message contains `No suitable endpoint could be found in the service catalog` | False | `CatalogEndpointMismatch` | a wrong `external.endpointType` or `spec.region`; fails loud rather than silently importing nothing |
+| message names `identity:create_application_credential` (403) | False | `CredentialDrift` | an application-credential create against a **stale** resolve-once import id; see [drift](#drift-is-surfaced-never-fought) |
+| admin import stuck on "Waiting for OpenStack resource to be created externally" beyond `externalImportStallGrace` | False | `ImportStalled` | the silent-empty detector |
+
+`externalImportStallGrace` is **2 minutes**. In External mode every import target
+pre-exists by definition, so an import that keeps waiting to be "created
+externally" never resolves on its own — K-ORC is looking in the wrong place. The
+message names the stuck import and points at `external.endpointType` and
+`spec.region`. The window is deliberately shorter than `remintStallTimeout` /
+`orcTeardownStallTimeout` (both 5m): those wait on work that is genuinely in
+flight, whereas a resolvable import has nothing to wait for.
+
+#### Drift is surfaced, never fought
+
+The external installation can change under the CR: the admin password is rotated
+without updating the referenced Secret, or the admin user is deleted and
+recreated. K-ORC imports are **resolve-once** — a resolved `status.id` is never
+re-resolved — so after a recreate the import stays `Available=True` with a stale
+id while an application-credential create against that id yields a Keystone
+**403** (`identity:create_application_credential`; Keystone's default policy
+allows creating an application credential only for the token's own user).
+
+The operator **never remediates the external installation**. It signals drift on
+the existing sub-conditions with the documented `CredentialDrift` reason, and
+`reconcileKORC` emits a `Warning` `CredentialDrift` event on the **transition**
+into the drifted state (not on every 10s requeue). The remedy is to update the
+Secret `spec.korc.adminCredential.passwordSecretRef` names, which changes its
+digest and drives a hash-driven re-mint.
 
 > **Hard CRD dependency.** K-ORC (like Memcached, ESO, MariaDB, and Keystone) is
 > a hard dependency: `SetupWithManager` `Owns`/`Watches` its kinds, so the
@@ -872,10 +989,21 @@ OpenBao:
   reason escalates from the transient `WaitingForCloudsYamlSync` to the alertable
   `CloudsYamlSyncStuck`, so a permanently broken sync is distinguishable from a
   2-second transient miss.
+- **Drift escalation (External mode).** When the `KORCReady` gate is closed
+  *because* the external Keystone reports drift, the gate reports
+  `CredentialDrift` rather than the opaque `WaitingForKORC`. Note that the **live**
+  drift signal is `KORCReady` itself: `reconcileKORC` requeues on the drift and
+  `RunPipeline` short-circuits on that non-zero result, so this sub-reconciler is
+  not re-entered in the same pass. The escalation is the defense-in-depth path
+  that keeps `AdminCredentialReady` honest for any caller that does observe a
+  drifted `KORCReady`. An unreachable endpoint, a TLS failure, a catalog mismatch
+  or a stalled import are **not** drift and keep `WaitingForKORC` — drift is a
+  statement about the credential.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
 | `KORCReady` not True | False | `WaitingForKORC` | requeue 10s |
+| `KORCReady` reports drift (`AuthenticationFailed` / `CredentialDrift`), External mode | False | `CredentialDrift` | requeue 10s; names the Secret the operator reads and states that the external installation is never remediated |
 | ClusterSecretStore not Ready | False | `SecretStoreNotReady` | requeue 10s; checked after the `KORCReady` gate so an OpenBao/ESO outage surfaces before the clouds.yaml wait |
 | clouds.yaml ES check errors | False | `CloudsYamlError` | returns the error (also covers a force-sync/materialised-Secret read error) |
 | clouds.yaml ES not Ready | False | `WaitingForCloudsYaml` | requeue 10s |
@@ -1156,12 +1284,40 @@ The `{name}-admin-app-credential-backup` PushSecret is the one child kept on
 | `Memcached` (unstructured) | `{spec.infrastructure.cache.clusterRef.name}` | ControlPlane CR | managed mode only |
 | `ExternalSecret` (DB credential) | `{name}-keystone-db-credentials` | ControlPlane CR | managed mode only; ESO owns the materialised Secret of the same name |
 | `ExternalSecret` (admin password) | `{name}-keystone-admin-credentials` | ControlPlane CR | managed mode only; ESO owns the materialised Secret of the same name |
-| `Keystone` | `{name}-keystone` | ControlPlane CR | — |
-| `ApplicationCredential` | `{name}-admin-app-credential` | ControlPlane CR | carries `forge.c5c3.io/admin-password-hash` |
-| `Secret` | `{name}-admin-app-credential` | ControlPlane CR | data written by K-ORC, not the operator |
-| `PushSecret` | `{name}-admin-app-credential-backup` | ControlPlane CR | `DeletionPolicy: None` |
+| `Keystone` | `{name}-keystone` | ControlPlane CR | managed mode only |
+| `ApplicationCredential` | `{name}-admin-app-credential` | ControlPlane CR | both modes; carries `forge.c5c3.io/admin-password-hash` |
+| `Secret` | `{name}-admin-app-credential` | ControlPlane CR | both modes; data written by K-ORC, not the operator |
+| `PushSecret` | `{name}-admin-app-credential-backup` | ControlPlane CR | both modes; `DeletionPolicy: None` |
+| `User` (K-ORC) | `{name}-user-admin` | ControlPlane CR | both modes; unmanaged import |
+| `Domain` (K-ORC) | `{name}-domain-default` | ControlPlane CR | both modes; unmanaged import |
 | `Service` (K-ORC) | `{name}-identity-service` | ControlPlane CR | identity catalog entry |
 | `Endpoint` (K-ORC) | `{name}-identity-endpoint` | ControlPlane CR | public interface |
+
+#### External-mode deletion resource set
+
+The sweep is correct for **both** keystone modes without a mode branch, because
+what a `Delete` does to the external OpenStack installation is decided by each
+K-ORC CR's `ManagementPolicy`, not by the ControlPlane's mode:
+
+- **`ApplicationCredential`** — `Managed`. Its K-ORC finalizer revokes the
+  credential at the Keystone level *before* the CR delete returns, so
+  authenticating with it immediately afterwards yields **404** `Could not find
+  Application Credential` (not 401). This is the one identity object the operator
+  minted, so it is the one it destroys.
+- **`User`, `Domain`** — `Unmanaged` imports. Deleting their CRs removes the
+  Kubernetes objects and leaves the OpenStack resources they imported untouched.
+  K-ORC's deletion-guard finalizers also enforce the teardown order: a `User`
+  cannot go while an `ApplicationCredential` still references it.
+- **`Service`, `Endpoint`** — managed catalog entries today, so the sweep deletes
+  them from Keystone's catalog. In External mode the catalog is owned by the
+  external installation; the import-first catalog work turns these into unmanaged
+  imports too, at which point this becomes a CR-only delete.
+
+The OpenBao-backed Secrets are torn down by owner-reference GC, **except** the
+path behind the `{name}-admin-app-credential-backup` PushSecret: its
+`DeletionPolicy` is deliberately `None`, so the last-pushed credential survives
+at its OpenBao path. Nothing else is touched — a K-ORC CR the ControlPlane does
+not own is never swept.
 
 ### Security invariant
 

--- a/operators/c5c3/internal/controller/external_mode.go
+++ b/operators/c5c3/internal/controller/external_mode.go
@@ -84,6 +84,16 @@ const (
 	conditionReasonInfrastructureNotConfigured = "InfrastructureNotConfigured"
 )
 
+// isCredentialDriftReason reports whether a KORCReady reason means the operator's
+// view of the external Keystone's admin identity no longer matches reality: either
+// the referenced admin password no longer authenticates (AuthenticationFailed), or
+// a resolve-once import id now points at a user Keystone has since replaced
+// (CredentialDrift). Both are drift in the external installation, which the
+// operator SURFACES and never fights.
+func isCredentialDriftReason(reason string) bool {
+	return reason == conditionReasonAuthenticationFailed || reason == conditionReasonCredentialDrift
+}
+
 // korcImportPendingExternalMarker is the message K-ORC stamps on an unmanaged
 // import's Available=False condition while the OpenStack resource it filters for
 // does not (yet) exist. It is the substring korcImportStalled keys the

--- a/operators/c5c3/internal/controller/external_mode.go
+++ b/operators/c5c3/internal/controller/external_mode.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"strings"
+	"time"
+
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// Condition reasons that only External keystone mode produces. They are the
+// single source of truth for the External-mode status contract: call sites MUST
+// reference these constants rather than inline string literals, mirroring the
+// conditionType* block in controlplane_controller.go.
+//
+// The vocabulary deliberately keeps three "nothing was projected" reasons apart,
+// because each answers a different operator question:
+//
+//   - ExternallyManaged — the ControlPlane manages identity against a
+//     pre-existing Keystone, so this sub-reconciler has nothing to project.
+//   - KeystoneNotManaged — spec.services.keystone is unset: there is no identity
+//     plane at all (staged adoption).
+//   - BrownfieldUserSuppliedCredential — the ControlPlane owns a Keystone but
+//     the *database* is brownfield, so the user supplies its credential Secret.
+//
+// Collapsing them would make "why is nothing deployed?" unanswerable from
+// `kubectl describe` alone.
+const (
+	// conditionReasonExternallyManaged marks a sub-reconciler that skipped its
+	// projection because the ControlPlane's Keystone is externally operated. The
+	// condition still reports Status=True so the condition schema — and therefore
+	// subConditionTypes, setReadyCondition and the condition_type drift guard —
+	// is identical across modes.
+	conditionReasonExternallyManaged = "ExternallyManaged"
+
+	// conditionReasonAuthenticationFailed reports that the external Keystone
+	// rejected the operator's admin credentials (HTTP 401). In practice this is
+	// the "admin password rotated out-of-band, passwordSecretRef is stale" drift.
+	conditionReasonAuthenticationFailed = "AuthenticationFailed"
+
+	// conditionReasonEndpointUnreachable reports that the external Keystone's
+	// authURL could not be dialled (DNS failure, connection refused, timeout).
+	conditionReasonEndpointUnreachable = "EndpointUnreachable"
+
+	// conditionReasonTLSVerificationFailed reports that the external Keystone's
+	// certificate did not verify against the client's trust store — typically a
+	// private CA that spec.services.keystone.external.caBundleSecretRef must
+	// supply.
+	conditionReasonTLSVerificationFailed = "TLSVerificationFailed"
+
+	// conditionReasonCatalogEndpointMismatch reports that authentication
+	// succeeded but the requested interface/region is absent from the external
+	// Keystone's service catalog — a wrong spec.services.keystone.external.
+	// endpointType or spec.region. It fails loud rather than silently importing
+	// nothing.
+	conditionReasonCatalogEndpointMismatch = "CatalogEndpointMismatch"
+
+	// conditionReasonImportStalled reports the silent-empty hazard: a K-ORC
+	// import that has been waiting to be "created externally" beyond
+	// externalImportStallGrace. In External mode every import target pre-exists
+	// by definition, so a persistent wait is a misconfiguration signal, never a
+	// legitimate wait. The reason is shared vocabulary with the catalog
+	// import-first work.
+	conditionReasonImportStalled = "ImportStalled"
+
+	// conditionReasonCredentialDrift reports that the operator's view of the
+	// external Keystone's admin identity no longer matches reality — the admin
+	// user was recreated behind a resolve-once import id, or the admin password
+	// changed without the referenced Secret following. Drift is SURFACED, never
+	// fought: the operator does not write to the external installation.
+	conditionReasonCredentialDrift = "CredentialDrift"
+
+	// conditionReasonInfrastructureNotConfigured reports a non-External
+	// ControlPlane that reached reconcileInfrastructure with no
+	// spec.infrastructure block. The validating webhook requires the block
+	// outside External mode, so this fails closed for a webhook-bypassed CR
+	// rather than dereferencing the nil pointer.
+	conditionReasonInfrastructureNotConfigured = "InfrastructureNotConfigured"
+)
+
+// korcImportPendingExternalMarker is the message K-ORC stamps on an unmanaged
+// import's Available=False condition while the OpenStack resource it filters for
+// does not (yet) exist. It is the substring korcImportStalled keys the
+// silent-empty detector on.
+const korcImportPendingExternalMarker = "Waiting for OpenStack resource to be created externally"
+
+// externalKeystoneAuthURL returns the external Keystone's identity endpoint, or
+// "" when the ControlPlane is not in External mode (or the block is absent, which
+// admission forbids). It is nil-safe on every level so the ExternallyManaged and
+// drift messages can name the endpoint without a guard at each call site.
+//
+// This helper is MESSAGE-ONLY. The mode-switching auth-URL resolver the
+// clouds.yaml builders consume — the one that decides whether K-ORC dials the
+// in-cluster Service DNS or this external endpoint — is a separate concern and
+// lands with the External-mode K-ORC/AdminCredential work.
+func externalKeystoneAuthURL(cp *c5c3v1alpha1.ControlPlane) string {
+	ks := cp.Spec.Services.Keystone
+	if ks == nil || ks.External == nil {
+		return ""
+	}
+	return ks.External.AuthURL
+}
+
+// classifyKORCMessage maps a K-ORC condition message onto an External-mode
+// condition reason, returning "" when the message matches no known failure class.
+//
+// SPIKE CONSTRAINT: K-ORC collapses EVERY hard failure against the OpenStack API
+// — a 401, a DNS/dial error, a TLS verification failure, a catalog mismatch —
+// into the same non-terminal Progressing condition with reason=TransientError.
+// Nothing in the observed inventory is terminal. The failure CLASS is therefore
+// only distinguishable from the free-text message, so the ControlPlane matches on
+// message substrings and relays K-ORC's message verbatim alongside the reason.
+//
+// The order below is the documented precedence, most specific first, and is
+// pinned by TestClassifyKORCMessage:
+//
+//  1. catalog mismatch  — the full gophercloud sentence, unambiguous
+//  2. credential drift  — a 403 naming the application-credential policy rule,
+//     which is what an AC create against a stale user id yields
+//  3. TLS              — "x509", which a dial error may also mention
+//  4. authentication   — 401 / Unauthorized
+//  5. reachability     — DNS / dial / timeout markers
+func classifyKORCMessage(msg string) string {
+	switch {
+	case strings.Contains(msg, "No suitable endpoint could be found in the service catalog"):
+		return conditionReasonCatalogEndpointMismatch
+	case strings.Contains(msg, "identity:create_application_credential"):
+		return conditionReasonCredentialDrift
+	case strings.Contains(msg, "x509"):
+		return conditionReasonTLSVerificationFailed
+	case strings.Contains(msg, "401") || strings.Contains(msg, "Unauthorized"):
+		return conditionReasonAuthenticationFailed
+	case strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "dial tcp"),
+		strings.Contains(msg, "i/o timeout"):
+		return conditionReasonEndpointUnreachable
+	default:
+		return ""
+	}
+}
+
+// classifyKORCObject returns the External-mode reason for the first condition on
+// obj whose message classifies, together with that message VERBATIM. An
+// unclassifiable object yields ("", "").
+//
+// The message is relayed byte-for-byte rather than reworded: K-ORC's text is the
+// only place the underlying gophercloud/OpenStack error survives, so truncating
+// or paraphrasing it would destroy the very signal the classification points at.
+func classifyKORCObject(obj orcv1alpha1.ObjectWithConditions) (reason, rawMessage string) {
+	if obj == nil {
+		return "", ""
+	}
+	for _, cond := range obj.GetConditions() {
+		if reason := classifyKORCMessage(cond.Message); reason != "" {
+			return reason, cond.Message
+		}
+	}
+	return "", ""
+}
+
+// classifyExternalKORCFailure walks objs in order and returns the first
+// classifiable failure. Call sites pass the admin Domain, then the admin User,
+// then the ApplicationCredential — the same dependency order ensureKORCAdminImports
+// uses for its status fragment, so the ROOT dependency is reported rather than the
+// downstream resource that merely blocked on it.
+func classifyExternalKORCFailure(objs ...orcv1alpha1.ObjectWithConditions) (reason, rawMessage string) {
+	for _, obj := range objs {
+		if reason, rawMessage := classifyKORCObject(obj); reason != "" {
+			return reason, rawMessage
+		}
+	}
+	return "", ""
+}
+
+// korcImportStalled reports whether a K-ORC import has been waiting for its
+// OpenStack resource to appear for longer than grace — the silent-empty detector.
+//
+// In External mode every import target (the admin Domain, the admin User) exists
+// in the external Keystone BY DEFINITION: the installation predates the
+// ControlPlane. An import that stays Available=False on
+// korcImportPendingExternalMarker therefore never resolves on its own. It means
+// K-ORC looked in the wrong place — a catalog interface or region that resolves to
+// a different Keystone, or an authURL pointing at an empty deployment — and the
+// only honest signal is a loud condition, not an eternal wait.
+//
+// A missing or True Available condition, a different message, or a transition
+// inside the grace window all read as "not stalled".
+func korcImportStalled(obj orcv1alpha1.ObjectWithConditions, grace time.Duration) bool {
+	if obj == nil {
+		return false
+	}
+	for _, cond := range obj.GetConditions() {
+		if cond.Type != orcv1alpha1.ConditionAvailable {
+			continue
+		}
+		return cond.Status == metav1.ConditionFalse &&
+			strings.Contains(cond.Message, korcImportPendingExternalMarker) &&
+			time.Since(cond.LastTransitionTime.Time) > grace
+	}
+	return false
+}

--- a/operators/c5c3/internal/controller/external_mode.go
+++ b/operators/c5c3/internal/controller/external_mode.go
@@ -74,7 +74,7 @@ const (
 	// user was recreated behind a resolve-once import id, or the admin password
 	// changed without the referenced Secret following. Drift is SURFACED, never
 	// fought: the operator does not write to the external installation.
-	conditionReasonCredentialDrift = "CredentialDrift"
+	conditionReasonCredentialDrift = "CredentialDrift" //nolint:gosec // G101 false positive: condition reason name, not a credential.
 
 	// conditionReasonInfrastructureNotConfigured reports a non-External
 	// ControlPlane that reached reconcileInfrastructure with no

--- a/operators/c5c3/internal/controller/external_mode_test.go
+++ b/operators/c5c3/internal/controller/external_mode_test.go
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the External keystone-mode helpers: the endpoint reader, the K-ORC
+// message classifier, and the stalled-import detector.
+package controller
+
+import (
+	"testing"
+	"time"
+
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// TestExternalKeystoneAuthURL_NilSafe covers the two absent-block edge paths
+// (no keystone service at all, keystone without an external block) alongside the
+// populated case: the helper is called from message builders that must never
+// panic on a Managed CR.
+func TestExternalKeystoneAuthURL_NilSafe(t *testing.T) {
+	g := NewWithT(t)
+
+	noKeystone := &c5c3v1alpha1.ControlPlane{}
+	g.Expect(externalKeystoneAuthURL(noKeystone)).To(BeEmpty(),
+		"a ControlPlane with no keystone service has no external endpoint")
+
+	noExternal := &c5c3v1alpha1.ControlPlane{
+		Spec: c5c3v1alpha1.ControlPlaneSpec{
+			Services: c5c3v1alpha1.ServicesSpec{Keystone: &c5c3v1alpha1.ServiceKeystoneSpec{}},
+		},
+	}
+	g.Expect(externalKeystoneAuthURL(noExternal)).To(BeEmpty(),
+		"a Managed keystone carries no external block")
+
+	external := &c5c3v1alpha1.ControlPlane{
+		Spec: c5c3v1alpha1.ControlPlaneSpec{
+			Services: c5c3v1alpha1.ServicesSpec{
+				Keystone: &c5c3v1alpha1.ServiceKeystoneSpec{
+					Mode:     c5c3v1alpha1.KeystoneModeExternal,
+					External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+				},
+			},
+		},
+	}
+	g.Expect(externalKeystoneAuthURL(external)).To(Equal("https://keystone.example.com/v3"))
+}
+
+// TestClassifyKORCMessage pins the D3 failure-class vocabulary AND the documented
+// precedence. K-ORC collapses every hard failure into reason=TransientError, so
+// these substrings are the only discriminator the ControlPlane has; a silent
+// reordering here would relabel a TLS failure as an unreachable endpoint.
+func TestClassifyKORCMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{
+			name: "wrong password yields AuthenticationFailed",
+			msg:  `Authentication failed: Expected HTTP response code [200 201] when accessing [POST https://keystone.example.com/v3/auth/tokens], but got 401 instead: {"error":{"code":401,"message":"The request you have made requires authentication."}}`,
+			want: conditionReasonAuthenticationFailed,
+		},
+		{
+			name: "Unauthorized without a numeric code still yields AuthenticationFailed",
+			msg:  "Unauthorized: the supplied credentials were rejected",
+			want: conditionReasonAuthenticationFailed,
+		},
+		{
+			name: "DNS failure yields EndpointUnreachable",
+			msg:  `Get "https://keystone.example.com/v3": dial tcp: lookup keystone.example.com: no such host`,
+			want: conditionReasonEndpointUnreachable,
+		},
+		{
+			name: "connection refused yields EndpointUnreachable",
+			msg:  `Post "https://10.0.0.1:5000/v3/auth/tokens": connection refused`,
+			want: conditionReasonEndpointUnreachable,
+		},
+		{
+			name: "timeout yields EndpointUnreachable",
+			msg:  `Get "https://keystone.example.com/v3": i/o timeout`,
+			want: conditionReasonEndpointUnreachable,
+		},
+		{
+			name: "private CA yields TLSVerificationFailed",
+			msg:  `Get "https://keystone.example.com/v3": x509: certificate signed by unknown authority`,
+			want: conditionReasonTLSVerificationFailed,
+		},
+		{
+			name: "wrong region or endpointType yields CatalogEndpointMismatch",
+			msg:  "No suitable endpoint could be found in the service catalog.",
+			want: conditionReasonCatalogEndpointMismatch,
+		},
+		{
+			name: "stale user id 403 yields CredentialDrift",
+			msg:  `Expected HTTP response code [201] when accessing [POST .../application_credentials], but got 403 instead: {"error":{"code":403,"message":"You are not authorized to perform the requested action: identity:create_application_credential."}}`,
+			want: conditionReasonCredentialDrift,
+		},
+		{
+			// Precedence guard: a TLS failure surfaced through a dial wrapper
+			// mentions BOTH x509 and dial tcp. TLS must win — telling the operator
+			// to check DNS when the CA bundle is missing sends them the wrong way.
+			name: "x509 outranks dial tcp",
+			msg:  `Get "https://keystone.example.com/v3": dial tcp 10.0.0.1:443: x509: certificate signed by unknown authority`,
+			want: conditionReasonTLSVerificationFailed,
+		},
+		{
+			// Precedence guard: the catalog sentence is emitted by an authenticated
+			// client, but gophercloud's wrapper can still carry a 401 from an earlier
+			// retry. The catalog class is the more specific, actionable one.
+			name: "catalog mismatch outranks a trailing 401",
+			msg:  "No suitable endpoint could be found in the service catalog. (previous attempt: 401)",
+			want: conditionReasonCatalogEndpointMismatch,
+		},
+		{
+			name: "an unrecognised message classifies to nothing",
+			msg:  "waiting for the OpenStack resource to settle",
+			want: "",
+		},
+		{
+			name: "an empty message classifies to nothing",
+			msg:  "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(classifyKORCMessage(tt.msg)).To(Equal(tt.want))
+		})
+	}
+}
+
+// korcConditions is a tiny builder for an ApplicationCredential carrying the
+// given conditions, used as a stand-in ObjectWithConditions.
+func acWithConditions(conds ...metav1.Condition) *orcv1alpha1.ApplicationCredential {
+	return &orcv1alpha1.ApplicationCredential{
+		Status: orcv1alpha1.ApplicationCredentialStatus{Conditions: conds},
+	}
+}
+
+// TestClassifyKORCObject_RelaysMessageVerbatim asserts the raw K-ORC message is
+// returned byte-identical (no truncation, no reformatting) and that an object
+// with no classifiable condition — the common not-yet-converged case — yields
+// the empty classification rather than a spurious reason.
+func TestClassifyKORCObject_RelaysMessageVerbatim(t *testing.T) {
+	g := NewWithT(t)
+
+	raw := `Authentication failed: got 401 instead: {"error":{"message":"The request you have made requires authentication."}}`
+	obj := acWithConditions(metav1.Condition{
+		Type:    orcv1alpha1.ConditionProgressing,
+		Status:  metav1.ConditionTrue,
+		Reason:  orcv1alpha1.ConditionReasonTransientError,
+		Message: raw,
+	})
+
+	reason, message := classifyKORCObject(obj)
+	g.Expect(reason).To(Equal(conditionReasonAuthenticationFailed))
+	g.Expect(message).To(Equal(raw), "K-ORC's message must be relayed verbatim")
+
+	// Edge: a converging object with no classifiable message.
+	reason, message = classifyKORCObject(acWithConditions(metav1.Condition{
+		Type:    orcv1alpha1.ConditionAvailable,
+		Status:  metav1.ConditionFalse,
+		Reason:  orcv1alpha1.ConditionReasonProgressing,
+		Message: "Waiting for the resource to be created",
+	}))
+	g.Expect(reason).To(BeEmpty())
+	g.Expect(message).To(BeEmpty())
+
+	// Edge: no conditions at all (freshly created CR).
+	reason, _ = classifyKORCObject(acWithConditions())
+	g.Expect(reason).To(BeEmpty())
+
+	// Edge: a nil object must not panic.
+	reason, _ = classifyKORCObject(nil)
+	g.Expect(reason).To(BeEmpty())
+}
+
+// TestClassifyExternalKORCFailure_FirstObjectWins asserts the root dependency
+// wins: when the admin Domain import already carries a classifiable failure, the
+// downstream User and ApplicationCredential — which merely blocked on it — must
+// not shadow it.
+func TestClassifyExternalKORCFailure_FirstObjectWins(t *testing.T) {
+	g := NewWithT(t)
+
+	domainMsg := `Get "https://keystone.example.com/v3": x509: certificate signed by unknown authority`
+	domain := &orcv1alpha1.Domain{
+		Status: orcv1alpha1.DomainStatus{Conditions: []metav1.Condition{{
+			Type:    orcv1alpha1.ConditionProgressing,
+			Status:  metav1.ConditionTrue,
+			Reason:  orcv1alpha1.ConditionReasonTransientError,
+			Message: domainMsg,
+		}}},
+	}
+	user := &orcv1alpha1.User{
+		Status: orcv1alpha1.UserStatus{Conditions: []metav1.Condition{{
+			Type:    orcv1alpha1.ConditionProgressing,
+			Status:  metav1.ConditionTrue,
+			Reason:  orcv1alpha1.ConditionReasonTransientError,
+			Message: "got 401 instead",
+		}}},
+	}
+	ac := acWithConditions(metav1.Condition{
+		Type:    orcv1alpha1.ConditionProgressing,
+		Status:  metav1.ConditionTrue,
+		Reason:  orcv1alpha1.ConditionReasonTransientError,
+		Message: "dial tcp: no such host",
+	})
+
+	reason, message := classifyExternalKORCFailure(domain, user, ac)
+	g.Expect(reason).To(Equal(conditionReasonTLSVerificationFailed))
+	g.Expect(message).To(Equal(domainMsg))
+
+	// Edge: nothing classifies — the caller must fall through to its own reason.
+	reason, message = classifyExternalKORCFailure(acWithConditions())
+	g.Expect(reason).To(BeEmpty())
+	g.Expect(message).To(BeEmpty())
+
+	// Edge: no objects at all.
+	reason, _ = classifyExternalKORCFailure()
+	g.Expect(reason).To(BeEmpty())
+}
+
+// TestKORCImportStalled exercises the silent-empty detector's grace window and
+// every non-stalled edge: an Available import, a different Available=False
+// message, a fresh transition, and an import with no Available condition yet.
+func TestKORCImportStalled(t *testing.T) {
+	const grace = 2 * time.Minute
+	stale := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	fresh := metav1.Now()
+
+	tests := []struct {
+		name  string
+		conds []metav1.Condition
+		want  bool
+	}{
+		{
+			name: "Available=False on the created-externally marker, past the grace window",
+			conds: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionFalse,
+				Message:            korcImportPendingExternalMarker,
+				LastTransitionTime: stale,
+			}},
+			want: true,
+		},
+		{
+			name: "same marker, still inside the grace window",
+			conds: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionFalse,
+				Message:            korcImportPendingExternalMarker,
+				LastTransitionTime: fresh,
+			}},
+			want: false,
+		},
+		{
+			name: "Available=True is never stalled",
+			conds: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionTrue,
+				Message:            "resource is available",
+				LastTransitionTime: stale,
+			}},
+			want: false,
+		},
+		{
+			name: "Available=False for an unrelated reason is not the silent-empty class",
+			conds: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionFalse,
+				Message:            "transient error contacting the OpenStack API",
+				LastTransitionTime: stale,
+			}},
+			want: false,
+		},
+		{
+			name: "no Available condition yet",
+			conds: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionProgressing,
+				Status:             metav1.ConditionTrue,
+				Message:            korcImportPendingExternalMarker,
+				LastTransitionTime: stale,
+			}},
+			want: false,
+		},
+		{
+			name:  "no conditions at all",
+			conds: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			domain := &orcv1alpha1.Domain{Status: orcv1alpha1.DomainStatus{Conditions: tt.conds}}
+			g.Expect(korcImportStalled(domain, grace)).To(Equal(tt.want))
+		})
+	}
+
+	// Edge: a nil object must not panic.
+	NewWithT(t).Expect(korcImportStalled(nil, grace)).To(BeFalse())
+}

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -1742,3 +1742,188 @@ func TestIntegration_ExternalMode_TransitionsRejected(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("phase-3"))
 	})
 }
+
+// driveExternalControlPlaneToReady creates the user-supplied admin-password
+// Secret an External-mode ControlPlane reads, then simulates every external
+// dependency the K-ORC chain waits on. The four skipped sub-reconcilers need no
+// simulation at all — that is the point of External mode.
+func driveExternalControlPlaneToReady(
+	t testing.TB, ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane,
+) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	ns := cp.Namespace
+	cpKey := types.NamespacedName{Name: cp.Name, Namespace: ns}
+
+	// In External mode effectiveAdminPasswordSecretRef resolves to the USER's
+	// Secret, so the cleartext readAdminPassword reads lives under that name.
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cp.Spec.KORC.AdminCredential.PasswordSecretRef.Name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{"password": []byte("super-secret-admin-password")},
+	}
+	g.Expect(c.Create(ctx, adminSecret)).To(Succeed(), "create the user-supplied admin password Secret")
+
+	g.Expect(c.Create(ctx, cp)).To(Succeed(), "create the External-mode ControlPlane CR")
+
+	// The four skipped sub-reconcilers converge with no simulation whatsoever.
+	for _, condType := range []string{
+		conditionTypeInfrastructureReady,
+		conditionTypeDBCredentialsReady,
+		conditionTypeAdminPasswordReady,
+		conditionTypeKeystoneReady,
+	} {
+		waitForControlPlaneCondition(t, ctx, c, cpKey, condType, metav1.ConditionTrue, itEventuallyTimeout)
+	}
+	// services.horizon is forbidden in External mode, so Horizon reports not-managed.
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeHorizonReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	// K-ORC chain: identical to managed mode, driven against the external Keystone.
+	simulateApplicationCredentialAvailableWhenPresent(t, ctx, c,
+		client.ObjectKey{Name: adminAppCredentialName(cp), Namespace: ns})
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeKORCReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: ns, Name: korcCloudsYamlSecretName}, &esov1.ExternalSecret{})
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(), "operator must create the k-orc clouds.yaml ExternalSecret")
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c,
+		client.ObjectKey{Namespace: ns, Name: korcCloudsYamlSecretName})).To(Succeed())
+
+	simulatePushSecretSyncedWhenPresent(t, ctx, c,
+		client.ObjectKey{Name: adminAppCredentialPushSecretName(cp), Namespace: ns})
+	simulateCloudsYamlMaterializedWhenPresent(t, ctx, c, cp)
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeAdminCredentialReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	simulateCatalogServiceEndpointAvailableWhenPresent(t, ctx, c, cp)
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeCatalogReady, metav1.ConditionTrue, itEventuallyTimeout)
+}
+
+// TestIntegration_ExternalMode_ConvergesToReadyWithNoWorkloads is the headline
+// acceptance criterion: an External-mode ControlPlane whose external dependencies
+// are reachable converges Ready=True while creating ZERO MariaDB, Memcached,
+// Keystone or Horizon resources — and no operator-owned credential ExternalSecrets.
+func TestIntegration_ExternalMode_ConvergesToReadyWithNoWorkloads(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupControlPlaneEnvTest(t)
+	ensureReadyClusterSecretStore(t, ctx, c)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cp-external-ready-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed(), "create test namespace")
+
+	cp := integrationExternalControlPlane("cp-external", ns.Name)
+	driveExternalControlPlaneToReady(t, ctx, c, cp)
+
+	cpKey := types.NamespacedName{Name: cp.Name, Namespace: ns.Name}
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	final := &c5c3v1alpha1.ControlPlane{}
+	g.Expect(c.Get(ctx, cpKey, final)).To(Succeed())
+
+	readyCond := meta.FindStatusCondition(final.Status.Conditions, conditionTypeReady)
+	g.Expect(readyCond.Reason).To(Equal("AllReady"))
+	g.Expect(final.Status.ObservedGeneration).To(Equal(final.Generation))
+
+	// Each skipped sub-reconciler reports the dedicated ExternallyManaged reason.
+	for _, condType := range []string{
+		conditionTypeInfrastructureReady,
+		conditionTypeDBCredentialsReady,
+		conditionTypeAdminPasswordReady,
+		conditionTypeKeystoneReady,
+	} {
+		cond := meta.FindStatusCondition(final.Status.Conditions, condType)
+		g.Expect(cond).NotTo(BeNil(), "condition %s should exist", condType)
+		g.Expect(cond.Reason).To(Equal(conditionReasonExternallyManaged),
+			"condition %s must report the External-mode skip reason", condType)
+		g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"),
+			"condition %s must name the external endpoint", condType)
+	}
+	horizonCond := meta.FindStatusCondition(final.Status.Conditions, conditionTypeHorizonReady)
+	g.Expect(horizonCond.Reason).To(Equal("HorizonNotManaged"))
+
+	// ZERO workloads. This is the acceptance criterion, so assert absence directly.
+	var mariadbList mariadbv1alpha1.MariaDBList
+	g.Expect(c.List(ctx, &mariadbList, client.InNamespace(ns.Name))).To(Succeed())
+	g.Expect(mariadbList.Items).To(BeEmpty(), "External mode must create no MariaDB")
+
+	memcachedList := &unstructured.UnstructuredList{}
+	memcachedList.SetGroupVersionKind(memcachedGVK)
+	g.Expect(c.List(ctx, memcachedList, client.InNamespace(ns.Name))).To(Succeed())
+	g.Expect(memcachedList.Items).To(BeEmpty(), "External mode must create no Memcached")
+
+	var keystoneList keystonev1alpha1.KeystoneList
+	g.Expect(c.List(ctx, &keystoneList, client.InNamespace(ns.Name))).To(Succeed())
+	g.Expect(keystoneList.Items).To(BeEmpty(), "External mode must create no Keystone child")
+
+	var horizonList horizonv1alpha1.HorizonList
+	g.Expect(c.List(ctx, &horizonList, client.InNamespace(ns.Name))).To(Succeed())
+	g.Expect(horizonList.Items).To(BeEmpty(), "External mode must create no Horizon child")
+
+	// No operator-owned credential projections either.
+	g.Expect(apierrors.IsNotFound(c.Get(ctx,
+		client.ObjectKey{Namespace: ns.Name, Name: dbCredentialSecretName(cp)}, &esov1.ExternalSecret{}))).
+		To(BeTrue(), "External mode must project no DB-credential ExternalSecret")
+	g.Expect(apierrors.IsNotFound(c.Get(ctx,
+		client.ObjectKey{Namespace: ns.Name, Name: adminPasswordSecretName(cp)}, &esov1.ExternalSecret{}))).
+		To(BeTrue(), "External mode must project no admin-password ExternalSecret")
+
+	// status.services reports the single configured service.
+	g.Expect(final.Status.Services).To(HaveLen(1))
+	g.Expect(final.Status.Services[0].Name).To(Equal(keystoneServiceKey))
+	g.Expect(final.Status.Services[0].Ready).To(BeTrue())
+}
+
+// TestIntegration_ExternalMode_DeletionLeavesUnmanagedImportsAlone is the AC-4
+// end-to-end guard: deleting a converged External-mode ControlPlane tears down the
+// operator-owned K-ORC CRs and provably nothing else — a foreign K-ORC User in the
+// same namespace survives.
+func TestIntegration_ExternalMode_DeletionLeavesUnmanagedImportsAlone(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := setupControlPlaneEnvTest(t)
+	ensureReadyClusterSecretStore(t, ctx, c)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cp-external-delete-"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed(), "create test namespace")
+
+	// A K-ORC User this ControlPlane never created. It shares the namespace and the
+	// kind of the operator's own admin import, so only NAME scoping keeps it safe.
+	foreign := &orcv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign-user", Namespace: ns.Name},
+		Spec: orcv1alpha1.UserSpec{
+			ManagementPolicy: orcv1alpha1.ManagementPolicyUnmanaged,
+			Import:           &orcv1alpha1.UserImport{Filter: &orcv1alpha1.UserFilter{}},
+		},
+	}
+	g.Expect(c.Create(ctx, foreign)).To(Succeed(), "create an unrelated K-ORC User import")
+
+	cp := integrationExternalControlPlane("cp-external", ns.Name)
+	driveExternalControlPlaneToReady(t, ctx, c, cp)
+
+	cpKey := types.NamespacedName{Name: cp.Name, Namespace: ns.Name}
+	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeReady, metav1.ConditionTrue, itEventuallyTimeout)
+
+	g.Expect(c.Delete(ctx, cp)).To(Succeed(), "delete the External-mode ControlPlane")
+
+	// Every owned K-ORC CR disappears and the finalizer releases the ControlPlane.
+	// envtest runs no garbage collector, so this is the reconcileDelete sweep, not GC.
+	g.Eventually(func() bool {
+		for _, child := range orcChildResources {
+			obj := child.newObj()
+			key := client.ObjectKey{Name: child.name(cp), Namespace: ns.Name}
+			if err := c.Get(ctx, key, obj); !apierrors.IsNotFound(err) {
+				return false
+			}
+		}
+		return apierrors.IsNotFound(c.Get(ctx, cpKey, &c5c3v1alpha1.ControlPlane{}))
+	}, itEventuallyTimeout, itPollInterval).Should(BeTrue(),
+		"the owned K-ORC CRs and the ControlPlane must be gone")
+
+	// ... and the foreign import is untouched.
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "foreign-user", Namespace: ns.Name}, &orcv1alpha1.User{})).
+		To(Succeed(), "a K-ORC CR the ControlPlane does not own must survive its deletion")
+}

--- a/operators/c5c3/internal/controller/korc_imports.go
+++ b/operators/c5c3/internal/controller/korc_imports.go
@@ -7,6 +7,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +45,58 @@ func adminDomainRef(cp *c5c3v1alpha1.ControlPlane) string {
 	return cp.Name + "-domain-default"
 }
 
+// korcAdminImports carries the two admin-identity imports ensureKORCAdminImports
+// reconciled, with their live status. reconcileKORC needs the OBJECTS, not just a
+// rendered message: in External mode it classifies K-ORC's condition messages to
+// distinguish the failure classes K-ORC itself collapses into TransientError.
+type korcAdminImports struct {
+	domain *orcv1alpha1.Domain
+	user   *orcv1alpha1.User
+}
+
+// objects returns the imports in dependency order — Domain before User — so a
+// classifier reports the ROOT stuck dependency rather than the resource that
+// merely blocked on it.
+func (i korcAdminImports) objects() []orcv1alpha1.ObjectWithConditions {
+	var objs []orcv1alpha1.ObjectWithConditions
+	if i.domain != nil {
+		objs = append(objs, i.domain)
+	}
+	if i.user != nil {
+		objs = append(objs, i.user)
+	}
+	return objs
+}
+
+// statusFragment reports the first admin import (Domain before User) that is not
+// yet usable — either a terminal K-ORC error or a not-yet-Available state — or an
+// empty string when both imports are Available with no terminal error.
+func (i korcAdminImports) statusFragment() string {
+	if i.domain != nil {
+		if frag := korcImportStatusFragment("Domain", i.domain.Name, i.domain); frag != "" {
+			return frag
+		}
+	}
+	if i.user != nil {
+		return korcImportStatusFragment("User", i.user.Name, i.user)
+	}
+	return ""
+}
+
+// stalledImport reports the first admin import that has been waiting to be
+// "created externally" for longer than grace, as a human-readable "Kind name"
+// pair. See korcImportStalled for why that is a misconfiguration signal in
+// External mode rather than a legitimate wait.
+func (i korcAdminImports) stalledImport(grace time.Duration) (string, bool) {
+	if korcImportStalled(i.domain, grace) {
+		return fmt.Sprintf("Domain %q", i.domain.Name), true
+	}
+	if korcImportStalled(i.user, grace) {
+		return fmt.Sprintf("User %q", i.user.Name), true
+	}
+	return "", false
+}
+
 // ensureKORCAdminImports ensures the K-ORC Domain and User that the admin
 // ApplicationCredential's UserRef depends on exist as UNMANAGED imports. The
 // Keystone bootstrap creates the real admin user (in the Default domain); K-ORC
@@ -51,13 +104,13 @@ func adminDomainRef(cp *c5c3v1alpha1.ControlPlane) string {
 // "Waiting for User/admin to be created". Both CRs are owned by the ControlPlane
 // for GC and reuse the admin clouds.yaml credentials.
 //
-// It returns a human-readable import-status fragment (empty when both imports are
-// Available with no terminal error) so reconcileKORC can fold the stuck dependency
-// into the KORCReady message — the documented failure class (wrong clouds.yaml
-// endpoint, K-ORC swallowing list errors, an import hanging on "created
-// externally") otherwise surfaces only as an eternal "WaitingForApplicationCredential"
-// with no pointer to the real cause.
-func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) (string, error) {
+// It returns both reconciled imports carrying live status (controllerutil.
+// CreateOrUpdate Gets first) so reconcileKORC can fold the stuck dependency into
+// the KORCReady message and, in External mode, classify its condition messages —
+// the documented failure class (wrong clouds.yaml endpoint, K-ORC swallowing list
+// errors, an import hanging on "created externally") otherwise surfaces only as an
+// eternal "WaitingForApplicationCredential" with no pointer to the real cause.
+func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) (korcAdminImports, error) {
 	domain := &orcv1alpha1.Domain{
 		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
 	}
@@ -69,7 +122,7 @@ func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp 
 		}
 		return controllerutil.SetControllerReference(cp, domain, r.Scheme)
 	}); err != nil {
-		return "", fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
+		return korcAdminImports{}, fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
 	}
 
 	user := &orcv1alpha1.User{
@@ -86,15 +139,10 @@ func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp 
 		}
 		return controllerutil.SetControllerReference(cp, user, r.Scheme)
 	}); err != nil {
-		return "", fmt.Errorf("admin User import %q: %w", user.Name, err)
+		return korcAdminImports{}, fmt.Errorf("admin User import %q: %w", user.Name, err)
 	}
-	// Report the first admin import (Domain before User) that is not yet usable —
-	// either a terminal K-ORC error or a not-yet-Available state — or an empty
-	// string when both imports are Available with no terminal error.
-	if frag := korcImportStatusFragment("Domain", domain.Name, domain); frag != "" {
-		return frag, nil
-	}
-	return korcImportStatusFragment("User", user.Name, user), nil
+
+	return korcAdminImports{domain: domain, user: user}, nil
 }
 
 // korcImportStatusFragment reports the import-status fragment for a single K-ORC

--- a/operators/c5c3/internal/controller/reconcile_admincredential.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential.go
@@ -45,6 +45,26 @@ func (r *ControlPlaneReconciler) reconcileAdminCredential(ctx context.Context, c
 	// Gate on KORCReady.
 	if !conditions.AllTrue(cp.Status.Conditions, conditionTypeKORCReady) {
 		logger.Info("KORC not ready, deferring admin credential push")
+		// In External mode, name the cause when KORCReady reports drift in the
+		// external installation rather than an ordinary wait: an eternal
+		// "WaitingForKORC" hides that the admin password Secret — not the operator —
+		// is what has to change.
+		//
+		// The LIVE drift signal is KORCReady itself: reconcileKORC requeues on the
+		// drift, and RunPipeline short-circuits on that non-zero result, so this
+		// sub-reconciler is not re-entered in the same pass. This escalation is the
+		// defense-in-depth path — it keeps AdminCredentialReady honest for any caller
+		// that does observe a drifted KORCReady.
+		if cp.IsExternalKeystone() {
+			if korc := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady); korc != nil && isCredentialDriftReason(korc.Reason) {
+				fail(conditionReasonCredentialDrift, fmt.Sprintf(
+					"the external Keystone at %s no longer matches the admin credential derived from Secret %q: %s; "+
+						"the operator never remediates the external installation — update the Secret to drive a re-mint",
+					externalKeystoneAuthURL(cp), cp.Spec.KORC.AdminCredential.PasswordSecretRef.Name, korc.Message,
+				))
+				return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
+			}
+		}
 		fail("WaitingForKORC", "KORCReady is not True; admin credential push deferred")
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}

--- a/operators/c5c3/internal/controller/reconcile_admincredential_test.go
+++ b/operators/c5c3/internal/controller/reconcile_admincredential_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the admin-credential sub-reconciler's KORCReady gate, in particular
+// the External-mode drift escalation (P6): drift in the external installation is
+// surfaced on the existing sub-condition with a dedicated reason, never fought.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// reconcileAdminCredentialAtKORCGate runs reconcileAdminCredential against a CR
+// whose KORCReady condition is False with the given reason, and returns the
+// resulting AdminCredentialReady condition. The gate returns before any client
+// call beyond the condition read, so a bare scheme suffices.
+func reconcileAdminCredentialAtKORCGate(
+	t *testing.T, cp *c5c3v1alpha1.ControlPlane, korcReason, korcMessage string,
+) *metav1.Condition {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeKORCReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: cp.Generation,
+		Reason:             korcReason,
+		Message:            korcMessage,
+	})
+
+	s := korcTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	res, err := r.reconcileAdminCredential(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+	return conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminCredentialReady)
+}
+
+// TestReconcileAdminCredential_ExternalModeDriftEscalatesReason asserts that both
+// drift classes on KORCReady — a stale admin password (AuthenticationFailed) and a
+// stale resolve-once import id (CredentialDrift) — escalate the gate from the
+// opaque WaitingForKORC to the documented CredentialDrift reason, naming the
+// Secret the operator reads and stating that it never remediates the external
+// installation.
+func TestReconcileAdminCredential_ExternalModeDriftEscalatesReason(t *testing.T) {
+	for _, korcReason := range []string{
+		conditionReasonAuthenticationFailed,
+		conditionReasonCredentialDrift,
+	} {
+		t.Run(korcReason, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cp := korcExternalControlPlane()
+
+			cond := reconcileAdminCredentialAtKORCGate(t, cp, korcReason, "got 401 instead")
+
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(cond.Reason).To(Equal(conditionReasonCredentialDrift))
+			g.Expect(cond.Message).To(ContainSubstring(`"keystone-admin"`),
+				"the message must name the admin-password Secret the operator reads")
+			g.Expect(cond.Message).To(ContainSubstring("never remediates"))
+			g.Expect(cond.Message).To(ContainSubstring("got 401 instead"),
+				"K-ORC's message must be carried through from KORCReady")
+		})
+	}
+}
+
+// TestReconcileAdminCredential_ExternalModeOtherKORCFailuresStayWaitingForKORC is
+// the discrimination guard: drift is a statement about the CREDENTIAL. An
+// unreachable endpoint, a TLS failure, a catalog mismatch or a stalled import are
+// not drift, so the gate must keep its ordinary WaitingForKORC reason.
+func TestReconcileAdminCredential_ExternalModeOtherKORCFailuresStayWaitingForKORC(t *testing.T) {
+	for _, korcReason := range []string{
+		conditionReasonEndpointUnreachable,
+		conditionReasonTLSVerificationFailed,
+		conditionReasonCatalogEndpointMismatch,
+		conditionReasonImportStalled,
+	} {
+		t.Run(korcReason, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cp := korcExternalControlPlane()
+
+			cond := reconcileAdminCredentialAtKORCGate(t, cp, korcReason, "some failure")
+
+			g.Expect(cond.Reason).To(Equal("WaitingForKORC"))
+			g.Expect(cond.Reason).NotTo(Equal(conditionReasonCredentialDrift))
+		})
+	}
+}
+
+// TestReconcileAdminCredential_ManagedModeGateUnchanged is the AC-2 regression
+// guard: a managed ControlPlane never picks up the External-mode drift vocabulary,
+// even when its KORCReady carries a reason that would escalate in External mode.
+func TestReconcileAdminCredential_ManagedModeGateUnchanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := korcControlPlane()
+
+	cond := reconcileAdminCredentialAtKORCGate(t, cp, conditionReasonAuthenticationFailed, "got 401 instead")
+
+	g.Expect(cond.Reason).To(Equal("WaitingForKORC"))
+}

--- a/operators/c5c3/internal/controller/reconcile_adminpassword.go
+++ b/operators/c5c3/internal/controller/reconcile_adminpassword.go
@@ -72,22 +72,35 @@ func adminPasswordExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalS
 }
 
 // effectiveAdminPasswordSecretRef returns the SecretRef every cp-side admin-password
-// consumer will read. In managed mode (Database.ClusterRef != nil)
-// the operator projects the admin password from OpenBao into the per-ControlPlane
-// Secret named adminPasswordSecretName(cp), so the effective ref points at that
-// Secret's "password" key. In brownfield mode the user supplies their own admin
-// password Secret out-of-band, so the ref is the user-declared
-// cp.Spec.KORC.AdminCredential.PasswordSecretRef verbatim. This NEVER mutates
-// cp.Spec — it returns the ref by value so callers cannot alias the user's spec.
+// consumer will read (readAdminPassword, the Keystone projection, and the Secret-name
+// field indexer).
 //
-// NOTE: callers of effectiveAdminPasswordSecretRef are added in Level 2 — defining
-// it now is intentional; it is not wired into any consumer yet.
+// External mode: the external Keystone's admin password is owned out-of-band, so
+// the ref is the user-declared cp.Spec.KORC.AdminCredential.PasswordSecretRef.
+// Updating THAT Secret is what feeds adminPasswordHashAnnotation and drives the
+// hash-driven application-credential re-mint — the only supported rotation path,
+// since the operator never writes to the external installation. The External
+// branch is keyed on the MODE discriminator, not on the database shape: External
+// mode has no infrastructure block, so inferring the identity mode from
+// Database.ClusterRef would couple two independent decisions.
 //
-//nolint:unused // declared by task 1.2; consumed by the Keystone projection, readAdminPassword, and the Secret-name extractor wired in Level 2 (tasks 2.1-2.3).
+// Managed mode (Database.ClusterRef != nil): the operator projects the admin
+// password from OpenBao into the per-ControlPlane Secret named
+// adminPasswordSecretName(cp), so the effective ref points at that Secret's
+// "password" key.
+//
+// Brownfield mode: the user supplies their own admin password Secret out-of-band,
+// so the ref is the user-declared PasswordSecretRef verbatim.
+//
+// This NEVER mutates cp.Spec — it returns the ref by value so callers cannot alias
+// the user's spec.
 func effectiveAdminPasswordSecretRef(cp *c5c3v1alpha1.ControlPlane) commonv1.SecretRefSpec {
-	// spec.infrastructure is optional (External keystone mode omits it). A nil
-	// block reads as "no managed database", so the effective ref is the
-	// user-supplied passwordSecretRef — the same branch brownfield mode takes.
+	if cp.IsExternalKeystone() {
+		return cp.Spec.KORC.AdminCredential.PasswordSecretRef
+	}
+	// A nil spec.infrastructure on a non-External CR is a webhook-bypass shape; it
+	// reads as "no managed database", so the effective ref is the user-supplied
+	// passwordSecretRef — the same branch brownfield mode takes.
 	if infra := cp.Spec.Infrastructure; infra != nil && infra.Database.ClusterRef != nil {
 		return commonv1.SecretRefSpec{Name: adminPasswordSecretName(cp), Key: "password"}
 	}
@@ -100,6 +113,10 @@ func effectiveAdminPasswordSecretRef(cp *c5c3v1alpha1.ControlPlane) commonv1.Sec
 // It runs BEFORE the Keystone sub-reconciler in the chain: the keystone-operator's
 // SecretsReady gate needs the admin-password ExternalSecret to exist before the
 // projected Keystone child references it.
+//
+// External CONTROL: the user-supplied passwordSecretRef Secret IS the admin
+// password source — there is no OpenBao bootstrap path to project from, because
+// the external Keystone's admin password was never minted by this operator.
 //
 // Brownfield CONTROL: when the ControlPlane supplies its own database connection
 // (Database.ClusterRef == nil, i.e. Host-based brownfield mode), the user owns the
@@ -114,10 +131,30 @@ func effectiveAdminPasswordSecretRef(cp *c5c3v1alpha1.ControlPlane) commonv1.Sec
 func (r *ControlPlaneReconciler) reconcileAdminPassword(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// External-mode short-circuit, keyed on the MODE discriminator: the admin
+	// password of a pre-existing Keystone is owned out-of-band, so the operator
+	// projects no ExternalSecret and seeds no OpenBao bootstrap path. The Secret
+	// effectiveAdminPasswordSecretRef resolves to is the user's own.
+	if cp.IsExternalKeystone() {
+		logger.Info("External keystone mode; the user-supplied Secret is the admin password source",
+			"secret", cp.Spec.KORC.AdminCredential.PasswordSecretRef.Name)
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeAdminPasswordReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cp.Generation,
+			Reason:             conditionReasonExternallyManaged,
+			Message: fmt.Sprintf("External keystone mode: the admin password is read from user-supplied "+
+				"Secret %q; no ExternalSecret is projected and no OpenBao bootstrap path is seeded "+
+				"(external Keystone at %s)",
+				cp.Spec.KORC.AdminCredential.PasswordSecretRef.Name, externalKeystoneAuthURL(cp)),
+		})
+		return ctrl.Result{}, nil
+	}
+
 	// Brownfield early-exit: the user supplies their own admin-password Secret, so
 	// there is nothing for the operator to project or reference in OpenBao. A nil
-	// spec.infrastructure (External keystone mode) is treated the same way — no
-	// managed database means no operator-owned admin-password projection.
+	// spec.infrastructure on a non-External CR is a webhook-bypass shape; treat it
+	// as brownfield rather than dereferencing it.
 	if infra := cp.Spec.Infrastructure; infra == nil || infra.Database.ClusterRef == nil {
 		logger.Info("brownfield database (user-supplied credential), skipping admin password ExternalSecret projection")
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{

--- a/operators/c5c3/internal/controller/reconcile_adminpassword_test.go
+++ b/operators/c5c3/internal/controller/reconcile_adminpassword_test.go
@@ -277,3 +277,82 @@ func TestAdminPasswordRemoteKeyFor_And_SecretName_DistinctPerControlPlane(t *tes
 		g.Expect(adminPasswordRemoteKeyFor(cp)).NotTo(Equal("keystone-admin"))
 	}
 }
+
+// adminPwExternalControlPlane builds an External-mode ControlPlane: no
+// spec.infrastructure block, and the admin password lives in a user-supplied
+// Secret the operator only ever reads.
+func adminPwExternalControlPlane() *c5c3v1alpha1.ControlPlane {
+	cp := adminPwManagedControlPlane()
+	cp.Spec.Infrastructure = nil
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		Mode:     c5c3v1alpha1.KeystoneModeExternal,
+		External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+	}
+	cp.Spec.KORC.AdminCredential.PasswordSecretRef = commonv1.SecretRefSpec{
+		Name: "external-admin",
+		Key:  "password",
+	}
+	return cp
+}
+
+// TestReconcileAdminPassword_ExternalMode_NoExternalSecret_ReadyTrue asserts the
+// External-mode short-circuit: AdminPasswordReady=True/ExternallyManaged, a
+// message naming both the user Secret and the external endpoint, and no
+// projection. No ClusterSecretStore is seeded, so a still-consulted store gate
+// would flip the condition to SecretStoreNotReady and fail this test.
+func TestReconcileAdminPassword_ExternalMode_NoExternalSecret_ReadyTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := adminPwExternalControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	result, err := r.reconcileAdminPassword(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}), "the External short-circuit must not requeue")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeAdminPasswordReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonExternallyManaged))
+	g.Expect(cond.Message).To(ContainSubstring(`"external-admin"`),
+		"the message must name the user-supplied admin-password Secret")
+	g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"))
+
+	_, getErr := getAdminPwES(t, r, cp)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"External mode must NOT project an admin-password ExternalSecret")
+}
+
+// TestEffectiveAdminPasswordSecretRef_ExternalModeReturnsUserSuppliedRef pins that
+// the External branch is keyed on the MODE discriminator, not on the database
+// shape. The second case is webhook-impossible on purpose: an External-mode CR
+// carrying a managed Database.ClusterRef. A Database.ClusterRef-keyed
+// implementation would return the operator-owned Secret name there and lose the
+// user's admin password — and with it the hash-driven re-mint input.
+func TestEffectiveAdminPasswordSecretRef_ExternalModeReturnsUserSuppliedRef(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := adminPwExternalControlPlane()
+	g.Expect(effectiveAdminPasswordSecretRef(cp)).
+		To(Equal(commonv1.SecretRefSpec{Name: "external-admin", Key: "password"}))
+
+	withManagedDB := adminPwExternalControlPlane()
+	withManagedDB.Spec.Infrastructure = &c5c3v1alpha1.InfrastructureSpec{
+		Database: commonv1.DatabaseSpec{ClusterRef: &corev1.LocalObjectReference{Name: "openstack-db"}},
+	}
+	g.Expect(effectiveAdminPasswordSecretRef(withManagedDB)).
+		To(Equal(commonv1.SecretRefSpec{Name: "external-admin", Key: "password"}),
+			"the identity mode, not the database shape, must select the External branch")
+}
+
+// TestEffectiveAdminPasswordSecretRef_ManagedUnchanged guards the AC-2 regression
+// contract: a managed CR still resolves to the operator-owned per-CP Secret.
+func TestEffectiveAdminPasswordSecretRef_ManagedUnchanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := adminPwManagedControlPlane()
+	g.Expect(effectiveAdminPasswordSecretRef(cp)).
+		To(Equal(commonv1.SecretRefSpec{Name: adminPasswordSecretName(cp), Key: "password"}))
+}

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials.go
@@ -268,6 +268,11 @@ func dbCredentialsDynamicEnabled(cp *c5c3v1alpha1.ControlPlane) bool {
 // reconcileDBCredentials projects (in managed mode) the per-ControlPlane service
 // DB-credential ExternalSecret and drives the DBCredentialsReady condition.
 //
+// External CONTROL: the ControlPlane has no database at all — no managed one to
+// issue credentials for, and no brownfield connection to reference. Neither
+// OpenBao nor the ClusterSecretStore is consulted; DBCredentialsReady is True
+// with the dedicated ExternallyManaged reason.
+//
 // Brownfield CONTROL: when the ControlPlane supplies its own database connection
 // (Database.ClusterRef == nil), the user owns the DB credential Secret
 // out-of-band, so the operator projects nothing and reports DBCredentialsReady
@@ -283,10 +288,29 @@ func dbCredentialsDynamicEnabled(cp *c5c3v1alpha1.ControlPlane) bool {
 func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// External-mode short-circuit, keyed on the MODE discriminator rather than on
+	// the database shape: an External-mode ControlPlane has no infrastructure
+	// block, so "no managed database" and "no database at all" are different
+	// states that must not collapse onto the brownfield reason below.
+	if cp.IsExternalKeystone() {
+		logger.Info("External keystone mode; no database is managed, skipping DB credential projection",
+			"authURL", externalKeystoneAuthURL(cp))
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeDBCredentialsReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cp.Generation,
+			Reason:             conditionReasonExternallyManaged,
+			Message: fmt.Sprintf("External keystone mode: the ControlPlane manages no database "+
+				"(external Keystone at %s); no DB-credential ExternalSecret is projected",
+				externalKeystoneAuthURL(cp)),
+		})
+		return ctrl.Result{}, nil
+	}
+
 	// Brownfield early-exit: the user supplies their own DB credential Secret, so
 	// there is nothing for the operator to project or reference in OpenBao. A nil
-	// spec.infrastructure (External keystone mode) is treated the same way — no
-	// managed database means no operator-owned DB-credential projection.
+	// spec.infrastructure on a non-External CR is a webhook-bypass shape; treat it
+	// as brownfield rather than dereferencing it.
 	if infra := cp.Spec.Infrastructure; infra == nil || infra.Database.ClusterRef == nil {
 		logger.Info("brownfield database (user-supplied credential), skipping DB credential ExternalSecret projection")
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
@@ -391,3 +391,70 @@ func TestDBDynamicRoleFor_DistinctPerControlPlane(t *testing.T) {
 	g.Expect(dbDynamicRoleFor(collideX)).NotTo(Equal(dbDynamicRoleFor(collideY)))
 	g.Expect(dbDynamicCredsPathFor(collideX)).NotTo(Equal(dbDynamicCredsPathFor(collideY)))
 }
+
+// dbCredExternalControlPlane builds an External-mode ControlPlane: no
+// spec.infrastructure block at all, so there is no database — managed OR
+// brownfield — to issue credentials for.
+func dbCredExternalControlPlane() *c5c3v1alpha1.ControlPlane {
+	cp := dbCredManagedControlPlane()
+	cp.Spec.Infrastructure = nil
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		Mode:     c5c3v1alpha1.KeystoneModeExternal,
+		External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+	}
+	return cp
+}
+
+// TestReconcileDBCredentials_ExternalMode_NoProjection_ReadyTrue asserts the
+// External-mode short-circuit reports ExternallyManaged and projects nothing.
+// No ClusterSecretStore is seeded into the fake client: were the store gate still
+// consulted, reconcileDBCredentials would flip the condition to
+// SecretStoreNotReady and requeue, so the assertions below double as proof that
+// External mode never touches OpenBao/ESO.
+func TestReconcileDBCredentials_ExternalMode_NoProjection_ReadyTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := dbCredExternalControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	result, err := r.reconcileDBCredentials(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}), "the External short-circuit must not requeue")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeDBCredentialsReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonExternallyManaged))
+	g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"))
+
+	_, getErr := getDBCredES(t, r, cp)
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"External mode must NOT project a DB-credential ExternalSecret")
+	_, vdsErr := getVDS(t, r, cp)
+	g.Expect(apierrors.IsNotFound(vdsErr)).To(BeTrue(),
+		"External mode must NOT project a VaultDynamicSecret generator")
+}
+
+// TestReconcileDBCredentials_BrownfieldStillReportsBrownfieldReason pins that the
+// External short-circuit did not swallow the brownfield one: a brownfield
+// *database* under a managed Keystone keeps its own documented reason, which is a
+// different operator situation from "no database at all".
+func TestReconcileDBCredentials_BrownfieldStillReportsBrownfieldReason(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := dbCredBrownfieldControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileDBCredentials(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeDBCredentialsReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Reason).To(Equal("BrownfieldUserSuppliedCredential"))
+	g.Expect(cond.Reason).NotTo(Equal(conditionReasonExternallyManaged),
+		"a brownfield database is not an externally-managed identity plane")
+}

--- a/operators/c5c3/internal/controller/reconcile_delete.go
+++ b/operators/c5c3/internal/controller/reconcile_delete.go
@@ -36,6 +36,30 @@ const korcFinalizerPrefix = orcv1alpha1.GroupName + "/"
 // objects it returns) iterate this list, so adding a kind only requires one
 // entry here. Each newObj returns a zeroed object for Get/Delete; name derives
 // the deterministic per-ControlPlane CR name (all live in childNamespace(cp)).
+//
+// DELETION BLAST RADIUS. The sweep is correct for BOTH keystone modes, because
+// what a Delete does to the external OpenStack installation is decided by each
+// CR's ManagementPolicy, not by the ControlPlane's mode:
+//
+//   - ApplicationCredential — ManagementPolicyManaged. Its K-ORC finalizer revokes
+//     the credential at the Keystone level BEFORE the CR delete returns, so
+//     authenticating with it immediately afterwards yields 404 "Could not find
+//     Application Credential" (not 401). This is the one identity object the
+//     operator minted, so it is the one it destroys.
+//   - User, Domain — ManagementPolicyUnmanaged imports (see ensureKORCAdminImports).
+//     Deleting their CRs removes the Kubernetes objects and leaves the OpenStack
+//     resources they imported untouched. K-ORC's deletion-guard finalizers also
+//     enforce the teardown order: a User cannot go while an ApplicationCredential
+//     still references it.
+//   - Service, Endpoint — managed catalog entries today, so the sweep deletes them
+//     from Keystone's catalog. In External mode the catalog is owned by the
+//     external installation; the import-first catalog work turns these into
+//     unmanaged imports too, at which point this entry becomes a CR-only delete.
+//
+// The OpenBao-backed Secrets are torn down by owner-reference GC, EXCEPT the path
+// behind the {name}-admin-app-credential-backup PushSecret: its DeletionPolicy is
+// deliberately None (see adminAppCredentialPushSecret), so the last-pushed
+// credential survives at its OpenBao path. Nothing else is touched.
 var orcChildResources = []struct {
 	newObj func() client.Object
 	name   func(*c5c3v1alpha1.ControlPlane) string

--- a/operators/c5c3/internal/controller/reconcile_delete_test.go
+++ b/operators/c5c3/internal/controller/reconcile_delete_test.go
@@ -232,3 +232,141 @@ func TestReconcileDelete_ForceRemovesORCFinalizersAfterStall(t *testing.T) {
 		ContainSubstring("ORCTeardownStalled"),
 	)), "the stall escape must emit a Warning ORCTeardownStalled event")
 }
+
+// deletingExternalControlPlane returns an External-mode ControlPlane being
+// deleted, carrying the ORC-teardown finalizer.
+func deletingExternalControlPlane() *c5c3v1alpha1.ControlPlane {
+	cp := korcExternalControlPlane()
+	ts := metav1.NewTime(metav1.Now().Add(-time.Second))
+	cp.DeletionTimestamp = &ts
+	cp.Finalizers = []string{controlPlaneORCFinalizer}
+	return cp
+}
+
+// externalModeORCChildren returns the five owned K-ORC CRs an External-mode
+// ControlPlane projects, with the ManagementPolicy each really carries: the
+// ApplicationCredential is Managed (its finalizer revokes at the Keystone level),
+// while the admin User/Domain are Unmanaged imports whose CR deletion cannot touch
+// the external Keystone.
+func externalModeORCChildren(cp *c5c3v1alpha1.ControlPlane) []client.Object {
+	ns := childNamespace(cp)
+	return []client.Object{
+		&orcv1alpha1.ApplicationCredential{
+			ObjectMeta: metav1.ObjectMeta{Name: adminAppCredentialName(cp), Namespace: ns},
+			Spec:       orcv1alpha1.ApplicationCredentialSpec{ManagementPolicy: orcv1alpha1.ManagementPolicyManaged},
+		},
+		&orcv1alpha1.Service{ObjectMeta: metav1.ObjectMeta{Name: keystoneServiceName(cp), Namespace: ns}},
+		&orcv1alpha1.Endpoint{ObjectMeta: metav1.ObjectMeta{Name: keystoneEndpointName(cp), Namespace: ns}},
+		&orcv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{Name: adminUserRef(cp), Namespace: ns},
+			Spec: orcv1alpha1.UserSpec{
+				ManagementPolicy: orcv1alpha1.ManagementPolicyUnmanaged,
+				Import:           &orcv1alpha1.UserImport{Filter: &orcv1alpha1.UserFilter{}},
+			},
+		},
+		&orcv1alpha1.Domain{
+			ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: ns},
+			Spec: orcv1alpha1.DomainSpec{
+				ManagementPolicy: orcv1alpha1.ManagementPolicyUnmanaged,
+				Import:           &orcv1alpha1.DomainImport{Filter: &orcv1alpha1.DomainFilter{}},
+			},
+		},
+	}
+}
+
+// TestReconcileDelete_ExternalMode_TearsDownOnlyOwnedORCCRs is the AC-4 guard:
+// deleting an External-mode ControlPlane removes exactly the K-ORC CRs the
+// operator owns — and provably nothing else. A same-namespace K-ORC User that the
+// ControlPlane never created (another tenant's import) must survive.
+func TestReconcileDelete_ExternalMode_TearsDownOnlyOwnedORCCRs(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	s := korcTestScheme(t)
+	cp := deletingExternalControlPlane()
+	foreign := &orcv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "someone-elses-user", Namespace: childNamespace(cp)},
+		Spec:       orcv1alpha1.UserSpec{ManagementPolicy: orcv1alpha1.ManagementPolicyUnmanaged},
+	}
+	objs := append([]client.Object{cp, foreign}, externalModeORCChildren(cp)...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	// No K-ORC finalizers are seeded, so the CRs vanish on Delete and the sweep
+	// releases the ControlPlane finalizer in one pass.
+	res, err := r.reconcileDelete(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+	g.Expect(controllerutil.ContainsFinalizer(cp, controlPlaneORCFinalizer)).To(BeFalse(),
+		"the ControlPlane finalizer must be released once every owned K-ORC CR is gone")
+
+	// Every owned K-ORC CR is gone.
+	for _, child := range orcChildResources {
+		obj := child.newObj()
+		key := types.NamespacedName{Name: child.name(cp), Namespace: childNamespace(cp)}
+		g.Expect(apierrors.IsNotFound(c.Get(ctx, key, obj))).To(BeTrue(),
+			"owned K-ORC CR %s must be deleted", key.Name)
+	}
+
+	// ... and provably nothing else. The unrelated import survives untouched.
+	survivor := &orcv1alpha1.User{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "someone-elses-user", Namespace: childNamespace(cp)}, survivor)).
+		To(Succeed(), "a K-ORC CR the ControlPlane does not own must never be swept")
+}
+
+// TestDeleteORCResources_ExternalMode_LeavesUnmanagedImportsUntouched pins WHY the
+// sweep has zero blast radius on the external installation: the admin User/Domain
+// the sweep deletes are Unmanaged imports, so removing their CRs cannot delete the
+// OpenStack resources behind them. Only the ApplicationCredential is Managed — its
+// K-ORC finalizer revokes at the Keystone level before the CR delete returns, so
+// authenticating with the revoked credential afterwards yields 404 "Could not find
+// Application Credential" (not 401).
+func TestDeleteORCResources_ExternalMode_LeavesUnmanagedImportsUntouched(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	s := korcTestScheme(t)
+	cp := deletingExternalControlPlane()
+	objs := append([]client.Object{cp}, externalModeORCChildren(cp)...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	// Read the management policies the sweep is about to act on, BEFORE the sweep.
+	user := &orcv1alpha1.User{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: adminUserRef(cp), Namespace: childNamespace(cp)}, user)).To(Succeed())
+	g.Expect(user.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyUnmanaged))
+	g.Expect(user.Spec.Import).NotTo(BeNil(), "the admin User is an import, not an owned resource")
+
+	domain := &orcv1alpha1.Domain{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: adminDomainRef(cp), Namespace: childNamespace(cp)}, domain)).To(Succeed())
+	g.Expect(domain.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyUnmanaged))
+	g.Expect(domain.Spec.Import).NotTo(BeNil())
+
+	ac := &orcv1alpha1.ApplicationCredential{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: adminAppCredentialName(cp), Namespace: childNamespace(cp)}, ac)).To(Succeed())
+	g.Expect(ac.Spec.ManagementPolicy).To(Equal(orcv1alpha1.ManagementPolicyManaged),
+		"the app credential is the only identity object the operator minted, so the only one it revokes")
+
+	remaining, hasLiveWork, err := r.deleteORCResources(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(hasLiveWork).To(BeTrue(), "live (not-yet-Terminating) CRs must announce the teardown once")
+	g.Expect(remaining).To(BeEmpty())
+}
+
+// TestReconcileDelete_ExternalMode_NoORCResources_ReleasesFinalizer covers the
+// edge path where the K-ORC chain never converged: an External-mode ControlPlane
+// deleted before any K-ORC CR was projected must still release its finalizer
+// rather than wedge on Terminating.
+func TestReconcileDelete_ExternalMode_NoORCResources_ReleasesFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := deletingExternalControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+
+	res, err := r.reconcileDelete(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+	g.Expect(controllerutil.ContainsFinalizer(cp, controlPlaneORCFinalizer)).To(BeFalse())
+}

--- a/operators/c5c3/internal/controller/reconcile_horizon.go
+++ b/operators/c5c3/internal/controller/reconcile_horizon.go
@@ -106,14 +106,13 @@ func (r *ControlPlaneReconciler) reconcileHorizon(ctx context.Context, cp *c5c3v
 		return ctrl.Result{}, nil
 	}
 
-	// spec.infrastructure is optional (External keystone mode omits it). The
-	// dashboard projection DeepCopies the shared cache from that block, so a nil
-	// block has nothing to project and the deref below would panic. Guard locally
-	// rather than trusting the pipeline short-circuit: reconcileInfrastructure
-	// runs first and halts a nil-block CR with an ExternalModeNotImplemented
-	// requeue, so this is unreachable today, but a later pipeline reorder must not
-	// reach the nil dereference. The Infrastructure sub-reconciler owns the
-	// External-mode requeue.
+	// Nil-safety fail-safe. The dashboard projection DeepCopies the shared cache
+	// from spec.infrastructure, so a nil block has nothing to project and the deref
+	// below would panic. The validating webhook forbids services.horizon in
+	// External mode (the dashboard needs its own External-mode design) and requires
+	// spec.infrastructure otherwise, so an External-mode CR always returns at the
+	// HorizonNotManaged early-exit above and this guard only fires for a
+	// webhook-bypassed CR.
 	if cp.Spec.Infrastructure == nil {
 		return ctrl.Result{RequeueAfter: infraRequeueAfter}, nil
 	}

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -102,27 +102,47 @@ var memcachedGVK = schema.GroupVersionKind{
 // is still converging the sub-reconciler requeues with InfrastructureReady
 // False. When the control plane uses only brownfield infra there is nothing to
 // provision, so InfrastructureReady is True immediately.
+//
+// External keystone mode has NO infrastructure block at all, so the skip is
+// keyed on the mode discriminator (cp.IsExternalKeystone) rather than on the
+// database shape the brownfield short-circuits read.
 func (r *ControlPlaneReconciler) reconcileInfrastructure(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// spec.infrastructure is optional now: an External-mode Keystone ControlPlane
-	// omits it (the validating webhook forbids it in External mode and requires it
-	// otherwise). External-mode reconciliation — managing identity against a
-	// pre-existing Keystone with no backing services to provision — lands with the
-	// External-mode reconciliation work; until then the CR is accepted at
-	// admission but this sub-reconciler halts the pipeline with a gentle requeue
-	// rather than dereferencing the nil block. Every non-External CR reaches this
-	// point with infrastructure materialized (webhook default), so the guard only
-	// fires for an External-mode CR.
+	// External-mode short-circuit: identity is managed against a pre-existing
+	// Keystone, so there are no backing services to provision. Report the
+	// condition True with the dedicated ExternallyManaged reason — the condition
+	// SCHEMA is identical across modes, so subConditionTypes, setReadyCondition
+	// and the condition_type drift guard need no mode awareness.
+	if cp.IsExternalKeystone() {
+		logger.Info("External keystone mode; no backing services are provisioned",
+			"authURL", externalKeystoneAuthURL(cp))
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeInfrastructureReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cp.Generation,
+			Reason:             conditionReasonExternallyManaged,
+			Message: fmt.Sprintf("External keystone mode: identity is managed against %s; "+
+				"no MariaDB/Memcached is provisioned", externalKeystoneAuthURL(cp)),
+		})
+		return ctrl.Result{}, nil
+	}
+
+	// Nil-safety fail-safe. spec.infrastructure is optional at the Go/CRD layer
+	// because External mode omits it, but the validating webhook REQUIRES it
+	// outside External mode — so this branch is unreachable on the admission path
+	// and only fires for a webhook-bypassed CR (direct etcd write, admission
+	// misconfigured). Fail closed with a named reason rather than dereferencing
+	// the nil block below.
 	if cp.Spec.Infrastructure == nil {
-		logger.Info("spec.infrastructure is unset (External keystone mode); infrastructure reconciliation not yet implemented")
+		logger.Info("spec.infrastructure is unset on a non-External ControlPlane; refusing to provision")
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeInfrastructureReady,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: cp.Generation,
-			Reason:             "ExternalModeNotImplemented",
-			Message: "spec.infrastructure is unset (External keystone mode); the ControlPlane is accepted " +
-				"but External-mode reconciliation is not yet implemented",
+			Reason:             conditionReasonInfrastructureNotConfigured,
+			Message: "spec.infrastructure is unset but services.keystone.mode is not External; " +
+				"the backing services cannot be provisioned",
 		})
 		return ctrl.Result{RequeueAfter: infraRequeueAfter}, nil
 	}

--- a/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure_test.go
@@ -487,3 +487,83 @@ func TestReconcileInfrastructure_BrownfieldSkipsChildren(t *testing.T) {
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 }
+
+// externalInfraControlPlane builds an External-mode ControlPlane: the identity
+// plane is a pre-existing Keystone and there is NO spec.infrastructure block
+// (the validating webhook forbids it in External mode).
+func externalInfraControlPlane() *c5c3v1alpha1.ControlPlane {
+	return &c5c3v1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp", Namespace: "default", Generation: 1},
+		Spec: c5c3v1alpha1.ControlPlaneSpec{
+			OpenStackRelease: "2025.2",
+			Services: c5c3v1alpha1.ServicesSpec{
+				Keystone: &c5c3v1alpha1.ServiceKeystoneSpec{
+					Mode:     c5c3v1alpha1.KeystoneModeExternal,
+					External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+				},
+			},
+		},
+	}
+}
+
+// TestReconcileInfrastructure_ExternalModeReportsExternallyManaged asserts the
+// External-mode short-circuit: InfrastructureReady=True with the dedicated
+// ExternallyManaged reason, a message naming the external endpoint, no requeue,
+// and provably zero backing-service children.
+func TestReconcileInfrastructure_ExternalModeReportsExternallyManaged(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := externalInfraControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileInfrastructure(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}), "the External short-circuit must not requeue")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeInfrastructureReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonExternallyManaged))
+	g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"),
+		"the ExternallyManaged message must name the external endpoint")
+
+	// Absence of the managed children is the acceptance criterion, so assert it
+	// explicitly rather than relying on the condition alone.
+	var mariadbList mariadbv1alpha1.MariaDBList
+	g.Expect(c.List(context.Background(), &mariadbList)).To(Succeed())
+	g.Expect(mariadbList.Items).To(BeEmpty(), "External mode must not create a MariaDB CR")
+
+	memcachedList := &unstructured.UnstructuredList{}
+	memcachedList.SetGroupVersionKind(memcachedGVK)
+	g.Expect(c.List(context.Background(), memcachedList)).To(Succeed())
+	g.Expect(memcachedList.Items).To(BeEmpty(), "External mode must not create a Memcached CR")
+}
+
+// TestReconcileInfrastructure_NilInfrastructureNonExternalFailsClosed covers the
+// webhook-bypass edge path: a Managed CR whose spec.infrastructure was dropped
+// must fail closed with a named reason rather than dereference the nil block or
+// silently report Ready.
+func TestReconcileInfrastructure_NilInfrastructureNonExternalFailsClosed(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := infraTestScheme(t)
+	cp := managedInfraControlPlane()
+	cp.Spec.Infrastructure = nil
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileInfrastructure(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(infraRequeueAfter))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeInfrastructureReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonInfrastructureNotConfigured))
+
+	var mariadbList mariadbv1alpha1.MariaDBList
+	g.Expect(c.List(context.Background(), &mariadbList)).To(Succeed())
+	g.Expect(mariadbList.Items).To(BeEmpty())
+}

--- a/operators/c5c3/internal/controller/reconcile_keystone.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone.go
@@ -125,15 +125,36 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 		return ctrl.Result{}, nil
 	}
 
-	// spec.infrastructure is optional (External keystone mode omits it). This
-	// managed projection points the Keystone child at the backing services the
-	// ControlPlane provisioned, so a nil block has nothing to project and the
-	// derefs below would panic. Guard locally rather than trusting the pipeline
-	// short-circuit: reconcileInfrastructure runs first and halts a nil-block CR
-	// with an ExternalModeNotImplemented requeue, so this is unreachable today,
-	// but a later pipeline reorder — or an Infrastructure sub-reconciler that
-	// reports Ready for External mode — must not reach the nil dereference. The
-	// Infrastructure sub-reconciler owns the External-mode requeue.
+	// External-mode short-circuit: identity is managed against a pre-existing
+	// Keystone, so no child is projected.
+	//
+	// It also does NOT delete a previously-projected child. A Managed -> External
+	// flip is rejected outright by the validating webhook (adopting an existing
+	// installation must be a fresh External-mode ControlPlane), so no child can
+	// exist here. Were one to appear anyway, the deliberate fail-safe above —
+	// preserve the child unless keystoneDeletionAllowedAnnotation opts in — is the
+	// only sanctioned teardown path, because the child's credential/fernet keys are
+	// irreplaceable.
+	if cp.IsExternalKeystone() {
+		logger.Info("External keystone mode; no Keystone child is projected",
+			"authURL", externalKeystoneAuthURL(cp))
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeKeystoneReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cp.Generation,
+			Reason:             conditionReasonExternallyManaged,
+			Message: fmt.Sprintf("External keystone mode: identity is managed against %s; "+
+				"no Keystone child is projected", externalKeystoneAuthURL(cp)),
+		})
+		return ctrl.Result{}, nil
+	}
+
+	// Nil-safety fail-safe. This managed projection points the Keystone child at
+	// the backing services the ControlPlane provisioned, so a nil block has nothing
+	// to project and the derefs below would panic. The validating webhook requires
+	// spec.infrastructure outside External mode, and the External branch above has
+	// already returned, so this only fires for a webhook-bypassed CR —
+	// reconcileInfrastructure halts the same CR with InfrastructureNotConfigured.
 	if cp.Spec.Infrastructure == nil {
 		return ctrl.Result{RequeueAfter: infraRequeueAfter}, nil
 	}

--- a/operators/c5c3/internal/controller/reconcile_keystone_test.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone_test.go
@@ -170,20 +170,15 @@ func TestReconcileKeystone_NotManagedWhenServiceUnset(t *testing.T) {
 }
 
 // TestReconcileKeystone_NilInfrastructureDoesNotPanic exercises the defensive
-// nil-Infrastructure guard. An External-mode ControlPlane omits
-// spec.infrastructure; the pipeline short-circuits at the Infrastructure
-// sub-reconciler before Keystone runs today, but the fixture carries
-// InfrastructureReady=True, so without a local guard the projection's
-// cp.Spec.Infrastructure derefs would panic once the gate is passed. The guard
-// must instead requeue and leave the Infrastructure sub-reconciler to own the
-// External-mode requeue.
+// nil-Infrastructure guard on a NON-External ControlPlane — the webhook-bypass
+// shape, since the validating webhook requires spec.infrastructure outside
+// External mode. The fixture keeps InfrastructureReady=True, so without a local
+// guard the projection's cp.Spec.Infrastructure derefs would panic once the gate
+// is passed. The guard must instead requeue and project no child.
 func TestReconcileKeystone_NilInfrastructureDoesNotPanic(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := keystoneTestScheme(t)
 	cp := keystoneControlPlane()
-	// External keystone mode omits the backing-services block. The fixture keeps
-	// InfrastructureReady=True, so the InfrastructureReady gate would pass and —
-	// without the guard — reach the nil dereference.
 	cp.Spec.Infrastructure = nil
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
@@ -688,4 +683,95 @@ func TestReconcileKeystone_BrownfieldLeavesSuppliedAdminPasswordRef(t *testing.T
 	g.Expect(k.Spec.Bootstrap.AdminPasswordSecretRef.Name).To(Equal("user-supplied-admin"),
 		"brownfield mode must leave the user-supplied admin-password ref untouched")
 	g.Expect(k.Spec.Bootstrap.AdminPasswordSecretRef.Key).To(Equal("pw"))
+}
+
+// keystoneExternalControlPlane builds an External-mode ControlPlane: no
+// spec.infrastructure block, identity managed against a pre-existing Keystone.
+func keystoneExternalControlPlane() *c5c3v1alpha1.ControlPlane {
+	cp := keystoneControlPlane()
+	cp.Spec.Infrastructure = nil
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		Mode:     c5c3v1alpha1.KeystoneModeExternal,
+		External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+	}
+	return cp
+}
+
+// TestReconcileKeystone_ExternalModeNoChildProjected asserts the External-mode
+// short-circuit: KeystoneReady=True/ExternallyManaged, a message naming the
+// external endpoint, no requeue, and provably no Keystone child.
+func TestReconcileKeystone_ExternalModeNoChildProjected(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := keystoneTestScheme(t)
+	cp := keystoneExternalControlPlane()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKeystone(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue(), "the External short-circuit must not requeue")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKeystoneReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonExternallyManaged))
+	g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"))
+
+	k := &keystonev1alpha1.Keystone{}
+	key := types.NamespacedName{Name: keystoneName(cp), Namespace: childNamespace(cp)}
+	g.Expect(apierrors.IsNotFound(c.Get(context.Background(), key, k))).To(BeTrue(),
+		"External mode must not project a Keystone child")
+}
+
+// TestReconcileKeystone_ExternalModeReasonDistinctFromNotManaged pins the
+// vocabulary split behaviorally: "identity lives elsewhere" (External) and "there
+// is no identity plane at all" (services.keystone unset) both report
+// KeystoneReady=True, but an operator must be able to tell them apart from the
+// reason alone.
+func TestReconcileKeystone_ExternalModeReasonDistinctFromNotManaged(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := keystoneTestScheme(t)
+
+	external := keystoneExternalControlPlane()
+	unmanaged := keystoneControlPlane()
+	unmanaged.Name = "cp-unmanaged"
+	unmanaged.Spec.Services.Keystone = nil
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(external, unmanaged).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKeystone(context.Background(), external)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, err = r.reconcileKeystone(context.Background(), unmanaged)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	externalCond := conditions.GetCondition(external.Status.Conditions, conditionTypeKeystoneReady)
+	unmanagedCond := conditions.GetCondition(unmanaged.Status.Conditions, conditionTypeKeystoneReady)
+	g.Expect(externalCond.Reason).To(Equal(conditionReasonExternallyManaged))
+	g.Expect(unmanagedCond.Reason).To(Equal("KeystoneNotManaged"))
+	g.Expect(externalCond.Reason).NotTo(Equal(unmanagedCond.Reason))
+}
+
+// TestReconcileKeystone_ExternalModePreservesAnUnexpectedChild covers the
+// destructive edge path. A Managed -> External flip is rejected at admission, so
+// no child can exist here; if one does anyway (a webhook-bypassed CR), the
+// External branch must NOT cascade-delete it — the child's credential/fernet keys
+// are irreplaceable.
+func TestReconcileKeystone_ExternalModePreservesAnUnexpectedChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := keystoneTestScheme(t)
+	cp := keystoneExternalControlPlane()
+	child := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: keystoneName(cp), Namespace: childNamespace(cp)},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, child).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	_, err := r.reconcileKeystone(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	k := &keystonev1alpha1.Keystone{}
+	key := types.NamespacedName{Name: keystoneName(cp), Namespace: childNamespace(cp)}
+	g.Expect(c.Get(context.Background(), key, k)).To(Succeed(),
+		"an unexpected pre-existing Keystone child must be preserved, never deleted")
 }

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -369,6 +369,19 @@ func (r *ControlPlaneReconciler) classifyExternalKORCState(
 
 	objs := append(imports.objects(), ac)
 	if reason, rawMessage := classifyExternalKORCFailure(objs...); reason != "" {
+		// Announce credential drift loudly — and exactly once per transition into
+		// the drifted state, not on every 10s requeue. Read the reason BEFORE fail()
+		// overwrites it: on this path no earlier fail() has fired, so the condition
+		// still carries the previous pass's reason.
+		if isCredentialDriftReason(reason) {
+			if prev := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady); prev == nil || !isCredentialDriftReason(prev.Reason) {
+				r.Recorder.Event(cp, "Warning", conditionReasonCredentialDrift, fmt.Sprintf(
+					"the external Keystone at %s no longer accepts the admin credential derived from Secret %q; "+
+						"the operator does not remediate the external installation: %s",
+					authURL, cp.Spec.KORC.AdminCredential.PasswordSecretRef.Name, rawMessage,
+				))
+			}
+		}
 		fail(reason, fmt.Sprintf("external Keystone at %s: %s", authURL, rawMessage))
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, true
 	}

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -148,11 +148,12 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// Default domain, so import it (and its domain) as UNMANAGED K-ORC resources
 	// before minting — otherwise the AC blocks forever on "Waiting for User/admin
 	// to be created".
-	importMsg, err := r.ensureKORCAdminImports(ctx, cp, importCredRef)
+	imports, err := r.ensureKORCAdminImports(ctx, cp, importCredRef)
 	if err != nil {
 		fail("AdminImportError", fmt.Sprintf("ensuring K-ORC admin User/Domain imports: %v", err))
 		return ctrl.Result{}, err
 	}
+	importMsg := imports.statusFragment()
 
 	// K-ORC's managed ApplicationCredential reads the DESIRED secret from
 	// Secret.Data["value"] and passes it to Keystone when creating the credential
@@ -278,6 +279,25 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 	// value while status is empty). LastRotation is stamped on a fresh mint/re-mint.
 	r.updateAdminApplicationCredentialStatus(cp, ac, restricted)
 
+	// EXTERNAL-MODE FAILURE CLASSIFICATION. K-ORC collapses every hard failure
+	// against a pre-existing Keystone — a wrong admin password (401), an
+	// unresolvable authURL, a private CA it does not trust, a region/endpointType
+	// absent from the catalog — into a NON-terminal Progressing condition with
+	// reason=TransientError. Nothing in the observed inventory is terminal, so
+	// neither GetTerminalError nor the reason discriminates: the failure class only
+	// survives in the free-text message. Classify on message substrings and relay
+	// K-ORC's message VERBATIM, so an operator can tell "fix the Secret" from "fix
+	// DNS" from "add the CA bundle" straight off `kubectl describe`.
+	//
+	// Gated on External mode so a managed CR's KORCReady reasons stay byte-identical:
+	// in managed mode the same transient message during bootstrap is a legitimate
+	// wait, not a misconfiguration.
+	if cp.IsExternalKeystone() {
+		if result, handled := r.classifyExternalKORCState(cp, imports, ac); handled {
+			return result, nil
+		}
+	}
+
 	// Surface a TERMINAL K-ORC failure distinctly: GetTerminalError is non-nil only
 	// when the AC's Progressing condition reports an unrecoverable/invalid-config
 	// reason (e.g. K-ORC cannot authenticate with the clouds.yaml). Without this the
@@ -318,6 +338,52 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		Message:            "K-ORC admin application credential is minted and available",
 	})
 	return ctrl.Result{}, nil
+}
+
+// classifyExternalKORCState maps an External-mode K-ORC failure onto a specific
+// KORCReady reason, returning handled=false when the generic (mode-agnostic)
+// branches in reconcileKORC should decide instead.
+//
+// It only ever fires while the ApplicationCredential is NOT usable — not Available,
+// or carrying a terminal error. A healthy, Available credential is never
+// re-classified: K-ORC leaves the message of the last transient attempt on the
+// Progressing condition, and classifying that would flip a converged ControlPlane
+// to AuthenticationFailed on a message it has already recovered from.
+//
+// Precedence:
+//
+//  1. A classifiable message on the admin Domain, the admin User, or the AC (in
+//     that dependency order) wins, and K-ORC's message is relayed verbatim.
+//  2. Otherwise, an import stuck past externalImportStallGrace on "waiting to be
+//     created externally" is the silent-empty hazard — every External-mode import
+//     target pre-exists, so the wait never ends on its own.
+//  3. Otherwise the caller's generic branches apply.
+func (r *ControlPlaneReconciler) classifyExternalKORCState(
+	cp *c5c3v1alpha1.ControlPlane, imports korcAdminImports, ac *orcv1alpha1.ApplicationCredential,
+) (ctrl.Result, bool) {
+	if orcv1alpha1.IsAvailable(ac) && orcv1alpha1.GetTerminalError(ac) == nil {
+		return ctrl.Result{}, false
+	}
+	fail := conditionFailer(cp, conditionTypeKORCReady)
+	authURL := externalKeystoneAuthURL(cp)
+
+	objs := append(imports.objects(), ac)
+	if reason, rawMessage := classifyExternalKORCFailure(objs...); reason != "" {
+		fail(reason, fmt.Sprintf("external Keystone at %s: %s", authURL, rawMessage))
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, true
+	}
+
+	if stuck, ok := imports.stalledImport(externalImportStallGrace); ok {
+		fail(conditionReasonImportStalled, fmt.Sprintf(
+			"admin import %s has been waiting to be created externally in %s for longer than %s; "+
+				"in External mode the import target already exists, so this is a misconfiguration — "+
+				"check spec.services.keystone.external.endpointType and spec.region",
+			stuck, authURL, externalImportStallGrace,
+		))
+		return ctrl.Result{RequeueAfter: korcRequeueAfter}, true
+	}
+
+	return ctrl.Result{}, false
 }
 
 // remintAdminApplicationCredential drives the actual re-mint when the stamped

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -2101,10 +2102,15 @@ func TestEnsureKORCAdminImports_CreatesUnmanagedUserAndDomain(t *testing.T) {
 	credRef := orcv1alpha1.CloudCredentialsReference{SecretName: "k-orc-clouds-yaml", CloudName: "admin"}
 	// Freshly-created imports are not yet Available, so the status fragment names the
 	// first import (Domain) as the stuck dependency.
-	importMsg, err := r.ensureKORCAdminImports(context.Background(), cp, credRef)
+	imports, err := r.ensureKORCAdminImports(context.Background(), cp, credRef)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(importMsg).To(ContainSubstring("Domain"))
-	g.Expect(importMsg).To(ContainSubstring("not yet Available"))
+	g.Expect(imports.statusFragment()).To(ContainSubstring("Domain"))
+	g.Expect(imports.statusFragment()).To(ContainSubstring("not yet Available"))
+	// Both imports are returned with live status, in Domain-before-User dependency
+	// order, so the External-mode classifier can read their condition messages.
+	g.Expect(imports.objects()).To(HaveLen(2))
+	g.Expect(imports.domain.Name).To(Equal(adminDomainRef(cp)))
+	g.Expect(imports.user.Name).To(Equal(adminUserRef(cp)))
 
 	var domain orcv1alpha1.Domain
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
@@ -2524,4 +2530,228 @@ func TestReconcileKORC_SteadyStateDoesNotOverwriteMintedCloudsYaml(t *testing.T)
 	g.Expect(string(after.Data[appCredCloudsYAMLKey])).To(ContainSubstring("application_credential_id"))
 	g.Expect(after.ResourceVersion).To(Equal(before.ResourceVersion),
 		"a steady-state pass must not churn the app-credential Secret via the seed")
+}
+
+// --- External keystone mode: K-ORC failure classification (KORCReady) ---
+
+// korcExternalControlPlane builds an External-mode ControlPlane whose admin
+// password lives in the user-supplied Secret adminPasswordSecret() provisions.
+// effectiveAdminPasswordSecretRef resolves to that Secret in External mode, so
+// readAdminPassword and the re-mint hash work unchanged.
+func korcExternalControlPlane() *c5c3v1alpha1.ControlPlane {
+	cp := korcControlPlane()
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		Mode:     c5c3v1alpha1.KeystoneModeExternal,
+		External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+	}
+	return cp
+}
+
+// korcProgressingAC returns an AC stamped with the current password hash (so no
+// re-mint fires) whose Progressing condition carries msg with K-ORC's
+// non-terminal TransientError reason — the shape every hard failure against the
+// external Keystone takes.
+func korcProgressingAC(cp *c5c3v1alpha1.ControlPlane, msg string) *orcv1alpha1.ApplicationCredential {
+	return &orcv1alpha1.ApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        adminAppCredentialName(cp),
+			Namespace:   childNamespace(cp),
+			Annotations: map[string]string{adminPasswordHashAnnotation: testPasswordHash()},
+		},
+		Status: orcv1alpha1.ApplicationCredentialStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionProgressing,
+				Status:             metav1.ConditionTrue,
+				Reason:             orcv1alpha1.ConditionReasonTransientError,
+				Message:            msg,
+				ObservedGeneration: 0,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}
+
+// reconcileKORCWithAC runs reconcileKORC against cp with the given seeded objects
+// and returns the resulting KORCReady condition.
+func reconcileKORCWithAC(
+	t *testing.T, cp *c5c3v1alpha1.ControlPlane, objs ...client.Object,
+) (*metav1.Condition, ctrl.Result) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	seeded := append([]client.Object{cp, adminPasswordSecret()}, objs...)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(seeded...).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	res, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	return conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady), res
+}
+
+// TestReconcileKORC_ExternalModeClassifiesFailures walks the D3 vocabulary: each
+// hard failure against the external Keystone reaches the ControlPlane as the same
+// non-terminal TransientError, so the message substring is the only discriminator.
+// Every case must produce its own documented reason AND relay K-ORC's message
+// verbatim.
+func TestReconcileKORC_ExternalModeClassifiesFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    string
+		wantReason string
+	}{
+		{
+			name:       "wrong password",
+			message:    `Authentication failed: got 401 instead: {"error":{"message":"The request you have made requires authentication."}}`,
+			wantReason: conditionReasonAuthenticationFailed,
+		},
+		{
+			name:       "unreachable authURL",
+			message:    `Get "https://keystone.example.com/v3": dial tcp: lookup keystone.example.com: no such host`,
+			wantReason: conditionReasonEndpointUnreachable,
+		},
+		{
+			name:       "untrusted private CA",
+			message:    `Get "https://keystone.example.com/v3": x509: certificate signed by unknown authority`,
+			wantReason: conditionReasonTLSVerificationFailed,
+		},
+		{
+			name:       "wrong region or endpointType",
+			message:    "No suitable endpoint could be found in the service catalog.",
+			wantReason: conditionReasonCatalogEndpointMismatch,
+		},
+		{
+			name:       "stale import id yields a 403 on application-credential create",
+			message:    `got 403 instead: {"error":{"message":"You are not authorized to perform the requested action: identity:create_application_credential."}}`,
+			wantReason: conditionReasonCredentialDrift,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cp := korcExternalControlPlane()
+
+			cond, res := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, tt.message))
+
+			g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(cond.Reason).To(Equal(tt.wantReason))
+			g.Expect(cond.Message).To(ContainSubstring(tt.message),
+				"K-ORC's message must be relayed verbatim")
+			g.Expect(cond.Message).To(ContainSubstring("https://keystone.example.com/v3"),
+				"the message must name the external endpoint")
+		})
+	}
+}
+
+// TestReconcileKORC_ManagedModeReasonsUnchanged is the AC-2 regression guard: the
+// very fixtures that classify in External mode must leave a MANAGED CR's KORCReady
+// reasons byte-identical. In managed mode the operator's own bootstrap has only
+// just created the admin user, so the same transient message is a legitimate wait.
+func TestReconcileKORC_ManagedModeReasonsUnchanged(t *testing.T) {
+	for _, msg := range []string{
+		`Authentication failed: got 401 instead`,
+		`dial tcp: lookup keystone: no such host`,
+		`x509: certificate signed by unknown authority`,
+		"No suitable endpoint could be found in the service catalog.",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cp := korcControlPlane()
+
+			cond, res := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, msg))
+
+			g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+			g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"),
+				"a managed CR must not pick up the External-mode failure vocabulary")
+		})
+	}
+}
+
+// stalledDomainImport returns an admin Domain import that has been reporting
+// "waiting to be created externally" since transitioned.
+func stalledDomainImport(cp *c5c3v1alpha1.ControlPlane, transitioned metav1.Time) *orcv1alpha1.Domain {
+	return &orcv1alpha1.Domain{
+		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
+		Status: orcv1alpha1.DomainStatus{
+			Conditions: []metav1.Condition{{
+				Type:               orcv1alpha1.ConditionAvailable,
+				Status:             metav1.ConditionFalse,
+				Reason:             orcv1alpha1.ConditionReasonProgressing,
+				Message:            korcImportPendingExternalMarker,
+				LastTransitionTime: transitioned,
+			}},
+		},
+	}
+}
+
+// TestReconcileKORC_ExternalModeStalledImportSetsImportStalled asserts the
+// silent-empty detector: an admin import that has waited past the grace window for
+// a resource that already exists in the external Keystone is a misconfiguration,
+// and the message must point at the two spec fields that cause it.
+func TestReconcileKORC_ExternalModeStalledImportSetsImportStalled(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := korcExternalControlPlane()
+	stale := metav1.NewTime(time.Now().Add(-externalImportStallGrace - time.Minute))
+
+	// The AC is not Available and carries no classifiable message, so the stall
+	// detector is what must speak.
+	cond, res := reconcileKORCWithAC(
+		t, cp,
+		stalledDomainImport(cp, stale),
+		korcProgressingAC(cp, "Waiting for dependencies"),
+	)
+
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonImportStalled))
+	g.Expect(cond.Message).To(ContainSubstring(adminDomainRef(cp)), "the stuck import must be named")
+	g.Expect(cond.Message).To(ContainSubstring("endpointType"))
+	g.Expect(cond.Message).To(ContainSubstring("spec.region"))
+}
+
+// TestReconcileKORC_ExternalModeFreshImportDoesNotStall guards the grace window:
+// an import that only just started waiting is still converging and must report the
+// ordinary wait, not the alertable ImportStalled.
+func TestReconcileKORC_ExternalModeFreshImportDoesNotStall(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := korcExternalControlPlane()
+
+	cond, res := reconcileKORCWithAC(
+		t, cp,
+		stalledDomainImport(cp, metav1.Now()),
+		korcProgressingAC(cp, "Waiting for dependencies"),
+	)
+
+	g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
+	g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"))
+	g.Expect(cond.Reason).NotTo(Equal(conditionReasonImportStalled))
+}
+
+// TestReconcileKORC_ExternalModeAvailableCredentialIsNotReclassified covers the
+// steady-state edge path. K-ORC leaves the message of the last transient attempt
+// on the Progressing condition, so a converged ControlPlane whose AC once saw a
+// 401 must NOT be flipped back to AuthenticationFailed.
+func TestReconcileKORC_ExternalModeAvailableCredentialIsNotReclassified(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := korcExternalControlPlane()
+
+	ac := korcProgressingAC(cp, `Authentication failed: got 401 instead`)
+	ac.Status.ID = ptr.To("ac-id")
+	ac.Status.Conditions = append(ac.Status.Conditions, metav1.Condition{
+		Type:               orcv1alpha1.ConditionAvailable,
+		Status:             metav1.ConditionTrue,
+		Reason:             orcv1alpha1.ConditionReasonSuccess,
+		Message:            "credential minted",
+		LastTransitionTime: metav1.Now(),
+	})
+
+	cond, res := reconcileKORCWithAC(t, cp, ac)
+
+	g.Expect(res.IsZero()).To(BeTrue())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal("ApplicationCredentialMinted"))
 }

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2572,21 +2573,23 @@ func korcProgressingAC(cp *c5c3v1alpha1.ControlPlane, msg string) *orcv1alpha1.A
 }
 
 // reconcileKORCWithAC runs reconcileKORC against cp with the given seeded objects
-// and returns the resulting KORCReady condition.
+// and returns the resulting KORCReady condition alongside the fake recorder, so
+// drift tests can assert on the emitted events.
 func reconcileKORCWithAC(
 	t *testing.T, cp *c5c3v1alpha1.ControlPlane, objs ...client.Object,
-) (*metav1.Condition, ctrl.Result) {
+) (*metav1.Condition, ctrl.Result, *record.FakeRecorder) {
 	t.Helper()
 	g := NewGomegaWithT(t)
 
 	s := korcTestScheme(t)
 	seeded := append([]client.Object{cp, adminPasswordSecret()}, objs...)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(seeded...).Build()
-	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
 
 	res, err := r.reconcileKORC(context.Background(), cp)
 	g.Expect(err).NotTo(HaveOccurred())
-	return conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady), res
+	return conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady), res, rec
 }
 
 // TestReconcileKORC_ExternalModeClassifiesFailures walks the D3 vocabulary: each
@@ -2632,7 +2635,7 @@ func TestReconcileKORC_ExternalModeClassifiesFailures(t *testing.T) {
 			g := NewGomegaWithT(t)
 			cp := korcExternalControlPlane()
 
-			cond, res := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, tt.message))
+			cond, res, _ := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, tt.message))
 
 			g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
 			g.Expect(cond).NotTo(BeNil())
@@ -2661,7 +2664,7 @@ func TestReconcileKORC_ManagedModeReasonsUnchanged(t *testing.T) {
 			g := NewGomegaWithT(t)
 			cp := korcControlPlane()
 
-			cond, res := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, msg))
+			cond, res, _ := reconcileKORCWithAC(t, cp, korcProgressingAC(cp, msg))
 
 			g.Expect(res.RequeueAfter).To(Equal(korcRequeueAfter))
 			g.Expect(cond.Reason).To(Equal("WaitingForApplicationCredential"),
@@ -2698,7 +2701,7 @@ func TestReconcileKORC_ExternalModeStalledImportSetsImportStalled(t *testing.T) 
 
 	// The AC is not Available and carries no classifiable message, so the stall
 	// detector is what must speak.
-	cond, res := reconcileKORCWithAC(
+	cond, res, _ := reconcileKORCWithAC(
 		t, cp,
 		stalledDomainImport(cp, stale),
 		korcProgressingAC(cp, "Waiting for dependencies"),
@@ -2720,7 +2723,7 @@ func TestReconcileKORC_ExternalModeFreshImportDoesNotStall(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cp := korcExternalControlPlane()
 
-	cond, res := reconcileKORCWithAC(
+	cond, res, _ := reconcileKORCWithAC(
 		t, cp,
 		stalledDomainImport(cp, metav1.Now()),
 		korcProgressingAC(cp, "Waiting for dependencies"),
@@ -2749,9 +2752,58 @@ func TestReconcileKORC_ExternalModeAvailableCredentialIsNotReclassified(t *testi
 		LastTransitionTime: metav1.Now(),
 	})
 
-	cond, res := reconcileKORCWithAC(t, cp, ac)
+	cond, res, _ := reconcileKORCWithAC(t, cp, ac)
 
 	g.Expect(res.IsZero()).To(BeTrue())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 	g.Expect(cond.Reason).To(Equal("ApplicationCredentialMinted"))
+}
+
+// TestReconcileKORC_ExternalModeDriftEmitsWarningEventOncePerTransition asserts
+// the drift announcement is transition-gated. reconcileKORC requeues every 10s
+// while the external Keystone stays drifted, so an ungated Recorder.Event would
+// bury the event stream; the Warning must fire on the way INTO the drifted state
+// and then stay quiet.
+func TestReconcileKORC_ExternalModeDriftEmitsWarningEventOncePerTransition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := korcExternalControlPlane()
+	msg := `Authentication failed: got 401 instead`
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, adminPasswordSecret(), korcProgressingAC(cp, msg)).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: rec}
+
+	// First pass: the transition into drift announces itself.
+	_, err := r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rec.Events).To(Receive(And(
+		ContainSubstring("Warning"),
+		ContainSubstring(conditionReasonCredentialDrift),
+		ContainSubstring("keystone-admin"),
+		ContainSubstring(msg),
+	)))
+
+	// Second pass with KORCReady already reporting drift: no further event.
+	_, err = r.reconcileKORC(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rec.Events).NotTo(Receive(), "the drift event must not repeat on every requeue")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeKORCReady)
+	g.Expect(cond.Reason).To(Equal(conditionReasonAuthenticationFailed))
+}
+
+// TestReconcileKORC_ExternalModeNonDriftFailureEmitsNoDriftEvent covers the
+// negative path: an unreachable endpoint is a connectivity fault, not a stale
+// credential, so it must not raise a CredentialDrift alarm.
+func TestReconcileKORC_ExternalModeNonDriftFailureEmitsNoDriftEvent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := korcExternalControlPlane()
+	cond, _, rec := reconcileKORCWithAC(t, cp,
+		korcProgressingAC(cp, `dial tcp: lookup keystone.example.com: no such host`))
+
+	g.Expect(cond.Reason).To(Equal(conditionReasonEndpointUnreachable))
+	g.Expect(rec.Events).NotTo(Receive(), "an unreachable endpoint is not credential drift")
 }

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -66,6 +66,20 @@ const (
 	// window is generous so a healthy force-sync is never flagged as stuck.
 	cloudsYamlSyncStuckTimeout = 15 * time.Minute
 
+	// externalImportStallGrace bounds how long an External-mode K-ORC admin
+	// import (Domain/User) may report Available=False on "Waiting for OpenStack
+	// resource to be created externally" before reconcileKORC escalates KORCReady
+	// from the transient "WaitingForApplicationCredential" reason to the alertable
+	// "ImportStalled". In External mode every import target pre-exists by
+	// definition, so a persistent wait is a misconfiguration (a wrong
+	// external.endpointType or spec.region resolving to a different Keystone), not
+	// a resource that is about to appear. Two minutes is deliberately shorter than
+	// remintStallTimeout / orcTeardownStallTimeout (both 5m) — those wait on work
+	// that is genuinely in flight, whereas a resolvable import has nothing to wait
+	// for — while staying generous enough that a slow K-ORC resync is never
+	// flagged.
+	externalImportStallGrace = 2 * time.Minute
+
 	// duplicateControlPlaneRequeueAfter is the backoff a parked duplicate
 	// ControlPlane uses while an older ControlPlane owns its namespace
 	// (defense-in-depth). Deleting the incumbent enqueues no

--- a/operators/c5c3/internal/controller/setupwithmanager_test.go
+++ b/operators/c5c3/internal/controller/setupwithmanager_test.go
@@ -207,3 +207,27 @@ func TestClusterSecretStoreToControlPlaneMapper_IgnoresOtherStores(t *testing.T)
 	g.Expect(reqs).To(BeEmpty(),
 		"a change to an unrelated ClusterSecretStore must enqueue nothing")
 }
+
+// TestControlPlaneSecretNameExtractor_ExternalModeIndexesUserSecret asserts the
+// field indexer follows effectiveAdminPasswordSecretRef into External mode: the
+// indexed name is the USER-supplied Secret, so an edit to it wakes the
+// ControlPlane and feeds the hash-driven application-credential re-mint. Indexing
+// the operator-owned name instead would leave an out-of-band password rotation
+// invisible until the next periodic resync.
+func TestControlPlaneSecretNameExtractor_ExternalModeIndexesUserSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := mapperControlPlane("cp", "default", "external-admin")
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		Mode:     c5c3v1alpha1.KeystoneModeExternal,
+		External: &c5c3v1alpha1.ExternalKeystoneSpec{AuthURL: "https://keystone.example.com/v3"},
+	}
+
+	g.Expect(controlPlaneSecretNameExtractor(cp)).To(ConsistOf("external-admin"))
+
+	// Even with a (webhook-impossible) managed database block, the mode
+	// discriminator keeps the user-supplied Secret indexed.
+	cp.Spec.Infrastructure = &c5c3v1alpha1.InfrastructureSpec{}
+	cp.Spec.Infrastructure.Database.ClusterRef = &corev1.LocalObjectReference{Name: "openstack-db"}
+	g.Expect(controlPlaneSecretNameExtractor(cp)).To(ConsistOf("external-admin"))
+}


### PR DESCRIPTION
Closes #585

Teaches the ControlPlane reconciler chain what External keystone mode means. The chain keeps its order (Infrastructure → DBCredentials → AdminPassword → Keystone → Horizon → KORC → AdminCredential → Catalog); External mode changes what each link *does*. Per decision P5 the skipped sub-reconcilers keep their condition types (`Status=True`, `Reason=ExternallyManaged`), so `subConditionTypes`, `setReadyCondition` and the `condition_type` drift guard are untouched.

## The change set, in commit order

**`ca5fa6eb` feat(c5c3): add External-mode helpers and the D3 reason vocabulary**
Lands `external_mode.go`: the reason constants (`ExternallyManaged`, `AuthenticationFailed`, `EndpointUnreachable`, `TLSVerificationFailed`, `CatalogEndpointMismatch`, `ImportStalled`, `CredentialDrift`, `InfrastructureNotConfigured`), the nil-safe `externalKeystoneAuthURL` message helper, the `classifyKORCMessage` substring classifier, and `korcImportStalled` — the silent-empty detector. Pure helpers, fully unit-tested, before any call site depends on them. `externalImportStallGrace = 2m` is added to `requeue_intervals.go` with a note on why it is deliberately shorter than the 5m `remintStallTimeout` / `orcTeardownStallTimeout`.

**`6b632617` feat(c5c3): short-circuit four sub-reconcilers in External mode**
`reconcileInfrastructure`, `reconcileDBCredentials`, `reconcileAdminPassword` and `reconcileKeystone` skip their projection and report `Status=True` / `Reason=ExternallyManaged` with a message naming the external endpoint. Every skip keys on `cp.IsExternalKeystone()`, never on `Database.ClusterRef` — External mode has no `spec.infrastructure` block at all, so "no managed database" and "no database" must not collapse onto the brownfield reason. `effectiveAdminPasswordSecretRef` follows suit, keeping the user-supplied `passwordSecretRef` as the admin-password source and therefore as the hash-driven re-mint input. `reconcileKeystone`'s External branch deliberately does *not* delete a previously-projected child (a Managed→External flip is rejected at admission).

**`2ad6fb80` feat(c5c3): classify External-mode K-ORC failures onto KORCReady**
`ensureKORCAdminImports` now returns the reconciled `Domain`/`User` objects (as `korcAdminImports`) instead of a pre-rendered status fragment, so `reconcileKORC` can read their condition messages. K-ORC collapses a 401, a DNS failure, an untrusted CA and a catalog mismatch into the same non-terminal `TransientError`, so the message is the only discriminator: `classifyExternalKORCState` matches on substrings and relays K-ORC's message verbatim. Classification is gated on External mode **and** never runs against an `Available` credential, so a managed CR's `KORCReady` reasons stay byte-identical and a converged ControlPlane is never flipped back to `AuthenticationFailed` on the stale message of a transient attempt it already recovered from.

**`2b0e4a73` feat(c5c3): surface credential drift on the existing sub-conditions**
Per P6, no new condition type. `reconcileKORC` emits a `Warning` `CredentialDrift` event on the transition *into* the drifted state (not on every 10s requeue). `reconcileAdminCredential`'s `KORCReady` gate escalates from the opaque `WaitingForKORC` to `CredentialDrift`, naming the Secret the operator reads and the fact that updating it is what drives a re-mint. Drift is surfaced, never fought — the operator does not write to the external installation.

**`1b814d16` test(c5c3): cover the External-mode deletion resource set**
Audit result: **the deletion sweep needs no code change.** What a Delete does to the external installation is decided by each K-ORC CR's `ManagementPolicy`, not by the ControlPlane's keystone mode. The `ApplicationCredential` is `Managed`, so its finalizer revokes at the Keystone level before the CR delete returns (authenticating afterwards yields `404 Could not find Application Credential`, not 401); the admin `User` and `Domain` are `Unmanaged` imports, so deleting their CRs leaves the external resources untouched. The tests pin both properties; the `orcChildResources` doc block now records the blast radius, including the deliberate `DeletionPolicy=None` on the app-credential PushSecret.

**`d61a498e` test(c5c3): drive an External-mode ControlPlane to Ready in envtest**
The headline acceptance criterion: an External-mode ControlPlane converges `Ready=True` while creating **zero** MariaDB/Memcached/Keystone/Horizon resources and projecting no operator-owned credential ExternalSecrets; each skipped sub-reconciler is asserted to report `ExternallyManaged` and to name the external endpoint. A second test deletes the converged CR and proves the teardown is scoped — the owned K-ORC CRs go, a foreign K-ORC `User` import sharing the namespace survives. (envtest runs no GC, so this exercises the `reconcileDelete` sweep rather than owner-reference GC.)

**`c075cfab` docs(c5c3): document the External-mode reconciler contracts**
Retires `ExternalModeNotImplemented` from `controlplane-crd.md` and `controlplane-reconciler.md`, records the four `ExternallyManaged` short-circuits and why that reason stays distinct from `KeystoneNotManaged` and `BrownfieldUserSuppliedCredential`, adds the failure-classification subsection (why we match on K-ORC message substrings at all), the reason vocabulary with its precedence, the 2-minute `ImportStalled` grace window, the drift posture, and the External-mode deletion resource set.

## Notes for the reviewer — where the diff diverges from the issue

- **`InfrastructureNotConfigured` is a new reason the issue does not name.** Retiring the interim `ExternalModeNotImplemented` left a hole: a *non*-External CR reaching `reconcileInfrastructure` with no `spec.infrastructure` block is a webhook-bypass shape. Rather than dereferencing the nil pointer it now fails closed with this reason. `grep -rn ExternalModeNotImplemented` over the tree is empty.
- **The deletion-path item produced tests and a doc block, not code.** The issue asked for an "audit + tests"; the audit found the existing sweep already correct for both modes. `reconcile_delete.go` gains only the blast-radius comment.
- **`reconcile_horizon.go` is a comment-only change.** Its pre-existing nil-`Infrastructure` guard is unchanged; the stale comment referencing the `ExternalModeNotImplemented` requeue is rewritten to state the real invariant (the webhook forbids `services.horizon` in External mode, so the guard only fires for a webhook-bypassed CR).
- **`authURL` is not yet dialled.** This PR consumes it for condition/event messages and the `ImportStalled` guidance only. The clouds.yaml builders and admin import filters that actually authenticate against the external endpoint are W4, and the identity catalog stays managed until the import-first W5 work — exactly the split the issue's own table draws. Consequently the "wrong password / unreachable URL produce their distinct documented reason" criterion is verified by unit tests over K-ORC's message shapes, not end-to-end against a live external Keystone.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2d4361e with Claude:claude-opus-4-8_
