### PR TITLE
feat: add a Nix flake devshell that mirrors the CI toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ node_modules/
 docs/.vitepress/cache/
 docs/.vitepress/dist/
 
+# Nix devshell — per-user direnv state (`echo 'use flake' > .envrc`). The
+# flake itself (flake.nix, flake.lock) is tracked; bin/ is ignored above.
+.direnv/
+
 # Collected CI evidence (debug-e2e-failure log excerpts, downloaded artifacts)
 # and other generated local output.
 _output/

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -136,6 +136,7 @@ export default defineConfig({
           { text: 'Adding a New Operator', link: '/contributing/adding-a-new-operator' },
           { text: 'Adding a New Release', link: '/contributing/adding-a-new-release' },
           { text: 'Dependency Management', link: '/contributing/dependency-management' },
+          { text: 'Nix Development Environment', link: '/contributing/nix-dev-environment' },
           { text: 'Claude Code Skills', link: '/contributing/claude-skills' },
         ],
       },

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -50,6 +50,14 @@ Major updates are **disabled** for all custom-regex managers — these touch dep
 CRDs, the OpenStack release matrix, and build tooling where a major bump always needs
 human-driven coordination.
 
+Separately, the native `nix` manager keeps the development flake fresh: it maintains
+`flake.lock` (the pinned `nixpkgs` revision) via lock-file maintenance, opening a grouped
+weekly re-lock PR. That PR is **not** automerged: `nixos-unstable` is a rolling ref, so the
+re-lock is not a version bump and the 3-day cooldown cannot gate it — a reviewer confirms
+the base-runtime bump instead. The Nix devshell re-reads the canonical tool pins
+(`ci.yaml`, the `Makefile`, `hack/install-test-deps.sh`) on entry, so a tool-version
+bump needs **no** flake edit — see [Nix Development Environment](./nix-dev-environment.md).
+
 ---
 
 ## Go version upgrades
@@ -371,3 +379,5 @@ filters are an optimization, not an exemption.
   changelog and deprecation announcements.
 - [CI Workflow](../reference/ci-cd/ci-workflow.md) — what each required
   check actually runs.
+- [Nix Development Environment](./nix-dev-environment.md) — the flake that
+  provisions the CI toolchain and how it stays in sync with these pins.

