### PR TITLE
test(keystone): close out the identity-backend documentation guard residuals

### DIFF
--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -215,7 +215,7 @@ a link to the full reference.
 | Policy overrides | `spec.policyOverrides` | Custom `oslo.policy` rules (inline or ConfigMap) | [PolicySpec](../reference/keystone/keystone-crd.md#policyspec) |
 | Middleware | `spec.middleware` | Custom WSGI filters in the `api-paste.ini` pipeline | [MiddlewareSpec](../reference/keystone/keystone-crd.md#middlewarespec) |
 | Plugins | `spec.plugins` | Service-side Keystone plugins/drivers | [PluginSpec](../reference/keystone/keystone-crd.md#pluginspec) |
-| Federation | `spec.federation` | Enables Keystone federation (SAML/OIDC, Shibboleth) | [FederationSpec](../reference/keystone/keystone-crd.md#federationspec) |
+| Federation | `spec.federation` | Federation sidecar knobs (proxy image, trusted dashboards); federation itself activates by attaching a [`KeystoneIdentityBackend`](../reference/keystone/identity-backend-crd.md), not by this block | [FederationSpec](../reference/keystone/keystone-crd.md#federationspec) |
 | Resource requests/limits | `spec.deployment.resources` | CPU/memory requests and limits on API pods | [KeystoneSpec](../reference/keystone/keystone-crd.md#keystonespec) |
 | Public endpoint | `spec.bootstrap.publicEndpoint` | External URL written to the Keystone service catalogue | [BootstrapSpec](../reference/keystone/keystone-crd.md#bootstrapspec) |
 

--- a/tests/unit/docs/identity_backend_crd_naming_convention_test.sh
+++ b/tests/unit/docs/identity_backend_crd_naming_convention_test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the docs/reference/keystone/identity-backend-crd.md reference page
+# documents the CRD's conditions and its projected-artefact naming convention.
+# Unlike the Keystone and Horizon CRDs, KeystoneIdentityBackend projects no
+# Service of its own — it renders config into the referenced Keystone's
+# Deployment — so the naming convention it must pin down is the one for the
+# per-domain config file and the content-hashed Secrets, plus the condition
+# set the dedicated reconciler writes.
+#
+#   1. The "### Conditions" section exists and documents every condition type
+#      the reconciler owns (DomainReady, ConfigProjected, FederationObjectsReady,
+#      MappingsReady, the aggregate Ready) plus the aggregated
+#      IdentityBackendsReady condition mirrored onto the Keystone CR.
+#   2. The "## Retained Artefacts" section documents the content-hashed Secret
+#      naming convention (<keystone>-domains-<hash>, <keystone>-federation-<hash>)
+#      and the stable-named <keystone>-oidc-crypto-passphrase Secret.
+#   3. The per-domain config-file naming convention (keystone.<domain>.conf) is
+#      documented.
+#
+# Usage: bash tests/unit/docs/identity_backend_crd_naming_convention_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+CRD_DOC="$PROJECT_ROOT/docs/reference/keystone/identity-backend-crd.md"
+
+# --- Test 1: conditions section documents the full condition set ---
+test_conditions_documented() {
+  echo "Test: '### Conditions' section documents the reconciler's condition set"
+
+  if [[ ! -f "$CRD_DOC" ]]; then
+    echo "  FAIL: $CRD_DOC does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_file_contains "conditions heading present" \
+    "$CRD_DOC" \
+    '^### Conditions'
+  assert_file_contains "documents DomainReady" \
+    "$CRD_DOC" \
+    'DomainReady'
+  assert_file_contains "documents ConfigProjected" \
+    "$CRD_DOC" \
+    'ConfigProjected'
+  assert_file_contains "documents the federation-only FederationObjectsReady" \
+    "$CRD_DOC" \
+    'FederationObjectsReady'
+  assert_file_contains "documents the federation-only MappingsReady" \
+    "$CRD_DOC" \
+    'MappingsReady'
+  assert_file_contains "documents the aggregate Ready reason AllReady" \
+    "$CRD_DOC" \
+    'AllReady'
+  assert_file_contains "documents the Keystone-side aggregate IdentityBackendsReady" \
+    "$CRD_DOC" \
+    'IdentityBackendsReady'
+}
+
+# --- Test 2: retained-artefact Secret naming convention ---
+test_retained_artefact_naming() {
+  echo "Test: '## Retained Artefacts' documents the content-hashed Secret naming"
+
+  assert_file_contains "retained-artefacts heading present" \
+    "$CRD_DOC" \
+    '^## Retained Artefacts'
+  assert_file_contains "documents the <keystone>-domains-<hash> Secret name" \
+    "$CRD_DOC" \
+    '<keystone>-domains-<hash>'
+  assert_file_contains "documents the <keystone>-federation-<hash> Secret name" \
+    "$CRD_DOC" \
+    '<keystone>-federation-<hash>'
+  assert_file_contains "documents the stable-named crypto-passphrase Secret" \
+    "$CRD_DOC" \
+    '<keystone>-oidc-crypto-passphrase'
+}
+
+# --- Test 3: per-domain config-file naming convention ---
+test_per_domain_config_naming() {
+  echo "Test: the per-domain config-file naming convention is documented"
+
+  assert_file_contains "documents the keystone.<domain>.conf per-domain file name" \
+    "$CRD_DOC" \
+    'keystone.<domain>.conf'
+}
+
+# --- Run ---
+echo "=== KeystoneIdentityBackend CRD naming-convention doc tests ==="
+echo ""
+test_conditions_documented
+echo ""
+test_retained_artefact_naming
+echo ""
+test_per_domain_config_naming
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #575.

## Context

Phase 5 of the external-identity-backends meta (#567) is a **continuous docs/guards workstream** rather than a one-shot deliverable — it gates each phase. Phases 0–4 (#570–#574) have all landed, and each shipped its own documentation inline: the `KeystoneIdentityBackend` CRD reference, the LDAP / OIDC / SAML / end-to-end-SSO guides (all wired into the VitePress sidebar), the quick-start extension, and the repurposed `FederationSpec` reference. The per-phase guard skills (crd-drift, validation-parity, fixture-drift, condition-coverage, renovate-coverage, spdx/reuse) were green at each phase merge.

A re-check of the current tree against the #575 checklist found only two forge-side residuals still open. This PR closes them, which is the last forge-side work #575 tracks.

## Changes

1. **`tests/unit/docs/identity_backend_crd_naming_convention_test.sh`** — the repo carried naming-convention doc guards for the Keystone and Horizon CRDs but none for `KeystoneIdentityBackend`. Add one, adapted to that CRD's shape: it projects no Service of its own (it renders config into the referenced Keystone's Deployment), so instead of a Service-DNS convention the guard pins:
   - the **condition set** the dedicated reconciler documents — `DomainReady`, `ConfigProjected`, the federation-only `FederationObjectsReady` / `MappingsReady`, the aggregate `Ready` (via its `AllReady` reason), and the Keystone-side aggregate `IdentityBackendsReady` (all five verified to exist in `operators/keystone/`);
   - the **projected-artefact naming convention** — the content-hashed `<keystone>-domains-<hash>` / `<keystone>-federation-<hash>` Secrets, the stable-named `<keystone>-oidc-crypto-passphrase` Secret, and the per-domain `keystone.<domain>.conf` file.

   Picked up automatically by the `make test-shell` `*_test.sh` glob — no registration needed. 12 assertions, all green; the neighbouring keystone/horizon/cross-links doc tests are unchanged.

2. **`docs/guides/advanced-configuration.md`** — the `spec.federation` row still read *"Enables Keystone federation (SAML/OIDC, Shibboleth)"*. Federation now activates by attaching a `KeystoneIdentityBackend`, not by that block; correct the row and link the CRD reference.

## Deliberately out of scope

The remaining #575 checkbox — the **architecture submodule (C5C3/C5C3)** implementation chapter and superseding the stale `FederationSpec` / domain-config sketches in `09-implementation/` — is intentionally **not** addressed here. It lives in a separate repository, is not gated by the forge CI, and is tracked outside this repo. #575 is closed on the forge side accordingly; the architecture-doc work, if still wanted, belongs in a C5C3/C5C3 issue.

---

_Prepared with Claude:claude-opus-4-8_
