### PR TITLE
docs(guides): establish guide conventions and consolidate example naming

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -136,6 +136,7 @@ export default defineConfig({
         items: [
           { text: 'Adding a New Operator', link: '/contributing/adding-a-new-operator' },
           { text: 'Adding a New Release', link: '/contributing/adding-a-new-release' },
+          { text: 'Guide Conventions', link: '/contributing/guide-conventions' },
           { text: 'Dependency Management', link: '/contributing/dependency-management' },
           { text: 'Nix Development Environment', link: '/contributing/nix-dev-environment' },
           { text: 'Claude Code Skills', link: '/contributing/claude-skills' },

--- a/docs/contributing/guide-conventions.md
+++ b/docs/contributing/guide-conventions.md
@@ -69,10 +69,9 @@ the ControlPlane devstack's real names: the projected Keystone child is
 [End-to-End SSO](../guides/end-to-end-sso.md). Do not interleave the two naming
 worlds in the primary walkthrough.
 
-Placeholder example names that no tutorial produces (for instance a bare
-`keystone-default`) are banned. If a value genuinely varies per reader, express
-it as a substitution rule anchored on a concrete devstack name, not as an
-invented literal.
+Placeholder example names that no tutorial produces are banned. If a value
+genuinely varies per reader, express it as a substitution rule anchored on a
+concrete devstack name, not as an invented literal.
 
 ## Never edit operator-projected children
 

--- a/docs/contributing/guide-conventions.md
+++ b/docs/contributing/guide-conventions.md
@@ -1,0 +1,115 @@
+---
+title: Guide Conventions
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guide Conventions
+
+The how-to guides under `docs/guides/` all lead an operator through a task on a
+running cluster. To keep them copy-pasteable, every guide must agree on the same
+few structural rules. Without them each guide re-derives its structure from a
+neighbour and inherits that neighbour's inconsistencies — most visibly, example
+names that name a resource the reader's cluster never created.
+
+This page is the contract. New guides follow it from the start; existing guides
+are being brought into conformance.
+
+## One devstack per guide
+
+A reader arriving at a guide has to know exactly which cluster to build before
+the first command runs. Every guide therefore opens with a standardized
+prerequisites block that names **exactly one** Getting-Started tutorial and its
+verbatim bring-up command.
+
+The block is machine-checkable. It must be:
+
+1. A `## Prerequisites` heading.
+2. Whose first element is a `::: info Devstack` container that holds, in order:
+   - exactly **one** link to a Getting-Started tutorial
+     (`../quick-start.md`, `../quick-start-extended.md`, or
+     `../quick-start-controlplane.md`);
+   - exactly **one** fenced ` ```bash ` block with the tutorial's verbatim
+     bring-up command, including every `WITH_*` opt-in flag the guide depends
+     on (a guide that needs Prometheus names `WITH_PROMETHEUS=true`, a guide
+     that needs a ControlPlane names `WITH_CONTROLPLANE=true`, and so on);
+   - a completion pointer — how far the reader follows the tutorial (its final
+     **Verify** step, so the devstack is running).
+3. Followed by any guide-specific prerequisite bullets (an external LDAP server,
+   a Keycloak realm, a CNI that enforces NetworkPolicy, ...).
+
+The three devstacks and the names each produces:
+
+| Devstack | Verbatim bring-up | Names the examples may use |
+| --- | --- | --- |
+| [Quick Start](../quick-start.md) | `KIND_HOST_PORT=8443 make deploy-infra` (then the operator, image, and CR steps) | Keystone CR `keystone` in `openstack`; admin Secret `keystone-admin`; DB Secret `keystone-db`; gateway `openstack-gw`; endpoint `https://keystone.127-0-0-1.nip.io:8443/v3` |
+| [Quick Start (Extended)](../quick-start-extended.md) | `kind create cluster --name forge --config hack/kind-config.yaml` then `make deploy-infra` (then the operator, image, and CR steps) | Same standalone names as the base Quick Start (`keystone`, `keystone-admin`, `keystone-db`) |
+| [Quick Start (ControlPlane)](../quick-start-controlplane.md) | `KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra` | ControlPlane CR `controlplane` in `openstack`; projected children `controlplane-keystone` / `controlplane-horizon`; admin Secret and ExternalSecret `controlplane-keystone-admin-credentials`; DB ExternalSecret `controlplane-keystone-db-credentials`; shared `openstack-db` / `openstack-memcached` / `openstack-gw` |
+
+Opt-in flags compose, so a guide that needs both a ControlPlane and Prometheus
+names `KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra`.
+
+## ControlPlane-first naming
+
+The primary path of a guide uses the resource names its declared devstack
+actually produces — never a placeholder name that no tutorial creates. A reader
+on that devstack must be able to copy a command and have it hit a resource that
+exists.
+
+When a guide's devstack is the ControlPlane Quick Start, the primary path uses
+the ControlPlane devstack's real names: the projected Keystone child is
+`controlplane-keystone`, its admin credential lives in
+`controlplane-keystone-admin-credentials`, and so on. Where a standalone
+(non-ControlPlane) installation differs, the differences go in a separate
+`## Standalone Keystone, without a ControlPlane` section at the end, modeled on
+[End-to-End SSO](../guides/end-to-end-sso.md). Do not interleave the two naming
+worlds in the primary walkthrough.
+
+Placeholder example names that no tutorial produces (for instance a bare
+`keystone-default`) are banned. If a value genuinely varies per reader, express
+it as a substitution rule anchored on a concrete devstack name, not as an
+invented literal.
+
+## Never edit operator-projected children
+
+On a ControlPlane devstack the Keystone and Horizon CRs are **projected** by the
+ControlPlane operator; editing them by hand is reverted on the next reconcile.
+A guide sets a knob on the `ControlPlane` CR, and lets the operator project it
+down. A knob the `ControlPlane` CRD does not expose is documented as
+standalone-only — in the guide's `## Standalone Keystone, without a ControlPlane`
+section, applied to a Keystone CR the reader owns.
+
+## Every guide is testable
+
+A guide describes behaviour the project also asserts in an end-to-end suite.
+Where a mirroring suite exists under `tests/e2e/`, the guide closes with a
+pointer to it and its invocation, so a reader can run the same flow the guide
+walks through:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/<suite>
+```
+
+## Single source of truth for manifests
+
+Where a guide mirrors an e2e suite, embed the CR manifests from the suite's
+fixture files rather than hand-maintaining a second copy that drifts. VitePress
+snippet imports keep the rendered YAML in lockstep with the fixture the suite
+actually applies:
+
+```md
+<<< @/../tests/e2e/keystone/<suite>/00-keystone-cr.yaml
+```
+
+## Housekeeping
+
+- Frontmatter (`title`, `quadrant: operator`) starts on **line 1**. VitePress
+  renders anything above the frontmatter as body text.
+- Register a new guide in the `Guides` sidebar in `docs/.vitepress/config.ts`.
+- Source describes behaviour, not internal tracking. Do not put internal
+  feature or requirement IDs, or issue references, in a guide.
+- Guides are written in English.

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -15,7 +15,21 @@ supports a number of configuration options for real cluster deployments. This gu
 walks through the four that cover the most common real-world needs and points to the
 reference for the rest.
 
-**Prerequisites:** A running Keystone CR from the [Quick Start (Extended)](../quick-start-extended.md).
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (Extended)](../quick-start-extended.md)** devstack. Stand it up first:
+
+```bash
+kind create cluster --name forge --config hack/kind-config.yaml
+make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify the deployment** step, so a
+Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
+resource name in the examples below is one that devstack produces.
+:::
+
 Each pattern below is an independent recipe — apply only what you need.
 
 ---

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -13,8 +13,20 @@ SPDX-License-Identifier: Apache-2.0
 Three operational patterns you will use most often on a running Keystone CR: scaling,
 upgrading the OpenStack release, and rotating Fernet keys.
 
-**Prerequisites:** A running Keystone CR from the [Quick Start (Extended)](../quick-start-extended.md) (Steps 1–9).
-The examples assume the CR is named `keystone` in the `openstack` namespace.
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (Extended)](../quick-start-extended.md)** devstack. Stand it up first:
+
+```bash
+kind create cluster --name forge --config hack/kind-config.yaml
+make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify the deployment** step, so a
+Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
+resource name in the examples below is one that devstack produces.
+:::
 
 ---
 

--- a/docs/guides/enable-horizon-operator-metrics.md
+++ b/docs/guides/enable-horizon-operator-metrics.md
@@ -25,11 +25,11 @@ condition), see
 [Horizon Reconciler Architecture](../reference/horizon/horizon-reconciler.md).
 
 ::: tip On kind
-If you are running the kind Quick Start, the prometheus-operator CRDs,
-Prometheus, and Grafana are already wrapped behind a single opt-in flag:
+If you are running the kind ControlPlane Quick Start, the prometheus-operator
+CRDs, Prometheus, and Grafana are already wrapped behind opt-in flags:
 
 ```bash
-WITH_PROMETHEUS=true make deploy-infra
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra
 ```
 
 The rest of this guide is the canonical path for non-kind clusters that run
@@ -37,6 +37,17 @@ their own Prometheus.
 :::
 
 ## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the horizon-operator
+(namespace `horizon-system`) is running with kube-prometheus-stack scraping it.
+:::
 
 1. A running `horizon-operator` Helm release (namespace `horizon-system`).
 2. The prometheus-operator CRDs (`servicemonitors.monitoring.coreos.com`)

--- a/docs/guides/enable-horizon-operator-networkpolicy.md
+++ b/docs/guides/enable-horizon-operator-networkpolicy.md
@@ -20,6 +20,18 @@ to the minimum required for correct reconciliation.
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the horizon-operator
+is running (namespace `horizon-system`) alongside the projected
+`controlplane-horizon` dashboard.
+:::
+
 1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy.** Confirm with
    your platform team — kindnet (the kind default) does NOT enforce policies,
    so on a kind cluster the object is created but has no effect.

--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -23,6 +23,19 @@ and
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step. That devstack already
+satisfies items 1–3 below (cert-manager, the `openstack-db-ca-issuer`
+ClusterIssuer, and a TLS-required `openstack-db` MariaDB); the numbered list is
+the checklist to confirm on a non-kind cluster.
+:::
+
 1. **cert-manager installed.** The chart from `deploy/flux-system/releases/cert-manager.yaml`
    provides the `cert-manager.io/v1` CRDs (`Certificate`, `Issuer`, `ClusterIssuer`).
    Confirm the controller is healthy:

--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -44,6 +44,18 @@ sections below cover that wiring end-to-end.
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_PROMETHEUS=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the keystone-operator
+is running with kube-prometheus-stack scraping it. (On kind the `WITH_PROMETHEUS`
+opt-in above wires the manual steps below automatically — see the tip above.)
+:::
+
 - A cluster with the `keystone-operator` Helm release installed and the
   operator Pod healthy (`Ready` condition `True`).
 - **prometheus-operator CRDs installed.** The chart does *not* install

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -22,6 +22,18 @@ authoritative rule table, failure modes, and schema contract, see
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the keystone-operator
+is running and a `keystone` CR is `Ready` in `openstack`. (kindnet does not enforce
+NetworkPolicy — see item 1 below to make the policy effective on kind.)
+:::
+
 1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy.** Confirm with
    your platform team. Common CNIs that enforce:
 
@@ -188,7 +200,7 @@ Create (or update) a `Keystone` CR and watch its `Ready` condition progress
 to `True`:
 
 ```bash
-kubectl -n openstack get keystone <name> \
+kubectl -n openstack get keystone keystone \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")]}{"\n"}'
 ```
 

--- a/docs/guides/end-to-end-sso.md
+++ b/docs/guides/end-to-end-sso.md
@@ -19,6 +19,25 @@ read [Attach an OIDC Federation Backend](./oidc-federation.md) and
 [Attach an LDAP Domain Backend](./ldap-domain-backend.md) first — this guide
 picks up where they leave off and shows what the ControlPlane does with them.
 
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the ControlPlane's
+projected `controlplane-keystone` and `controlplane-horizon` children are
+running. Every resource name in the examples below is one that devstack produces.
+:::
+
+- [Attach an OIDC Federation Backend](./oidc-federation.md) — how to stand up the
+  federation backend this guide projects onto the login page.
+- [Attach an LDAP Domain Backend](./ldap-domain-backend.md) — how to stand up the
+  LDAP domain backend used in the multi-domain step.
+
 ## What the ControlPlane does for you
 
 Attaching a `KeystoneIdentityBackend` to a ControlPlane's Keystone child is the

--- a/docs/guides/keystone-admin-password-rotation.md
+++ b/docs/guides/keystone-admin-password-rotation.md
@@ -20,24 +20,39 @@ event reasons, the failure path), see
 [reconcileBootstrap](../reference/keystone/keystone-reconciler.md#reconcilebootstrap)
 in [Keystone Reconciler Architecture](../reference/keystone/keystone-reconciler.md).
 
-> **Terminology.** In this document `<ks>` is the Keystone CR's `.metadata.name`
-> (e.g. `keystone-default`) and `<ns>` is its namespace (typically `openstack`).
-> The admin password lives in the Secret referenced by
-> `spec.bootstrap.adminPasswordSecretRef` under the key `password`; this guide
-> calls it the *admin Secret* and refers to it as `<admin-secret>`.
+> **Names.** The examples target the ControlPlane devstack's projected Keystone:
+> the CR is `controlplane-keystone` in the `openstack` namespace, and its admin
+> password lives in the Secret referenced by
+> `spec.bootstrap.adminPasswordSecretRef` — `controlplane-keystone-admin-credentials`,
+> under the key `password`; this guide calls it the *admin Secret*. If your
+> Keystone CR has a different name, substitute it (and the Secret and Job names
+> derived from it) throughout. For a standalone Keystone with no ControlPlane,
+> read the final section.
 
 ---
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the ControlPlane's
+projected `controlplane-keystone` Keystone is `Ready`. Every resource name in the
+examples below is one that devstack produces.
+:::
+
 - A bootstrapped Keystone CR (`BootstrapReady=True`) — see [Observability & Diagnostics](./observability.md).
-- The admin password projected via ESO: the `keystone-admin` ExternalSecret is present
-  and `Ready`. Plain (non-ESO) admin Secrets never go `Ready` — rotate at the OpenBao
-  source, not by editing the Secret.
+- The admin password projected via ESO: the `controlplane-keystone-admin-credentials`
+  ExternalSecret is present and `Ready`. Plain (non-ESO) admin Secrets never go `Ready`
+  — rotate at the OpenBao source, not by editing the Secret.
 - `bao` CLI access to the OpenBao KV mount (in kind, OpenBao enforces mTLS, so the CLI
   needs a client certificate signed by the OpenBao CA — a connection reset without one
   is expected, not a pod defect).
-- `kubectl` access to the CR's namespace (`<ns>`).
+- `kubectl` access to the CR's namespace (`openstack`).
 
 ---
 
@@ -47,9 +62,9 @@ The admin password is not stored on the Keystone CR. It flows through three hops
 
 | Actor | Writes to | Reads from |
 | --- | --- | --- |
-| Operator/secrets-tooling | OpenBao path `kv-v2/bootstrap/<ns>/<ks>/admin` (key `password`) | — |
-| External Secrets Operator (ESO) | The admin Secret `<admin-secret>` (key `password`, `creationPolicy: Owner`) | OpenBao path `bootstrap/<ns>/<ks>/admin`, property `password` |
-| Keystone operator | The `<ks>-bootstrap` Job's pod template | The admin Secret `<admin-secret>` (key `password`) |
+| Operator/secrets-tooling | OpenBao path `kv-v2/bootstrap/openstack/controlplane-keystone/admin` (key `password`) | — |
+| External Secrets Operator (ESO) | The admin Secret `controlplane-keystone-admin-credentials` (key `password`, `creationPolicy: Owner`) | OpenBao path `bootstrap/openstack/controlplane-keystone/admin`, property `password` |
+| Keystone operator | The `controlplane-keystone-bootstrap` Job's pod template | The admin Secret `controlplane-keystone-admin-credentials` (key `password`) |
 
 On every reconcile the operator reads the `password` key of the admin Secret,
 computes `hex(SHA-256(password))`, and stamps it onto the bootstrap Job's pod
@@ -60,7 +75,7 @@ gate is keyed on the password digest *alone*, deliberately **not** on the full
 pod template: an image-tag change must not re-run bootstrap, because re-running
 `keystone-manage bootstrap` after a cross-version DB migration fails on the
 already-migrated admin user. When the password digest changes, the operator
-deletes the stale `<ks>-bootstrap` Job and recreates it, re-running
+deletes the stale `controlplane-keystone-bootstrap` Job and recreates it, re-running
 `keystone-manage bootstrap`, which updates the admin credential to the new password.
 
 The operator also watches the admin Secret directly (`secretToKeystoneMapper`),
@@ -76,23 +91,24 @@ so an ESO write triggers a reconcile with **no CR edit**. During the re-run
 
 ## 1. Write the new password to OpenBao
 
-The admin password is sourced from OpenBao at `kv-v2/bootstrap/<ns>/<ks>/admin`
+The admin password is sourced from OpenBao at `kv-v2/bootstrap/openstack/controlplane-keystone/admin`
 (key `password`). Write the new value there:
 
 ```bash
-bao kv put kv-v2/bootstrap/<ns>/<ks>/admin password=<new-password>
+bao kv put kv-v2/bootstrap/openstack/controlplane-keystone/admin password=<new-password>
 ```
 
-> **Path convention (per-CR).** The admin-password path is
-> scoped per Keystone CR as `bootstrap/<ns>/<ks>/admin`, so two
-> Model-B-enabled Keystone CRs never collide on a shared OpenBao object. This is
-> the path the ESO `keystone-admin` ExternalSecret reads
-> (`remoteRef.key: bootstrap/<ns>/<ks>/admin`, `property: password`) and the path
-> `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` seeds — for the default
-> Quick Start CR `controlplane-keystone` in `openstack`, that is
-> `bootstrap/openstack/controlplane-keystone/admin`. If your deployment uses a
-> different KV mount or path, substitute it here and in step 2's ExternalSecret
-> name accordingly.
+> **Path convention (per-CR).** The admin-password path is scoped per Keystone
+> CR as `bootstrap/{namespace}/{name}/admin` — for the `controlplane-keystone`
+> CR in `openstack`, that is `bootstrap/openstack/controlplane-keystone/admin`.
+> Per-CR scoping keeps two Model-B-enabled Keystone CRs from colliding on a
+> shared OpenBao object. This is the path the ESO
+> `controlplane-keystone-admin-credentials` ExternalSecret reads
+> (`remoteRef.key: bootstrap/openstack/controlplane-keystone/admin`,
+> `property: password`) and the path
+> `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` seeds. If your deployment
+> uses a different KV mount or path, substitute it here and in step 2's
+> ExternalSecret name accordingly.
 
 Nothing happens in the cluster yet — OpenBao now holds the new value, but the
 admin Secret still carries the old one until ESO syncs.
@@ -106,7 +122,7 @@ ESO refreshes on its `spec.refreshInterval` (the shipped ExternalSecret uses
 refresh, annotate the ExternalSecret to force a sync:
 
 ```bash
-kubectl -n <ns> annotate externalsecret keystone-admin \
+kubectl -n openstack annotate externalsecret controlplane-keystone-admin-credentials \
   force-sync=$(date +%s) --overwrite
 ```
 
@@ -114,7 +130,7 @@ ESO re-reads OpenBao and PATCHes the admin Secret's `password` key. Confirm the
 Secret now carries the new value (compare the fingerprint before and after):
 
 ```bash
-kubectl -n <ns> get secret <admin-secret> \
+kubectl -n openstack get secret controlplane-keystone-admin-credentials \
   -o jsonpath='{.data.password}' | base64 -d | sha256sum
 ```
 
@@ -125,19 +141,19 @@ in step 3 — keep it handy to confirm the match.
 
 ## 3. Observe the recreated bootstrap Job
 
-The operator detects that the live `{ks}-bootstrap` Job's
+The operator detects that the live `controlplane-keystone-bootstrap` Job's
 `forge.c5c3.io/admin-password-hash` no longer matches the Secret, deletes the
 stale Job, and recreates one carrying the new hash:
 
 ```bash
-kubectl -n <ns> get jobs
+kubectl -n openstack get jobs
 ```
 
 Inspect the recreated Job's admin-password-hash annotation and confirm it equals
 the digest from step 2:
 
 ```bash
-kubectl -n <ns> get job <ks>-bootstrap \
+kubectl -n openstack get job controlplane-keystone-bootstrap \
   -o jsonpath="{.spec.template.metadata.annotations['forge\.c5c3\.io/admin-password-hash']}{\"\n\"}"
 ```
 
@@ -152,7 +168,7 @@ You can prove the Job was delete+recreated (not patched) by capturing its
 UID:
 
 ```bash
-kubectl -n <ns> get job <ks>-bootstrap -o jsonpath='{.metadata.uid}{"\n"}'
+kubectl -n openstack get job controlplane-keystone-bootstrap -o jsonpath='{.metadata.uid}{"\n"}'
 ```
 
 > **Job retention.** The bootstrap Job carries no `TTLSecondsAfterFinished` — it
@@ -160,7 +176,7 @@ kubectl -n <ns> get job <ks>-bootstrap -o jsonpath='{.metadata.uid}{"\n"}'
 > applied password digest (its re-run key), so it is retained, not
 > garbage-collected, and is removed only when the Keystone CR is deleted via
 > owner-reference GC. The steady state is therefore a single completed
-> `<ks>-bootstrap` Job present at all times; a rotation deletes and recreates it
+> `controlplane-keystone-bootstrap` Job present at all times; a rotation deletes and recreates it
 > in place rather than leaving a gap.
 
 ---
@@ -171,13 +187,13 @@ While the recreated Job runs, `BootstrapReady` drops to `False` with reason
 `BootstrapInProgress`, then returns to `True` with reason `BootstrapComplete`:
 
 ```bash
-kubectl -n <ns> describe keystone <ks> | grep -A4 'Conditions:'
+kubectl -n openstack describe keystone controlplane-keystone | grep -A4 'Conditions:'
 ```
 
 Or watch just the condition's status and reason:
 
 ```bash
-kubectl -n <ns> get keystone <ks> \
+kubectl -n openstack get keystone controlplane-keystone \
   -o jsonpath="{range .status.conditions[?(@.type=='BootstrapReady')]}{.status}/{.reason}{\"\n\"}{end}" -w
 ```
 
@@ -198,8 +214,8 @@ API never goes down during an admin-password rotation.
 On a successful re-bootstrap the operator emits a Normal event on the Keystone CR:
 
 ```bash
-kubectl -n <ns> get events \
-  --field-selector reason=BootstrapComplete,involvedObject.name=<ks> \
+kubectl -n openstack get events \
+  --field-selector reason=BootstrapComplete,involvedObject.name=controlplane-keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -207,7 +223,7 @@ Expected output:
 
 ```
 LAST SEEN   TYPE     REASON             OBJECT            MESSAGE
-5s          Normal   BootstrapComplete  keystone/<ks>     Keystone bootstrap completed successfully
+5s          Normal   BootstrapComplete  keystone/controlplane-keystone     Keystone bootstrap completed successfully
 ```
 
 If instead you see a **Warning** with reason `AdminSecretInvalid`, the admin
@@ -215,7 +231,7 @@ Secret is missing, unreadable, or its `password` key is empty — see
 [Recover from `AdminSecretInvalid`](#6-recover-from-adminsecretinvalid).
 
 ```bash
-kubectl -n <ns> describe keystone <ks> | grep -A1 -E 'AdminSecretInvalid|BootstrapComplete'
+kubectl -n openstack describe keystone controlplane-keystone | grep -A1 -E 'AdminSecretInvalid|BootstrapComplete'
 ```
 
 ---
@@ -230,8 +246,8 @@ reason `AdminSecretInvalid`, emits a Warning event, and requeues with backoff.
 ### Symptoms
 
 ```bash
-kubectl -n <ns> get events \
-  --field-selector reason=AdminSecretInvalid,involvedObject.name=<ks> \
+kubectl -n openstack get events \
+  --field-selector reason=AdminSecretInvalid,involvedObject.name=controlplane-keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -239,7 +255,7 @@ Example output:
 
 ```
 LAST SEEN   TYPE      REASON              OBJECT            MESSAGE
-12s         Warning   AdminSecretInvalid  keystone/<ks>     Admin password Secret <ns>/<admin-secret> is missing, unreadable, or has an empty "password" value
+12s         Warning   AdminSecretInvalid  keystone/controlplane-keystone     Admin password Secret openstack/controlplane-keystone-admin-credentials is missing, unreadable, or has an empty "password" value
 ```
 
 ### Inspect
@@ -248,7 +264,7 @@ Confirm the admin Secret exists and that its `password` key decodes to a
 non-empty value:
 
 ```bash
-kubectl -n <ns> get secret <admin-secret> \
+kubectl -n openstack get secret controlplane-keystone-admin-credentials \
   -o jsonpath='{.data.password}' | base64 -d | wc -c
 ```
 
@@ -256,14 +272,14 @@ A result of `0` (or a `NotFound` error on the `get`) is the cause. The usual
 culprit is ESO: check that the ExternalSecret synced cleanly.
 
 ```bash
-kubectl -n <ns> get externalsecret keystone-admin \
+kubectl -n openstack get externalsecret controlplane-keystone-admin-credentials \
   -o jsonpath="{range .status.conditions[*]}{.type}={.status}/{.reason}{\"\n\"}{end}"
 ```
 
 ### Remediate
 
 1. Fix the source. Ensure the OpenBao path holds a non-empty `password`
-   (`bao kv get kv-v2/bootstrap/<ns>/<ks>/admin`), then re-sync ESO as in step 2.
+   (`bao kv get kv-v2/bootstrap/openstack/controlplane-keystone/admin`), then re-sync ESO as in step 2.
 2. Once ESO repopulates the admin Secret, the operator's pending requeue (or a
    fresh `secretToKeystoneMapper` event from the Secret write) re-runs bootstrap
    automatically; `BootstrapReady` returns to `True`/`BootstrapComplete`. No CR
@@ -298,6 +314,41 @@ OS_PASSWORD=<old-password> openstack token issue
 
 A token minted before the rotation remains valid until its native TTL expires;
 only new authentications with the old password are rejected.
+
+---
+
+## Standalone Keystone, without a ControlPlane
+
+The [Quick Start](../quick-start.md) and
+[Quick Start (Extended)](../quick-start-extended.md) devstacks run a standalone
+Keystone CR — no ControlPlane projects it. There the names are:
+
+| ControlPlane devstack | Standalone devstack |
+| --- | --- |
+| CR `controlplane-keystone` | CR `keystone` |
+| admin Secret `controlplane-keystone-admin-credentials` | admin Secret `keystone-admin` |
+| ExternalSecret `controlplane-keystone-admin-credentials` | ExternalSecret `keystone-admin` |
+| bootstrap Job `controlplane-keystone-bootstrap` | bootstrap Job `keystone-bootstrap` |
+
+Substitute those names in every command above. The re-bootstrap contract,
+condition transitions, and smoke check are identical.
+
+::: warning The kind shim reads the default-identity path
+On the kind Quick Start, the `keystone-admin` ExternalSecret is a standalone
+shim (`deploy/kind/infrastructure/keystone-admin-externalsecret.yaml`). It reads
+the **default ControlPlane identity's** per-CR path
+`bootstrap/openstack/controlplane-keystone/admin` — *not*
+`bootstrap/openstack/keystone/admin` — regardless of the standalone CR's name.
+So on the standalone kind devstack, write the new password to that same
+default-identity path in step 1:
+
+```bash
+bao kv put kv-v2/bootstrap/openstack/controlplane-keystone/admin password=<new-password>
+```
+
+On a non-kind standalone deployment you own the ExternalSecret's `remoteRef.key`,
+so write to whatever path it reads.
+:::
 
 ---
 

--- a/docs/guides/keystone-admin-password-scheduled-rotation.md
+++ b/docs/guides/keystone-admin-password-scheduled-rotation.md
@@ -24,26 +24,40 @@ Both flows converge on the same final hop — `reconcileBootstrap` re-runs
 `keystone-manage bootstrap` against the new credential. This guide therefore
 *cross-links* the manual guide's verification steps rather than repeating them.
 
-> **Terminology.** In this document `<ks>` is the Keystone CR's `.metadata.name`
-> (e.g. `keystone-default`) and `<ns>` is its namespace (typically `openstack`).
-> The admin password lives in the Secret referenced by
-> `spec.bootstrap.adminPasswordSecretRef` under the key `password`; this guide
-> calls it the *admin Secret* and refers to it as `<admin-secret>`. The
-> Model B resources are named after `<ks>` (e.g. the CronJob is
-> `<ks>-admin-password-rotate`).
+> **Names.** The examples target the ControlPlane devstack's projected Keystone:
+> the CR is `controlplane-keystone` in the `openstack` namespace, and its admin
+> password lives in the Secret referenced by
+> `spec.bootstrap.adminPasswordSecretRef` — `controlplane-keystone-admin-credentials`,
+> under the key `password`; this guide calls it the *admin Secret*. The Model B
+> resources are named after the CR (e.g. the CronJob is
+> `controlplane-keystone-admin-password-rotate`). If your Keystone CR has a
+> different name, substitute it throughout; for a standalone Keystone, read the
+> per-CR path isolation section.
 
 ---
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the ControlPlane's
+projected `controlplane-keystone` Keystone is `Ready`. Every resource name in the
+examples below is one that devstack produces.
+:::
+
 - A bootstrapped Keystone CR (`BootstrapReady=True`) with the **manual** admin-password
   flow already working — scheduled rotation reuses the same ESO/OpenBao path and final
   re-bootstrap hop. See [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md).
-- The per-CR OpenBao path `bootstrap/<ns>/<ks>/admin` already seeded **and** stamped with
+- The per-CR OpenBao path `bootstrap/openstack/controlplane-keystone/admin` already seeded **and** stamped with
   `custom_metadata managed-by=external-secrets`; without that marker ESO refuses the very
   first PushSecret. `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` stamps it for the
   default CR (see [Topology](#2-topology-what-the-operator-stands-up) below).
-- `kubectl` access to the CR's namespace (`<ns>`).
+- `kubectl` access to the CR's namespace (`openstack`).
 
 ---
 
@@ -56,13 +70,13 @@ Keystone CR:
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: Keystone
 metadata:
-  name: <ks>
-  namespace: <ns>
+  name: controlplane-keystone
+  namespace: openstack
 spec:
   bootstrap:
     adminUser: admin
     adminPasswordSecretRef:
-      name: <admin-secret>
+      name: controlplane-keystone-admin-credentials
   passwordRotation:
     enabled: true
     schedule: "0 0 1 * *"   # monthly, midnight on the 1st (default)
@@ -93,20 +107,20 @@ When `enabled: true`, the `reconcilePasswordRotation` sub-reconciler ensures a
 chain of resources. A rotation flows left to right:
 
 ```
-CronJob <ks>-admin-password-rotate
+CronJob controlplane-keystone-admin-password-rotate
   │  (mounts only /scripts/admin_password_rotate.sh; never runs keystone-manage)
   │  PATCH password + forge.c5c3.io/rotation-completed-at
   ▼
-staging Secret <ks>-admin-password-rotation
+staging Secret controlplane-keystone-admin-password-rotation
   │  operator validates (non-empty, >= min length) and COMMITS
   ▼
-push-source Secret <ks>-admin-password-next   (operator-owned)
-  │  PushSecret <ks>-admin-password-backup mirrors it
+push-source Secret controlplane-keystone-admin-password-next   (operator-owned)
+  │  PushSecret controlplane-keystone-admin-password-backup mirrors it
   ▼
-OpenBao  bootstrap/<ns>/<ks>/admin   (per-CR path)
-  │  ESO keystone-admin ExternalSecret syncs it
+OpenBao  bootstrap/openstack/controlplane-keystone/admin   (per-CR path)
+  │  ESO controlplane-keystone-admin-credentials ExternalSecret syncs it
   ▼
-admin Secret <admin-secret>
+admin Secret controlplane-keystone-admin-credentials
   │  secretToKeystoneMapper triggers a reconcile
   ▼
 reconcileBootstrap re-runs `keystone-manage bootstrap`  →  credential cut over
@@ -116,17 +130,17 @@ The resources, by name:
 
 | Resource | Name | Role |
 | --- | --- | --- |
-| CronJob | `<ks>-admin-password-rotate` | Mints a fresh password on `schedule` and PATCHes it onto the staging Secret. Mounts only the rotation script; never runs `keystone-manage`. |
-| Staging Secret | `<ks>-admin-password-rotation` | Drop box the CronJob writes; the only Secret the CronJob SA may patch. |
-| Push-source Secret | `<ks>-admin-password-next` | Operator-owned. The operator commits the validated password here; the PushSecret selects it. |
-| PushSecret | `<ks>-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/<ns>/<ks>/admin` (per-CR path). |
-| RBAC trio | `<ks>-admin-password-rotate` (ServiceAccount, Role, RoleBinding) | The CronJob's split-RBAC identity. |
-| Script ConfigMap | `<ks>-admin-password-rotate-script` (content-hash suffixed) | Immutable mount of `admin_password_rotate.sh`. |
+| CronJob | `controlplane-keystone-admin-password-rotate` | Mints a fresh password on `schedule` and PATCHes it onto the staging Secret. Mounts only the rotation script; never runs `keystone-manage`. |
+| Staging Secret | `controlplane-keystone-admin-password-rotation` | Drop box the CronJob writes; the only Secret the CronJob SA may patch. |
+| Push-source Secret | `controlplane-keystone-admin-password-next` | Operator-owned. The operator commits the validated password here; the PushSecret selects it. |
+| PushSecret | `controlplane-keystone-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/openstack/controlplane-keystone/admin` (per-CR path). |
+| RBAC trio | `controlplane-keystone-admin-password-rotate` (ServiceAccount, Role, RoleBinding) | The CronJob's split-RBAC identity. |
+| Script ConfigMap | `controlplane-keystone-admin-password-rotate-script` (content-hash suffixed) | Immutable mount of `admin_password_rotate.sh`. |
 
 Two safety properties are worth calling out:
 
 > **Split RBAC.** The CronJob's Role grants `get` + `patch` on **only** the
-> staging Secret `<ks>-admin-password-rotation`, and `get` (read-only) on the
+> staging Secret `controlplane-keystone-admin-password-rotation`, and `get` (read-only) on the
 > push-source Secret. The CronJob can never write the push-source Secret — *the
 > operator* validates the staged value and writes the push-source. Write access to
 > the Secret a PushSecret backs is a token-forgery primitive, and it is kept off
@@ -136,18 +150,18 @@ Two safety properties are worth calling out:
 > Secret actually holds a valid password (non-empty, at least the minimum length).
 > Before the first rotation completes the push-source Secret is empty, so the
 > operator does not push — it would otherwise overwrite the seeded
-> `bootstrap/<ns>/<ks>/admin` value with nothing.
+> `bootstrap/openstack/controlplane-keystone/admin` value with nothing.
 
 > **ESO-managed source path.** The PushSecret can only write
-> `bootstrap/<ns>/<ks>/admin` if that OpenBao path carries the custom-metadata
+> `bootstrap/openstack/controlplane-keystone/admin` if that OpenBao path carries the custom-metadata
 > marker `managed-by=external-secrets`. The ESO Vault/OpenBao provider refuses to
 > overwrite a path it does not own and fails the PushSecret with `secret not
 > managed by external-secrets`. The standard bootstrap
 > (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) stamps the marker when it
 > seeds the path, and re-running it adopts a path written by an older bootstrap
-> that predates this marker. If you seed `bootstrap/<ns>/<ks>/admin` by hand, set
+> that predates this marker. If you seed `bootstrap/openstack/controlplane-keystone/admin` by hand, set
 > the marker too:
-> `bao kv metadata put -custom-metadata=managed-by=external-secrets kv-v2/bootstrap/<ns>/<ks>/admin`.
+> `bao kv metadata put -custom-metadata=managed-by=external-secrets kv-v2/bootstrap/openstack/controlplane-keystone/admin`.
 
 For the full sub-reconciler contract (validation rules, event reasons, the
 clobber-safe gate, RBAC shape) see
@@ -164,7 +178,7 @@ can run and confirm.
 ### 3.1 Confirm the CronJob exists with your schedule
 
 ```bash
-kubectl -n <ns> get cronjob <ks>-admin-password-rotate
+kubectl -n openstack get cronjob controlplane-keystone-admin-password-rotate
 ```
 
 The `SCHEDULE` column should show your `spec.passwordRotation.schedule`
@@ -175,17 +189,17 @@ The `SCHEDULE` column should show your `spec.passwordRotation.schedule`
 Instantiate a one-shot Job from the CronJob template and wait for it to finish:
 
 ```bash
-JOB=<ks>-admin-password-rotate-manual-$(date +%s)
-kubectl -n <ns> create job --from=cronjob/<ks>-admin-password-rotate "$JOB"
+JOB=controlplane-keystone-admin-password-rotate-manual-$(date +%s)
+kubectl -n openstack create job --from=cronjob/controlplane-keystone-admin-password-rotate "$JOB"
 
-kubectl -n <ns> wait --for=condition=complete job/"$JOB" --timeout=120s
+kubectl -n openstack wait --for=condition=complete job/"$JOB" --timeout=120s
 ```
 
 The timestamp suffix keeps the Job name unique, so re-running this step never
 collides with a prior manual Job (`AlreadyExists`) before it is cleaned up.
 
 The Job's pod mints a fresh password and PATCHes it onto the staging Secret
-`<ks>-admin-password-rotation`.
+`controlplane-keystone-admin-password-rotation`.
 
 ### 3.3 Observe the operator commit
 
@@ -195,15 +209,15 @@ three:
 
 ```bash
 # Push-source Secret now carries a non-empty password and the completion stamp.
-kubectl -n <ns> get secret <ks>-admin-password-next \
+kubectl -n openstack get secret controlplane-keystone-admin-password-next \
   -o jsonpath="{.metadata.annotations['forge\.c5c3\.io/rotation-completed-at']}{\"\n\"}"
 
 # Staging Secret has been deleted (NotFound is the success signal here).
-kubectl -n <ns> get secret <ks>-admin-password-rotation
+kubectl -n openstack get secret controlplane-keystone-admin-password-rotation
 
 # The success event.
-kubectl -n <ns> get events \
-  --field-selector reason=AdminPasswordRotated,involvedObject.name=<ks> \
+kubectl -n openstack get events \
+  --field-selector reason=AdminPasswordRotated,involvedObject.name=controlplane-keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -211,7 +225,7 @@ Expected event:
 
 ```
 LAST SEEN   TYPE     REASON               OBJECT          MESSAGE
-5s          Normal   AdminPasswordRotated keystone/<ks>   admin password rotation applied from staging secret <ks>-admin-password-rotation
+5s          Normal   AdminPasswordRotated keystone/controlplane-keystone   admin password rotation applied from staging secret controlplane-keystone-admin-password-rotation
 ```
 
 > **Note.** The password value itself is never logged or echoed in an event. If
@@ -223,8 +237,8 @@ LAST SEEN   TYPE     REASON               OBJECT          MESSAGE
 ### 3.4 Confirm the OpenBao value changed and ESO synced it
 
 The PushSecret mirrors the push-source Secret into OpenBao at
-`bootstrap/<ns>/<ks>/admin`, and the `keystone-admin` ExternalSecret projects it
-back into the admin Secret `<admin-secret>`. Use the manual guide's
+`bootstrap/openstack/controlplane-keystone/admin`, and the `controlplane-keystone-admin-credentials` ExternalSecret projects it
+back into the admin Secret `controlplane-keystone-admin-credentials`. Use the manual guide's
 force-sync + fingerprint technique to confirm the admin Secret carries the new
 value: see
 [step 2 of the manual guide](keystone-admin-password-rotation.md#2-optional-force-eso-to-sync-the-new-value).
@@ -232,7 +246,7 @@ value: see
 The short version:
 
 ```bash
-kubectl -n <ns> get secret <admin-secret> \
+kubectl -n openstack get secret controlplane-keystone-admin-credentials \
   -o jsonpath='{.data.password}' | base64 -d | sha256sum
 ```
 
@@ -247,7 +261,7 @@ idempotent bootstrap Job. Follow the manual guide's steps, which are the
 authoritative walkthrough:
 
 - [Step 3 — Observe the recreated bootstrap Job](keystone-admin-password-rotation.md#3-observe-the-recreated-bootstrap-job)
-  (the `<ks>-bootstrap` Job is delete+recreated with a fresh UID and the new
+  (the `controlplane-keystone-bootstrap` Job is delete+recreated with a fresh UID and the new
   `forge.c5c3.io/admin-password-hash`).
 - [Step 4 — Watch the `BootstrapReady` transitions](keystone-admin-password-rotation.md#4-watch-the-bootstrapready-transitions)
   (`False`/`BootstrapInProgress` → `True`/`BootstrapComplete`).
@@ -259,10 +273,10 @@ authoritative walkthrough:
 
 ### 3.6 Note the separation from the live credential
 
-The push-source Secret `<ks>-admin-password-next` is a **distinct object** from
-the live admin Secret `<admin-secret>`. The operator commits the new password onto
+The push-source Secret `controlplane-keystone-admin-password-next` is a **distinct object** from
+the live admin Secret `controlplane-keystone-admin-credentials`. The operator commits the new password onto
 the push-source Secret; the running Keystone keeps using the value in
-`<admin-secret>` until ESO has synced the new value back. A scheduled rotation
+`controlplane-keystone-admin-credentials` until ESO has synced the new value back. A scheduled rotation
 never clobbers the credential the running Keystone is using mid-flight.
 
 ---
@@ -270,20 +284,33 @@ never clobbers the credential the running Keystone is using mid-flight.
 ## 4. Per-CR path isolation
 
 Model B scopes the OpenBao RemoteKey **per Keystone CR** to
-`bootstrap/<ns>/<ks>/admin`, where `<ns>`/`<ks>` are the
-Keystone CR's namespace and name. Each Model-B-enabled Keystone CR therefore
-writes its admin password to its **own** OpenBao object, and the matching
-`keystone-admin` ExternalSecret reads that same per-CR path. Two Model-B-enabled
-Keystone CRs in the same cluster no longer share one OpenBao object — they cannot
-clobber each other's rotations, so scheduled rotation can be enabled on multiple
-Keystone CRs concurrently.
+`bootstrap/{namespace}/{name}/admin` — for `controlplane-keystone` in
+`openstack`, that is `bootstrap/openstack/controlplane-keystone/admin`. Each
+Model-B-enabled Keystone CR therefore writes its admin password to its **own**
+OpenBao object, and the matching admin-credentials ExternalSecret reads that same
+per-CR path. Two Model-B-enabled Keystone CRs in the same cluster no longer share
+one OpenBao object — they cannot clobber each other's rotations, so scheduled
+rotation can be enabled on multiple Keystone CRs concurrently.
 
-> **Path in lockstep.** The `keystone-admin` ExternalSecret's `remoteRef.key` must
-> match the per-CR path of the Keystone CR whose rotation feeds it. The bootstrap
-> seed (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) seeds
-> `bootstrap/<ns>/<ks>/admin` for each ControlPlane identity in
+> **Path in lockstep.** The admin-credentials ExternalSecret's `remoteRef.key`
+> must match the per-CR path of the Keystone CR whose rotation feeds it. On the
+> ControlPlane devstack that ExternalSecret is the operator-projected
+> `controlplane-keystone-admin-credentials`, reading
+> `bootstrap/openstack/controlplane-keystone/admin`. The bootstrap seed
+> (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) seeds
+> `bootstrap/{namespace}/{name}/admin` for each ControlPlane identity in
 > `KORC_CONTROLPLANES` (default `openstack/controlplane`, whose projected Keystone
 > CR is `controlplane-keystone`, i.e. `bootstrap/openstack/controlplane-keystone/admin`).
+
+> **Standalone Keystone.** For a standalone Keystone (no ControlPlane), the
+> ExternalSecret feeding the admin Secret is one you supply, and its
+> `remoteRef.key` must match the per-CR path this rotation writes —
+> `bootstrap/{namespace}/{name}/admin` for a CR named `{name}` in `{namespace}`.
+> The kind `keystone-admin` shim
+> (`deploy/kind/infrastructure/keystone-admin-externalsecret.yaml`) instead reads
+> the fixed default-identity path `bootstrap/openstack/controlplane-keystone/admin`,
+> so scheduled rotation on the kind Quick Start is exercised against the
+> ControlPlane's `controlplane-keystone`, not a separately named standalone CR.
 
 ---
 
@@ -294,7 +321,7 @@ There are two ways to stop rotating, with different blast radius.
 **Suspend** — keep every resource but stop new runs:
 
 ```bash
-kubectl -n <ns> patch keystone <ks> --type merge \
+kubectl -n openstack patch keystone controlplane-keystone --type merge \
   -p '{"spec":{"passwordRotation":{"suspend":true}}}'
 ```
 
@@ -304,7 +331,7 @@ resources remain. No new password is minted until you set `suspend: false` again
 **Disable** — tear everything down:
 
 ```bash
-kubectl -n <ns> patch keystone <ks> --type merge \
+kubectl -n openstack patch keystone controlplane-keystone --type merge \
   -p '{"spec":{"passwordRotation":{"enabled":false}}}'
 ```
 
@@ -315,7 +342,7 @@ Secrets, the RBAC trio, the PushSecret, and the script ConfigMap — and reports
 
 > **Safety note.** Disabling does **not** remove the last-pushed password from
 > OpenBao. The PushSecret uses `DeletionPolicy: None`, so the value already in
-> `bootstrap/<ns>/<ks>/admin` stays put when the PushSecret is deleted. Disabling
+> `bootstrap/openstack/controlplane-keystone/admin` stays put when the PushSecret is deleted. Disabling
 > rotation can never lock the admin out of Keystone.
 
 ---

--- a/docs/guides/keystone-key-rotation.md
+++ b/docs/guides/keystone-key-rotation.md
@@ -16,31 +16,46 @@ validation rules, event reasons), see
 under the Fernet and credential sub-reconciler sections in
 [Keystone Reconciler Architecture](../reference/keystone/keystone-reconciler.md).
 
-> **Terminology.** In this document `<ks>` is the Keystone CR's `.metadata.name`
-> (e.g. `keystone-default`) and `<ns>` is its namespace (typically `openstack`).
-> Commands target Fernet rotation; swap `fernet` → `credential` everywhere for
-> credential-key rotation.
+> **Names.** The examples target the ControlPlane devstack's projected Keystone:
+> the CR is `controlplane-keystone` in the `openstack` namespace, so the rotation
+> CronJobs and Secrets are named after it
+> (`controlplane-keystone-fernet-rotate`, `controlplane-keystone-fernet-keys`, ...).
+> If your Keystone CR has a different name, substitute it throughout; for a
+> standalone Keystone, read the final section. Commands target Fernet rotation;
+> swap `fernet` → `credential` everywhere for credential-key rotation.
 
 ---
 
 ## Prerequisites
 
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the ControlPlane's
+projected `controlplane-keystone` Keystone is `Ready`. Every resource name in the
+examples below is one that devstack produces.
+:::
+
 - A healthy Keystone CR (`Ready=True`) — see [Observability & Diagnostics](./observability.md).
-- `kubectl` access to the CR's namespace (`<ns>`).
+- `kubectl` access to the CR's namespace (`openstack`).
 - The rotation CronJobs already reconciled —
-  `kubectl -n <ns> get cronjob <ks>-fernet-rotate <ks>-credential-rotate` returns both.
+  `kubectl -n openstack get cronjob controlplane-keystone-fernet-rotate controlplane-keystone-credential-rotate` returns both.
 
 ---
 
 ## Background: Who Writes What
 
 Earlier the rotation CronJob wrote directly to the production
-`<ks>-fernet-keys` Secret with `patch` RBAC. The current design splits that path:
+`controlplane-keystone-fernet-keys` Secret with `patch` RBAC. The current design splits that path:
 
 | Actor | Writes to | Reads from |
 | --- | --- | --- |
-| Rotation CronJob (ServiceAccount `<ks>-fernet-rotate`) | Staging Secret `<ks>-fernet-keys-rotation` (via `patch`) | Production Secret `<ks>-fernet-keys` (via `get`, mounted as volume) |
-| Operator (controller-manager ServiceAccount) | Production Secret `<ks>-fernet-keys` (via `patch`) | Staging Secret `<ks>-fernet-keys-rotation` (validates, then deletes) |
+| Rotation CronJob (ServiceAccount `controlplane-keystone-fernet-rotate`) | Staging Secret `controlplane-keystone-fernet-keys-rotation` (via `patch`) | Production Secret `controlplane-keystone-fernet-keys` (via `get`, mounted as volume) |
+| Operator (controller-manager ServiceAccount) | Production Secret `controlplane-keystone-fernet-keys` (via `patch`) | Staging Secret `controlplane-keystone-fernet-keys-rotation` (validates, then deletes) |
 
 The staging Secret carries one controller-observable marker — the
 `forge.c5c3.io/rotation-completed-at` annotation — that tells the operator
@@ -60,15 +75,15 @@ any sibling resource, set `spec.fernet.suspend: true` (or
 To trigger one on demand, create a one-shot Job from the CronJob template:
 
 ```bash
-kubectl -n <ns> create job --from=cronjob/<ks>-fernet-rotate \
-  <ks>-fernet-rotate-manual-$(date +%s)
+kubectl -n openstack create job --from=cronjob/controlplane-keystone-fernet-rotate \
+  controlplane-keystone-fernet-rotate-manual-$(date +%s)
 ```
 
 Watch the Job run to completion:
 
 ```bash
-kubectl -n <ns> get jobs -l job-name -w
-kubectl -n <ns> logs job/<ks>-fernet-rotate-manual-<ts>
+kubectl -n openstack get jobs -l job-name -w
+kubectl -n openstack logs job/controlplane-keystone-fernet-rotate-manual-<ts>
 ```
 
 Expected log tail:
@@ -90,7 +105,7 @@ operator's next reconcile, which typically closes the window in seconds.
 To catch it, watch the staging Secret during a rotation:
 
 ```bash
-kubectl -n <ns> get secret <ks>-fernet-keys-rotation \
+kubectl -n openstack get secret controlplane-keystone-fernet-keys-rotation \
   -o jsonpath='{.metadata.annotations.forge\.c5c3\.io/rotation-completed-at}{"\n"}'
 ```
 
@@ -105,8 +120,8 @@ After the operator applies the rotation, the staging Secret is deleted
 entirely:
 
 ```bash
-$ kubectl -n <ns> get secret <ks>-fernet-keys-rotation
-Error from server (NotFound): secrets "<ks>-fernet-keys-rotation" not found
+$ kubectl -n openstack get secret controlplane-keystone-fernet-keys-rotation
+Error from server (NotFound): secrets "controlplane-keystone-fernet-keys-rotation" not found
 ```
 
 The operator recreates the empty staging Secret on the next reconcile —
@@ -120,20 +135,20 @@ empty `Data`, that is the steady state between rotations.
 On a successful apply the operator emits a Normal event on the Keystone CR:
 
 ```bash
-kubectl -n <ns> describe keystone <ks> | grep -A1 -E 'FernetKeysRotated|CredentialKeysRotated'
+kubectl -n openstack describe keystone controlplane-keystone | grep -A1 -E 'FernetKeysRotated|CredentialKeysRotated'
 ```
 
 Expected output:
 
 ```
-Normal  FernetKeysRotated  5s  keystone-controller  rotation applied from staging secret <ks>-fernet-keys-rotation (3 active keys)
+Normal  FernetKeysRotated  5s  keystone-controller  rotation applied from staging secret controlplane-keystone-fernet-keys-rotation (3 active keys)
 ```
 
 Alternatively, filter the namespace's event stream:
 
 ```bash
-kubectl -n <ns> get events \
-  --field-selector reason=FernetKeysRotated,involvedObject.name=<ks> \
+kubectl -n openstack get events \
+  --field-selector reason=FernetKeysRotated,involvedObject.name=controlplane-keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -146,15 +161,15 @@ before and after to prove the apply went through:
 
 ```bash
 # Before triggering rotation
-kubectl -n <ns> get secret <ks>-fernet-keys \
+kubectl -n openstack get secret controlplane-keystone-fernet-keys \
   -o jsonpath='{.metadata.resourceVersion}{"\n"}'
-kubectl -n <ns> get secret <ks>-fernet-keys \
+kubectl -n openstack get secret controlplane-keystone-fernet-keys \
   -o jsonpath='{range .data.*}{@}{"\n"}{end}' | sha256sum
 
 # After: resourceVersion has advanced and the hash differs
-kubectl -n <ns> get secret <ks>-fernet-keys \
+kubectl -n openstack get secret controlplane-keystone-fernet-keys \
   -o jsonpath='{.metadata.resourceVersion}{"\n"}'
-kubectl -n <ns> get secret <ks>-fernet-keys \
+kubectl -n openstack get secret controlplane-keystone-fernet-keys \
   -o jsonpath='{range .data.*}{@}{"\n"}{end}' | sha256sum
 ```
 
@@ -180,8 +195,8 @@ contents, is the record of what was rejected.
 ### Symptoms
 
 ```bash
-kubectl -n <ns> get events \
-  --field-selector reason=RotationRejected,involvedObject.name=<ks> \
+kubectl -n openstack get events \
+  --field-selector reason=RotationRejected,involvedObject.name=controlplane-keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -189,7 +204,7 @@ Example output:
 
 ```
 LAST SEEN   TYPE      REASON              OBJECT                       MESSAGE
-12s         Warning   RotationRejected    keystone/<ks>                staging secret <ks>-fernet-keys-rotation rejected: invalid key format: key "0" length=32, want 44
+12s         Warning   RotationRejected    keystone/controlplane-keystone                staging secret controlplane-keystone-fernet-keys-rotation rejected: invalid key format: key "0" length=32, want 44
 ```
 
 The companion Warning reason `RotationAnnotationInvalid` indicates the
@@ -222,9 +237,9 @@ The recovery sequence is always:
    belt-and-suspenders:
 
    ```bash
-   kubectl -n <ns> delete secret <ks>-fernet-keys-rotation   # optional
-   kubectl -n <ns> create job --from=cronjob/<ks>-fernet-rotate \
-     <ks>-fernet-rotate-recover-$(date +%s)
+   kubectl -n openstack delete secret controlplane-keystone-fernet-keys-rotation   # optional
+   kubectl -n openstack create job --from=cronjob/controlplane-keystone-fernet-rotate \
+     controlplane-keystone-fernet-rotate-recover-$(date +%s)
    ```
 
    The new Job PATCHes the (already-empty) staging Secret; the operator
@@ -245,9 +260,9 @@ Everything above applies to credential rotation unchanged — substitute:
 
 | Fernet | Credential |
 | --- | --- |
-| `<ks>-fernet-keys` | `<ks>-credential-keys` |
-| `<ks>-fernet-keys-rotation` | `<ks>-credential-keys-rotation` |
-| `<ks>-fernet-rotate` | `<ks>-credential-rotate` |
+| `controlplane-keystone-fernet-keys` | `controlplane-keystone-credential-keys` |
+| `controlplane-keystone-fernet-keys-rotation` | `controlplane-keystone-credential-keys-rotation` |
+| `controlplane-keystone-fernet-rotate` | `controlplane-keystone-credential-rotate` |
 | `FernetKeysRotated` event | `CredentialKeysRotated` event |
 | `spec.fernet.*` | `spec.credentialKeys.*` |
 
@@ -264,6 +279,26 @@ aging-out.
 > running Keystone pods still have the old keyset mounted and cannot decrypt
 > rows already re-encrypted under the new primary. This is an inherent
 > property of the rotation flow, not a regression.
+
+---
+
+## Standalone Keystone, without a ControlPlane
+
+The [Quick Start](../quick-start.md) and
+[Quick Start (Extended)](../quick-start-extended.md) devstacks run a standalone
+Keystone CR named `keystone`. The rotation resources are named after that CR, so
+substitute the `controlplane-keystone-` prefix with `keystone-` throughout:
+
+| ControlPlane devstack | Standalone devstack |
+| --- | --- |
+| CronJob `controlplane-keystone-fernet-rotate` | CronJob `keystone-fernet-rotate` |
+| Secret `controlplane-keystone-fernet-keys` | Secret `keystone-fernet-keys` |
+| Secret `controlplane-keystone-fernet-keys-rotation` | Secret `keystone-fernet-keys-rotation` |
+| (credential variants of each) | (credential variants of each) |
+
+Everything else — the staging/production split, the completion annotation, the
+validation rules, and the credential-key `credential_migrate` step — is
+identical.
 
 ---
 

--- a/docs/guides/ldap-domain-backend.md
+++ b/docs/guides/ldap-domain-backend.md
@@ -18,8 +18,19 @@ For the full field reference, see the
 
 ## Prerequisites
 
-- A Keystone CR that reaches `Ready=True` (see the
-  [Quick Start](../quick-start.md)); backends can be applied before the
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so a Keystone CR named
+`keystone` is `Ready` in the `openstack` namespace. Every resource name in the
+examples below is one that devstack produces.
+:::
+
+- A Keystone CR that reaches `Ready=True`; backends can be applied before the
   Keystone exists, but nothing is provisioned until its API is up.
 - An LDAP server reachable from the cluster, plus a bind DN allowed to
   search the user/group trees.

--- a/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
+++ b/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
@@ -32,7 +32,20 @@ engine wired for the Keystone service DB user (issue #439).
 The engine issues an ephemeral MySQL user per lease (for example `v-kube-...`)
 with `ALL PRIVILEGES` on the Keystone database and drops it at lease end.
 
-## Preconditions
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step. On this devstack the
+ControlPlane is `controlplane` in `openstack`, so its projected Keystone is
+`controlplane-keystone` and its DB-credential Secret is
+`controlplane-keystone-db-credentials` — the names the migration below manages.
+:::
 
 - The OpenBao `database` secrets engine is mounted at `database/mariadb` (the
   `setup-secret-engines.sh` bootstrap step). On a greenfield cluster this is

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -38,6 +38,19 @@ Adopt namespace-scoped mode when your deployment fits in one namespace.
 
 ## Prerequisites
 
+::: info Devstack
+This guide builds on the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack for the cluster, CRDs, and shared infrastructure (MariaDB, Memcached, External Secrets Operator). Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step. This guide then
+re-deploys the keystone-operator **namespace-scoped** (the steps below), so treat
+the tutorial as the cluster-and-infrastructure baseline rather than its
+cluster-wide operator install.
+:::
+
 Before deploying the operator in namespace-scoped mode, ensure:
 
 1. **CRDs are installed cluster-wide.** Keystone CRDs (`keystones.keystone.openstack.c5c3.io`)

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -12,7 +12,20 @@ SPDX-License-Identifier: Apache-2.0
 
 How to read what the Keystone operator is doing — without tailing controller logs.
 
-**Prerequisites:** A running Keystone CR from the [Quick Start (Extended)](../quick-start-extended.md) (Steps 1–9).
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (Extended)](../quick-start-extended.md)** devstack. Stand it up first:
+
+```bash
+kind create cluster --name forge --config hack/kind-config.yaml
+make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify the deployment** step, so a
+Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
+resource name in the examples below is one that devstack produces.
+:::
 
 The operator surfaces its state through three complementary channels:
 

--- a/docs/guides/oidc-federation.md
+++ b/docs/guides/oidc-federation.md
@@ -23,8 +23,18 @@ For the full field reference, see the
 
 ## Prerequisites
 
-- A Keystone CR that reaches `Ready=True` (see the
-  [Quick Start](../quick-start.md)).
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so a Keystone CR named
+`keystone` is `Ready` in the `openstack` namespace. Every resource name in the
+examples below is one that devstack produces.
+:::
+
 - An OIDC identity provider reachable from the cluster (this guide uses a
   Keycloak realm) with a **confidential client** registered for keystone.
   The client's redirect URIs must cover

--- a/docs/guides/saml-federation.md
+++ b/docs/guides/saml-federation.md
@@ -26,8 +26,18 @@ For the full field reference, see the
 
 ## Prerequisites
 
-- A Keystone CR that reaches `Ready=True` (see the
-  [Quick Start](../quick-start.md)).
+::: info Devstack
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so a Keystone CR named
+`keystone` is `Ready` in the `openstack` namespace. Every resource name in the
+examples below is one that devstack produces.
+:::
+
 - A SAML identity provider whose EntityDescriptor metadata is available
   inline, as a Secret, or by URL.
 - **A federation proxy image.** The managed ControlPlane path projects


### PR DESCRIPTION
Closes #611

## What this does

Establishes a single set of authoring conventions for the how-to guides under `docs/guides/` and consolidates their example naming, so a reader can copy a command and have it hit a resource their cluster actually created. Documentation-only — no operator code changes.

The recurring problem this fixes: guides re-derived their structure (and their example names) from a neighbour, so several demonstrated with the placeholder name `keystone-default`, which no Getting-Started tutorial produces. A reader had to translate names before the first command worked.

## Change set, in commit order

1. **`e55d5df` docs(contributing): write down the guide authoring conventions**
   Adds `docs/contributing/guide-conventions.md` — the contract every guide implements: one devstack per guide (a standardized `## Prerequisites` block naming exactly one Getting-Started tutorial plus its verbatim bring-up command), ControlPlane-first naming with a separate standalone section, never editing operator-projected children, a tested-by pointer, and fixture-sourced manifests. The prerequisites-block format is written down in a machine-checkable form so a future docs check can enforce it. Registers the page in the Contributing sidebar (`docs/.vitepress/config.ts`).

2. **`7aab89a` docs(guides): anchor the rotation guides on the ControlPlane devstack**
   Retires the `keystone-default` placeholder from the three rotation guides (`keystone-admin-password-rotation`, `keystone-admin-password-scheduled-rotation`, `keystone-key-rotation`). Concretizes the walkthroughs onto the ControlPlane devstack's real names (`controlplane-keystone`, `controlplane-keystone-admin-credentials`, and resources derived from them), points the admin-password ExternalSecret references at the operator-projected `controlplane-keystone-admin-credentials`, adds the standardized prerequisites block, and adds a standalone-Keystone section for base/Extended Quick Start naming (including the kind `keystone-admin` shim's default-identity-path subtlety).

3. **`6b52637` docs(guides): add the devstack prerequisites block to every guide**
   Gives every remaining guide the standardized `## Prerequisites` block: a `::: info Devstack` container naming one Getting-Started tutorial, its verbatim bring-up command with the opt-in flags the guide depends on (`WITH_CONTROLPLANE`, `WITH_PROMETHEUS`), and a completion pointer. Also fixes two stray placeholders: renames `## Preconditions` → `## Prerequisites` in the DB dynamic-credentials migration guide, replaces the `<name>` placeholder in the keystone-operator NetworkPolicy verification command with the devstack CR name `keystone`, and drops the last `keystone-default` literal from the conventions doc so the placeholder is retired everywhere.

## Scope note / divergence from the issue

The rotation-guide commit deliberately limits itself to the **naming consolidation and structural pieces**. The ControlPlane-level rework of the `spec.passwordRotation` patch steps and the accompanying revert warnings are called out in that commit message as a **separate follow-up**, not part of this change. Reviewers should expect the rotation guides' patch-step content to be revisited later; this PR aligns their example names and prerequisites blocks with the new conventions.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