--- a/docs/contributing/nix-dev-environment.md
+++ b/docs/contributing/nix-dev-environment.md
@@ -1,0 +1,137 @@
+---
+title: Nix Development Environment
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Nix Development Environment
+
+The repository ships a Nix flake so that entering the development environment
+yields the same toolchain a CI run gets, pinned to the versions the pipeline
+pins. It is a second, equally complete entry point next to
+`make install-test-deps` — the dependency-installation script and the CI setup
+steps are unchanged, and no pipeline behavior depends on the flake.
+
+```bash
+nix develop
+```
+
+The one command drops you into a shell where `controller-gen`, `gofumpt`,
+`golangci-lint`, `chainsaw`, `kind`, `kubectl`, `flux`, `kustomize`, the
+`helm-unittest` plugin, and the envtest assets are all on `PATH` (via a
+gitignored `bin/`) at the versions CI uses.
+
+## What you get
+
+- **Base runtimes** — Go, Node, Python 3, Helm, `shellcheck`, `yq`, `jq`, and a
+  GNU userland — come from the `nixpkgs` revision pinned in `flake.lock`. The
+  GNU userland is deliberate: it makes macOS behave like the Linux-only CI
+  runner (for example, `make chainsaw-lint` relies on GNU `xargs`).
+- **Exact CI-pinned tools** are installed by `hack/nix-devshell-hook.sh`, which
+  the flake sources on entry. Rather than duplicate any version into the flake,
+  the hook reads each pin **where it already lives**, so a Renovate bump to a
+  canonical file self-heals the shell on the next entry.
+
+Print the pins the hook resolves without installing anything:
+
+```bash
+bash hack/nix-devshell-hook.sh --print-pins
+```
+
+## Where each version comes from
+
+The hook installs these at the **exact** version CI uses, reading the pin from
+its authoritative location:
+
+| Tool | Pin source |
+|------|------------|
+| `controller-gen` | `.github/workflows/ci.yaml` env `CONTROLLER_GEN_VERSION` |
+| `gofumpt` | `.github/workflows/ci.yaml` env `GOFUMPT_VERSION` (mirrored in the `Makefile`) |
+| `golangci-lint` | `.github/workflows/ci.yaml` env `GOLANGCI_LINT_VERSION` |
+| `setup-envtest` | `.github/workflows/ci.yaml` (`setup-envtest@<ref>`) |
+| envtest assets | `Makefile` `ENVTEST_K8S_VERSION` (the pinned Kubernetes minor) |
+| `kustomize` | `.github/workflows/ci.yaml` (`KUSTOMIZE_VERSION=`) |
+| `helm-unittest` | `.github/workflows/ci.yaml` (`helm plugin install … --version`) |
+| `chainsaw`, `kind`, `kubectl`, `flux` | `hack/install-test-deps.sh` (reused as-is, with its SHA256 verification) |
+
+These come from `nixpkgs` and track it, because the pipeline itself does **not**
+pin them to an exact patch:
+
+| Tool | Note |
+|------|------|
+| Go | `go_1_26` from nixpkgs; `go.work` sets only the minimum the modules need |
+| Node | `nodejs_24` from nixpkgs (CI pins the major only, `node-version: 24`) |
+| Python 3 | the runtime the Helm-schema generator and the docs site need |
+| Helm | CI uses `azure/setup-helm` with no version input, so it floats |
+| `shellcheck`, `jq`, GNU userland | runner-preinstalled and unpinned in `ci.yaml` |
+| `yq` | pinned (`v4.53.3`) in `verify-container-images.yaml` and `build-images.yaml`; `ci.yaml` uses the runner's floating `yq`, so the flake tracks the nixpkgs `yq-go` |
+
+## Prerequisites
+
+- **Nix ≥ 2.19** with the `nix-command` and `flakes` experimental features
+  enabled. If they are not enabled globally, pass them per invocation:
+
+  ```bash
+  nix --extra-experimental-features 'nix-command flakes' develop
+  ```
+
+- **Docker** is deliberately **not** provided by the flake — a running daemon
+  cannot be nix-provisioned, and `kind` needs one. Install Docker separately
+  (see the [Quick Start (Extended)](../quick-start-extended.md) prerequisites).
+
+## First entry and offline behavior
+
+The first `nix develop` performs network installs (`go install` for the Go
+tools, tarball downloads for `kustomize`/`chainsaw`/`kind`/`kubectl`/`flux`, the
+`helm-unittest` plugin, and the envtest assets). This is impure by design and is
+the same kind of work CI does per job. Subsequent entries skip anything already
+installed at the pinned version.
+
+If you enter the shell offline, provisioning **degrades loudly** — each tool
+that could not be installed is listed in a warning summary and the shell still
+opens. Re-run `source hack/nix-devshell-hook.sh` once you are back online.
+
+## Keeping in sync
+
+- **Tool pins** are bumped by Renovate in their canonical files (`ci.yaml`, the
+  `Makefile`, `hack/install-test-deps.sh`). The devshell re-reads those files on
+  entry, so it self-heals with no flake edit — see
+  [Dependency Management](./dependency-management.md).
+- **`flake.lock`** (the `nixpkgs` revision) is maintained by Renovate's native
+  `nix` manager, which opens a grouped weekly re-lock PR for review. The
+  `nixos-unstable` re-lock is not automerged — a human confirms the base-runtime
+  bump the devshell inherits.
+
+## Optional: direnv
+
+To enter the shell automatically when you `cd` into the checkout:
+
+```bash
+echo 'use flake' > .envrc
+direnv allow
+```
+
+`.envrc` is untracked and `.direnv/` is gitignored.
+
+## Running the CI checks inside the shell
+
+Because the shell holds the CI tool versions, the same targets CI runs work
+locally against the same tools:
+
+```bash
+make format-check     # gofumpt at the pinned version
+make lint             # golangci-lint at the pinned version
+make verify-helm-schema
+make chainsaw-lint
+make test-integration OPERATOR=keystone   # uses the pinned envtest assets
+```
+
+## See also
+
+- [Dependency Management](./dependency-management.md) — how Renovate keeps the
+  pinned versions (and `flake.lock`) fresh.
+- [Quick Start (Extended)](../quick-start-extended.md) — the
+  `make install-test-deps` path and the full prerequisites.

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -69,6 +69,14 @@ By default, binaries are installed to `~/.local/bin`. Make sure that directory i
 export PATH="${HOME}/.local/bin:${PATH}"
 ```
 
+::: tip Nix users
+Instead of `make install-test-deps`, you can run `nix develop` to get every
+tool in the table above — plus `controller-gen`, `gofumpt`, `golangci-lint`,
+`kustomize`, `chainsaw`, and the envtest assets — at the versions CI pins. See
+[Nix Development Environment](./contributing/nix-dev-environment.md). Docker
+still has to be installed separately (kind needs a running daemon).
+:::
+
 ---
 
 ## Step 1 — Clone the repository

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782948114,
+        "narHash": "sha256-AXmz9ho4Lud5CsbrZsuSVwpQZ4o5FgZ1chxBn5cJ8+0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e92285f211dad236540fd617d7e30e0b99bc0e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# A development environment that mirrors the CI toolchain. `nix develop` yields
+# the same tools a CI run gets: the base runtimes come from the pinned nixpkgs
+# below; the tools the pipeline pins *exactly* (controller-gen, gofumpt,
+# golangci-lint, setup-envtest, kustomize, chainsaw, kind, kubectl, flux, the
+# helm-unittest plugin, and the envtest assets) are installed by
+# hack/nix-devshell-hook.sh, which reads the pins where they already live
+# (ci.yaml, Makefile, hack/install-test-deps.sh) so no version is declared twice.
+#
+# Deliberately NOT provided: Docker (a daemon cannot be nix-provisioned; kind
+# needs a running Docker — see docs/contributing/nix-dev-environment.md).
+{
+  description = "forge development environment mirroring the CI toolchain";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          # Plain mkShell (with a C compiler): `go test -race` needs cgo, matching
+          # the CI runner. The GNU userland is included on purpose so macOS
+          # behaves like the Linux-only CI runner (e.g. chainsaw-lint uses GNU
+          # xargs). go_1_26 / nodejs_24 fall back to the unversioned attrs if a
+          # future nixpkgs revision renames them.
+          default = pkgs.mkShell {
+            name = "forge-devshell";
+
+            packages = [
+              (pkgs.go_1_26 or pkgs.go)
+              (pkgs.nodejs_24 or pkgs.nodejs)
+              pkgs.python3
+              pkgs.kubernetes-helm
+              pkgs.shellcheck
+              pkgs.yq-go
+              pkgs.jq
+              pkgs.git
+              pkgs.gnumake
+              pkgs.curl
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.gawk
+              pkgs.findutils
+            ];
+
+            # Source the hook from the working tree (not a ${./…} store path) so
+            # it reads the live pins and resolves the repo root via git.
+            shellHook = ''
+              _forge_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+              if [ -f "$_forge_root/hack/nix-devshell-hook.sh" ]; then
+                # shellcheck source=/dev/null
+                source "$_forge_root/hack/nix-devshell-hook.sh"
+              else
+                echo "forge: hack/nix-devshell-hook.sh not found under $_forge_root — run 'nix develop' from within the forge checkout." >&2
+              fi
+              unset _forge_root
+            '';
+          };
+        }
+      );
+    };
+}

--- a/hack/nix-devshell-hook.sh
+++ b/hack/nix-devshell-hook.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# hack/nix-devshell-hook.sh — Provision the exactly-pinned CI toolchain inside
+# the Nix devshell (flake.nix sources this on `nix develop`).
+#
+# The flake pins the base runtimes (Go, Node, Python, Helm, shellcheck, yq, jq,
+# GNU userland) from nixpkgs. This hook installs the tools the pipeline pins
+# *exactly* — controller-gen, gofumpt, golangci-lint, setup-envtest, kustomize,
+# chainsaw, kind, kubectl, flux, the helm-unittest plugin, and the envtest
+# assets — by reading the pins *where they already live*, so no version literal
+# is ever duplicated into the flake:
+#
+#   - .github/workflows/ci.yaml  env block  → CONTROLLER_GEN_VERSION,
+#                                              GOFUMPT_VERSION,
+#                                              GOLANGCI_LINT_VERSION
+#   - .github/workflows/ci.yaml  inline     → setup-envtest@<ref>,
+#                                              KUSTOMIZE_VERSION,
+#                                              helm-unittest --version
+#   - Makefile                              → ENVTEST_K8S_VERSION
+#   - hack/install-test-deps.sh (reused)    → chainsaw, kind, kubectl, flux
+#
+# Everything installs into the repo's gitignored bin/ (the Makefile's LOCALBIN)
+# and bin/ is prepended to PATH. A Renovate bump to any canonical file above
+# self-heals the shell on the next entry — no flake edit needed.
+#
+# COUPLING: the resolver functions grep the canonical files by their current
+# shape (the ci.yaml env block, the `setup-envtest@` / `KUSTOMIZE_VERSION=` /
+# `helm-unittest --version` lines, and Makefile ENVTEST_K8S_VERSION). A refactor
+# that moves or reshapes those lines needs a matching change here; the unit test
+# tests/unit/hack/nix_devshell_hook_test.sh fails loudly if the coupling drifts.
+#
+# Usage:
+#   source hack/nix-devshell-hook.sh     # provision the devshell (flake.nix)
+#   bash hack/nix-devshell-hook.sh --print-pins   # print the resolved pins
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CI_FILE="${REPO_ROOT}/.github/workflows/ci.yaml"
+MAKEFILE="${REPO_ROOT}/Makefile"
+
+# ---------------------------------------------------------------------------
+# Pin resolvers — each reads one value from its canonical file. Single-process
+# awk (no `| head`) keeps them safe under `set -o pipefail`.
+# ---------------------------------------------------------------------------
+resolve_controller_gen_version() {
+  awk '$1 == "CONTROLLER_GEN_VERSION:" { print $2; exit }' "${CI_FILE}"
+}
+
+resolve_gofumpt_version() {
+  awk '$1 == "GOFUMPT_VERSION:" { print $2; exit }' "${CI_FILE}"
+}
+
+resolve_golangci_lint_version() {
+  awk '$1 == "GOLANGCI_LINT_VERSION:" { print $2; exit }' "${CI_FILE}"
+}
+
+resolve_setup_envtest_ref() {
+  awk 'match($0, /setup-envtest@[^[:space:]]+/) {
+         s = substr($0, RSTART, RLENGTH); sub(/.*@/, "", s); print s; exit
+       }' "${CI_FILE}"
+}
+
+resolve_envtest_k8s_version() {
+  # Mirror the exact awk the CI job "Get envtest k8s version" uses so the shell
+  # and CI resolve the same value from the Makefile.
+  awk '/ENVTEST_K8S_VERSION/ { print $NF; exit }' "${MAKEFILE}"
+}
+
+resolve_kustomize_version() {
+  awk 'match($0, /KUSTOMIZE_VERSION=v[0-9][0-9.]*/) {
+         s = substr($0, RSTART, RLENGTH); sub(/.*=/, "", s); print s; exit
+       }' "${CI_FILE}"
+}
+
+resolve_helm_unittest_version() {
+  awk '/helm-unittest/ && match($0, /--version[[:space:]]+v[0-9][0-9.]*/) {
+         s = substr($0, RSTART, RLENGTH); sub(/.*[[:space:]]/, "", s); print s; exit
+       }' "${CI_FILE}"
+}
+
+# print_pins — emit the seven resolved KEY=VALUE pins (the test/doc surface).
+print_pins() {
+  printf 'CONTROLLER_GEN_VERSION=%s\n' "$(resolve_controller_gen_version)"
+  printf 'GOFUMPT_VERSION=%s\n' "$(resolve_gofumpt_version)"
+  printf 'GOLANGCI_LINT_VERSION=%s\n' "$(resolve_golangci_lint_version)"
+  printf 'SETUP_ENVTEST_REF=%s\n' "$(resolve_setup_envtest_ref)"
+  printf 'ENVTEST_K8S_VERSION=%s\n' "$(resolve_envtest_k8s_version)"
+  printf 'KUSTOMIZE_VERSION=%s\n' "$(resolve_kustomize_version)"
+  printf 'HELM_UNITTEST_VERSION=%s\n' "$(resolve_helm_unittest_version)"
+}
+
+# ---------------------------------------------------------------------------
+# Install helpers (used only by the provisioning path).
+# ---------------------------------------------------------------------------
+
+# _tool_has <path> <version-arg> <pin> — true when the installed tool already
+# reports the pinned version, so the install is skipped (idempotency, mirroring
+# hack/install-test-deps.sh and `make install-gofumpt`).
+_tool_has() {
+  local path="$1" varg="$2" pin="$3" re
+  [ -x "${path}" ] || return 1
+  # Anchor the pin to a whole version token so a pin that is a prefix of the
+  # installed version (e.g. "2.12.2" vs "2.12.20") does not spuriously match and
+  # skip a needed reinstall. Escape the dots before using the pin as a regex.
+  re="${pin//./\\.}"
+  "${path}" "${varg}" 2>/dev/null | grep -qE "(^|[^0-9.])${re}([^0-9.]|$)"
+}
+
+# _helm_plugin_pinned <plugin-list-output> <name> <pin> — true when the helm
+# plugin list already reports <name> at exactly <pin>, so the install is skipped.
+# Anchors the pin to a whole version token (dots escaped, trailing non-version
+# boundary) so a pin that is a prefix of the installed version (e.g. "1.0.3" vs
+# "1.0.30") does not spuriously match and skip a needed reinstall — the same
+# guard _tool_has applies, kept in sync by the unit test.
+_helm_plugin_pinned() {
+  local list="$1" name="$2" pin="$3" re
+  re="${pin#v}"
+  re="${re//./\\.}"
+  printf '%s\n' "${list}" | grep -qiE "${name}[[:space:]]+${re}([^0-9.]|$)"
+}
+
+# _detect_platform — echo "<os> <arch>" (linux|darwin amd64|arm64) or fail.
+_detect_platform() {
+  local os arch
+  case "$(uname -s)" in
+    Linux) os=linux ;;
+    Darwin) os=darwin ;;
+    *) return 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *) return 1 ;;
+  esac
+  printf '%s %s\n' "${os}" "${arch}"
+}
+
+# _sha256 <file> — print the file's SHA256 hex digest (GNU or BSD userland).
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+# _install_kustomize <version> <dest-dir> — fetch the kustomize release tarball
+# for the detected platform (same URL shape the CI test-shell job uses) and
+# verify it against the release's checksums.txt before installing. Returns
+# non-zero without installing on a download or checksum failure, so a corrupted
+# or truncated tarball never lands in bin/.
+#
+# SECURITY SCOPE: the checksums.txt is live-fetched from the same release, so
+# this is a transmission-integrity check only. It matches how
+# hack/install-test-deps.sh verifies chainsaw — NOT the stronger pinned-constant
+# hashes that script applies to kind, kubectl, and flux (whose repo-side hashes
+# survive a compromised release page that swaps both the binary and its checksum
+# file). Kustomize stays on the live-fetch path deliberately: its version is
+# resolved dynamically from ci.yaml's KUSTOMIZE_VERSION, so pinning four platform
+# hashes here would duplicate a version-coupled literal and break the Renovate
+# self-heal the rest of this hook is built around.
+_install_kustomize() {
+  local version="$1" dest="$2" plat os arch tarball url sums tmp expected actual
+  plat="$(_detect_platform)" || return 1
+  os="${plat% *}"
+  arch="${plat#* }"
+  tarball="kustomize_${version}_${os}_${arch}.tar.gz"
+  url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${version}/${tarball}"
+  sums="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${version}/checksums.txt"
+  tmp="$(mktemp -d)" || return 1
+  # Bound both fetches: this hook is sourced synchronously on every `nix develop`,
+  # so a blackholed or crawling mirror must surface as a collected warning rather
+  # than wedge shell entry with a curl that hangs forever.
+  if curl -fsSL --connect-timeout 10 --max-time 120 "${url}" -o "${tmp}/kustomize.tar.gz" &&
+    curl -fsSL --connect-timeout 10 --max-time 120 "${sums}" -o "${tmp}/checksums.txt"; then
+    expected="$(awk -v f="${tarball}" '$2 == f { print $1; exit }' "${tmp}/checksums.txt")"
+    actual="$(_sha256 "${tmp}/kustomize.tar.gz")"
+    if [ -n "${expected}" ] && [ "${expected}" = "${actual}" ] &&
+      tar -xzf "${tmp}/kustomize.tar.gz" -C "${tmp}" kustomize; then
+      install -m 0755 "${tmp}/kustomize" "${dest}/kustomize"
+      rm -rf "${tmp}"
+      return 0
+    fi
+  fi
+  rm -rf "${tmp}"
+  return 1
+}
+
+# provision_devshell — install every pinned tool into bin/, then export PATH and
+# KUBEBUILDER_ASSETS. Each step degrades loudly (collected warning summary)
+# instead of aborting the interactive shell when offline.
+provision_devshell() {
+  local repo_bin="${REPO_ROOT}/bin"
+  mkdir -p "${repo_bin}"
+
+  local controller_gen_version gofumpt_version golangci_lint_version
+  local setup_envtest_ref envtest_k8s_version kustomize_version helm_unittest_version
+  controller_gen_version="$(resolve_controller_gen_version)"
+  gofumpt_version="$(resolve_gofumpt_version)"
+  golangci_lint_version="$(resolve_golangci_lint_version)"
+  setup_envtest_ref="$(resolve_setup_envtest_ref)"
+  envtest_k8s_version="$(resolve_envtest_k8s_version)"
+  kustomize_version="$(resolve_kustomize_version)"
+  helm_unittest_version="$(resolve_helm_unittest_version)"
+
+  local -a warnings=()
+
+  if ! command -v go >/dev/null 2>&1; then
+    echo "forge devshell: go not found on PATH — skipping Go-tool installs." >&2
+    warnings+=("go toolchain (not on PATH)")
+  else
+    # gofumpt — reuse the Makefile target (installs into bin/ at the pin).
+    make -C "${REPO_ROOT}" -s install-gofumpt || warnings+=("gofumpt ${gofumpt_version}")
+
+    if ! _tool_has "${repo_bin}/controller-gen" --version "${controller_gen_version}"; then
+      GOBIN="${repo_bin}" go install \
+        "sigs.k8s.io/controller-tools/cmd/controller-gen@${controller_gen_version}" ||
+        warnings+=("controller-gen ${controller_gen_version}")
+    fi
+
+    # golangci-lint prints its version without a leading "v".
+    if ! _tool_has "${repo_bin}/golangci-lint" version "${golangci_lint_version#v}"; then
+      GOBIN="${repo_bin}" go install \
+        "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${golangci_lint_version}" ||
+        warnings+=("golangci-lint ${golangci_lint_version}")
+    fi
+
+    # setup-envtest is pinned to a branch ref (not version-checkable) — stamp it.
+    local envtest_stamp="${repo_bin}/.setup-envtest-ref"
+    if [ ! -x "${repo_bin}/setup-envtest" ] ||
+      [ "$(cat "${envtest_stamp}" 2>/dev/null || true)" != "${setup_envtest_ref}" ]; then
+      if GOBIN="${repo_bin}" go install \
+        "sigs.k8s.io/controller-runtime/tools/setup-envtest@${setup_envtest_ref}"; then
+        printf '%s\n' "${setup_envtest_ref}" >"${envtest_stamp}"
+      else
+        warnings+=("setup-envtest ${setup_envtest_ref}")
+      fi
+    fi
+  fi
+
+  # kustomize — release tarball for the detected platform.
+  if ! _tool_has "${repo_bin}/kustomize" version "${kustomize_version}"; then
+    _install_kustomize "${kustomize_version}" "${repo_bin}" ||
+      warnings+=("kustomize ${kustomize_version}")
+  fi
+
+  # chainsaw, kind, kubectl, flux — reuse the pinned, checksum-verifying script.
+  INSTALL_DIR="${repo_bin}" WITH_FLUX_CLI=true bash "${REPO_ROOT}/hack/install-test-deps.sh" ||
+    warnings+=("chainsaw/kind/kubectl/flux (hack/install-test-deps.sh)")
+
+  # helm-unittest — install into a project-scoped plugin dir so the user's global
+  # helm plugin store is never mutated. --verify=false matches CI (the plugin is
+  # unsigned).
+  if command -v helm >/dev/null 2>&1; then
+    local helm_plugins_project="${repo_bin}/helm-plugins"
+    mkdir -p "${helm_plugins_project}"
+    # `helm plugin install` treats HELM_PLUGINS as a single install target (a
+    # ListSeparator-joined value would create a bogus colon-named directory), so
+    # scope the override to the install invocation and the idempotency probe.
+    if ! _helm_plugin_pinned \
+      "$(HELM_PLUGINS="${helm_plugins_project}" helm plugin list 2>/dev/null)" \
+      unittest "${helm_unittest_version}"; then
+      HELM_PLUGINS="${helm_plugins_project}" helm plugin install \
+        https://github.com/helm-unittest/helm-unittest \
+        --version "${helm_unittest_version}" --verify=false ||
+        warnings+=("helm-unittest ${helm_unittest_version}")
+    fi
+    # For the interactive session, prepend the project dir to helm's plugin
+    # search path (a ListSeparator-joined list helm scans in full) instead of
+    # replacing it, so globally-installed plugins (helm-diff, helm-secrets, …)
+    # stay visible. Query helm for the effective path first so an unset
+    # HELM_PLUGINS still keeps the default global plugins.
+    local helm_plugins_existing
+    helm_plugins_existing="$(helm env 2>/dev/null | sed -n 's/^HELM_PLUGINS="\(.*\)"$/\1/p')"
+    export HELM_PLUGINS="${helm_plugins_project}${helm_plugins_existing:+:${helm_plugins_existing}}"
+  else
+    warnings+=("helm-unittest (helm not on PATH)")
+  fi
+
+  export PATH="${repo_bin}:${PATH}"
+
+  # envtest assets at the pinned k8s minor — the Makefile's SETUP_ENVTEST ?= …
+  # picks up this export so `make test-integration` uses bin/setup-envtest.
+  export SETUP_ENVTEST="${repo_bin}/setup-envtest"
+  if [ -x "${SETUP_ENVTEST}" ]; then
+    local assets
+    if assets="$("${SETUP_ENVTEST}" use "${envtest_k8s_version}" -p path 2>/dev/null)" &&
+      [ -n "${assets}" ]; then
+      export KUBEBUILDER_ASSETS="${assets}"
+    else
+      warnings+=("envtest assets (k8s ${envtest_k8s_version})")
+    fi
+  fi
+
+  if [ "${#warnings[@]}" -gt 0 ]; then
+    echo "forge devshell: could not provision the following (offline/network?):" >&2
+    local w
+    for w in "${warnings[@]}"; do
+      echo "  - ${w}" >&2
+    done
+    echo "forge devshell: re-run 'source hack/nix-devshell-hook.sh' when back online." >&2
+  else
+    echo "forge devshell: CI toolchain ready — bin/ prepended to PATH."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Entry point. --print-pins runs strict (executed by the unit test); the
+# provisioning path stays lenient because it is sourced into an interactive
+# shell where `set -e` would kill the session on the first offline install.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--print-pins" ]; then
+  set -euo pipefail
+  print_pins
+  exit 0
+fi
+
+# Provision on entry (the flake sources this with no arguments). The unit test
+# sources the hook only to exercise the pure helpers, so it sets
+# NIX_DEVSHELL_HOOK_NO_PROVISION=1 to skip the side-effecting install path.
+if [ "${NIX_DEVSHELL_HOOK_NO_PROVISION:-}" != "1" ]; then
+  provision_devshell
+fi

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,14 @@
   "extends": [
     "config:recommended"
   ],
+  "nix": {
+    "enabled": true,
+    "lockFileMaintenance": {
+      "enabled": true,
+      "automerge": false,
+      "schedule": ["before 6am on monday"]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -466,6 +474,12 @@
         "github.com/external-secrets/external-secrets/apis"
       ],
       "schedule": ["before 6am on monday"]
+    },
+    {
+      "matchManagers": ["nix"],
+      "groupName": "nix flake inputs",
+      "automerge": false,
+      "minimumReleaseAge": "3 days"
     }
   ]
 }

--- a/tests/unit/hack/nix_devshell_hook_test.sh
+++ b/tests/unit/hack/nix_devshell_hook_test.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify hack/nix-devshell-hook.sh resolves the CI toolchain pins from their
+# canonical locations, so the Nix devshell installs the exact versions CI uses.
+#
+# The hook reads each pin with awk `match()`; this test re-extracts the same
+# value a different way (grep/sed) from the same canonical file and asserts they
+# agree. That bidirectional guard fails loudly if either the pin location moves
+# or the hook's resolver drifts — the coupling the hook's header comment warns
+# about.
+#
+# Usage: bash tests/unit/hack/nix_devshell_hook_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+HOOK="$PROJECT_ROOT/hack/nix-devshell-hook.sh"
+CI="$PROJECT_ROOT/.github/workflows/ci.yaml"
+MK="$PROJECT_ROOT/Makefile"
+FLAKE="$PROJECT_ROOT/flake.nix"
+
+# The seven keys the hook must emit, in order.
+EXPECTED_KEYS="CONTROLLER_GEN_VERSION GOFUMPT_VERSION GOLANGCI_LINT_VERSION SETUP_ENVTEST_REF ENVTEST_K8S_VERSION KUSTOMIZE_VERSION HELM_UNITTEST_VERSION"
+
+# Capture --print-pins once.
+PINS_OUT="$(bash "$HOOK" --print-pins)"
+PINS_RC=$?
+
+# pin_value KEY — extract the value the hook printed for KEY.
+pin_value() {
+  printf '%s\n' "$PINS_OUT" | awk -F= -v k="$1" '$1 == k { print $2; exit }'
+}
+
+# Source the hook to exercise its pure helpers directly. The guard suppresses the
+# side-effecting provisioning path so no network installs run during the test.
+export NIX_DEVSHELL_HOOK_NO_PROVISION=1
+# shellcheck source=hack/nix-devshell-hook.sh
+source "$HOOK"
+
+test_print_pins_exit_zero() {
+  echo "Test: --print-pins exits 0"
+  assert_eq "--print-pins exit code" "0" "$PINS_RC"
+}
+
+test_print_pins_emits_exactly_seven_keys() {
+  echo "Test: --print-pins emits exactly the seven expected keys"
+
+  local count
+  count="$(printf '%s\n' "$PINS_OUT" | grep -Ec '^[A-Z0-9_]+=')"
+  assert_eq "seven KEY=VALUE lines" "7" "$count"
+
+  local key
+  for key in $EXPECTED_KEYS; do
+    if printf '%s\n' "$PINS_OUT" | grep -q "^${key}="; then
+      echo "  PASS: key $key present"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: key $key missing from --print-pins output"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+}
+
+test_pins_non_empty_and_well_formed() {
+  echo "Test: each pin is non-empty and matches its expected format"
+
+  # Accept an optional pre-release / build / fourth component (e.g. v2.13.0-rc1
+  # or v1.2.3.4) so a legitimate Renovate bump the hook resolves fine does not
+  # false-fail here; the non-empty and canonical-file-match guards prove the pin.
+  local semver='^v[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$'
+  local minor='^[0-9]+\.[0-9]+$'
+  local branchref='^release-[0-9]+\.[0-9]+$'
+
+  local key fmt val
+  for key in $EXPECTED_KEYS; do
+    case "$key" in
+      SETUP_ENVTEST_REF) fmt="$branchref" ;;
+      ENVTEST_K8S_VERSION) fmt="$minor" ;;
+      *) fmt="$semver" ;;
+    esac
+    val="$(pin_value "$key")"
+    assert_not_empty "$key is non-empty" "$val"
+    if printf '%s' "$val" | grep -Eq "$fmt"; then
+      echo "  PASS: $key '$val' matches $fmt"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: $key '$val' does not match $fmt"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+}
+
+test_pins_match_canonical_files() {
+  echo "Test: each pin agrees with an independent extraction from its canonical file"
+
+  # Independent (grep/sed) extractions — deliberately not the hook's awk match().
+  local ci_controller ci_golangci ci_setup_ref ci_kustomize ci_helm mk_envtest
+  ci_controller="$(grep -Em1 '^[[:space:]]+CONTROLLER_GEN_VERSION:' "$CI" | sed -E 's/.*:[[:space:]]*//')"
+  ci_golangci="$(grep -Em1 '^[[:space:]]+GOLANGCI_LINT_VERSION:' "$CI" | sed -E 's/.*:[[:space:]]*//')"
+  ci_setup_ref="$(grep -Em1 'setup-envtest@' "$CI" | sed -E 's/.*setup-envtest@([^[:space:]]+).*/\1/')"
+  ci_kustomize="$(grep -Em1 'KUSTOMIZE_VERSION=v' "$CI" | sed -E 's/.*KUSTOMIZE_VERSION=(v[0-9.]+).*/\1/')"
+  ci_helm="$(grep -Em1 'helm-unittest.*--version' "$CI" | sed -E 's/.*--version[[:space:]]+(v[0-9.]+).*/\1/')"
+  mk_envtest="$(grep -Em1 'ENVTEST_K8S_VERSION' "$MK" | sed -E 's/.*\?=[[:space:]]*//')"
+
+  assert_eq "CONTROLLER_GEN_VERSION matches ci.yaml" "$ci_controller" "$(pin_value CONTROLLER_GEN_VERSION)"
+  assert_eq "GOLANGCI_LINT_VERSION matches ci.yaml" "$ci_golangci" "$(pin_value GOLANGCI_LINT_VERSION)"
+  assert_eq "SETUP_ENVTEST_REF matches ci.yaml" "$ci_setup_ref" "$(pin_value SETUP_ENVTEST_REF)"
+  assert_eq "KUSTOMIZE_VERSION matches ci.yaml" "$ci_kustomize" "$(pin_value KUSTOMIZE_VERSION)"
+  assert_eq "HELM_UNITTEST_VERSION matches ci.yaml" "$ci_helm" "$(pin_value HELM_UNITTEST_VERSION)"
+  assert_eq "ENVTEST_K8S_VERSION matches Makefile" "$mk_envtest" "$(pin_value ENVTEST_K8S_VERSION)"
+}
+
+test_gofumpt_pin_consistent_across_ci_and_makefile() {
+  echo "Test: GOFUMPT_VERSION agrees across ci.yaml, the Makefile, and the hook"
+
+  local ci_gofumpt mk_gofumpt hook_gofumpt
+  ci_gofumpt="$(grep -Em1 '^[[:space:]]+GOFUMPT_VERSION:' "$CI" | sed -E 's/.*:[[:space:]]*//')"
+  mk_gofumpt="$(grep -Em1 '^GOFUMPT_VERSION' "$MK" | sed -E 's/.*(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+  hook_gofumpt="$(pin_value GOFUMPT_VERSION)"
+
+  assert_eq "hook GOFUMPT_VERSION matches ci.yaml env block" "$ci_gofumpt" "$hook_gofumpt"
+  assert_eq "ci.yaml and Makefile GOFUMPT_VERSION are in sync" "$ci_gofumpt" "$mk_gofumpt"
+}
+
+test_detect_platform() {
+  echo "Test: _detect_platform maps supported uname pairs and rejects others"
+
+  local out rc
+  # Supported pairs — stub uname inside a subshell so the real binary is untouched.
+  out="$( uname() { case "$1" in -s) echo Linux ;; -m) echo x86_64 ;; esac; }; _detect_platform )"
+  assert_eq "linux/x86_64 -> 'linux amd64'" "linux amd64" "$out"
+
+  out="$( uname() { case "$1" in -s) echo Darwin ;; -m) echo arm64 ;; esac; }; _detect_platform )"
+  assert_eq "darwin/arm64 -> 'darwin arm64'" "darwin arm64" "$out"
+
+  # aarch64 must fold to arm64 — the mapping the kustomize download URL relies on
+  # for Apple Silicon and Linux ARM, the platforms the flake advertises.
+  out="$( uname() { case "$1" in -s) echo Linux ;; -m) echo aarch64 ;; esac; }; _detect_platform )"
+  assert_eq "linux/aarch64 -> 'linux arm64'" "linux arm64" "$out"
+
+  # Unsupported OS / arch must fail loudly (return 1) rather than emit a bad pair.
+  ( uname() { case "$1" in -s) echo Windows_NT ;; -m) echo x86_64 ;; esac; }; _detect_platform >/dev/null 2>&1 )
+  rc=$?
+  assert_nonzero_exit "unsupported OS exits non-zero" "$rc"
+
+  ( uname() { case "$1" in -s) echo Linux ;; -m) echo riscv64 ;; esac; }; _detect_platform >/dev/null 2>&1 )
+  rc=$?
+  assert_nonzero_exit "unsupported arch exits non-zero" "$rc"
+}
+
+test_tool_has_anchors_version_token() {
+  echo "Test: _tool_has matches whole version tokens, not prefixes (regression)"
+
+  local dir tool rc
+  dir="$(mktemp -d)"
+  tool="$dir/faketool"
+
+  # Installed reports 2.12.20; a pin of 2.12.2 is a PREFIX and must NOT match, or
+  # the reinstall of the real pin would be wrongly skipped (the grep -qF bug).
+  printf '#!/usr/bin/env bash\necho "faketool has version 2.12.20 built from x"\n' >"$tool"
+  chmod +x "$tool"
+
+  _tool_has "$tool" version "2.12.2"
+  rc=$?
+  assert_eq "prefix pin 2.12.2 does not match installed 2.12.20" "1" "$rc"
+
+  _tool_has "$tool" version "2.12.20"
+  rc=$?
+  assert_eq "exact pin 2.12.20 matches installed 2.12.20" "0" "$rc"
+
+  # v-prefixed format (controller-gen / kustomize style) is anchored the same way.
+  printf '#!/usr/bin/env bash\necho "Version: v0.17.30"\n' >"$tool"
+  _tool_has "$tool" --version "v0.17.3"
+  rc=$?
+  assert_eq "prefix pin v0.17.3 does not match installed v0.17.30" "1" "$rc"
+
+  _tool_has "$dir/absent" version "1.0.0"
+  rc=$?
+  assert_eq "missing binary reported as not-installed" "1" "$rc"
+
+  rm -rf "$dir"
+}
+
+test_helm_plugin_pinned_anchors_version_token() {
+  echo "Test: _helm_plugin_pinned matches whole version tokens, not prefixes (regression)"
+
+  # `helm plugin list` already reports unittest 1.0.30; a pin of 1.0.3 is a
+  # PREFIX and must NOT match, or the install of the real pin would be wrongly
+  # skipped — the same anchoring guard _tool_has applies (kept in sync here).
+  local list rc
+  list=$'NAME\tVERSION\tDESCRIPTION\nunittest\t1.0.30\tunit test'
+
+  _helm_plugin_pinned "$list" unittest "1.0.3"
+  rc=$?
+  assert_eq "prefix pin 1.0.3 does not match installed 1.0.30" "1" "$rc"
+
+  _helm_plugin_pinned "$list" unittest "1.0.30"
+  rc=$?
+  assert_eq "exact pin 1.0.30 matches installed 1.0.30" "0" "$rc"
+
+  # A v-prefixed pin (as resolved from ci.yaml) is stripped before anchoring.
+  _helm_plugin_pinned "$list" unittest "v1.0.30"
+  rc=$?
+  assert_eq "v-prefixed pin v1.0.30 matches installed 1.0.30" "0" "$rc"
+
+  # Only the header row present (plugin not installed) reports not-installed.
+  _helm_plugin_pinned $'NAME\tVERSION\tDESCRIPTION' unittest "1.0.30"
+  rc=$?
+  assert_eq "absent plugin reported as not-installed" "1" "$rc"
+}
+
+test_flake_sources_hook() {
+  echo "Test: flake.nix shellHook sources the devshell hook"
+
+  if [[ ! -f "$FLAKE" ]]; then
+    echo "  FAIL: $FLAKE does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  assert_file_contains "flake.nix references the hook script" \
+    "$FLAKE" "hack/nix-devshell-hook.sh"
+  assert_file_contains "flake.nix sources the hook" \
+    "$FLAKE" "source \"\$_forge_root/hack/nix-devshell-hook.sh\""
+}
+
+test_print_pins_exit_zero
+test_print_pins_emits_exactly_seven_keys
+test_pins_non_empty_and_well_formed
+test_pins_match_canonical_files
+test_gofumpt_pin_consistent_across_ci_and_makefile
+test_detect_platform
+test_tool_has_anchors_version_token
+test_helm_plugin_pinned_anchors_version_token
+test_flake_sources_hook
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/nix_flake_manager_test.sh
+++ b/tests/unit/renovate/nix_flake_manager_test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json keeps the Nix flake input fresh: the `nix` manager is
+# enabled with lockFileMaintenance (scoped to nix so npm's package-lock.json is
+# untouched), and a packageRule groups the nix updates. Without lockFileMaintenance
+# the committed flake.lock would become the one pinned artifact Renovate stops
+# bumping — a silent regression.
+#
+# The weekly re-lock is opened for human review (automerge off): nixos-unstable is
+# a rolling ref, so the re-lock is not a version bump and minimumReleaseAge cannot
+# gate it — a reviewer confirms the base-runtime bump the devshell inherits instead.
+#
+# Usage: bash tests/unit/renovate/nix_flake_manager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+
+test_nix_manager_enabled_with_lock_maintenance() {
+  echo "Test: the nix manager is enabled with scoped lockFileMaintenance"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  assert_eq "nix.enabled is true" \
+    "true" "$(jq -r '.nix.enabled' "$RENOVATE_FILE")"
+  assert_eq "nix.lockFileMaintenance.enabled is true" \
+    "true" "$(jq -r '.nix.lockFileMaintenance.enabled' "$RENOVATE_FILE")"
+  assert_eq "nix.lockFileMaintenance.automerge is false (human-reviewed re-lock)" \
+    "false" "$(jq -r '.nix.lockFileMaintenance.automerge' "$RENOVATE_FILE")"
+}
+
+test_nix_package_rule_present() {
+  echo "Test: a packageRule groups the nix manager updates for a review-gated re-lock"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local rule
+  rule="$(jq -c '.packageRules[]
+    | select(((.matchManagers // []) | index("nix")) != null)' \
+    "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$rule" ]; then
+    echo "  FAIL: no packageRule matches the nix manager"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: found a packageRule for matchManagers=[nix]"
+  PASS=$((PASS + 1))
+
+  assert_eq "nix packageRule leaves automerge off (human-reviewed re-lock)" \
+    "false" "$(jq -r '.automerge' <<<"$rule")"
+  assert_eq "nix packageRule groups updates" \
+    "nix flake inputs" "$(jq -r '.groupName' <<<"$rule")"
+  assert_eq "nix packageRule gates automerge on release age" \
+    "3 days" "$(jq -r '.minimumReleaseAge' <<<"$rule")"
+}
+
+test_lock_maintenance_scoped_to_nix_only() {
+  echo "Test: lockFileMaintenance is scoped to the nix manager, not global"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  # A top-level lockFileMaintenance would also churn npm's package-lock.json.
+  assert_eq "no top-level lockFileMaintenance" \
+    "null" "$(jq -r '.lockFileMaintenance // "null"' "$RENOVATE_FILE")"
+}
+
+test_nix_manager_enabled_with_lock_maintenance
+test_nix_package_rule_present
+test_lock_maintenance_scoped_to_nix_only
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Provides a Nix flake devshell that mirrors the CI toolchain, so a contributor
can run `nix develop` and get the same tools a CI run gets — without
duplicating a single version literal. Base runtimes come from a pinned
nixpkgs; every tool the pipeline pins *exactly* is installed by a shell hook
that reads the pins where they already live (`ci.yaml`, the `Makefile`,
`hack/install-test-deps.sh`), so a Renovate bump to any canonical file
self-heals the shell on the next entry. The only new pinned artifact is
`flake.lock`.

Closes #608

## Change set (in commit order)

1. **`b1aecbf9` feat: add a Nix flake devshell that mirrors the CI toolchain**
   - `flake.nix`: a root flake whose single `devShells.default` (built across
     all four `{x86_64,aarch64}-{linux,darwin}` systems) provisions the base
     runtimes CI uses — Go, Node, Python, Helm, shellcheck, yq, jq, and the GNU
     userland (included on purpose so macOS behaves like the Linux-only CI
     runner). It uses a plain `mkShell` with a C compiler because `go test
     -race` needs cgo. Docker is deliberately *not* provided (a daemon cannot
     be nix-provisioned). `go_1_26` / `nodejs_24` fall back to the unversioned
     attrs if a future nixpkgs revision renames them.
   - `hack/nix-devshell-hook.sh`: sourced by the `shellHook` from the working
     tree (not a `${./…}` store path) so it reads the *live* pins and resolves
     the repo root via git. It installs the exactly-pinned tools
     (controller-gen, gofumpt, golangci-lint, setup-envtest, kustomize,
     chainsaw, kind, kubectl, flux, the helm-unittest plugin, and the envtest
     assets) into the gitignored `bin/` (the Makefile's `LOCALBIN`), reusing
     `hack/install-test-deps.sh` verbatim with its SHA256 verification. It
     degrades loudly (never silently) when entered offline.
   - `flake.nix`/`flake.lock`: the new pinned nixpkgs input and its lock.
   - `.gitignore`: ignore the Nix build/direnv artifacts.

2. **`565fc01b` test(hack): cover the nix devshell hook pin resolution**
   - `tests/unit/hack/nix_devshell_hook_test.sh`: locks the hook's pin-reading
     contract to the real `ci.yaml` and `Makefile` — `--print-pins` must emit
     exactly the seven expected keys, each well-formed, and each must agree
     with an independent grep/sed extraction from its canonical file (a
     bidirectional drift guard). Also asserts `GOFUMPT_VERSION` stays in sync
     across `ci.yaml` and the `Makefile`, and that `flake.nix` sources the
     hook. A pin-location refactor now fails `make test-shell` instead of
     silently breaking the shell.

3. **`53799ce7` chore(renovate): keep the nix flake input fresh**
   - `renovate.json`: enables the native `nix` manager with
     `lockFileMaintenance` scoped to nix (so npm's `package-lock.json` gets no
     lock-maintenance PRs), plus a packageRule that groups the nix updates
     behind the standard 3-day cooldown (no automerge). Without this the
     committed `flake.lock` would become the one pinned artifact Renovate stops
     bumping.
   - `tests/unit/renovate/nix_flake_manager_test.sh`: guards the config shape.

4. **`9fa19433` docs: document the Nix devshell as a second toolchain entry point**
   - `docs/contributing/nix-dev-environment.md`: a Contributing page describing
     what `nix develop` provides, which tools are pinned exactly to CI (and
     where each pin lives) versus tracked from nixpkgs, the Nix/Docker
     prerequisites, first-entry and offline behavior, and how Renovate keeps
     both the tool pins and `flake.lock` fresh.
   - `docs/.vitepress/config.ts`: registers the page in the sidebar.
   - `docs/quick-start-extended.md`: adds a tip to the tools section.
   - `docs/contributing/dependency-management.md`: cross-links the new page.

## Divergences from the issue

None material. The issue asks for "a Nix flake with every tool the CI pipeline
uses"; the flake provides the base runtimes directly and defers the
exactly-pinned tools to the shared hook rather than duplicating their versions
into the flake, so the single source of truth for each pin stays in its
canonical file. Docker is intentionally excluded (a daemon cannot be
nix-provisioned) — kind still needs a running Docker, which the docs call out.
No pipeline behavior changes.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 9ce865e with Claude:claude-opus-4-8_
