### PR TITLE
Promote copied sub-reconciler scaffolding into the shared library and align on server-side apply

### DIFF
--- a/docs/contributing/adding-a-new-operator.md
+++ b/docs/contributing/adding-a-new-operator.md
@@ -24,20 +24,22 @@ The keystone operator is the reference consumer for every package listed.
 | --- | --- |
 | `internal/common/types` | Shared CRD spec types (`DatabaseSpec`, `CacheSpec`, `GatewaySpec`, `ImageSpec`, `DeploymentSpec`, `AutoscalingSpec`, `NetworkPolicySpec`, `LoggingSpec`, ...) with their CEL rules and `Default()` methods |
 | `internal/common/naming` | Label keys, `CommonLabels`/`SelectorLabels`, `SubResourceName` — the workload naming convention (and the cross-service endpoint contract, see below) |
-| `internal/common/reconcile` | Table-driven pipeline (`Step`/`RunPipeline`), parallel groups (`ParallelStep`/`RunParallelGroup`), `ShortestRequeue`, `SetAggregateReady`, the no-op-skipping `UpdateStatus`, `EnsureFinalizer` |
-| `internal/common/watch` | `CRUpdatePredicate` for the `For(...)` watch, `SecretToOwnersMapper` + `RegisterSecretNameIndex`, `ClusterSecretStoreFanOut` |
+| `internal/common/reconcile` | Table-driven pipeline (`Step`/`RunPipeline`), parallel groups (`ParallelStep`/`RunParallelGroup`), `ShortestRequeue`, `SetAggregateReady`, the no-op-skipping `UpdateStatus`, `EnsureFinalizer`, the shared requeue constants (`RequeueDeploymentPolling`/`RequeueSecretPolling`), the `Skeleton[T,S]` controller-skeleton glue (Ready aggregation, status write, `MarkFailed`, parallel-group), and `ProjectChild`/`DeleteOrphanedChild` for orchestrating operators that project child CRs |
+| `internal/common/watch` | `CRUpdatePredicate` for the `For(...)` watch, `SecretToOwnersMapper` + `RegisterSecretNameIndex`, `ClusterSecretStoreFanOut`, `ClusterRefMapper` (database-cluster reference to owning CRs) |
 | `internal/common/bootstrap` | `Run`/`ManagerConfig` manager bootstrap, `ControllerOptions` (concurrency + tuned rate limiter), `DetectOperatorNamespace` |
-| `internal/common/instrumentation` | Sub-reconciler duration/error metrics; declare a `NewMetrics("<op>_operator")` instance beside the instrumenter glue |
-| `internal/common/deployment` | SSA ensure primitives, `RestrictedSecurityContext`, PDB/HPA builders, replica normalization, pod-knob default helpers |
-| `internal/common/gateway` | `IsGVKAvailable` CRD probe, HTTPRoute builder/acceptance/ensure/delete over the shared `GatewaySpec` |
-| `internal/common/secrets` | ESO primitives, `OpenBaoClusterStoreName`, the `GateSyncedSecret` ladder |
+| `internal/common/instrumentation` | Sub-reconciler duration/error metrics; declare a `NewSubReconcilerInstrumenter("<op>_operator", conditionTypes)` beside the instrumenter glue and register it from a `RegisterMetrics()` wired into `main.go` (registration returns an error instead of panicking) |
+| `internal/common/deployment` | SSA ensure primitives, `RestrictedSecurityContext`, PDB/HPA builders, `ReconcileHPA` flow, replica normalization, pod-knob default helpers |
+| `internal/common/networkpolicy` | `Ensure`/`Delete`, the auto-derived egress rules (`DNSEgressRule`/`DatabaseEgressRule`/`CacheEgressRule`/`CacheEgressPorts`), `IngressPeers`, and the three-path `Reconcile` flow with the fail-closed empty-ingress guard |
+| `internal/common/gateway` | `IsGVKAvailable` CRD probe, HTTPRoute builder/acceptance/ensure/delete over the shared `GatewaySpec`, and the three-path `ReconcileHTTPRoute` flow |
+| `internal/common/secrets` | ESO primitives, `OpenBaoClusterStoreName`, the `GateSyncedSecret` ladder, the `GateClusterStoreReady` gate and `GateCredential`/`GateCredentials` condition-reporting loop |
 | `internal/common/validation` | Shared webhook validators (DB/cache XOR, dynamic-credentials rule, cron parse, TSC selector, PriorityClass lookup) |
-| `internal/common/database`, `internal/common/cache` | MariaDB CR apply, host/port/username resolution, pymysql DSN + TLS params + rollout digest, memcache server resolution |
+| `internal/common/database`, `internal/common/cache` | MariaDB CR apply, `BuildDatabase`/`BuildUser`/`BuildGrant` provisioning builders, host/port/username resolution, pymysql DSN + TLS params + rollout digest, memcache server resolution |
+| `internal/common/rotation` | Split-compute-write credential rotation: `EnsureStagingSecret`, `CommitStaged`/`CommitSpec`, `EnsureRBAC`, `CompletedAt`/`ObserveAge`, `BuildCronJob`/`CronJobParams` |
 | `internal/common/release` | OpenStack release parsing and upgrade/downgrade classification |
-| `internal/common/healthcheck` | `HTTPDoer` seam, probe-error classifier, TTL probe cache |
-| `internal/common/job` | `RunJob`/`RunJobWithRerunKey`/`EnsureCronJob`/`DeleteCronJob` |
+| `internal/common/healthcheck` | `HTTPDoer` seam, probe-error classifier, TTL probe cache, the shared timing constants, and the `ReconcileProbe` flow |
+| `internal/common/job` | `RunJob`/`RunJobWithRerunKey`/`EnsureCronJob`/`DeleteCronJob`, the `BuildMigrationJob` skeleton, and the at-most-once `RecordJobTerminalState` recorder |
 | `internal/common/config` | oslo INI rendering + immutable-ConfigMap lifecycle (see the design decisions below for non-INI services) |
-| `internal/common/testutil/envtest` | envtest bootstrap, `BuildScheme`, `CommonFakeCRDDirs`, `StartManagedEnvTest` |
+| `internal/common/testutil/envtest` | envtest bootstrap, `BuildScheme`, `CommonExternalSchemes`, `CommonFakeCRDDirs`, `StartManagedEnvTest`, `SetupEnvTestWithCRDs` (webhook-less), `SetupUnstartedManager` |
 
 ## Residual touch list
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -638,8 +638,8 @@ mirrors `reconcileDBCredentials`'s wait/condition handling. The database is
   `{namespace}/{keystone-name}` scoping still keeps two ControlPlanes from
   colliding on the cluster-global OpenBao backend. The builder
   `adminPasswordExternalSecret(cp)` sets **no** owner reference; the reconciler
-  sets the ControlPlane controller reference inside the `CreateOrUpdate` mutate
-  closure for GC.
+  applies the ExternalSecret via Server-Side Apply under the shared field manager
+  (`forge-operator`), which stamps the ControlPlane controller reference for GC.
 
 The managed-mode effective admin-password ref (`effectiveAdminPasswordSecretRef`)
 points the projected Keystone child's `spec.bootstrap.adminPasswordSecretRef` at
@@ -1183,8 +1183,9 @@ CRD-not-installed condition.
 as owned K-ORC CRs: an `identity`-type `Service` named
 `keystone`, plus a `public` `Endpoint` whose URL defaults to the conventional
 in-cluster identity URL `http://keystone.<namespace>.svc:5000/v3` and whose
-`serviceRef` points at the identity Service. Both children are idempotent
-create-or-updates.
+`serviceRef` points at the identity Service. Both children are projected
+idempotently via Server-Side Apply under the shared field manager
+(`forge-operator`).
 
 Registering the child CRs only instructs K-ORC to create the catalog entries — it
 does not mean they exist in Keystone — so `CatalogReady` is gated on both children

--- a/docs/reference/keystone-operator-metrics.md
+++ b/docs/reference/keystone-operator-metrics.md
@@ -20,12 +20,15 @@ The sub-reconciler duration/error pair
 `keystone_operator_reconcile_errors_total`) is shared with the other
 forge operators. It lives in the
 [`internal/common/instrumentation`](https://github.com/c5c3/forge/blob/main/internal/common/instrumentation/instrumentation.go)
-package and is exposed as the `subReconcilerMetrics` instance declared beside
-the instrumenter glue in `internal/controller/instrumentation.go`, which
-registers on the controller-runtime registry lazily on first use. The
-per-CR collectors (rotation age and `db_sync`) register via the
-process-wide `sync.Once` initializer `globalCollectors()` in
-[`operators/keystone/internal/metrics/collectors.go`](https://github.com/c5c3/forge/blob/main/operators/keystone/internal/metrics/collectors.go).
+package and is exposed as the instrumenter declared beside the glue in
+`internal/controller/instrumentation.go`. Both the sub-reconciler vectors and
+the per-CR collectors (rotation age and `db_sync`) register on the
+controller-runtime registry once at operator startup through `RegisterMetrics()`,
+which `main.go` calls before wiring the controllers. Registration returns an
+error rather than panicking mid-reconcile, so a duplicate-registration fails
+startup cleanly. The per-CR collectors live in
+[`operators/keystone/internal/metrics/collectors.go`](https://github.com/c5c3/forge/blob/main/operators/keystone/internal/metrics/collectors.go)
+and are registered by `RegisterMetrics()` via their `Register()` function.
 All collectors attach to the controller-runtime registry
 (`sigs.k8s.io/controller-runtime/pkg/metrics`) and are served on the
 operator's metrics listener at `:8080/metrics` by default; see

--- a/internal/common/database/builders.go
+++ b/internal/common/database/builders.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Values the provisioning builders apply to every built resource.
+const (
+	defaultCharacterSet = "utf8"
+	defaultCollate      = "utf8_general_ci"
+	defaultPasswordKey  = "password"
+)
+
+// ProvisionParams carries the inputs of the MariaDB provisioning builders. Every
+// database-backed service operator provisions the same three resources — a
+// Database, a User, and a Grant — against a MariaDB cluster; only the names, the
+// cluster reference, and the credential Secret differ. The operator supplies
+// those; the builders assemble the mariadb-operator CRs.
+type ProvisionParams struct {
+	// Name is the Database/User/Grant resource name and the SQL username; the
+	// operator's naming convention chooses it.
+	Name string
+	// Namespace is the resource namespace.
+	Namespace string
+	// Labels are applied to every built resource; nil leaves the resources
+	// unlabelled.
+	Labels map[string]string
+	// ClusterRef is the MariaDB cluster the resources attach to
+	// (spec.database.clusterRef.name).
+	ClusterRef string
+	// DatabaseName is the SQL database to create and grant on.
+	DatabaseName string
+	// PasswordSecretName locates the user password Secret.
+	PasswordSecretName string
+}
+
+func (p ProvisionParams) mariaDBRef() mariadbv1alpha1.MariaDBRef {
+	return mariadbv1alpha1.MariaDBRef{
+		ObjectReference: mariadbv1alpha1.ObjectReference{Name: p.ClusterRef},
+	}
+}
+
+func (p ProvisionParams) objectMeta() metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace, Labels: p.Labels}
+}
+
+// BuildDatabase builds the mariadb-operator Database CR that creates the SQL
+// database.
+func BuildDatabase(p ProvisionParams) *mariadbv1alpha1.Database {
+	return &mariadbv1alpha1.Database{
+		ObjectMeta: p.objectMeta(),
+		Spec: mariadbv1alpha1.DatabaseSpec{
+			MariaDBRef:   p.mariaDBRef(),
+			CharacterSet: defaultCharacterSet,
+			Collate:      defaultCollate,
+			Name:         p.DatabaseName,
+		},
+	}
+}
+
+// BuildUser builds the mariadb-operator User CR that creates the SQL user,
+// reading its password from the referenced Secret.
+func BuildUser(p ProvisionParams) *mariadbv1alpha1.User {
+	return &mariadbv1alpha1.User{
+		ObjectMeta: p.objectMeta(),
+		Spec: mariadbv1alpha1.UserSpec{
+			MariaDBRef: p.mariaDBRef(),
+			PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+				LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+					Name: p.PasswordSecretName,
+				},
+				Key: defaultPasswordKey,
+			},
+		},
+	}
+}
+
+// BuildGrant builds the mariadb-operator Grant CR that grants the user ALL
+// PRIVILEGES on the database.
+func BuildGrant(p ProvisionParams) *mariadbv1alpha1.Grant {
+	return &mariadbv1alpha1.Grant{
+		ObjectMeta: p.objectMeta(),
+		Spec: mariadbv1alpha1.GrantSpec{
+			MariaDBRef: p.mariaDBRef(),
+			Privileges: []string{"ALL PRIVILEGES"},
+			Database:   p.DatabaseName,
+			Table:      "*",
+			Username:   p.Name,
+		},
+	}
+}

--- a/internal/common/database/builders_test.go
+++ b/internal/common/database/builders_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func provisionParams() ProvisionParams {
+	return ProvisionParams{
+		Name:               "keystone",
+		Namespace:          "openstack",
+		ClusterRef:         "mariadb",
+		DatabaseName:       "keystone",
+		PasswordSecretName: "keystone-db",
+	}
+}
+
+func TestBuildDatabase(t *testing.T) {
+	g := gomega.NewWithT(t)
+	db := BuildDatabase(provisionParams())
+	g.Expect(db.Name).To(gomega.Equal("keystone"))
+	g.Expect(db.Namespace).To(gomega.Equal("openstack"))
+	g.Expect(db.Spec.MariaDBRef.Name).To(gomega.Equal("mariadb"))
+	g.Expect(db.Spec.Name).To(gomega.Equal("keystone"))
+	// utf8 / utf8_general_ci are applied to every built database.
+	g.Expect(db.Spec.CharacterSet).To(gomega.Equal("utf8"))
+	g.Expect(db.Spec.Collate).To(gomega.Equal("utf8_general_ci"))
+	g.Expect(db.Labels).To(gomega.BeNil())
+}
+
+func TestBuildDatabase_Labels(t *testing.T) {
+	g := gomega.NewWithT(t)
+	p := provisionParams()
+	p.Labels = map[string]string{"app": "nova"}
+	db := BuildDatabase(p)
+	g.Expect(db.Labels).To(gomega.HaveKeyWithValue("app", "nova"))
+}
+
+func TestBuildUser(t *testing.T) {
+	g := gomega.NewWithT(t)
+	user := BuildUser(provisionParams())
+	g.Expect(user.Name).To(gomega.Equal("keystone"))
+	g.Expect(user.Spec.MariaDBRef.Name).To(gomega.Equal("mariadb"))
+	g.Expect(user.Spec.PasswordSecretKeyRef.Name).To(gomega.Equal("keystone-db"))
+	// The password Secret key is always "password".
+	g.Expect(user.Spec.PasswordSecretKeyRef.Key).To(gomega.Equal("password"))
+}
+
+func TestBuildGrant(t *testing.T) {
+	g := gomega.NewWithT(t)
+	grant := BuildGrant(provisionParams())
+	g.Expect(grant.Name).To(gomega.Equal("keystone"))
+	g.Expect(grant.Spec.MariaDBRef.Name).To(gomega.Equal("mariadb"))
+	g.Expect(grant.Spec.Privileges).To(gomega.Equal([]string{"ALL PRIVILEGES"}))
+	g.Expect(grant.Spec.Database).To(gomega.Equal("keystone"))
+	g.Expect(grant.Spec.Table).To(gomega.Equal("*"))
+	g.Expect(grant.Spec.Username).To(gomega.Equal("keystone"))
+}

--- a/internal/common/deployment/hpa_flow.go
+++ b/internal/common/deployment/hpa_flow.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// Condition reason constants for the HPA readiness condition, shared so every
+// operator's condition uses the same vocabulary.
+const (
+	ReasonHPAReady       = "HPAReady"
+	ReasonHPANotRequired = "HPANotRequired"
+)
+
+// HPAFlowParams carries everything ReconcileHPA needs. The service-specific
+// parts — whether autoscaling is enabled, the built desired HPA, the identity,
+// and the condition type — are supplied by the caller; the two-path flow itself
+// is identical across operators.
+type HPAFlowParams struct {
+	// Enabled reports whether spec.autoscaling is set.
+	Enabled bool
+	// Desired is the built HorizontalPodAutoscaler, applied when Enabled.
+	Desired *autoscalingv2.HorizontalPodAutoscaler
+	// Name and Namespace identify the HPA for the delete path.
+	Name      string
+	Namespace string
+	// Conditions is the CR's condition slice, mutated in place.
+	Conditions *[]metav1.Condition
+	// Generation is stamped onto every condition the flow writes.
+	Generation int64
+	// ConditionType is the readiness condition the flow reports on.
+	ConditionType string
+}
+
+// ReconcileHPA ensures the HorizontalPodAutoscaler matches the desired state. It
+// is the shared body of every operator's reconcileHPA sub-reconciler:
+//
+//   - spec.autoscaling nil: delete any existing HPA and set the condition
+//     True/HPANotRequired.
+//   - spec.autoscaling set: apply the HPA via SSA and set the condition
+//     True/HPAReady.
+func ReconcileHPA(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, p HPAFlowParams) (ctrl.Result, error) {
+	if !p.Enabled {
+		if err := DeleteHPA(ctx, c, p.Namespace, p.Name); err != nil {
+			return ctrl.Result{}, fmt.Errorf("deleting HorizontalPodAutoscaler: %w", err)
+		}
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonHPANotRequired,
+			Message:            "Autoscaling is not configured",
+		})
+		return ctrl.Result{}, nil
+	}
+
+	if err := EnsureHPA(ctx, c, scheme, owner, p.Desired); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring HorizontalPodAutoscaler: %w", err)
+	}
+	conditions.SetCondition(p.Conditions, metav1.Condition{
+		Type:               p.ConditionType,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: p.Generation,
+		Reason:             ReasonHPAReady,
+		Message:            "HorizontalPodAutoscaler is configured",
+	})
+	return ctrl.Result{}, nil
+}

--- a/internal/common/deployment/hpa_flow_test.go
+++ b/internal/common/deployment/hpa_flow_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+func TestReconcileHPA_disabledDeletes(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	existing := testHPA()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	var conds []metav1.Condition
+
+	res, err := ReconcileHPA(context.Background(), c, s, testOwner(), HPAFlowParams{
+		Enabled: false, Name: "test-hpa", Namespace: "default",
+		Conditions: &conds, Generation: 4, ConditionType: "HPAReady",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	err = c.Get(context.Background(), client.ObjectKey{Name: "test-hpa", Namespace: "default"}, &autoscalingv2.HorizontalPodAutoscaler{})
+	g.Expect(err).To(HaveOccurred())
+	cond := conditions.GetCondition(conds, "HPAReady")
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(ReasonHPANotRequired))
+	g.Expect(cond.Message).To(Equal("Autoscaling is not configured"))
+	g.Expect(cond.ObservedGeneration).To(Equal(int64(4)))
+}
+
+func TestReconcileHPA_enabledEnsures(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(testOwner()).Build()
+	var conds []metav1.Condition
+
+	res, err := ReconcileHPA(context.Background(), c, s, testOwner(), HPAFlowParams{
+		Enabled: true, Desired: testHPA(), Name: "test-hpa", Namespace: "default",
+		Conditions: &conds, Generation: 4, ConditionType: "HPAReady",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	created := &autoscalingv2.HorizontalPodAutoscaler{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-hpa", Namespace: "default"}, created)).To(Succeed())
+	g.Expect(created.OwnerReferences).To(HaveLen(1))
+	cond := conditions.GetCondition(conds, "HPAReady")
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(ReasonHPAReady))
+	g.Expect(cond.Message).To(Equal("HorizontalPodAutoscaler is configured"))
+}

--- a/internal/common/gateway/flow.go
+++ b/internal/common/gateway/flow.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// Condition reason constants for the HTTPRoute readiness condition, shared so
+// every operator's route condition uses the same vocabulary.
+const (
+	ReasonHTTPRouteAccepted      = "HTTPRouteAccepted"
+	ReasonHTTPRouteNotAccepted   = "HTTPRouteNotAccepted"
+	ReasonHTTPRouteNotRequired   = "HTTPRouteNotRequired"
+	ReasonGatewayAPINotInstalled = "GatewayAPINotInstalled"
+)
+
+// RouteFlowParams carries everything ReconcileHTTPRoute needs. The
+// service-specific parts — whether the Gateway API is installed, whether
+// spec.gateway is set, the built desired route, the route identity, the
+// exposure noun for the messages, and the condition type — are supplied by the
+// caller; the three-path flow itself is identical across operators.
+type RouteFlowParams struct {
+	// GatewayAPIAvailable reports whether the HTTPRoute CRD is installed (the
+	// watch was registered at startup).
+	GatewayAPIAvailable bool
+	// GatewayConfigured reports whether the CR requests external exposure
+	// (spec.gateway != nil).
+	GatewayConfigured bool
+	// Desired is the built HTTPRoute, applied when GatewayConfigured is true.
+	Desired *gatewayv1.HTTPRoute
+	// RouteName and RouteNamespace identify the route for the delete path.
+	RouteName      string
+	RouteNamespace string
+	// ExposureNoun is the human-readable noun for the not-required and
+	// not-installed messages, for example "API" or "dashboard".
+	ExposureNoun string
+	// Conditions is the CR's condition slice, mutated in place.
+	Conditions *[]metav1.Condition
+	// Generation is stamped onto every condition the flow writes.
+	Generation int64
+	// ConditionType is the readiness condition the flow reports on (for example
+	// "HTTPRouteReady").
+	ConditionType string
+	// RequeueAccepted is the interval to requeue while waiting for the Gateway
+	// controller to report Accepted=True.
+	RequeueAccepted time.Duration
+}
+
+// ReconcileHTTPRoute ensures the HTTPRoute that exposes a service through a
+// Gateway matches the desired state. It is the shared body of every operator's
+// reconcileHTTPRoute sub-reconciler and implements three lifecycle paths:
+//
+//   - Gateway API CRD absent: skip the delete (which would fail with "no matches
+//     for kind HTTPRoute") and surface a clear condition.
+//   - spec.gateway nil: delete any existing HTTPRoute and set the condition
+//     True/HTTPRouteNotRequired.
+//   - spec.gateway set: apply the route via SSA and reflect the parent Accepted
+//     condition as the readiness condition.
+func ReconcileHTTPRoute(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, p RouteFlowParams) (ctrl.Result, error) {
+	notConfiguredMsg := fmt.Sprintf("External %s exposure via Gateway API is not configured", p.ExposureNoun)
+
+	// Path 0: Gateway API CRD is not installed.
+	if !p.GatewayAPIAvailable {
+		if !p.GatewayConfigured {
+			conditions.SetCondition(p.Conditions, metav1.Condition{
+				Type:               p.ConditionType,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: p.Generation,
+				Reason:             ReasonHTTPRouteNotRequired,
+				Message:            notConfiguredMsg,
+			})
+			return ctrl.Result{}, nil
+		}
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonGatewayAPINotInstalled,
+			Message: fmt.Sprintf("spec.gateway is set but the gateway.networking.k8s.io/v1 HTTPRoute CRD is "+
+				"not installed in this cluster; install Gateway API and restart the operator to enable "+
+				"external %s exposure", p.ExposureNoun),
+		})
+		return ctrl.Result{}, nil
+	}
+
+	// Path 2: gateway disabled — delete any existing HTTPRoute.
+	if !p.GatewayConfigured {
+		if err := DeleteHTTPRoute(ctx, c, p.RouteNamespace, p.RouteName); err != nil {
+			return ctrl.Result{}, err
+		}
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonHTTPRouteNotRequired,
+			Message:            notConfiguredMsg,
+		})
+		return ctrl.Result{}, nil
+	}
+
+	// Path 1: gateway enabled — create or update the HTTPRoute. EnsureHTTPRoute
+	// applies via Server-Side Apply and decodes the server response back into
+	// desired, so its parent status — written by the Gateway controller — is
+	// already populated without a second Get (issue #361).
+	if err := EnsureHTTPRoute(ctx, c, scheme, owner, p.Desired); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring HTTPRoute: %w", err)
+	}
+
+	if IsHTTPRouteAccepted(p.Desired) {
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonHTTPRouteAccepted,
+			Message:            "HTTPRoute accepted by Gateway",
+		})
+		return ctrl.Result{}, nil
+	}
+
+	conditions.SetCondition(p.Conditions, metav1.Condition{
+		Type:               p.ConditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: p.Generation,
+		Reason:             ReasonHTTPRouteNotAccepted,
+		Message:            "HTTPRoute not yet accepted by Gateway",
+	})
+	return ctrl.Result{RequeueAfter: p.RequeueAccepted}, nil
+}

--- a/internal/common/gateway/flow_test.go
+++ b/internal/common/gateway/flow_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+func flowScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := gatewayv1.Install(s); err != nil {
+		t.Fatalf("installing gateway scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("adding corev1 scheme: %v", err)
+	}
+	return s
+}
+
+func flowOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "openstack", UID: "owner-uid"},
+	}
+}
+
+func baseRouteParams(conds *[]metav1.Condition) RouteFlowParams {
+	return RouteFlowParams{
+		RouteName:       "ks",
+		RouteNamespace:  "openstack",
+		ExposureNoun:    "API",
+		Conditions:      conds,
+		Generation:      2,
+		ConditionType:   "HTTPRouteReady",
+		RequeueAccepted: 10 * time.Second,
+	}
+}
+
+func TestReconcileHTTPRoute_APIAbsentGatewaySet(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.GatewayAPIAvailable = false
+	p.GatewayConfigured = true
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("enable external API exposure"))
+}
+
+func TestReconcileHTTPRoute_APIAbsentGatewayNil(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.GatewayAPIAvailable = false
+	p.GatewayConfigured = false
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonHTTPRouteNotRequired))
+	g.Expect(cond.Message).To(gomega.Equal("External API exposure via Gateway API is not configured"))
+}
+
+func TestReconcileHTTPRoute_GatewayNilDeletes(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	existing := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "ks", Namespace: "openstack"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.GatewayAPIAvailable = true
+	p.GatewayConfigured = false
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	// The existing route is deleted.
+	fetched := &gatewayv1.HTTPRoute{}
+	err = c.Get(context.Background(), types.NamespacedName{Namespace: "openstack", Name: "ks"}, fetched)
+	g.Expect(err).To(gomega.HaveOccurred())
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonHTTPRouteNotRequired))
+}
+
+func TestReconcileHTTPRoute_GatewayEnabledNotAccepted(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(flowOwner()).Build()
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.GatewayAPIAvailable = true
+	p.GatewayConfigured = true
+	p.Desired = BuildHTTPRoute(testGatewaySpec(), RouteParams{
+		Name: "ks", Namespace: "openstack", BackendService: "ks", BackendPort: 5000,
+	})
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	// A fresh route has no accepted parent status, so the flow requeues.
+	g.Expect(res.RequeueAfter).To(gomega.Equal(p.RequeueAccepted))
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonHTTPRouteNotAccepted))
+}

--- a/internal/common/healthcheck/flow.go
+++ b/internal/common/healthcheck/flow.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// ProbeFlowParams carries everything ReconcileProbe needs to run one operator's
+// API-readiness probe. The service-specific parts — the endpoint, the condition
+// vocabulary, and the human-readable Subject — are supplied by the caller; the
+// flow itself (endpoint gate, TTL cache, timeout-bounded GET, error
+// classification, condition reporting) is identical across operators.
+type ProbeFlowParams struct {
+	// Doer performs the HTTP GET. Tests inject a stub transport.
+	Doer HTTPDoer
+	// Cache memoizes the last successful probe per CR so a steady-state
+	// reconcile skips the synchronous GET.
+	Cache *ProbeCache
+	// Key and UID identify the CR in the probe cache.
+	Key types.NamespacedName
+	UID types.UID
+	// Subject is the human-readable name of the probed component (for example
+	// "Keystone API" or "Horizon dashboard"). It drives both the log lines and
+	// the healthy/unhealthy condition messages.
+	Subject string
+	// EndpointConfigured reports whether the CR's advertised status endpoint is
+	// set; when false the flow reports the endpoint-not-ready condition and
+	// requeues.
+	EndpointConfigured bool
+	// ProbeEndpoint is the in-cluster URL the flow GETs. It is always the
+	// Service URL, independent of any external gateway path, because the flow
+	// verifies API readiness rather than the ingress path.
+	ProbeEndpoint string
+	// Conditions is the CR's condition slice, mutated in place.
+	Conditions *[]metav1.Condition
+	// Generation is the CR generation stamped onto every condition it writes.
+	Generation int64
+	// ConditionType is the condition the flow reports on (for example
+	// "KeystoneAPIReady").
+	ConditionType string
+	// HealthyReason and UnhealthyReason are the condition reasons for a 2xx and
+	// a non-2xx response respectively.
+	HealthyReason   string
+	UnhealthyReason string
+	// Timeout bounds the HTTP GET. CacheTTL bounds cache reuse. RequeueAfter is
+	// the requeue interval on any not-ready outcome.
+	Timeout      time.Duration
+	CacheTTL     time.Duration
+	RequeueAfter time.Duration
+}
+
+// cacheHit reports whether the last successful probe for this CR can be reused
+// in place of a fresh GET: the readiness condition is already True and the TTL
+// cache holds a matching entry.
+func (p ProbeFlowParams) cacheHit() bool {
+	current := conditions.GetCondition(*p.Conditions, p.ConditionType)
+	if current == nil || current.Status != metav1.ConditionTrue {
+		return false
+	}
+	return p.Cache.Hit(p.Key, p.UID, p.ProbeEndpoint, p.CacheTTL)
+}
+
+// ReconcileProbe performs an HTTP GET against the CR's in-cluster API endpoint
+// and sets the readiness condition based on the response. It is the shared body
+// of every operator's reconcileHealthCheck sub-reconciler; the operator supplies
+// only the endpoint and condition vocabulary. All network errors requeue rather
+// than returning a hard error, except a cancelled parent context (a peer in the
+// parallel group failed), which propagates unchanged so an unrelated failure
+// cannot masquerade as "API down".
+func ReconcileProbe(ctx context.Context, p ProbeFlowParams) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !p.EndpointConfigured {
+		logger.Info(p.Subject + " endpoint not yet configured, requeuing")
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonEndpointNotReady,
+			Message:            "endpoint not yet configured",
+		})
+		return ctrl.Result{RequeueAfter: p.RequeueAfter}, nil
+	}
+
+	endpoint := p.ProbeEndpoint
+
+	// Serve from the probe cache when the last successful probe for this exact
+	// endpoint is still fresh and the readiness condition is already True. This
+	// keeps the synchronous GET off the hot path for a steady CR. The condition
+	// is re-upserted (not left untouched) so its ObservedGeneration tracks the
+	// current spec; the message matches the probe path verbatim so a cache pass
+	// and a probe pass produce byte-identical status and the status-diff gate
+	// skips the write.
+	if p.cacheHit() {
+		logger.V(1).Info(p.Subject+" health check served from cache", "endpoint", endpoint)
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             p.HealthyReason,
+			Message:            fmt.Sprintf("%s is responding at %s", p.Subject, endpoint),
+		})
+		return ctrl.Result{}, nil
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, p.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building health check request: %w", err)
+	}
+
+	resp, err := p.Doer.Do(req)
+	if err != nil {
+		// A cancelled parent context means a peer in the parallel post-deployment
+		// group failed and errgroup cancelled gctx — the aborted probe is not an
+		// API-health signal. Propagate the cancellation without flipping the
+		// condition or evicting the probe cache, so an unrelated sub-reconciler
+		// failure cannot masquerade as "API down" (issue #361). A genuine probe
+		// timeout fires checkCtx's deadline while the parent ctx stays live
+		// (ctx.Err()==nil), so it still routes through the error path below.
+		if cerr := ctx.Err(); cerr != nil {
+			return ctrl.Result{}, cerr
+		}
+		// Any other probe error must evict so the next reconcile re-probes rather
+		// than serving a stale success.
+		p.Cache.Evict(p.Key)
+		reason, message := ClassifyError(err)
+		logger.Info(p.Subject+" health check error", "reason", reason, "error", err)
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             reason,
+			Message:            message,
+		})
+		return ctrl.Result{RequeueAfter: p.RequeueAfter}, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		logger.V(1).Info(p.Subject+" health check passed", "status", resp.StatusCode)
+		p.Cache.Store(p.Key, p.UID, endpoint)
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             p.HealthyReason,
+			Message:            fmt.Sprintf("%s is responding at %s", p.Subject, endpoint),
+		})
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info(p.Subject+" health check failed", "status", resp.StatusCode)
+	// A non-2xx response is a failed probe: evict so recovery is detected on the
+	// next reconcile instead of masked by a stale cached success.
+	p.Cache.Evict(p.Key)
+	conditions.SetCondition(p.Conditions, metav1.Condition{
+		Type:               p.ConditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: p.Generation,
+		Reason:             p.UnhealthyReason,
+		Message:            fmt.Sprintf("%s returned HTTP %d", p.Subject, resp.StatusCode),
+	})
+	return ctrl.Result{RequeueAfter: p.RequeueAfter}, nil
+}

--- a/internal/common/healthcheck/flow_test.go
+++ b/internal/common/healthcheck/flow_test.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// mockDoer returns a fixed response or error and counts invocations.
+type mockDoer struct {
+	status int
+	err    error
+	calls  int
+}
+
+func (m *mockDoer) Do(*http.Request) (*http.Response, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{StatusCode: m.status, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func baseParams(conds *[]metav1.Condition, doer HTTPDoer, cache *ProbeCache) ProbeFlowParams {
+	return ProbeFlowParams{
+		Doer:               doer,
+		Cache:              cache,
+		Key:                types.NamespacedName{Namespace: "ns", Name: "cr"},
+		UID:                "uid-1",
+		Subject:            "Test API",
+		EndpointConfigured: true,
+		ProbeEndpoint:      "http://cr.ns.svc:5000/v3",
+		Conditions:         conds,
+		Generation:         3,
+		ConditionType:      "TestAPIReady",
+		HealthyReason:      "APIHealthy",
+		UnhealthyReason:    "APIUnhealthy",
+		Timeout:            2 * time.Second,
+		CacheTTL:           30 * time.Second,
+		RequeueAfter:       10 * time.Second,
+	}
+}
+
+func TestReconcileProbe_EndpointNotConfigured(t *testing.T) {
+	g := gomega.NewWithT(t)
+	var conds []metav1.Condition
+	p := baseParams(&conds, &mockDoer{status: 200}, &ProbeCache{})
+	p.EndpointConfigured = false
+
+	res, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.RequeueAfter).To(gomega.Equal(p.RequeueAfter))
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond).NotTo(gomega.BeNil())
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonEndpointNotReady))
+	g.Expect(cond.Message).To(gomega.Equal("endpoint not yet configured"))
+}
+
+func TestReconcileProbe_Healthy(t *testing.T) {
+	g := gomega.NewWithT(t)
+	var conds []metav1.Condition
+	doer := &mockDoer{status: 204}
+	cache := &ProbeCache{}
+	p := baseParams(&conds, doer, cache)
+
+	res, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(gomega.Equal("APIHealthy"))
+	g.Expect(cond.Message).To(gomega.Equal("Test API is responding at " + p.ProbeEndpoint))
+	// A successful probe is memoized.
+	g.Expect(cache.Has(p.Key)).To(gomega.BeTrue())
+}
+
+func TestReconcileProbe_NonSuccessEvicts(t *testing.T) {
+	g := gomega.NewWithT(t)
+	var conds []metav1.Condition
+	cache := &ProbeCache{}
+	cache.Store(types.NamespacedName{Namespace: "ns", Name: "cr"}, "uid-1", "http://cr.ns.svc:5000/v3")
+	p := baseParams(&conds, &mockDoer{status: 503}, cache)
+
+	res, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.RequeueAfter).To(gomega.Equal(p.RequeueAfter))
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal("APIUnhealthy"))
+	g.Expect(cond.Message).To(gomega.Equal("Test API returned HTTP 503"))
+	// A failed probe evicts so recovery is detected next reconcile.
+	g.Expect(cache.Has(p.Key)).To(gomega.BeFalse())
+}
+
+func TestReconcileProbe_ErrorClassifiedAndEvicts(t *testing.T) {
+	g := gomega.NewWithT(t)
+	var conds []metav1.Condition
+	cache := &ProbeCache{}
+	cache.Store(types.NamespacedName{Namespace: "ns", Name: "cr"}, "uid-1", "http://cr.ns.svc:5000/v3")
+	p := baseParams(&conds, &mockDoer{err: fmt.Errorf("dial tcp 10.0.0.1:5000: connection refused")}, cache)
+
+	res, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.RequeueAfter).To(gomega.Equal(p.RequeueAfter))
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonConnectionFailed))
+	g.Expect(cache.Has(p.Key)).To(gomega.BeFalse())
+}
+
+func TestReconcileProbe_ParentCancelPropagatesWithoutFlip(t *testing.T) {
+	g := gomega.NewWithT(t)
+	// Seed a fresh, matching cache entry and a True condition — a cache hit
+	// would normally serve without probing, so age it past the TTL to force a
+	// probe, then cancel the parent context so the probe error is the
+	// cancellation.
+	clk := time.Unix(1_700_000_000, 0)
+	cache := &ProbeCache{Now: func() time.Time { return clk }}
+	key := types.NamespacedName{Namespace: "ns", Name: "cr"}
+	cache.Store(key, "uid-1", "http://cr.ns.svc:5000/v3")
+	clk = clk.Add(31 * time.Second)
+
+	conds := []metav1.Condition{{
+		Type:   "TestAPIReady",
+		Status: metav1.ConditionTrue,
+	}}
+	p := baseParams(&conds, &mockDoer{err: context.Canceled}, cache)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := ReconcileProbe(ctx, p)
+	g.Expect(err).To(gomega.MatchError(context.Canceled))
+	// The condition must not flip and the cache entry must not be evicted.
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(cache.Has(key)).To(gomega.BeTrue())
+}
+
+func TestReconcileProbe_CacheHitSkipsProbe(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clk := time.Unix(1_700_000_000, 0)
+	cache := &ProbeCache{Now: func() time.Time { return clk }}
+	key := types.NamespacedName{Namespace: "ns", Name: "cr"}
+	cache.Store(key, "uid-1", "http://cr.ns.svc:5000/v3")
+
+	conds := []metav1.Condition{{Type: "TestAPIReady", Status: metav1.ConditionTrue}}
+	doer := &mockDoer{status: 200}
+	p := baseParams(&conds, doer, cache)
+
+	res, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	g.Expect(doer.calls).To(gomega.Equal(0), "a fresh cache hit must not probe")
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Reason).To(gomega.Equal("APIHealthy"))
+}
+
+func TestReconcileProbe_CacheMissWhenConditionNotTrue(t *testing.T) {
+	g := gomega.NewWithT(t)
+	cache := &ProbeCache{}
+	cache.Store(types.NamespacedName{Namespace: "ns", Name: "cr"}, "uid-1", "http://cr.ns.svc:5000/v3")
+	// Condition is unset, so the "already True" gate fails and a probe fires.
+	var conds []metav1.Condition
+	doer := &mockDoer{status: 200}
+	p := baseParams(&conds, doer, cache)
+
+	_, err := ReconcileProbe(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(doer.calls).To(gomega.Equal(1), "a non-True condition must force a probe even with a fresh cache entry")
+}

--- a/internal/common/healthcheck/healthcheck.go
+++ b/internal/common/healthcheck/healthcheck.go
@@ -37,6 +37,37 @@ const (
 	ReasonHealthCheckFailed  = "HealthCheckFailed"
 )
 
+// Timing constants shared by every operator's HTTP health-check flow.
+const (
+	// RequeueHealthCheck is the interval for requeuing when the service API
+	// health check fails. The API may take a few seconds to start responding
+	// after the Deployment reports ready, so a moderate interval is
+	// appropriate.
+	RequeueHealthCheck = 10 * time.Second
+
+	// HealthCheckTimeout is the bounded timeout for the HTTP health check
+	// request. Prevents a hanging API from blocking the reconcile loop
+	// indefinitely.
+	HealthCheckTimeout = 10 * time.Second
+
+	// HealthCheckCacheTTL bounds how long a successful API probe is reused
+	// before the operator re-probes. Every reconcile pass otherwise fires a
+	// synchronous HTTP GET (bounded by HealthCheckTimeout, up to 10s on a
+	// flapping API), which dominates hot-path latency once a CR is Ready.
+	// Caching for 30s suppresses re-probes during event/resync bursts.
+	//
+	// Trade-off: a wedged-but-Ready API — one whose pods still pass their
+	// readiness probe (so DeploymentReady stays True) while requests hang — is
+	// masked for up to HealthCheckCacheTTL after the last good probe. Within
+	// that window reconciles serve the API-ready condition True from cache
+	// without probing, so failure-detection latency for this case is increased
+	// by up to HealthCheckCacheTTL. The probe-error/non-2xx eviction does NOT
+	// bound this: eviction fires only once a probe runs, and inside the TTL the
+	// cache is exactly what suppresses that probe. Keep this TTL at or below the
+	// API-ready outage-detection SLO.
+	HealthCheckCacheTTL = 30 * time.Second
+)
+
 // ClassifyError returns the condition Reason and Message for the given HTTP
 // client error.
 func ClassifyError(err error) (reason, message string) {

--- a/internal/common/instrumentation/instrumentation.go
+++ b/internal/common/instrumentation/instrumentation.go
@@ -7,12 +7,10 @@ package instrumentation
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // ConditionTypeUnknown is the condition_type label emitted when an
@@ -34,16 +32,12 @@ var reconcileDurationBuckets = []float64{
 // Metrics bundles the two sub-reconciler metric vectors a single operator
 // exposes: a duration histogram labelled by sub_reconciler, and an error
 // counter labelled by sub_reconciler and condition_type. Construct one per
-// operator with NewMetrics (production, lazily registered on the
-// controller-runtime registry) or NewMetricsOnRegistry (tests, eagerly
-// registered on a caller-supplied registry).
+// operator with NewMetrics (unregistered — call Register at startup) or
+// NewMetricsOnRegistry (tests, eagerly registered on a caller-supplied
+// registry).
 type Metrics struct {
 	reconcileDuration *prometheus.HistogramVec
 	reconcileErrors   *prometheus.CounterVec
-
-	// lazy registration on ctrlmetrics.Registry for the production instance.
-	lazy         bool
-	registerOnce sync.Once
 }
 
 // newMetrics builds the metric vectors for prefix without registering them.
@@ -61,15 +55,13 @@ func newMetrics(prefix string) *Metrics {
 	}
 }
 
-// NewMetrics returns a Metrics instance for prefix that registers its vectors
-// on the controller-runtime metrics registry lazily, the first time a sample
-// is recorded. Registration uses a per-instance sync.Once and panics on a
-// duplicate-registration error, matching the fail-fast semantics of the
-// operator metrics packages this replaces.
+// NewMetrics returns an unregistered Metrics instance for prefix. Call Register
+// (directly, or via NewSubReconcilerInstrumenter and Instrumenter.Register)
+// during operator startup to expose its vectors on the controller-runtime
+// registry. Recording a sample before registration is inert: the vector holds
+// the sample locally but it is never scraped until the vector is registered.
 func NewMetrics(prefix string) *Metrics {
-	m := newMetrics(prefix)
-	m.lazy = true
-	return m
+	return newMetrics(prefix)
 }
 
 // NewMetricsOnRegistry returns a Metrics instance for prefix whose vectors are
@@ -80,14 +72,18 @@ func NewMetrics(prefix string) *Metrics {
 // test setup.
 func NewMetricsOnRegistry(prefix string, reg prometheus.Registerer) *Metrics {
 	m := newMetrics(prefix)
-	if err := m.register(reg); err != nil {
+	if err := m.Register(reg); err != nil {
 		panic(fmt.Sprintf("instrumentation: registry rejected %s collectors: %v", prefix, err))
 	}
 	return m
 }
 
-// register adds both vectors to reg, returning the first error it emits.
-func (m *Metrics) register(reg prometheus.Registerer) error {
+// Register adds both vectors to reg, returning the first error it emits.
+// Registration is not idempotent — registering the same vectors twice on one
+// registry returns a duplicate-registration error — so operators call it
+// exactly once at startup and surface any error as a clean startup failure
+// instead of a mid-reconcile panic.
+func (m *Metrics) Register(reg prometheus.Registerer) error {
 	for _, coll := range []prometheus.Collector{m.reconcileDuration, m.reconcileErrors} {
 		if err := reg.Register(coll); err != nil {
 			return err
@@ -96,31 +92,16 @@ func (m *Metrics) register(reg prometheus.Registerer) error {
 	return nil
 }
 
-// ensureRegistered registers the lazy production instance on the
-// controller-runtime registry exactly once. It is a no-op for instances
-// created via NewMetricsOnRegistry, which register eagerly.
-func (m *Metrics) ensureRegistered() {
-	if !m.lazy {
-		return
-	}
-	m.registerOnce.Do(func() {
-		if err := m.register(ctrlmetrics.Registry); err != nil {
-			panic(fmt.Sprintf("instrumentation: failed to register collectors on controller-runtime registry: %v", err))
-		}
-	})
-}
-
 // ObserveReconcileDuration records a single duration sample for the named
-// sub-reconciler.
+// sub-reconciler. It is a no-op-visible operation until the vector is
+// registered.
 func (m *Metrics) ObserveReconcileDuration(subReconciler string, d time.Duration) {
-	m.ensureRegistered()
 	m.reconcileDuration.WithLabelValues(subReconciler).Observe(d.Seconds())
 }
 
 // RecordReconcileError increments the error counter for a sub-reconciler and
 // the condition type it failed to drive to True.
 func (m *Metrics) RecordReconcileError(subReconciler, conditionType string) {
-	m.ensureRegistered()
 	m.reconcileErrors.WithLabelValues(subReconciler, conditionType).Inc()
 }
 
@@ -137,6 +118,23 @@ type Instrumenter struct {
 // map falls back to ConditionTypeUnknown.
 func NewInstrumenter(m *Metrics, conditionTypes map[string]string) *Instrumenter {
 	return &Instrumenter{metrics: m, conditionTypes: conditionTypes}
+}
+
+// NewSubReconcilerInstrumenter builds an unregistered Metrics for prefix and
+// wraps it in an Instrumenter that resolves the condition_type error label via
+// conditionTypes. Operators declare one at package scope and call
+// Instrumenter.Register once at startup to expose the metrics. This is the
+// single constructor an operator's instrumentation glue needs; the metrics are
+// owned by the returned Instrumenter.
+func NewSubReconcilerInstrumenter(prefix string, conditionTypes map[string]string) *Instrumenter {
+	return NewInstrumenter(NewMetrics(prefix), conditionTypes)
+}
+
+// Register exposes the Instrumenter's metric vectors on reg, returning any
+// registration error rather than panicking so a duplicate-registration surfaces
+// as a clean operator-startup failure.
+func (i *Instrumenter) Register(reg prometheus.Registerer) error {
+	return i.metrics.Register(reg)
 }
 
 // Instrument runs fn, observing its duration on every path (success, error,

--- a/internal/common/instrumentation/instrumentation_test.go
+++ b/internal/common/instrumentation/instrumentation_test.go
@@ -256,23 +256,32 @@ func TestSubReconcilerMetricsHaveNoCRLabels(t *testing.T) {
 	}
 }
 
-// TestLazyRegistrationIdempotent verifies that a lazy Metrics instance
-// registers on the controller-runtime registry exactly once and that repeated
-// recording does not panic. A unique prefix avoids colliding with any other
-// lazy registration in this test binary.
-func TestLazyRegistrationIdempotent(t *testing.T) {
+// TestRegisterExposesMetrics verifies that a NewMetrics instance records inertly
+// before registration, exposes its samples on the registry once Register
+// succeeds, and reports a duplicate-registration error (rather than panicking)
+// when Register is called twice.
+func TestRegisterExposesMetrics(t *testing.T) {
 	g := NewGomegaWithT(t)
-	m := NewMetrics("lazy_instr_test_operator")
+	reg := prometheus.NewRegistry()
+	m := NewMetrics("explicit_instr_test_operator")
 
+	// Recording before Register must not panic (the vector is simply not yet
+	// scraped).
 	g.Expect(func() {
 		m.ObserveReconcileDuration("foo", time.Millisecond)
-		m.ObserveReconcileDuration("foo", time.Millisecond)
-		m.RecordReconcileError("foo", "FooReady")
-	}).NotTo(Panic(), "lazy registration must be idempotent across repeated records")
+	}).NotTo(Panic(), "recording before registration must be inert, not panic")
+
+	g.Expect(m.Register(reg)).To(Succeed())
+
+	m.ObserveReconcileDuration("foo", time.Millisecond)
+	m.RecordReconcileError("foo", "FooReady")
 
 	durLabels := map[string]string{"sub_reconciler": "foo"}
-	g.Expect(histogramSampleCount(t, ctrlmetrics.Registry, "lazy_instr_test_operator_reconcile_duration_seconds", durLabels)).
-		To(Equal(uint64(2)), "both observations must land on the same registered vector")
+	g.Expect(histogramSampleCount(t, reg, "explicit_instr_test_operator_reconcile_duration_seconds", durLabels)).
+		To(BeNumerically(">=", 1), "observations after Register must land on the registered vector")
+
+	// Registering the same vectors twice returns an error instead of panicking.
+	g.Expect(m.Register(reg)).To(HaveOccurred(), "duplicate registration must return an error")
 }
 
 // TestNewMetricsOnRegistryIsolation proves a private-registry instance does

--- a/internal/common/job/migration.go
+++ b/internal/common/job/migration.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package job
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MigrationJobParams carries the inputs of BuildMigrationJob: the generic
+// database-migration Job skeleton every database-backed service operator runs
+// (db_sync, expand/migrate/contract, schema check). The service-specific parts
+// — the image, the command, the config mount path, the DB-connection env, and
+// any TLS/domain volumes — are supplied by the caller; the skeleton assembles a
+// single-container, RestartPolicy=Never Job with the config ConfigMap mounted
+// read-only.
+type MigrationJobParams struct {
+	// Name is the full Job name; Namespace is its namespace.
+	Name      string
+	Namespace string
+	// Labels are applied to the Job; nil leaves it unlabelled.
+	Labels map[string]string
+	// Image is the container image the migration runs.
+	Image string
+	// ContainerName names the single container (usually the phase suffix).
+	ContainerName string
+	// Command is the container command (for example keystone-manage db_sync).
+	Command []string
+	// ConfigMapName is the rendered config ConfigMap, mounted read-only at
+	// ConfigMountPath under the volume name "config".
+	ConfigMapName   string
+	ConfigMountPath string
+	// Env are extra environment variables (for example the DB-connection URL).
+	Env []corev1.EnvVar
+	// ExtraVolumes and ExtraVolumeMounts are appended after the config volume
+	// (for example a DB-TLS keypair or per-domain config).
+	ExtraVolumes      []corev1.Volume
+	ExtraVolumeMounts []corev1.VolumeMount
+	// PriorityClassName sets the Pod priority class; empty leaves it unset.
+	PriorityClassName string
+	// BackoffLimit sets spec.backoffLimit.
+	BackoffLimit int32
+	// TTLSecondsAfterFinished, when non-nil, sets spec.ttlSecondsAfterFinished.
+	TTLSecondsAfterFinished *int32
+	// SecurityContext is applied to the container; supply a restricted context.
+	SecurityContext *corev1.SecurityContext
+}
+
+// BuildMigrationJob constructs the shared migration-Job skeleton from p. It
+// mounts the config ConfigMap read-only at ConfigMountPath, then appends any
+// ExtraVolumes/ExtraVolumeMounts, so a caller with no extras gets a plain
+// config-mounted Job.
+func BuildMigrationJob(p MigrationJobParams) *batchv1.Job {
+	backoffLimit := p.BackoffLimit
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.Name,
+			Namespace: p.Namespace,
+			Labels:    p.Labels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: p.TTLSecondsAfterFinished,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy:     corev1.RestartPolicyNever,
+					PriorityClassName: p.PriorityClassName,
+					Containers: []corev1.Container{{
+						Name:            p.ContainerName,
+						Image:           p.Image,
+						Command:         p.Command,
+						SecurityContext: p.SecurityContext,
+						Env:             p.Env,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "config",
+							MountPath: p.ConfigMountPath,
+							ReadOnly:  true,
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "config",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: p.ConfigMapName,
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if len(p.ExtraVolumes) > 0 {
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, p.ExtraVolumes...)
+	}
+	if len(p.ExtraVolumeMounts) > 0 {
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts, p.ExtraVolumeMounts...,
+		)
+	}
+	return job
+}

--- a/internal/common/job/migration_test.go
+++ b/internal/common/job/migration_test.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package job
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func migrationParams() MigrationJobParams {
+	return MigrationJobParams{
+		Name:              "keystone-db-sync",
+		Namespace:         "openstack",
+		Image:             "keystone:2025.2",
+		ContainerName:     "db-sync",
+		Command:           []string{"keystone-manage", "db_sync"},
+		ConfigMapName:     "keystone-config",
+		ConfigMountPath:   "/etc/keystone/keystone.conf.d/",
+		Env:               []corev1.EnvVar{{Name: "OS_DATABASE__CONNECTION", Value: "mysql://x"}},
+		PriorityClassName: "high",
+		BackoffLimit:      4,
+		SecurityContext:   &corev1.SecurityContext{RunAsNonRoot: ptr.To(true)},
+	}
+}
+
+func TestBuildMigrationJob_BaseSpec(t *testing.T) {
+	g := gomega.NewWithT(t)
+	j := BuildMigrationJob(migrationParams())
+	g.Expect(j.Name).To(gomega.Equal("keystone-db-sync"))
+	g.Expect(*j.Spec.BackoffLimit).To(gomega.Equal(int32(4)))
+	g.Expect(j.Spec.TTLSecondsAfterFinished).To(gomega.BeNil())
+	spec := j.Spec.Template.Spec
+	g.Expect(spec.RestartPolicy).To(gomega.Equal(corev1.RestartPolicyNever))
+	g.Expect(spec.PriorityClassName).To(gomega.Equal("high"))
+	g.Expect(spec.Containers).To(gomega.HaveLen(1))
+	ctr := spec.Containers[0]
+	g.Expect(ctr.Name).To(gomega.Equal("db-sync"))
+	g.Expect(ctr.Command).To(gomega.Equal([]string{"keystone-manage", "db_sync"}))
+	g.Expect(ctr.SecurityContext).NotTo(gomega.BeNil())
+	g.Expect(ctr.Env).To(gomega.HaveLen(1))
+	// The config ConfigMap is mounted read-only under the "config" volume.
+	g.Expect(ctr.VolumeMounts).To(gomega.HaveLen(1))
+	g.Expect(ctr.VolumeMounts[0].Name).To(gomega.Equal("config"))
+	g.Expect(ctr.VolumeMounts[0].MountPath).To(gomega.Equal("/etc/keystone/keystone.conf.d/"))
+	g.Expect(ctr.VolumeMounts[0].ReadOnly).To(gomega.BeTrue())
+	g.Expect(spec.Volumes).To(gomega.HaveLen(1))
+	g.Expect(spec.Volumes[0].ConfigMap.Name).To(gomega.Equal("keystone-config"))
+}
+
+func TestBuildMigrationJob_ExtrasAppendedAndOverrides(t *testing.T) {
+	g := gomega.NewWithT(t)
+	p := migrationParams()
+	p.TTLSecondsAfterFinished = ptr.To(int32(300))
+	p.BackoffLimit = 2
+	p.ExtraVolumes = []corev1.Volume{{Name: "tls"}, {Name: "domains"}}
+	p.ExtraVolumeMounts = []corev1.VolumeMount{{Name: "tls"}, {Name: "domains"}}
+	j := BuildMigrationJob(p)
+	g.Expect(*j.Spec.BackoffLimit).To(gomega.Equal(int32(2)))
+	g.Expect(*j.Spec.TTLSecondsAfterFinished).To(gomega.Equal(int32(300)))
+	// Config volume/mount stays first, extras appended in order.
+	vols := j.Spec.Template.Spec.Volumes
+	g.Expect(vols).To(gomega.HaveLen(3))
+	g.Expect(vols[0].Name).To(gomega.Equal("config"))
+	g.Expect(vols[1].Name).To(gomega.Equal("tls"))
+	g.Expect(vols[2].Name).To(gomega.Equal("domains"))
+	mounts := j.Spec.Template.Spec.Containers[0].VolumeMounts
+	g.Expect(mounts).To(gomega.HaveLen(3))
+	g.Expect(mounts[1].Name).To(gomega.Equal("tls"))
+	g.Expect(mounts[2].Name).To(gomega.Equal("domains"))
+}
+
+func TestJobUIDAnnotationKey(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(JobUIDAnnotationKey("db-sync")).To(gomega.Equal("forge.c5c3.io/last-db-sync-job-uid"))
+	g.Expect(JobUIDAnnotationKey("db-expand")).NotTo(gomega.Equal(JobUIDAnnotationKey("db-sync")))
+}
+
+func terminalScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1: %v", err)
+	}
+	return s
+}
+
+func completedJob(uid string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "db-sync", Namespace: "ns", UID: apitypes.UID(uid),
+			CreationTimestamp: metav1.NewTime(time.Unix(1_700_000_000, 0)),
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Unix(1_700_000_030, 0)),
+		}}},
+	}
+}
+
+func TestRecordJobTerminalState_NilObservedNoOp(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := terminalScheme(t)
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "o", Namespace: "ns"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+	called := false
+	RecordJobTerminalState(context.Background(), c, nil, owner, "db-sync", nil, "R",
+		func(string, time.Duration) { called = true })
+	g.Expect(called).To(gomega.BeFalse())
+}
+
+func TestRecordJobTerminalState_AtMostOncePerUID(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := terminalScheme(t)
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "o", Namespace: "ns"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+	job := completedJob("uid-1")
+
+	var results []string
+	recordFn := func(result string, d time.Duration) { results = append(results, result) }
+
+	RecordJobTerminalState(context.Background(), c, nil, owner, "db-sync", job, "R", recordFn)
+	g.Expect(results).To(gomega.Equal([]string{"succeeded"}))
+	g.Expect(owner.Annotations).To(gomega.HaveKeyWithValue(JobUIDAnnotationKey("db-sync"), "uid-1"))
+
+	// Re-observing the same UID must not re-emit.
+	RecordJobTerminalState(context.Background(), c, nil, owner, "db-sync", job, "R", recordFn)
+	g.Expect(results).To(gomega.HaveLen(1), "same UID must emit at most once")
+
+	// A recreated Job (fresh UID) drives a fresh emission.
+	RecordJobTerminalState(context.Background(), c, nil, owner, "db-sync", completedJob("uid-2"), "R", recordFn)
+	g.Expect(results).To(gomega.HaveLen(2))
+}
+
+func TestRecordJobTerminalState_PatchFailureDefersAndEvents(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := terminalScheme(t)
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "o", Namespace: "ns"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+				return context.DeadlineExceeded
+			},
+		}).Build()
+	rec := record.NewFakeRecorder(4)
+	called := false
+	RecordJobTerminalState(context.Background(), c, rec, owner, "db-sync", completedJob("uid-1"), "DeferReason",
+		func(string, time.Duration) { called = true })
+
+	g.Expect(called).To(gomega.BeFalse(), "record must be deferred when the UID patch fails")
+	g.Expect(owner.Annotations).NotTo(gomega.HaveKey(JobUIDAnnotationKey("db-sync")))
+	var ev string
+	g.Eventually(rec.Events).Should(gomega.Receive(&ev))
+	g.Expect(ev).To(gomega.ContainSubstring("Warning DeferReason"))
+}

--- a/internal/common/job/terminal.go
+++ b/internal/common/job/terminal.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package job
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// JobUIDAnnotationFormat builds the annotation key used to dedupe terminal
+// metric emission for a migration Job. The annotation lives on the owner CR so
+// it survives Job deletion (for example when a job runner recreates the Job
+// after a PodSpec hash change) and the operator can still skip re-emission when
+// the same UID is observed twice. The %s placeholder is the Job phase suffix
+// ("db-sync", "db-expand", …); each phase keeps an independent dedupe
+// annotation so terminal emission for one phase never silently suppresses
+// another.
+const JobUIDAnnotationFormat = "forge.c5c3.io/last-%s-job-uid"
+
+// JobUIDAnnotationKey returns the dedupe annotation key for the Job identified
+// by the given phase suffix.
+func JobUIDAnnotationKey(jobSuffix string) string {
+	return fmt.Sprintf(JobUIDAnnotationFormat, jobSuffix)
+}
+
+// RecordJobTerminalState observes the given migration Job's terminal condition
+// and invokes record exactly once per (jobSuffix, Job UID) tuple, deduping via
+// a per-phase annotation on owner. record receives the terminal result
+// ("succeeded"/"failed") and the observed duration (LastTransitionTime minus
+// Job CreationTimestamp, clamped at zero), so the caller can emit its
+// service-specific metric.
+//
+// observed is the Job the caller already read this pass, threaded in so this
+// function does not re-Get it; a nil observed (a just-created Job with no
+// terminal condition) is a no-op.
+//
+// Ordering: the dedupe annotation is patched BEFORE record is called. If the
+// patch fails (transient apiserver error, stale-RV conflict), record is NOT
+// invoked this pass — the caller re-evaluates next reconcile — preserving the
+// at-most-once-per-UID guarantee against transient failures. On a patch failure
+// the function logs at Info and, when recorder is non-nil, records a Warning
+// event with deferEventReason on owner so persistent failures are visible via
+// `kubectl describe` without raising log verbosity. It is best-effort: errors
+// are swallowed rather than surfaced as a reconcile failure.
+func RecordJobTerminalState(
+	ctx context.Context,
+	c client.Client,
+	recorder record.EventRecorder,
+	owner client.Object,
+	jobSuffix string,
+	observed *batchv1.Job,
+	deferEventReason string,
+	record func(result string, duration time.Duration),
+) {
+	// A just-created Job (the runner returned nil) has no terminal condition.
+	if observed == nil {
+		return
+	}
+	annotationKey := JobUIDAnnotationKey(jobSuffix)
+
+	var (
+		result       string
+		transitionAt metav1.Time
+	)
+	for _, cond := range observed.Status.Conditions {
+		if cond.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch cond.Type {
+		case batchv1.JobComplete:
+			result = "succeeded"
+			transitionAt = cond.LastTransitionTime
+		case batchv1.JobFailed:
+			result = "failed"
+			transitionAt = cond.LastTransitionTime
+		case batchv1.JobSuspended, batchv1.JobFailureTarget, batchv1.JobSuccessCriteriaMet:
+			// Non-terminal transitions: a Suspended Job may be resumed and
+			// FailureTarget/SuccessCriteriaMet flip briefly before the terminal
+			// JobFailed/JobComplete is set. Ignore — emit only on terminal
+			// transitions.
+		}
+		if result != "" {
+			break
+		}
+	}
+	if result == "" {
+		return
+	}
+
+	uid := string(observed.UID)
+	if uid != "" && owner.GetAnnotations()[annotationKey] == uid {
+		return
+	}
+
+	// Persist the observed UID BEFORE recording so a transient patch failure
+	// cannot cause double-counting on the next reconcile. Patch a DeepCopy so
+	// the client does not overwrite the caller's in-memory status conditions
+	// (accumulated by earlier sub-reconcilers this pass) with the backend copy;
+	// the annotation and post-patch ResourceVersion are mirrored back onto the
+	// caller's object so a later Status().Update does not hit a stale-RV
+	// conflict.
+	patchTarget, ok := owner.DeepCopyObject().(client.Object)
+	if !ok {
+		return
+	}
+	patchBase, ok := patchTarget.DeepCopyObject().(client.Object)
+	if !ok {
+		return
+	}
+	patch := client.MergeFrom(patchBase)
+	anns := patchTarget.GetAnnotations()
+	if anns == nil {
+		anns = make(map[string]string)
+	}
+	anns[annotationKey] = uid
+	patchTarget.SetAnnotations(anns)
+	if err := c.Patch(ctx, patchTarget, patch); err != nil {
+		log.FromContext(ctx).Info(
+			"RecordJobTerminalState: patching last-observed Job UID failed; "+
+				"metric emission deferred to the next reconcile",
+			"owner", owner.GetName(),
+			"jobSuffix", jobSuffix,
+			"err", err.Error(),
+		)
+		if recorder != nil {
+			recorder.Eventf(owner, corev1.EventTypeWarning, deferEventReason,
+				"Patching last-observed %s Job UID failed; metric emission deferred to the next reconcile: %v",
+				jobSuffix, err)
+		}
+		return
+	}
+	ownerAnns := owner.GetAnnotations()
+	if ownerAnns == nil {
+		ownerAnns = make(map[string]string)
+	}
+	ownerAnns[annotationKey] = uid
+	owner.SetAnnotations(ownerAnns)
+	owner.SetResourceVersion(patchTarget.GetResourceVersion())
+
+	duration := transitionAt.Sub(observed.CreationTimestamp.Time)
+	if duration < 0 {
+		duration = 0
+	}
+	record(result, duration)
+}

--- a/internal/common/networkpolicy/doc.go
+++ b/internal/common/networkpolicy/doc.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package networkpolicy provides the NetworkPolicy scaffolding shared by the
+// service operators: the SSA ensure / delete helpers, the auto-derived egress
+// rule builders (DNS, database, cache) and cache-port parsing, the ingress-peer
+// assembly over the shared ingress-source type plus the gateway- and
+// operator-namespace peers, and the three-path reconcile flow (enabled /
+// disabled / fail-closed guard). Each operator keeps only its service-specific
+// egress tail (the kube-apiserver, federation, or keystone-endpoint rules) and
+// its ingress target port.
+package networkpolicy

--- a/internal/common/networkpolicy/networkpolicy.go
+++ b/internal/common/networkpolicy/networkpolicy.go
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/internal/common/apply"
+	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/database"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// Condition reason constants for the NetworkPolicy readiness condition, shared
+// so every operator's condition uses the same vocabulary.
+const (
+	ReasonNetworkPolicyReady       = "NetworkPolicyReady"
+	ReasonNetworkPolicyNotRequired = "NetworkPolicyNotRequired"
+)
+
+// Ensure creates or updates the NetworkPolicy via Server-Side Apply under the
+// shared field manager and sets the owner CR as its controller owner so it is
+// garbage-collected with the CR.
+//
+// Merge strategy: the field manager owns exactly the fields the builder sets
+// (the whole Spec and the operator's labels). Labels or annotations the operator
+// no longer sets are relinquished and removed by the API server, while keys
+// owned by other managers are preserved. A converged NetworkPolicy is applied
+// without a write.
+func Ensure(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, np *networkingv1.NetworkPolicy) error {
+	return apply.EnsureObject(ctx, c, scheme, owner, np, apply.FieldManager)
+}
+
+// Delete deletes the NetworkPolicy identified by namespace and name. It is a
+// no-op if the NetworkPolicy does not exist.
+func Delete(ctx context.Context, c client.Client, namespace, name string) error {
+	np := &networkingv1.NetworkPolicy{}
+	np.SetName(name)
+	np.SetNamespace(namespace)
+	if err := client.IgnoreNotFound(c.Delete(ctx, np)); err != nil {
+		return fmt.Errorf("deleting NetworkPolicy %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// DNSEgressRule returns the always-required DNS egress rule (UDP+TCP 53).
+// Destination is unrestricted so NodeLocal DNSCache setups outside kube-system
+// keep resolving.
+func DNSEgressRule() networkingv1.NetworkPolicyEgressRule {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+	port53 := intstr.FromInt32(53)
+	return networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &udp, Port: &port53},
+			{Protocol: &tcp, Port: &port53},
+		},
+	}
+}
+
+// DatabaseEgressRule returns the database egress rule (TCP, port from the
+// database spec, honoring spec.database.port with the 3306 default). It is
+// emitted in both managed (ClusterRef) and brownfield (host) modes; the port is
+// the same value the readiness probe TCP-connects to. Destination is
+// unrestricted, matching the DNS/cache egress posture.
+func DatabaseEgressRule(db commonv1.DatabaseSpec) networkingv1.NetworkPolicyEgressRule {
+	tcp := corev1.ProtocolTCP
+	dbPort := intstr.FromInt32(database.Port(&db))
+	return networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &dbPort},
+		},
+	}
+}
+
+// CacheEgressRule returns the cache egress rule (TCP, ports from
+// CacheEgressPorts) and ok=true, or a zero rule and ok=false when no cache is
+// configured (neither ClusterRef nor Servers), in which case no cache egress
+// should be emitted.
+func CacheEgressRule(cache commonv1.CacheSpec) (networkingv1.NetworkPolicyEgressRule, bool) {
+	cachePorts := CacheEgressPorts(cache)
+	if len(cachePorts) == 0 {
+		return networkingv1.NetworkPolicyEgressRule{}, false
+	}
+	tcp := corev1.ProtocolTCP
+	ports := make([]networkingv1.NetworkPolicyPort, 0, len(cachePorts))
+	for i := range cachePorts {
+		cachePort := intstr.FromInt32(cachePorts[i])
+		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &cachePort})
+	}
+	return networkingv1.NetworkPolicyEgressRule{Ports: ports}, true
+}
+
+// CacheEgressPorts returns the distinct Memcached ports the pods must reach,
+// derived from the cache spec. In managed mode (cache.clusterRef set) the
+// memcached operator exposes the standard 11211. In brownfield mode
+// (cache.servers set) the ports are parsed from each "host:port" entry,
+// defaulting to 11211 when an entry omits the port or cannot be parsed. The
+// result preserves input order and is deduplicated. It returns nil when no cache
+// is configured.
+func CacheEgressPorts(cache commonv1.CacheSpec) []int32 {
+	servers := cache.Servers
+	if len(servers) == 0 {
+		if cache.ClusterRef != nil {
+			return []int32{11211}
+		}
+		return nil
+	}
+
+	const defaultMemcachedPort int32 = 11211
+	const maxPort = 65535
+	seen := make(map[int32]struct{}, len(servers))
+	var ports []int32
+	for _, server := range servers {
+		port := defaultMemcachedPort
+		if _, portStr, err := net.SplitHostPort(server); err == nil {
+			// ParseInt with bitSize 32 bounds the result to int32; the explicit
+			// range check rejects non-port values before the conversion.
+			if n, err := strconv.ParseInt(portStr, 10, 32); err == nil && n > 0 && n <= maxPort {
+				port = int32(n)
+			}
+		}
+		if _, ok := seen[port]; ok {
+			continue
+		}
+		seen[port] = struct{}{}
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+// IngressPeersParams carries the inputs of IngressPeers: the user-declared
+// sources plus the optional gateway- and operator-namespace peers.
+type IngressPeersParams struct {
+	// Sources are the user-declared ingress sources.
+	Sources []commonv1.NetworkPolicyIngressSource
+	// GatewayNamespace, when non-empty, appends a peer selecting that entire
+	// namespace so the Gateway data plane can reach the Service.
+	GatewayNamespace string
+	// OperatorNamespace, when non-empty, appends a peer selecting the operator's
+	// namespace so its health check can reach the Service.
+	OperatorNamespace string
+}
+
+// IngressPeers assembles the NetworkPolicy ingress peers in a deterministic
+// order: the user-declared sources, then the gateway-namespace peer (if any),
+// then the operator-namespace peer (if any). The gateway and operator peers
+// select the entire namespace by the well-known kubernetes.io/metadata.name
+// label because those pods' labels are not known to the caller.
+func IngressPeers(p IngressPeersParams) []networkingv1.NetworkPolicyPeer {
+	var peers []networkingv1.NetworkPolicyPeer
+	for _, src := range p.Sources {
+		peer := networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: src.NamespaceSelector.DeepCopy(),
+		}
+		if src.PodSelector != nil {
+			peer.PodSelector = src.PodSelector.DeepCopy()
+		}
+		peers = append(peers, peer)
+	}
+	if p.GatewayNamespace != "" {
+		peers = append(peers, namespacePeer(p.GatewayNamespace))
+	}
+	if p.OperatorNamespace != "" {
+		peers = append(peers, namespacePeer(p.OperatorNamespace))
+	}
+	return peers
+}
+
+func namespacePeer(namespace string) networkingv1.NetworkPolicyPeer {
+	return networkingv1.NetworkPolicyPeer{
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": namespace,
+			},
+		},
+	}
+}
+
+// FlowParams carries everything Reconcile needs. The service-specific parts —
+// whether spec.networkPolicy is set, the built desired policy, its identity, and
+// the condition type — are supplied by the caller; the three-path flow itself
+// (delete / fail-closed guard / ensure) is identical across operators.
+type FlowParams struct {
+	// Configured reports whether spec.networkPolicy is set.
+	Configured bool
+	// IngressSourceCount is the number of user-declared ingress sources; the
+	// fail-closed guard refuses to create a policy with zero sources.
+	IngressSourceCount int
+	// Desired is the built NetworkPolicy, applied when Configured is true.
+	Desired *networkingv1.NetworkPolicy
+	// Name and Namespace identify the policy for the delete path.
+	Name      string
+	Namespace string
+	// Conditions is the CR's condition slice, mutated in place.
+	Conditions *[]metav1.Condition
+	// Generation is stamped onto every condition the flow writes.
+	Generation int64
+	// ConditionType is the readiness condition the flow reports on.
+	ConditionType string
+}
+
+// Reconcile ensures the NetworkPolicy matches the desired state. It is the
+// shared body of every operator's reconcileNetworkPolicy sub-reconciler:
+//
+//   - spec.networkPolicy nil: delete any existing NetworkPolicy and set the
+//     condition True/NetworkPolicyNotRequired.
+//   - empty ingress sources: refuse to create a policy that would allow all
+//     ingress (fail closed), returning an error.
+//   - spec.networkPolicy set: apply the policy via SSA and set the condition
+//     True/NetworkPolicyReady.
+func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, p FlowParams) (ctrl.Result, error) {
+	// Path 2: networkPolicy disabled — delete any existing NetworkPolicy.
+	if !p.Configured {
+		if err := Delete(ctx, c, p.Namespace, p.Name); err != nil {
+			return ctrl.Result{}, fmt.Errorf("deleting NetworkPolicy: %w", err)
+		}
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: p.Generation,
+			Reason:             ReasonNetworkPolicyNotRequired,
+			Message:            "Network isolation is not configured",
+		})
+		return ctrl.Result{}, nil
+	}
+
+	// Defensive guard: refuse to create a NetworkPolicy with empty ingress
+	// sources. CRD validation (XValidation) requires size(self.ingress) > 0, but
+	// validation can be bypassed (old stored objects, disabled webhooks, direct
+	// etcd writes). An Ingress rule with an empty From slice allows all sources,
+	// which is an unsafe default for a hardening feature. Fail closed.
+	if p.IngressSourceCount == 0 {
+		return ctrl.Result{}, fmt.Errorf("spec.networkPolicy.ingress must not be empty: refusing to create NetworkPolicy that would allow all ingress")
+	}
+
+	// Path 1: networkPolicy enabled — create or update NetworkPolicy.
+	if err := Ensure(ctx, c, scheme, owner, p.Desired); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring NetworkPolicy: %w", err)
+	}
+	conditions.SetCondition(p.Conditions, metav1.Condition{
+		Type:               p.ConditionType,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: p.Generation,
+		Reason:             ReasonNetworkPolicyReady,
+		Message:            "NetworkPolicy is configured",
+	})
+	return ctrl.Result{}, nil
+}

--- a/internal/common/networkpolicy/networkpolicy_test.go
+++ b/internal/common/networkpolicy/networkpolicy_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+func npScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1: %v", err)
+	}
+	if err := networkingv1.AddToScheme(s); err != nil {
+		t.Fatalf("networkingv1: %v", err)
+	}
+	return s
+}
+
+func npOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns", UID: "u"}}
+}
+
+func desiredPolicy() *networkingv1.NetworkPolicy {
+	tcp := corev1.ProtocolTCP
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From:  IngressPeers(IngressPeersParams{OperatorNamespace: "op"}),
+				Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp}},
+			}},
+		},
+	}
+}
+
+func TestCacheEgressPorts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		clusterRef bool
+		servers    []string
+		want       []int32
+	}{
+		{name: "no cache", want: nil},
+		{name: "managed", clusterRef: true, want: []int32{11211}},
+		{name: "brownfield bare host defaults", servers: []string{"mc"}, want: []int32{11211}},
+		{name: "brownfield explicit", servers: []string{"mc:11212"}, want: []int32{11212}},
+		{name: "brownfield deduped", servers: []string{"a:11211", "b:11212", "c:11211"}, want: []int32{11211, 11212}},
+		{name: "brownfield ipv6", servers: []string{"[::1]:11213"}, want: []int32{11213}},
+		{name: "brownfield malformed defaults", servers: []string{"mc:notaport"}, want: []int32{11211}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			cache := commonv1.CacheSpec{Servers: tc.servers}
+			if tc.clusterRef {
+				cache.ClusterRef = &corev1.LocalObjectReference{Name: "mc"}
+			}
+			g.Expect(CacheEgressPorts(cache)).To(gomega.Equal(tc.want))
+		})
+	}
+}
+
+func TestDNSEgressRule(t *testing.T) {
+	g := gomega.NewWithT(t)
+	rule := DNSEgressRule()
+	g.Expect(rule.Ports).To(gomega.HaveLen(2))
+	g.Expect(*rule.Ports[0].Protocol).To(gomega.Equal(corev1.ProtocolUDP))
+	g.Expect(rule.Ports[0].Port.IntValue()).To(gomega.Equal(53))
+	g.Expect(*rule.Ports[1].Protocol).To(gomega.Equal(corev1.ProtocolTCP))
+	g.Expect(rule.Ports[1].Port.IntValue()).To(gomega.Equal(53))
+}
+
+func TestDatabaseEgressRule(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(DatabaseEgressRule(commonv1.DatabaseSpec{}).Ports[0].Port.IntValue()).To(gomega.Equal(3306))
+	g.Expect(DatabaseEgressRule(commonv1.DatabaseSpec{Port: 13306}).Ports[0].Port.IntValue()).To(gomega.Equal(13306))
+}
+
+func TestCacheEgressRule(t *testing.T) {
+	g := gomega.NewWithT(t)
+	_, ok := CacheEgressRule(commonv1.CacheSpec{})
+	g.Expect(ok).To(gomega.BeFalse())
+	rule, ok := CacheEgressRule(commonv1.CacheSpec{ClusterRef: &corev1.LocalObjectReference{Name: "mc"}})
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(rule.Ports[0].Port.IntValue()).To(gomega.Equal(11211))
+}
+
+func TestIngressPeers_Order(t *testing.T) {
+	g := gomega.NewWithT(t)
+	src := commonv1.NetworkPolicyIngressSource{
+		NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"team": "a"}},
+	}
+	peers := IngressPeers(IngressPeersParams{
+		Sources:           []commonv1.NetworkPolicyIngressSource{src},
+		GatewayNamespace:  "gw-ns",
+		OperatorNamespace: "op-ns",
+	})
+	g.Expect(peers).To(gomega.HaveLen(3))
+	g.Expect(peers[0].NamespaceSelector.MatchLabels).To(gomega.HaveKeyWithValue("team", "a"))
+	g.Expect(peers[1].NamespaceSelector.MatchLabels).To(gomega.HaveKeyWithValue("kubernetes.io/metadata.name", "gw-ns"))
+	g.Expect(peers[2].NamespaceSelector.MatchLabels).To(gomega.HaveKeyWithValue("kubernetes.io/metadata.name", "op-ns"))
+}
+
+func TestIngressPeers_OmitsEmptyNamespaces(t *testing.T) {
+	g := gomega.NewWithT(t)
+	peers := IngressPeers(IngressPeersParams{})
+	g.Expect(peers).To(gomega.BeEmpty())
+}
+
+func TestReconcile_DeletesWhenNotConfigured(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := npScheme(t)
+	existing := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	var conds []metav1.Condition
+
+	res, err := Reconcile(context.Background(), c, s, npOwner(), FlowParams{
+		Configured: false, Name: "svc", Namespace: "ns",
+		Conditions: &conds, Generation: 1, ConditionType: "NetworkPolicyReady",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	err = c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "svc"}, &networkingv1.NetworkPolicy{})
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(conditions.GetCondition(conds, "NetworkPolicyReady").Reason).To(gomega.Equal(ReasonNetworkPolicyNotRequired))
+}
+
+func TestReconcile_FailsClosedOnEmptyIngress(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := npScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	var conds []metav1.Condition
+
+	_, err := Reconcile(context.Background(), c, s, npOwner(), FlowParams{
+		Configured: true, IngressSourceCount: 0, Name: "svc", Namespace: "ns",
+		Conditions: &conds, Generation: 1, ConditionType: "NetworkPolicyReady",
+	})
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("must not be empty")))
+	// No condition is written on the fail-closed path.
+	g.Expect(conds).To(gomega.BeEmpty())
+}
+
+func TestReconcile_EnsuresWhenConfigured(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := npScheme(t)
+	// The fake client's default typed converter cannot apply a NetworkPolicy
+	// ("expected objects with types from the same schema"); the deduced
+	// converter applies it uniformly. Real SSA is exercised by the envtest suite.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(npOwner()).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).Build()
+	var conds []metav1.Condition
+
+	res, err := Reconcile(context.Background(), c, s, npOwner(), FlowParams{
+		Configured: true, IngressSourceCount: 1, Desired: desiredPolicy(),
+		Name: "svc", Namespace: "ns",
+		Conditions: &conds, Generation: 1, ConditionType: "NetworkPolicyReady",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	fetched := &networkingv1.NetworkPolicy{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "svc"}, fetched)).To(gomega.Succeed())
+	g.Expect(fetched.OwnerReferences).To(gomega.HaveLen(1))
+	g.Expect(conditions.GetCondition(conds, "NetworkPolicyReady").Reason).To(gomega.Equal(ReasonNetworkPolicyReady))
+}

--- a/internal/common/reconcile/intervals.go
+++ b/internal/common/reconcile/intervals.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import "time"
+
+// Requeue interval constants centralise the polling durations shared by every
+// service operator's sub-reconcilers. Keeping them in one place makes tuning
+// straightforward and ensures test assertions stay in sync with production
+// code. Service-specific intervals (database, bootstrap, upgrade, …) stay in
+// the operator that owns them.
+const (
+	// RequeueDeploymentPolling is the interval for polling Deployment readiness.
+	// Deployments converge quickly, so a short interval is appropriate.
+	RequeueDeploymentPolling = 10 * time.Second
+
+	// RequeueSecretPolling is the interval for polling ESO-managed Secret
+	// readiness. ESO sync is fast but depends on an external vault, so a
+	// moderate interval balances responsiveness with API load.
+	RequeueSecretPolling = 15 * time.Second
+)

--- a/internal/common/reconcile/project.go
+++ b/internal/common/reconcile/project.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/internal/common/apply"
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// ChildProjectionParams carries the inputs of ProjectChild: the fully-built
+// desired child CR, the readiness condition to drive, and its reason/message
+// vocabulary. An orchestrating operator (the ControlPlane) projects a child
+// service CR — a Keystone, a Horizon — and mirrors its readiness; this captures
+// the five-step projector every such projection repeats.
+type ChildProjectionParams[T client.Object] struct {
+	// Child is the fully-built desired child; ProjectChild applies it via SSA
+	// (so the builder must be a pure projection of the owner spec, reading no
+	// live child state) and decodes the server response back into it, so its
+	// status is populated for the readiness mirror.
+	Child T
+	// ConditionType is the readiness condition the projection reports on (for
+	// example "KeystoneReady").
+	ConditionType string
+	// ReadyReason / ReadyMessage describe a ready child.
+	ReadyReason  string
+	ReadyMessage string
+	// WaitingReason / WaitingMessage describe a not-yet-ready child.
+	WaitingReason  string
+	WaitingMessage string
+	// RejectedReason / RejectedMessage describe an Invalid (HTTP 422) rejection —
+	// typically an immutable child field the projected change would violate. Kept
+	// distinct from ErrorReason so the wedge is diagnosable from the condition.
+	RejectedReason  string
+	RejectedMessage func(error) string
+	// ErrorReason / ErrorMessage describe any other apply error.
+	ErrorReason  string
+	ErrorMessage func(error) string
+	// WaitRequeue is the interval to requeue while the child is not ready.
+	WaitRequeue time.Duration
+	// Conditions is the owner's condition slice, mutated in place.
+	Conditions *[]metav1.Condition
+	// Generation is the owner generation stamped onto every condition written.
+	Generation int64
+	// ChildConditions extracts the child's status conditions for the readiness
+	// mirror.
+	ChildConditions func(T) []metav1.Condition
+}
+
+// ProjectChild applies the desired child via Server-Side Apply under the shared
+// field manager (which sets ownership), classifies an Invalid rejection
+// distinctly from other errors, mirrors the child's readiness into the owner's
+// condition, and requeues while the child is not ready. It is the generic form
+// of the ControlPlane's per-service projection so onboarding a new service adds
+// configuration rather than another copy.
+func ProjectChild[T client.Object](ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, p ChildProjectionParams[T]) (ctrl.Result, error) {
+	if err := apply.EnsureObject(ctx, c, scheme, owner, p.Child, apply.FieldManager); err != nil {
+		reason := p.ErrorReason
+		message := p.ErrorMessage(err)
+		if apierrors.IsInvalid(err) {
+			reason = p.RejectedReason
+			message = p.RejectedMessage(err)
+		}
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             reason,
+			Message:            message,
+		})
+		return ctrl.Result{}, err
+	}
+
+	if !conditions.IsReady(p.ChildConditions(p.Child)) {
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             p.WaitingReason,
+			Message:            p.WaitingMessage,
+		})
+		return ctrl.Result{RequeueAfter: p.WaitRequeue}, nil
+	}
+
+	conditions.SetCondition(p.Conditions, metav1.Condition{
+		Type:               p.ConditionType,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: p.Generation,
+		Reason:             p.ReadyReason,
+		Message:            p.ReadyMessage,
+	})
+	return ctrl.Result{}, nil
+}
+
+// DeleteOrphanedChild deletes a previously-projected child that the owner no
+// longer manages, but only when the owner still controls it (a colliding
+// externally-owned object is left alone). It is NotFound-tolerant and uses
+// background propagation so the child's own resources are garbage-collected
+// behind it. child is a zero-valued object of the child type with its Name and
+// Namespace set.
+func DeleteOrphanedChild(ctx context.Context, c client.Client, owner, child client.Object) error {
+	key := client.ObjectKeyFromObject(child)
+	if err := c.Get(ctx, key, child); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting %T %s for orphan cleanup: %w", child, key, err)
+	}
+	if !metav1.IsControlledBy(child, owner) {
+		// Not our child (externally managed with a colliding name) — leave it.
+		return nil
+	}
+	if err := c.Delete(ctx, child, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting orphaned %T %s: %w", child, key, err)
+	}
+	return nil
+}

--- a/internal/common/reconcile/project_test.go
+++ b/internal/common/reconcile/project_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// projectParams builds a ChildProjectionParams over the skelCR test type.
+func projectParams(child *skelCR, conds *[]metav1.Condition) ChildProjectionParams[*skelCR] {
+	return ChildProjectionParams[*skelCR]{
+		Child:           child,
+		ConditionType:   "ChildReady",
+		ReadyReason:     "ChildIsReady",
+		ReadyMessage:    "child is ready",
+		WaitingReason:   "WaitingForChild",
+		WaitingMessage:  "child not ready",
+		RejectedReason:  "ChildRejected",
+		RejectedMessage: func(err error) string { return "rejected: " + err.Error() },
+		ErrorReason:     "ChildError",
+		ErrorMessage:    func(err error) string { return "error: " + err.Error() },
+		WaitRequeue:     10 * time.Second,
+		Conditions:      conds,
+		Generation:      5,
+		ChildConditions: func(c *skelCR) []metav1.Condition { return c.Status.Conditions },
+	}
+}
+
+func TestProjectChild_MirrorsChildReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	owner := newSkelCR()
+	owner.Name = "owner"
+	// Pre-create the child with a Ready condition so the applied server object
+	// carries it back for the readiness mirror.
+	child := newSkelCR()
+	child.Name = "child"
+	conditions.SetCondition(&child.Status.Conditions, metav1.Condition{Type: "Ready", Status: metav1.ConditionTrue})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, child).
+		WithStatusSubresource(child).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).Build()
+
+	desired := newSkelCR()
+	desired.Name = "child"
+	var conds []metav1.Condition
+	res, err := ProjectChild(context.Background(), c, s, owner, projectParams(desired, &conds))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	cond := conditions.GetCondition(conds, "ChildReady")
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(gomega.Equal("ChildIsReady"))
+	g.Expect(cond.ObservedGeneration).To(gomega.Equal(int64(5)))
+	// SSA set the owner as controller.
+	fetched := &skelCR{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(desired), fetched)).To(gomega.Succeed())
+	g.Expect(metav1.IsControlledBy(fetched, owner)).To(gomega.BeTrue())
+}
+
+func TestProjectChild_WaitsWhenChildNotReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	owner := newSkelCR()
+	owner.Name = "owner"
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).Build()
+
+	desired := newSkelCR()
+	desired.Name = "child"
+	var conds []metav1.Condition
+	res, err := ProjectChild(context.Background(), c, s, owner, projectParams(desired, &conds))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.RequeueAfter).To(gomega.Equal(10 * time.Second))
+	cond := conditions.GetCondition(conds, "ChildReady")
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal("WaitingForChild"))
+}
+
+func TestProjectChild_InvalidRejectionSurfacesDistinctReason(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	owner := newSkelCR()
+	owner.Name = "owner"
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(context.Context, client.WithWatch, k8sruntime.ApplyConfiguration, ...client.ApplyOption) error {
+				return apierrors.NewInvalid(schema.GroupKind{Kind: "SkelCR"}, "child", nil)
+			},
+		}).Build()
+
+	desired := newSkelCR()
+	desired.Name = "child"
+	var conds []metav1.Condition
+	_, err := ProjectChild(context.Background(), c, s, owner, projectParams(desired, &conds))
+	g.Expect(err).To(gomega.HaveOccurred())
+	cond := conditions.GetCondition(conds, "ChildReady")
+	g.Expect(cond.Reason).To(gomega.Equal("ChildRejected"))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("rejected:"))
+}
+
+func TestProjectChild_GenericErrorReason(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	owner := newSkelCR()
+	owner.Name = "owner"
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(context.Context, client.WithWatch, k8sruntime.ApplyConfiguration, ...client.ApplyOption) error {
+				return fmt.Errorf("boom")
+			},
+		}).Build()
+
+	desired := newSkelCR()
+	desired.Name = "child"
+	var conds []metav1.Condition
+	_, err := ProjectChild(context.Background(), c, s, owner, projectParams(desired, &conds))
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(conditions.GetCondition(conds, "ChildReady").Reason).To(gomega.Equal("ChildError"))
+}
+
+func TestDeleteOrphanedChild(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	owner := newSkelCR()
+	owner.Name = "owner"
+	owner.UID = "owner-uid"
+
+	// Owned child is deleted.
+	child := newSkelCR()
+	child.Name = "child"
+	g.Expect(controllerutil.SetControllerReference(owner, child, s)).To(gomega.Succeed())
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, child).Build()
+	g.Expect(DeleteOrphanedChild(context.Background(), c, owner, &skelCR{ObjectMeta: metav1.ObjectMeta{Name: "child", Namespace: child.Namespace}})).To(gomega.Succeed())
+	err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: "child"}, &skelCR{})
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+
+	// Absent child is a no-op.
+	g.Expect(DeleteOrphanedChild(context.Background(), c, owner, &skelCR{ObjectMeta: metav1.ObjectMeta{Name: "absent", Namespace: child.Namespace}})).To(gomega.Succeed())
+
+	// Externally-owned child (not controlled by owner) is left alone.
+	foreign := newSkelCR()
+	foreign.Name = "foreign"
+	c2 := fake.NewClientBuilder().WithScheme(s).WithObjects(foreign).Build()
+	g.Expect(DeleteOrphanedChild(context.Background(), c2, owner, &skelCR{ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: foreign.Namespace}})).To(gomega.Succeed())
+	g.Expect(c2.Get(context.Background(), client.ObjectKey{Namespace: foreign.Namespace, Name: "foreign"}, &skelCR{})).To(gomega.Succeed(), "foreign child must survive")
+}

--- a/internal/common/reconcile/skeleton.go
+++ b/internal/common/reconcile/skeleton.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// Skeleton bundles the per-operator controller-skeleton glue every service
+// operator repeated: aggregating its sub-conditions into the Ready condition,
+// writing the status subresource only when it changed, flipping a condition to
+// False on a pre-aggregation failure, and running a group of sub-reconcilers in
+// parallel. An operator declares one Skeleton value with its sub-condition
+// vocabulary and its status-conditions accessor, then its thin wrapper methods
+// delegate here.
+//
+// T is the operator's CR pointer type (a client.Object that also DeepCopies to
+// itself, as controller-gen generates); S is its status struct type, compared
+// by UpdateStatus to skip a no-op write.
+type Skeleton[T interface {
+	client.Object
+	DeepCopy() T
+}, S any] struct {
+	// SubConditionTypes are the sub-condition types SetReady aggregates into the
+	// Ready condition, in the operator's vocabulary.
+	SubConditionTypes []string
+	// Conditions resolves a CR (the primary or a DeepCopy) to its status
+	// conditions slice pointer.
+	Conditions func(T) *[]metav1.Condition
+}
+
+// SetReady aggregates the CR's sub-conditions into its Ready condition at the
+// CR's current generation.
+func (s Skeleton[T, S]) SetReady(obj T) {
+	SetAggregateReady(s.Conditions(obj), obj.GetGeneration(), s.SubConditionTypes)
+}
+
+// UpdateStatus aggregates the Ready condition, runs extraMutate (typically
+// stamping status.observedGeneration and any operator-specific status fields),
+// then writes the status subresource only when it differs from before. Passing
+// a nil extraMutate is allowed. It preserves the reconcile error semantics of
+// the shared UpdateStatus: a converged steady-state pass produces no write.
+func (s Skeleton[T, S]) UpdateStatus(ctx context.Context, c client.Client, obj T, before, current *S, extraMutate func(), result ctrl.Result, reconcileErr error) (ctrl.Result, error) {
+	return UpdateStatus(ctx, c, obj, before, current, func() {
+		s.SetReady(obj)
+		if extraMutate != nil {
+			extraMutate()
+		}
+	}, result, reconcileErr)
+}
+
+// MarkFailed flips the named condition to False with the given reason and the
+// error's message, so a failed sub-reconciler that runs before Ready
+// aggregation cannot leave the aggregate Ready stale-True at the new
+// observedGeneration.
+func (s Skeleton[T, S]) MarkFailed(obj T, conditionType, reason string, err error) {
+	conditions.SetCondition(s.Conditions(obj), metav1.Condition{
+		Type:               conditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: obj.GetGeneration(),
+		Reason:             reason,
+		Message:            err.Error(),
+	})
+}
+
+// RunParallelGroup runs the sub-reconcilers concurrently via RunParallelGroup,
+// resolving each CR's conditions through the Skeleton's accessor and
+// instrumenting each member through instrument. Conditions from every member —
+// including those that succeeded before a peer failed — are merged back into
+// obj, and on success the shortest non-zero RequeueAfter is returned.
+func (s Skeleton[T, S]) RunParallelGroup(ctx context.Context, obj T, instrument InstrumentFunc, steps []ParallelStep[T]) (ctrl.Result, error) {
+	return RunParallelGroup(ctx, obj, s.Conditions, instrument, steps)
+}

--- a/internal/common/reconcile/skeleton_test.go
+++ b/internal/common/reconcile/skeleton_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+// skelStatus and skelCR are a minimal registrable CR carrying a metav1.Condition
+// status, so the generic Skeleton can be exercised against a fake client.
+type skelStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+type skelCR struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Status            skelStatus `json:"status,omitempty"`
+}
+
+func (c *skelCR) DeepCopyObject() runtime.Object { return c.DeepCopy() }
+
+func (c *skelCR) DeepCopy() *skelCR {
+	out := &skelCR{TypeMeta: c.TypeMeta, ObjectMeta: *c.ObjectMeta.DeepCopy()}
+	out.Status.Conditions = append([]metav1.Condition(nil), c.Status.Conditions...)
+	return out
+}
+
+var skelGVK = schema.GroupVersion{Group: "test.c5c3.io", Version: "v1"}
+
+func skelScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(skelGVK.WithKind("SkelCR"), &skelCR{})
+	metav1.AddToGroupVersion(s, skelGVK)
+	return s
+}
+
+func snapSkelStatus(cr *skelCR) *skelStatus {
+	return &skelStatus{Conditions: append([]metav1.Condition(nil), cr.Status.Conditions...)}
+}
+
+func newSkelCR() *skelCR {
+	return &skelCR{
+		TypeMeta:   metav1.TypeMeta{Kind: "SkelCR", APIVersion: "test.c5c3.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cr", Namespace: "ns", Generation: 7},
+	}
+}
+
+func skelSkeleton() Skeleton[*skelCR, skelStatus] {
+	return Skeleton[*skelCR, skelStatus]{
+		SubConditionTypes: []string{"AReady", "BReady"},
+		Conditions:        func(c *skelCR) *[]metav1.Condition { return &c.Status.Conditions },
+	}
+}
+
+func TestSkeleton_SetReadyAggregates(t *testing.T) {
+	g := gomega.NewWithT(t)
+	cr := newSkelCR()
+	conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{Type: "AReady", Status: metav1.ConditionTrue})
+	conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{Type: "BReady", Status: metav1.ConditionTrue})
+
+	skelSkeleton().SetReady(cr)
+
+	ready := conditions.GetCondition(cr.Status.Conditions, "Ready")
+	g.Expect(ready).NotTo(gomega.BeNil())
+	g.Expect(ready.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(ready.ObservedGeneration).To(gomega.Equal(int64(7)))
+}
+
+func TestSkeleton_MarkFailedSetsCondition(t *testing.T) {
+	g := gomega.NewWithT(t)
+	cr := newSkelCR()
+
+	skelSkeleton().MarkFailed(cr, "AReady", "ConfigError", context.DeadlineExceeded)
+
+	cond := conditions.GetCondition(cr.Status.Conditions, "AReady")
+	g.Expect(cond).NotTo(gomega.BeNil())
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal("ConfigError"))
+	g.Expect(cond.Message).To(gomega.Equal(context.DeadlineExceeded.Error()))
+	g.Expect(cond.ObservedGeneration).To(gomega.Equal(int64(7)))
+}
+
+func TestSkeleton_UpdateStatusAggregatesAndRunsExtraMutate(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := skelScheme(t)
+	cr := newSkelCR()
+	conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{Type: "AReady", Status: metav1.ConditionTrue})
+	conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{Type: "BReady", Status: metav1.ConditionTrue})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cr).WithStatusSubresource(cr).Build()
+
+	before := snapSkelStatus(cr)
+	extraRan := false
+	res, err := skelSkeleton().UpdateStatus(context.Background(), c, cr, before, &cr.Status, func() {
+		extraRan = true
+	}, ctrl.Result{}, nil)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	g.Expect(extraRan).To(gomega.BeTrue(), "extraMutate must run")
+	g.Expect(conditions.GetCondition(cr.Status.Conditions, "Ready").Status).To(gomega.Equal(metav1.ConditionTrue))
+
+	// A converged pass (before == current) writes nothing new but still returns
+	// the result.
+	after := snapSkelStatus(cr)
+	res2, err2 := skelSkeleton().UpdateStatus(context.Background(), c, cr, after, &cr.Status, nil, ctrl.Result{}, nil)
+	g.Expect(err2).NotTo(gomega.HaveOccurred())
+	g.Expect(res2.IsZero()).To(gomega.BeTrue())
+}
+
+func skelConditions(c *skelCR) *[]metav1.Condition { return &c.Status.Conditions }
+
+func TestSkeleton_RunParallelGroupMergesConditions(t *testing.T) {
+	g := gomega.NewWithT(t)
+	cr := newSkelCR()
+	steps := []ParallelStep[*skelCR]{
+		{Name: "a", ConditionType: "AReady", Fn: func(_ context.Context, c *skelCR) (ctrl.Result, error) {
+			conditions.SetCondition(skelConditions(c), metav1.Condition{Type: "AReady", Status: metav1.ConditionTrue})
+			return ctrl.Result{}, nil
+		}},
+		{Name: "b", ConditionType: "BReady", Fn: func(_ context.Context, c *skelCR) (ctrl.Result, error) {
+			conditions.SetCondition(skelConditions(c), metav1.Condition{Type: "BReady", Status: metav1.ConditionTrue})
+			return ctrl.Result{}, nil
+		}},
+	}
+	// A pass-through instrument that just runs the sub-reconciler.
+	instrument := func(ctx context.Context, _ string, fn func(context.Context) (ctrl.Result, error)) (ctrl.Result, error) {
+		return fn(ctx)
+	}
+
+	_, err := skelSkeleton().RunParallelGroup(context.Background(), cr, instrument, steps)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(conditions.GetCondition(cr.Status.Conditions, "AReady")).NotTo(gomega.BeNil())
+	g.Expect(conditions.GetCondition(cr.Status.Conditions, "BReady")).NotTo(gomega.BeNil())
+}
+
+var _ client.Object = (*skelCR)(nil)

--- a/internal/common/rotation/doc.go
+++ b/internal/common/rotation/doc.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rotation provides the split-compute-write credential-rotation
+// mechanics shared by service operators: the staging Secret the rotation
+// CronJob PATCHes, the operator-side commit that copies a validated staging
+// payload onto the production Secret and deletes the staging Secret, the
+// least-privilege ServiceAccount/Role/RoleBinding the CronJob runs under, the
+// rotation-completed timestamp helpers, and the CronJob skeleton. The
+// service-specific parts — the key kinds, the rotation script, the payload
+// validation, and the event vocabulary — stay in the consuming operator.
+package rotation

--- a/internal/common/rotation/rotation.go
+++ b/internal/common/rotation/rotation.go
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rotation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// StagingSecretLabelKey labels staging Secrets so operator watches and
+// consumers can distinguish them from the production key Secrets.
+const StagingSecretLabelKey = "forge.c5c3.io/rotation-target" //nolint:gosec // label key, not a credential
+
+// CompletedAnnotation is the RFC3339 UTC timestamp the rotation CronJob writes
+// atomically with its staging Secret PATCH. Its presence is the single-shot
+// commit marker gating the operator's apply path.
+const CompletedAnnotation = "forge.c5c3.io/rotation-completed-at" //nolint:gosec // annotation key, not a credential
+
+// CompletedAt parses the CompletedAnnotation off the given Secret. It returns
+// (zero, false) when the Secret is nil, the annotation is missing, or the
+// timestamp does not parse as RFC3339 — all valid steady-state observations for
+// the gauge caller. It performs no client reads.
+func CompletedAt(secret *corev1.Secret) (time.Time, bool) {
+	if secret == nil {
+		return time.Time{}, false
+	}
+	completedAt := secret.Annotations[CompletedAnnotation]
+	if completedAt == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, completedAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+// ObserveAge invokes record with the rotation-completed timestamp, preferring
+// the production (main) Secret — where CommitStaged stamps it durably — and
+// falling back to the staging Secret to cover the post-PATCH/pre-apply window.
+// It is best-effort: an absent annotation on both (either Secret may be nil) or
+// a malformed timestamp is silently skipped, and record's error is ignored, so
+// a metric refresh never surfaces as a reconcile failure.
+func ObserveAge(mainSecret, stagingSecret *corev1.Secret, record func(completedAt time.Time) error) {
+	if completedAt, ok := CompletedAt(mainSecret); ok {
+		_ = record(completedAt)
+		return
+	}
+	if completedAt, ok := CompletedAt(stagingSecret); ok {
+		_ = record(completedAt)
+	}
+}
+
+// EnsureStagingSecret creates (or ensures) an empty staging Secret that the
+// rotation CronJob PATCHes rotated payload into. The operator owns the object's
+// metadata and lifecycle — labels, owner reference — while the CronJob owns the
+// `.data` field via a narrow get+patch RBAC grant. Data is deliberately left nil
+// on creation and untouched on update so the CronJob's PATCH is never clobbered
+// by a reconcile. labels is the complete label set applied on every call
+// (rebuilt so operator-owned labels stay authoritative).
+//
+// It returns the ensured Secret so the caller can thread it into ObserveAge and
+// CommitStaged without re-reading it; its UID/ResourceVersion drive the commit's
+// delete preconditions.
+func EnsureStagingSecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, name string, labels map[string]string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: owner.GetNamespace(),
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		secret.Labels = labels
+		// Do NOT touch secret.Data — the CronJob's PATCH owns that field.
+		return controllerutil.SetControllerReference(owner, secret, scheme)
+	}); err != nil {
+		return nil, fmt.Errorf("ensuring staging secret %s: %w", name, err)
+	}
+	return secret, nil
+}
+
+// CommitSpec parameterises CommitStaged for one rotation flavour. Every
+// difference between flavours is captured here; the commit sequence is identical.
+type CommitSpec struct {
+	// TargetNoun names the target Secret in returned error messages.
+	TargetNoun string
+	// Validate enforces the per-flavour staging-payload contract; a non-nil
+	// error rejects the commit.
+	Validate func(data map[string][]byte) error
+	// ClearStagingOnReject, when true, wipes the staged .data and completion
+	// annotation when Validate rejects the payload, so the next CronJob
+	// strategic-merge PATCH starts from an empty base rather than accumulating
+	// leftover entries over the rejected payload.
+	ClearStagingOnReject bool
+	// AnnotationInvalidReason / RejectedReason are the Warning event reasons
+	// emitted when the completion annotation is malformed or the payload is
+	// rejected.
+	AnnotationInvalidReason string
+	RejectedReason          string
+	// AppliedReason / AppliedMessage build the Normal event emitted on a
+	// successful commit.
+	AppliedReason  string
+	AppliedMessage func(stagingSecretName string, data map[string][]byte) string
+}
+
+// CommitStaged copies a completed staging Secret onto an operator-owned target
+// Secret and deletes the staging Secret. It is the operator-side commit for the
+// split-compute-write rotation architecture, shared by every rotation flavour
+// via CommitSpec:
+//
+//  1. Require CompletedAnnotation present and parseable as RFC3339; a malformed
+//     annotation emits spec.AnnotationInvalidReason and is retried next run.
+//  2. Validate the staged Data via spec.Validate; a rejection emits
+//     spec.RejectedReason and, when spec.ClearStagingOnReject, clears the staged
+//     Data and completion annotation.
+//  3. Replace the target's Data verbatim, stamp the annotation, and Update —
+//     full replacement realises the atomic swap.
+//  4. Delete the staging Secret under UID+ResourceVersion preconditions from the
+//     caller's read; tolerate NotFound and Conflict.
+//  5. Emit a Normal event from spec.AppliedReason / spec.AppliedMessage.
+//
+// staging is the object EnsureStagingSecret returned; target is the
+// operator-owned Secret the caller already read. Both are threaded in rather
+// than re-read. A nil staging is a no-op.
+func CommitStaged(ctx context.Context, c client.Client, recorder record.EventRecorder, owner client.Object, staging, target *corev1.Secret, spec CommitSpec) (applied bool, err error) {
+	if staging == nil {
+		return false, nil
+	}
+	stagingName := staging.Name
+
+	completedAt := staging.Annotations[CompletedAnnotation]
+	if completedAt == "" {
+		if len(staging.Data) > 0 {
+			log.FromContext(ctx).V(1).Info(
+				"staging secret has data without completion annotation; "+
+					"skipping apply until next CronJob run writes the annotation",
+				"staging", stagingName,
+				"annotation", CompletedAnnotation,
+				"dataKeys", len(staging.Data),
+			)
+		}
+		return false, nil
+	}
+	if _, parseErr := time.Parse(time.RFC3339, completedAt); parseErr != nil {
+		recorder.Eventf(owner, corev1.EventTypeWarning, spec.AnnotationInvalidReason,
+			"staging secret %s has malformed %s annotation: %v",
+			stagingName, CompletedAnnotation, parseErr)
+		return false, nil
+	}
+
+	if valErr := spec.Validate(staging.Data); valErr != nil {
+		recorder.Eventf(owner, corev1.EventTypeWarning, spec.RejectedReason,
+			"staging secret %s rejected: %v", stagingName, valErr)
+		if spec.ClearStagingOnReject {
+			staging.Data = nil
+			delete(staging.Annotations, CompletedAnnotation)
+			if updErr := c.Update(ctx, staging); updErr != nil {
+				if !apierrors.IsConflict(updErr) && !apierrors.IsNotFound(updErr) {
+					return false, fmt.Errorf("clearing rejected staging secret %s: %w", stagingName, updErr)
+				}
+				log.FromContext(ctx).V(1).Info(
+					"rejected staging secret changed since read; clear retried next reconcile",
+					"staging", stagingName,
+				)
+			}
+		}
+		return false, nil
+	}
+
+	// Skip the target Update and the success event when the target already holds
+	// this exact payload and completion timestamp: a prior pass committed it and
+	// only its staging delete is outstanding. Step 4 still runs so the staging
+	// Secret is cleaned up.
+	alreadyCommitted := maps.EqualFunc(target.Data, staging.Data, bytes.Equal) &&
+		target.Annotations[CompletedAnnotation] == completedAt
+
+	if !alreadyCommitted {
+		target.Data = staging.Data
+		if target.Annotations == nil {
+			target.Annotations = map[string]string{}
+		}
+		target.Annotations[CompletedAnnotation] = completedAt
+		if updateErr := c.Update(ctx, target); updateErr != nil {
+			return false, fmt.Errorf("updating %s %s: %w", spec.TargetNoun, target.Name, updateErr)
+		}
+	}
+
+	// Delete the staging Secret under UID+ResourceVersion preconditions so a
+	// concurrent CronJob PATCH surfaces as Conflict rather than being silently
+	// deleted uncommitted; the newer payload commits next reconcile. Conflict and
+	// NotFound are both tolerated — this run's payload is already on the target.
+	delOpts := client.Preconditions{UID: &staging.UID, ResourceVersion: &staging.ResourceVersion}
+	if delErr := c.Delete(ctx, staging, delOpts); delErr != nil {
+		if !apierrors.IsNotFound(delErr) && !apierrors.IsConflict(delErr) {
+			return false, fmt.Errorf("deleting staging secret %s: %w", stagingName, delErr)
+		}
+		log.FromContext(ctx).V(1).Info(
+			"staging secret changed since read; newer rotation output applied next reconcile",
+			"staging", stagingName,
+		)
+	}
+
+	if alreadyCommitted {
+		return false, nil
+	}
+
+	recorder.Event(owner, corev1.EventTypeNormal, spec.AppliedReason,
+		spec.AppliedMessage(stagingName, staging.Data))
+	return true, nil
+}
+
+// EnsureRBAC creates the ServiceAccount, Role, and RoleBinding a
+// split-compute-write rotation CronJob runs under, all named saName and owned by
+// owner. The Role is split into two least-privilege rules: read-only get on
+// readSecret (the operator-owned source the CronJob reads), and get+patch scoped
+// by resourceNames to stagingSecret (the CronJob's write target; create/delete
+// are withheld because the operator owns the staging Secret's lifecycle). RoleRef
+// is immutable after creation, so it is only set on new RoleBindings.
+func EnsureRBAC(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, saName, readSecret, stagingSecret string) error {
+	namespace := owner.GetNamespace()
+
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, func() error {
+		return controllerutil.SetControllerReference(owner, sa, scheme)
+	}); err != nil {
+		return fmt.Errorf("ensuring ServiceAccount %s: %w", saName, err)
+	}
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, role, func() error {
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				Verbs:         []string{"get"},
+				ResourceNames: []string{readSecret},
+			},
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				Verbs:         []string{"get", "patch"},
+				ResourceNames: []string{stagingSecret},
+			},
+		}
+		return controllerutil.SetControllerReference(owner, role, scheme)
+	}); err != nil {
+		return fmt.Errorf("ensuring Role %s: %w", saName, err)
+	}
+
+	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, rb, func() error {
+		rb.Subjects = []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: namespace,
+		}}
+		if rb.RoleRef.Name == "" {
+			rb.RoleRef = rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     saName,
+			}
+		}
+		return controllerutil.SetControllerReference(owner, rb, scheme)
+	}); err != nil {
+		return fmt.Errorf("ensuring RoleBinding %s: %w", saName, err)
+	}
+
+	return nil
+}
+
+// CronJobParams carries the inputs of BuildCronJob: the CronJob identity, its
+// schedule, and the fully-assembled Pod (the operator supplies the
+// service-specific init/main containers and volumes).
+type CronJobParams struct {
+	Name      string
+	Namespace string
+	Labels    map[string]string
+	Schedule  string
+	// PodLabels are set on the Job's Pod template.
+	PodLabels map[string]string
+	// PodSpec is the fully-assembled rotation Pod spec.
+	PodSpec corev1.PodSpec
+}
+
+// BuildCronJob wraps the caller's Pod spec in the CronJob/JobTemplate/PodTemplate
+// boilerplate shared by every rotation CronJob.
+func BuildCronJob(p CronJobParams) *batchv1.CronJob {
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.Name,
+			Namespace: p.Namespace,
+			Labels:    p.Labels,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: p.Schedule,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: p.PodLabels},
+						Spec:       p.PodSpec,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/common/rotation/rotation_test.go
+++ b/internal/common/rotation/rotation_test.go
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func rotationScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1: %v", err)
+	}
+	if err := rbacv1.AddToScheme(s); err != nil {
+		t.Fatalf("rbacv1: %v", err)
+	}
+	return s
+}
+
+func rotationOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "keystone", Namespace: "openstack", UID: "u"}}
+}
+
+func TestCompletedAt(t *testing.T) {
+	g := gomega.NewWithT(t)
+	_, ok := CompletedAt(nil)
+	g.Expect(ok).To(gomega.BeFalse())
+	_, ok = CompletedAt(&corev1.Secret{})
+	g.Expect(ok).To(gomega.BeFalse())
+	_, ok = CompletedAt(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CompletedAnnotation: "not-a-time"}}})
+	g.Expect(ok).To(gomega.BeFalse())
+	ts := time.Unix(1_700_000_000, 0).UTC().Format(time.RFC3339)
+	parsed, ok := CompletedAt(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CompletedAnnotation: ts}}})
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(parsed.Unix()).To(gomega.Equal(int64(1_700_000_000)))
+}
+
+func TestObserveAge_PrefersMainThenStaging(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ts := time.Unix(1_700_000_000, 0).UTC().Format(time.RFC3339)
+	main := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CompletedAnnotation: ts}}}
+	staging := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CompletedAnnotation: time.Unix(1, 0).UTC().Format(time.RFC3339)}}}
+
+	var got time.Time
+	ObserveAge(main, staging, func(c time.Time) error { got = c; return nil })
+	g.Expect(got.Unix()).To(gomega.Equal(int64(1_700_000_000)), "main wins over staging")
+
+	// No main annotation → staging is used.
+	got = time.Time{}
+	ObserveAge(&corev1.Secret{}, staging, func(c time.Time) error { got = c; return nil })
+	g.Expect(got.Unix()).To(gomega.Equal(int64(1)))
+
+	// Neither → callback never runs.
+	called := false
+	ObserveAge(&corev1.Secret{}, &corev1.Secret{}, func(time.Time) error { called = true; return nil })
+	g.Expect(called).To(gomega.BeFalse())
+}
+
+func TestEnsureStagingSecret_CreatesOwnedEmpty(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	owner := rotationOwner()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+
+	secret, err := EnsureStagingSecret(context.Background(), c, s, owner, "keystone-fernet-keys-rotation",
+		map[string]string{StagingSecretLabelKey: "fernet-keys"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(secret.Data).To(gomega.BeNil(), "staging data is owned by the CronJob PATCH, not this call")
+	g.Expect(secret.Labels).To(gomega.HaveKeyWithValue(StagingSecretLabelKey, "fernet-keys"))
+	g.Expect(secret.OwnerReferences).To(gomega.HaveLen(1))
+}
+
+func TestEnsureRBAC_LeastPrivilege(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	owner := rotationOwner()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+
+	g.Expect(EnsureRBAC(context.Background(), c, s, owner, "keystone-fernet-rotate", "keystone-fernet-keys", "keystone-fernet-keys-rotation")).To(gomega.Succeed())
+
+	role := &rbacv1.Role{}
+	g.Expect(c.Get(context.Background(), apitypes.NamespacedName{Namespace: "openstack", Name: "keystone-fernet-rotate"}, role)).To(gomega.Succeed())
+	g.Expect(role.Rules).To(gomega.HaveLen(2))
+	// Rule 1: read-only get on the source secret.
+	g.Expect(role.Rules[0].Verbs).To(gomega.Equal([]string{"get"}))
+	g.Expect(role.Rules[0].ResourceNames).To(gomega.Equal([]string{"keystone-fernet-keys"}))
+	// Rule 2: get+patch on the staging secret only (no create/delete).
+	g.Expect(role.Rules[1].Verbs).To(gomega.Equal([]string{"get", "patch"}))
+	g.Expect(role.Rules[1].ResourceNames).To(gomega.Equal([]string{"keystone-fernet-keys-rotation"}))
+
+	rb := &rbacv1.RoleBinding{}
+	g.Expect(c.Get(context.Background(), apitypes.NamespacedName{Namespace: "openstack", Name: "keystone-fernet-rotate"}, rb)).To(gomega.Succeed())
+	g.Expect(rb.RoleRef.Name).To(gomega.Equal("keystone-fernet-rotate"))
+}
+
+func commitSpec() CommitSpec {
+	return CommitSpec{
+		TargetNoun:              "main secret",
+		Validate:                func(map[string][]byte) error { return nil },
+		ClearStagingOnReject:    true,
+		AnnotationInvalidReason: "AnnInvalid",
+		RejectedReason:          "Rejected",
+		AppliedReason:           "Rotated",
+		AppliedMessage:          func(name string, _ map[string][]byte) string { return "applied from " + name },
+	}
+}
+
+func stagingSecret(annotated bool, data map[string][]byte) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "staging", Namespace: "openstack", UID: "s-uid", ResourceVersion: "1"},
+		Data:       data,
+	}
+	if annotated {
+		s.Annotations = map[string]string{CompletedAnnotation: time.Unix(1_700_000_000, 0).UTC().Format(time.RFC3339)}
+	}
+	return s
+}
+
+func TestCommitStaged_AppliesAndDeletes(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	staging := stagingSecret(true, map[string][]byte{"key1": []byte("v")})
+	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "openstack"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(staging, target).Build()
+	rec := record.NewFakeRecorder(4)
+
+	applied, err := CommitStaged(context.Background(), c, rec, rotationOwner(), staging, target, commitSpec())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(applied).To(gomega.BeTrue())
+	// Target holds the payload and the completion annotation.
+	g.Expect(target.Data).To(gomega.HaveKeyWithValue("key1", []byte("v")))
+	g.Expect(target.Annotations).To(gomega.HaveKey(CompletedAnnotation))
+	// Staging secret deleted.
+	err = c.Get(context.Background(), apitypes.NamespacedName{Namespace: "openstack", Name: "staging"}, &corev1.Secret{})
+	g.Expect(err).To(gomega.HaveOccurred())
+	var ev string
+	g.Eventually(rec.Events).Should(gomega.Receive(&ev))
+	g.Expect(ev).To(gomega.ContainSubstring("Normal Rotated"))
+}
+
+func TestCommitStaged_NoAnnotationNoOp(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	staging := stagingSecret(false, nil)
+	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "openstack"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(staging, target).Build()
+
+	applied, err := CommitStaged(context.Background(), c, record.NewFakeRecorder(1), rotationOwner(), staging, target, commitSpec())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(applied).To(gomega.BeFalse())
+	g.Expect(target.Data).To(gomega.BeNil())
+}
+
+func TestCommitStaged_RejectClearsStaging(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	staging := stagingSecret(true, map[string][]byte{"bad": []byte("x")})
+	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "openstack"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(staging, target).Build()
+	rec := record.NewFakeRecorder(4)
+	spec := commitSpec()
+	spec.Validate = func(map[string][]byte) error { return fmt.Errorf("bad payload") }
+
+	applied, err := CommitStaged(context.Background(), c, rec, rotationOwner(), staging, target, spec)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(applied).To(gomega.BeFalse())
+	// Staging Data cleared so the next PATCH starts from an empty base.
+	g.Expect(staging.Data).To(gomega.BeNil())
+	g.Expect(staging.Annotations).NotTo(gomega.HaveKey(CompletedAnnotation))
+	var ev string
+	g.Eventually(rec.Events).Should(gomega.Receive(&ev))
+	g.Expect(ev).To(gomega.ContainSubstring("Warning Rejected"))
+}
+
+func TestBuildCronJob(t *testing.T) {
+	g := gomega.NewWithT(t)
+	cj := BuildCronJob(CronJobParams{
+		Name: "keystone-fernet-rotate", Namespace: "openstack",
+		Labels: map[string]string{"app": "keystone"}, Schedule: "0 0 * * 0",
+		PodLabels: map[string]string{"app": "keystone"},
+		PodSpec:   corev1.PodSpec{ServiceAccountName: "keystone-fernet-rotate"},
+	})
+	g.Expect(cj.Name).To(gomega.Equal("keystone-fernet-rotate"))
+	g.Expect(cj.Spec.Schedule).To(gomega.Equal("0 0 * * 0"))
+	g.Expect(cj.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal("keystone-fernet-rotate"))
+	g.Expect(cj.Spec.JobTemplate.Spec.Template.Labels).To(gomega.HaveKeyWithValue("app", "keystone"))
+}
+
+var _ client.Object = (*corev1.ConfigMap)(nil)

--- a/internal/common/secrets/gate.go
+++ b/internal/common/secrets/gate.go
@@ -6,8 +6,12 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/internal/common/conditions"
 )
 
 // OpenBaoClusterStoreName is the ClusterSecretStore that fronts the OpenBao
@@ -71,4 +75,100 @@ func GateSyncedSecret(ctx context.Context, c client.Client, key client.ObjectKey
 	default:
 		return GateExternalSecretNotSynced, nil
 	}
+}
+
+// GateClusterStoreReady checks the named ClusterSecretStore's Ready condition
+// before the per-Secret gate, so an upstream backend outage surfaces as the
+// readiness condition False even while per-ExternalSecret caches still report
+// Ready from their last successful sync. On a not-ready store it sets a
+// SecretStoreNotReady condition on conds and returns (false, nil); the caller
+// requeues. A backend error is propagated as (false, err).
+func GateClusterStoreReady(ctx context.Context, c client.Client, storeName string,
+	conds *[]metav1.Condition, generation int64, conditionType string,
+) (bool, error) {
+	ready, err := IsClusterSecretStoreReady(ctx, c, storeName)
+	if err != nil {
+		return false, err
+	}
+	if ready {
+		return true, nil
+	}
+	conditions.SetCondition(conds, metav1.Condition{
+		Type:               conditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             "SecretStoreNotReady",
+		Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
+			storeName),
+	})
+	return false, nil
+}
+
+// CredentialGateSpec describes one credential Secret to gate on: its object
+// key, the required keys, and the service-specific condition vocabulary (the
+// reason, the human-readable noun, and the generic waiting message).
+type CredentialGateSpec struct {
+	Key          client.ObjectKey
+	Reason       string
+	Noun         string
+	WaitingMsg   string
+	ExpectedKeys []string
+}
+
+// GateCredential verifies that a credential Secret is usable, checking the
+// materialized Secret before the ExternalSecret to save a read in steady state.
+// It returns (true, nil) when the Secret exists with all ExpectedKeys. On a
+// miss it consults the ExternalSecret only to produce a precise condition
+// message — "ExternalSecret not found yet" vs "waiting to sync" vs "missing
+// expected keys" — sets the condition itself with the spec's reason, and
+// returns (false, nil). A backend error is propagated as (false, err).
+func GateCredential(ctx context.Context, c client.Client, spec CredentialGateSpec,
+	conds *[]metav1.Condition, generation int64, conditionType string,
+) (bool, error) {
+	state, err := GateSyncedSecret(ctx, c, spec.Key, spec.ExpectedKeys...)
+	if err != nil {
+		return false, err
+	}
+	if state == GateReady {
+		return true, nil
+	}
+
+	// The materialized Secret is absent or missing keys; the gate state
+	// attributes the cause so the operator surfaces an actionable message.
+	msg := spec.WaitingMsg
+	switch state {
+	case GateExternalSecretMissing:
+		msg = fmt.Sprintf("%s ExternalSecret %s/%s not found yet", spec.Noun, spec.Key.Namespace, spec.Key.Name)
+	case GateSecretKeysMissing:
+		msg = fmt.Sprintf("%s Secret exists but is missing expected keys", spec.Noun)
+	case GateExternalSecretNotSynced, GateReady:
+		// NotSynced keeps the generic waiting message; Ready returned above.
+	}
+	conditions.SetCondition(conds, metav1.Condition{
+		Type:               conditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             spec.Reason,
+		Message:            msg,
+	})
+	return false, nil
+}
+
+// GateCredentials runs GateCredential over each spec in order. It returns
+// (true, nil) only when every credential is ready. On the first not-ready
+// credential it returns (false, nil) with the condition already set; on a
+// backend error it returns (false, err).
+func GateCredentials(ctx context.Context, c client.Client, specs []CredentialGateSpec,
+	conds *[]metav1.Condition, generation int64, conditionType string,
+) (bool, error) {
+	for _, spec := range specs {
+		ready, err := GateCredential(ctx, c, spec, conds, generation, conditionType)
+		if err != nil {
+			return false, err
+		}
+		if !ready {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/internal/common/secrets/gate_flow_test.go
+++ b/internal/common/secrets/gate_flow_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/conditions"
+)
+
+func TestGateClusterStoreReady_ready(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := gateTestScheme(t)
+	store := &esov1.ClusterSecretStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "openbao-cluster-store"},
+		Status: esov1.SecretStoreStatus{Conditions: []esov1.SecretStoreStatusCondition{
+			{Type: esov1.SecretStoreReady, Status: corev1.ConditionTrue},
+		}},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(store).WithStatusSubresource(store).Build()
+
+	var conds []metav1.Condition
+	ready, err := GateClusterStoreReady(context.Background(), c, "openbao-cluster-store", &conds, 2, "SecretsReady")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ready).To(gomega.BeTrue())
+	g.Expect(conds).To(gomega.BeEmpty(), "a ready store writes no condition")
+}
+
+func TestGateClusterStoreReady_notReadySetsCondition(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := gateTestScheme(t)
+	// No store object exists, so it is treated as not ready.
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var conds []metav1.Condition
+	ready, err := GateClusterStoreReady(context.Background(), c, "openbao-cluster-store", &conds, 2, "SecretsReady")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ready).To(gomega.BeFalse())
+	cond := conditions.GetCondition(conds, "SecretsReady")
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal("SecretStoreNotReady"))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("upstream secret backend unreachable"))
+}
+
+func TestGateCredential_states(t *testing.T) {
+	key := client.ObjectKey{Namespace: "ns", Name: "cred"}
+	spec := CredentialGateSpec{
+		Key: key, Reason: "WaitingForDBCredentials", Noun: "Database credentials",
+		WaitingMsg: "Waiting for ESO to sync", ExpectedKeys: []string{"username", "password"},
+	}
+	full := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cred", Namespace: "ns"},
+		Data:       map[string][]byte{"username": []byte("u"), "password": []byte("p")},
+	}
+	partial := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cred", Namespace: "ns"},
+		Data:       map[string][]byte{"username": []byte("u")},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		objs       []client.Object
+		wantReady  bool
+		wantMsgSub string
+	}{
+		{name: "ready", objs: []client.Object{full}, wantReady: true},
+		{name: "es missing", objs: nil, wantReady: false, wantMsgSub: "ExternalSecret ns/cred not found yet"},
+		{name: "es not synced", objs: []client.Object{gateExternalSecret("cred", false)}, wantReady: false, wantMsgSub: "Waiting for ESO to sync"},
+		{name: "keys missing", objs: []client.Object{partial, gateExternalSecret("cred", true)}, wantReady: false, wantMsgSub: "missing expected keys"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			s := gateTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.objs...).Build()
+			var conds []metav1.Condition
+			ready, err := GateCredential(context.Background(), c, spec, &conds, 3, "SecretsReady")
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(ready).To(gomega.Equal(tc.wantReady))
+			if tc.wantReady {
+				g.Expect(conds).To(gomega.BeEmpty())
+				return
+			}
+			cond := conditions.GetCondition(conds, "SecretsReady")
+			g.Expect(cond.Reason).To(gomega.Equal("WaitingForDBCredentials"))
+			g.Expect(cond.Message).To(gomega.ContainSubstring(tc.wantMsgSub))
+		})
+	}
+}
+
+func TestGateCredentials_shortCircuitsOnFirstNotReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := gateTestScheme(t)
+	// Only the second credential's Secret exists; the first is missing so the
+	// loop short-circuits with the first spec's reason.
+	second := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"},
+		Data:       map[string][]byte{"password": []byte("p")},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(second).Build()
+	specs := []CredentialGateSpec{
+		{Key: client.ObjectKey{Namespace: "ns", Name: "a"}, Reason: "WaitingForA", Noun: "A", ExpectedKeys: []string{"password"}},
+		{Key: client.ObjectKey{Namespace: "ns", Name: "b"}, Reason: "WaitingForB", Noun: "B", ExpectedKeys: []string{"password"}},
+	}
+	var conds []metav1.Condition
+	ready, err := GateCredentials(context.Background(), c, specs, &conds, 3, "SecretsReady")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ready).To(gomega.BeFalse())
+	g.Expect(conditions.GetCondition(conds, "SecretsReady").Reason).To(gomega.Equal("WaitingForA"))
+}

--- a/internal/common/testutil/envtest/manager.go
+++ b/internal/common/testutil/envtest/manager.go
@@ -180,3 +180,50 @@ func stopEnv(t testing.TB, env *envtest.Environment) {
 		t.Logf("additionally failed to stop envtest environment: %v", err)
 	}
 }
+
+// UnstartedManagerConfig configures SetupUnstartedManager: the scheme the
+// manager knows and the CRD directories the envtest API server installs.
+type UnstartedManagerConfig struct {
+	Scheme            *k8sruntime.Scheme
+	CRDDirectoryPaths []string
+}
+
+// SetupUnstartedManager starts an envtest API server with the given CRDs and
+// returns a controller-runtime Manager whose scheme is cfg.Scheme, WITHOUT
+// starting it — callers can invoke mgr.GetFieldIndexer() or other pre-Start APIs
+// without incurring a background goroutine. The metrics and health-probe servers
+// are disabled and no webhooks are installed. This is the shared body of the
+// per-operator minimal-manager setups. Tear-down is wired via t.Cleanup().
+func SetupUnstartedManager(t testing.TB, cfg UnstartedManagerConfig) (ctrl.Manager, context.Context, context.CancelFunc) {
+	t.Helper()
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     cfg.CRDDirectoryPaths,
+		ErrorIfCRDPathMissing: true,
+	}
+
+	restCfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest environment for unstarted manager: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
+		Scheme:                 cfg.Scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		stopEnv(t, env)
+		t.Fatalf("failed to create unstarted controller-runtime manager: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		if err := env.Stop(); err != nil {
+			t.Errorf("failed to stop envtest environment for unstarted manager: %v", err)
+		}
+	})
+
+	return mgr, ctx, cancel
+}

--- a/internal/common/testutil/envtest/setup.go
+++ b/internal/common/testutil/envtest/setup.go
@@ -23,6 +23,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // SetupEnvTest starts an envtest API server with etcd, installs fake CRDs, and
@@ -30,9 +31,20 @@ import (
 // function. The environment is torn down automatically via t.Cleanup().
 func SetupEnvTest(t testing.TB) (client.Client, context.Context, context.CancelFunc) {
 	t.Helper()
+	return SetupEnvTestWithCRDs(t, SharedScheme(), fakeCRDsDirs())
+}
+
+// SetupEnvTestWithCRDs starts a webhook-less envtest API server with the given
+// scheme and CRD directories and returns a direct (non-caching) client, so tests
+// can submit CRs and observe exactly the schema-layer validation the API server
+// enforces (kubebuilder markers + x-kubernetes-validations CEL rules) without a
+// validating webhook short-circuiting the rejection. This is the shared body of
+// the per-operator no-webhook setups. Tear-down is wired via t.Cleanup().
+func SetupEnvTestWithCRDs(t testing.TB, scheme *k8sruntime.Scheme, crdDirs []string) (client.Client, context.Context, context.CancelFunc) {
+	t.Helper()
 
 	env := &envtest.Environment{
-		CRDDirectoryPaths:     fakeCRDsDirs(),
+		CRDDirectoryPaths:     crdDirs,
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -41,7 +53,7 @@ func SetupEnvTest(t testing.TB) (client.Client, context.Context, context.CancelF
 		t.Fatalf("failed to start envtest environment: %v", err)
 	}
 
-	c, err := client.New(cfg, client.Options{Scheme: SharedScheme()})
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		// Stop the environment before registering cleanup since client
 		// creation failed before we could register t.Cleanup for env.Stop().
@@ -51,17 +63,13 @@ func SetupEnvTest(t testing.TB) (client.Client, context.Context, context.CancelF
 		t.Fatalf("failed to create controller-runtime client: %v", err)
 	}
 
-	// Register cleanup only after client.New succeeds so env.Stop() is
-	// called exactly once — either here on success, or explicitly above
-	// on failure.
+	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
+		cancel()
 		if err := env.Stop(); err != nil {
 			t.Errorf("failed to stop envtest environment: %v", err)
 		}
 	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 
 	return c, ctx, cancel
 }
@@ -116,6 +124,22 @@ func SharedScheme() *k8sruntime.Scheme {
 // package is the single owner of the fake_crds location.
 func CommonFakeCRDDirs() []string {
 	return fakeCRDsDirs()
+}
+
+// CommonExternalSchemes returns the AddToScheme functions for the external API
+// groups a database-backed service operator's reconciler typically registers:
+// MariaDB, ESO v1 and v1alpha1, cert-manager, and Gateway API. Operators compose
+// these with their own CR types via BuildScheme; an operator that needs only a
+// subset (or additional single-consumer groups like K-ORC) composes the ones it
+// needs instead.
+func CommonExternalSchemes() []func(*k8sruntime.Scheme) error {
+	return []func(*k8sruntime.Scheme) error{
+		mariadbv1alpha1.AddToScheme,
+		esov1.AddToScheme,
+		esov1alpha1.AddToScheme,
+		certmanagerv1.AddToScheme,
+		gatewayv1.Install,
+	}
 }
 
 // BuildScheme creates a runtime.Scheme with the core client-go and

--- a/internal/common/testutil/envtest/setup_test.go
+++ b/internal/common/testutil/envtest/setup_test.go
@@ -76,3 +76,18 @@ func TestSharedScheme_registersExternalOperatorTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestCommonExternalSchemes_registersFiveExternalGroups(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := BuildScheme(CommonExternalSchemes()...)
+
+	for _, gvk := range []schema.GroupVersionKind{
+		{Group: "k8s.mariadb.com", Version: "v1alpha1", Kind: "Database"},
+		{Group: "external-secrets.io", Version: "v1", Kind: "ExternalSecret"},
+		{Group: "external-secrets.io", Version: "v1alpha1", Kind: "PushSecret"},
+		{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"},
+	} {
+		g.Expect(s.Recognizes(gvk)).To(BeTrue(), "CommonExternalSchemes should register %s", gvk)
+	}
+}

--- a/internal/common/types/types.go
+++ b/internal/common/types/types.go
@@ -49,14 +49,14 @@ const (
 // supply-chain-sensitive deployment can pin the image by immutable digest while
 // the common case keeps a human-readable tag.
 //
-// Digest-mode (Tag empty, Digest set) disables Keystone release
+// Digest-mode (Tag empty, Digest set) disables release
 // tracking/upgrades, which key on the tag; the managed ControlPlane path always
 // projects a tag, so it is unaffected.
 //
 // +kubebuilder:validation:XValidation:rule="has(self.tag) != has(self.digest)",message="exactly one of image.tag or image.digest must be set"
 type ImageSpec struct {
 	// Repository is the OCI image repository, optionally including the registry
-	// host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+	// host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
 	// permissive OCI reference — lowercase alphanumeric components separated by
 	// ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
 	// are accepted while an empty string (which "required" alone admits) and
@@ -146,8 +146,8 @@ type DatabaseSpec struct {
 	// managed-mode projection honours it (a single replica yields a
 	// single-instance non-Galera MariaDB, three or more yield a Galera cluster),
 	// so a constrained cluster such as a single-node kind can schedule the
-	// fresh-create path. Operators that adopt an existing MariaDB (keystone, and
-	// the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+	// fresh-create path. Operators that adopt an existing MariaDB (the c5c3 adopted-infra path,
+	// and every service operator) ignore it. Only meaningful when ClusterRef is
 	// set.
 	// +optional
 	// +kubebuilder:default=3
@@ -157,7 +157,7 @@ type DatabaseSpec struct {
 	// MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
 	// operator's managed-mode projection honours it (it is written to the owned
 	// MariaDB's spec.storage.size); operators that adopt an existing MariaDB
-	// (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+	// (the c5c3 adopted-infra path, and every service operator) ignore it. The default 100Gi
 	// mirrors the production baseline (deploy/flux-system/infrastructure/
 	// mariadb.yaml); a constrained cluster such as a single-node kind can pin a
 	// far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
@@ -238,7 +238,7 @@ type CacheSpec struct {
 type SecretRefSpec struct {
 	// Name is the referenced Secret's name. It must be a non-empty DNS-1123
 	// subdomain (the Kubernetes object-name grammar). Tightening the shared type
-	// fixes every consumer at once — keystone adminPasswordSecretRef /
+	// fixes every consumer at once — a service operator adminPasswordSecretRef /
 	// database.secretRef / messaging / TLS cert refs and the c5c3
 	// passwordSecretRef — so an empty name no longer slips through "required".
 	// +kubebuilder:validation:MinLength=1
@@ -271,7 +271,7 @@ type PolicySpec struct {
 
 // PluginSpec defines a service plugin/driver configuration.
 type PluginSpec struct {
-	// Name of the plugin (e.g., "keystone-keycloak-backend")
+	// Name of the plugin (e.g., "myservice-keycloak-backend")
 	Name string `json:"name"`
 	// ConfigSection is the INI section name (e.g., "keycloak")
 	ConfigSection string `json:"configSection"`
@@ -305,7 +305,7 @@ type MiddlewareSpec struct {
 
 // GatewaySpec configures the Gateway API HTTPRoute used to expose an OpenStack
 // service externally. It is the single source of truth for the shared Gateway
-// shape: both the keystone and c5c3 operators reuse this commonv1 type instead
+// shape: the service operators and the c5c3 operator reuse this commonv1 type instead
 // of maintaining their own field-for-field copies.
 //
 // The operator plays the application-developer role in the Gateway API model:
@@ -334,8 +334,8 @@ type GatewaySpec struct {
 }
 
 // GatewayParentRefSpec references a pre-existing Gateway that the operator
-// attaches the HTTPRoute to. It is shared by both the keystone and c5c3
-// operators as the single source of truth for the Gateway parent reference.
+// attaches the HTTPRoute to. It is shared across the service operators and the
+// c5c3 operator as the single source of truth for the Gateway parent reference.
 type GatewayParentRefSpec struct {
 	// Name is the Gateway resource name. Required.
 	// +kubebuilder:validation:MinLength=1

--- a/internal/common/types/workload.go
+++ b/internal/common/types/workload.go
@@ -40,17 +40,33 @@ const (
 	DefaultReplicas int32 = 3
 )
 
-// Default resource requests and limits for the service API container.
-// These vars are the single source of truth for the defaulting webhooks.
-// They ensure Burstable QoS class and enable HPA utilization-based scaling.
-// Exported because operator controller tests reference them for assertion.
-// Mutation is safe: all call sites use DeepCopy().
+// Default resource requests and limits for the service API container. These
+// unexported vars are the single source of truth for the defaulting webhooks;
+// they ensure Burstable QoS class and enable HPA utilization-based scaling. They
+// are exposed only through the accessor functions below, which return a copy so
+// no caller can mutate the shared default.
 var (
-	DefaultMemoryRequest = resource.MustParse("256Mi")
-	DefaultCPURequest    = resource.MustParse("100m")
-	DefaultMemoryLimit   = resource.MustParse("512Mi")
-	DefaultCPULimit      = resource.MustParse("500m")
+	defaultMemoryRequest = resource.MustParse("256Mi")
+	defaultCPURequest    = resource.MustParse("100m")
+	defaultMemoryLimit   = resource.MustParse("512Mi")
+	defaultCPULimit      = resource.MustParse("500m")
 )
+
+// DefaultMemoryRequest returns a copy of the default memory request for the
+// service API container.
+func DefaultMemoryRequest() resource.Quantity { return defaultMemoryRequest.DeepCopy() }
+
+// DefaultCPURequest returns a copy of the default CPU request for the service
+// API container.
+func DefaultCPURequest() resource.Quantity { return defaultCPURequest.DeepCopy() }
+
+// DefaultMemoryLimit returns a copy of the default memory limit for the service
+// API container.
+func DefaultMemoryLimit() resource.Quantity { return defaultMemoryLimit.DeepCopy() }
+
+// DefaultCPULimit returns a copy of the default CPU limit for the service API
+// container.
+func DefaultCPULimit() resource.Quantity { return defaultCPULimit.DeepCopy() }
 
 // DeploymentSpec groups the pod-level knobs for the Keystone API Deployment.
 // Grouping them under spec.deployment keeps the KeystoneSpec root legible as
@@ -150,12 +166,12 @@ func (d *DeploymentSpec) Default() {
 	if d.Resources == nil || (len(d.Resources.Requests) == 0 && len(d.Resources.Limits) == 0) {
 		d.Resources = &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: DefaultMemoryRequest.DeepCopy(),
-				corev1.ResourceCPU:    DefaultCPURequest.DeepCopy(),
+				corev1.ResourceMemory: DefaultMemoryRequest(),
+				corev1.ResourceCPU:    DefaultCPURequest(),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: DefaultMemoryLimit.DeepCopy(),
-				corev1.ResourceCPU:    DefaultCPULimit.DeepCopy(),
+				corev1.ResourceMemory: DefaultMemoryLimit(),
+				corev1.ResourceCPU:    DefaultCPULimit(),
 			},
 		}
 	}

--- a/internal/common/types/workload.go
+++ b/internal/common/types/workload.go
@@ -68,23 +68,24 @@ func DefaultMemoryLimit() resource.Quantity { return defaultMemoryLimit.DeepCopy
 // container.
 func DefaultCPULimit() resource.Quantity { return defaultCPULimit.DeepCopy() }
 
-// DeploymentSpec groups the pod-level knobs for the Keystone API Deployment.
-// Grouping them under spec.deployment keeps the KeystoneSpec root legible as
+// DeploymentSpec groups the pod-level knobs for the service API Deployment.
+// Grouping them under spec.deployment keeps the CR spec root legible as
 // further scheduling knobs (affinity/tolerations/nodeSelector) are added.
 //
 // The drain-window CEL rule mirrors the validating webhook: when one or both of
 // the nil-preserving pointers is unset, the rule substitutes the same effective
 // defaults the reconciler applies. The literals 5 and 30 must stay in sync with
-// DefaultPreStopSleepSeconds and DefaultTerminationGracePeriodSeconds in
-// keystone_webhook.go — kubebuilder/CEL rules cannot reference Go constants.
+// DefaultPreStopSleepSeconds and DefaultTerminationGracePeriodSeconds — the
+// operator webhook applies the same effective defaults; kubebuilder/CEL rules
+// cannot reference Go constants.
 // +kubebuilder:validation:XValidation:rule="(has(self.preStopSleepSeconds) ? self.preStopSleepSeconds : 5) < (has(self.terminationGracePeriodSeconds) ? self.terminationGracePeriodSeconds : 30)",message="preStopSleepSeconds must be strictly less than terminationGracePeriodSeconds"
 type DeploymentSpec struct {
-	// Replicas is the desired number of Keystone API pods.
+	// Replicas is the desired number of service API pods.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=3
 	Replicas int32 `json:"replicas,omitempty"`
 
-	// Resources defines the CPU and memory requests and limits for the Keystone API
+	// Resources defines the CPU and memory requests and limits for the service API
 	// container. When unset, the defaulting webhook injects sensible defaults
 	// (256Mi/512Mi memory, 100m/500m CPU) to ensure Burstable QoS class and
 	// enable HPA utilization calculations.
@@ -101,9 +102,9 @@ type DeploymentSpec struct {
 	// controller-gen excludes it from `kubectl explain` output.
 
 	// TerminationGracePeriodSeconds is the grace period (seconds) granted to
-	// Keystone API pods between SIGTERM and SIGKILL during rolling updates
+	// service API pods between SIGTERM and SIGKILL during rolling updates
 	// Extend this to cover slow upstream token validation (LDAP/DB)
-	// so in-flight requests finish before the kubelet forcibly kills uWSGI.
+	// so in-flight requests finish before the kubelet forcibly kills the API process.
 	// When nil, the reconciler omits the field from the pod template and the
 	// Kubernetes default of 30s applies. Must be at least 10s when set.
 	// +optional
@@ -114,7 +115,7 @@ type DeploymentSpec struct {
 	// lifecycle hook, configured independently of the overall grace period
 	// This covers the window between EndpointSlice removal and
 	// kube-proxy/ingress-controller propagation so new requests stop arriving
-	// before SIGTERM reaches uWSGI. When nil, the reconciler applies a default
+	// before SIGTERM reaches the API process. When nil, the reconciler applies a default
 	// of 5s. Zero is permitted to disable the sleep. The cross-field rule
 	// preStopSleepSeconds < terminationGracePeriodSeconds is enforced by the
 	// validating webhook to guarantee a non-zero drain window.
@@ -122,7 +123,7 @@ type DeploymentSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	PreStopSleepSeconds *int64 `json:"preStopSleepSeconds,omitempty"`
 
-	// Strategy overrides the Deployment rollout strategy for the Keystone API
+	// Strategy overrides the Deployment rollout strategy for the service API
 	// Deployment. When nil, the reconciler applies RollingUpdate
 	// with MaxUnavailable=0 and MaxSurge=1 to guarantee surge-before-remove
 	// behavior — available capacity never dips below spec.deployment.replicas
@@ -141,7 +142,7 @@ type DeploymentSpec struct {
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
-	// PriorityClassName sets the priority class for Keystone API pods.
+	// PriorityClassName sets the priority class for service API pods.
 	// When set, the operator passes the value through to the PodSpec, allowing
 	// cluster administrators to control scheduling priority and preemption.
 	// When unset, no priority class is configured and the cluster default applies.
@@ -204,13 +205,13 @@ type AutoscalingSpec struct {
 	TargetMemoryUtilization *int32 `json:"targetMemoryUtilization,omitempty"`
 }
 
-// NetworkPolicySpec defines network isolation for Keystone API pods.
+// NetworkPolicySpec defines network isolation for the service API pods.
 // When applied, the operator creates a NetworkPolicy that restricts ingress
-// to TCP 5000 from the specified sources and auto-derives egress rules for
+// to the service API port from the specified sources and auto-derives egress rules for
 // DNS, MariaDB (from database.ClusterRef), and Memcached (from cache.ClusterRef).
 // +kubebuilder:validation:XValidation:rule="size(self.ingress) > 0",message="at least one ingress source must be specified"
 type NetworkPolicySpec struct {
-	// Ingress defines the sources allowed to reach Keystone API on TCP 5000.
+	// Ingress defines the sources allowed to reach the service API on its API port.
 	// Each source specifies a namespace selector and an optional pod selector.
 	// Multiple sources produce multiple From peers in a single ingress rule
 	// (OR across peers, AND within a peer's selectors).
@@ -224,10 +225,10 @@ type NetworkPolicySpec struct {
 }
 
 // NetworkPolicyIngressSource defines a source from which traffic is allowed
-// to reach the Keystone API pods on TCP 5000.
+// to reach the service API pods on the API port.
 type NetworkPolicyIngressSource struct {
 	// NamespaceSelector selects namespaces from which traffic is allowed.
-	// All pods in matching namespaces can reach Keystone on port 5000
+	// All pods in matching namespaces can reach the service on its API port
 	// unless PodSelector further restricts the set. It is a full
 	// metav1.LabelSelector, so set-based matchExpressions are supported in
 	// addition to matchLabels.
@@ -235,15 +236,15 @@ type NetworkPolicyIngressSource struct {
 
 	// PodSelector optionally restricts allowed traffic to pods matching
 	// these labels within the selected namespaces. When set, only pods
-	// matching both NamespaceSelector AND PodSelector can reach Keystone
+	// matching both NamespaceSelector AND PodSelector can reach the service
 	// (AND logic within a single peer). It is a full metav1.LabelSelector,
 	// so set-based matchExpressions are supported in addition to matchLabels.
 	// +optional
 	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 }
 
-// LoggingSpec configures oslo.log output for the Keystone API container.
-// Exposed as an optional pointer field on KeystoneSpec; the defaulting webhook
+// LoggingSpec configures oslo.log output for the service API container.
+// Exposed as an optional pointer field on the CR spec; the defaulting webhook
 // materializes a baseline LoggingSpec when the pointer is nil so downstream
 // reconciler code never sees a nil pointer (mirrors UWSGISpec / Resources precedent).
 type LoggingSpec struct {
@@ -270,7 +271,7 @@ type LoggingSpec struct {
 
 	// PerLoggerLevels overrides the level of named loggers, mirroring
 	// oslo.log's `default_log_levels`. Example:
-	// {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
+	// {"sqlalchemy.engine": "WARNING", "myservice.middleware": "DEBUG"}.
 	// Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
 	// logger name must be non-empty. These are now enforced by the CRD CEL
 	// XValidation rules below as well as by the validating webhook (a plain

--- a/internal/common/types/workload_test.go
+++ b/internal/common/types/workload_test.go
@@ -21,10 +21,10 @@ func TestDeploymentSpecDefault_FillsZeroValues(t *testing.T) {
 
 	g.Expect(d.Replicas).To(gomega.Equal(DefaultReplicas))
 	g.Expect(d.Resources).NotTo(gomega.BeNil())
-	g.Expect(d.Resources.Requests[corev1.ResourceMemory]).To(gomega.Equal(DefaultMemoryRequest))
-	g.Expect(d.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(DefaultCPURequest))
-	g.Expect(d.Resources.Limits[corev1.ResourceMemory]).To(gomega.Equal(DefaultMemoryLimit))
-	g.Expect(d.Resources.Limits[corev1.ResourceCPU]).To(gomega.Equal(DefaultCPULimit))
+	g.Expect(d.Resources.Requests[corev1.ResourceMemory]).To(gomega.Equal(DefaultMemoryRequest()))
+	g.Expect(d.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(DefaultCPURequest()))
+	g.Expect(d.Resources.Limits[corev1.ResourceMemory]).To(gomega.Equal(DefaultMemoryLimit()))
+	g.Expect(d.Resources.Limits[corev1.ResourceCPU]).To(gomega.Equal(DefaultCPULimit()))
 }
 
 // An empty-but-non-nil Resources block (`resources: {}`) would produce

--- a/internal/common/watch/mappers.go
+++ b/internal/common/watch/mappers.go
@@ -171,3 +171,39 @@ func ClusterSecretStoreFanOut(c client.Reader, storeName string, newList func() 
 		return requests
 	}
 }
+
+// ClusterRefMapper returns a MapFunc that maps a database-cluster event (a
+// MariaDB cluster, a Memcached cluster, …) to reconcile requests for the CRs in
+// the same namespace whose clusterRef targets that cluster by name. newList
+// supplies the CR list type and clusterRefName extracts a CR's cluster
+// reference name (empty when it has none). On a List or extract error the mapper
+// logs via log.FromContext and returns nil per the handler.MapFunc contract.
+func ClusterRefMapper(c client.Reader, newList func() client.ObjectList, clusterRefName func(client.Object) string) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		list := newList()
+		if err := c.List(ctx, list, client.InNamespace(obj.GetNamespace())); err != nil {
+			log.FromContext(ctx).Error(err, "listing CRs for cluster-ref watch")
+			return nil
+		}
+		items, err := apimeta.ExtractList(list)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "extracting CR list for cluster-ref watch")
+			return nil
+		}
+
+		clusterName := obj.GetName()
+		var requests []reconcile.Request
+		for _, item := range items {
+			o, ok := item.(client.Object)
+			if !ok {
+				continue
+			}
+			if clusterRefName(o) == clusterName {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(o),
+				})
+			}
+		}
+		return requests
+	}
+}

--- a/internal/common/watch/mappers_test.go
+++ b/internal/common/watch/mappers_test.go
@@ -178,3 +178,45 @@ func TestClusterSecretStoreFanOut_EnqueuesAllCRs(t *testing.T) {
 		reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns2", Name: "cr-b"}},
 	), "the store transition must fan out to every CR cluster-wide")
 }
+
+func cmWithRef(name, namespace, ref string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: namespace,
+		Annotations: map[string]string{"clusterRef": ref},
+	}}
+}
+
+func TestClusterRefMapper_MatchesRefInSameNamespace(t *testing.T) {
+	g := gomega.NewWithT(t)
+	// ConfigMaps stand in for CRs; the clusterRef name lives in an annotation.
+	c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).
+		WithObjects(
+			cmWithRef("cr-a", "ns1", "mariadb"), // matches
+			cmWithRef("cr-b", "ns1", "other"),   // wrong ref
+			cmWithRef("cr-c", "ns1", ""),        // no ref
+			cmWithRef("cr-d", "ns2", "mariadb"), // wrong namespace
+		).Build()
+
+	mapper := ClusterRefMapper(c,
+		func() client.ObjectList { return &corev1.ConfigMapList{} },
+		func(o client.Object) string { return o.GetAnnotations()["clusterRef"] })
+
+	changed := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "mariadb", Namespace: "ns1"}}
+	reqs := mapper(context.Background(), changed)
+	g.Expect(reqs).To(gomega.ConsistOf(
+		reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "cr-a"}},
+	))
+}
+
+func TestClusterRefMapper_NoMatchReturnsNil(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).
+		WithObjects(cmWithRef("cr-a", "ns1", "mariadb")).Build()
+
+	mapper := ClusterRefMapper(c,
+		func() client.ObjectList { return &corev1.ConfigMapList{} },
+		func(o client.Object) string { return o.GetAnnotations()["clusterRef"] })
+
+	changed := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "absent", Namespace: "ns1"}}
+	g.Expect(mapper(context.Background(), changed)).To(gomega.BeEmpty())
+}

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -1018,8 +1018,8 @@ func validateKeystoneMode(cp *ControlPlane) field.ErrorList {
 			allErrs = append(allErrs, field.Required(ksPath.Child("external"),
 				"external is required when services.keystone.mode is External"))
 		} else {
-			switch {
-			case ks.External.AuthURL == "":
+			switch ks.External.AuthURL {
+			case "":
 				allErrs = append(allErrs, field.Required(ksPath.Child("external", "authURL"),
 					"authURL is required when services.keystone.mode is External"))
 			default:

--- a/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
@@ -227,8 +227,8 @@ spec:
                           managed-mode projection honours it (a single replica yields a
                           single-instance non-Galera MariaDB, three or more yield a Galera cluster),
                           so a constrained cluster such as a single-node kind can schedule the
-                          fresh-create path. Operators that adopt an existing MariaDB (keystone, and
-                          the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                          fresh-create path. Operators that adopt an existing MariaDB (the c5c3 adopted-infra path,
+                          and every service operator) ignore it. Only meaningful when ClusterRef is
                           set.
                         format: int32
                         minimum: 1
@@ -242,7 +242,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -258,7 +258,7 @@ spec:
                           MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
                           operator's managed-mode projection honours it (it is written to the owned
                           MariaDB's spec.storage.size); operators that adopt an existing MariaDB
-                          (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                          (the c5c3 adopted-infra path, and every service operator) ignore it. The default 100Gi
                           mirrors the production baseline (deploy/flux-system/infrastructure/
                           mariadb.yaml); a constrained cluster such as a single-node kind can pin a
                           far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
@@ -286,7 +286,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -306,7 +306,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -519,7 +519,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -795,7 +795,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and
@@ -875,7 +875,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -942,7 +942,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -1129,7 +1129,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and
@@ -1227,7 +1227,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
@@ -230,8 +230,8 @@ spec:
                           managed-mode projection honours it (a single replica yields a
                           single-instance non-Galera MariaDB, three or more yield a Galera cluster),
                           so a constrained cluster such as a single-node kind can schedule the
-                          fresh-create path. Operators that adopt an existing MariaDB (keystone, and
-                          the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                          fresh-create path. Operators that adopt an existing MariaDB (the c5c3 adopted-infra path,
+                          and every service operator) ignore it. Only meaningful when ClusterRef is
                           set.
                         format: int32
                         minimum: 1
@@ -245,7 +245,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -261,7 +261,7 @@ spec:
                           MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
                           operator's managed-mode projection honours it (it is written to the owned
                           MariaDB's spec.storage.size); operators that adopt an existing MariaDB
-                          (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                          (the c5c3 adopted-infra path, and every service operator) ignore it. The default 100Gi
                           mirrors the production baseline (deploy/flux-system/infrastructure/
                           mariadb.yaml); a constrained cluster such as a single-node kind can pin a
                           far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
@@ -289,7 +289,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -309,7 +309,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -522,7 +522,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -798,7 +798,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and
@@ -878,7 +878,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -945,7 +945,7 @@ spec:
                                 description: |-
                                   Name is the referenced Secret's name. It must be a non-empty DNS-1123
                                   subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                                  fixes every consumer at once — keystone adminPasswordSecretRef /
+                                  fixes every consumer at once — a service operator adminPasswordSecretRef /
                                   database.secretRef / messaging / TLS cert refs and the c5c3
                                   passwordSecretRef — so an empty name no longer slips through "required".
                                 minLength: 1
@@ -1132,7 +1132,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and
@@ -1230,7 +1230,7 @@ spec:
                           repository:
                             description: |-
                               Repository is the OCI image repository, optionally including the registry
-                              host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                              host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                               permissive OCI reference — lowercase alphanumeric components separated by
                               ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                               are accepted while an empty string (which "required" alone admits) and

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -253,20 +253,27 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // setServicesStatus, and stamps status.observedGeneration so a stale status
 // is distinguishable from a current one.
 func (r *ControlPlaneReconciler) updateStatus(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, statusBefore *c5c3v1alpha1.ControlPlaneStatus, result ctrl.Result, reconcileErr error) (ctrl.Result, error) {
-	return commonreconcile.UpdateStatus(ctx, r.Client, cp, statusBefore, &cp.Status, func() {
-		setReadyCondition(cp)
+	return controlPlaneSkeleton.UpdateStatus(ctx, r.Client, cp, statusBefore, &cp.Status, func() {
 		setServicesStatus(cp)
 		cp.Status.ObservedGeneration = cp.Generation
 	}, result, reconcileErr)
 }
 
+// controlPlaneSkeleton bundles the shared controller-skeleton glue (Ready
+// aggregation and the no-op-skipping status write) with the ControlPlane's
+// sub-condition vocabulary and status accessor.
+var controlPlaneSkeleton = commonreconcile.Skeleton[*c5c3v1alpha1.ControlPlane, c5c3v1alpha1.ControlPlaneStatus]{
+	SubConditionTypes: subConditionTypes,
+	Conditions:        func(cp *c5c3v1alpha1.ControlPlane) *[]metav1.Condition { return &cp.Status.Conditions },
+}
+
 // setReadyCondition sets the aggregate Ready condition based on all
-// sub-conditions, delegating to the shared aggregation helper with the
-// ControlPlane sub-condition vocabulary. conditions.AllTrue checks only the
+// sub-conditions, delegating to the shared skeleton with the ControlPlane
+// sub-condition vocabulary. conditions.AllTrue checks only the
 // subConditionTypes, not the Ready condition itself, so this is not
 // self-referential.
 func setReadyCondition(cp *c5c3v1alpha1.ControlPlane) {
-	commonreconcile.SetAggregateReady(&cp.Status.Conditions, cp.Generation, subConditionTypes)
+	controlPlaneSkeleton.SetReady(cp)
 }
 
 // duplicateControlPlaneIncumbent returns the name of the ControlPlane that owns
@@ -308,22 +315,24 @@ func (r *ControlPlaneReconciler) duplicateControlPlaneIncumbent(ctx context.Cont
 // fully deleted — no watch event fires on the duplicate's behalf when that
 // happens.
 func (r *ControlPlaneReconciler) parkDuplicateControlPlane(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, incumbent string) (ctrl.Result, error) {
-	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: cp.Generation,
-		Reason:             "DuplicateControlPlane",
-		Message: fmt.Sprintf(
-			"parked: ControlPlane %q is older and owns namespace %q; only one ControlPlane is permitted per namespace",
-			incumbent, cp.Namespace,
-		),
-	})
-	cp.Status.ObservedGeneration = cp.Generation
-	if err := r.Status().Update(ctx, cp); err != nil {
-		log.FromContext(ctx).Error(err, "unable to update ControlPlane status")
-		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
-	}
-	return ctrl.Result{RequeueAfter: duplicateControlPlaneRequeueAfter}, nil
+	// Route through the shared status writer so a steady parked state skips the
+	// no-op write, but keep the deliberate no-re-aggregation semantics: the
+	// mutate hook sets ONLY the DuplicateControlPlane Ready condition (updateStatus
+	// would recompute Ready from the sub-conditions and overwrite this reason).
+	statusBefore := cp.Status.DeepCopy()
+	return commonreconcile.UpdateStatus(ctx, r.Client, cp, statusBefore, &cp.Status, func() {
+		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cp.Generation,
+			Reason:             "DuplicateControlPlane",
+			Message: fmt.Sprintf(
+				"parked: ControlPlane %q is older and owns namespace %q; only one ControlPlane is permitted per namespace",
+				incumbent, cp.Namespace,
+			),
+		})
+		cp.Status.ObservedGeneration = cp.Generation
+	}, ctrl.Result{RequeueAfter: duplicateControlPlaneRequeueAfter}, nil)
 }
 
 // keystoneServiceKey is the key under which status.services reports the

--- a/operators/c5c3/internal/controller/instrumentation.go
+++ b/operators/c5c3/internal/controller/instrumentation.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/c5c3/forge/internal/common/instrumentation"
 )
@@ -34,18 +35,22 @@ var subReconcilerConditionTypes = map[string]string{
 	"ServiceAccounts": conditionTypeServiceAccountsReady,
 }
 
-// subReconcilerMetrics holds the shared sub-reconciler instrumentation metrics
-// for the c5c3 operator (c5c3_operator_reconcile_duration_seconds and
-// c5c3_operator_reconcile_errors_total). The vectors register lazily on the
-// controller-runtime registry the first time a sample is recorded.
-var subReconcilerMetrics = instrumentation.NewMetrics("c5c3_operator")
-
 // instrumenter wraps every sub-reconciler call with the shared duration/error
-// instrumentation, recording through subReconcilerMetrics. It indirects
-// through a package-level var so unit tests can rebind it to an isolated
-// prometheus registry without polluting the controller-runtime production
-// registry. Production code MUST NOT reassign it.
-var instrumenter = instrumentation.NewInstrumenter(subReconcilerMetrics, subReconcilerConditionTypes)
+// instrumentation (c5c3_operator_reconcile_duration_seconds and
+// c5c3_operator_reconcile_errors_total). It owns its metric vectors, which
+// RegisterMetrics exposes on the controller-runtime registry at startup. The
+// var indirection lets unit tests rebind it to an isolated prometheus registry
+// without polluting the production registry; production code MUST NOT reassign
+// it.
+var instrumenter = instrumentation.NewSubReconcilerInstrumenter("c5c3_operator", subReconcilerConditionTypes)
+
+// RegisterMetrics exposes the operator's sub-reconciler duration/error vectors
+// on the controller-runtime registry, returning an error on a
+// duplicate-registration rather than panicking mid-reconcile so main.go can
+// fail startup cleanly. Call it exactly once during operator setup.
+func RegisterMetrics() error {
+	return instrumenter.Register(ctrlmetrics.Registry)
+}
 
 // instrumentSubReconciler wraps a sub-reconciler call, observing duration on
 // every path (success, error, panic) and recording an error count if fn

--- a/operators/c5c3/internal/controller/korc_eso.go
+++ b/operators/c5c3/internal/controller/korc_eso.go
@@ -12,8 +12,8 @@ import (
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/secrets"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
@@ -130,49 +130,44 @@ func adminAppCredentialPushSecret(cp *c5c3v1alpha1.ControlPlane) *esov1alpha1.Pu
 // the PushSecret immediately before calling this; ESO re-pushes on that metadata
 // change and retries the ExternalSecret until the property resolves.
 //
-// Dropping the bundle drops the entry on the next CreateOrUpdate (the Data slice is
-// rewritten, not merged), and the same stamp re-pushes a source Secret that no
-// longer carries the key.
+// Dropping the bundle drops the entry on the next apply (Server-Side Apply owns
+// spec.data, so re-applying the shorter list removes the cacert entry it no longer
+// declares), and the same stamp re-pushes a source Secret that no longer carries
+// the key.
 func (r *ControlPlaneReconciler) ensureKORCCloudsYAMLExternalSecret(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, caBundle string) error {
 	name := cp.Spec.KORC.AdminCredential.CloudCredentialsRef.SecretName
 	if name == "" {
 		name = korcCloudsYamlSecretName
+	}
+	data := []esov1.ExternalSecretData{{
+		SecretKey: appCredCloudsYAMLKey,
+		RemoteRef: esov1.ExternalSecretDataRemoteRef{
+			Key:      adminAppCredentialRemoteKeyFor(cp),
+			Property: appCredCloudsYAMLKey,
+		},
+	}}
+	if caBundle != "" {
+		data = append(data, esov1.ExternalSecretData{
+			SecretKey: korcCACertKey,
+			RemoteRef: esov1.ExternalSecretDataRemoteRef{
+				Key:      adminAppCredentialRemoteKeyFor(cp),
+				Property: korcCACertKey,
+			},
+		})
 	}
 	es := &esov1.ExternalSecret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: childNamespace(cp),
 		},
+		Spec: esov1.ExternalSecretSpec{
+			RefreshInterval: &metav1.Duration{Duration: time.Hour},
+			SecretStoreRef:  esov1.SecretStoreRef{Kind: "ClusterSecretStore", Name: openBaoClusterStoreName},
+			Target:          esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner},
+			Data:            data,
+		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, es, func() error {
-		es.Spec.RefreshInterval = &metav1.Duration{Duration: time.Hour}
-		es.Spec.SecretStoreRef = esov1.SecretStoreRef{
-			Kind: "ClusterSecretStore",
-			Name: openBaoClusterStoreName,
-		}
-		es.Spec.Target = esov1.ExternalSecretTarget{
-			Name:           name,
-			CreationPolicy: esov1.CreatePolicyOwner,
-		}
-		data := []esov1.ExternalSecretData{{
-			SecretKey: appCredCloudsYAMLKey,
-			RemoteRef: esov1.ExternalSecretDataRemoteRef{
-				Key:      adminAppCredentialRemoteKeyFor(cp),
-				Property: appCredCloudsYAMLKey,
-			},
-		}}
-		if caBundle != "" {
-			data = append(data, esov1.ExternalSecretData{
-				SecretKey: korcCACertKey,
-				RemoteRef: esov1.ExternalSecretDataRemoteRef{
-					Key:      adminAppCredentialRemoteKeyFor(cp),
-					Property: korcCACertKey,
-				},
-			})
-		}
-		es.Spec.Data = data
-		return controllerutil.SetControllerReference(cp, es, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, es, apply.FieldManager); err != nil {
 		return fmt.Errorf("ensuring k-orc clouds.yaml ExternalSecret %q: %w", es.Name, err)
 	}
 	return nil

--- a/operators/c5c3/internal/controller/korc_imports.go
+++ b/operators/c5c3/internal/controller/korc_imports.go
@@ -13,8 +13,8 @@ import (
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
 
@@ -135,8 +135,8 @@ func (i korcAdminImports) stalledImport(grace time.Duration) (string, bool) {
 // "Waiting for User/admin to be created". Both CRs are owned by the ControlPlane
 // for GC and reuse the admin clouds.yaml credentials.
 //
-// It returns both reconciled imports carrying live status (controllerutil.
-// CreateOrUpdate Gets first) so reconcileKORC can fold the stuck dependency into
+// It returns both reconciled imports carrying live status (Server-Side Apply
+// writes the server response back) so reconcileKORC can fold the stuck dependency into
 // the KORCReady message and, in External mode, classify its condition messages —
 // the documented failure class (wrong clouds.yaml endpoint, K-ORC swallowing list
 // errors, an import hanging on "created externally") otherwise surfaces only as an
@@ -144,35 +144,35 @@ func (i korcAdminImports) stalledImport(grace time.Duration) (string, bool) {
 func (r *ControlPlaneReconciler) ensureKORCAdminImports(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, credRef orcv1alpha1.CloudCredentialsReference) (korcAdminImports, error) {
 	domain := &orcv1alpha1.Domain{
 		ObjectMeta: metav1.ObjectMeta{Name: adminDomainRef(cp), Namespace: childNamespace(cp)},
+		Spec: orcv1alpha1.DomainSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			Import: &orcv1alpha1.DomainImport{
+				Filter: &orcv1alpha1.DomainFilter{Name: ptr.To(orcv1alpha1.KeystoneName(adminDomainName(cp)))},
+			},
+		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, domain, func() error {
-		domain.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		domain.Spec.CloudCredentialsRef = credRef
-		domain.Spec.Import = &orcv1alpha1.DomainImport{
-			Filter: &orcv1alpha1.DomainFilter{Name: ptr.To(orcv1alpha1.KeystoneName(adminDomainName(cp)))},
-		}
-		return controllerutil.SetControllerReference(cp, domain, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, domain, apply.FieldManager); err != nil {
 		return korcAdminImports{}, fmt.Errorf("admin Domain import %q: %w", domain.Name, err)
 	}
 
 	user := &orcv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{Name: adminUserRef(cp), Namespace: childNamespace(cp)},
-	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, user, func() error {
-		user.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		user.Spec.CloudCredentialsRef = credRef
-		// The filter name MUST be the same identity buildPasswordCloudsYAML renders
-		// as `username`: Keystone's default policy only lets a token mint an
-		// application credential for its own user, and this User is the AC's UserRef.
-		user.Spec.Import = &orcv1alpha1.UserImport{
-			Filter: &orcv1alpha1.UserFilter{
-				Name:      ptr.To(orcv1alpha1.OpenStackName(adminUserName(cp))),
-				DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(adminDomainRef(cp))),
+		Spec: orcv1alpha1.UserSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			// The filter name MUST be the same identity buildPasswordCloudsYAML renders
+			// as `username`: Keystone's default policy only lets a token mint an
+			// application credential for its own user, and this User is the AC's UserRef.
+			Import: &orcv1alpha1.UserImport{
+				Filter: &orcv1alpha1.UserFilter{
+					Name:      ptr.To(orcv1alpha1.OpenStackName(adminUserName(cp))),
+					DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(adminDomainRef(cp))),
+				},
 			},
-		}
-		return controllerutil.SetControllerReference(cp, user, r.Scheme)
-	}); err != nil {
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, user, apply.FieldManager); err != nil {
 		return korcAdminImports{}, fmt.Errorf("admin User import %q: %w", user.Name, err)
 	}
 

--- a/operators/c5c3/internal/controller/korc_secrets.go
+++ b/operators/c5c3/internal/controller/korc_secrets.go
@@ -59,7 +59,10 @@ func adminAppCredentialSecretName(cp *c5c3v1alpha1.ControlPlane) string {
 // `name` in childNamespace(cp), with cp set as the controller owner reference.
 // The Secret's Data map is guaranteed non-nil before `mutate` runs, so callers
 // only set the keys they own; `mutate` may return an error to abort the write
-// (e.g. when generating a random value fails). It centralises the four
+// (e.g. when generating a random value fails). It stays read-modify-write (not
+// Server-Side Apply) precisely because `mutate` reads the LIVE Secret's Data to
+// preserve generated-once random values across reconciles, which cannot be a
+// pure projection. It centralises the four
 // near-identical owned-Secret CreateOrUpdate wrappers (ensureAppCredentialSecret,
 // ensureAdminPasswordCloud, seedBootstrapCloudsYAML and
 // regenerateAppCredentialSecretValue); each keeps its own error wrapping so the

--- a/operators/c5c3/internal/controller/reconcile_adminpassword.go
+++ b/operators/c5c3/internal/controller/reconcile_adminpassword.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/secrets"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -188,14 +188,11 @@ func (r *ControlPlaneReconciler) reconcileAdminPassword(ctx context.Context, cp 
 		return ctrl.Result{RequeueAfter: adminPasswordRequeueAfter}, nil
 	}
 
-	// Managed mode: create-or-update the per-CP admin-password ExternalSecret,
-	// owner-referencing it to the ControlPlane so it is garbage-collected with the CR.
-	desired := adminPasswordExternalSecret(cp)
-	es := &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, es, func() error {
-		es.Spec = desired.Spec
-		return controllerutil.SetControllerReference(cp, es, r.Scheme)
-	}); err != nil {
+	// Managed mode: project the per-CP admin-password ExternalSecret via
+	// Server-Side Apply under the shared field manager, owner-referencing it to the
+	// ControlPlane so it is garbage-collected with the CR. The desired spec is a
+	// pure projection of cp.Spec.
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, adminPasswordExternalSecret(cp), apply.FieldManager); err != nil {
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeAdminPasswordReady,
 			Status:             metav1.ConditionFalse,

--- a/operators/c5c3/internal/controller/reconcile_catalog.go
+++ b/operators/c5c3/internal/controller/reconcile_catalog.go
@@ -12,9 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
@@ -79,55 +79,56 @@ func (r *ControlPlaneReconciler) reconcileCatalog(ctx context.Context, cp *c5c3v
 		return r.reconcileCatalogExternal(ctx, cp, credRef)
 	}
 
-	// 1. Identity (Keystone) Service.
+	// 1. Identity (Keystone) Service. The desired spec is a pure projection of
+	// cp.Spec, so it is applied via Server-Side Apply under the shared field
+	// manager rather than read-modify-write.
 	service := &orcv1alpha1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keystoneServiceName(cp),
 			Namespace: childNamespace(cp),
 		},
+		Spec: orcv1alpha1.ServiceSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyManaged,
+			CloudCredentialsRef: credRef,
+			Resource: &orcv1alpha1.ServiceResourceSpec{
+				Type:    "identity",
+				Name:    ptr.To(orcv1alpha1.OpenStackName("keystone")),
+				Enabled: ptr.To(true),
+			},
+		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
-		service.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
-		service.Spec.CloudCredentialsRef = credRef
-		if service.Spec.Resource == nil {
-			service.Spec.Resource = &orcv1alpha1.ServiceResourceSpec{}
-		}
-		service.Spec.Resource.Type = "identity"
-		service.Spec.Resource.Name = ptr.To(orcv1alpha1.OpenStackName("keystone"))
-		service.Spec.Resource.Enabled = ptr.To(true)
-		return controllerutil.SetControllerReference(cp, service, r.Scheme)
-	}); err != nil {
-		fail("ServiceError", fmt.Sprintf("create-or-update identity Service: %v", err))
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, service, apply.FieldManager); err != nil {
+		fail("ServiceError", fmt.Sprintf("applying identity Service: %v", err))
 		return ctrl.Result{}, err
 	}
 
 	// 2. Public Endpoint for the Keystone API.
+	//
+	// DECISION (Endpoint URL): K-ORC's EndpointResourceSpec.URL is REQUIRED.
+	// When the ControlPlane exposes Keystone externally (a gateway or explicit
+	// publicEndpoint is set) we register that public URL so the catalog matches
+	// what Keystone's own bootstrap advertises; otherwise we fall back to the
+	// in-cluster Keystone Service URL derived from the PROJECTED Keystone
+	// Service — keystoneName(cp) = "{cp.Name}-keystone" in the ControlPlane
+	// namespace — which is the Service the keystone-operator actually exposes.
 	endpoint := &orcv1alpha1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keystoneEndpointName(cp),
 			Namespace: childNamespace(cp),
 		},
+		Spec: orcv1alpha1.EndpointSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyManaged,
+			CloudCredentialsRef: credRef,
+			Resource: &orcv1alpha1.EndpointResourceSpec{
+				Interface:  "public",
+				URL:        keystoneCatalogURL(cp),
+				ServiceRef: orcv1alpha1.KubernetesNameRef(keystoneServiceName(cp)),
+				Enabled:    ptr.To(true),
+			},
+		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, endpoint, func() error {
-		endpoint.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
-		endpoint.Spec.CloudCredentialsRef = credRef
-		if endpoint.Spec.Resource == nil {
-			endpoint.Spec.Resource = &orcv1alpha1.EndpointResourceSpec{}
-		}
-		endpoint.Spec.Resource.Interface = "public"
-		// DECISION (Endpoint URL): K-ORC's EndpointResourceSpec.URL is REQUIRED.
-		// When the ControlPlane exposes Keystone externally (a gateway or explicit
-		// publicEndpoint is set) we register that public URL so the catalog matches
-		// what Keystone's own bootstrap advertises; otherwise we fall back to the
-		// in-cluster Keystone Service URL derived from the PROJECTED Keystone
-		// Service — keystoneName(cp) = "{cp.Name}-keystone" in the ControlPlane
-		// namespace — which is the Service the keystone-operator actually exposes.
-		endpoint.Spec.Resource.URL = keystoneCatalogURL(cp)
-		endpoint.Spec.Resource.ServiceRef = orcv1alpha1.KubernetesNameRef(keystoneServiceName(cp))
-		endpoint.Spec.Resource.Enabled = ptr.To(true)
-		return controllerutil.SetControllerReference(cp, endpoint, r.Scheme)
-	}); err != nil {
-		fail("EndpointError", fmt.Sprintf("create-or-update identity Endpoint: %v", err))
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, endpoint, apply.FieldManager); err != nil {
+		fail("EndpointError", fmt.Sprintf("applying identity Endpoint: %v", err))
 		return ctrl.Result{}, err
 	}
 

--- a/operators/c5c3/internal/controller/reconcile_catalog_external.go
+++ b/operators/c5c3/internal/controller/reconcile_catalog_external.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
@@ -473,20 +474,21 @@ func (r *ControlPlaneReconciler) ensureExternalCatalogImports(
 ) ([]catalogImport, error) {
 	ns := childNamespace(cp)
 
+	// The desired import spec is a pure projection of cp.Spec, so it is applied
+	// via Server-Side Apply under the shared field manager.
+	serviceFilter := &orcv1alpha1.ServiceFilter{Type: ptr.To(c5c3v1alpha1.IdentityCatalogServiceType)}
+	if name := externalIdentityServiceName(cp); name != "" {
+		serviceFilter.Name = ptr.To(orcv1alpha1.OpenStackName(name))
+	}
 	service := &orcv1alpha1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: keystoneServiceName(cp), Namespace: ns},
+		Spec: orcv1alpha1.ServiceSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			Import:              &orcv1alpha1.ServiceImport{Filter: serviceFilter},
+		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
-		service.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		service.Spec.CloudCredentialsRef = credRef
-		service.Spec.Resource = nil
-		filter := &orcv1alpha1.ServiceFilter{Type: ptr.To(c5c3v1alpha1.IdentityCatalogServiceType)}
-		if name := externalIdentityServiceName(cp); name != "" {
-			filter.Name = ptr.To(orcv1alpha1.OpenStackName(name))
-		}
-		service.Spec.Import = &orcv1alpha1.ServiceImport{Filter: filter}
-		return controllerutil.SetControllerReference(cp, service, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, service, apply.FieldManager); err != nil {
 		return nil, fmt.Errorf("identity Service import %q: %w", service.Name, err)
 	}
 
@@ -502,19 +504,18 @@ func (r *ControlPlaneReconciler) ensureExternalCatalogImports(
 	for _, iface := range externalCatalogInterfaces {
 		endpoint := &orcv1alpha1.Endpoint{
 			ObjectMeta: metav1.ObjectMeta{Name: keystoneEndpointImportName(cp, iface), Namespace: ns},
-		}
-		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, endpoint, func() error {
-			endpoint.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-			endpoint.Spec.CloudCredentialsRef = credRef
-			endpoint.Spec.Resource = nil
-			endpoint.Spec.Import = &orcv1alpha1.EndpointImport{
-				Filter: &orcv1alpha1.EndpointFilter{
-					Interface:  string(iface),
-					ServiceRef: ptr.To(orcv1alpha1.KubernetesNameRef(service.Name)),
+			Spec: orcv1alpha1.EndpointSpec{
+				ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+				CloudCredentialsRef: credRef,
+				Import: &orcv1alpha1.EndpointImport{
+					Filter: &orcv1alpha1.EndpointFilter{
+						Interface:  string(iface),
+						ServiceRef: ptr.To(orcv1alpha1.KubernetesNameRef(service.Name)),
+					},
 				},
-			}
-			return controllerutil.SetControllerReference(cp, endpoint, r.Scheme)
-		}); err != nil {
+			},
+		}
+		if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, endpoint, apply.FieldManager); err != nil {
 			return nil, fmt.Errorf("identity Endpoint import %q: %w", endpoint.Name, err)
 		}
 		imports = append(imports, catalogImport{
@@ -588,6 +589,12 @@ func (r *ControlPlaneReconciler) ensureManagedCatalogEntries(
 	ns := childNamespace(cp)
 
 	for _, entry := range externalManagedCatalogEntries(cp) {
+		// The managed catalog entries stay read-modify-write (not Server-Side Apply):
+		// they participate in a remove/re-add lifecycle where reconcileCatalogExternal
+		// gates CatalogReady on the LIVE Terminating CR returned by the write.
+		// CreateOrUpdate's no-op-on-identical-spec returns the still-Terminating object
+		// without a generation bump, which the deletion guard reads; re-applying a spec
+		// to a K-ORC-finalized Terminating entry is not a pure projection.
 		service := &orcv1alpha1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: catalogEntryServiceName(cp, entry.Type), Namespace: ns},
 		}
@@ -611,6 +618,8 @@ func (r *ControlPlaneReconciler) ensureManagedCatalogEntries(
 		reconciled = append(reconciled, managedCatalogEntry{kind: "Service", name: service.Name, obj: service})
 
 		for _, ep := range entry.Endpoints {
+			// Read-modify-write for the same remove/re-add deletion-race reason as the
+			// managed catalog entry Service above.
 			endpoint := &orcv1alpha1.Endpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      catalogEntryEndpointName(cp, entry.Type, ep.Interface),

--- a/operators/c5c3/internal/controller/reconcile_credentialrotation.go
+++ b/operators/c5c3/internal/controller/reconcile_credentialrotation.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	"github.com/c5c3/forge/internal/common/secrets"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 )
@@ -403,19 +404,17 @@ func (r *CredentialRotationReconciler) finish(
 	ctx context.Context, cr *c5c3v1alpha1.CredentialRotation, result ctrl.Result,
 	status metav1.ConditionStatus, reason, message string,
 ) (ctrl.Result, error) {
-	conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeRotationReady,
-		Status:             status,
-		ObservedGeneration: cr.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
-	cr.Status.ObservedGeneration = cr.Generation
-	if err := r.Status().Update(ctx, cr); err != nil {
-		log.FromContext(ctx).Error(err, "unable to update CredentialRotation status")
-		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
-	}
-	return result, nil
+	statusBefore := cr.Status.DeepCopy()
+	return commonreconcile.UpdateStatus(ctx, r.Client, cr, statusBefore, &cr.Status, func() {
+		conditions.SetCondition(&cr.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeRotationReady,
+			Status:             status,
+			ObservedGeneration: cr.Generation,
+			Reason:             reason,
+			Message:            message,
+		})
+		cr.Status.ObservedGeneration = cr.Generation
+	}, result, nil)
 }
 
 // SetupWithManager registers the CredentialRotationReconciler with the manager.

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/secrets"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -359,12 +360,7 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 		// Static opt-out: tear down any dynamic-mode objects left from a prior
 		// Dynamic deployment, then project the stage-(a) KV-backed ExternalSecret.
 		r.deleteDynamicDBCredentialObjects(ctx, cp)
-		desired := dbCredentialStaticExternalSecret(cp)
-		es := &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, es, func() error {
-			es.Spec = desired.Spec
-			return controllerutil.SetControllerReference(cp, es, r.Scheme)
-		}); err != nil {
+		if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, dbCredentialStaticExternalSecret(cp), apply.FieldManager); err != nil {
 			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 				Type:               conditionTypeDBCredentialsReady,
 				Status:             metav1.ConditionFalse,
@@ -388,13 +384,14 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 func (r *ControlPlaneReconciler) ensureDynamicDBCredentialObjects(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
 	server, mountPath := r.openBaoConnection(ctx)
 
-	sa := dbCredentialServiceAccount(cp)
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
-		return controllerutil.SetControllerReference(cp, sa, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, dbCredentialServiceAccount(cp), apply.FieldManager); err != nil {
 		return fmt.Errorf("ensuring DB credential ServiceAccount: %w", err)
 	}
 
+	// The cert-manager Certificate is handled as an unstructured object (no Go
+	// module ships its type), and apply.EnsureObject converts typed structs, not
+	// unstructured inputs — so this projection stays read-modify-write while the
+	// typed sibling objects around it use Server-Side Apply.
 	live := &unstructured.Unstructured{}
 	live.SetGroupVersionKind(certificateGVK)
 	live.SetName(dbCredentialClientCertName(cp))
@@ -406,21 +403,11 @@ func (r *ControlPlaneReconciler) ensureDynamicDBCredentialObjects(ctx context.Co
 		return fmt.Errorf("ensuring DB credential Certificate: %w", err)
 	}
 
-	vds := dbCredentialVaultDynamicSecret(cp, server, mountPath)
-	liveVDS := &esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{Name: vds.Name, Namespace: vds.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, liveVDS, func() error {
-		liveVDS.Spec = vds.Spec
-		return controllerutil.SetControllerReference(cp, liveVDS, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, dbCredentialVaultDynamicSecret(cp, server, mountPath), apply.FieldManager); err != nil {
 		return fmt.Errorf("ensuring VaultDynamicSecret generator: %w", err)
 	}
 
-	desired := dbCredentialGeneratorExternalSecret(cp)
-	es := &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, es, func() error {
-		es.Spec = desired.Spec
-		return controllerutil.SetControllerReference(cp, es, r.Scheme)
-	}); err != nil {
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, dbCredentialGeneratorExternalSecret(cp), apply.FieldManager); err != nil {
 		return fmt.Errorf("ensuring DB credential ExternalSecret: %w", err)
 	}
 	return nil

--- a/operators/c5c3/internal/controller/reconcile_horizon.go
+++ b/operators/c5c3/internal/controller/reconcile_horizon.go
@@ -12,11 +12,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
@@ -174,6 +174,13 @@ func (r *ControlPlaneReconciler) reconcileHorizon(ctx context.Context, cp *c5c3v
 		},
 	}
 
+	// This projection is deliberately read-modify-write (controllerutil.
+	// CreateOrUpdate) rather than the shared Server-Side Apply ProjectChild: the
+	// mutate closure READS the fetched child's spec.websso/spec.multiDomain and
+	// passes them to projectWebSSO/projectMultiDomain, which retain the current
+	// block while identity backends are attached but unhealthy. That retention
+	// cannot be expressed as a pure projection of cp.Spec, so this site keeps the
+	// read-modify-write client path.
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, horizon, func() error {
 		horizon.Spec.Image = image
 
@@ -458,21 +465,8 @@ func horizonKeystoneEndpoint(cp *c5c3v1alpha1.ControlPlane) string {
 // Service, ConfigMaps) behind it. Not-found and an externally-owned collision
 // are both treated as nothing to do.
 func (r *ControlPlaneReconciler) deleteOrphanedHorizon(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
-	key := client.ObjectKey{Name: horizonName(cp), Namespace: childNamespace(cp)}
-	horizon := &horizonv1alpha1.Horizon{}
-	if err := r.Get(ctx, key, horizon); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("getting Horizon %s for orphan cleanup: %w", key, err)
+	child := &horizonv1alpha1.Horizon{
+		ObjectMeta: metav1.ObjectMeta{Name: horizonName(cp), Namespace: childNamespace(cp)},
 	}
-	if !metav1.IsControlledBy(horizon, cp) {
-		// Not our child (externally managed with a colliding name) — leave it.
-		return nil
-	}
-	if err := r.Delete(ctx, horizon, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("deleting orphaned Horizon %s: %w", key, err)
-	}
-	log.FromContext(ctx).Info("Deleted orphaned Horizon child after services.horizon was unset", "horizon", key)
-	return nil
+	return commonreconcile.DeleteOrphanedChild(ctx, r.Client, cp, child)
 }

--- a/operators/c5c3/internal/controller/reconcile_infrastructure.go
+++ b/operators/c5c3/internal/controller/reconcile_infrastructure.go
@@ -232,6 +232,12 @@ func (r *ControlPlaneReconciler) reconcileInfrastructure(ctx context.Context, cp
 
 // ensureMariaDB create-or-updates the owned MariaDB CR named after
 // spec.infrastructure.database.clusterRef and reports whether it is Ready.
+//
+// It stays read-modify-write (not Server-Side Apply): the write is gated on the
+// LIVE object's owner references — an owned CR has its topology re-projected,
+// while an externally-provisioned CR sharing the name is adopted read-only and
+// never has ownership claimed. That adoption-vs-projection decision reads live
+// state, so it cannot be expressed as a pure projection of cp.Spec.
 func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (bool, error) {
 	key := types.NamespacedName{
 		Name:      cp.Spec.Infrastructure.Database.ClusterRef.Name,
@@ -319,6 +325,11 @@ func (r *ControlPlaneReconciler) ensureMariaDB(ctx context.Context, cp *c5c3v1al
 // spec.infrastructure.cache.clusterRef and reports whether it is Ready. The
 // Memcached CR is handled as an unstructured.Unstructured because
 // memcached.c5c3.io ships no Go module (see memcachedGVK).
+//
+// Like ensureMariaDB it stays read-modify-write: it reads the live object's
+// owner references to project only onto an owned CR and adopt an externally
+// provisioned one read-only (never claiming GC ownership), and it is
+// unstructured, which apply.EnsureObject's typed-struct path does not cover.
 func (r *ControlPlaneReconciler) ensureMemcached(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) (bool, error) {
 	key := types.NamespacedName{
 		Name:      cp.Spec.Infrastructure.Cache.ClusterRef.Name,

--- a/operators/c5c3/internal/controller/reconcile_keystone.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone.go
@@ -9,15 +9,13 @@ import (
 	"fmt"
 	"strconv"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/policy"
+	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -219,145 +217,99 @@ func (r *ControlPlaneReconciler) reconcileKeystone(ctx context.Context, cp *c5c3
 
 	merged := policy.MergePolicies(cp.Spec.GlobalPolicyOverrides, cp.Spec.Services.Keystone.PolicyOverrides)
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, keystone, func() error {
-		keystone.Spec.Image = image
+	// Build the fully-projected desired Keystone. The projection is a pure
+	// function of cp.Spec (it reads no live child state), so it is applied via
+	// the shared child projector under Server-Side Apply.
+	keystone.Spec.Image = image
 
-		// Project the federation proxy (mod_auth_openidc sidecar) image so
-		// attaching an OIDC KeystoneIdentityBackend works out of the box on the
-		// managed path, and the WebSSO origin of the ControlPlane's own
-		// dashboard so Keystone will accept the hand-off. Both fields are
-		// assigned unconditionally: clearing the override or the horizon block
-		// must revert the child rather than leave the previously-projected
-		// value pinned (the same lost-update reasoning as replicas). Both are
-		// inert until a federation backend attaches.
-		keystone.Spec.Federation = &keystonev1alpha1.FederationSpec{
-			ProxyImage:        federationProxyImage(cp),
-			TrustedDashboards: trustedDashboards(cp),
+	// Project the federation proxy (mod_auth_openidc sidecar) image so
+	// attaching an OIDC KeystoneIdentityBackend works out of the box on the
+	// managed path, and the WebSSO origin of the ControlPlane's own dashboard so
+	// Keystone will accept the hand-off. Both fields are assigned unconditionally:
+	// clearing the override or the horizon block must revert the child rather than
+	// leave the previously-projected value pinned. Both are inert until a
+	// federation backend attaches.
+	keystone.Spec.Federation = &keystonev1alpha1.FederationSpec{
+		ProxyImage:        federationProxyImage(cp),
+		TrustedDashboards: trustedDashboards(cp),
+	}
+
+	// Point Keystone at the SAME backing services the ControlPlane provisioned by
+	// reusing the infrastructure specs. DeepCopy (over a plain struct copy) is
+	// required because DatabaseSpec carries pointer fields (ClusterRef, TLS): a
+	// shallow copy would share those pointers with cp.Spec (#476).
+	keystone.Spec.Database = *cp.Spec.Infrastructure.Database.DeepCopy()
+
+	// in managed mode the operator OWNS the service DB credential —
+	// reconcileDBCredentials materialises it into a per-ControlPlane Secret named
+	// dbCredentialSecretName(cp). Override the projected Keystone CR's
+	// database.secretRef to that operator-owned Secret (key "password"). Brownfield
+	// (Database.ClusterRef == nil) leaves the user-supplied secretRef in place.
+	if cp.Spec.Infrastructure.Database.ClusterRef != nil {
+		keystone.Spec.Database.SecretRef = commonv1.SecretRefSpec{Name: dbCredentialSecretName(cp), Key: "password"}
+		// Project the EFFECTIVE credentials mode (Dynamic unless the CP opted into
+		// Static), matching reconcileDBCredentials' effective-mode decision.
+		if dbCredentialsDynamicEnabled(cp) {
+			keystone.Spec.Database.CredentialsMode = commonv1.CredentialsModeDynamic
+		} else {
+			keystone.Spec.Database.CredentialsMode = commonv1.CredentialsModeStatic
 		}
+	}
 
-		// Point Keystone at the SAME backing services the ControlPlane
-		// provisioned by reusing the infrastructure specs. DeepCopy (over a plain
-		// struct copy) is required because DatabaseSpec carries pointer fields
-		// (ClusterRef, TLS): a shallow copy would share those pointers with
-		// cp.Spec, so the SecretRef override below — or any later mutation of
-		// either spec — could alias the ControlPlane's own spec, exactly as the
-		// Gateway projection already guards against with DeepCopy (#476).
-		keystone.Spec.Database = *cp.Spec.Infrastructure.Database.DeepCopy()
+	// DeepCopy for the same reason as Database above (#476).
+	keystone.Spec.Cache = *cp.Spec.Infrastructure.Cache.DeepCopy()
 
-		// in managed mode the operator OWNS the service DB
-		// credential — reconcileDBCredentials materialises it into a per-ControlPlane
-		// Secret named dbCredentialSecretName(cp). Override the projected Keystone CR's
-		// database.secretRef to that operator-owned Secret (key "password") so Keystone
-		// consumes the scoped credential rather than the cp-level default name. This
-		// reassigns only the projected child's SecretRef value; cp.Spec is left
-		// untouched. Brownfield (Database.ClusterRef == nil) leaves the user-supplied
-		// secretRef in place — the user owns that Secret out-of-band.
-		if cp.Spec.Infrastructure.Database.ClusterRef != nil {
-			keystone.Spec.Database.SecretRef = commonv1.SecretRefSpec{Name: dbCredentialSecretName(cp), Key: "password"}
-			// Project the EFFECTIVE credentials mode (Dynamic unless the CP opted
-			// into Static) so the Keystone operator consumes the engine-issued
-			// credential, overriding its webhook's Static-when-empty default. This
-			// must match reconcileDBCredentials' effective-mode decision
-			// (dbCredentialsDynamicEnabled) or the projected Keystone would read a
-			// Secret shaped for the other mode.
-			if dbCredentialsDynamicEnabled(cp) {
-				keystone.Spec.Database.CredentialsMode = commonv1.CredentialsModeDynamic
-			} else {
-				keystone.Spec.Database.CredentialsMode = commonv1.CredentialsModeStatic
-			}
-		}
+	// in managed mode the operator OWNS the admin password —
+	// reconcileAdminPassword projects it from OpenBao into a per-ControlPlane
+	// Secret named adminPasswordSecretName(cp). Brownfield leaves the
+	// user-supplied ref in place.
+	keystone.Spec.Bootstrap.AdminPasswordSecretRef = effectiveAdminPasswordSecretRef(cp)
+	keystone.Spec.Bootstrap.Region = cp.Spec.Region
 
-		// DeepCopy for the same reason as Database above: CacheSpec carries a
-		// pointer ClusterRef and a Servers slice, so a shallow copy would alias
-		// cp.Spec (#476).
-		keystone.Spec.Cache = *cp.Spec.Infrastructure.Cache.DeepCopy()
+	// Project external exposure onto the Keystone CR's spec.gateway, then advertise
+	// the externally routable URL via the bootstrap public endpoint. DeepCopy keeps
+	// the projected gateway an independent object; a nil source yields nil,
+	// clearing any previously-projected gateway.
+	keystone.Spec.Gateway = cp.Spec.Services.Keystone.Gateway.DeepCopy()
+	keystone.Spec.Bootstrap.PublicEndpoint = keystonePublicEndpoint(cp.Spec.Services.Keystone)
 
-		// in managed mode the operator OWNS the admin password —
-		// reconcileAdminPassword projects it from OpenBao into a per-ControlPlane
-		// Secret named adminPasswordSecretName(cp). Point the projected Keystone CR's
-		// bootstrap admin-password ref (via effectiveAdminPasswordSecretRef) at that
-		// operator-owned Secret (key "password") so Keystone consumes the scoped
-		// credential rather than the cp-level default name. This reassigns only the
-		// projected child's ref value; cp.Spec is left untouched. Brownfield
-		// (Database.ClusterRef == nil) leaves the user-supplied ref in place — the
-		// user owns that Secret out-of-band.
-		keystone.Spec.Bootstrap.AdminPasswordSecretRef = effectiveAdminPasswordSecretRef(cp)
-		keystone.Spec.Bootstrap.Region = cp.Spec.Region
+	if cp.Spec.Services.Keystone.Replicas != nil {
+		keystone.Spec.Deployment.Replicas = *cp.Spec.Services.Keystone.Replicas
+	}
 
-		// Project external exposure onto the Keystone CR's spec.gateway, then
-		// advertise the externally routable URL via the bootstrap public endpoint.
-		//
-		// DECISION both sides are now commonv1.GatewaySpec, so the L2
-		// mapping is a single DeepCopy instead of a field-by-field copy. DeepCopy
-		// (over a direct pointer share) keeps the projected Keystone CR's gateway an
-		// independent object, so a later mutation of either spec can never alias the
-		// other. A nil source yields nil (DeepCopy handles a nil receiver), clearing
-		// any previously-projected gateway so removal tears the HTTPRoute down and
-		// Keystone falls back to its in-cluster DNS.
-		keystone.Spec.Gateway = cp.Spec.Services.Keystone.Gateway.DeepCopy()
-		keystone.Spec.Bootstrap.PublicEndpoint = keystonePublicEndpoint(cp.Spec.Services.Keystone)
+	keystone.Spec.PolicyOverrides = merged
 
-		if cp.Spec.Services.Keystone.Replicas != nil {
-			keystone.Spec.Deployment.Replicas = *cp.Spec.Services.Keystone.Replicas
-		}
+	if rotationSchedule != "" {
+		keystone.Spec.Fernet.RotationSchedule = rotationSchedule
+		keystone.Spec.CredentialKeys.RotationSchedule = rotationSchedule
+	}
 
-		keystone.Spec.PolicyOverrides = merged
-
-		if rotationSchedule != "" {
-			keystone.Spec.Fernet.RotationSchedule = rotationSchedule
-			keystone.Spec.CredentialKeys.RotationSchedule = rotationSchedule
-		}
-
-		return controllerutil.SetControllerReference(cp, keystone, r.Scheme)
-	}); err != nil {
-		reason := "KeystoneError"
-		message := fmt.Sprintf("create-or-update Keystone: %v", err)
-		// An Invalid (HTTP 422) rejection from the Keystone API server is almost
-		// always a now-immutable db/bootstrap field whose CEL transition rule
-		// (self == oldSelf) refuses the projected change — e.g. a spec.region or
-		// spec.database.database edit that landed on the ControlPlane before its
-		// own immutability webhook existed, leaving it diverged from the already-
-		// frozen Keystone child (#466). validateImmutable cannot catch that
-		// pre-webhook edit, so this projection loops forever with no self-heal.
-		// Surface a distinct, actionable reason so the wedge is diagnosable from
-		// the condition instead of being buried under a generic KeystoneError.
-		if apierrors.IsInvalid(err) {
-			reason = "KeystoneProjectionRejected"
-			message = fmt.Sprintf("Keystone API server rejected the projected spec (likely an immutable db/bootstrap field "+
+	return commonreconcile.ProjectChild(ctx, r.Client, r.Scheme, cp, commonreconcile.ChildProjectionParams[*keystonev1alpha1.Keystone]{
+		Child:         keystone,
+		ConditionType: conditionTypeKeystoneReady,
+		ReadyReason:   "KeystoneReady",
+		ReadyMessage:  "Projected Keystone CR is ready",
+		WaitingReason: "WaitingForKeystone",
+		// keystone.Name is set from keystoneName(cp) above.
+		WaitingMessage: fmt.Sprintf("Keystone %q is not ready", keystone.Name),
+		// An Invalid (HTTP 422) rejection is almost always a now-immutable
+		// db/bootstrap field whose CEL transition rule refuses the projected change
+		// — e.g. a spec.region edit that landed on the ControlPlane before its own
+		// immutability webhook existed, leaving it diverged from the frozen child
+		// (#466). Surface a distinct, actionable reason so the wedge is diagnosable.
+		RejectedReason: "KeystoneProjectionRejected",
+		RejectedMessage: func(err error) string {
+			return fmt.Sprintf("Keystone API server rejected the projected spec (likely an immutable db/bootstrap field "+
 				"diverged from the frozen Keystone child); reconcile the ControlPlane spec back to the child's values or "+
 				"recreate the Keystone child to recover: %v", err)
-		}
-		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKeystoneReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: cp.Generation,
-			Reason:             reason,
-			Message:            message,
-		})
-		return ctrl.Result{}, err
-	}
-
-	// Mirror the child's Ready condition into KeystoneReady.
-	if !conditions.IsReady(keystone.Status.Conditions) {
-		logger.Info("Keystone CR not ready, requeuing", "keystone", keystone.Name)
-		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKeystoneReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: cp.Generation,
-			Reason:             "WaitingForKeystone",
-			Message:            fmt.Sprintf("Keystone %q is not ready", keystone.Name),
-		})
-		return ctrl.Result{RequeueAfter: infraRequeueAfter}, nil
-	}
-
-	conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeKeystoneReady,
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: cp.Generation,
-		Reason:             "KeystoneReady",
-		Message:            "Projected Keystone CR is ready",
+		},
+		ErrorReason:     "KeystoneError",
+		ErrorMessage:    func(err error) string { return fmt.Sprintf("create-or-update Keystone: %v", err) },
+		WaitRequeue:     infraRequeueAfter,
+		Conditions:      &cp.Status.Conditions,
+		Generation:      cp.Generation,
+		ChildConditions: func(k *keystonev1alpha1.Keystone) []metav1.Condition { return k.Status.Conditions },
 	})
-	return ctrl.Result{}, nil
 }
 
 // federationProxyImage resolves the mod_auth_openidc sidecar image projected
@@ -423,21 +375,8 @@ func keystonePublicEndpoint(ks *c5c3v1alpha1.ServiceKeystoneSpec) string {
 // children (Deployment, Jobs, Secrets) behind it. Not-found and an
 // externally-owned collision are both treated as nothing to do.
 func (r *ControlPlaneReconciler) deleteOrphanedKeystone(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
-	key := client.ObjectKey{Name: keystoneName(cp), Namespace: childNamespace(cp)}
-	keystone := &keystonev1alpha1.Keystone{}
-	if err := r.Get(ctx, key, keystone); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("getting Keystone %s for orphan cleanup: %w", key, err)
+	child := &keystonev1alpha1.Keystone{
+		ObjectMeta: metav1.ObjectMeta{Name: keystoneName(cp), Namespace: childNamespace(cp)},
 	}
-	if !metav1.IsControlledBy(keystone, cp) {
-		// Not our child (externally managed with a colliding name) — leave it.
-		return nil
-	}
-	if err := r.Delete(ctx, keystone, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("deleting orphaned Keystone %s: %w", key, err)
-	}
-	log.FromContext(ctx).Info("Deleted orphaned Keystone child after services.keystone was unset", "keystone", key)
-	return nil
+	return commonreconcile.DeleteOrphanedChild(ctx, r.Client, cp, child)
 }

--- a/operators/c5c3/internal/controller/reconcile_keystone_test.go
+++ b/operators/c5c3/internal/controller/reconcile_keystone_test.go
@@ -540,8 +540,8 @@ func TestReconcileKeystone_InvalidRejectionSurfacesDistinctReason(t *testing.T) 
 	cp := keystoneControlPlane()
 
 	// A pre-existing Keystone child whose region differs from the ControlPlane's,
-	// so CreateOrUpdate finds it and takes the UPDATE path (which the interceptor
-	// rejects, standing in for the CEL immutability transition rule).
+	// so the SSA apply is rejected by the interceptor, standing in for the CEL
+	// immutability transition rule.
 	existing := &keystonev1alpha1.Keystone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keystoneName(cp),
@@ -561,7 +561,7 @@ func TestReconcileKeystone_InvalidRejectionSurfacesDistinctReason(t *testing.T) 
 	)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, existing).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+			Apply: func(context.Context, client.WithWatch, runtime.ApplyConfiguration, ...client.ApplyOption) error {
 				return invalidErr
 			},
 		}).Build()

--- a/operators/c5c3/internal/controller/reconcile_korc.go
+++ b/operators/c5c3/internal/controller/reconcile_korc.go
@@ -308,6 +308,10 @@ func (r *ControlPlaneReconciler) reconcileKORC(ctx context.Context, cp *c5c3v1al
 		},
 	}
 
+	// This projection stays read-modify-write (not Server-Side Apply): the mutate
+	// closure reads the LIVE AC's annotations via shouldStampPasswordHash to
+	// preserve the CredentialRotation reconciler's re-mint nudge marker, which
+	// cannot be expressed as a pure projection of cp.Spec.
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, ac, func() error {
 		ac.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
 		ac.Spec.CloudCredentialsRef = acCredRef

--- a/operators/c5c3/internal/controller/reconcile_korc_test.go
+++ b/operators/c5c3/internal/controller/reconcile_korc_test.go
@@ -1886,7 +1886,10 @@ func TestReconcileCatalog_Idempotent(t *testing.T) {
 		Name: keystoneEndpointName(cp), Namespace: childNamespace(cp),
 	}, ep1)).To(Succeed())
 
-	// Second reconcile must not churn either CR.
+	// Second reconcile must project a byte-identical spec (idempotent projection).
+	// The fake client bumps ResourceVersion on a no-op Server-Side Apply — a
+	// limitation a real apiserver does not share, where an unchanged apply is a true
+	// no-op — so spec stability is asserted rather than ResourceVersion equality.
 	_, err = r.reconcileCatalog(context.Background(), cp)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -1899,8 +1902,8 @@ func TestReconcileCatalog_Idempotent(t *testing.T) {
 		Name: keystoneEndpointName(cp), Namespace: childNamespace(cp),
 	}, ep2)).To(Succeed())
 
-	g.Expect(svc2.ResourceVersion).To(Equal(svc1.ResourceVersion), "Service must not churn on re-reconcile")
-	g.Expect(ep2.ResourceVersion).To(Equal(ep1.ResourceVersion), "Endpoint must not churn on re-reconcile")
+	g.Expect(svc2.Spec).To(Equal(svc1.Spec), "Service projection must be idempotent")
+	g.Expect(ep2.Spec).To(Equal(ep1.Spec), "Endpoint projection must be idempotent")
 }
 
 // HARD CRD DEPENDENCY: as for reconcileKORC, the catalog sub-reconciler's
@@ -1915,11 +1918,12 @@ func TestReconcileCatalog_MissingCRDReturnsError(t *testing.T) {
 	setAdminCredentialReady(cp)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if _, ok := obj.(*orcv1alpha1.Service); ok {
-					return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "openstack.k-orc.cloud", Kind: "Service"}}
-				}
-				return c.Get(ctx, key, obj, opts...)
+			// Under Server-Side Apply reconcileCatalog writes the Service via Apply (no
+			// Get first), so a missing CRD surfaces on the Apply. The Service is applied
+			// before the Endpoint, so failing every Apply reproduces the no-match error
+			// on the Service and its ServiceError condition.
+			Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "openstack.k-orc.cloud", Kind: "Service"}}
 			},
 		}).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
@@ -2530,7 +2534,9 @@ func TestEnsureKORCCloudsYAMLExternalSecret_PerCRRemoteKeyForNonDefaultName(t *t
 }
 
 // TestEnsureKORCCloudsYAMLExternalSecret_IdempotentNoChurn asserts a second pass over
-// an unchanged spec does not bump the ExternalSecret's ResourceVersion.
+// an unchanged spec projects a byte-identical ExternalSecret spec. The fake client
+// bumps ResourceVersion on a no-op Server-Side Apply — unlike a real apiserver — so
+// spec stability is asserted rather than ResourceVersion equality.
 func TestEnsureKORCCloudsYAMLExternalSecret_IdempotentNoChurn(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -2548,8 +2554,8 @@ func TestEnsureKORCCloudsYAMLExternalSecret_IdempotentNoChurn(t *testing.T) {
 	second := &esov1.ExternalSecret{}
 	g.Expect(c.Get(context.Background(), esKey, second)).To(Succeed())
 
-	g.Expect(second.ResourceVersion).To(Equal(first.ResourceVersion),
-		"an unchanged ExternalSecret spec must not churn on re-reconcile")
+	g.Expect(second.Spec).To(Equal(first.Spec),
+		"an unchanged ExternalSecret spec must project identically on re-reconcile")
 }
 
 // --- reconcileKORC edge cases around the seed steps ---
@@ -3168,6 +3174,15 @@ func recordPushAndESWrites(writes *[]string) interceptor.Funcs {
 				*writes = append(*writes, "external-secret")
 			}
 			return cl.Update(ctx, obj, opts...)
+		},
+		// The clouds.yaml ExternalSecret is now written via Server-Side Apply, so the
+		// read-back write lands here rather than on Create/Update.
+		Apply: func(ctx context.Context, cl client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+			if o, ok := obj.(interface{ GetObjectKind() schema.ObjectKind }); ok &&
+				o.GetObjectKind().GroupVersionKind().Kind == "ExternalSecret" {
+				*writes = append(*writes, "external-secret")
+			}
+			return cl.Apply(ctx, obj, opts...)
 		},
 	}
 }

--- a/operators/c5c3/internal/controller/reconcile_serviceaccounts.go
+++ b/operators/c5c3/internal/controller/reconcile_serviceaccounts.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/secrets"
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
@@ -474,15 +475,17 @@ func (r *ControlPlaneReconciler) ensureServiceAccountDomain(
 	if name == adminDomainRef(cp) {
 		return name, nil
 	}
-	domain := &orcv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, domain, func() error {
-		domain.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		domain.Spec.CloudCredentialsRef = credRef
-		domain.Spec.Import = &orcv1alpha1.DomainImport{
-			Filter: &orcv1alpha1.DomainFilter{Name: ptr.To(orcv1alpha1.KeystoneName(serviceAccountDomainName(cp, sa)))},
-		}
-		return controllerutil.SetControllerReference(cp, domain, r.Scheme)
-	}); err != nil {
+	domain := &orcv1alpha1.Domain{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)},
+		Spec: orcv1alpha1.DomainSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			Import: &orcv1alpha1.DomainImport{
+				Filter: &orcv1alpha1.DomainFilter{Name: ptr.To(orcv1alpha1.KeystoneName(serviceAccountDomainName(cp, sa)))},
+			},
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, domain, apply.FieldManager); err != nil {
 		return "", fmt.Errorf("service-account Domain import %q: %w", name, err)
 	}
 	return name, nil
@@ -500,19 +503,20 @@ func (r *ControlPlaneReconciler) ensureServiceAccountProject(
 	name := serviceAccountProjectRef(cp, sa)
 
 	if !sa.Project.Create {
-		project := &orcv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
-		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, project, func() error {
-			project.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-			project.Spec.Resource = nil
-			project.Spec.CloudCredentialsRef = credRef
-			project.Spec.Import = &orcv1alpha1.ProjectImport{
-				Filter: &orcv1alpha1.ProjectFilter{
-					Name:      ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name)),
-					DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+		project := &orcv1alpha1.Project{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: orcv1alpha1.ProjectSpec{
+				ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+				CloudCredentialsRef: credRef,
+				Import: &orcv1alpha1.ProjectImport{
+					Filter: &orcv1alpha1.ProjectFilter{
+						Name:      ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name)),
+						DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+					},
 				},
-			}
-			return controllerutil.SetControllerReference(cp, project, r.Scheme)
-		}); err != nil {
+			},
+		}
+		if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, project, apply.FieldManager); err != nil {
 			return nil, false, fmt.Errorf("service-account referenced Project import %q: %w", name, err)
 		}
 		return project, korcAvailableUpToDate(project), nil
@@ -555,18 +559,18 @@ func (r *ControlPlaneReconciler) ensureServiceAccountProject(
 		return nil, false, fmt.Errorf("reading managed Project %q: %w", name, err)
 	}
 
-	project := &orcv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, project, func() error {
-		project.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
-		project.Spec.Import = nil
-		project.Spec.CloudCredentialsRef = managedCredRef
-		if project.Spec.Resource == nil {
-			project.Spec.Resource = &orcv1alpha1.ProjectResourceSpec{}
-		}
-		project.Spec.Resource.Name = ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name))
-		project.Spec.Resource.DomainRef = ptr.To(orcv1alpha1.KubernetesNameRef(domainRef))
-		return controllerutil.SetControllerReference(cp, project, r.Scheme)
-	}); err != nil {
+	project := &orcv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: orcv1alpha1.ProjectSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyManaged,
+			CloudCredentialsRef: managedCredRef,
+			Resource: &orcv1alpha1.ProjectResourceSpec{
+				Name:      ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name)),
+				DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+			},
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, project, apply.FieldManager); err != nil {
 		return nil, false, fmt.Errorf("service-account managed Project %q: %w", name, err)
 	}
 	return project, korcAvailableUpToDate(project), nil
@@ -651,19 +655,20 @@ func (r *ControlPlaneReconciler) serviceAccountUserProbe(
 	ctx context.Context, cp *c5c3v1alpha1.ControlPlane, sa c5c3v1alpha1.ServiceAccountSpec,
 	credRef orcv1alpha1.CloudCredentialsReference, userName, domainRef string,
 ) (probeVerdict, *orcv1alpha1.User, error) {
-	probe := &orcv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountUserProbeRef(cp, sa), Namespace: childNamespace(cp)}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, probe, func() error {
-		probe.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		probe.Spec.Resource = nil
-		probe.Spec.CloudCredentialsRef = credRef
-		probe.Spec.Import = &orcv1alpha1.UserImport{
-			Filter: &orcv1alpha1.UserFilter{
-				Name:      ptr.To(orcv1alpha1.OpenStackName(userName)),
-				DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+	probe := &orcv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceAccountUserProbeRef(cp, sa), Namespace: childNamespace(cp)},
+		Spec: orcv1alpha1.UserSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			Import: &orcv1alpha1.UserImport{
+				Filter: &orcv1alpha1.UserFilter{
+					Name:      ptr.To(orcv1alpha1.OpenStackName(userName)),
+					DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+				},
 			},
-		}
-		return controllerutil.SetControllerReference(cp, probe, r.Scheme)
-	}); err != nil {
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, probe, apply.FieldManager); err != nil {
 		return probePending, nil, fmt.Errorf("service-account User probe %q: %w", probe.Name, err)
 	}
 	return interpretProbe(probe), probe, nil
@@ -675,19 +680,20 @@ func (r *ControlPlaneReconciler) serviceAccountProjectProbe(
 	ctx context.Context, cp *c5c3v1alpha1.ControlPlane, sa c5c3v1alpha1.ServiceAccountSpec,
 	credRef orcv1alpha1.CloudCredentialsReference, domainRef string,
 ) (probeVerdict, *orcv1alpha1.Project, error) {
-	probe := &orcv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountProjectProbeRef(cp, sa), Namespace: childNamespace(cp)}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, probe, func() error {
-		probe.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyUnmanaged
-		probe.Spec.Resource = nil
-		probe.Spec.CloudCredentialsRef = credRef
-		probe.Spec.Import = &orcv1alpha1.ProjectImport{
-			Filter: &orcv1alpha1.ProjectFilter{
-				Name:      ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name)),
-				DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+	probe := &orcv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceAccountProjectProbeRef(cp, sa), Namespace: childNamespace(cp)},
+		Spec: orcv1alpha1.ProjectSpec{
+			ManagementPolicy:    orcv1alpha1.ManagementPolicyUnmanaged,
+			CloudCredentialsRef: credRef,
+			Import: &orcv1alpha1.ProjectImport{
+				Filter: &orcv1alpha1.ProjectFilter{
+					Name:      ptr.To(orcv1alpha1.KeystoneName(sa.Project.Name)),
+					DomainRef: ptr.To(orcv1alpha1.KubernetesNameRef(domainRef)),
+				},
 			},
-		}
-		return controllerutil.SetControllerReference(cp, probe, r.Scheme)
-	}); err != nil {
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, probe, apply.FieldManager); err != nil {
 		return probePending, nil, fmt.Errorf("service-account Project probe %q: %w", probe.Name, err)
 	}
 	return interpretProbe(probe), probe, nil
@@ -742,6 +748,10 @@ func (r *ControlPlaneReconciler) ensureServiceAccountUser(
 	}
 	passwordRefName := serviceAccountPasswordSecretName(cp, sa, desiredGen)
 
+	// This projection stays read-modify-write (not Server-Side Apply): the mutate
+	// closure reads the LIVE User's CreationTimestamp and existing
+	// serviceAccountPasswordGenerationAnnotation to decide whether to (re-)stamp the
+	// generation, which cannot be expressed as a pure projection of cp.Spec.
 	user := &orcv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, user, func() error {
 		user.Spec.ManagementPolicy = orcv1alpha1.ManagementPolicyManaged
@@ -933,23 +943,25 @@ func (r *ControlPlaneReconciler) ensureServiceAccountExternalSecret(
 ) error {
 	name := serviceAccountCredentialsSecretName(cp, sa)
 	remoteKey := serviceAccountRemoteKeyFor(cp, sa.Name)
-	es := &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, es, func() error {
-		es.Spec.RefreshInterval = &metav1.Duration{Duration: time.Hour}
-		es.Spec.SecretStoreRef = esov1.SecretStoreRef{Kind: "ClusterSecretStore", Name: openBaoClusterStoreName}
-		es.Spec.Target = esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner}
-		es.Spec.Data = []esov1.ExternalSecretData{
-			{
-				SecretKey: serviceAccountPasswordKey,
-				RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: serviceAccountPasswordKey},
+	es := &esov1.ExternalSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: childNamespace(cp)},
+		Spec: esov1.ExternalSecretSpec{
+			RefreshInterval: &metav1.Duration{Duration: time.Hour},
+			SecretStoreRef:  esov1.SecretStoreRef{Kind: "ClusterSecretStore", Name: openBaoClusterStoreName},
+			Target:          esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner},
+			Data: []esov1.ExternalSecretData{
+				{
+					SecretKey: serviceAccountPasswordKey,
+					RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: serviceAccountPasswordKey},
+				},
+				{
+					SecretKey: appCredCloudsYAMLKey,
+					RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: appCredCloudsYAMLKey},
+				},
 			},
-			{
-				SecretKey: appCredCloudsYAMLKey,
-				RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: appCredCloudsYAMLKey},
-			},
-		}
-		return controllerutil.SetControllerReference(cp, es, r.Scheme)
-	}); err != nil {
+		},
+	}
+	if err := apply.EnsureObject(ctx, r.Client, r.Scheme, cp, es, apply.FieldManager); err != nil {
 		return fmt.Errorf("ensuring service-account ExternalSecret %q: %w", name, err)
 	}
 	return nil

--- a/operators/c5c3/main.go
+++ b/operators/c5c3/main.go
@@ -69,6 +69,13 @@ func main() {
 		Scheme:           scheme,
 		LeaderElectionID: leaderElectionID,
 		SetupFunc: func(mgr ctrl.Manager, webhooks bool, maxConcurrentReconciles int) error {
+			// Register the operator's Prometheus collectors on the
+			// controller-runtime registry before wiring controllers, so a
+			// duplicate-registration fails startup cleanly instead of panicking
+			// mid-reconcile.
+			if err := controller.RegisterMetrics(); err != nil {
+				return err
+			}
 			// +kubebuilder:scaffold:builder — register controllers here
 			if err := (&controller.ControlPlaneReconciler{
 				Client:                  mgr.GetClient(),

--- a/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
@@ -158,7 +158,7 @@ spec:
                       lifecycle hook, configured independently of the overall grace period
                       This covers the window between EndpointSlice removal and
                       kube-proxy/ingress-controller propagation so new requests stop arriving
-                      before SIGTERM reaches uWSGI. When nil, the reconciler applies a default
+                      before SIGTERM reaches the API process. When nil, the reconciler applies a default
                       of 5s. Zero is permitted to disable the sleep. The cross-field rule
                       preStopSleepSeconds < terminationGracePeriodSeconds is enforced by the
                       validating webhook to guarantee a non-zero drain window.
@@ -167,20 +167,20 @@ spec:
                     type: integer
                   priorityClassName:
                     description: |-
-                      PriorityClassName sets the priority class for Keystone API pods.
+                      PriorityClassName sets the priority class for service API pods.
                       When set, the operator passes the value through to the PodSpec, allowing
                       cluster administrators to control scheduling priority and preemption.
                       When unset, no priority class is configured and the cluster default applies.
                     type: string
                   replicas:
                     default: 3
-                    description: Replicas is the desired number of Keystone API pods.
+                    description: Replicas is the desired number of service API pods.
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
                     description: |-
-                      Resources defines the CPU and memory requests and limits for the Keystone API
+                      Resources defines the CPU and memory requests and limits for the service API
                       container. When unset, the defaulting webhook injects sensible defaults
                       (256Mi/512Mi memory, 100m/500m CPU) to ensure Burstable QoS class and
                       enable HPA utilization calculations.
@@ -243,7 +243,7 @@ spec:
                     type: object
                   strategy:
                     description: |-
-                      Strategy overrides the Deployment rollout strategy for the Keystone API
+                      Strategy overrides the Deployment rollout strategy for the service API
                       Deployment. When nil, the reconciler applies RollingUpdate
                       with MaxUnavailable=0 and MaxSurge=1 to guarantee surge-before-remove
                       behavior — available capacity never dips below spec.deployment.replicas
@@ -297,9 +297,9 @@ spec:
                   terminationGracePeriodSeconds:
                     description: |-
                       TerminationGracePeriodSeconds is the grace period (seconds) granted to
-                      Keystone API pods between SIGTERM and SIGKILL during rolling updates
+                      service API pods between SIGTERM and SIGKILL during rolling updates
                       Extend this to cover slow upstream token validation (LDAP/DB)
-                      so in-flight requests finish before the kubelet forcibly kills uWSGI.
+                      so in-flight requests finish before the kubelet forcibly kills the API process.
                       When nil, the reconciler omits the field from the pod template and the
                       Kubernetes default of 30s applies. Must be at least 10s when set.
                     format: int64
@@ -576,7 +576,7 @@ spec:
                   repository:
                     description: |-
                       Repository is the OCI image repository, optionally including the registry
-                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                       permissive OCI reference — lowercase alphanumeric components separated by
                       ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                       are accepted while an empty string (which "required" alone admits) and
@@ -652,7 +652,7 @@ spec:
                     description: |-
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
-                      {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
+                      {"sqlalchemy.engine": "WARNING", "myservice.middleware": "DEBUG"}.
                       Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
                       logger name must be non-empty. These are now enforced by the CRD CEL
                       XValidation rules below as well as by the validating webhook (a plain
@@ -932,19 +932,19 @@ spec:
                     type: array
                   ingress:
                     description: |-
-                      Ingress defines the sources allowed to reach Keystone API on TCP 5000.
+                      Ingress defines the sources allowed to reach the service API on its API port.
                       Each source specifies a namespace selector and an optional pod selector.
                       Multiple sources produce multiple From peers in a single ingress rule
                       (OR across peers, AND within a peer's selectors).
                     items:
                       description: |-
                         NetworkPolicyIngressSource defines a source from which traffic is allowed
-                        to reach the Keystone API pods on TCP 5000.
+                        to reach the service API pods on the API port.
                       properties:
                         namespaceSelector:
                           description: |-
                             NamespaceSelector selects namespaces from which traffic is allowed.
-                            All pods in matching namespaces can reach Keystone on port 5000
+                            All pods in matching namespaces can reach the service on its API port
                             unless PodSelector further restricts the set. It is a full
                             metav1.LabelSelector, so set-based matchExpressions are supported in
                             addition to matchLabels.
@@ -996,7 +996,7 @@ spec:
                           description: |-
                             PodSelector optionally restricts allowed traffic to pods matching
                             these labels within the selected namespaces. When set, only pods
-                            matching both NamespaceSelector AND PodSelector can reach Keystone
+                            matching both NamespaceSelector AND PodSelector can reach the service
                             (AND logic within a single peer). It is a full metav1.LabelSelector,
                             so set-based matchExpressions are supported in addition to matchLabels.
                           properties:
@@ -1069,7 +1069,7 @@ spec:
                     description: |-
                       Name is the referenced Secret's name. It must be a non-empty DNS-1123
                       subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                      fixes every consumer at once — keystone adminPasswordSecretRef /
+                      fixes every consumer at once — a service operator adminPasswordSecretRef /
                       database.secretRef / messaging / TLS cert refs and the c5c3
                       passwordSecretRef — so an empty name no longer slips through "required".
                     minLength: 1

--- a/operators/horizon/dashboards/dashboard_test.go
+++ b/operators/horizon/dashboards/dashboard_test.go
@@ -126,8 +126,12 @@ func TestDashboardReferencesOnlyRegisteredMetrics(t *testing.T) {
 	// received a sample, so each helper is probed once with a disposable
 	// label set. This test binary is the only horizon_operator registrant,
 	// so no duplicate registration occurs.
+	// Registration is now explicit (lazy registration was removed in favour of
+	// RegisterMetrics at operator startup), so register the vectors here before
+	// probing.
 	const probe = "dashboard_test_probe"
 	subReconcilerMetrics := instrumentation.NewMetrics("horizon_operator")
+	g.Expect(subReconcilerMetrics.Register(ctrlmetrics.Registry)).To(Succeed())
 	subReconcilerMetrics.ObserveReconcileDuration(probe, 0)
 	subReconcilerMetrics.RecordReconcileError(probe, probe)
 

--- a/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
@@ -161,7 +161,7 @@ spec:
                       lifecycle hook, configured independently of the overall grace period
                       This covers the window between EndpointSlice removal and
                       kube-proxy/ingress-controller propagation so new requests stop arriving
-                      before SIGTERM reaches uWSGI. When nil, the reconciler applies a default
+                      before SIGTERM reaches the API process. When nil, the reconciler applies a default
                       of 5s. Zero is permitted to disable the sleep. The cross-field rule
                       preStopSleepSeconds < terminationGracePeriodSeconds is enforced by the
                       validating webhook to guarantee a non-zero drain window.
@@ -170,20 +170,20 @@ spec:
                     type: integer
                   priorityClassName:
                     description: |-
-                      PriorityClassName sets the priority class for Keystone API pods.
+                      PriorityClassName sets the priority class for service API pods.
                       When set, the operator passes the value through to the PodSpec, allowing
                       cluster administrators to control scheduling priority and preemption.
                       When unset, no priority class is configured and the cluster default applies.
                     type: string
                   replicas:
                     default: 3
-                    description: Replicas is the desired number of Keystone API pods.
+                    description: Replicas is the desired number of service API pods.
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
                     description: |-
-                      Resources defines the CPU and memory requests and limits for the Keystone API
+                      Resources defines the CPU and memory requests and limits for the service API
                       container. When unset, the defaulting webhook injects sensible defaults
                       (256Mi/512Mi memory, 100m/500m CPU) to ensure Burstable QoS class and
                       enable HPA utilization calculations.
@@ -246,7 +246,7 @@ spec:
                     type: object
                   strategy:
                     description: |-
-                      Strategy overrides the Deployment rollout strategy for the Keystone API
+                      Strategy overrides the Deployment rollout strategy for the service API
                       Deployment. When nil, the reconciler applies RollingUpdate
                       with MaxUnavailable=0 and MaxSurge=1 to guarantee surge-before-remove
                       behavior — available capacity never dips below spec.deployment.replicas
@@ -300,9 +300,9 @@ spec:
                   terminationGracePeriodSeconds:
                     description: |-
                       TerminationGracePeriodSeconds is the grace period (seconds) granted to
-                      Keystone API pods between SIGTERM and SIGKILL during rolling updates
+                      service API pods between SIGTERM and SIGKILL during rolling updates
                       Extend this to cover slow upstream token validation (LDAP/DB)
-                      so in-flight requests finish before the kubelet forcibly kills uWSGI.
+                      so in-flight requests finish before the kubelet forcibly kills the API process.
                       When nil, the reconciler omits the field from the pod template and the
                       Kubernetes default of 30s applies. Must be at least 10s when set.
                     format: int64
@@ -579,7 +579,7 @@ spec:
                   repository:
                     description: |-
                       Repository is the OCI image repository, optionally including the registry
-                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                       permissive OCI reference — lowercase alphanumeric components separated by
                       ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                       are accepted while an empty string (which "required" alone admits) and
@@ -655,7 +655,7 @@ spec:
                     description: |-
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
-                      {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
+                      {"sqlalchemy.engine": "WARNING", "myservice.middleware": "DEBUG"}.
                       Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
                       logger name must be non-empty. These are now enforced by the CRD CEL
                       XValidation rules below as well as by the validating webhook (a plain
@@ -935,19 +935,19 @@ spec:
                     type: array
                   ingress:
                     description: |-
-                      Ingress defines the sources allowed to reach Keystone API on TCP 5000.
+                      Ingress defines the sources allowed to reach the service API on its API port.
                       Each source specifies a namespace selector and an optional pod selector.
                       Multiple sources produce multiple From peers in a single ingress rule
                       (OR across peers, AND within a peer's selectors).
                     items:
                       description: |-
                         NetworkPolicyIngressSource defines a source from which traffic is allowed
-                        to reach the Keystone API pods on TCP 5000.
+                        to reach the service API pods on the API port.
                       properties:
                         namespaceSelector:
                           description: |-
                             NamespaceSelector selects namespaces from which traffic is allowed.
-                            All pods in matching namespaces can reach Keystone on port 5000
+                            All pods in matching namespaces can reach the service on its API port
                             unless PodSelector further restricts the set. It is a full
                             metav1.LabelSelector, so set-based matchExpressions are supported in
                             addition to matchLabels.
@@ -999,7 +999,7 @@ spec:
                           description: |-
                             PodSelector optionally restricts allowed traffic to pods matching
                             these labels within the selected namespaces. When set, only pods
-                            matching both NamespaceSelector AND PodSelector can reach Keystone
+                            matching both NamespaceSelector AND PodSelector can reach the service
                             (AND logic within a single peer). It is a full metav1.LabelSelector,
                             so set-based matchExpressions are supported in addition to matchLabels.
                           properties:
@@ -1072,7 +1072,7 @@ spec:
                     description: |-
                       Name is the referenced Secret's name. It must be a non-empty DNS-1123
                       subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                      fixes every consumer at once — keystone adminPasswordSecretRef /
+                      fixes every consumer at once — a service operator adminPasswordSecretRef /
                       database.secretRef / messaging / TLS cert refs and the c5c3
                       passwordSecretRef — so an empty name no longer slips through "required".
                     minLength: 1

--- a/operators/horizon/internal/controller/controller_helpers_test.go
+++ b/operators/horizon/internal/controller/controller_helpers_test.go
@@ -6,6 +6,9 @@
 package controller
 
 import (
+	"context"
+	"testing"
+
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +18,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -63,6 +67,34 @@ func newTestReconciler(s *runtime.Scheme, objs ...client.Object) *HorizonReconci
 		Client: cb.Build(),
 		Scheme: s,
 	}
+}
+
+// newUpdateStatusReconciler builds a HorizonReconciler backed by a fake client
+// seeded with the given Horizon. When statusUpdateErr is non-nil the status
+// subresource update is intercepted to always fail, so a skipped write is
+// observable as a nil error return.
+func newUpdateStatusReconciler(t *testing.T, h *horizonv1alpha1.Horizon, statusUpdateErr error) (*HorizonReconciler, *horizonv1alpha1.Horizon) {
+	t.Helper()
+	s := testScheme()
+	cb := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(h.DeepCopy()).
+		WithStatusSubresource(&horizonv1alpha1.Horizon{})
+	if statusUpdateErr != nil {
+		cb = cb.WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return statusUpdateErr
+			},
+		})
+	}
+	c := cb.Build()
+
+	// Re-fetch so the object carries the ResourceVersion assigned by the fake client.
+	fetched := &horizonv1alpha1.Horizon{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(h), fetched); err != nil {
+		t.Fatalf("fetching Horizon from fake client: %v", err)
+	}
+	return &HorizonReconciler{Client: c, Scheme: s}, fetched
 }
 
 // readyClusterSecretStore returns a ClusterSecretStore with a Ready=True

--- a/operators/horizon/internal/controller/horizon_controller.go
+++ b/operators/horizon/internal/controller/horizon_controller.go
@@ -32,7 +32,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/gateway"
 	"github.com/c5c3/forge/internal/common/healthcheck"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
@@ -276,30 +275,32 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // the original reconcile failure stays visible. The mutate hook re-aggregates
 // the Ready condition on every persist and stamps status.observedGeneration.
 func (r *HorizonReconciler) updateStatus(ctx context.Context, horizon *horizonv1alpha1.Horizon, statusBefore *horizonv1alpha1.HorizonStatus, result ctrl.Result, reconcileErr error) (ctrl.Result, error) {
-	return commonreconcile.UpdateStatus(ctx, r.Client, horizon, statusBefore, &horizon.Status, func() {
-		setReadyCondition(horizon)
+	return horizonSkeleton.UpdateStatus(ctx, r.Client, horizon, statusBefore, &horizon.Status, func() {
 		horizon.Status.ObservedGeneration = horizon.Generation
 	}, result, reconcileErr)
 }
 
+// horizonSkeleton bundles the shared controller-skeleton glue (Ready
+// aggregation, no-op-skipping status writes, config-failure marking, and
+// parallel-group execution) with horizon's sub-condition vocabulary and status
+// accessor. The wrapper methods below delegate to it.
+var horizonSkeleton = commonreconcile.Skeleton[*horizonv1alpha1.Horizon, horizonv1alpha1.HorizonStatus]{
+	SubConditionTypes: subConditionTypes,
+	Conditions:        func(h *horizonv1alpha1.Horizon) *[]metav1.Condition { return &h.Status.Conditions },
+}
+
 // setReadyCondition sets the aggregate Ready condition based on all
-// sub-conditions, delegating to the shared aggregation helper with horizon's
+// sub-conditions, delegating to the shared skeleton with horizon's
 // sub-condition vocabulary.
 func setReadyCondition(horizon *horizonv1alpha1.Horizon) {
-	commonreconcile.SetAggregateReady(&horizon.Status.Conditions, horizon.Generation, subConditionTypes)
+	horizonSkeleton.SetReady(horizon)
 }
 
 // markConfigFailed flips ConfigReady to False so a reconcileConfig or config
 // prune failure cannot leave the aggregate Ready condition stale-True at the
 // new ObservedGeneration.
 func markConfigFailed(horizon *horizonv1alpha1.Horizon, err error) {
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeConfigReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: horizon.Generation,
-		Reason:             conditionReasonConfigError,
-		Message:            err.Error(),
-	})
+	horizonSkeleton.MarkFailed(horizon, conditionTypeConfigReady, conditionReasonConfigError, err)
 }
 
 // reconcileParallelGroup runs the given sub-reconcilers concurrently,
@@ -313,9 +314,7 @@ func (r *HorizonReconciler) reconcileParallelGroup(
 	horizon *horizonv1alpha1.Horizon,
 	subs []commonreconcile.ParallelStep[*horizonv1alpha1.Horizon],
 ) (ctrl.Result, error) {
-	return commonreconcile.RunParallelGroup(ctx, horizon,
-		func(h *horizonv1alpha1.Horizon) *[]metav1.Condition { return &h.Status.Conditions },
-		instrumentSubReconciler, subs)
+	return horizonSkeleton.RunParallelGroup(ctx, horizon, instrumentSubReconciler, subs)
 }
 
 // SetupWithManager registers the HorizonReconciler with the controller manager.

--- a/operators/horizon/internal/controller/horizon_controller_test.go
+++ b/operators/horizon/internal/controller/horizon_controller_test.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -82,6 +83,28 @@ func TestReconcile_SecretsGateShortCircuitsAndPersistsStatus(t *testing.T) {
 
 	// The chain short-circuited: no downstream condition was set.
 	g.Expect(conditions.GetCondition(got.Status.Conditions, "DeploymentReady")).To(BeNil())
+}
+
+// TestUpdateStatus_SkipsWriteWhenUnchanged verifies the C3 gate: when the
+// snapshot equals the status updateStatus computes, no Status().Update is
+// issued. The reconciler's Status().Update is wired to always fail, so a
+// skipped write is observable as a nil error return.
+func TestUpdateStatus_SkipsWriteWhenUnchanged(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	statusErr := fmt.Errorf("status update must not be called on an unchanged status")
+	r, h := newUpdateStatusReconciler(t, testHorizon(), statusErr)
+
+	// Bring h.Status into the exact state updateStatus would compute (Ready
+	// aggregated + ObservedGeneration stamped), then snapshot it — a converged
+	// steady-state pass.
+	setReadyCondition(h)
+	h.Status.ObservedGeneration = h.Generation
+	snapshot := h.Status.DeepCopy()
+
+	_, err := r.updateStatus(context.Background(), h, snapshot, ctrl.Result{}, nil)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"an unchanged status must skip the write; the failing Status().Update proves it was not called")
 }
 
 func TestHorizonSecretNameExtractor(t *testing.T) {

--- a/operators/horizon/internal/controller/instrumentation.go
+++ b/operators/horizon/internal/controller/instrumentation.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/c5c3/forge/internal/common/instrumentation"
 )
@@ -36,19 +37,22 @@ var subReconcilerConditionTypes = map[string]string{
 	"NetworkPolicy": conditionTypeNetworkPolicyReady,
 }
 
-// subReconcilerMetrics holds the shared sub-reconciler instrumentation
-// metrics for the horizon operator
-// (horizon_operator_reconcile_duration_seconds and
-// horizon_operator_reconcile_errors_total). The vectors register lazily on
-// the controller-runtime registry the first time a sample is recorded.
-var subReconcilerMetrics = instrumentation.NewMetrics("horizon_operator")
-
 // instrumenter wraps every sub-reconciler call with the shared duration/error
-// instrumentation, recording through subReconcilerMetrics. It indirects
-// through a package-level var so unit tests can rebind it to an isolated
-// prometheus registry without polluting the controller-runtime production
-// registry. Production code MUST NOT reassign it.
-var instrumenter = instrumentation.NewInstrumenter(subReconcilerMetrics, subReconcilerConditionTypes)
+// instrumentation (horizon_operator_reconcile_duration_seconds and
+// horizon_operator_reconcile_errors_total). It owns its metric vectors, which
+// RegisterMetrics exposes on the controller-runtime registry at startup. The
+// var indirection lets unit tests rebind it to an isolated prometheus registry
+// without polluting the production registry; production code MUST NOT reassign
+// it.
+var instrumenter = instrumentation.NewSubReconcilerInstrumenter("horizon_operator", subReconcilerConditionTypes)
+
+// RegisterMetrics exposes the operator's sub-reconciler duration/error vectors
+// on the controller-runtime registry, returning an error on a
+// duplicate-registration rather than panicking mid-reconcile so main.go can
+// fail startup cleanly. Call it exactly once during operator setup.
+func RegisterMetrics() error {
+	return instrumenter.Register(ctrlmetrics.Registry)
+}
 
 // instrumentSubReconciler wraps a sub-reconciler call, observing duration on
 // every path (success, error, panic) and recording an error count if fn

--- a/operators/horizon/internal/controller/reconcile_healthcheck.go
+++ b/operators/horizon/internal/controller/reconcile_healthcheck.go
@@ -6,17 +6,13 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/healthcheck"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
 )
@@ -42,24 +38,6 @@ func (r *HorizonReconciler) httpClient() HTTPDoer {
 	return http.DefaultClient
 }
 
-// healthProbeCacheHit reports whether the cached probe for this CR can be
-// reused in place of a fresh HTTP GET: the HorizonAPIReady condition is
-// already True, and the shared TTL probe cache holds an entry matching the
-// CR's UID and endpoint within HealthCheckCacheTTL.
-func (r *HorizonReconciler) healthProbeCacheHit(horizon *horizonv1alpha1.Horizon, endpoint string) bool {
-	current := conditions.GetCondition(horizon.Status.Conditions, conditionTypeHorizonAPIReady)
-	if current == nil || current.Status != metav1.ConditionTrue {
-		return false
-	}
-	return r.healthProbeCache.Hit(client.ObjectKeyFromObject(horizon), horizon.UID, endpoint, HealthCheckCacheTTL)
-}
-
-// storeHealthProbe records a successful probe so reconciles within the TTL
-// can skip the synchronous HTTP GET.
-func (r *HorizonReconciler) storeHealthProbe(horizon *horizonv1alpha1.Horizon, endpoint string) {
-	r.healthProbeCache.Store(client.ObjectKeyFromObject(horizon), horizon.UID, endpoint)
-}
-
 // evictHealthProbe drops the cached probe for a CR so the next reconcile
 // re-probes. Called on any probe failure and on CR deletion.
 func (r *HorizonReconciler) evictHealthProbe(key types.NamespacedName) {
@@ -75,110 +53,26 @@ func dashboardLoginURL(horizon *horizonv1alpha1.Horizon) string {
 }
 
 // reconcileHealthCheck performs an HTTP GET to the cluster-local dashboard
-// login page and sets the HorizonAPIReady condition based on the response.
-// The probe target is always the in-cluster Service URL, independent of
-// spec.gateway: we are verifying dashboard readiness, not the
-// ingress/DNS/cert/Gateway path that status.endpoint may advertise
-// externally.
+// login page and sets the HorizonAPIReady condition based on the response, via
+// the shared probe flow. The probe target is always the in-cluster Service URL,
+// independent of spec.gateway: we are verifying dashboard readiness, not the
+// ingress/DNS/cert/Gateway path that status.endpoint may advertise externally.
 func (r *HorizonReconciler) reconcileHealthCheck(ctx context.Context, horizon *horizonv1alpha1.Horizon) (ctrl.Result, error) {
-	if horizon.Status.Endpoint == "" {
-		log.FromContext(ctx).Info("Horizon dashboard endpoint not yet configured, requeuing")
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHorizonAPIReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonEndpointNotReady,
-			Message:            "endpoint not yet configured",
-		})
-		return ctrl.Result{RequeueAfter: RequeueHealthCheck}, nil
-	}
-	endpoint := dashboardLoginURL(horizon)
-	key := client.ObjectKeyFromObject(horizon)
-
-	// Serve from the probe cache when the last successful probe for this
-	// exact endpoint is still fresh and HorizonAPIReady is already True. The
-	// condition is re-upserted (not left untouched) so its ObservedGeneration
-	// tracks the current spec; the message matches the probe path verbatim so
-	// a cache pass and a probe pass produce byte-identical status and the
-	// status-diff gate skips the write.
-	if r.healthProbeCacheHit(horizon, endpoint) {
-		log.FromContext(ctx).V(1).Info("Horizon dashboard health check served from cache", "endpoint", endpoint)
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHorizonAPIReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonAPIHealthy,
-			Message:            fmt.Sprintf("Horizon dashboard is responding at %s", endpoint),
-		})
-		return ctrl.Result{}, nil
-	}
-
-	checkCtx, cancel := context.WithTimeout(ctx, HealthCheckTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("building health check request: %w", err)
-	}
-
-	resp, err := r.httpClient().Do(req)
-	if err != nil {
-		// A cancelled parent context means a peer in the parallel group
-		// failed and errgroup cancelled gctx — the aborted probe is not a
-		// dashboard-health signal. Propagate the cancellation without
-		// flipping HorizonAPIReady or evicting the probe cache. A genuine
-		// probe timeout fires checkCtx's deadline while the parent ctx stays
-		// live (ctx.Err()==nil), so it still routes through
-		// handleHealthCheckError below.
-		if cerr := ctx.Err(); cerr != nil {
-			return ctrl.Result{}, cerr
-		}
-		// Any other probe error must evict so the next reconcile re-probes
-		// rather than serving a stale success.
-		r.evictHealthProbe(key)
-		return r.handleHealthCheckError(ctx, horizon, err), nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		log.FromContext(ctx).V(1).Info("Horizon dashboard health check passed", "status", resp.StatusCode)
-		r.storeHealthProbe(horizon, endpoint)
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHorizonAPIReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonAPIHealthy,
-			Message:            fmt.Sprintf("Horizon dashboard is responding at %s", endpoint),
-		})
-		return ctrl.Result{}, nil
-	}
-
-	log.FromContext(ctx).Info("Horizon dashboard health check failed", "status", resp.StatusCode)
-	// A non-2xx response is a failed probe: evict so recovery is detected on
-	// the next reconcile instead of masked by a stale cached success.
-	r.evictHealthProbe(key)
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeHorizonAPIReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: horizon.Generation,
-		Reason:             conditionReasonAPIUnhealthy,
-		Message:            fmt.Sprintf("Horizon dashboard returned HTTP %d", resp.StatusCode),
+	return healthcheck.ReconcileProbe(ctx, healthcheck.ProbeFlowParams{
+		Doer:               r.httpClient(),
+		Cache:              &r.healthProbeCache,
+		Key:                client.ObjectKeyFromObject(horizon),
+		UID:                horizon.UID,
+		Subject:            "Horizon dashboard",
+		EndpointConfigured: horizon.Status.Endpoint != "",
+		ProbeEndpoint:      dashboardLoginURL(horizon),
+		Conditions:         &horizon.Status.Conditions,
+		Generation:         horizon.Generation,
+		ConditionType:      conditionTypeHorizonAPIReady,
+		HealthyReason:      conditionReasonAPIHealthy,
+		UnhealthyReason:    conditionReasonAPIUnhealthy,
+		Timeout:            HealthCheckTimeout,
+		CacheTTL:           HealthCheckCacheTTL,
+		RequeueAfter:       RequeueHealthCheck,
 	})
-	return ctrl.Result{RequeueAfter: RequeueHealthCheck}, nil
-}
-
-// handleHealthCheckError classifies the HTTP client error via the shared
-// classifier and sets the HorizonAPIReady condition with an appropriate
-// Reason. All network errors result in a requeue rather than a hard error.
-func (r *HorizonReconciler) handleHealthCheckError(ctx context.Context, horizon *horizonv1alpha1.Horizon, err error) ctrl.Result {
-	reason, message := healthcheck.ClassifyError(err)
-	log.FromContext(ctx).Info("Horizon dashboard health check error", "reason", reason, "error", err)
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeHorizonAPIReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: horizon.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
-	return ctrl.Result{RequeueAfter: RequeueHealthCheck}
 }

--- a/operators/horizon/internal/controller/reconcile_hpa.go
+++ b/operators/horizon/internal/controller/reconcile_hpa.go
@@ -6,53 +6,31 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/deployment"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
 )
 
-// reconcileHPA ensures the HorizontalPodAutoscaler for the dashboard
-// deployment matches the desired state. Three lifecycle paths:
-//   - spec.autoscaling set: create or update HPA targeting the deployment
-//   - spec.autoscaling nil: delete any existing HPA
-//   - error: propagate errors from ensure/delete operations
+// reconcileHPA ensures the HorizontalPodAutoscaler for the dashboard deployment
+// matches the desired state, via the shared HPA flow. It keeps only the
+// service-specific desired HPA builder.
 func (r *HorizonReconciler) reconcileHPA(ctx context.Context, horizon *horizonv1alpha1.Horizon) (ctrl.Result, error) {
-	hpaName := subResourceName(horizon)
-
-	// Path 2: autoscaling disabled — delete any existing HPA.
-	if horizon.Spec.Autoscaling == nil {
-		if err := deployment.DeleteHPA(ctx, r.Client, horizon.Namespace, hpaName); err != nil {
-			return ctrl.Result{}, fmt.Errorf("deleting HorizontalPodAutoscaler: %w", err)
-		}
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               "HPAReady",
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             "HPANotRequired",
-			Message:            "Autoscaling is not configured",
-		})
-		return ctrl.Result{}, nil
+	var desired *autoscalingv2.HorizontalPodAutoscaler
+	if horizon.Spec.Autoscaling != nil {
+		desired = buildHorizonHPA(horizon)
 	}
-
-	// Path 1: autoscaling enabled — create or update HPA.
-	hpa := buildHorizonHPA(horizon)
-	if err := deployment.EnsureHPA(ctx, r.Client, r.Scheme, horizon, hpa); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring HorizontalPodAutoscaler: %w", err)
-	}
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               "HPAReady",
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: horizon.Generation,
-		Reason:             "HPAReady",
-		Message:            "HorizontalPodAutoscaler is configured",
+	return deployment.ReconcileHPA(ctx, r.Client, r.Scheme, horizon, deployment.HPAFlowParams{
+		Enabled:       horizon.Spec.Autoscaling != nil,
+		Desired:       desired,
+		Name:          subResourceName(horizon),
+		Namespace:     horizon.Namespace,
+		Conditions:    &horizon.Status.Conditions,
+		Generation:    horizon.Generation,
+		ConditionType: "HPAReady",
 	})
-	return ctrl.Result{}, nil
 }
 
 // buildHorizonHPA constructs the desired HorizontalPodAutoscaler for the

--- a/operators/horizon/internal/controller/reconcile_httproute.go
+++ b/operators/horizon/internal/controller/reconcile_httproute.go
@@ -8,22 +8,21 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/gateway"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
 )
 
-// Condition type and reason constants for HTTPRoute readiness.
+// Condition type and reason constants for HTTPRoute readiness. The reason
+// vocabulary is shared across operators via the gateway package.
 const (
 	conditionTypeHTTPRouteReady           = "HTTPRouteReady"
-	conditionReasonHTTPRouteAccepted      = "HTTPRouteAccepted"
-	conditionReasonHTTPRouteNotAccepted   = "HTTPRouteNotAccepted"
-	conditionReasonHTTPRouteNotRequired   = "HTTPRouteNotRequired"
-	conditionReasonGatewayAPINotInstalled = "GatewayAPINotInstalled"
+	conditionReasonHTTPRouteAccepted      = gateway.ReasonHTTPRouteAccepted
+	conditionReasonHTTPRouteNotAccepted   = gateway.ReasonHTTPRouteNotAccepted
+	conditionReasonHTTPRouteNotRequired   = gateway.ReasonHTTPRouteNotRequired
+	conditionReasonGatewayAPINotInstalled = gateway.ReasonGatewayAPINotInstalled
 )
 
 // requeueHTTPRouteAccepted is the interval for requeuing while waiting for a
@@ -51,82 +50,30 @@ func internalDashboardURL(horizon *horizonv1alpha1.Horizon) string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/", subResourceName(horizon), horizon.Namespace, horizonAPIPort)
 }
 
-// reconcileHTTPRoute ensures the HTTPRoute that exposes the dashboard
-// through a Gateway matches the desired state. Three lifecycle paths:
-//
-//   - spec.gateway set: create or update the HTTPRoute and reflect the
-//     parent Accepted condition as HTTPRouteReady.
-//   - spec.gateway nil: delete any existing HTTPRoute and set
-//     HTTPRouteReady=True/HTTPRouteNotRequired.
-//   - error: propagate errors from ensure/delete operations.
+// reconcileHTTPRoute ensures the HTTPRoute that exposes the dashboard through a
+// Gateway matches the desired state, via the shared route flow. It keeps only
+// the service-specific parts: the desired route builder, the backend identity,
+// and the exposure noun for the messages.
 func (r *HorizonReconciler) reconcileHTTPRoute(ctx context.Context, horizon *horizonv1alpha1.Horizon) (ctrl.Result, error) {
-	// Path 0: Gateway API CRD is not installed. The watch was skipped in
-	// SetupWithManager; skip the delete attempt too and surface a clear
-	// condition instead of erroring.
-	if !r.gatewayAPIAvailable {
-		if horizon.Spec.Gateway == nil {
-			conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-				Type:               conditionTypeHTTPRouteReady,
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: horizon.Generation,
-				Reason:             conditionReasonHTTPRouteNotRequired,
-				Message:            "External dashboard exposure via Gateway API is not configured",
-			})
-			return ctrl.Result{}, nil
-		}
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonGatewayAPINotInstalled,
-			Message:            "spec.gateway is set but the gateway.networking.k8s.io/v1 HTTPRoute CRD is not installed in this cluster; install Gateway API and restart the operator to enable external dashboard exposure",
-		})
-		return ctrl.Result{}, nil
+	// buildHorizonHTTPRoute dereferences spec.gateway, so build the desired
+	// route only when external exposure is requested; the flow uses Desired only
+	// on the gateway-enabled path.
+	var desired *gatewayv1.HTTPRoute
+	if horizon.Spec.Gateway != nil {
+		desired = buildHorizonHTTPRoute(horizon)
 	}
-
-	// Path 2: gateway disabled — delete any existing HTTPRoute.
-	if horizon.Spec.Gateway == nil {
-		if err := gateway.DeleteHTTPRoute(ctx, r.Client, horizon.Namespace, subResourceName(horizon)); err != nil {
-			return ctrl.Result{}, err
-		}
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonHTTPRouteNotRequired,
-			Message:            "External dashboard exposure via Gateway API is not configured",
-		})
-		return ctrl.Result{}, nil
-	}
-
-	// Path 1: gateway enabled — create or update the HTTPRoute.
-	// EnsureHTTPRoute applies via Server-Side Apply and decodes the server
-	// response back into desired, so its parent status — written by the
-	// Gateway controller — is already populated without a second Get.
-	desired := buildHorizonHTTPRoute(horizon)
-	if err := gateway.EnsureHTTPRoute(ctx, r.Client, r.Scheme, horizon, desired); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring HTTPRoute: %w", err)
-	}
-
-	if gateway.IsHTTPRouteAccepted(desired) {
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonHTTPRouteAccepted,
-			Message:            "HTTPRoute accepted by Gateway",
-		})
-		return ctrl.Result{}, nil
-	}
-
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeHTTPRouteReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: horizon.Generation,
-		Reason:             conditionReasonHTTPRouteNotAccepted,
-		Message:            "HTTPRoute not yet accepted by Gateway",
+	return gateway.ReconcileHTTPRoute(ctx, r.Client, r.Scheme, horizon, gateway.RouteFlowParams{
+		GatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:   horizon.Spec.Gateway != nil,
+		Desired:             desired,
+		RouteName:           subResourceName(horizon),
+		RouteNamespace:      horizon.Namespace,
+		ExposureNoun:        "dashboard",
+		Conditions:          &horizon.Status.Conditions,
+		Generation:          horizon.Generation,
+		ConditionType:       conditionTypeHTTPRouteReady,
+		RequeueAccepted:     requeueHTTPRouteAccepted,
 	})
-	return ctrl.Result{RequeueAfter: requeueHTTPRouteAccepted}, nil
 }
 
 // buildHorizonHTTPRoute constructs the desired HTTPRoute for the dashboard.

--- a/operators/horizon/internal/controller/reconcile_networkpolicy.go
+++ b/operators/horizon/internal/controller/reconcile_networkpolicy.go
@@ -6,138 +6,84 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"net/url"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/c5c3/forge/internal/common/apply"
-	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/networkpolicy"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
 )
 
-// Condition type and reason constants for NetworkPolicy readiness.
+// Condition type and reason constants for NetworkPolicy readiness. The reason
+// vocabulary is shared across operators via the networkpolicy package.
 const (
 	conditionTypeNetworkPolicyReady         = "NetworkPolicyReady"
-	conditionReasonNetworkPolicyReady       = "NetworkPolicyReady"
-	conditionReasonNetworkPolicyNotRequired = "NetworkPolicyNotRequired"
+	conditionReasonNetworkPolicyReady       = networkpolicy.ReasonNetworkPolicyReady
+	conditionReasonNetworkPolicyNotRequired = networkpolicy.ReasonNetworkPolicyNotRequired
 )
 
-// reconcileNetworkPolicy ensures the NetworkPolicy for the dashboard
-// deployment matches the desired state. Three lifecycle paths:
-//   - spec.networkPolicy set: create or update NetworkPolicy
-//   - spec.networkPolicy nil: delete any existing NetworkPolicy
-//   - error: propagate errors from ensure/delete operations
+// reconcileNetworkPolicy ensures the NetworkPolicy for the dashboard deployment
+// matches the desired state, via the shared network-policy flow. It keeps only
+// the service-specific parts: the desired policy builder (with its
+// keystone-endpoint egress) and the backend identity.
 func (r *HorizonReconciler) reconcileNetworkPolicy(ctx context.Context, horizon *horizonv1alpha1.Horizon) (ctrl.Result, error) {
-	// Path 2: networkPolicy disabled — delete any existing NetworkPolicy.
-	if horizon.Spec.NetworkPolicy == nil {
-		if err := deleteNetworkPolicy(ctx, r.Client, horizon.Namespace, subResourceName(horizon)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("deleting NetworkPolicy: %w", err)
+	// buildHorizonNetworkPolicy is only applied on the enabled+non-empty path;
+	// build it lazily so a nil or empty-ingress spec takes the delete or
+	// fail-closed path without a wasted build.
+	var desired *networkingv1.NetworkPolicy
+	ingressCount := 0
+	if horizon.Spec.NetworkPolicy != nil {
+		ingressCount = len(horizon.Spec.NetworkPolicy.Ingress)
+		if ingressCount > 0 {
+			desired = buildHorizonNetworkPolicy(horizon, r.OperatorNamespace)
 		}
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeNetworkPolicyReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: horizon.Generation,
-			Reason:             conditionReasonNetworkPolicyNotRequired,
-			Message:            "Network isolation is not configured",
-		})
-		return ctrl.Result{}, nil
 	}
-
-	// Defensive guard: refuse to create a NetworkPolicy with empty ingress
-	// sources. CRD validation (XValidation) requires size(self.ingress) > 0,
-	// but validation can be bypassed (old stored objects, disabled webhooks,
-	// direct etcd writes). An Ingress rule with an empty From slice allows
-	// all sources on port 8080, which is an unsafe default for a hardening
-	// feature. Fail closed rather than open.
-	if len(horizon.Spec.NetworkPolicy.Ingress) == 0 {
-		return ctrl.Result{}, fmt.Errorf("spec.networkPolicy.ingress must not be empty: refusing to create NetworkPolicy that would allow all ingress")
-	}
-
-	// Path 1: networkPolicy enabled — create or update NetworkPolicy.
-	np := buildHorizonNetworkPolicy(horizon, r.OperatorNamespace)
-	if err := ensureNetworkPolicy(ctx, r.Client, r.Scheme, horizon, np); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring NetworkPolicy: %w", err)
-	}
-	conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeNetworkPolicyReady,
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: horizon.Generation,
-		Reason:             conditionReasonNetworkPolicyReady,
-		Message:            "NetworkPolicy is configured",
+	return networkpolicy.Reconcile(ctx, r.Client, r.Scheme, horizon, networkpolicy.FlowParams{
+		Configured:         horizon.Spec.NetworkPolicy != nil,
+		IngressSourceCount: ingressCount,
+		Desired:            desired,
+		Name:               subResourceName(horizon),
+		Namespace:          horizon.Namespace,
+		Conditions:         &horizon.Status.Conditions,
+		Generation:         horizon.Generation,
+		ConditionType:      conditionTypeNetworkPolicyReady,
 	})
-	return ctrl.Result{}, nil
 }
 
 // buildHorizonNetworkPolicy constructs the desired NetworkPolicy for the
-// dashboard pods. It restricts ingress to TCP 8080 from the specified
+// dashboard pods. It restricts ingress to the dashboard port from the specified
 // sources and auto-derives egress rules for DNS (UDP+TCP 53), the Keystone
-// endpoint (TCP, port parsed from spec.keystoneEndpoint), and the cache
-// (TCP, ports derived from the cache spec). AdditionalEgress rules are
-// appended after auto-derived rules.
+// endpoint (TCP, port parsed from spec.keystoneEndpoint), and the cache (TCP,
+// ports derived from the cache spec). AdditionalEgress rules are appended after
+// auto-derived rules.
 //
-// operatorNamespace is the Namespace the operator Pod runs in. When
-// non-empty, an ingress peer selecting that Namespace is appended so the
-// operator's own health check can reach the dashboard on TCP 8080. When
-// empty (namespace unknown) no such peer is added.
+// operatorNamespace is the Namespace the operator Pod runs in. When non-empty,
+// an ingress peer selecting that Namespace is appended so the operator's own
+// health check can reach the dashboard. When empty (namespace unknown) no such
+// peer is added.
 func buildHorizonNetworkPolicy(horizon *horizonv1alpha1.Horizon, operatorNamespace string) *networkingv1.NetworkPolicy {
 	npSpec := horizon.Spec.NetworkPolicy
 
-	// Build ingress peers from spec.networkPolicy.ingress sources.
-	var peers []networkingv1.NetworkPolicyPeer
-	for _, src := range npSpec.Ingress {
-		peer := networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: src.NamespaceSelector.DeepCopy(),
-		}
-		if src.PodSelector != nil {
-			peer.PodSelector = src.PodSelector.DeepCopy()
-		}
-		peers = append(peers, peer)
-	}
-
-	// When spec.gateway is also set, append an ingress peer targeting the
-	// Gateway's namespace (via kubernetes.io/metadata.name) so the Gateway's
-	// data-plane pods can reach the dashboard Service. The gateway data
-	// plane's pod labels are implementation-specific and not known to this
-	// operator, so we select the entire gateway namespace. When
-	// spec.gateway.parentRef.namespace is empty, the Horizon CR's own
-	// namespace is assumed, matching the ParentRef lookup semantics.
+	// When spec.gateway is set, an ingress peer selects the whole Gateway
+	// namespace so the Gateway data plane can reach the dashboard Service. An
+	// empty parentRef.namespace defaults to the CR's own namespace.
+	gatewayNamespace := ""
 	if horizon.Spec.Gateway != nil {
-		gatewayNS := horizon.Spec.Gateway.ParentRef.Namespace
-		if gatewayNS == "" {
-			gatewayNS = horizon.Namespace
+		gatewayNamespace = horizon.Spec.Gateway.ParentRef.Namespace
+		if gatewayNamespace == "" {
+			gatewayNamespace = horizon.Namespace
 		}
-		peers = append(peers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name": gatewayNS,
-				},
-			},
-		})
 	}
-
-	// Append an ingress peer for the operator's own Namespace so
-	// reconcileHealthCheck can reach the dashboard Service on TCP 8080. The
-	// peer selects the entire operator Namespace by the well-known
-	// kubernetes.io/metadata.name label. When operatorNamespace is empty
-	// (namespace could not be resolved) no peer is added.
-	if operatorNamespace != "" {
-		peers = append(peers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name": operatorNamespace,
-				},
-			},
-		})
-	}
+	peers := networkpolicy.IngressPeers(networkpolicy.IngressPeersParams{
+		Sources:           npSpec.Ingress,
+		GatewayNamespace:  gatewayNamespace,
+		OperatorNamespace: operatorNamespace,
+	})
 
 	dashboardPort := intstr.FromInt32(horizonAPIPort)
 	tcp := corev1.ProtocolTCP
@@ -176,28 +122,18 @@ func buildHorizonNetworkPolicy(horizon *horizonv1alpha1.Horizon, operatorNamespa
 
 // buildAutoEgressRules constructs the auto-derived egress rules for DNS
 // (UDP+TCP 53), the Keystone endpoint (TCP, port from keystoneEndpointPort),
-// and the cache (TCP, ports from cacheEgressPorts). The dashboard has no
-// database and no rotation CronJobs, so no DB or kube-apiserver egress is
-// emitted. Rule order is deterministic: DNS, keystone, cache.
+// and the cache (TCP, ports from the cache spec). The dashboard has no database
+// and no rotation CronJobs, so no DB or kube-apiserver egress is emitted. Rule
+// order is deterministic: DNS, keystone, cache.
 func buildAutoEgressRules(horizon *horizonv1alpha1.Horizon) []networkingv1.NetworkPolicyEgressRule {
 	tcp := corev1.ProtocolTCP
-	udp := corev1.ProtocolUDP
 
-	// DNS egress: always required (UDP+TCP 53). Destination unrestricted so
-	// NodeLocal DNSCache setups outside kube-system keep resolving.
-	port53 := intstr.FromInt32(53)
-	rules := []networkingv1.NetworkPolicyEgressRule{
-		{
-			Ports: []networkingv1.NetworkPolicyPort{
-				{Protocol: &udp, Port: &port53},
-				{Protocol: &tcp, Port: &port53},
-			},
-		},
-	}
+	// DNS egress: always required (UDP+TCP 53).
+	rules := []networkingv1.NetworkPolicyEgressRule{networkpolicy.DNSEgressRule()}
 
 	// Keystone egress: the dashboard authenticates every login against
-	// spec.keystoneEndpoint. Port-only — destination unrestricted, matching
-	// the keystone-operator's DB/cache egress posture.
+	// spec.keystoneEndpoint. Port-only — destination unrestricted, matching the
+	// keystone-operator's DB/cache egress posture.
 	keystonePort := intstr.FromInt32(keystoneEndpointPort(horizon))
 	rules = append(rules, networkingv1.NetworkPolicyEgressRule{
 		Ports: []networkingv1.NetworkPolicyPort{
@@ -205,25 +141,20 @@ func buildAutoEgressRules(horizon *horizonv1alpha1.Horizon) []networkingv1.Netwo
 		},
 	})
 
-	// Cache egress: emitted in both managed (cache.clusterRef) and brownfield
-	// (cache.servers) modes. Cache egress does not gate readiness, so a wrong
-	// cache port degrades caching without depooling pods.
-	if cachePorts := cacheEgressPorts(horizon); len(cachePorts) > 0 {
-		ports := make([]networkingv1.NetworkPolicyPort, 0, len(cachePorts))
-		for i := range cachePorts {
-			cachePort := intstr.FromInt32(cachePorts[i])
-			ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &cachePort})
-		}
-		rules = append(rules, networkingv1.NetworkPolicyEgressRule{Ports: ports})
+	// Cache egress: emitted in both managed and brownfield modes. Cache egress
+	// does not gate readiness, so a wrong cache port degrades caching without
+	// depooling pods.
+	if rule, ok := networkpolicy.CacheEgressRule(horizon.Spec.Cache); ok {
+		rules = append(rules, rule)
 	}
 
 	return rules
 }
 
 // keystoneEndpointPort returns the TCP port of spec.keystoneEndpoint: the
-// explicit URL port when present, otherwise 443 for https and 80 for http.
-// An unparseable URL (rejected by the webhook, but validation can be
-// bypassed) falls back to 443 — the fail-closed choice for an egress rule.
+// explicit URL port when present, otherwise 443 for https and 80 for http. An
+// unparseable URL (rejected by the webhook, but validation can be bypassed)
+// falls back to 443 — the fail-closed choice for an egress rule.
 func keystoneEndpointPort(horizon *horizonv1alpha1.Horizon) int32 {
 	const maxPort = 65535
 	u, err := url.Parse(horizon.Spec.KeystoneEndpoint)
@@ -243,62 +174,8 @@ func keystoneEndpointPort(horizon *horizonv1alpha1.Horizon) int32 {
 	return 443
 }
 
-// cacheEgressPorts returns the distinct Memcached ports the dashboard pods
-// must reach, derived from the cache spec. In managed mode (cache.clusterRef
-// set) the memcached operator exposes the standard 11211. In brownfield mode
-// (cache.servers set) the ports are parsed from each "host:port" entry,
-// defaulting to 11211 when an entry omits the port or cannot be parsed. The
-// result preserves input order and is deduplicated. It returns nil when no
-// cache is configured, in which case no cache egress rule is emitted.
+// cacheEgressPorts returns the distinct Memcached ports the dashboard pods must
+// reach, derived from the cache spec, via the shared helper.
 func cacheEgressPorts(horizon *horizonv1alpha1.Horizon) []int32 {
-	servers := horizon.Spec.Cache.Servers
-	if len(servers) == 0 {
-		if horizon.Spec.Cache.ClusterRef != nil {
-			return []int32{11211}
-		}
-		return nil
-	}
-
-	const defaultMemcachedPort int32 = 11211
-	const maxPort = 65535
-	seen := make(map[int32]struct{}, len(servers))
-	var ports []int32
-	for _, server := range servers {
-		port := defaultMemcachedPort
-		if _, portStr, err := net.SplitHostPort(server); err == nil {
-			if n, err := strconv.ParseInt(portStr, 10, 32); err == nil && n > 0 && n <= maxPort {
-				port = int32(n)
-			}
-		}
-		if _, ok := seen[port]; ok {
-			continue
-		}
-		seen[port] = struct{}{}
-		ports = append(ports, port)
-	}
-	return ports
-}
-
-// ensureNetworkPolicy creates or updates the NetworkPolicy via Server-Side
-// Apply under a fixed field manager and sets the Horizon CR as its controller
-// owner so it is garbage-collected with the CR.
-//
-// Merge strategy: the field manager owns exactly the fields the builder sets
-// (the whole Spec and the operator's labels). Labels or annotations the
-// operator no longer sets are relinquished and removed by the API server,
-// while keys owned by other managers are preserved.
-func ensureNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, np *networkingv1.NetworkPolicy) error {
-	return apply.EnsureObject(ctx, c, scheme, owner, np, apply.FieldManager)
-}
-
-// deleteNetworkPolicy deletes the NetworkPolicy identified by namespace and
-// name. It is a no-op if the NetworkPolicy does not exist.
-func deleteNetworkPolicy(ctx context.Context, c client.Client, namespace, name string) error {
-	np := &networkingv1.NetworkPolicy{}
-	np.SetName(name)
-	np.SetNamespace(namespace)
-	if err := client.IgnoreNotFound(c.Delete(ctx, np)); err != nil {
-		return fmt.Errorf("deleting NetworkPolicy %s/%s: %w", namespace, name, err)
-	}
-	return nil
+	return networkpolicy.CacheEgressPorts(horizon.Spec.Cache)
 }

--- a/operators/horizon/internal/controller/reconcile_secrets.go
+++ b/operators/horizon/internal/controller/reconcile_secrets.go
@@ -42,19 +42,12 @@ func (r *HorizonReconciler) reconcileSecrets(ctx context.Context,
 	// Check the ClusterSecretStore first so upstream backend outages surface
 	// as SecretsReady=False even while the per-ExternalSecret cache still
 	// reports Ready=True from its last successful sync.
-	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	storeReady, err := secrets.GateClusterStoreReady(ctx, r.Client, openBaoClusterStoreName,
+		&horizon.Status.Conditions, horizon.Generation, "SecretsReady")
 	if err != nil {
 		return ctrl.Result{}, "", err
 	}
 	if !storeReady {
-		conditions.SetCondition(&horizon.Status.Conditions, metav1.Condition{
-			Type:               "SecretsReady",
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: horizon.Generation,
-			Reason:             "SecretStoreNotReady",
-			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
-				openBaoClusterStoreName),
-		})
 		return ctrl.Result{RequeueAfter: RequeueSecretPolling}, "", nil
 	}
 

--- a/operators/horizon/internal/controller/requeue_intervals.go
+++ b/operators/horizon/internal/controller/requeue_intervals.go
@@ -4,35 +4,31 @@
 
 package controller
 
-import "time"
+import (
+	"github.com/c5c3/forge/internal/common/healthcheck"
+	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
+)
 
-// Requeue interval constants centralise the polling durations used by each
-// sub-reconciler. Keeping them in a single file makes tuning straightforward
-// and ensures test assertions stay in sync with production code.
+// The polling and health-check timing durations shared by every service
+// operator now live in the shared library so a tuning change lands once. These
+// aliases keep the package-local names the sub-reconcilers reference.
 const (
 	// RequeueDeploymentPolling is the interval for polling Deployment readiness.
-	// Deployments converge quickly, so a short interval is appropriate.
-	RequeueDeploymentPolling = 10 * time.Second
+	RequeueDeploymentPolling = commonreconcile.RequeueDeploymentPolling
 
 	// RequeueSecretPolling is the interval for polling ESO-managed Secret
-	// readiness. ESO sync is fast but depends on an external vault, so a
-	// moderate interval balances responsiveness with API load.
-	RequeueSecretPolling = 15 * time.Second
+	// readiness.
+	RequeueSecretPolling = commonreconcile.RequeueSecretPolling
 
 	// RequeueHealthCheck is the interval for requeuing when the dashboard
-	// health check fails. The login page may take a few seconds to start
-	// responding after the Deployment reports ready.
-	RequeueHealthCheck = 10 * time.Second
+	// health check fails.
+	RequeueHealthCheck = healthcheck.RequeueHealthCheck
 
 	// HealthCheckTimeout is the bounded timeout for the HTTP health check
-	// request. Prevents a hanging dashboard from blocking the reconcile loop
-	// indefinitely.
-	HealthCheckTimeout = 10 * time.Second
+	// request.
+	HealthCheckTimeout = healthcheck.HealthCheckTimeout
 
 	// HealthCheckCacheTTL bounds how long a successful login-page probe is
-	// reused before the operator re-probes. Every reconcile pass otherwise
-	// fires a synchronous HTTP GET (bounded by HealthCheckTimeout) which
-	// dominates hot-path latency once a CR is Ready. Keep this TTL at or
-	// below the HorizonAPIReady outage-detection SLO.
-	HealthCheckCacheTTL = 30 * time.Second
+	// reused before the operator re-probes.
+	HealthCheckCacheTTL = healthcheck.HealthCheckCacheTTL
 )

--- a/operators/horizon/main.go
+++ b/operators/horizon/main.go
@@ -42,6 +42,13 @@ func main() {
 		Scheme:           scheme,
 		LeaderElectionID: "horizon.openstack.c5c3.io",
 		SetupFunc: func(mgr ctrl.Manager, webhooks bool, maxConcurrentReconciles int) error {
+			// Register the operator's Prometheus collectors on the
+			// controller-runtime registry before wiring controllers, so a
+			// duplicate-registration fails startup cleanly instead of panicking
+			// mid-reconcile.
+			if err := controller.RegisterMetrics(); err != nil {
+				return err
+			}
 			// +kubebuilder:scaffold:builder — register controllers here
 			if err := (&controller.HorizonReconciler{
 				Client:                  mgr.GetClient(),

--- a/operators/keystone/api/v1alpha1/integration_test.go
+++ b/operators/keystone/api/v1alpha1/integration_test.go
@@ -609,10 +609,10 @@ func TestIntegration_ResourcesDefaultedWhenNil(t *testing.T) {
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: "res-default", Namespace: ns.Name}, got)).To(Succeed())
 
 	g.Expect(got.Spec.Deployment.Resources).NotTo(BeNil(), "resources should be defaulted")
-	g.Expect(got.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryRequest))
-	g.Expect(got.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPURequest))
-	g.Expect(got.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryLimit))
-	g.Expect(got.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPULimit))
+	g.Expect(got.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryRequest()))
+	g.Expect(got.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPURequest()))
+	g.Expect(got.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryLimit()))
+	g.Expect(got.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPULimit()))
 }
 
 func TestIntegration_ResourcesPreservedWhenExplicit(t *testing.T) {

--- a/operators/keystone/api/v1alpha1/keystone_webhook.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook.go
@@ -94,18 +94,6 @@ const (
 	DefaultAdminPasswordMinLength int32 = 24
 )
 
-// Default resource requests and limits for the Keystone API container.
-// The canonical values moved to internal/common/types beside the shared
-// DeploymentSpec (applied by its Default method); the re-exports keep the
-// controller package tests (reconcile_deployment_test.go) compiling
-// unchanged. Mutation is safe: all call sites use DeepCopy().
-var (
-	DefaultMemoryRequest = commonv1.DefaultMemoryRequest
-	DefaultCPURequest    = commonv1.DefaultCPURequest
-	DefaultMemoryLimit   = commonv1.DefaultMemoryLimit
-	DefaultCPULimit      = commonv1.DefaultCPULimit
-)
-
 // KeystoneWebhook implements defaulting and validation webhooks for the Keystone CRD.
 // Client is injected at startup for cluster-scoped resource lookups (e.g. PriorityClass validation). Production wiring injects mgr.GetAPIReader() — a direct,
 // uncached reader — so admission never rejects a just-created object from a stale

--- a/operators/keystone/api/v1alpha1/keystone_webhook_test.go
+++ b/operators/keystone/api/v1alpha1/keystone_webhook_test.go
@@ -66,10 +66,10 @@ func TestDefault_SetsZeroValueDefaults(t *testing.T) {
 	g.Expect(k.Spec.Bootstrap.Region).To(Equal("RegionOne"))
 	// Verify Resources defaults are applied.
 	g.Expect(k.Spec.Deployment.Resources).NotTo(BeNil())
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryRequest))
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPURequest))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryLimit))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPULimit))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryRequest()))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPURequest()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryLimit()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPULimit()))
 }
 
 func TestDefault_DoesNotSetFernetRotationSchedule(t *testing.T) {
@@ -1908,10 +1908,10 @@ func TestDefault_ResourcesSetWhenNil(t *testing.T) {
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 
 	g.Expect(k.Spec.Deployment.Resources).NotTo(BeNil())
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryRequest))
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPURequest))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryLimit))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPULimit))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryRequest()))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPURequest()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryLimit()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPULimit()))
 }
 
 // TestDefault_ResourcesSetWhenEmpty verifies that `resources: {}` (non-nil but
@@ -1929,10 +1929,10 @@ func TestDefault_ResourcesSetWhenEmpty(t *testing.T) {
 	g.Expect(w.Default(context.Background(), k)).To(Succeed())
 
 	g.Expect(k.Spec.Deployment.Resources).NotTo(BeNil())
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryRequest))
-	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPURequest))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, DefaultMemoryLimit))
-	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, DefaultCPULimit))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryRequest()))
+	g.Expect(k.Spec.Deployment.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPURequest()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryLimit()))
+	g.Expect(k.Spec.Deployment.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPULimit()))
 }
 
 func TestDefault_ResourcesPreservedWhenExplicit(t *testing.T) {

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystoneidentitybackends.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystoneidentitybackends.yaml
@@ -255,7 +255,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -350,7 +350,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -655,7 +655,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -888,7 +888,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -952,7 +952,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -107,7 +107,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -312,8 +312,8 @@ spec:
                       managed-mode projection honours it (a single replica yields a
                       single-instance non-Galera MariaDB, three or more yield a Galera cluster),
                       so a constrained cluster such as a single-node kind can schedule the
-                      fresh-create path. Operators that adopt an existing MariaDB (keystone, and
-                      the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                      fresh-create path. Operators that adopt an existing MariaDB (the c5c3 adopted-infra path,
+                      and every service operator) ignore it. Only meaningful when ClusterRef is
                       set.
                     format: int32
                     minimum: 1
@@ -327,7 +327,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -343,7 +343,7 @@ spec:
                       MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
                       operator's managed-mode projection honours it (it is written to the owned
                       MariaDB's spec.storage.size); operators that adopt an existing MariaDB
-                      (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                      (the c5c3 adopted-infra path, and every service operator) ignore it. The default 100Gi
                       mirrors the production baseline (deploy/flux-system/infrastructure/
                       mariadb.yaml); a constrained cluster such as a single-node kind can pin a
                       far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
@@ -371,7 +371,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -391,7 +391,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -455,7 +455,7 @@ spec:
                       lifecycle hook, configured independently of the overall grace period
                       This covers the window between EndpointSlice removal and
                       kube-proxy/ingress-controller propagation so new requests stop arriving
-                      before SIGTERM reaches uWSGI. When nil, the reconciler applies a default
+                      before SIGTERM reaches the API process. When nil, the reconciler applies a default
                       of 5s. Zero is permitted to disable the sleep. The cross-field rule
                       preStopSleepSeconds < terminationGracePeriodSeconds is enforced by the
                       validating webhook to guarantee a non-zero drain window.
@@ -464,20 +464,20 @@ spec:
                     type: integer
                   priorityClassName:
                     description: |-
-                      PriorityClassName sets the priority class for Keystone API pods.
+                      PriorityClassName sets the priority class for service API pods.
                       When set, the operator passes the value through to the PodSpec, allowing
                       cluster administrators to control scheduling priority and preemption.
                       When unset, no priority class is configured and the cluster default applies.
                     type: string
                   replicas:
                     default: 3
-                    description: Replicas is the desired number of Keystone API pods.
+                    description: Replicas is the desired number of service API pods.
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
                     description: |-
-                      Resources defines the CPU and memory requests and limits for the Keystone API
+                      Resources defines the CPU and memory requests and limits for the service API
                       container. When unset, the defaulting webhook injects sensible defaults
                       (256Mi/512Mi memory, 100m/500m CPU) to ensure Burstable QoS class and
                       enable HPA utilization calculations.
@@ -540,7 +540,7 @@ spec:
                     type: object
                   strategy:
                     description: |-
-                      Strategy overrides the Deployment rollout strategy for the Keystone API
+                      Strategy overrides the Deployment rollout strategy for the service API
                       Deployment. When nil, the reconciler applies RollingUpdate
                       with MaxUnavailable=0 and MaxSurge=1 to guarantee surge-before-remove
                       behavior — available capacity never dips below spec.deployment.replicas
@@ -594,9 +594,9 @@ spec:
                   terminationGracePeriodSeconds:
                     description: |-
                       TerminationGracePeriodSeconds is the grace period (seconds) granted to
-                      Keystone API pods between SIGTERM and SIGKILL during rolling updates
+                      service API pods between SIGTERM and SIGKILL during rolling updates
                       Extend this to cover slow upstream token validation (LDAP/DB)
-                      so in-flight requests finish before the kubelet forcibly kills uWSGI.
+                      so in-flight requests finish before the kubelet forcibly kills the API process.
                       When nil, the reconciler omits the field from the pod template and the
                       Kubernetes default of 30s applies. Must be at least 10s when set.
                     format: int64
@@ -822,7 +822,7 @@ spec:
                       repository:
                         description: |-
                           Repository is the OCI image repository, optionally including the registry
-                          host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                          host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                           permissive OCI reference — lowercase alphanumeric components separated by
                           ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                           are accepted while an empty string (which "required" alone admits) and
@@ -984,7 +984,7 @@ spec:
                   repository:
                     description: |-
                       Repository is the OCI image repository, optionally including the registry
-                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                       permissive OCI reference — lowercase alphanumeric components separated by
                       ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                       are accepted while an empty string (which "required" alone admits) and
@@ -1048,7 +1048,7 @@ spec:
                     description: |-
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
-                      {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
+                      {"sqlalchemy.engine": "WARNING", "myservice.middleware": "DEBUG"}.
                       Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
                       logger name must be non-empty. These are now enforced by the CRD CEL
                       XValidation rules below as well as by the validating webhook (a plain
@@ -1296,19 +1296,19 @@ spec:
                     type: array
                   ingress:
                     description: |-
-                      Ingress defines the sources allowed to reach Keystone API on TCP 5000.
+                      Ingress defines the sources allowed to reach the service API on its API port.
                       Each source specifies a namespace selector and an optional pod selector.
                       Multiple sources produce multiple From peers in a single ingress rule
                       (OR across peers, AND within a peer's selectors).
                     items:
                       description: |-
                         NetworkPolicyIngressSource defines a source from which traffic is allowed
-                        to reach the Keystone API pods on TCP 5000.
+                        to reach the service API pods on the API port.
                       properties:
                         namespaceSelector:
                           description: |-
                             NamespaceSelector selects namespaces from which traffic is allowed.
-                            All pods in matching namespaces can reach Keystone on port 5000
+                            All pods in matching namespaces can reach the service on its API port
                             unless PodSelector further restricts the set. It is a full
                             metav1.LabelSelector, so set-based matchExpressions are supported in
                             addition to matchLabels.
@@ -1360,7 +1360,7 @@ spec:
                           description: |-
                             PodSelector optionally restricts allowed traffic to pods matching
                             these labels within the selected namespaces. When set, only pods
-                            matching both NamespaceSelector AND PodSelector can reach Keystone
+                            matching both NamespaceSelector AND PodSelector can reach the service
                             (AND logic within a single peer). It is a full metav1.LabelSelector,
                             so set-based matchExpressions are supported in addition to matchLabels.
                           properties:
@@ -1475,7 +1475,7 @@ spec:
                       description: ConfigSection is the INI section name (e.g., "keycloak")
                       type: string
                     name:
-                      description: Name of the plugin (e.g., "keystone-keycloak-backend")
+                      description: Name of the plugin (e.g., "myservice-keycloak-backend")
                       type: string
                   required:
                   - configSection

--- a/operators/keystone/dashboards/dashboard_test.go
+++ b/operators/keystone/dashboards/dashboard_test.go
@@ -131,15 +131,19 @@ func TestDashboardReferencesOnlyRegisteredMetrics(t *testing.T) {
 	// probe samples clearly distinguishable if they ever leak into a
 	// live registry.
 	//
-	// DECISION: use the production metrics surface (a lazily-registered
+	// DECISION: use the production metrics surface (an
 	// instrumentation.NewMetrics instance with the production prefix and the
 	// metrics.* per-CR helpers, not the private newCollectorsForTest) so this
-	// test exercises the exact code path that wires production collectors
-	// onto ctrlmetrics.Registry. The instance mirrors the controller
-	// package's subReconcilerMetrics glue; this test binary is its only
+	// test exercises the exact collectors the controller registers on
+	// ctrlmetrics.Registry at startup. The instance mirrors the controller
+	// package's instrumenter glue; this test binary is its only
 	// keystone_operator registrant, so no duplicate registration occurs.
+	// Registration is now explicit (lazy registration was removed in favour of
+	// RegisterMetrics at operator startup), so register both surfaces here.
 	const probe = "dashboard_test_probe"
 	subReconcilerMetrics := instrumentation.NewMetrics("keystone_operator")
+	g.Expect(subReconcilerMetrics.Register(ctrlmetrics.Registry)).To(Succeed())
+	g.Expect(metrics.Register()).To(Succeed())
 	subReconcilerMetrics.ObserveReconcileDuration(probe, 0)
 	subReconcilerMetrics.RecordReconcileError(probe, probe)
 	g.Expect(metrics.SetKeyRotationAge(probe, probe, probe, time.Now())).To(Succeed())

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystoneidentitybackends.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystoneidentitybackends.yaml
@@ -258,7 +258,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -353,7 +353,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -658,7 +658,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -891,7 +891,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -955,7 +955,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -110,7 +110,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -315,8 +315,8 @@ spec:
                       managed-mode projection honours it (a single replica yields a
                       single-instance non-Galera MariaDB, three or more yield a Galera cluster),
                       so a constrained cluster such as a single-node kind can schedule the
-                      fresh-create path. Operators that adopt an existing MariaDB (keystone, and
-                      the c5c3 adopted-infra path) ignore it. Only meaningful when ClusterRef is
+                      fresh-create path. Operators that adopt an existing MariaDB (the c5c3 adopted-infra path,
+                      and every service operator) ignore it. Only meaningful when ClusterRef is
                       set.
                     format: int32
                     minimum: 1
@@ -330,7 +330,7 @@ spec:
                         description: |-
                           Name is the referenced Secret's name. It must be a non-empty DNS-1123
                           subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                          fixes every consumer at once — keystone adminPasswordSecretRef /
+                          fixes every consumer at once — a service operator adminPasswordSecretRef /
                           database.secretRef / messaging / TLS cert refs and the c5c3
                           passwordSecretRef — so an empty name no longer slips through "required".
                         minLength: 1
@@ -346,7 +346,7 @@ spec:
                       MariaDB replica in fresh-create mode. Like Replicas, only the c5c3
                       operator's managed-mode projection honours it (it is written to the owned
                       MariaDB's spec.storage.size); operators that adopt an existing MariaDB
-                      (keystone, and the c5c3 adopted-infra path) ignore it. The default 100Gi
+                      (the c5c3 adopted-infra path, and every service operator) ignore it. The default 100Gi
                       mirrors the production baseline (deploy/flux-system/infrastructure/
                       mariadb.yaml); a constrained cluster such as a single-node kind can pin a
                       far smaller value (e.g. 512Mi) so CI does not request a 100Gi volume it
@@ -374,7 +374,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -394,7 +394,7 @@ spec:
                             description: |-
                               Name is the referenced Secret's name. It must be a non-empty DNS-1123
                               subdomain (the Kubernetes object-name grammar). Tightening the shared type
-                              fixes every consumer at once — keystone adminPasswordSecretRef /
+                              fixes every consumer at once — a service operator adminPasswordSecretRef /
                               database.secretRef / messaging / TLS cert refs and the c5c3
                               passwordSecretRef — so an empty name no longer slips through "required".
                             minLength: 1
@@ -458,7 +458,7 @@ spec:
                       lifecycle hook, configured independently of the overall grace period
                       This covers the window between EndpointSlice removal and
                       kube-proxy/ingress-controller propagation so new requests stop arriving
-                      before SIGTERM reaches uWSGI. When nil, the reconciler applies a default
+                      before SIGTERM reaches the API process. When nil, the reconciler applies a default
                       of 5s. Zero is permitted to disable the sleep. The cross-field rule
                       preStopSleepSeconds < terminationGracePeriodSeconds is enforced by the
                       validating webhook to guarantee a non-zero drain window.
@@ -467,20 +467,20 @@ spec:
                     type: integer
                   priorityClassName:
                     description: |-
-                      PriorityClassName sets the priority class for Keystone API pods.
+                      PriorityClassName sets the priority class for service API pods.
                       When set, the operator passes the value through to the PodSpec, allowing
                       cluster administrators to control scheduling priority and preemption.
                       When unset, no priority class is configured and the cluster default applies.
                     type: string
                   replicas:
                     default: 3
-                    description: Replicas is the desired number of Keystone API pods.
+                    description: Replicas is the desired number of service API pods.
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
                     description: |-
-                      Resources defines the CPU and memory requests and limits for the Keystone API
+                      Resources defines the CPU and memory requests and limits for the service API
                       container. When unset, the defaulting webhook injects sensible defaults
                       (256Mi/512Mi memory, 100m/500m CPU) to ensure Burstable QoS class and
                       enable HPA utilization calculations.
@@ -543,7 +543,7 @@ spec:
                     type: object
                   strategy:
                     description: |-
-                      Strategy overrides the Deployment rollout strategy for the Keystone API
+                      Strategy overrides the Deployment rollout strategy for the service API
                       Deployment. When nil, the reconciler applies RollingUpdate
                       with MaxUnavailable=0 and MaxSurge=1 to guarantee surge-before-remove
                       behavior — available capacity never dips below spec.deployment.replicas
@@ -597,9 +597,9 @@ spec:
                   terminationGracePeriodSeconds:
                     description: |-
                       TerminationGracePeriodSeconds is the grace period (seconds) granted to
-                      Keystone API pods between SIGTERM and SIGKILL during rolling updates
+                      service API pods between SIGTERM and SIGKILL during rolling updates
                       Extend this to cover slow upstream token validation (LDAP/DB)
-                      so in-flight requests finish before the kubelet forcibly kills uWSGI.
+                      so in-flight requests finish before the kubelet forcibly kills the API process.
                       When nil, the reconciler omits the field from the pod template and the
                       Kubernetes default of 30s applies. Must be at least 10s when set.
                     format: int64
@@ -825,7 +825,7 @@ spec:
                       repository:
                         description: |-
                           Repository is the OCI image repository, optionally including the registry
-                          host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                          host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                           permissive OCI reference — lowercase alphanumeric components separated by
                           ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                           are accepted while an empty string (which "required" alone admits) and
@@ -987,7 +987,7 @@ spec:
                   repository:
                     description: |-
                       Repository is the OCI image repository, optionally including the registry
-                      host (e.g. "ghcr.io/c5c3/keystone" or "c5c3/keystone"). The pattern is a
+                      host (e.g. "ghcr.io/c5c3/<service>" or "c5c3/<service>"). The pattern is a
                       permissive OCI reference — lowercase alphanumeric components separated by
                       ".", "_", "-", "/", or ":" (registry port) — so mirror and host:port forms
                       are accepted while an empty string (which "required" alone admits) and
@@ -1051,7 +1051,7 @@ spec:
                     description: |-
                       PerLoggerLevels overrides the level of named loggers, mirroring
                       oslo.log's `default_log_levels`. Example:
-                      {"sqlalchemy.engine": "WARNING", "keystone.middleware": "DEBUG"}.
+                      {"sqlalchemy.engine": "WARNING", "myservice.middleware": "DEBUG"}.
                       Each value must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL and every
                       logger name must be non-empty. These are now enforced by the CRD CEL
                       XValidation rules below as well as by the validating webhook (a plain
@@ -1299,19 +1299,19 @@ spec:
                     type: array
                   ingress:
                     description: |-
-                      Ingress defines the sources allowed to reach Keystone API on TCP 5000.
+                      Ingress defines the sources allowed to reach the service API on its API port.
                       Each source specifies a namespace selector and an optional pod selector.
                       Multiple sources produce multiple From peers in a single ingress rule
                       (OR across peers, AND within a peer's selectors).
                     items:
                       description: |-
                         NetworkPolicyIngressSource defines a source from which traffic is allowed
-                        to reach the Keystone API pods on TCP 5000.
+                        to reach the service API pods on the API port.
                       properties:
                         namespaceSelector:
                           description: |-
                             NamespaceSelector selects namespaces from which traffic is allowed.
-                            All pods in matching namespaces can reach Keystone on port 5000
+                            All pods in matching namespaces can reach the service on its API port
                             unless PodSelector further restricts the set. It is a full
                             metav1.LabelSelector, so set-based matchExpressions are supported in
                             addition to matchLabels.
@@ -1363,7 +1363,7 @@ spec:
                           description: |-
                             PodSelector optionally restricts allowed traffic to pods matching
                             these labels within the selected namespaces. When set, only pods
-                            matching both NamespaceSelector AND PodSelector can reach Keystone
+                            matching both NamespaceSelector AND PodSelector can reach the service
                             (AND logic within a single peer). It is a full metav1.LabelSelector,
                             so set-based matchExpressions are supported in addition to matchLabels.
                           properties:
@@ -1478,7 +1478,7 @@ spec:
                       description: ConfigSection is the INI section name (e.g., "keycloak")
                       type: string
                     name:
-                      description: Name of the plugin (e.g., "keystone-keycloak-backend")
+                      description: Name of the plugin (e.g., "myservice-keycloak-backend")
                       type: string
                   required:
                   - configSection

--- a/operators/keystone/internal/controller/database_jobs.go
+++ b/operators/keystone/internal/controller/database_jobs.go
@@ -12,72 +12,36 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
-func buildDatabase(keystone *keystonev1alpha1.Keystone) *mariadbv1alpha1.Database {
+// keystoneProvisionParams derives the shared MariaDB provisioning inputs from
+// the Keystone CR: the resource name and SQL username are the CR name, the
+// database and cluster reference come from spec.database, and the password is
+// read from the database credentials Secret.
+func keystoneProvisionParams(keystone *keystonev1alpha1.Keystone) database.ProvisionParams {
 	key := mariaDBResourceKey(keystone)
-	return &mariadbv1alpha1.Database{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-		Spec: mariadbv1alpha1.DatabaseSpec{
-			MariaDBRef: mariadbv1alpha1.MariaDBRef{
-				ObjectReference: mariadbv1alpha1.ObjectReference{
-					Name: keystone.Spec.Database.ClusterRef.Name,
-				},
-			},
-			CharacterSet: "utf8",
-			Collate:      "utf8_general_ci",
-			Name:         keystone.Spec.Database.Database,
-		},
+	return database.ProvisionParams{
+		Name:               key.Name,
+		Namespace:          key.Namespace,
+		ClusterRef:         keystone.Spec.Database.ClusterRef.Name,
+		DatabaseName:       keystone.Spec.Database.Database,
+		PasswordSecretName: keystone.Spec.Database.SecretRef.Name,
 	}
+}
+
+func buildDatabase(keystone *keystonev1alpha1.Keystone) *mariadbv1alpha1.Database {
+	return database.BuildDatabase(keystoneProvisionParams(keystone))
 }
 
 func buildUser(keystone *keystonev1alpha1.Keystone) *mariadbv1alpha1.User {
-	key := mariaDBResourceKey(keystone)
-	return &mariadbv1alpha1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-		Spec: mariadbv1alpha1.UserSpec{
-			MariaDBRef: mariadbv1alpha1.MariaDBRef{
-				ObjectReference: mariadbv1alpha1.ObjectReference{
-					Name: keystone.Spec.Database.ClusterRef.Name,
-				},
-			},
-			PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-				LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-					Name: keystone.Spec.Database.SecretRef.Name,
-				},
-				Key: "password",
-			},
-		},
-	}
+	return database.BuildUser(keystoneProvisionParams(keystone))
 }
 
 func buildGrant(keystone *keystonev1alpha1.Keystone) *mariadbv1alpha1.Grant {
-	key := mariaDBResourceKey(keystone)
-	return &mariadbv1alpha1.Grant{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-		Spec: mariadbv1alpha1.GrantSpec{
-			MariaDBRef: mariadbv1alpha1.MariaDBRef{
-				ObjectReference: mariadbv1alpha1.ObjectReference{
-					Name: keystone.Spec.Database.ClusterRef.Name,
-				},
-			},
-			Privileges: []string{"ALL PRIVILEGES"},
-			Database:   keystone.Spec.Database.Database,
-			Table:      "*",
-			Username:   key.Name,
-		},
-	}
+	return database.BuildGrant(keystoneProvisionParams(keystone))
 }
 
 // buildDBJob constructs a keystone-manage db_sync Job with the shared container spec,

--- a/operators/keystone/internal/controller/database_jobs.go
+++ b/operators/keystone/internal/controller/database_jobs.go
@@ -10,10 +10,10 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
+	"github.com/c5c3/forge/internal/common/job"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
@@ -57,69 +57,42 @@ func buildGrant(keystone *keystonev1alpha1.Keystone) *mariadbv1alpha1.Grant {
 // container. Currently runs as BestEffort QoS. See reconcile_deployment.go
 // containerResources() for the pattern used by the keystone container.
 func buildDBJob(keystone *keystonev1alpha1.Keystone, configMapName, domainsSecretName, image, nameSuffix string, command []string) *batchv1.Job {
-	backoffLimit := int32(4)
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", keystone.Name, nameSuffix),
-			Namespace: keystone.Namespace,
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy:     corev1.RestartPolicyNever,
-					PriorityClassName: priorityClassName(keystone),
-					Containers: []corev1.Container{{
-						Name:            nameSuffix,
-						Image:           image,
-						Command:         command,
-						SecurityContext: deployment.RestrictedSecurityContext(),
-						// Override [database].connection via oslo.config env-var so every
-						// db_sync variant (db-sync, expand, migrate, contract, schema-check)
-						// reads the DB URL from the derived Secret instead of the ConfigMap.
-						Env: []corev1.EnvVar{buildDBConnectionEnvVar(keystone)},
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      "config",
-							MountPath: "/etc/keystone/keystone.conf.d/",
-							ReadOnly:  true,
-						}},
-					}},
-					Volumes: []corev1.Volume{{
-						Name: "config",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: configMapName,
-								},
-							},
-						},
-					}},
-				},
-			},
-		},
-	}
-	// Project the db-tls client keypair into every db_sync variant
-	// (db-sync, expand, migrate, contract, schema-check) when DB TLS is
-	// enabled; the gate is centralised in dbTLSEnabled so deployment and job
-	// builders decide identically.
+	// Project the db-tls client keypair into every db_sync variant (db-sync,
+	// expand, migrate, contract, schema-check) when DB TLS is enabled; the gate
+	// is centralised in dbTLSEnabled so deployment and job builders decide
+	// identically. Then project the per-domain identity-backend config so
+	// keystone-manage sees the same domain-specific driver files the API pods
+	// load; an empty name (no backend projected) appends nothing.
+	var extraVolumes []corev1.Volume
+	var extraMounts []corev1.VolumeMount
 	if dbTLSEnabled(keystone) {
 		tlsVol, tlsMount := dbTLSVolumeAndMount(keystone)
-		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, tlsVol)
-		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-			job.Spec.Template.Spec.Containers[0].VolumeMounts, tlsMount,
-		)
+		extraVolumes = append(extraVolumes, tlsVol)
+		extraMounts = append(extraMounts, tlsMount)
 	}
-	// Project the per-domain identity-backend config so keystone-manage sees
-	// the same domain-specific driver files the API pods load; an empty name
-	// (no backend projected) leaves the Job byte-identical to before.
 	if domainsSecretName != "" {
 		domVol, domMount := domainsVolumeAndMount(domainsSecretName)
-		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, domVol)
-		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-			job.Spec.Template.Spec.Containers[0].VolumeMounts, domMount,
-		)
+		extraVolumes = append(extraVolumes, domVol)
+		extraMounts = append(extraMounts, domMount)
 	}
-	return job
+	return job.BuildMigrationJob(job.MigrationJobParams{
+		Name:            fmt.Sprintf("%s-%s", keystone.Name, nameSuffix),
+		Namespace:       keystone.Namespace,
+		Image:           image,
+		ContainerName:   nameSuffix,
+		Command:         command,
+		ConfigMapName:   configMapName,
+		ConfigMountPath: "/etc/keystone/keystone.conf.d/",
+		// Override [database].connection via oslo.config env-var so every db_sync
+		// variant reads the DB URL from the derived Secret instead of the
+		// ConfigMap.
+		Env:               []corev1.EnvVar{buildDBConnectionEnvVar(keystone)},
+		ExtraVolumes:      extraVolumes,
+		ExtraVolumeMounts: extraMounts,
+		PriorityClassName: priorityClassName(keystone),
+		BackoffLimit:      4,
+		SecurityContext:   deployment.RestrictedSecurityContext(),
+	})
 }
 
 func buildDBSyncJob(keystone *keystonev1alpha1.Keystone, configMapName, domainsSecretName string) *batchv1.Job {

--- a/operators/keystone/internal/controller/db_job_metrics.go
+++ b/operators/keystone/internal/controller/db_job_metrics.go
@@ -6,160 +6,37 @@ package controller
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/job"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 	"github.com/c5c3/forge/operators/keystone/internal/metrics"
 )
 
-// dbJobUIDAnnotationFormat builds the annotation key used to dedupe terminal
-// metric emission for a given DB-related Job. The annotation lives on the
-// Keystone CR so it survives Job deletion (e.g. when RunJob recreates the Job
-// after a PodSpec hash change) and the operator can still skip re-emission
-// when the same UID is observed twice.
-//
-// The %s placeholder is the buildDBJob nameSuffix ("db-sync", "db-expand",
-// "db-migrate", "db-contract", "schema-check"). Each phase keeps an
-// independent dedupe annotation so metric emission for the expand-migrate-
-// contract upgrade Jobs and the post-sync schema-check Job is never silently
-// suppressed by an unrelated phase having already been observed.
-const dbJobUIDAnnotationFormat = "forge.c5c3.io/last-%s-job-uid"
-
-// dbJobUIDAnnotationKey returns the dedupe annotation key for the Job
-// identified by the given nameSuffix (see dbJobUIDAnnotationFormat).
+// dbJobUIDAnnotationKey returns the dedupe annotation key for the DB-related Job
+// identified by the given phase suffix ("db-sync", "db-expand", …), via the
+// shared job.JobUIDAnnotationKey. The annotation lives on the Keystone CR so it
+// survives Job deletion; each phase keeps an independent dedupe annotation.
 func dbJobUIDAnnotationKey(jobSuffix string) string {
-	return fmt.Sprintf(dbJobUIDAnnotationFormat, jobSuffix)
+	return job.JobUIDAnnotationKey(jobSuffix)
 }
 
 // recordDBJobTerminalState observes the named DB-related Job's terminal
 // condition and emits keystone_operator_db_sync_total /
 // keystone_operator_db_sync_duration_seconds exactly once per (Job suffix, Job
-// UID) tuple. The jobSuffix argument is the buildDBJob
-// nameSuffix that identifies the phase ("db-sync", "db-expand", "db-migrate",
-// "db-contract", "schema-check"); the same suffix selects the per-phase
-// dedupe annotation via dbJobUIDAnnotationKey, so terminal emission for one
-// phase never silently suppresses another. The function is best-effort: any
-// error reading the Job or persisting the UID annotation is swallowed rather
-// than surfaced as a reconcile failure, because the metric is an observability
-// signal that must not block the sub-reconciler.
-//
-// Idempotence: the last-observed Job UID is stored as a Keystone CR
-// annotation. Re-observing the same UID skips emission; a Job recreated by
-// RunJob (e.g. after a PodSpec hash change) carries a fresh UID and therefore
-// drives a fresh metric observation. Duration is computed as
-// condition.LastTransitionTime minus Job.CreationTimestamp.
-//
-// observed is the Job that RunJob already read this pass, threaded in so this
-// function does not re-Get it (issue #361). A nil observed (the Job was just
-// created, so has no terminal condition yet) is a no-op.
-//
-// Ordering: the dedupe annotation is patched
-// BEFORE metrics.RecordDBSync. If the patch fails (transient apiserver error,
-// stale-RV conflict), the metric is NOT emitted on this pass — the next
-// reconcile re-evaluates the Job and either emits then (after a successful
-// patch) or surfaces a single deferred-emission log line. This preserves the
-// at-most-once-per-UID guarantee documented in
-// docs/reference/keystone-operator-metrics.md against transient apiserver
-// failures, at the cost of postponing the observation by one reconcile.
-//
-// Visibility on persistent patch failure:
-// the deferred-emission log is emitted at Info (default level) and a
-// Warning event is recorded on the Keystone CR. A persistent apiserver
-// Patch failure would otherwise silently degrade db_sync metric emission
-// to at-most-once-per-UID-per-successful-patch — invisible at default log
-// levels until an alert fires for missing samples. Emitting at Info plus a
-// CR-visible event ensures cluster operators notice the degradation
-// directly via `kubectl describe keystone` and default-verbosity logs.
+// UID) tuple, delegating to the shared job.RecordJobTerminalState. The jobSuffix
+// identifies the phase ("db-sync", "db-expand", …) and selects the per-phase
+// dedupe annotation; observed is the Job RunJob already read this pass, threaded
+// in so this function does not re-Get it (issue #361). It is best-effort: a
+// transient patch failure defers emission to the next reconcile and records a
+// DBSyncMetricEmissionDeferred Warning event so the degradation is visible via
+// `kubectl describe keystone`.
 func (r *KeystoneReconciler) recordDBJobTerminalState(ctx context.Context, keystone *keystonev1alpha1.Keystone, jobSuffix string, observed *batchv1.Job) {
-	// A just-created Job (RunJob returned nil) has no terminal condition yet.
-	if observed == nil {
-		return
-	}
-	annotationKey := dbJobUIDAnnotationKey(jobSuffix)
-	dbJob := observed
-
-	var (
-		result       string
-		transitionAt metav1.Time
-	)
-	for _, c := range dbJob.Status.Conditions {
-		if c.Status != corev1.ConditionTrue {
-			continue
-		}
-		switch c.Type {
-		case batchv1.JobComplete:
-			result = "succeeded"
-			transitionAt = c.LastTransitionTime
-		case batchv1.JobFailed:
-			result = "failed"
-			transitionAt = c.LastTransitionTime
-		case batchv1.JobSuspended, batchv1.JobFailureTarget, batchv1.JobSuccessCriteriaMet:
-			// Non-terminal transitions: a Suspended Job may be resumed and
-			// FailureTarget/SuccessCriteriaMet flip briefly before the
-			// terminal JobFailed/JobComplete is set. Ignore here — the
-			// metric is emitted only on terminal transitions.
-		}
-		if result != "" {
-			break
-		}
-	}
-	if result == "" {
-		return
-	}
-
-	uid := string(dbJob.UID)
-	if uid != "" && keystone.Annotations[annotationKey] == uid {
-		return
-	}
-
-	// Persist the observed UID BEFORE recording the metric so a transient
-	// patch failure cannot cause double-counting on the next reconcile.
-	// Patching the caller's keystone directly
-	// would let the client overwrite its in-memory status conditions
-	// (accumulated by earlier sub-reconcilers on this pass) with the
-	// backend copy, so the patch operates on a separate DeepCopy. The
-	// annotation and post-patch ResourceVersion are mirrored back onto the
-	// caller's object so a later Status().Update does not hit a stale-RV
-	// conflict.
-	patchTarget := keystone.DeepCopy()
-	patch := client.MergeFrom(patchTarget.DeepCopy())
-	if patchTarget.Annotations == nil {
-		patchTarget.Annotations = make(map[string]string)
-	}
-	patchTarget.Annotations[annotationKey] = uid
-	if err := r.Patch(ctx, patchTarget, patch); err != nil {
-		// Log at Info (default level) and
-		// emit a Warning event on the Keystone CR so persistent apiserver
-		// Patch failures are visible without raising log verbosity. A
-		// silent V(1) line could let the at-most-once-per-UID degradation
-		// persist until alerts fire for missing samples.
-		log.FromContext(ctx).Info(
-			"recordDBJobTerminalState: patching last-observed Job UID failed; "+
-				"db_sync metric emission deferred to the next reconcile",
-			"keystone", keystone.Name,
-			"jobSuffix", jobSuffix,
-			"err", err.Error(),
-		)
-		r.Recorder.Eventf(keystone, corev1.EventTypeWarning, "DBSyncMetricEmissionDeferred",
-			"Patching last-observed %s Job UID failed; db_sync metric emission deferred to the next reconcile: %v",
-			jobSuffix, err)
-		return
-	}
-	if keystone.Annotations == nil {
-		keystone.Annotations = make(map[string]string)
-	}
-	keystone.Annotations[annotationKey] = uid
-	keystone.ResourceVersion = patchTarget.ResourceVersion
-
-	duration := transitionAt.Sub(dbJob.CreationTimestamp.Time)
-	if duration < 0 {
-		duration = 0
-	}
-	metrics.RecordDBSync(keystone.Name, keystone.Namespace, result, duration)
+	job.RecordJobTerminalState(ctx, r.Client, r.Recorder, keystone, jobSuffix, observed,
+		"DBSyncMetricEmissionDeferred",
+		func(result string, duration time.Duration) {
+			metrics.RecordDBSync(keystone.Name, keystone.Namespace, result, duration)
+		})
 }

--- a/operators/keystone/internal/controller/instrumentation.go
+++ b/operators/keystone/internal/controller/instrumentation.go
@@ -7,10 +7,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/c5c3/forge/internal/common/instrumentation"
+	"github.com/c5c3/forge/operators/keystone/internal/metrics"
 )
 
 // subReconcilerConditionTypes maps a sub_reconciler label value to the
@@ -56,22 +59,29 @@ var subReconcilerConditionTypes = map[string]string{
 	"PasswordRotation":   conditionTypePasswordRotationReady,
 }
 
-// subReconcilerMetrics holds the shared sub-reconciler instrumentation
-// metrics for the keystone operator
-// (keystone_operator_reconcile_duration_seconds and
-// keystone_operator_reconcile_errors_total). The vectors register lazily on
-// the controller-runtime registry the first time a sample is recorded.
-// Declared beside the instrumenter glue — matching the c5c3 operator's
-// placement — rather than in internal/metrics, which keeps the keystone-only
-// collectors.
-var subReconcilerMetrics = instrumentation.NewMetrics("keystone_operator")
-
 // instrumenter wraps every sub-reconciler call with the shared duration/error
-// instrumentation, recording through subReconcilerMetrics. It indirects
-// through a package-level var so unit tests can rebind it to an isolated
-// prometheus registry without polluting the controller-runtime production
-// registry. Production code MUST NOT reassign it.
-var instrumenter = instrumentation.NewInstrumenter(subReconcilerMetrics, subReconcilerConditionTypes)
+// instrumentation (keystone_operator_reconcile_duration_seconds and
+// keystone_operator_reconcile_errors_total). It owns its metric vectors, which
+// RegisterMetrics exposes on the controller-runtime registry at startup. The
+// var indirection lets unit tests rebind it to an isolated prometheus registry
+// without polluting the production registry; production code MUST NOT reassign
+// it.
+var instrumenter = instrumentation.NewSubReconcilerInstrumenter("keystone_operator", subReconcilerConditionTypes)
+
+// RegisterMetrics exposes the operator's Prometheus collectors on the
+// controller-runtime registry: the shared sub-reconciler duration/error vectors
+// and the keystone-only per-CR collectors. It returns an error on a
+// duplicate-registration rather than panicking mid-reconcile, so main.go can
+// fail startup cleanly. Call it exactly once during operator setup.
+func RegisterMetrics() error {
+	if err := instrumenter.Register(ctrlmetrics.Registry); err != nil {
+		return fmt.Errorf("registering keystone_operator sub-reconciler metrics: %w", err)
+	}
+	if err := metrics.Register(); err != nil {
+		return fmt.Errorf("registering keystone per-CR metrics: %w", err)
+	}
+	return nil
+}
 
 // instrumentSubReconciler wraps a sub-reconciler call, observing duration on
 // every path (success, error, panic) and recording an error count if fn

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -35,7 +35,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/gateway"
 	"github.com/c5c3/forge/internal/common/healthcheck"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
@@ -756,17 +755,25 @@ func (r *KeystoneReconciler) hasLiveOpenBaoBackupPushSecrets(ctx context.Context
 // already Ready (SC-CHAOS-006) — and stamps status.observedGeneration so a
 // stale status is distinguishable from one reflecting the current spec.
 func (r *KeystoneReconciler) updateStatus(ctx context.Context, keystone *keystonev1alpha1.Keystone, statusBefore *keystonev1alpha1.KeystoneStatus, result ctrl.Result, reconcileErr error) (ctrl.Result, error) {
-	return commonreconcile.UpdateStatus(ctx, r.Client, keystone, statusBefore, &keystone.Status, func() {
-		setReadyCondition(keystone)
+	return keystoneSkeleton.UpdateStatus(ctx, r.Client, keystone, statusBefore, &keystone.Status, func() {
 		keystone.Status.ObservedGeneration = keystone.Generation
 	}, result, reconcileErr)
 }
 
+// keystoneSkeleton bundles the shared controller-skeleton glue (Ready
+// aggregation, no-op-skipping status writes, config-failure marking, and
+// parallel-group execution) with keystone's sub-condition vocabulary and status
+// accessor. The wrapper methods below delegate to it.
+var keystoneSkeleton = commonreconcile.Skeleton[*keystonev1alpha1.Keystone, keystonev1alpha1.KeystoneStatus]{
+	SubConditionTypes: subConditionTypes,
+	Conditions:        func(ks *keystonev1alpha1.Keystone) *[]metav1.Condition { return &ks.Status.Conditions },
+}
+
 // setReadyCondition sets the aggregate Ready condition based on all
-// sub-conditions, delegating to the shared aggregation helper with keystone's
+// sub-conditions, delegating to the shared skeleton with keystone's
 // sub-condition vocabulary.
 func setReadyCondition(keystone *keystonev1alpha1.Keystone) {
-	commonreconcile.SetAggregateReady(&keystone.Status.Conditions, keystone.Generation, subConditionTypes)
+	keystoneSkeleton.SetReady(keystone)
 }
 
 // conditionReasonConfigError is the SecretsReady=False reason set when
@@ -784,13 +791,7 @@ const conditionReasonConfigError = "ConfigError"
 // Ready=True at the new generation; the failure was visible only in logs and
 // the reconcile_errors counter (issue #467).
 func markConfigFailed(keystone *keystonev1alpha1.Keystone, err error) {
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               "SecretsReady",
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: keystone.Generation,
-		Reason:             conditionReasonConfigError,
-		Message:            err.Error(),
-	})
+	keystoneSkeleton.MarkFailed(keystone, "SecretsReady", conditionReasonConfigError, err)
 }
 
 // reconcileParallelGroup runs the given sub-reconcilers concurrently,
@@ -804,9 +805,7 @@ func (r *KeystoneReconciler) reconcileParallelGroup(
 	keystone *keystonev1alpha1.Keystone,
 	subs []commonreconcile.ParallelStep[*keystonev1alpha1.Keystone],
 ) (ctrl.Result, error) {
-	return commonreconcile.RunParallelGroup(ctx, keystone,
-		func(ks *keystonev1alpha1.Keystone) *[]metav1.Condition { return &ks.Status.Conditions },
-		instrumentSubReconciler, subs)
+	return keystoneSkeleton.RunParallelGroup(ctx, keystone, instrumentSubReconciler, subs)
 }
 
 // SetupWithManager registers the KeystoneReconciler with the controller manager.

--- a/operators/keystone/internal/controller/keystone_watches.go
+++ b/operators/keystone/internal/controller/keystone_watches.go
@@ -44,33 +44,18 @@ func secretToKeystoneMapper(c client.Reader) handler.MapFunc {
 
 // mariaDBToKeystoneMapper returns a MapFunc that maps MariaDB cluster events
 // to reconcile requests for Keystone CRs whose spec.database.clusterRef
-// targets the MariaDB by name in the same namespace.
-//
-// DECISION: this mapper — like pushSecretToKeystoneMapper and
-// pushSecretRelevantChangePredicate below — stays keystone-local rather than
-// moving to internal/common/watch: each has a single consumer today, so the
-// rule of two is not met. Revisit when a second operator needs the same
-// shape.
+// targets the MariaDB by name in the same namespace. It binds the shared
+// watch.ClusterRefMapper to the Keystone list type and its database clusterRef.
 func mariaDBToKeystoneMapper(c client.Reader) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		var keystones keystonev1alpha1.KeystoneList
-		if err := c.List(ctx, &keystones, client.InNamespace(obj.GetNamespace())); err != nil {
-			log.FromContext(ctx).Error(err, "listing Keystone CRs for MariaDB watch")
-			return nil
-		}
-
-		mariadbName := obj.GetName()
-		var requests []reconcile.Request
-		for i := range keystones.Items {
-			ks := &keystones.Items[i]
-			if ks.Spec.Database.ClusterRef != nil && ks.Spec.Database.ClusterRef.Name == mariadbName {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: client.ObjectKeyFromObject(ks),
-				})
+	return watch.ClusterRefMapper(c,
+		func() client.ObjectList { return &keystonev1alpha1.KeystoneList{} },
+		func(o client.Object) string {
+			ks, ok := o.(*keystonev1alpha1.Keystone)
+			if !ok || ks.Spec.Database.ClusterRef == nil {
+				return ""
 			}
-		}
-		return requests
-	}
+			return ks.Spec.Database.ClusterRef.Name
+		})
 }
 
 // clusterSecretStoreToKeystoneMapper returns a MapFunc that enqueues every

--- a/operators/keystone/internal/controller/metrics_testmain_test.go
+++ b/operators/keystone/internal/controller/metrics_testmain_test.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain registers the operator's production Prometheus collectors on the
+// controller-runtime registry once for the whole test binary. Lazy registration
+// was removed in favor of explicit startup registration (RegisterMetrics), so
+// the metric-assertion tests that read ctrlmetrics.Registry — the reconcile
+// duration/error wiring checks and the per-CR rotation-age/db-sync tests — must
+// trigger registration themselves, exactly as main.go does at operator startup.
+func TestMain(m *testing.M) {
+	if err := RegisterMetrics(); err != nil {
+		panic("registering production metrics for test binary: " + err.Error())
+	}
+	os.Exit(m.Run())
+}

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -55,12 +55,12 @@ func deployTestKeystone() *keystonev1alpha1.Keystone {
 				Replicas: 3,
 				Resources: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: keystonev1alpha1.DefaultMemoryRequest.DeepCopy(),
-						corev1.ResourceCPU:    keystonev1alpha1.DefaultCPURequest.DeepCopy(),
+						corev1.ResourceMemory: commonv1.DefaultMemoryRequest(),
+						corev1.ResourceCPU:    commonv1.DefaultCPURequest(),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: keystonev1alpha1.DefaultMemoryLimit.DeepCopy(),
-						corev1.ResourceCPU:    keystonev1alpha1.DefaultCPULimit.DeepCopy(),
+						corev1.ResourceMemory: commonv1.DefaultMemoryLimit(),
+						corev1.ResourceCPU:    commonv1.DefaultCPULimit(),
 					},
 				},
 			},
@@ -909,10 +909,10 @@ func TestReconcileDeployment_ContainerResources(t *testing.T) {
 
 	g.Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 	container := deploy.Spec.Template.Spec.Containers[0]
-	g.Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, keystonev1alpha1.DefaultMemoryRequest))
-	g.Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, keystonev1alpha1.DefaultCPURequest))
-	g.Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, keystonev1alpha1.DefaultMemoryLimit))
-	g.Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, keystonev1alpha1.DefaultCPULimit))
+	g.Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryRequest()))
+	g.Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPURequest()))
+	g.Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, commonv1.DefaultMemoryLimit()))
+	g.Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, commonv1.DefaultCPULimit()))
 }
 
 func TestReconcileDeployment_CustomResources(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_healthcheck.go
+++ b/operators/keystone/internal/controller/reconcile_healthcheck.go
@@ -6,37 +6,15 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/healthcheck"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
-
-// healthProbeCacheHit reports whether the cached probe for this CR can be
-// reused in place of a fresh HTTP GET: the KeystoneAPIReady condition is
-// already True, and the shared TTL probe cache holds an entry matching the
-// CR's UID and endpoint within HealthCheckCacheTTL.
-func (r *KeystoneReconciler) healthProbeCacheHit(keystone *keystonev1alpha1.Keystone, endpoint string) bool {
-	current := conditions.GetCondition(keystone.Status.Conditions, conditionTypeKeystoneAPIReady)
-	if current == nil || current.Status != metav1.ConditionTrue {
-		return false
-	}
-	return r.healthProbeCache.Hit(client.ObjectKeyFromObject(keystone), keystone.UID, endpoint, HealthCheckCacheTTL)
-}
-
-// storeHealthProbe records a successful probe so reconciles within the TTL can
-// skip the synchronous HTTP GET.
-func (r *KeystoneReconciler) storeHealthProbe(keystone *keystonev1alpha1.Keystone, endpoint string) {
-	r.healthProbeCache.Store(client.ObjectKeyFromObject(keystone), keystone.UID, endpoint)
-}
 
 // evictHealthProbe drops the cached probe for a CR so the next reconcile
 // re-probes. Called on any probe failure and on CR deletion.
@@ -70,119 +48,27 @@ func (r *KeystoneReconciler) httpClient() HTTPDoer {
 }
 
 // reconcileHealthCheck performs an HTTP GET to the cluster-local Keystone /v3
-// endpoint and sets the KeystoneAPIReady condition based on the response.
-// The probe target is always the in-cluster Service URL returned by
-// internalAPIURL, independent of spec.gateway: we are verifying API readiness,
-// not the ingress/DNS/cert/Gateway path that keystone.Status.Endpoint may
-// advertise externally.
+// endpoint and sets the KeystoneAPIReady condition based on the response, via
+// the shared probe flow. The probe target is always the in-cluster Service URL
+// returned by internalAPIURL, independent of spec.gateway: we are verifying API
+// readiness, not the ingress/DNS/cert/Gateway path that keystone.Status.Endpoint
+// may advertise externally.
 func (r *KeystoneReconciler) reconcileHealthCheck(ctx context.Context, keystone *keystonev1alpha1.Keystone) (ctrl.Result, error) {
-	if keystone.Status.Endpoint == "" {
-		log.FromContext(ctx).Info("Keystone API endpoint not yet configured, requeuing")
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKeystoneAPIReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonEndpointNotReady,
-			Message:            "endpoint not yet configured",
-		})
-		return ctrl.Result{RequeueAfter: RequeueHealthCheck}, nil
-	}
-	endpoint := internalAPIURL(keystone)
-	key := client.ObjectKeyFromObject(keystone)
-
-	// Serve from the probe cache when the last successful probe for this exact
-	// endpoint is still fresh and KeystoneAPIReady is already True. This keeps
-	// the synchronous HTTP GET — which can take up to HealthCheckTimeout on a
-	// flapping API — off the hot path for a steady CR. The condition is
-	// re-upserted (not left untouched) so its ObservedGeneration tracks the
-	// current spec; the message matches the probe path verbatim so a cache pass
-	// and a probe pass produce byte-identical status and the status-diff gate
-	// skips the write.
-	if r.healthProbeCacheHit(keystone, endpoint) {
-		log.FromContext(ctx).V(1).Info("Keystone API health check served from cache", "endpoint", endpoint)
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKeystoneAPIReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonAPIHealthy,
-			Message:            fmt.Sprintf("Keystone API is responding at %s", endpoint),
-		})
-		return ctrl.Result{}, nil
-	}
-
-	checkCtx, cancel := context.WithTimeout(ctx, HealthCheckTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("building health check request: %w", err)
-	}
-
-	resp, err := r.httpClient().Do(req)
-	if err != nil {
-		// A cancelled parent context means a peer in the parallel post-deployment
-		// group failed and errgroup cancelled gctx — the aborted probe is not an
-		// API-health signal. Propagate the cancellation without flipping
-		// KeystoneAPIReady or evicting the probe cache, so an unrelated
-		// Bootstrap/HPA/HTTPRoute/TrustFlush failure cannot masquerade as
-		// "Keystone API down" (issue #361). A genuine probe timeout fires
-		// checkCtx's deadline while the parent ctx stays live (ctx.Err()==nil),
-		// so it still routes through handleHealthCheckError below.
-		if cerr := ctx.Err(); cerr != nil {
-			return ctrl.Result{}, cerr
-		}
-		// Any other probe error must evict so the next reconcile re-probes rather
-		// than serving a stale success.
-		r.evictHealthProbe(key)
-		return r.handleHealthCheckError(ctx, keystone, err), nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		log.FromContext(ctx).V(1).Info("Keystone API health check passed", "status", resp.StatusCode)
-		r.storeHealthProbe(keystone, endpoint)
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeKeystoneAPIReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonAPIHealthy,
-			Message:            fmt.Sprintf("Keystone API is responding at %s", endpoint),
-		})
-		return ctrl.Result{}, nil
-	}
-
-	log.FromContext(ctx).Info("Keystone API health check failed", "status", resp.StatusCode)
-	// A non-2xx response is a failed probe: evict so recovery is detected on
-	// the next reconcile instead of masked by a stale cached success.
-	r.evictHealthProbe(key)
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeKeystoneAPIReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: keystone.Generation,
-		Reason:             conditionReasonAPIUnhealthy,
-		Message:            fmt.Sprintf("Keystone API returned HTTP %d", resp.StatusCode),
+	return healthcheck.ReconcileProbe(ctx, healthcheck.ProbeFlowParams{
+		Doer:               r.httpClient(),
+		Cache:              &r.healthProbeCache,
+		Key:                client.ObjectKeyFromObject(keystone),
+		UID:                keystone.UID,
+		Subject:            "Keystone API",
+		EndpointConfigured: keystone.Status.Endpoint != "",
+		ProbeEndpoint:      internalAPIURL(keystone),
+		Conditions:         &keystone.Status.Conditions,
+		Generation:         keystone.Generation,
+		ConditionType:      conditionTypeKeystoneAPIReady,
+		HealthyReason:      conditionReasonAPIHealthy,
+		UnhealthyReason:    conditionReasonAPIUnhealthy,
+		Timeout:            HealthCheckTimeout,
+		CacheTTL:           HealthCheckCacheTTL,
+		RequeueAfter:       RequeueHealthCheck,
 	})
-	return ctrl.Result{RequeueAfter: RequeueHealthCheck}, nil
-}
-
-// handleHealthCheckError classifies the HTTP client error and sets the
-// KeystoneAPIReady condition with an appropriate Reason. All network errors
-// result in a requeue rather than a hard error.
-func (r *KeystoneReconciler) handleHealthCheckError(ctx context.Context, keystone *keystonev1alpha1.Keystone, err error) ctrl.Result {
-	reason, message := classifyHealthCheckError(err)
-	log.FromContext(ctx).Info("Keystone API health check error", "reason", reason, "error", err)
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeKeystoneAPIReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: keystone.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
-	return ctrl.Result{RequeueAfter: RequeueHealthCheck}
-}
-
-// classifyHealthCheckError returns the condition Reason and Message for the
-// given HTTP client error, via the shared classifier.
-func classifyHealthCheckError(err error) (reason, message string) {
-	return healthcheck.ClassifyError(err)
 }

--- a/operators/keystone/internal/controller/reconcile_healthcheck_test.go
+++ b/operators/keystone/internal/controller/reconcile_healthcheck_test.go
@@ -493,7 +493,7 @@ func TestReconcileHealthCheck_ParentContextCancelled_PropagatesWithoutFlipping(t
 
 	// Seed a cache entry, then age it past the TTL so this pass actually
 	// re-probes (a fresh entry would serve from cache and never hit the network).
-	r.storeHealthProbe(ks, internalAPIURL(ks))
+	r.healthProbeCache.Store(client.ObjectKeyFromObject(ks), ks.UID, internalAPIURL(ks))
 	key := client.ObjectKeyFromObject(ks)
 	clk = clk.Add(HealthCheckCacheTTL + time.Second)
 
@@ -649,7 +649,7 @@ func TestReconcileHealthCheck_ConditionNotTrue_ReProbes(t *testing.T) {
 
 	// Seed a fresh, matching cache entry but leave the condition unset so the
 	// hit criterion "condition already True" fails.
-	r.storeHealthProbe(ks, internalAPIURL(ks))
+	r.healthProbeCache.Store(client.ObjectKeyFromObject(ks), ks.UID, internalAPIURL(ks))
 
 	_, err := r.reconcileHealthCheck(context.Background(), ks)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -671,7 +671,7 @@ func TestReconcileHealthCheck_EndpointChange_ReProbes(t *testing.T) {
 
 	// Seed a fresh entry for a stale endpoint; the reconcile targets
 	// internalAPIURL, so the endpoints differ and the entry must be a miss.
-	r.storeHealthProbe(ks, "http://stale.endpoint/v3")
+	r.healthProbeCache.Store(client.ObjectKeyFromObject(ks), ks.UID, "http://stale.endpoint/v3")
 
 	_, err := r.reconcileHealthCheck(context.Background(), ks)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -690,7 +690,7 @@ func TestReconcileHealthCheck_UIDChange_ReProbes(t *testing.T) {
 	ks := newTestKeystoneForHealthCheck("http://ignored/v3", 1)
 	ks.UID = "uid-old"
 	healthyReadyCondition(ks)
-	r.storeHealthProbe(ks, internalAPIURL(ks))
+	r.healthProbeCache.Store(client.ObjectKeyFromObject(ks), ks.UID, internalAPIURL(ks))
 
 	// A CR recreated under the same name/namespace carries a new UID.
 	ks.UID = "uid-new"

--- a/operators/keystone/internal/controller/reconcile_hpa.go
+++ b/operators/keystone/internal/controller/reconcile_hpa.go
@@ -6,13 +6,10 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/deployment"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -26,41 +23,22 @@ func subResourceName(keystone *keystonev1alpha1.Keystone) string {
 }
 
 // reconcileHPA ensures the HorizontalPodAutoscaler for the Keystone API
-// deployment matches the desired state. Three lifecycle paths:
-//   - spec.autoscaling set: create or update HPA targeting the deployment
-//   - spec.autoscaling nil: delete any existing HPA
-//   - error: propagate errors from ensure/delete operations
+// deployment matches the desired state, via the shared HPA flow. It keeps only
+// the service-specific desired HPA builder.
 func (r *KeystoneReconciler) reconcileHPA(ctx context.Context, keystone *keystonev1alpha1.Keystone) (ctrl.Result, error) {
-	hpaName := subResourceName(keystone)
-
-	// Path 2: autoscaling disabled — delete any existing HPA.
-	if keystone.Spec.Autoscaling == nil {
-		if err := deployment.DeleteHPA(ctx, r.Client, keystone.Namespace, hpaName); err != nil {
-			return ctrl.Result{}, fmt.Errorf("deleting HorizontalPodAutoscaler: %w", err)
-		}
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               "HPAReady",
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             "HPANotRequired",
-			Message:            "Autoscaling is not configured",
-		})
-		return ctrl.Result{}, nil
+	var desired *autoscalingv2.HorizontalPodAutoscaler
+	if keystone.Spec.Autoscaling != nil {
+		desired = buildKeystoneHPA(keystone)
 	}
-
-	// Path 1: autoscaling enabled — create or update HPA.
-	hpa := buildKeystoneHPA(keystone)
-	if err := deployment.EnsureHPA(ctx, r.Client, r.Scheme, keystone, hpa); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring HorizontalPodAutoscaler: %w", err)
-	}
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               "HPAReady",
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: keystone.Generation,
-		Reason:             "HPAReady",
-		Message:            "HorizontalPodAutoscaler is configured",
+	return deployment.ReconcileHPA(ctx, r.Client, r.Scheme, keystone, deployment.HPAFlowParams{
+		Enabled:       keystone.Spec.Autoscaling != nil,
+		Desired:       desired,
+		Name:          subResourceName(keystone),
+		Namespace:     keystone.Namespace,
+		Conditions:    &keystone.Status.Conditions,
+		Generation:    keystone.Generation,
+		ConditionType: "HPAReady",
 	})
-	return ctrl.Result{}, nil
 }
 
 // buildKeystoneHPA constructs the desired HorizontalPodAutoscaler for the

--- a/operators/keystone/internal/controller/reconcile_httproute.go
+++ b/operators/keystone/internal/controller/reconcile_httproute.go
@@ -8,22 +8,21 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/gateway"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
-// Condition type and reason constants for HTTPRoute readiness.
+// Condition type and reason constants for HTTPRoute readiness. The reason
+// vocabulary is shared across operators via the gateway package.
 const (
 	conditionTypeHTTPRouteReady           = "HTTPRouteReady"
-	conditionReasonHTTPRouteAccepted      = "HTTPRouteAccepted"
-	conditionReasonHTTPRouteNotAccepted   = "HTTPRouteNotAccepted"
-	conditionReasonHTTPRouteNotRequired   = "HTTPRouteNotRequired"
-	conditionReasonGatewayAPINotInstalled = "GatewayAPINotInstalled"
+	conditionReasonHTTPRouteAccepted      = gateway.ReasonHTTPRouteAccepted
+	conditionReasonHTTPRouteNotAccepted   = gateway.ReasonHTTPRouteNotAccepted
+	conditionReasonHTTPRouteNotRequired   = gateway.ReasonHTTPRouteNotRequired
+	conditionReasonGatewayAPINotInstalled = gateway.ReasonGatewayAPINotInstalled
 )
 
 // keystoneStatusEndpoint returns the externally reachable Keystone API endpoint
@@ -85,82 +84,29 @@ const keystoneAPIPort = gatewayv1.PortNumber(5000)
 const requeueHTTPRouteAccepted = RequeueDeploymentPolling
 
 // reconcileHTTPRoute ensures the HTTPRoute that exposes the Keystone API
-// through a Gateway matches the desired state. Three lifecycle paths
-//
-//   - spec.gateway set: create or update the HTTPRoute and reflect the
-//     parent Accepted condition as HTTPRouteReady.
-//   - spec.gateway nil: delete any existing HTTPRoute and set
-//     HTTPRouteReady=True/HTTPRouteNotRequired.
-//   - error: propagate errors from ensure/delete operations.
+// through a Gateway matches the desired state, via the shared route flow. It
+// keeps only the service-specific parts: the desired route builder, the backend
+// identity, and the exposure noun for the messages.
 func (r *KeystoneReconciler) reconcileHTTPRoute(ctx context.Context, keystone *keystonev1alpha1.Keystone) (ctrl.Result, error) {
-	// Path 0: Gateway API CRD is not installed. The watch was
-	// skipped in SetupWithManager; skip the delete attempt too — c.Delete
-	// would fail with "no matches for kind HTTPRoute" — and surface a clear
-	// condition instead of erroring.
-	if !r.gatewayAPIAvailable {
-		if keystone.Spec.Gateway == nil {
-			conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-				Type:               conditionTypeHTTPRouteReady,
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: keystone.Generation,
-				Reason:             conditionReasonHTTPRouteNotRequired,
-				Message:            "External API exposure via Gateway API is not configured",
-			})
-			return ctrl.Result{}, nil
-		}
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonGatewayAPINotInstalled,
-			Message:            "spec.gateway is set but the gateway.networking.k8s.io/v1 HTTPRoute CRD is not installed in this cluster; install Gateway API and restart the operator to enable external API exposure",
-		})
-		return ctrl.Result{}, nil
+	// buildKeystoneHTTPRoute dereferences spec.gateway, so build the desired
+	// route only when external exposure is requested; the flow uses Desired
+	// only on the gateway-enabled path.
+	var desired *gatewayv1.HTTPRoute
+	if keystone.Spec.Gateway != nil {
+		desired = buildKeystoneHTTPRoute(keystone)
 	}
-
-	// Path 2: gateway disabled — delete any existing HTTPRoute.
-	if keystone.Spec.Gateway == nil {
-		if err := gateway.DeleteHTTPRoute(ctx, r.Client, keystone.Namespace, subResourceName(keystone)); err != nil {
-			return ctrl.Result{}, err
-		}
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonHTTPRouteNotRequired,
-			Message:            "External API exposure via Gateway API is not configured",
-		})
-		return ctrl.Result{}, nil
-	}
-
-	// Path 1: gateway enabled — create or update the HTTPRoute. ensureHTTPRoute
-	// applies via Server-Side Apply and decodes the server response back into
-	// desired, so its parent status — written by the Gateway controller — is
-	// already populated without a second Get (issue #361).
-	desired := buildKeystoneHTTPRoute(keystone)
-	if err := gateway.EnsureHTTPRoute(ctx, r.Client, r.Scheme, keystone, desired); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring HTTPRoute: %w", err)
-	}
-
-	if gateway.IsHTTPRouteAccepted(desired) {
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeHTTPRouteReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonHTTPRouteAccepted,
-			Message:            "HTTPRoute accepted by Gateway",
-		})
-		return ctrl.Result{}, nil
-	}
-
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeHTTPRouteReady,
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: keystone.Generation,
-		Reason:             conditionReasonHTTPRouteNotAccepted,
-		Message:            "HTTPRoute not yet accepted by Gateway",
+	return gateway.ReconcileHTTPRoute(ctx, r.Client, r.Scheme, keystone, gateway.RouteFlowParams{
+		GatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:   keystone.Spec.Gateway != nil,
+		Desired:             desired,
+		RouteName:           subResourceName(keystone),
+		RouteNamespace:      keystone.Namespace,
+		ExposureNoun:        "API",
+		Conditions:          &keystone.Status.Conditions,
+		Generation:          keystone.Generation,
+		ConditionType:       conditionTypeHTTPRouteReady,
+		RequeueAccepted:     requeueHTTPRouteAccepted,
 	})
-	return ctrl.Result{RequeueAfter: requeueHTTPRouteAccepted}, nil
 }
 
 // buildKeystoneHTTPRoute constructs the desired HTTPRoute for the Keystone API.

--- a/operators/keystone/internal/controller/reconcile_networkpolicy.go
+++ b/operators/keystone/internal/controller/reconcile_networkpolicy.go
@@ -6,157 +6,95 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/c5c3/forge/internal/common/apply"
-	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/networkpolicy"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
-// Condition type and reason constants for NetworkPolicy readiness.
+// Condition type and reason constants for NetworkPolicy readiness. The reason
+// vocabulary is shared across operators via the networkpolicy package.
 const (
 	conditionTypeNetworkPolicyReady         = "NetworkPolicyReady"
-	conditionReasonNetworkPolicyReady       = "NetworkPolicyReady"
-	conditionReasonNetworkPolicyNotRequired = "NetworkPolicyNotRequired"
+	conditionReasonNetworkPolicyReady       = networkpolicy.ReasonNetworkPolicyReady
+	conditionReasonNetworkPolicyNotRequired = networkpolicy.ReasonNetworkPolicyNotRequired
 )
 
 // reconcileNetworkPolicy ensures the NetworkPolicy for the Keystone API
-// deployment matches the desired state. Three lifecycle paths:
-//   - spec.networkPolicy set: create or update NetworkPolicy
-//   - spec.networkPolicy nil: delete any existing NetworkPolicy
-//   - error: propagate errors from ensure/delete operations
+// deployment matches the desired state, via the shared network-policy flow. It
+// keeps only the service-specific parts: the desired policy builder (with its
+// federation- and apiserver-aware egress tail) and the backend identity.
 func (r *KeystoneReconciler) reconcileNetworkPolicy(ctx context.Context, keystone *keystonev1alpha1.Keystone, fed *federationProjection) (ctrl.Result, error) {
-	// Path 2: networkPolicy disabled — delete any existing NetworkPolicy.
-	if keystone.Spec.NetworkPolicy == nil {
-		if err := deleteNetworkPolicy(ctx, r.Client, keystone.Namespace, subResourceName(keystone)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("deleting NetworkPolicy: %w", err)
+	// buildKeystoneNetworkPolicy is only applied on the enabled+non-empty path;
+	// build it lazily so a nil or empty-ingress spec takes the delete or
+	// fail-closed path without a wasted build.
+	var desired *networkingv1.NetworkPolicy
+	ingressCount := 0
+	if keystone.Spec.NetworkPolicy != nil {
+		ingressCount = len(keystone.Spec.NetworkPolicy.Ingress)
+		if ingressCount > 0 {
+			desired = buildKeystoneNetworkPolicy(keystone, r.OperatorNamespace, fed)
 		}
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeNetworkPolicyReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: keystone.Generation,
-			Reason:             conditionReasonNetworkPolicyNotRequired,
-			Message:            "Network isolation is not configured",
-		})
-		return ctrl.Result{}, nil
 	}
-
-	// Defensive guard: refuse to create a NetworkPolicy with empty ingress sources.
-	// CRD validation (XValidation) requires size(self.ingress) > 0, but validation can be
-	// bypassed (old stored objects, disabled webhooks, direct etcd writes). An Ingress rule
-	// with an empty From slice allows all sources on port 5000, which is an unsafe default
-	// for a hardening feature. Fail closed rather than open.
-	if len(keystone.Spec.NetworkPolicy.Ingress) == 0 {
-		return ctrl.Result{}, fmt.Errorf("spec.networkPolicy.ingress must not be empty: refusing to create NetworkPolicy that would allow all ingress")
-	}
-
-	// Path 1: networkPolicy enabled — create or update NetworkPolicy.
-	np := buildKeystoneNetworkPolicy(keystone, r.OperatorNamespace, fed)
-	if err := ensureNetworkPolicy(ctx, r.Client, r.Scheme, keystone, np); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring NetworkPolicy: %w", err)
-	}
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               conditionTypeNetworkPolicyReady,
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: keystone.Generation,
-		Reason:             conditionReasonNetworkPolicyReady,
-		Message:            "NetworkPolicy is configured",
+	return networkpolicy.Reconcile(ctx, r.Client, r.Scheme, keystone, networkpolicy.FlowParams{
+		Configured:         keystone.Spec.NetworkPolicy != nil,
+		IngressSourceCount: ingressCount,
+		Desired:            desired,
+		Name:               subResourceName(keystone),
+		Namespace:          keystone.Namespace,
+		Conditions:         &keystone.Status.Conditions,
+		Generation:         keystone.Generation,
+		ConditionType:      conditionTypeNetworkPolicyReady,
 	})
-	return ctrl.Result{}, nil
 }
 
 // buildKeystoneNetworkPolicy constructs the desired NetworkPolicy for the
-// Keystone API pods. It restricts ingress to TCP 5000 from the specified
+// Keystone API pods. It restricts ingress to the API port from the specified
 // sources and auto-derives egress rules for DNS (UDP+TCP 53), the
 // kube-apiserver (TCP 443+6443, required by the rotation CronJob pods that
-// share this selector), the database (TCP, port from dbPort, both managed and
-// brownfield modes), and the cache (TCP, ports derived from the cache spec,
-// both managed and brownfield modes). AdditionalEgress rules are appended after
-// auto-derived rules.
+// share this selector), the database (TCP, port from the database spec, both
+// managed and brownfield modes), and the cache (TCP, ports derived from the
+// cache spec, both managed and brownfield modes). AdditionalEgress rules are
+// appended after auto-derived rules.
 //
 // operatorNamespace is the Namespace the operator Pod runs in. When non-empty,
 // an ingress peer selecting that Namespace is appended so the operator's own
-// health check (reconcileHealthCheck GETs the Keystone Service on TCP 5000) is
-// not blocked by the policy (issue #461). When empty (namespace unknown) no
-// such peer is added.
+// health check (reconcileHealthCheck GETs the Keystone Service) is not blocked
+// by the policy (issue #461). When empty (namespace unknown) no such peer is
+// added.
 //
 // fed is the federation projection: when set, the ingress target port is the
-// sidecar's (the Service targetPort switched there) and per-issuer egress
-// ports are appended so the sidecar can reach the identity provider.
+// sidecar's (the Service targetPort switched there) and per-issuer egress ports
+// are appended so the sidecar can reach the identity provider.
 func buildKeystoneNetworkPolicy(keystone *keystonev1alpha1.Keystone, operatorNamespace string, fed *federationProjection) *networkingv1.NetworkPolicy {
 	npSpec := keystone.Spec.NetworkPolicy
 
-	// Build ingress peers from spec.networkPolicy.ingress sources.
-	var peers []networkingv1.NetworkPolicyPeer
-	for _, src := range npSpec.Ingress {
-		peer := networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: src.NamespaceSelector.DeepCopy(),
-		}
-		if src.PodSelector != nil {
-			peer.PodSelector = src.PodSelector.DeepCopy()
-		}
-		peers = append(peers, peer)
-	}
-
-	// DECISION: When spec.gateway is also set, append an ingress peer targeting
-	// the Gateway's namespace (via kubernetes.io/metadata.name) on TCP 5000 so
-	// the Gateway's data-plane pods can reach the Keystone Service. The gateway
-	// data plane's pod labels are implementation-specific (Kong/Envoy/NGINX/…)
-	// and not known to this operator, so we select by the entire gateway
-	// namespace rather than by pod labels. When spec.gateway.parentRef.namespace
-	// is empty, the Keystone CR's own namespace is assumed, matching the
-	// ParentRef lookup semantics. When spec.networkPolicy is nil we take the
-	// delete path above — no extra rule is needed. requires Gateway
-	// reachability whenever both spec.gateway and spec.networkPolicy are set;
-	// the tradeoff is that shared Gateway namespaces grant namespace-wide
-	// ingress rather than pod-level scoping.
+	// When spec.gateway is set, the Gateway data plane's pods (labels
+	// implementation-specific and unknown here) must reach the Service, so an
+	// ingress peer selects the whole Gateway namespace. An empty
+	// parentRef.namespace defaults to the CR's own namespace, matching the
+	// ParentRef lookup semantics.
+	gatewayNamespace := ""
 	if keystone.Spec.Gateway != nil {
-		gatewayNS := keystone.Spec.Gateway.ParentRef.Namespace
-		if gatewayNS == "" {
-			gatewayNS = keystone.Namespace
+		gatewayNamespace = keystone.Spec.Gateway.ParentRef.Namespace
+		if gatewayNamespace == "" {
+			gatewayNamespace = keystone.Namespace
 		}
-		peers = append(peers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name": gatewayNS,
-				},
-			},
-		})
 	}
-
-	// DECISION: Append an ingress peer for the operator's own Namespace so
-	// reconcileHealthCheck can reach the Keystone API Service on TCP 5000. The
-	// operator runs in a dedicated Namespace (keystone-system) distinct from the
-	// workload Namespace, and ingress otherwise only admits the user-declared
-	// sources and the gateway namespace — so without this peer KeystoneAPIReady
-	// flips False permanently for a healthy deployment (issue #461). The peer
-	// selects the entire operator Namespace by the well-known
-	// kubernetes.io/metadata.name label rather than the operator's pod labels,
-	// which are not known to this build helper. When operatorNamespace is empty
-	// (namespace could not be resolved) no peer is added.
-	if operatorNamespace != "" {
-		peers = append(peers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name": operatorNamespace,
-				},
-			},
-		})
-	}
+	peers := networkpolicy.IngressPeers(networkpolicy.IngressPeersParams{
+		Sources:           npSpec.Ingress,
+		GatewayNamespace:  gatewayNamespace,
+		OperatorNamespace: operatorNamespace,
+	})
 
 	// The ingress target is the port the Service targetPort points at: the
-	// sidecar's when federation is active, uWSGI's 5000 otherwise
-	// (NetworkPolicy ports are evaluated against the pod port, post-DNAT).
+	// sidecar's when federation is active, uWSGI's 5000 otherwise (NetworkPolicy
+	// ports are evaluated against the pod port, post-DNAT).
 	ingressPort := intstr.FromInt32(5000)
 	if fed != nil {
 		ingressPort = intstr.FromInt32(federationProxyPort)
@@ -176,8 +114,7 @@ func buildKeystoneNetworkPolicy(keystone *keystonev1alpha1.Keystone, operatorNam
 
 	// Federation egress: the sidecar's mod_auth_openidc talks to the identity
 	// provider (token/jwks/userinfo/introspection endpoints) from inside the
-	// pod. Port-only like the database/cache rules — see the DNS DECISION in
-	// buildAutoEgressRules for why destination scoping is deferred.
+	// pod. Port-only like the database/cache rules.
 	if fed != nil && len(fed.EgressPorts) > 0 {
 		ports := make([]networkingv1.NetworkPolicyPort, 0, len(fed.EgressPorts))
 		for _, p := range fed.EgressPorts {
@@ -211,45 +148,23 @@ func buildKeystoneNetworkPolicy(keystone *keystonev1alpha1.Keystone, operatorNam
 }
 
 // buildAutoEgressRules constructs the auto-derived egress rules for DNS
-// (UDP+TCP 53), the kube-apiserver (TCP 443+6443), the database (TCP, port from
-// dbPort), and the cache (TCP, ports from cacheEgressPorts). Database and cache
-// egress are emitted in both managed (ClusterRef) and brownfield modes. Rule
-// order is deterministic: DNS, apiserver, database, cache.
+// (UDP+TCP 53), the kube-apiserver (TCP 443+6443), the database, and the cache.
+// Rule order is deterministic: DNS, apiserver, database, cache.
 func buildAutoEgressRules(keystone *keystonev1alpha1.Keystone) []networkingv1.NetworkPolicyEgressRule {
 	tcp := corev1.ProtocolTCP
-	udp := corev1.ProtocolUDP
-
-	// DECISION: DNS egress allows traffic to any destination on port 53 rather
-	// than restricting to kube-system — Chose broad rule because CoreDNS may
-	// run outside kube-system (e.g., NodeLocal DNSCache in each node's
-	// namespace). A namespace-restricted rule would silently break DNS
-	// resolution in such environments.
 
 	// DNS egress: always required (UDP+TCP 53).
-	port53 := intstr.FromInt32(53)
-	rules := []networkingv1.NetworkPolicyEgressRule{
-		{
-			Ports: []networkingv1.NetworkPolicyPort{
-				{Protocol: &udp, Port: &port53},
-				{Protocol: &tcp, Port: &port53},
-			},
-		},
-	}
+	rules := []networkingv1.NetworkPolicyEgressRule{networkpolicy.DNSEgressRule()}
 
-	// kube-apiserver egress: always required (TCP 443+6443).
-	// DECISION: The fernet/credential/admin-password rotation CronJob pods carry
-	// commonLabels — a superset of the Deployment selectorLabels — so they are
-	// selected by this NetworkPolicy's podSelector and share its egress rules.
-	// Those scripts PATCH the rotated keys back to a Kubernetes Secret via
+	// kube-apiserver egress: always required (TCP 443+6443). The
+	// fernet/credential/admin-password rotation CronJob pods carry commonLabels
+	// — a superset of the Deployment selectorLabels — so they are selected by
+	// this NetworkPolicy's podSelector and share its egress rules. Those scripts
+	// PATCH the rotated keys back to a Kubernetes Secret via
 	// kubernetes.default.svc, so the policy must allow egress to the apiserver or
 	// every scheduled rotation stops at its first run (issue #461). The ClusterIP
-	// Service port is 443; on enforcing CNIs (Calico/Cilium) egress is evaluated
-	// after DNAT against the kube-apiserver pod port, commonly 6443 — both are
-	// allowed (port-only, destination unrestricted). Giving the apiserver port to
-	// the Keystone API pods that share this selector is a small, accepted
-	// attack-surface increase: the Deployment pod selector is immutable, so the
-	// rotation pods cannot be handed a distinct label set without recreating the
-	// Deployment.
+	// Service port is 443; on enforcing CNIs egress is evaluated after DNAT
+	// against the kube-apiserver pod port, commonly 6443 — both are allowed.
 	port443 := intstr.FromInt32(443)
 	port6443 := intstr.FromInt32(6443)
 	rules = append(rules, networkingv1.NetworkPolicyEgressRule{
@@ -259,103 +174,23 @@ func buildAutoEgressRules(keystone *keystonev1alpha1.Keystone) []networkingv1.Ne
 		},
 	})
 
-	// Database egress: emitted in both managed (database.ClusterRef) and
-	// brownfield (database.host) modes. The port is derived from dbPort, which
-	// honors spec.database.port (default 3306) — the same value the readiness
-	// probe TCP-connects to via OS_DATABASE__CONNECTION. Without this rule the
-	// probe fails on an enforcing CNI and every pod is depooled (issue #461).
-	// NOTE: port-only — destination unrestricted, see the DNS DECISION above for
-	// why tightening to pod labels is deferred.
-	dbPortValue := intstr.FromInt32(dbPort(keystone))
-	rules = append(rules, networkingv1.NetworkPolicyEgressRule{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &tcp, Port: &dbPortValue},
-		},
-	})
+	// Database egress: emitted in both managed and brownfield modes. Without
+	// this rule the readiness probe fails on an enforcing CNI and every pod is
+	// depooled (issue #461).
+	rules = append(rules, networkpolicy.DatabaseEgressRule(keystone.Spec.Database))
 
-	// Cache egress: emitted in both managed (cache.ClusterRef) and brownfield
-	// (cache.servers) modes. Ports are derived from cacheEgressPorts; in
-	// brownfield mode they come from the "host:port" server strings (issue #461).
-	// Cache egress does not gate readiness, so a wrong cache port degrades
-	// caching without depooling pods. NOTE: port-only — destination unrestricted.
-	if cachePorts := cacheEgressPorts(keystone); len(cachePorts) > 0 {
-		ports := make([]networkingv1.NetworkPolicyPort, 0, len(cachePorts))
-		for i := range cachePorts {
-			cachePort := intstr.FromInt32(cachePorts[i])
-			ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &cachePort})
-		}
-		rules = append(rules, networkingv1.NetworkPolicyEgressRule{Ports: ports})
+	// Cache egress: emitted in both managed and brownfield modes. Cache egress
+	// does not gate readiness, so a wrong cache port degrades caching without
+	// depooling pods.
+	if rule, ok := networkpolicy.CacheEgressRule(keystone.Spec.Cache); ok {
+		rules = append(rules, rule)
 	}
 
 	return rules
 }
 
 // cacheEgressPorts returns the distinct Memcached ports the Keystone API pods
-// must reach, derived from the cache spec. In managed mode (cache.clusterRef
-// set) the memcached operator exposes the standard 11211. In brownfield mode
-// (cache.servers set) the ports are parsed from each "host:port" entry,
-// defaulting to 11211 when an entry omits the port or cannot be parsed. The
-// result preserves input order and is deduplicated. It returns nil when no
-// cache is configured (neither ClusterRef nor Servers), in which case no cache
-// egress rule is emitted.
+// must reach, derived from the cache spec, via the shared helper.
 func cacheEgressPorts(keystone *keystonev1alpha1.Keystone) []int32 {
-	servers := keystone.Spec.Cache.Servers
-	if len(servers) == 0 {
-		if keystone.Spec.Cache.ClusterRef != nil {
-			return []int32{11211}
-		}
-		return nil
-	}
-
-	const defaultMemcachedPort int32 = 11211
-	const maxPort = 65535
-	seen := make(map[int32]struct{}, len(servers))
-	var ports []int32
-	for _, server := range servers {
-		port := defaultMemcachedPort
-		if _, portStr, err := net.SplitHostPort(server); err == nil {
-			// ParseInt with bitSize 32 bounds the result to int32; the explicit
-			// range check rejects non-port values before the conversion.
-			if n, err := strconv.ParseInt(portStr, 10, 32); err == nil && n > 0 && n <= maxPort {
-				port = int32(n)
-			}
-		}
-		if _, ok := seen[port]; ok {
-			continue
-		}
-		seen[port] = struct{}{}
-		ports = append(ports, port)
-	}
-	return ports
-}
-
-// DECISION: ensureNetworkPolicy and deleteNetworkPolicy live in the controller
-// package rather than internal/common/deployment/ — Chose to keep them here
-// because NetworkPolicy is Keystone-specific (no second consumer yet). Moving
-// to the common package is warranted when a second operator needs the same
-// create-or-update logic.
-
-// ensureNetworkPolicy creates or updates the NetworkPolicy via Server-Side
-// Apply under a fixed field manager and sets the Keystone CR as its controller
-// owner so it is garbage-collected with the CR.
-//
-// Merge strategy: the field manager owns exactly the fields the builder sets
-// (the whole Spec and the operator's labels). Labels or annotations the
-// operator no longer sets are relinquished and removed by the API server, while
-// keys owned by other managers (e.g. user- or mesh-added metadata) are
-// preserved. A converged NetworkPolicy is applied without a write.
-func ensureNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, np *networkingv1.NetworkPolicy) error {
-	return apply.EnsureObject(ctx, c, scheme, owner, np, apply.FieldManager)
-}
-
-// deleteNetworkPolicy deletes the NetworkPolicy identified by namespace and
-// name. It is a no-op if the NetworkPolicy does not exist.
-func deleteNetworkPolicy(ctx context.Context, c client.Client, namespace, name string) error {
-	np := &networkingv1.NetworkPolicy{}
-	np.SetName(name)
-	np.SetNamespace(namespace)
-	if err := client.IgnoreNotFound(c.Delete(ctx, np)); err != nil {
-		return fmt.Errorf("deleting NetworkPolicy %s/%s: %w", namespace, name, err)
-	}
-	return nil
+	return networkpolicy.CacheEgressPorts(keystone.Spec.Cache)
 }

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c5c3/forge/internal/common/config"
 	"github.com/c5c3/forge/internal/common/deployment"
 	"github.com/c5c3/forge/internal/common/job"
+	"github.com/c5c3/forge/internal/common/rotation"
 	"github.com/c5c3/forge/internal/common/secrets"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 
@@ -439,13 +440,13 @@ func (r *KeystoneReconciler) applyAdminPasswordRotation(
 	staging, pushSource *corev1.Secret,
 	minLength int,
 ) (applied bool, err error) {
-	return r.commitStagedRotation(ctx, keystone, staging, pushSource, rotationCommitSpec{
-		targetNoun:              "push-source secret",
-		validate:                func(data map[string][]byte) error { return validateAdminPasswordRotationOutput(data, minLength) },
-		annotationInvalidReason: "AdminPasswordRotationAnnotationInvalid",
-		rejectedReason:          "AdminPasswordRotationRejected",
-		appliedReason:           "AdminPasswordRotated",
-		appliedMessage: func(stagingSecretName string, _ map[string][]byte) string {
+	return r.commitStagedRotation(ctx, keystone, staging, pushSource, rotation.CommitSpec{
+		TargetNoun:              "push-source secret",
+		Validate:                func(data map[string][]byte) error { return validateAdminPasswordRotationOutput(data, minLength) },
+		AnnotationInvalidReason: "AdminPasswordRotationAnnotationInvalid",
+		RejectedReason:          "AdminPasswordRotationRejected",
+		AppliedReason:           "AdminPasswordRotated",
+		AppliedMessage: func(stagingSecretName string, _ map[string][]byte) string {
 			return fmt.Sprintf("admin password rotation applied from staging secret %s", stagingSecretName)
 		},
 	})

--- a/operators/keystone/internal/controller/reconcile_secrets.go
+++ b/operators/keystone/internal/controller/reconcile_secrets.go
@@ -65,57 +65,43 @@ func (r *KeystoneReconciler) reconcileSecrets(ctx context.Context,
 	// Check the ClusterSecretStore first so upstream backend outages surface
 	// as SecretsReady=False even while per-ExternalSecret caches still report
 	// Ready=True from their last successful sync.
-	storeReady, err := secrets.IsClusterSecretStoreReady(ctx, r.Client, openBaoClusterStoreName)
+	storeReady, err := secrets.GateClusterStoreReady(ctx, r.Client, openBaoClusterStoreName,
+		&keystone.Status.Conditions, keystone.Generation, "SecretsReady")
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if !storeReady {
-		conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-			Type:               "SecretsReady",
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: keystone.Generation,
-			Reason:             "SecretStoreNotReady",
-			Message: fmt.Sprintf("ClusterSecretStore %q is not ready; upstream secret backend unreachable",
-				openBaoClusterStoreName),
-		})
 		return ctrl.Result{RequeueAfter: RequeueSecretPolling}, nil
 	}
 
 	// Validate the credential Secrets from a declarative (secretRef,
 	// expectedKeys) list. Each check reads the materialized Secret first (the
 	// steady-state fast path) and only consults the ExternalSecret to build a
-	// precise SecretsReady=False message when the Secret is not yet usable
-	// (secrets.GateSyncedSecret). On a not-ready check the helper sets the
-	// condition and the caller requeues.
-	credentialGates := []struct {
-		key          client.ObjectKey
-		reason       string
-		noun         string
-		waitingMsg   string
-		expectedKeys []string
-	}{
+	// precise SecretsReady=False message when the Secret is not yet usable. On a
+	// not-ready check the shared gate sets the condition and the caller requeues.
+	credentialGates := []secrets.CredentialGateSpec{
 		{
-			key:          client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Database.SecretRef.Name},
-			reason:       "WaitingForDBCredentials",
-			noun:         "Database credentials",
-			waitingMsg:   "Waiting for ESO to sync database credentials from OpenBao",
-			expectedKeys: []string{"username", "password"},
+			Key:          client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Database.SecretRef.Name},
+			Reason:       "WaitingForDBCredentials",
+			Noun:         "Database credentials",
+			WaitingMsg:   "Waiting for ESO to sync database credentials from OpenBao",
+			ExpectedKeys: []string{"username", "password"},
 		},
 		{
-			key:          client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Bootstrap.AdminPasswordSecretRef.Name},
-			reason:       "WaitingForAdminCredentials",
-			noun:         "Admin credentials",
-			waitingMsg:   "Waiting for ESO to sync admin credentials from OpenBao",
-			expectedKeys: []string{"password"},
+			Key:          client.ObjectKey{Namespace: keystone.Namespace, Name: keystone.Spec.Bootstrap.AdminPasswordSecretRef.Name},
+			Reason:       "WaitingForAdminCredentials",
+			Noun:         "Admin credentials",
+			WaitingMsg:   "Waiting for ESO to sync admin credentials from OpenBao",
+			ExpectedKeys: []string{"password"},
 		},
 	}
-	for _, gate := range credentialGates {
-		if ready, err := r.checkCredentialSecret(ctx, keystone, gate.key,
-			gate.reason, gate.noun, gate.waitingMsg, gate.expectedKeys...); err != nil {
-			return ctrl.Result{}, err
-		} else if !ready {
-			return ctrl.Result{RequeueAfter: RequeueSecretPolling}, nil
-		}
+	ready, err := secrets.GateCredentials(ctx, r.Client, credentialGates,
+		&keystone.Status.Conditions, keystone.Generation, "SecretsReady")
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !ready {
+		return ctrl.Result{RequeueAfter: RequeueSecretPolling}, nil
 	}
 
 	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
@@ -125,55 +111,6 @@ func (r *KeystoneReconciler) reconcileSecrets(ctx context.Context,
 		Reason:             "SecretsAvailable",
 	})
 	return ctrl.Result{}, nil
-}
-
-// checkCredentialSecret verifies that a credential Secret is usable, checking
-// the materialized Secret before the ExternalSecret to save a read in steady
-// state. It returns (true, nil) when the Secret exists with all requiredKeys.
-// On a miss it consults the ExternalSecret only to produce a precise
-// SecretsReady=False message — "ExternalSecret not found yet" vs "waiting for
-// ESO to sync" vs "missing expected keys" — sets the condition itself with the
-// given reason, and returns (false, nil).
-//
-// Semantic note: because the materialized Secret is checked first, an
-// ExternalSecret whose Ready condition is momentarily False while the Secret
-// still holds valid keys no longer flips SecretsReady=False. That matches how
-// pods consume the Secret directly; the ClusterSecretStore check in
-// reconcileSecrets remains the authoritative backend-outage detector.
-func (r *KeystoneReconciler) checkCredentialSecret(
-	ctx context.Context,
-	keystone *keystonev1alpha1.Keystone,
-	key client.ObjectKey,
-	reason, noun, waitingMsg string,
-	requiredKeys ...string,
-) (bool, error) {
-	state, err := secrets.GateSyncedSecret(ctx, r.Client, key, requiredKeys...)
-	if err != nil {
-		return false, err
-	}
-	if state == secrets.GateReady {
-		return true, nil
-	}
-
-	// The materialized Secret is absent or missing keys; the gate state
-	// attributes the cause so the operator surfaces an actionable message.
-	msg := waitingMsg
-	switch state {
-	case secrets.GateExternalSecretMissing:
-		msg = fmt.Sprintf("%s ExternalSecret %s/%s not found yet", noun, key.Namespace, key.Name)
-	case secrets.GateSecretKeysMissing:
-		msg = fmt.Sprintf("%s Secret exists but is missing expected keys", noun)
-	case secrets.GateExternalSecretNotSynced, secrets.GateReady:
-		// NotSynced keeps the generic waiting message; Ready returned above.
-	}
-	conditions.SetCondition(&keystone.Status.Conditions, metav1.Condition{
-		Type:               "SecretsReady",
-		Status:             metav1.ConditionFalse,
-		ObservedGeneration: keystone.Generation,
-		Reason:             reason,
-		Message:            msg,
-	})
-	return false, nil
 }
 
 // openBaoBackupPushSecretNames returns the names of the backup PushSecrets

--- a/operators/keystone/internal/controller/requeue_intervals.go
+++ b/operators/keystone/internal/controller/requeue_intervals.go
@@ -4,21 +4,39 @@
 
 package controller
 
-import "time"
+import (
+	"time"
 
-// Requeue interval constants centralise the polling durations used by each
-// sub-reconciler. Keeping them in a single file makes tuning straightforward
-// and ensures test assertions stay in sync with production code.
+	"github.com/c5c3/forge/internal/common/healthcheck"
+	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
+)
+
+// The polling and health-check timing durations shared by every service
+// operator now live in the shared library so a tuning change lands once. These
+// aliases keep the package-local names the sub-reconcilers reference.
 const (
 	// RequeueDeploymentPolling is the interval for polling Deployment readiness.
-	// Deployments converge quickly, so a short interval is appropriate.
-	RequeueDeploymentPolling = 10 * time.Second
+	RequeueDeploymentPolling = commonreconcile.RequeueDeploymentPolling
 
 	// RequeueSecretPolling is the interval for polling ESO-managed Secret
-	// readiness. ESO sync is fast but depends on an external vault, so a
-	// moderate interval balances responsiveness with API load.
-	RequeueSecretPolling = 15 * time.Second
+	// readiness.
+	RequeueSecretPolling = commonreconcile.RequeueSecretPolling
 
+	// RequeueHealthCheck is the interval for requeuing when the Keystone API
+	// health check fails.
+	RequeueHealthCheck = healthcheck.RequeueHealthCheck
+
+	// HealthCheckTimeout is the bounded timeout for the HTTP health check
+	// request.
+	HealthCheckTimeout = healthcheck.HealthCheckTimeout
+
+	// HealthCheckCacheTTL bounds how long a successful Keystone API probe is
+	// reused before the operator re-probes.
+	HealthCheckCacheTTL = healthcheck.HealthCheckCacheTTL
+)
+
+// Keystone-specific requeue intervals that no other operator shares.
+const (
 	// RequeueDatabaseWait is the interval for waiting on MariaDB CR readiness
 	// and db_sync Job completion. These operations are moderately slow, so a
 	// longer interval avoids unnecessary API churn.
@@ -38,33 +56,6 @@ const (
 	// completion. The oslopolicy-validator runs quickly, so a short interval
 	// balances responsiveness with API load.
 	RequeueValidationWait = 15 * time.Second
-
-	// RequeueHealthCheck is the interval for requeuing when the Keystone API
-	// health check fails. The API may take a few seconds to start responding
-	// after the Deployment reports ready, so a moderate interval is appropriate.
-	RequeueHealthCheck = 10 * time.Second
-
-	// HealthCheckTimeout is the bounded timeout for the HTTP health check
-	// request. Prevents a hanging Keystone API from blocking the reconcile
-	// loop indefinitely.
-	HealthCheckTimeout = 10 * time.Second
-
-	// HealthCheckCacheTTL bounds how long a successful Keystone API probe is
-	// reused before the operator re-probes. Every reconcile pass otherwise
-	// fires a synchronous HTTP GET (bounded by HealthCheckTimeout, up to 10s on
-	// a flapping API), which dominates hot-path latency once a CR is Ready.
-	// Caching for 30s suppresses re-probes during event/resync bursts.
-	//
-	// Trade-off: a wedged-but-Ready Keystone API — one whose pods still pass
-	// their readiness probe (so DeploymentReady stays True) while requests hang
-	// — is masked for up to HealthCheckCacheTTL after the last good probe.
-	// Within that window reconciles serve KeystoneAPIReady=True from cache
-	// without probing, so failure-detection latency for this case is increased
-	// by up to HealthCheckCacheTTL. The probe-error/non-2xx eviction does NOT
-	// bound this: eviction fires only once a probe runs, and inside the TTL the
-	// cache is exactly what suppresses that probe. Keep this TTL at or below the
-	// KeystoneAPIReady outage-detection SLO.
-	HealthCheckCacheTTL = 30 * time.Second
 
 	// OpenBaoAdoptionWaitTimeout bounds how long the OpenBao finalizer's Pass-0
 	// adoption gate blocks Keystone CR deletion while waiting for ESO to stamp

--- a/operators/keystone/internal/controller/rotation_cronjob.go
+++ b/operators/keystone/internal/controller/rotation_cronjob.go
@@ -10,10 +10,10 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/c5c3/forge/internal/common/deployment"
+	"github.com/c5c3/forge/internal/common/rotation"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
@@ -81,139 +81,126 @@ func keyRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapName, scri
 		extraMounts = append(extraMounts, domMount)
 	}
 
-	cronJob := &batchv1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: keystone.Namespace,
-			Labels:    commonLabels(keystone),
-		},
-		Spec: batchv1.CronJobSpec{
-			Schedule: p.schedule,
-			JobTemplate: batchv1.JobTemplateSpec{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: commonLabels(keystone),
-						},
-						Spec: corev1.PodSpec{
-							ServiceAccountName: name,
-							RestartPolicy:      corev1.RestartPolicyOnFailure,
-							PriorityClassName:  priorityClassName(keystone),
-							// FSGroup makes the kubelet group-own mounted Secret volumes by
-							// the openstack GID so DefaultMode 0o400 still lets the openstack
-							// UID read the keys via the group bit. Without it, kubelet would
-							// project files as root:root mode 0o400 and the openstack process
-							// could not read them; upstream Keystone logs a "key_repository is
-							// world readable" WARNING via fernet_utils._check_key_repository
-							// for any default-mode (0o644) workaround.
-							SecurityContext: &corev1.PodSecurityContext{FSGroup: ptr.To(deployment.OpenStackUID)},
-							InitContainers: []corev1.Container{{
-								Name:  "copy-keys",
-								Image: image,
-								// `install -m 0400` materialises each key in the writable emptyDir
-								// at owner-read-only mode. A plain `cp` would inherit the kubelet
-								// emptyDir mode and re-introduce the world-readable directory for the
-								// rotation Pod.
-								Command:         []string{"sh", "-c", fmt.Sprintf("install -m 0400 %s/* %s/", srcMountPath, keyDir)},
-								SecurityContext: deployment.RestrictedSecurityContext(),
-								VolumeMounts: []corev1.VolumeMount{
-									{Name: srcVolName, MountPath: srcMountPath, ReadOnly: true},
-									{Name: keyVolName, MountPath: keyDir},
-								},
-							}},
-							Containers: []corev1.Container{{
-								Name:  p.keyKind + "-rotate",
-								Image: image,
-								// TODO: Wire spec.Resources (or a smaller Job-specific default) to
-								// this container. Currently runs as BestEffort QoS. See reconcile_deployment.go
-								// containerResources() for the pattern used by the keystone container.
-								Command:         []string{"/scripts/" + p.keyKind + "_rotate.sh"},
-								SecurityContext: deployment.RestrictedSecurityContext(),
-								Env: []corev1.EnvVar{
-									// SECRET_NAME points at the staging Secret — the CronJob SA
-									// is only permitted to patch the staging Secret, never the
-									// production Secret.
-									{Name: "SECRET_NAME", Value: p.stagingSecretName},
-									{Name: "SECRET_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-									}},
-									// oslo.config honours OS_<GROUP>__<KEY> env var overrides, so this
-									// takes precedence over the compiled-in default (3) without needing
-									// to mount the ConfigMap. Uses the normalized value to stay
-									// consistent with the Secret's minimum floor of 3.
-									{
-										Name:  p.maxActiveKeysEnv,
-										Value: strconv.Itoa(p.maxActiveKeys),
-									},
-									// Override [database].connection via oslo.config env-var so the
-									// rotate CronJob reads the DB URL from the derived Secret instead
-									// of the ConfigMap.
-									buildDBConnectionEnvVar(keystone),
-								},
-								VolumeMounts: []corev1.VolumeMount{
-									{Name: keyVolName, MountPath: keyDir},
-									{Name: otherVolName, MountPath: otherKeyDir, ReadOnly: true},
-									{Name: "config", MountPath: "/etc/keystone/keystone.conf.d/", ReadOnly: true},
-									{Name: "scripts", MountPath: "/scripts", ReadOnly: true},
-								},
-							}},
-							Volumes: []corev1.Volume{
-								{
-									Name: srcVolName,
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName:  secretName,
-											DefaultMode: ptr.To(int32(0o400)),
-										},
-									},
-								},
-								{
-									Name: keyVolName,
-									VolumeSource: corev1.VolumeSource{
-										EmptyDir: &corev1.EmptyDirVolumeSource{},
-									},
-								},
-								{
-									// keystone-manage reads the full config which references both
-									// key repositories; mount the sibling keys read-only so the
-									// directory exists even though this job only rotates one kind.
-									Name: otherVolName,
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName:  otherSecretName,
-											DefaultMode: ptr.To(int32(0o400)),
-										},
-									},
-								},
-								{
-									Name: "config",
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-										},
-									},
-								},
-								{
-									Name: "scripts",
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{Name: scriptConfigMapName},
-											DefaultMode:          ptr.To(int32(0o555)),
-										},
-									},
-								},
-							},
-						},
+	podSpec := corev1.PodSpec{
+		ServiceAccountName: name,
+		RestartPolicy:      corev1.RestartPolicyOnFailure,
+		PriorityClassName:  priorityClassName(keystone),
+		// FSGroup makes the kubelet group-own mounted Secret volumes by
+		// the openstack GID so DefaultMode 0o400 still lets the openstack
+		// UID read the keys via the group bit. Without it, kubelet would
+		// project files as root:root mode 0o400 and the openstack process
+		// could not read them; upstream Keystone logs a "key_repository is
+		// world readable" WARNING via fernet_utils._check_key_repository
+		// for any default-mode (0o644) workaround.
+		SecurityContext: &corev1.PodSecurityContext{FSGroup: ptr.To(deployment.OpenStackUID)},
+		InitContainers: []corev1.Container{{
+			Name:  "copy-keys",
+			Image: image,
+			// `install -m 0400` materialises each key in the writable emptyDir
+			// at owner-read-only mode. A plain `cp` would inherit the kubelet
+			// emptyDir mode and re-introduce the world-readable directory for the
+			// rotation Pod.
+			Command:         []string{"sh", "-c", fmt.Sprintf("install -m 0400 %s/* %s/", srcMountPath, keyDir)},
+			SecurityContext: deployment.RestrictedSecurityContext(),
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: srcVolName, MountPath: srcMountPath, ReadOnly: true},
+				{Name: keyVolName, MountPath: keyDir},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:  p.keyKind + "-rotate",
+			Image: image,
+			// TODO: Wire spec.Resources (or a smaller Job-specific default) to
+			// this container. Currently runs as BestEffort QoS. See reconcile_deployment.go
+			// containerResources() for the pattern used by the keystone container.
+			Command:         []string{"/scripts/" + p.keyKind + "_rotate.sh"},
+			SecurityContext: deployment.RestrictedSecurityContext(),
+			Env: []corev1.EnvVar{
+				// SECRET_NAME points at the staging Secret — the CronJob SA
+				// is only permitted to patch the staging Secret, never the
+				// production Secret.
+				{Name: "SECRET_NAME", Value: p.stagingSecretName},
+				{Name: "SECRET_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+				}},
+				// oslo.config honours OS_<GROUP>__<KEY> env var overrides, so this
+				// takes precedence over the compiled-in default (3) without needing
+				// to mount the ConfigMap. Uses the normalized value to stay
+				// consistent with the Secret's minimum floor of 3.
+				{
+					Name:  p.maxActiveKeysEnv,
+					Value: strconv.Itoa(p.maxActiveKeys),
+				},
+				// Override [database].connection via oslo.config env-var so the
+				// rotate CronJob reads the DB URL from the derived Secret instead
+				// of the ConfigMap.
+				buildDBConnectionEnvVar(keystone),
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: keyVolName, MountPath: keyDir},
+				{Name: otherVolName, MountPath: otherKeyDir, ReadOnly: true},
+				{Name: "config", MountPath: "/etc/keystone/keystone.conf.d/", ReadOnly: true},
+				{Name: "scripts", MountPath: "/scripts", ReadOnly: true},
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: srcVolName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  secretName,
+						DefaultMode: ptr.To(int32(0o400)),
+					},
+				},
+			},
+			{
+				Name: keyVolName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				// keystone-manage reads the full config which references both
+				// key repositories; mount the sibling keys read-only so the
+				// directory exists even though this job only rotates one kind.
+				Name: otherVolName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  otherSecretName,
+						DefaultMode: ptr.To(int32(0o400)),
+					},
+				},
+			},
+			{
+				Name: "config",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+					},
+				},
+			},
+			{
+				Name: "scripts",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: scriptConfigMapName},
+						DefaultMode:          ptr.To(int32(0o555)),
 					},
 				},
 			},
 		},
 	}
-	cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(
-		cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes, extraVolumes...,
-	)
-	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].VolumeMounts, extraMounts...,
-	)
-	return cronJob
+	// Append the per-domain identity-backend volume/mount when a backend is
+	// projected, then wrap the pod spec in the shared CronJob boilerplate.
+	podSpec.Volumes = append(podSpec.Volumes, extraVolumes...)
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, extraMounts...)
+
+	return rotation.BuildCronJob(rotation.CronJobParams{
+		Name:      name,
+		Namespace: keystone.Namespace,
+		Labels:    commonLabels(keystone),
+		Schedule:  p.schedule,
+		PodLabels: commonLabels(keystone),
+		PodSpec:   podSpec,
+	})
 }

--- a/operators/keystone/internal/controller/rotation_rbac.go
+++ b/operators/keystone/internal/controller/rotation_rbac.go
@@ -6,88 +6,17 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
+	"github.com/c5c3/forge/internal/common/rotation"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
 
 // ensureRotationRBAC creates the ServiceAccount, Role, and RoleBinding shared by
 // every split-compute-write rotation CronJob — Fernet keys, credential keys, and
-// the Model B admin password. The three flavours are
-// structurally identical: a dedicated ServiceAccount, a two-rule Role, and a
-// RoleBinding with an immutable RoleRef, all named saName and owned by keystone.
-//
-// The Role is split into two PolicyRules to enforce least-privilege on the
-// CronJob ServiceAccount:
-//
-//  1. Read-only `get` on readSecret — the operator-owned source Secret the
-//     CronJob reads (the production keys Secret, or the admin push-source
-//     Secret). The CronJob can never write it, so a compromised CronJob cannot
-//     forge production keys or a privileged admin credential.
-//  2. `get`+`patch` scoped by resourceNames to stagingSecret — the CronJob
-//     writes its rotation output there. `create` and `delete` are deliberately
-//     withheld because the operator owns the staging Secret's lifecycle.
-//
-// RoleRef is immutable after creation, so it is only set on new RoleBindings.
+// the Model B admin password — via the shared rotation.EnsureRBAC. The Role is
+// split into a read-only get on readSecret and a get+patch scoped to
+// stagingSecret so a compromised CronJob can neither forge production keys nor
+// write outside its staging Secret.
 func (r *KeystoneReconciler) ensureRotationRBAC(ctx context.Context, keystone *keystonev1alpha1.Keystone, saName, readSecret, stagingSecret string) error {
-	// ServiceAccount
-	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: keystone.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
-		return controllerutil.SetControllerReference(keystone, sa, r.Scheme)
-	}); err != nil {
-		return fmt.Errorf("ensuring ServiceAccount %s: %w", saName, err)
-	}
-
-	// Role split into two PolicyRules:
-	//   1. `get` on the read-only source Secret (operator owns writes).
-	//   2. `get`+`patch` on the staging Secret only; no `create`/`delete`
-	//      because the operator manages the staging Secret's lifecycle.
-	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: keystone.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				Verbs:         []string{"get"},
-				ResourceNames: []string{readSecret},
-			},
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				Verbs:         []string{"get", "patch"},
-				ResourceNames: []string{stagingSecret},
-			},
-		}
-		return controllerutil.SetControllerReference(keystone, role, r.Scheme)
-	}); err != nil {
-		return fmt.Errorf("ensuring Role %s: %w", saName, err)
-	}
-
-	// RoleBinding
-	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: keystone.Namespace}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
-		rb.Subjects = []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      saName,
-			Namespace: keystone.Namespace,
-		}}
-		// RoleRef is immutable after creation; only set on new objects.
-		if rb.RoleRef.Name == "" {
-			rb.RoleRef = rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     saName,
-			}
-		}
-		return controllerutil.SetControllerReference(keystone, rb, r.Scheme)
-	}); err != nil {
-		return fmt.Errorf("ensuring RoleBinding %s: %w", saName, err)
-	}
-
-	return nil
+	return rotation.EnsureRBAC(ctx, r.Client, r.Scheme, keystone, saName, readSecret, stagingSecret)
 }

--- a/operators/keystone/internal/controller/rotation_staging.go
+++ b/operators/keystone/internal/controller/rotation_staging.go
@@ -3,37 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package controller — staging Secret helpers for the split-compute-write
-// rotation architecture. The rotation CronJob PATCHes
-// a dedicated staging Secret; the operator reads it, validates, and applies
-// the keys to the production Secret using its own privileged ServiceAccount.
+// rotation architecture. The rotation CronJob PATCHes a dedicated staging
+// Secret; the operator reads it, validates, and applies the keys to the
+// production Secret using its own privileged ServiceAccount. The mechanics are
+// shared via internal/common/rotation; these thin wrappers bind the
+// keystone-specific labels, metrics, and event vocabulary.
 package controller
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"maps"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/rotation"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 	"github.com/c5c3/forge/operators/keystone/internal/metrics"
 )
 
 // StagingSecretLabelKey labels staging Secrets so operator watches and
 // consumers can distinguish them from the production key Secrets.
-const StagingSecretLabelKey = "forge.c5c3.io/rotation-target" //nolint:gosec // label key, not a credential
+const StagingSecretLabelKey = rotation.StagingSecretLabelKey //nolint:gosec // label key, not a credential
 
 // RotationCompletedAnnotation is the RFC3339 UTC timestamp the rotation
 // CronJob writes atomically with its staging Secret PATCH. Its presence is
 // the single-shot commit marker gating the operator's apply path.
-const RotationCompletedAnnotation = "forge.c5c3.io/rotation-completed-at" //nolint:gosec // annotation key, not a credential
+const RotationCompletedAnnotation = rotation.CompletedAnnotation //nolint:gosec // annotation key, not a credential
 
 // fernetStagingSecretName returns the staging Secret name for Fernet key
 // rotation: `<keystone>-fernet-keys-rotation`.
@@ -48,317 +44,48 @@ func credentialStagingSecretName(keystone *keystonev1alpha1.Keystone) string {
 }
 
 // observeRotationAge refreshes the keystone_operator_key_rotation_age_seconds
-// gauge from the rotation-completed annotation. It reads the annotation from
-// the production keys Secret first — applyRotationOutput stamps it there on
-// every successful apply, so the annotation is durable across the inter-rotation
-// steady state and the gauge value (computed as time.Since(completedAt) on every
-// reconcile) tracks wall-clock time correctly. If the production Secret has no
-// annotation (the very-first rotation has not yet been applied) the helper falls
-// back to the staging Secret to cover the post-CronJob-PATCH/pre-apply window.
-//
-// Both Secrets are passed in by the caller — the production Secret it already
-// fetched at the top of the pass and the staging Secret returned by
-// ensureStagingSecret — so this helper performs no client reads (issue #361).
-//
-// The gauge is a best-effort observability signal: an absent annotation on both
-// (either Secret may be nil) or a malformed timestamp is silently skipped rather
-// than surfaced as a reconcile failure. PromQL absent(...) remains the alerting
-// signal for "rotation has never completed".
+// gauge from the rotation-completed annotation, via the shared rotation.ObserveAge.
+// It reads the annotation from the production keys Secret first (durable across
+// the steady state) and falls back to the staging Secret for the
+// post-CronJob-PATCH/pre-apply window. Both Secrets are passed in so this helper
+// performs no client reads (issue #361).
 func (r *KeystoneReconciler) observeRotationAge(
 	keystone *keystonev1alpha1.Keystone,
 	mainSecret, stagingSecret *corev1.Secret,
 	keyType string,
 ) {
-	if completedAt, ok := rotationCompletedAt(mainSecret); ok {
-		_ = metrics.SetKeyRotationAge(keystone.Name, keystone.Namespace, keyType, completedAt)
-		return
-	}
-	if completedAt, ok := rotationCompletedAt(stagingSecret); ok {
-		_ = metrics.SetKeyRotationAge(keystone.Name, keystone.Namespace, keyType, completedAt)
-	}
+	rotation.ObserveAge(mainSecret, stagingSecret, func(completedAt time.Time) error {
+		return metrics.SetKeyRotationAge(keystone.Name, keystone.Namespace, keyType, completedAt)
+	})
 }
 
 // rotationCompletedAt parses the RotationCompletedAnnotation off the given
-// Secret. It returns (zero, false) when the Secret is nil, the annotation is
-// missing, or the timestamp does not parse as RFC3339 — all valid steady-state
-// observations for the gauge caller. It performs no client reads.
+// Secret via the shared rotation.CompletedAt.
 func rotationCompletedAt(secret *corev1.Secret) (time.Time, bool) {
-	if secret == nil {
-		return time.Time{}, false
-	}
-	completedAt := secret.Annotations[RotationCompletedAnnotation]
-	if completedAt == "" {
-		return time.Time{}, false
-	}
-	parsed, err := time.Parse(time.RFC3339, completedAt)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return parsed, true
+	return rotation.CompletedAt(secret)
 }
 
 // ensureStagingSecret creates (or ensures) an empty staging Secret that the
-// rotation CronJob PATCHes rotated keys into. The operator owns the
-// object's metadata and lifecycle — labels, owner reference — while the
-// CronJob owns the `.data` field via a narrow get+patch RBAC grant. Data is
-// deliberately left nil on creation and untouched on update so the CronJob's
-// PATCH is never clobbered by a reconcile.
-//
-// labelValue is the per-kind value written to the StagingSecretLabelKey label
-// (e.g. "fernet-keys", "credential-keys") so operators can grep label state
-// per sub-reconciler.
-//
-// Note on CronJob/operator PATCH-vs-Update race controllerutil.
-// CreateOrUpdate runs Get → mutate → Update. If the CronJob PATCHes the
-// staging Secret's `.data` between this function's Get and Update, the
-// Update carries a stale ResourceVersion and the API server rejects it with
-// 409 Conflict. The reconciler requeues; the next invocation's Get observes
-// the CronJob's Data and — because the mutator above does not touch
-// `secret.Data` — the CronJob's payload is preserved through the subsequent
-// Update. Net effect: the CronJob's rotation output is never lost, but
-// transient error-requeue log lines are expected during rotation windows
-// and are not a bug.
-// It returns the ensured Secret so the caller can thread it into
-// observeRotationAge and commitStagedRotation without re-reading it — after
-// CreateOrUpdate the object reflects the server state (including any CronJob
-// PATCH observed at CreateOrUpdate's read), and its UID/ResourceVersion drive
-// the commit's delete preconditions (issue #361).
+// rotation CronJob PATCHes rotated keys into, via the shared
+// rotation.EnsureStagingSecret. labelValue is the per-kind value written to the
+// StagingSecretLabelKey label (e.g. "fernet-keys", "credential-keys").
 func (r *KeystoneReconciler) ensureStagingSecret(
 	ctx context.Context,
 	keystone *keystonev1alpha1.Keystone,
 	name, labelValue string,
 ) (*corev1.Secret, error) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: keystone.Namespace,
-		},
-	}
-
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		// Merge commonLabels with the rotation-target marker. Rebuilt every
-		// call so operator-owned labels stay authoritative.
-		labels := commonLabels(keystone)
-		labels[StagingSecretLabelKey] = labelValue
-		secret.Labels = labels
-
-		// Do NOT touch secret.Data — the CronJob's PATCH owns that field.
-		return controllerutil.SetControllerReference(keystone, secret, r.Scheme)
-	}); err != nil {
-		return nil, fmt.Errorf("ensuring staging secret %s: %w", name, err)
-	}
-
-	return secret, nil
-}
-
-// rotationCommitSpec parameterises commitStagedRotation for one rotation
-// flavour (Fernet keys, credential keys, or the Model B admin password). Every
-// difference between the flavours is captured here; the commit sequence itself
-// is identical.
-type rotationCommitSpec struct {
-	// targetNoun names the target Secret in returned error messages
-	// ("main secret" for keys, "push-source secret" for the admin password).
-	targetNoun string
-	// validate enforces the per-flavour staging-payload contract; a non-nil
-	// error rejects the commit and retains the staging Secret for inspection.
-	validate func(data map[string][]byte) error
-	// clearStagingOnReject, when true, wipes the staged .data and the
-	// completion annotation when validate rejects the payload, so the next
-	// CronJob strategic-merge PATCH starts from an empty base rather than
-	// accumulating leftover key indices over the rejected payload. The
-	// Fernet/credential key flavours set this because their .data is a
-	// multi-key map; the admin-password flavour leaves it false because its
-	// single `password` key cannot accumulate stale indices and the rejected
-	// value is retained verbatim for operator inspection (issue #475).
-	clearStagingOnReject bool
-	// annotationInvalidReason / rejectedReason are the Warning event reasons
-	// emitted when the completion annotation is malformed or the payload is
-	// rejected; the commit is retried on the next CronJob run.
-	annotationInvalidReason string
-	rejectedReason          string
-	// appliedReason / appliedMessage build the Normal event emitted on a
-	// successful commit. appliedMessage receives the staging Secret name and
-	// the committed data so flavours can vary the wording (e.g. the key
-	// flavours append the active-key count; the password flavour does not).
-	appliedReason  string
-	appliedMessage func(stagingSecretName string, data map[string][]byte) string
+	// Merge commonLabels with the rotation-target marker so operator-owned
+	// labels stay authoritative.
+	labels := commonLabels(keystone)
+	labels[StagingSecretLabelKey] = labelValue
+	return rotation.EnsureStagingSecret(ctx, r.Client, r.Scheme, keystone, name, labels)
 }
 
 // commitStagedRotation copies a completed staging Secret onto an operator-owned
-// target Secret and deletes the staging Secret. It is the operator-side commit
-// for the split-compute-write rotation architecture, shared by every rotation
-// flavour via rotationCommitSpec:
-//
-//  1. GET the staging Secret. If absent, return (false, nil) — nothing to do.
-//  2. Require RotationCompletedAnnotation to be present and parseable as
-//     RFC3339; a malformed annotation emits spec.annotationInvalidReason and is
-//     retried on the next CronJob run (no requeue-with-error).
-//  3. Validate the Secret's Data via spec.validate; a rejection emits
-//     spec.rejectedReason. When spec.clearStagingOnReject is set the staged
-//     Data and completion annotation are cleared (the staging Secret object is
-//     kept) so the next CronJob strategic-merge PATCH starts from an empty base
-//     rather than accumulating leftover key indices over a rejected payload;
-//     otherwise the staging Secret is retained verbatim for operator
-//     inspection.
-//  4. GET the target Secret, replace its Data with the staging payload
-//     verbatim, stamp the annotation, and Update — full-object replacement
-//     guarantees the atomic-swap semantics (stale indices not in the staging
-//     payload are removed).
-//  5. DELETE the staging Secret under client.Preconditions{UID,
-//     ResourceVersion} from the step-1 read; tolerate NotFound and Conflict.
-//  6. Emit a Normal event built from spec.appliedReason / spec.appliedMessage.
-//
-// DECISION: UPDATE-then-DELETE ordering — if DELETE fails, the target Secret is
-// already updated; a subsequent reconcile will no-op on the next CronJob PATCH
-// because the annotation flips to a new timestamp (and a stale, pre-this-run
-// annotation would fail validation the same way on retry). Tolerating NotFound
-// on DELETE handles the common race where a human operator removed the staging
-// Secret by hand.
-//
-// DECISION: the step-5 DELETE carries client.Preconditions with the UID and
-// ResourceVersion read in step 1. An unconditional DELETE would silently remove
-// a staging Secret the CronJob had PATCHed with fresh rotation output between
-// the step-1 Get and the DELETE, losing that output uncommitted. With the
-// preconditions the API server returns 409 Conflict instead; the newer payload
-// survives on the staging Secret and commits on the next reconcile. Both
-// Conflict (concurrent PATCH) and NotFound (concurrent delete) are therefore
-// tolerated — this run's payload is already on the target Secret, so the apply
-// is complete either way.
-//
-// DECISION: The target Secret's `.data` field is fully replaced under the
-// controller-owned ResourceVersion via a GET+Update round-trip. A
-// strategic-merge PATCH would merge map entries by key rather than replace the
-// map (corev1.Secret.Data has no patchStrategy tag), which would allow stale
-// key indices — e.g. those trimmed by a max_active_keys reduction or renumbered
-// by keystone-manage fernet_rotate — to accumulate indefinitely. Full
-// replacement is the only semantic that realises the intended atomic swap.
-//
-// Persisting the annotation on the target Secret is also what makes the
-// keystone_operator_key_rotation_age_seconds gauge refresh on every reconcile:
-// the staging Secret is deleted on step 5, so the target Secret is the only
-// durable record of the last successful rotation timestamp.
-func (r *KeystoneReconciler) commitStagedRotation(ctx context.Context, keystone *keystonev1alpha1.Keystone, staging, target *corev1.Secret, spec rotationCommitSpec) (applied bool, err error) {
-	// staging is the object ensureStagingSecret returned (never nil in
-	// production); target is the operator-owned Secret the caller already read.
-	// Both are threaded in rather than re-read here (issue #361). A nil staging
-	// means there is nothing to commit — treated as a no-op for defence in depth.
-	if staging == nil {
-		return false, nil
-	}
-	stagingName := staging.Name
-
-	// 1. Require RotationCompletedAnnotation present and well-formed RFC3339.
-	completedAt := staging.Annotations[RotationCompletedAnnotation]
-	if completedAt == "" {
-		// Distinguish "CronJob hasn't run yet" (empty staging.Data — expected
-		// steady state between rotations) from "CronJob wrote Data but forgot
-		// to annotate" (non-empty Data — likely a script bug). Logged at V(1)
-		// so normal operation is not spammed.
-		if len(staging.Data) > 0 {
-			log.FromContext(ctx).V(1).Info(
-				"staging secret has data without completion annotation; "+
-					"skipping apply until next CronJob run writes the annotation",
-				"staging", stagingName,
-				"annotation", RotationCompletedAnnotation,
-				"dataKeys", len(staging.Data),
-			)
-		}
-		return false, nil
-	}
-	if _, parseErr := time.Parse(time.RFC3339, completedAt); parseErr != nil {
-		r.Recorder.Eventf(keystone, corev1.EventTypeWarning, spec.annotationInvalidReason,
-			"staging secret %s has malformed %s annotation: %v",
-			stagingName, RotationCompletedAnnotation, parseErr)
-		return false, nil
-	}
-
-	// 2. Validate staging payload. On rejection, emit the Warning event; when
-	//    spec.clearStagingOnReject is set, clear the staged Data and completion
-	//    annotation before returning. The key-rotation scripts PATCH the staging
-	//    Secret with strategic-merge semantics over a multi-key `.data` map
-	//    (scripts/fernet_rotate.sh, credential_rotate.sh), so leftover key
-	//    indices from a rejected payload would otherwise survive and merge under
-	//    the next CronJob run — letting the validator accept a key set
-	//    keystone-manage never produced together. Clearing makes the next PATCH
-	//    start from an empty base. The rejection event message (not the
-	//    now-empty staging Data) is the diagnostic of record (issue #475).
-	if valErr := spec.validate(staging.Data); valErr != nil {
-		r.Recorder.Eventf(keystone, corev1.EventTypeWarning, spec.rejectedReason,
-			"staging secret %s rejected: %v", stagingName, valErr)
-		if spec.clearStagingOnReject {
-			staging.Data = nil
-			delete(staging.Annotations, RotationCompletedAnnotation)
-			if updErr := r.Update(ctx, staging); updErr != nil {
-				if !apierrors.IsConflict(updErr) && !apierrors.IsNotFound(updErr) {
-					return false, fmt.Errorf("clearing rejected staging secret %s: %w", stagingName, updErr)
-				}
-				// A concurrent CronJob PATCH (Conflict) or a manual delete
-				// (NotFound) raced the clear; the next reconcile re-reads and
-				// re-validates, so the stale base cannot survive (issue #475).
-				log.FromContext(ctx).V(1).Info(
-					"rejected staging secret changed since read; clear retried next reconcile",
-					"staging", stagingName,
-				)
-			}
-		}
-		return false, nil
-	}
-
-	// 3. Skip the target Update and the success event when the target already
-	//    holds this exact payload and completion timestamp: a prior pass
-	//    committed it, and only its staging delete is outstanding (e.g. a
-	//    transient delete error requeued the pass). Re-Updating would be a no-op
-	//    write and re-emitting the event would double-announce the rotation.
-	//    Secret.Data is map[string][]byte, so compare with maps.EqualFunc over
-	//    bytes.Equal. Step 4 still runs so the staging Secret is cleaned up.
-	alreadyCommitted := maps.EqualFunc(target.Data, staging.Data, bytes.Equal) &&
-		target.Annotations[RotationCompletedAnnotation] == completedAt
-
-	if !alreadyCommitted {
-		// Replace the target's Data verbatim, stamp the rotation-completed
-		// annotation, and Update. The target was read by the caller at the top of
-		// the pass; only ensureStagingSecret (which touches the staging Secret,
-		// not this one) ran in between, so its ResourceVersion is still current.
-		// Full Data replacement is required — see the DECISION comment above.
-		target.Data = staging.Data
-		if target.Annotations == nil {
-			target.Annotations = map[string]string{}
-		}
-		target.Annotations[RotationCompletedAnnotation] = completedAt
-		if updateErr := r.Update(ctx, target); updateErr != nil {
-			return false, fmt.Errorf("updating %s %s: %w", spec.targetNoun, target.Name, updateErr)
-		}
-	}
-
-	// 4. DELETE staging Secret under the UID + ResourceVersion observed when the
-	//    caller ensured it. The preconditions make a concurrent CronJob PATCH
-	//    (fresh rotation output written between the read and this DELETE) surface
-	//    as 409 Conflict rather than being silently deleted uncommitted; the
-	//    newer payload then commits on the next reconcile. Conflict and NotFound
-	//    are both tolerated — this run's payload is already on the target Secret.
-	delOpts := client.Preconditions{UID: &staging.UID, ResourceVersion: &staging.ResourceVersion}
-	if delErr := r.Delete(ctx, staging, delOpts); delErr != nil {
-		if !apierrors.IsNotFound(delErr) && !apierrors.IsConflict(delErr) {
-			return false, fmt.Errorf("deleting staging secret %s: %w", stagingName, delErr)
-		}
-		log.FromContext(ctx).V(1).Info(
-			"staging secret changed since read; newer rotation output applied next reconcile",
-			"staging", stagingName,
-		)
-	}
-
-	// 5. A prior pass already committed this payload — the target write and the
-	//    success event were emitted then, so report applied=false without
-	//    re-announcing.
-	if alreadyCommitted {
-		return false, nil
-	}
-
-	// 6. Emit a success event for the commit performed this pass.
-	r.Recorder.Event(keystone, corev1.EventTypeNormal, spec.appliedReason,
-		spec.appliedMessage(stagingName, staging.Data))
-
-	return true, nil
+// target Secret and deletes the staging Secret, via the shared
+// rotation.CommitStaged.
+func (r *KeystoneReconciler) commitStagedRotation(ctx context.Context, keystone *keystonev1alpha1.Keystone, staging, target *corev1.Secret, spec rotation.CommitSpec) (applied bool, err error) {
+	return rotation.CommitStaged(ctx, r.Client, r.Recorder, keystone, staging, target, spec)
 }
 
 // applyRotationOutput commits a completed Fernet/credential key rotation from
@@ -374,14 +101,14 @@ func (r *KeystoneReconciler) applyRotationOutput(
 	eventReason string,
 	minKeys, maxKeys int,
 ) (applied bool, err error) {
-	return r.commitStagedRotation(ctx, keystone, staging, mainSecret, rotationCommitSpec{
-		targetNoun:              "main secret",
-		validate:                func(data map[string][]byte) error { return validateRotationOutput(data, minKeys, maxKeys) },
-		clearStagingOnReject:    true,
-		annotationInvalidReason: "RotationAnnotationInvalid",
-		rejectedReason:          "RotationRejected",
-		appliedReason:           eventReason,
-		appliedMessage: func(stagingSecretName string, data map[string][]byte) string {
+	return r.commitStagedRotation(ctx, keystone, staging, mainSecret, rotation.CommitSpec{
+		TargetNoun:              "main secret",
+		Validate:                func(data map[string][]byte) error { return validateRotationOutput(data, minKeys, maxKeys) },
+		ClearStagingOnReject:    true,
+		AnnotationInvalidReason: "RotationAnnotationInvalid",
+		RejectedReason:          "RotationRejected",
+		AppliedReason:           eventReason,
+		AppliedMessage: func(stagingSecretName string, data map[string][]byte) string {
 			// Count reflects the number of active keys now in the production
 			// Secret (len(staging.Data) == len(main.Data) after replacement).
 			return fmt.Sprintf("rotation applied from staging secret %s (%d active keys)", stagingSecretName, len(data))

--- a/operators/keystone/internal/metrics/collectors.go
+++ b/operators/keystone/internal/metrics/collectors.go
@@ -72,26 +72,25 @@ func (c *collectors) register(reg prometheus.Registerer) error {
 	return nil
 }
 
-// globalColls is the single production instance, registered on the
-// controller-runtime metrics registry exactly once via initOnce.
+// globalColls is the single production instance. It is constructed at package
+// init but not registered; Register exposes it on the controller-runtime
+// registry exactly once at operator startup. Recording before Register is inert
+// (the vectors hold samples locally until registered).
 var (
-	globalColls *collectors
-	initOnce    sync.Once
+	globalColls  = newCollectors()
+	registerOnce sync.Once
+	registerErr  error
 )
 
-// globalCollectors returns the lazily-initialized package-wide collectors,
-// registering them on ctrlmetrics.Registry on first access. Using
-// sync.Once ensures registration is idempotent across repeated test runs
-func globalCollectors() *collectors {
-	initOnce.Do(func() {
-		globalColls = newCollectors()
-		if err := globalColls.register(ctrlmetrics.Registry); err != nil {
-			// Duplicate-registration on the controller-runtime registry
-			// is a startup bug; fail fast rather than silently hide it.
-			panic(fmt.Sprintf("metrics: failed to register collectors on controller-runtime registry: %v", err))
-		}
+// Register exposes the per-CR collectors on the controller-runtime metrics
+// registry exactly once and returns any registration error, so a
+// duplicate-registration surfaces as a clean operator-startup failure rather
+// than a mid-reconcile panic. Repeated calls return the memoized first result.
+func Register() error {
+	registerOnce.Do(func() {
+		registerErr = globalColls.register(ctrlmetrics.Registry)
 	})
-	return globalColls
+	return registerErr
 }
 
 // SetKeyRotationAge publishes the age in seconds of the most recent key
@@ -99,7 +98,7 @@ func globalCollectors() *collectors {
 // NOT update the gauge if completedAt is the zero Time (e.g. when the CR
 // annotation is missing or malformed).
 func SetKeyRotationAge(keystone, namespace, keyType string, completedAt time.Time) error {
-	return globalCollectors().setKeyRotationAge(keystone, namespace, keyType, completedAt)
+	return globalColls.setKeyRotationAge(keystone, namespace, keyType, completedAt)
 }
 
 // RecordDBSync increments the db_sync terminal-state counter and records
@@ -111,7 +110,7 @@ func SetKeyRotationAge(keystone, namespace, keyType string, completedAt time.Tim
 // job does not inflate it. Level 2 wires the call-site at the job's
 // terminal-state branch in reconcile_database.go.
 func RecordDBSync(keystone, namespace, result string, duration time.Duration) {
-	globalCollectors().recordDBSync(keystone, namespace, result, duration)
+	globalColls.recordDBSync(keystone, namespace, result, duration)
 }
 
 // DeleteForKeystone drops every series tagged with the given keystone name
@@ -119,14 +118,14 @@ func RecordDBSync(keystone, namespace, result string, duration time.Duration) {
 // sub-reconciler metrics intentionally carry no CR labels, so there is
 // nothing to delete there.
 func DeleteForKeystone(name, namespace string) {
-	globalCollectors().deleteForKeystone(name, namespace)
+	globalColls.deleteForKeystone(name, namespace)
 }
 
 // --- internal methods (bound to an instance) -------------------------------
 //
 // Each public package-level helper above (SetKeyRotationAge, RecordDBSync,
-// DeleteForKeystone) is a thin wrapper that resolves globalCollectors() and
-// forwards to the matching method below. The methods are also exercised
+// DeleteForKeystone) is a thin wrapper that forwards to the matching method
+// below on globalColls. The methods are also exercised
 // directly by collectors_test.go against an isolated registry so they are
 // not test-only.
 

--- a/operators/keystone/internal/metrics/collectors_test.go
+++ b/operators/keystone/internal/metrics/collectors_test.go
@@ -238,22 +238,23 @@ func seriesForKeystone(fam *dto.MetricFamily, keystone, namespace string) []*dto
 // (RecordDBSync, SetKeyRotationAge, DeleteForKeystone) against the real
 // controller-runtime registry — the in-process path production uses, which the
 // instance-method tests above (bound to private registries) never touch. It
-// proves recording publishes series on ctrlmetrics.Registry, that
-// DeleteForKeystone reaps only the target CR's series (stale-series leak guard),
-// and that globalCollectors() is idempotent.
+// proves Register publishes the package-global collectors on
+// ctrlmetrics.Registry and that DeleteForKeystone reaps only the target CR's
+// series (stale-series leak guard).
 //
-// The panic branch in globalCollectors (duplicate registration on
-// ctrlmetrics.Registry) is intentionally NOT exercised here: triggering it would
-// poison the process-global sync.Once and corrupt every other test in this
-// binary. The equivalent duplicate-registration error is covered against a fresh
-// registry by TestRegisterDuplicateReturnsError.
+// Register's error branch (duplicate registration on ctrlmetrics.Registry) is
+// intentionally NOT exercised here: triggering it would poison the
+// process-global sync.Once and corrupt every other test in this binary. The
+// equivalent duplicate-registration error is covered against a fresh registry
+// by TestRegisterDuplicateReturnsError.
 func TestGlobalCollectorPathRecordsAndDeletes(t *testing.T) {
 	g := NewGomegaWithT(t)
 	reg := ctrlmetrics.Registry
 
-	// globalCollectors() must return the same registered instance every time.
-	g.Expect(globalCollectors()).To(BeIdenticalTo(globalCollectors()),
-		"globalCollectors must be idempotent (sync.Once)")
+	// Register exposes the package-global collectors on ctrlmetrics.Registry so
+	// the global-path helpers below publish there. Register is memoized, so
+	// repeated calls across tests are safe.
+	g.Expect(Register()).To(Succeed())
 
 	// Two distinct CRs so DeleteForKeystone can be proven to reap only one.
 	const (

--- a/operators/keystone/internal/testutil/envtest_setup.go
+++ b/operators/keystone/internal/testutil/envtest_setup.go
@@ -11,16 +11,9 @@ import (
 	"runtime"
 	"testing"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
-	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
-	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonenvtest "github.com/c5c3/forge/internal/common/testutil/envtest"
 )
@@ -83,37 +76,7 @@ func SetupKeystoneEnvTestNoWebhook(
 	t.Helper()
 
 	crdDir, _ := keystonePaths()
-
-	env := &envtest.Environment{
-		CRDDirectoryPaths:     []string{crdDir},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	cfg, err := env.Start()
-	if err != nil {
-		t.Fatalf("failed to start no-webhook Keystone envtest environment: %v", err)
-	}
-
-	s := buildScheme(addToScheme)
-
-	c, err := client.New(cfg, client.Options{Scheme: s})
-	if err != nil {
-		if stopErr := env.Stop(); stopErr != nil {
-			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
-		}
-		t.Fatalf("failed to create direct client: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	t.Cleanup(func() {
-		cancel()
-		if err := env.Stop(); err != nil {
-			t.Errorf("failed to stop no-webhook Keystone envtest environment: %v", err)
-		}
-	})
-
-	return c, ctx, cancel
+	return commonenvtest.SetupEnvTestWithCRDs(t, buildScheme(addToScheme), []string{crdDir})
 }
 
 // keystonePaths returns absolute paths to the Keystone CRD and webhook
@@ -141,17 +104,9 @@ func buildScheme(addToScheme func(*k8sruntime.Scheme) error) *k8sruntime.Scheme 
 // and all external operator types (MariaDB, ESO, cert-manager).
 // It is created fresh per test.
 func buildControllerScheme(addToScheme func(*k8sruntime.Scheme) error) *k8sruntime.Scheme {
-	return commonenvtest.BuildScheme(
-		// External operator types needed by the reconciler.
-		mariadbv1alpha1.AddToScheme,
-		esov1.AddToScheme,
-		esov1alpha1.AddToScheme,
-		certmanagerv1.AddToScheme,
-		// Gateway API types for HTTPRoute reconciliation.
-		gatewayv1.Install,
-		// Keystone types.
-		addToScheme,
-	)
+	// The reconciler's external API groups (MariaDB, ESO v1/v1alpha1,
+	// cert-manager, Gateway API) are exactly the shared common set.
+	return commonenvtest.BuildScheme(append(commonenvtest.CommonExternalSchemes(), addToScheme)...)
 }
 
 // SetupMinimalEnvTest starts a minimal envtest API server with the Keystone
@@ -174,41 +129,10 @@ func SetupMinimalEnvTest(
 	// setup does not install. Fail-fast on a missing CRD directory is already
 	// covered by envtest's ErrorIfCRDPathMissing=true below.
 	crdDir, _ := keystonePaths()
-
-	env := &envtest.Environment{
-		CRDDirectoryPaths:     []string{crdDir},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	cfg, err := env.Start()
-	if err != nil {
-		t.Fatalf("failed to start minimal Keystone envtest environment: %v", err)
-	}
-
-	s := buildScheme(addToScheme)
-
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 s,
-		Metrics:                metricsserver.Options{BindAddress: "0"},
-		HealthProbeBindAddress: "0",
+	return commonenvtest.SetupUnstartedManager(t, commonenvtest.UnstartedManagerConfig{
+		Scheme:            buildScheme(addToScheme),
+		CRDDirectoryPaths: []string{crdDir},
 	})
-	if err != nil {
-		if stopErr := env.Stop(); stopErr != nil {
-			t.Logf("additionally failed to stop envtest environment: %v", stopErr)
-		}
-		t.Fatalf("failed to create minimal controller-runtime manager: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	t.Cleanup(func() {
-		cancel()
-		if err := env.Stop(); err != nil {
-			t.Errorf("failed to stop minimal Keystone envtest environment: %v", err)
-		}
-	})
-
-	return mgr, ctx, cancel
 }
 
 // SetupKeystoneEnvTestWithController starts an envtest API server with the

--- a/operators/keystone/main.go
+++ b/operators/keystone/main.go
@@ -52,6 +52,13 @@ func main() {
 		Scheme:           scheme,
 		LeaderElectionID: "keystone.openstack.c5c3.io",
 		SetupFunc: func(mgr ctrl.Manager, webhooks bool, maxConcurrentReconciles int) error {
+			// Register the operator's Prometheus collectors on the
+			// controller-runtime registry before wiring controllers, so a
+			// duplicate-registration fails startup cleanly instead of panicking
+			// mid-reconcile.
+			if err := controller.RegisterMetrics(); err != nil {
+				return err
+			}
 			// +kubebuilder:scaffold:builder — register controllers here
 			if err := (&controller.KeystoneReconciler{
 				Client:                  mgr.GetClient(),

--- a/tests/e2e-chaos/keystone-federation/chainsaw-test.yaml
+++ b/tests/e2e-chaos/keystone-federation/chainsaw-test.yaml
@@ -126,6 +126,46 @@ spec:
   - try:
     - apply:
         file: 03-container-kill.yaml
+    - script:
+        # Budget: 3 attempts × (20s injection poll + delete/re-apply) ≈ 70s
+        # worst case; 120s leaves margin for a slow chaos-daemon RPC.
+        timeout: 120s
+        content: |
+          # Chaos Mesh resolves a one-shot container-kill's targets exactly
+          # once, at apply time. When that selection races the tail of the
+          # sidecar rollout (the old ReplicaSet's pods are still
+          # terminating), it reports "no target has been selected" and never
+          # retries — the kill silently never happens and the restart-count
+          # gate in the next step starves. Gate on AllInjected=True and
+          # re-apply the experiment a bounded number of times. The chainsaw
+          # apply above stays authoritative for cleanup tracking; the first
+          # kubectl apply below is a no-op on the same object.
+          # NOTE: set -euo pipefail is intentionally omitted — a transient
+          # kubectl failure must count as "not yet injected", not abort.
+          for attempt in 1 2 3; do
+            kubectl apply -f 03-container-kill.yaml
+            for i in $(seq 1 10); do
+              INJECTED=$(kubectl get podchaos kill-federation-proxy -n $NAMESPACE \
+                -o jsonpath='{.status.conditions[?(@.type=="AllInjected")].status}')
+              if [ "$INJECTED" = "True" ]; then
+                echo "Container kill injected (attempt ${attempt})"
+                exit 0
+              fi
+              SELECTED=$(kubectl get podchaos kill-federation-proxy -n $NAMESPACE \
+                -o jsonpath='{.status.conditions[?(@.type=="Selected")].status}')
+              if [ "$SELECTED" = "False" ]; then
+                break
+              fi
+              sleep 2
+            done
+            echo "Chaos not injected (attempt ${attempt}); deleting and re-applying the experiment"
+            kubectl delete podchaos kill-federation-proxy -n $NAMESPACE --ignore-not-found --wait=true
+          done
+          echo "ERROR: container-kill chaos never injected after 3 attempts"
+          exit 1
+    catch:
+    - script:
+        content: ../diagnostics.sh chaos keystone-chaos-fed --dep-label=app.kubernetes.io/name=keycloak-chaos --log-label=app.kubernetes.io/instance=keystone-chaos-fed
   # ── Step 4: Restart observed, Keystone recovers, federated auth back ────
   - try:
     - script:


### PR DESCRIPTION
## What & why

The keystone and horizon operators grew by copy-paste: their sub-reconcilers (health check, HTTPRoute, HPA, NetworkPolicy, secrets gates, controller skeleton, DB provisioning, migration job, credential rotation, envtest harness) were near-byte-identical, so every tuning or fix had to be made twice. This branch promotes that shared scaffolding into `internal/common`, reduces each operator's copy to a thin service-specific binding, and aligns the `c5c3` ControlPlane operator on the same Server-Side Apply write path the other operators already use.

Closes #621

## How to read this

The branch is ordered as: **(1)** grow `internal/common` with the promoted building blocks, **(2)** adopt them in the `c5c3` ControlPlane operator plus switch its child projections to SSA, **(3)** documentation. Reviewing in commit order follows that arc.

### 1. Promotions into `internal/common`

- **`d2ace526` — centralize shared requeue and health-check constants.** `RequeueDeploymentPolling` / `RequeueSecretPolling` and the `RequeueHealthCheck` / `HealthCheckTimeout` / `HealthCheckCacheTTL` timings, previously defined identically in both operators, move into `internal/common/reconcile` and `internal/common/healthcheck`; each operator's copy becomes a re-export alias.
- **`598c576d` — shared health-check probe flow.** Promotes the endpoint gate / TTL probe cache / timeout-bounded GET / error-classification / condition-reporting flow to `healthcheck.ReconcileProbe`, parameterized by the service endpoint, condition vocabulary, and a `Subject` string that reproduces the log lines and condition messages byte-for-byte.
- **`af16262a` — shared HTTPRoute flow.** The three-path (Gateway API absent / disabled / enabled) flow becomes `gateway.ReconcileHTTPRoute` with an `ExposureNoun` parameter; HTTPRoute condition reasons are exported so both operators alias one vocabulary.
- **`01b11dd3` — networkpolicy flow package.** New `internal/common/networkpolicy` with `Ensure` / `Delete`, `DNSEgressRule`, `DatabaseEgressRule`, `CacheEgressRule` / `CacheEgressPorts`, `IngressPeers`, and the `Reconcile` flow. Each operator keeps only its service-specific egress tail (keystone: kube-apiserver + federation; horizon: keystone-endpoint) and its ingress port.
- **`b270365b` — shared HPA flow.** The two-path (delete-when-disabled / SSA-ensure) flow becomes `deployment.ReconcileHPA` over an `HPAFlowParams` struct with exported HPA condition reasons.
- **`1ad147cc` — condition-reporting credential gates.** `secrets.GateClusterStoreReady` (the `SecretStoreNotReady` gate) and `secrets.GateCredential` / `GateCredentials` (the `GateSyncedSecret` ladder → per-state `SecretsReady=False` message). Both operators bind the store gate; keystone binds the credential loop and keeps its OpenBao finalizer subsystem, horizon keeps its `SECRET_KEY` digest gate.
- **`9c798355` — return errors from metrics registration.** Replaces lazy first-sample registration (which could panic on a duplicate deep inside a reconcile) with explicit startup `Register` returning an error, wired into each operator's `main.go` `SetupFunc` via a new `RegisterMetrics`; adds `NewSubReconcilerInstrumenter`.
- **`8df8062a` — controller-skeleton helpers.** The four thin wrappers (`updateStatus`, `setReadyCondition`, `markConfigFailed`, `reconcileParallelGroup`) become a generic `reconcile.Skeleton` parameterized by CR/status/condition-vocabulary/accessor; each operator declares one `Skeleton` value and delegates.
- **`3e01c9b4` — dashboard tests register explicitly.** Follow-up to `9c798355`: the dashboard drift-guard tests register the sub-reconciler vectors and keystone per-CR collectors before gathering, since registration is no longer lazy.
- **`0c746f7f` — MariaDB provisioning builders.** `database.BuildDatabase` / `BuildUser` / `BuildGrant` over a `ProvisionParams` struct with utf8 / utf8_general_ci and password-key defaults; the keystone builders become thin wrappers deriving params from the CR.
- **`56d373f1` — migration-job skeleton and metrics.** `job.BuildMigrationJob` (shared single-container, config-mounted, `RestartPolicy=Never` skeleton) and `job.RecordJobTerminalState` (at-most-once per `(phase, Job UID)` terminal observation with a parameterized Warning event on patch failure); keystone's `buildDBJob` / `recordDBJobTerminalState` bind the keystone specifics.
- **`fdd7b36c` — credential-rotation package.** Promotes the split-compute-write rotation mechanics: `rotation.EnsureStagingSecret`, `CommitStaged` over a `CommitSpec`, `EnsureRBAC`, `CompletedAt` / `ObserveAge`, and `BuildCronJob` / `CronJobParams`. Keystone's rotation files become thin wrappers.
- **`515fcde4` — grow envtest harness modes.** Adds `SetupEnvTestWithCRDs` (webhook-less; `SetupEnvTest` now delegates), `SetupUnstartedManager` (FieldIndexer tests), and `CommonExternalSchemes` (MariaDB / ESO / cert-manager / Gateway); keystone's hand-rolled variants become delegates.
- **`07fa3f04` — cluster-ref watch mapper.** The MariaDB-cluster-event → same-namespace CRs-by-`clusterRef` mapper becomes `watch.ClusterRefMapper`, parameterized by CR list type and a name extractor.
- **`673b89c5` — immutable resource-default accessors.** The exported mutable `resource.Quantity` default vars become unexported behind `DefaultMemoryRequest` / `DefaultCPURequest` / `DefaultMemoryLimit` / `DefaultCPULimit` accessors returning copies; keystone re-export aliases are deleted.
- **`b7bf598d` — service-neutral shared CRD type descriptions.** Neutralizes keystone-specific godoc ("Keystone API", "uWSGI", "TCP 5000", "keystone.middleware") on the shared `DeploymentSpec` / `NetworkPolicySpec` / `LoggingSpec` / `ImageSpec` / `DatabaseSpec` / `PluginSpec` / `Gateway` types and regenerates all three operators' CRDs (bases + synced Helm copies). Description-only; no schema fields move.
- **`d89cd39b` — generic child-CR projector.** `reconcile.ProjectChild` (apply-via-SSA under the shared field manager, distinct `Invalid` classification, readiness mirror, requeue) and `reconcile.DeleteOrphanedChild` (owned-only, NotFound-tolerant orphan cleanup).

### 2. `c5c3` ControlPlane adoption + SSA alignment

- **`30bc316f` — project service children via the shared projector.** `reconcileKeystone` (a pure function of `cp.Spec`) applies its Keystone child through `ProjectChild` (SSA under `forge-operator`) and routes both orphan-cleanup paths through `DeleteOrphanedChild`.
- **`247cda7f` — route status writes through the shared writer.** Adopts `reconcile.Skeleton` for the ControlPlane Ready aggregation/status write and moves `parkDuplicateControlPlane` and the CredentialRotation `finish` helper onto the shared no-op-skipping `UpdateStatus`.
- **`7e7db688` — switch child projections to server-side apply.** Converts the pure-projection child writes from `controllerutil.CreateOrUpdate` to SSA under the shared field manager (K-ORC admin Domain/User imports, managed identity Service/Endpoint, external identity imports, service-account imports/probes + consumer ExternalSecret, DB-credential SA / VaultDynamicSecret / ExternalSecrets, admin-password ExternalSecret, K-ORC clouds.yaml ExternalSecret). Unit tests are adapted to the Apply write path (spec-stability assertions and an Apply interceptor).

### Deliberate divergences from a blanket promotion (called out in the commits)

These are the interesting review points — where the branch intentionally did **not** collapse to the shared path:

- **`reconcileHorizon` keeps read-modify-write (`30bc316f`).** Its projection reads the fetched child's `websso` / `multiDomain` to retain them while identity backends are attached but unhealthy, so it is not a pure projection; only its orphan cleanup moves to `DeleteOrphanedChild`.
- **Several `c5c3` write sites stay read-modify-write with inline constraint comments (`7e7db688`):** the MariaDB/Memcached adoption path (reads owner references so it never claims shared infra), the K-ORC `ApplicationCredential` and service-account `User` (preserve rotation/re-mint annotation markers), `ensureOwnedSecret` (preserves generated-once values), the unstructured cert-manager `Certificate`, and the managed catalog entries (no-churn probe of the live Terminating CR the deletion-race gate reads).

### 3. Documentation

- **`1e77ac6f`** updates the new-operator onboarding guide's shared-packages table with every promoted block and updates the keystone metrics reference to describe startup-time `RegisterMetrics`.

## Notes for the reviewer

- The diff is large (~4.8k insertions / 2.8k deletions across 100 files) but the net direction is deduplication: the bulk of the deletions are the copies being replaced by thin bindings, and much of the CRD churn is regenerated description-only text plus synced Helm copies.
- No behavior change is intended for keystone/horizon — the promoted flows preserve log lines and condition messages byte-for-byte; the observable change is on the `c5c3` side (SSA write path) and the operator-wide metrics-registration timing (startup instead of first-sample).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
