### PR TITLE
docs(guides): rework operator-projected-resource guides ControlPlane-first

### DIFF
--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -10,36 +10,162 @@ SPDX-License-Identifier: Apache-2.0
 
 # Advanced Configuration
 
-Beyond the minimal `Keystone` CR from the [Quick Start (Extended)](../quick-start-extended.md), the operator
-supports a number of configuration options for real cluster deployments. This guide
-walks through the four that cover the most common real-world needs and points to the
-reference for the rest.
+Beyond the minimal control plane from the
+[Quick Start (ControlPlane)](../quick-start-controlplane.md), the operators
+support a number of configuration options for real cluster deployments. This
+guide covers the ones the `ControlPlane` CR exposes and points to the reference
+for the rest — and to the [Standalone Keystone](#standalone-keystone-without-a-controlplane)
+section for the knobs that live only on a Keystone CR you own.
 
 ## Prerequisites
 
 ::: info Devstack
-This guide is written against the **[Quick Start (Extended)](../quick-start-extended.md)** devstack. Stand it up first:
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
 
 ```bash
-kind create cluster --name forge --config hack/kind-config.yaml
-make deploy-infra
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
-Follow that tutorial through to its final **Verify the deployment** step, so a
-Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
-resource name in the examples below is one that devstack produces.
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
+`controlplane-keystone` Keystone child is running. Every resource name in the
+examples below is one that devstack produces.
+:::
+
+::: warning The Keystone child is operator-owned
+On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
+**projected** by the c5c3-operator; the projected fields are re-asserted on every
+reconcile, so editing them on the child is reverted. Configure the knobs the
+`ControlPlane` CRD exposes on the `ControlPlane` CR. A knob the CRD does not
+expose is **standalone-only** — apply it to a Keystone CR you own, in the
+[Standalone Keystone](#standalone-keystone-without-a-controlplane) section. See
+the [ControlPlane Reconciler](../reference/c5c3/controlplane-reconciler.md) for
+the projection contract.
 :::
 
 Each pattern below is an independent recipe — apply only what you need.
 
 ---
 
-## Brownfield database
+## Brownfield database and cache
 
-The Quick Start uses the "managed mode" where the operator creates the `MariaDB`
-Database, User, and Grant CRs for you (`spec.database.clusterRef`). If you already run
-MariaDB/Galera outside the operator's reach — managed by another team, hosted
-externally, or on a different operator — use **brownfield mode** with an explicit host.
+The Quick Start uses "managed mode", where the operator provisions the MariaDB
+and Memcached the control plane connects to (`spec.infrastructure.database.clusterRef`
+/ `cache.clusterRef`). If you already run MariaDB/Galera and Memcached outside the
+operator's reach — managed by another team, hosted externally, or on a different
+operator — use **brownfield mode** with explicit connection parameters on the
+`ControlPlane` CR.
+
+Brownfield is a **creation-time** decision. The validating webhook freezes
+infrastructure presence and the database/cache mode (managed `clusterRef` vs
+brownfield `host`/`servers`), the database name, replicas, and storageSize after
+the ControlPlane is created, so you cannot flip a managed control plane to
+brownfield in place — set `spec.infrastructure` when you first apply the CR:
+
+```yaml
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: controlplane
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  # services.keystone and korc as in the Quick Start (ControlPlane)
+  infrastructure:
+    database:
+      # brownfield: explicit host/port, no clusterRef
+      host: mariadb.db.example.com
+      port: 3306
+      database: keystone
+      secretRef:
+        name: keystone-db
+    cache:
+      backend: dogpile.cache.pymemcache
+      # brownfield cache: explicit server list, no clusterRef
+      servers:
+        - "memcached.cache.example.com:11211"
+```
+
+The reconciler deep-copies the whole `infrastructure.database` and
+`infrastructure.cache` blocks onto the `controlplane-keystone` child, so the
+child connects to exactly the servers you declared here.
+
+::: warning In brownfield mode you own schema setup
+In brownfield mode (no `clusterRef`) the operator leaves the `secretRef` you
+supplied in place — you own that Secret out-of-band — and does **not** create the
+database, user, or grants. Provision them before the control plane reconciles:
+
+```sql
+CREATE DATABASE keystone DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE USER 'keystone'@'%' IDENTIFIED BY '<password-from-secretRef>';
+GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%';
+FLUSH PRIVILEGES;
+```
+
+The Secret referenced by `secretRef` must contain both a `username` and a
+`password` key matching the SQL user — the keystone-operator gates `SecretsReady`
+on the child on both, so a Secret with only `password` leaves
+`controlplane-keystone` stuck at `SecretsReady=False`. Once those exist,
+`db_sync` creates the Keystone schema on first reconcile. The OpenBao
+database-tenant onboarding from the [Quick Start (ControlPlane)](../quick-start-controlplane.md)
+(Step 4) applies to **managed** mode's engine-issued (Dynamic) credentials only —
+a brownfield control plane draws no credentials from the OpenBao database engine.
+:::
+
+The webhook enforces that exactly one of `clusterRef` or `host` (`servers` for
+cache) is set — never both — for both `database` and `cache`.
+
+---
+
+## Feature pointer table
+
+Everything else the control plane supports. One-line hints, the ControlPlane knob
+that projects it (or "not exposed" where it is standalone-only), and a link to the
+full Keystone CR reference.
+
+| Feature | Keystone CR field | ControlPlane path | Reference |
+|---------|-------------------|-------------------|-----------|
+| Replica count | `spec.deployment.replicas` | `spec.services.keystone.replicas` | [Day 2 — Scale](./day-2-operations.md#scale-replicas) |
+| Release / image | `spec.image` | `spec.openStackRelease` (tag) + `spec.services.keystone.image` (override) | [Day 2 — Upgrade](./day-2-operations.md#upgrade-the-openstack-release) |
+| Policy overrides | `spec.policyOverrides` | `spec.services.keystone.policyOverrides` (+ `spec.globalPolicyOverrides`) | [PolicySpec](../reference/keystone/keystone-crd.md#policyspec) |
+| Federation proxy image | `spec.federation.proxyImage` | `spec.services.keystone.federationProxyImage` | [Attach an OIDC Federation Backend](./oidc-federation.md) |
+| Public endpoint / gateway | `spec.bootstrap.publicEndpoint`, `spec.gateway` | `spec.services.keystone.publicEndpoint`, `spec.services.keystone.gateway` | [BootstrapSpec](../reference/keystone/keystone-crd.md#bootstrapspec) |
+| Fernet / credential-key schedule | `spec.fernet`, `spec.credentialKeys` | `spec.services.keystone.rotationInterval` (schedule only) | [Day 2 — Rotate Fernet keys](./day-2-operations.md#rotate-fernet-keys-manually) |
+| Database TLS/mTLS | `spec.database.tls` | `spec.infrastructure.database.tls` | [Enable Keystone Database TLS/mTLS](./enable-keystone-database-tls.md) |
+| Autoscaling (HPA) | `spec.autoscaling` | not exposed — standalone-only | [Autoscaling (HPA)](#autoscaling-hpa) |
+| Network policy | `spec.networkPolicy` | not exposed — standalone-only | [Network policy](#network-policy) |
+| Free-form INI (`extraConfig`) | `spec.extraConfig` | not exposed — standalone-only | [ExtraConfig](#extraconfig-free-form-ini-sections) |
+| Scheduled admin-password rotation | `spec.passwordRotation` | not exposed — standalone-only | [Schedule Admin Password Rotation](./keystone-admin-password-scheduled-rotation.md) |
+| uWSGI tuning | `spec.uwsgi` | not exposed — standalone-only | [UWSGISpec](../reference/keystone/keystone-crd.md#uwsgispec) |
+| Logging | `spec.logging` | not exposed — standalone-only | [LoggingSpec](../reference/keystone/keystone-crd.md#loggingspec) |
+| Trust flush | `spec.trustFlush` | not exposed — standalone-only | [TrustFlushSpec](../reference/keystone/keystone-crd.md#trustflushspec) |
+| Middleware | `spec.middleware` | not exposed — standalone-only | [MiddlewareSpec](../reference/keystone/keystone-crd.md#middlewarespec) |
+| Plugins | `spec.plugins` | not exposed — standalone-only | [PluginSpec](../reference/keystone/keystone-crd.md#pluginspec) |
+| Rollout strategy | `spec.deployment.strategy` | not exposed — standalone-only | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
+| Graceful termination | `spec.deployment.terminationGracePeriodSeconds`, `spec.deployment.preStopSleepSeconds` | not exposed — standalone-only | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
+| Topology spread | `spec.deployment.topologySpreadConstraints` | not exposed — standalone-only | [TopologySpreadConstraints](../reference/keystone/keystone-crd.md#topologyspreadconstraints) |
+| Priority class | `spec.deployment.priorityClassName` | not exposed — standalone-only | [PriorityClassName](../reference/keystone/keystone-crd.md#priorityclassname) |
+| Resource requests/limits | `spec.deployment.resources` | not exposed — standalone-only | [KeystoneSpec](../reference/keystone/keystone-crd.md#keystonespec) |
+
+The "not exposed — standalone-only" knobs are not projectable through the
+`ControlPlane` CRD today; set them on a Keystone CR you own, as shown in the
+[Standalone Keystone](#standalone-keystone-without-a-controlplane) section.
+
+---
+
+## Standalone Keystone, without a ControlPlane
+
+On the [Quick Start](../quick-start.md) / [Quick Start (Extended)](../quick-start-extended.md)
+devstacks a standalone Keystone CR named `keystone` runs with no ControlPlane
+projecting it. The recipes below apply to that CR. Several of them —
+`spec.autoscaling`, `spec.networkPolicy`, `spec.extraConfig` — are **not exposed
+on the `ControlPlane` CRD today**, so a standalone Keystone is the only place they
+can be set.
+
+### Brownfield database
+
+The standalone equivalent of the ControlPlane brownfield recipe above — explicit
+`host`/`port` and `servers` set directly on the Keystone CR:
 
 ```yaml
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
@@ -75,33 +201,16 @@ spec:
     region: RegionOne
 ```
 
-::: warning In brownfield mode you own schema setup
-The operator does **not** create the database, user, or grants. You must provision
-them before the CR reconciles:
+The same SQL provisioning and `username`+`password` Secret contract from the
+ControlPlane recipe apply. The webhook enforces that exactly one of `clusterRef`
+or `host` is set — never both — for both `database` and `cache`.
 
-```sql
-CREATE DATABASE keystone DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
-CREATE USER 'keystone'@'%' IDENTIFIED BY '<password-from-secretRef>';
-GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%';
-FLUSH PRIVILEGES;
-```
+### Autoscaling (HPA)
 
-The secret referenced by `secretRef` must contain both a `username` and a `password`
-key matching the SQL user — the operator gates `SecretsReady` on both, so a Secret with
-only `password` leaves the CR stuck at `SecretsReady=False`. Once those exist, `db_sync`
-will create the Keystone schema on first reconcile.
-:::
-
-The webhook enforces that exactly one of `clusterRef` or `host` is set — never both —
-for both `database` and `cache`.
-
----
-
-## Autoscaling (HPA)
-
-Replace hand-patching `spec.deployment.replicas` with a `HorizontalPodAutoscaler` managed by the
-operator. When `spec.autoscaling` is present, the HPA owns the Deployment's replica
-count.
+`spec.autoscaling` is not exposed on the `ControlPlane` CRD today, so autoscaling
+is standalone-only. Replace hand-patching `spec.deployment.replicas` with a
+`HorizontalPodAutoscaler` managed by the operator. When `spec.autoscaling` is
+present, the HPA owns the Deployment's replica count.
 
 ```yaml
 spec:
@@ -144,11 +253,10 @@ Removing `spec.autoscaling` deletes the HPA and returns replica control to
 `spec.deployment.replicas`. See [HPA Resource Mapping in the CRD reference](../reference/keystone/keystone-crd.md#hpa-resource-mapping)
 for the exact field-to-resource mapping.
 
----
+### Network policy
 
-## Network policy
-
-When set, `spec.networkPolicy` creates a Kubernetes `NetworkPolicy` that restricts
+`spec.networkPolicy` is not exposed on the `ControlPlane` CRD today, so it is
+standalone-only. When set, it creates a Kubernetes `NetworkPolicy` that restricts
 ingress to the Keystone API pods. Egress rules for database, cache, and DNS are
 derived automatically from the rest of the CR — you only declare the ingress sources.
 
@@ -183,14 +291,13 @@ Removing `spec.networkPolicy` deletes the NetworkPolicy and restores unrestricte
 traffic. See the [NetworkPolicy reference](../reference/keystone/keystone-crd.md#networkpolicyspec)
 for the auto-derived egress rules (Keystone API → MariaDB, Memcached, DNS).
 
----
+### ExtraConfig — free-form INI sections
 
-## ExtraConfig — free-form INI sections
-
-The typed fields on the CR cover the supported configuration surface. For everything
-else — logging levels, oslo.messaging tuning, experimental Keystone flags —
-`spec.extraConfig` takes a `map[section][key] = value` that is rendered into the
-generated `keystone.conf`.
+`spec.extraConfig` is not exposed on the `ControlPlane` CRD today, so it is
+standalone-only. The typed fields on the CR cover the supported configuration
+surface. For everything else — logging levels, oslo.messaging tuning, experimental
+Keystone flags — `spec.extraConfig` takes a `map[section][key] = value` that is
+rendered into the generated `keystone.conf`.
 
 ```yaml
 spec:
@@ -211,32 +318,9 @@ A change to `extraConfig` triggers a ConfigMap rehash and a rolling Deployment u
 
 ---
 
-## Feature pointer table
-
-Everything else the CR supports — the flags you did not see above. One-line hints plus
-a link to the full reference.
-
-| Feature | Field | What it does | Reference |
-|---------|-------|--------------|-----------|
-| Credential-key tuning | `spec.credentialKeys` | Credential-key rotation is always on; this field only tunes the rotation schedule and max active keys | [CredentialKeysSpec](../reference/keystone/keystone-crd.md#credentialkeysspec) |
-| Trust flush | `spec.trustFlush` | CronJob running `keystone-manage trust_flush` on a schedule. Default-on (hourly) — to pause without deleting the CronJob, set `spec.trustFlush.suspend: true` rather than removing the field | [TrustFlushSpec](../reference/keystone/keystone-crd.md#trustflushspec) |
-| uWSGI tuning | `spec.uwsgi` | Worker processes, threads, HTTP keep-alive, plus `harakiri` (per-request kill timer) and `httpKeepAliveTimeout` (idle-socket bound) | [UWSGISpec](../reference/keystone/keystone-crd.md#uwsgispec) |
-| Logging | `spec.logging` | oslo.log output: `format` (text/json), `level`, `debug`, per-logger level overrides | [LoggingSpec](../reference/keystone/keystone-crd.md#loggingspec) |
-| Rollout strategy | `spec.deployment.strategy` | Overrides the Deployment rollout strategy; default is `RollingUpdate` with `maxSurge=1`/`maxUnavailable=0` (surge-before-remove) | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
-| Graceful termination | `spec.deployment.terminationGracePeriodSeconds`, `spec.deployment.preStopSleepSeconds` | SIGTERM→SIGKILL envelope and preStop drain sleep for zero-downtime rolling updates | [Graceful-termination fields](../reference/keystone/keystone-crd.md#graceful-termination-fields) |
-| Topology spread | `spec.deployment.topologySpreadConstraints` | Pod spread across zones/hostnames | [TopologySpreadConstraints](../reference/keystone/keystone-crd.md#topologyspreadconstraints) |
-| Priority class | `spec.deployment.priorityClassName` | Scheduling priority and preemption class | [PriorityClassName](../reference/keystone/keystone-crd.md#priorityclassname) |
-| Policy overrides | `spec.policyOverrides` | Custom `oslo.policy` rules (inline or ConfigMap) | [PolicySpec](../reference/keystone/keystone-crd.md#policyspec) |
-| Middleware | `spec.middleware` | Custom WSGI filters in the `api-paste.ini` pipeline | [MiddlewareSpec](../reference/keystone/keystone-crd.md#middlewarespec) |
-| Plugins | `spec.plugins` | Service-side Keystone plugins/drivers | [PluginSpec](../reference/keystone/keystone-crd.md#pluginspec) |
-| Federation | `spec.federation` | Federation sidecar knobs (proxy image, trusted dashboards); federation itself activates by attaching a [`KeystoneIdentityBackend`](../reference/keystone/identity-backend-crd.md), not by this block | [FederationSpec](../reference/keystone/keystone-crd.md#federationspec) |
-| Resource requests/limits | `spec.deployment.resources` | CPU/memory requests and limits on API pods | [KeystoneSpec](../reference/keystone/keystone-crd.md#keystonespec) |
-| Public endpoint | `spec.bootstrap.publicEndpoint` | External URL written to the Keystone service catalogue | [BootstrapSpec](../reference/keystone/keystone-crd.md#bootstrapspec) |
-
----
-
 ## Further reading
 
 - [Keystone CRD API Reference](../reference/keystone/keystone-crd.md) — complete field-by-field reference with validation rules and examples
+- [ControlPlane CRD API Reference](../reference/c5c3/controlplane-crd.md) — the `spec.*` fields the ControlPlane exposes, including `spec.infrastructure`
 - [Observability & Diagnostics](./observability.md) — how to verify a new configuration took effect
 - [Day 2 Operations](./day-2-operations.md) — scale, upgrade, rotate using the configured CR

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -10,77 +10,106 @@ SPDX-License-Identifier: Apache-2.0
 
 # Day 2 Operations
 
-Three operational patterns you will use most often on a running Keystone CR: scaling,
-upgrading the OpenStack release, and rotating Fernet keys.
+Three operational patterns you will use most often on a running control plane:
+scaling, upgrading the OpenStack release, and rotating Fernet keys.
 
 ## Prerequisites
 
 ::: info Devstack
-This guide is written against the **[Quick Start (Extended)](../quick-start-extended.md)** devstack. Stand it up first:
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
 
 ```bash
-kind create cluster --name forge --config hack/kind-config.yaml
-make deploy-infra
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
-Follow that tutorial through to its final **Verify the deployment** step, so a
-Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
-resource name in the examples below is one that devstack produces.
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
+`controlplane-keystone` Keystone child is running. Every resource name in the
+examples below is one that devstack produces.
+:::
+
+::: warning The Keystone child is operator-owned
+On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
+**projected** by the c5c3-operator. It re-asserts the projected fields
+(image, database, cache, replicas, federation, policy overrides, gateway,
+rotation schedule) on every reconcile, so a knob you set directly on the child
+is reverted. Set operational knobs on the `ControlPlane` CR and let the operator
+project them down. Where the `ControlPlane` CRD does not expose a knob, this
+guide points to the [Standalone Keystone](#standalone-keystone-without-a-controlplane)
+section, which drives a Keystone CR you own. See the
+[ControlPlane Reconciler](../reference/c5c3/controlplane-reconciler.md) for the
+full projection contract.
 :::
 
 ---
 
 ## Scale replicas
 
-`spec.deployment.replicas` can be patched at any time; the operator updates the Deployment and the
-rollout is handled by Kubernetes.
+Set the Keystone replica count on the `ControlPlane` CR; the operator projects it
+onto the `controlplane-keystone` child and Kubernetes handles the rollout.
 
 ```bash
-kubectl patch keystone keystone -n openstack \
+kubectl patch controlplane controlplane -n openstack \
   --type merge \
-  -p '{"spec":{"replicas":5}}'
+  -p '{"spec":{"services":{"keystone":{"replicas":5}}}}'
 ```
 
-Watch the rollout:
+Watch the rollout on the projected child:
 
 ```bash
-kubectl rollout status deploy/keystone -n openstack
+kubectl rollout status deploy/controlplane-keystone -n openstack
 ```
 
-Scale down the same way. The operator maintains a `PodDisruptionBudget` sized from
-`spec.deployment.replicas`: at `replicas > 1` it sets `minAvailable=1` so a voluntary disruption
-never drains the last healthy pod; at `replicas == 1` it sets `maxUnavailable=1`
-instead, deliberately allowing eviction so a node drain cannot deadlock on a
-single-replica CR.
+Scale down the same way. The keystone-operator maintains a `PodDisruptionBudget`
+named `controlplane-keystone`, sized from the child's replica count: at
+`replicas > 1` it sets `minAvailable=1` so a voluntary disruption never drains
+the last healthy pod; at `replicas == 1` it sets `maxUnavailable=1` instead,
+deliberately allowing eviction so a node drain cannot deadlock on a
+single-replica child.
 
-::: tip Prefer autoscaling?
-For load-driven scaling use `spec.autoscaling` instead of hand-patching `spec.deployment.replicas`
-— see [Advanced Configuration — Autoscaling (HPA)](./advanced-configuration.md#autoscaling-hpa).
-The HPA then owns `spec.replicas` on the Deployment.
+::: tip Load-driven autoscaling is standalone-only
+The `ControlPlane` CRD does not expose `spec.autoscaling`, so on a ControlPlane
+deployment there is no HPA knob — scale by setting
+`spec.services.keystone.replicas`. Load-driven autoscaling with a
+`HorizontalPodAutoscaler` is available only on a standalone Keystone CR — see
+[Advanced Configuration — Autoscaling (HPA)](./advanced-configuration.md#autoscaling-hpa).
 :::
 
 ---
 
-## Image upgrade with UpgradePhase
+## Upgrade the OpenStack release
 
-Changing `spec.image.tag` to a newer OpenStack release triggers the operator's
-expand-migrate-contract pipeline. The API stays available throughout — old and new
-schemas coexist while data is migrated.
+Change `spec.openStackRelease` on the `ControlPlane` CR to a newer release. The
+operator projects the new image tag (`ghcr.io/c5c3/keystone:<release>`) onto the
+`controlplane-keystone` child, which triggers the keystone-operator's
+expand-migrate-contract pipeline. The API stays available throughout — old and
+new schemas coexist while data is migrated.
 
 ```bash
-kubectl patch keystone keystone -n openstack \
+kubectl patch controlplane controlplane -n openstack \
   --type merge \
-  -p '{"spec":{"image":{"tag":"2026.1"}}}'
+  -p '{"spec":{"openStackRelease":"2026.1"}}'
 ```
 
-Watch the four phases:
+The child image tag is derived from `spec.openStackRelease` **unless**
+`spec.services.keystone.image` overrides the whole image reference. An image
+override pins the tag, so it must be dropped before a release upgrade takes
+effect; likewise a patch-suffix build such as `2025.2-p1` is not a valid
+`openStackRelease` value (the field only accepts the `YYYY.N` cadence) and is
+delivered through the image override instead.
+
+Watch the ControlPlane's driven release and the child's upgrade phases:
 
 ```bash
-kubectl get keystone keystone -n openstack -w \
+kubectl get controlplane controlplane -n openstack -w
+```
+
+```bash
+kubectl get keystone controlplane-keystone -n openstack -w \
   -o custom-columns=NAME:.metadata.name,PHASE:.status.upgradePhase,FROM:.status.installedRelease,TO:.status.targetRelease,READY:.status.conditions[?(@.type=='Ready')].status
 ```
 
-Expected timeline:
+Expected timeline on the child:
 
 | Phase | What the operator does |
 |-------|------------------------|
@@ -91,71 +120,82 @@ Expected timeline:
 
 When all four complete successfully:
 
-- `.status.installedRelease` is set to the new tag
+- The child's `.status.installedRelease` is set to the new tag
 - `.status.targetRelease` and `.status.upgradePhase` are cleared
-- A `UpgradeComplete` event is emitted
+- The ControlPlane's `.status.services[?(@.name=='keystone')].release` reports the new release
+- A `UpgradeComplete` event is emitted on the child
 
 ::: warning Upgrade constraints
 Only **sequential** upgrades are supported: `2025.1 → 2025.2`, `2025.2 → 2026.1`,
-`2026.1 → 2026.2`. Skip-level jumps (e.g. `2024.2 → 2026.1`) and downgrades are
-rejected with `UpgradePathInvalid` or `DowngradeNotSupported` Warning events. Tags
-that differ only in patch suffix (`2025.2` → `2025.2-p1`) use the plain `db_sync`
-path — no upgrade pipeline.
+`2026.1 → 2026.2`. A **downgrade** is rejected at ControlPlane admission with
+`openStackRelease downgrade from "…" to "…" is not permitted; Keystone DB
+migrations are not reversible`. A **skip-level** jump (e.g. `2024.2 → 2026.1`) is
+admitted at the ControlPlane but surfaces as an `UpgradePathInvalid` Warning
+event on the `controlplane-keystone` child, which the keystone-operator refuses
+to run.
 
 Full contract in [Keystone Upgrade Flow](../reference/keystone/keystone-upgrade-flow.md).
 :::
 
-### Rolling back a bad upgrade
+### Recovering from a bad upgrade
 
-The upgrade pipeline is forward-only. If a new release is broken, the recovery path is
-to restore the database from backup, then patch `spec.image.tag` back. There is no
-`db_sync --downgrade`. Plan cut-overs around a maintenance window and a tested backup.
+The upgrade pipeline is forward-only at both levels: the keystone-operator has no
+`db_sync --downgrade`, and the ControlPlane webhook rejects lowering
+`spec.openStackRelease`. There is therefore no in-place rollback. If a new release
+is broken, recovery is to restore the database from backup and redeploy at the
+restored release. Plan cut-overs around a maintenance window and a tested backup.
 
 ---
 
 ## Rotate Fernet keys manually
 
-The operator ships a `CronJob` that rotates the Fernet keys on the schedule in
-`spec.fernet.rotationSchedule` (default weekly). You can trigger a rotation immediately
-without waiting for the cron job to fire — useful after a suspected key compromise.
-The inverse also works: `spec.fernet.suspend: true` (and
-`spec.credentialKeys.suspend: true`) pauses scheduled rotation during an
-incident without deleting the CronJob.
+The keystone-operator ships a `CronJob` on the projected child that rotates the
+Fernet keys on a schedule. You can trigger a rotation immediately without waiting
+for the cron job to fire — useful after a suspected key compromise.
 
-Rotation uses a split staging→production path: the CronJob writes the new key set to a
-*staging* Secret, and the operator validates it and applies it to the production
-`keystone-fernet-keys` Secret on its next reconcile. So the right signal that a manual
-rotation landed is the operator's event on the CR, not the production Secret's contents
-immediately after the Job finishes.
+On the ControlPlane path the schedule is set through
+`spec.services.keystone.rotationInterval` — a duration (e.g. `168h`) the operator
+converts to a cron expression and projects onto the child's
+`spec.fernet.rotationSchedule` and `spec.credentialKeys.rotationSchedule`. The
+`ControlPlane` CRD does not expose the `suspend` or `maxActiveKeys` knobs; pausing
+scheduled rotation or tuning the overlap window is standalone-only (see the
+[Standalone Keystone](#standalone-keystone-without-a-controlplane) section).
+
+Rotation uses a split staging→production path: the CronJob writes the new key set
+to a *staging* Secret, and the operator validates it and applies it to the
+production `controlplane-keystone-fernet-keys` Secret on its next reconcile. So
+the right signal that a manual rotation landed is the operator's event on the
+child, not the production Secret's contents immediately after the Job finishes.
+Creating a Job from the CronJob is not a CR edit, so it is valid against the
+operator-owned child.
 
 ```bash
 # Trigger an on-demand rotation by creating a Job from the CronJob
 kubectl -n openstack create job \
-  --from=cronjob/keystone-fernet-rotate \
-  keystone-fernet-rotate-manual-$(date +%s)
+  --from=cronjob/controlplane-keystone-fernet-rotate \
+  controlplane-keystone-fernet-rotate-manual-$(date +%s)
 ```
 
 Confirm the operator applied the staged rotation:
 
 ```bash
-kubectl -n openstack describe keystone keystone | grep FernetKeysRotated
+kubectl -n openstack describe keystone controlplane-keystone | grep FernetKeysRotated
 ```
 
 ### What to expect
 
-- The production Secret now holds a new primary key. Older keys stay until
-  `spec.fernet.maxActiveKeys` is exceeded — tokens issued before rotation remain valid
-  through the overlap window.
-- **No Deployment rollout happens.** Running pods pick up the new keys via the in-place
-  Secret projection (~60s) — their UIDs stay unchanged.
-- Credential keys rotate the same way and are **always managed** (independent of whether
-  `spec.credentialKeys` is set, which only tunes the schedule). Swap `fernet` →
+- The production Secret now holds a new primary key. Older keys stay until the
+  child's `maxActiveKeys` is exceeded — tokens issued before rotation remain
+  valid through the overlap window.
+- **No Deployment rollout happens.** Running pods pick up the new keys via the
+  in-place Secret projection (~60s) — their UIDs stay unchanged.
+- Credential keys rotate the same way and are **always managed**. Swap `fernet` →
   `credential` in the CronJob name:
 
   ```bash
   kubectl -n openstack create job \
-    --from=cronjob/keystone-credential-rotate \
-    keystone-credential-rotate-manual-$(date +%s)
+    --from=cronjob/controlplane-keystone-credential-rotate \
+    controlplane-keystone-credential-rotate-manual-$(date +%s)
   ```
 
 For the full staging-aware verification flow, the operator's validation contract, and
@@ -168,10 +208,59 @@ them often — delete them after verification:
 
 ```bash
 kubectl -n openstack get jobs -o name \
-  | grep -E '/keystone-(fernet|credential)-rotate-manual-' \
+  | grep -E '/controlplane-keystone-(fernet|credential)-rotate-manual-' \
   | xargs -r kubectl -n openstack delete
 ```
 :::
+
+---
+
+## Standalone Keystone, without a ControlPlane
+
+On the [Quick Start](../quick-start.md) / [Quick Start (Extended)](../quick-start-extended.md)
+devstacks a standalone Keystone CR named `keystone` runs with no ControlPlane
+projecting it. Drive these operations directly on that CR.
+
+**Scale** by patching `spec.deployment.replicas`:
+
+```bash
+kubectl patch keystone keystone -n openstack \
+  --type merge \
+  -p '{"spec":{"deployment":{"replicas":5}}}'
+
+kubectl rollout status deploy/keystone -n openstack
+```
+
+For load-driven scaling use `spec.autoscaling` instead — see
+[Advanced Configuration — Autoscaling (HPA)](./advanced-configuration.md#autoscaling-hpa).
+
+**Upgrade** by patching `spec.image.tag`:
+
+```bash
+kubectl patch keystone keystone -n openstack \
+  --type merge \
+  -p '{"spec":{"image":{"tag":"2026.1"}}}'
+```
+
+The same sequential-only constraint, the four-phase pipeline, and the
+forward-only recovery path apply. The target tag must be pullable by the cluster
+(`ghcr.io/c5c3/keystone:<tag>`), or the `RollingUpdate` phase stalls on an image
+pull error.
+
+**Rotate Fernet keys** against the `keystone-fernet-rotate` /
+`keystone-credential-rotate` CronJobs, and tune or pause scheduled rotation with
+the standalone-only `spec.fernet` fields:
+
+```bash
+kubectl -n openstack create job \
+  --from=cronjob/keystone-fernet-rotate \
+  keystone-fernet-rotate-manual-$(date +%s)
+```
+
+`spec.fernet.rotationSchedule` (a cron string, default weekly) sets the cadence,
+`spec.fernet.suspend: true` (and `spec.credentialKeys.suspend: true`) pauses
+scheduled rotation during an incident without deleting the CronJob, and
+`spec.fernet.maxActiveKeys` bounds the overlap window.
 
 ---
 

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -31,12 +31,12 @@ examples below is one that devstack produces.
 ::: warning The Keystone child is operator-owned
 On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
 **projected** by the c5c3-operator. It re-asserts the projected fields
-(image, database, cache, replicas, federation, policy overrides, gateway,
-rotation schedule) on every reconcile, so a knob you set directly on the child
-is reverted. Set operational knobs on the `ControlPlane` CR and let the operator
-project them down. Where the `ControlPlane` CRD does not expose a knob, this
-guide points to the [Standalone Keystone](#standalone-keystone-without-a-controlplane)
-section, which drives a Keystone CR you own. See the
+(image, database, cache, replicas, federation, policy overrides, gateway) on
+every reconcile, so a knob you set directly on the child is reverted. Set
+operational knobs on the `ControlPlane` CR and let the operator project them
+down. Where the `ControlPlane` CRD does not expose a knob, this guide points to
+the [Standalone Keystone](#standalone-keystone-without-a-controlplane) section,
+which drives a Keystone CR you own. See the
 [ControlPlane Reconciler](../reference/c5c3/controlplane-reconciler.md) for the
 full projection contract.
 :::

--- a/docs/guides/enable-horizon-operator-networkpolicy.md
+++ b/docs/guides/enable-horizon-operator-networkpolicy.md
@@ -60,8 +60,22 @@ kubectl -n horizon-system get networkpolicy
 kubectl -n horizon-system describe networkpolicy horizon-operator
 ```
 
-Then confirm reconciliation still works end-to-end: patch any Horizon CR
-(e.g. bump `spec.deployment.replicas`) and watch the change roll out. If the
-operator loses apiserver connectivity after enabling the policy, your CNI
-maps the apiserver behind a different port — compare the policy's egress
+Then confirm reconciliation still works end-to-end by driving a change
+through the `ControlPlane` CR and watching the projected dashboard roll out:
+
+```bash
+kubectl patch controlplane controlplane -n openstack --type merge \
+  -p '{"spec":{"services":{"horizon":{"replicas":2}}}}'
+kubectl rollout status deploy/controlplane-horizon -n openstack
+
+# revert
+kubectl patch controlplane controlplane -n openstack --type merge \
+  -p '{"spec":{"services":{"horizon":{"replicas":1}}}}'
+```
+
+Set the replica count on the `ControlPlane` CR, not on the projected
+`controlplane-horizon` child: the c5c3-operator re-asserts the child's
+`spec.deployment.replicas` on every reconcile, so a direct edit of the child is
+reverted. If the operator loses apiserver connectivity after enabling the policy,
+your CNI maps the apiserver behind a different port — compare the policy's egress
 ports with `kubectl get endpoints kubernetes -n default`.

--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -5,16 +5,22 @@ quadrant: operator
 
 # How-to: Enable Keystone Database TLS/mTLS
 
-This guide walks an operator through opting a `Keystone` CR into encrypted,
-mutually-authenticated connections to MariaDB/MaxScale. When enabled,
-the keystone-operator provisions a cert-manager `Certificate` from the shared
-OpenStack DB CA, mounts the resulting keypair into every Keystone workload that
-opens a database connection, and appends the `ssl_*` parameters to the database
-DSN so the live transport is TLS-protected.
+This guide walks an operator through opting a control plane's Keystone into
+encrypted, mutually-authenticated connections to MariaDB/MaxScale. On a
+ControlPlane deployment the knob lives on the `ControlPlane` CR
+(`spec.infrastructure.database.tls`); the c5c3-operator projects the whole
+database block — including `tls` — onto the projected `controlplane-keystone`
+child. When enabled, the keystone-operator provisions a cert-manager
+`Certificate` from the shared OpenStack DB CA, mounts the resulting keypair into
+every Keystone workload that opens a database connection, and appends the
+`ssl_*` parameters to the database DSN so the live transport is TLS-protected.
 
 For the authoritative field reference, see
 [DatabaseTLSSpec](../reference/keystone/keystone-crd.md#databasetlsspec) in the
-Keystone CRD reference. For the underlying MariaDB and CA issuer manifests, see
+Keystone CRD reference and
+[InfrastructureSpec](../reference/c5c3/controlplane-crd.md#infrastructurespec) in
+the ControlPlane CRD reference. For the underlying MariaDB and CA issuer
+manifests, see
 [OpenStack DB CA Issuer](../reference/infrastructure/infrastructure-manifests.md#openstack-db-ca-issuer)
 and
 [MariaDB Galera Cluster](../reference/infrastructure/infrastructure-manifests.md#mariadb-galera-cluster).
@@ -24,16 +30,16 @@ and
 ## Prerequisites
 
 ::: info Devstack
-This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
 
 ```bash
-KIND_HOST_PORT=8443 make deploy-infra
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
-Follow that tutorial through to its final **Verify** step. That devstack already
-satisfies items 1–3 below (cert-manager, the `openstack-db-ca-issuer`
-ClusterIssuer, and a TLS-required `openstack-db` MariaDB); the numbered list is
-the checklist to confirm on a non-kind cluster.
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
+`controlplane-keystone` Keystone child is running. Every resource name in the
+examples below is one that devstack produces.
 :::
 
 1. **cert-manager installed.** The chart from `deploy/flux-system/releases/cert-manager.yaml`
@@ -46,8 +52,7 @@ the checklist to confirm on a non-kind cluster.
 
 2. **`openstack-db-ca-issuer` ClusterIssuer Ready.** The dedicated DB CA is
    declared in `deploy/flux-system/infrastructure/db-ca-issuer.yaml`.
-   `hack/deploy-infra.sh` applies it in Phase 2 so MariaDB can resolve
-   the issuer when it renders its server certificate. Verify:
+   `hack/deploy-infra.sh` applies it in Phase 2. Verify:
 
    ```bash
    kubectl get clusterissuer openstack-db-ca-issuer \
@@ -56,10 +61,17 @@ the checklist to confirm on a non-kind cluster.
 
    Expected: `True`.
 
-3. **MariaDB CR with `spec.tls.enabled=true, required=true`.** The MariaDB
-   manifest under `deploy/flux-system/infrastructure/mariadb.yaml` enables TLS
-   on the Galera nodes and the MaxScale listener via the same
-   `openstack-db-ca-issuer`. Confirm the cluster is healthy:
+3. **A MariaDB that offers server-side TLS.** Client-side DB TLS only works
+   against a server that speaks it. On the **managed** ControlPlane devstack the
+   c5c3-operator provisions the `openstack-db` MariaDB from a minimal spec and
+   deliberately leaves server-side TLS/issuerRefs unset — DB-server hardening is a
+   platform-team concern outside the aggregate's knowledge (see the DECISION on
+   `reconcileInfrastructure` in `operators/c5c3/internal/controller/reconcile_infrastructure.go`).
+   So before enabling client DB TLS on a ControlPlane, run a MariaDB with
+   `spec.tls.enabled=true` (and, for the plaintext-rejection check below,
+   `required=true`) — either harden the managed MariaDB out-of-band or point
+   `spec.infrastructure.database` at a brownfield MariaDB that already enables TLS
+   via the same `openstack-db-ca-issuer`. Confirm the cluster is healthy:
 
    ```bash
    kubectl -n openstack get mariadb openstack-db
@@ -67,79 +79,103 @@ the checklist to confirm on a non-kind cluster.
 
    Expected: `STATUS=Ready`.
 
+   ::: warning Do not enable `verify-full` against a plaintext MariaDB
+   Enabling `verify-full` client TLS against a MariaDB that offers no server TLS
+   breaks the connection — the child Keystone reports `DatabaseReady=False`.
+   The [standalone Quick Start](#standalone-keystone-without-a-controlplane)
+   devstack ships its `openstack-db` with `spec.tls.required=true`, so the
+   standalone flow at the end of this guide is fully runnable end-to-end without
+   extra MariaDB hardening.
+   :::
+
 4. **keystone-operator running.** Either via the Helm release in
    `deploy/flux-system/releases/keystone-operator.yaml` or a locally built
    image deployed with `hack/ci-deploy-operator.sh`. The operator's RBAC must
    include the `cert-manager.io/certificates` rule; the chart's
    ClusterRole carries it by default.
 
-5. **A `Keystone` CR you control.** New CRs and existing plaintext CRs both
-   work — the `tls` block is an optional pointer (a `nil` value preserves the
-   previous plaintext behavior), so flipping it on is a no-mutation patch.
+5. **The `controlplane` ControlPlane CR you own.** The `tls` block is an optional
+   pointer on `spec.infrastructure.database` (a `nil` value preserves the previous
+   plaintext behavior), and it is **not** frozen by the ControlPlane immutability
+   webhook, so flipping it on is a no-mutation patch on a live control plane.
 
 ---
 
 ## Steps
 
-### 1. Patch the Keystone CR with a `spec.database.tls` block
+### 1. Patch the `ControlPlane` CR with a `spec.infrastructure.database.tls` block
 
-The minimal TLS-enabled block uses `mode: verify-full` (the strongest mode —
-verifies the server certificate chain AND that the server hostname matches the
-certificate identity). In managed mode, the operator-provisioned Secret
-`<name>-db-client` carries `ca.crt`, `tls.crt`, and `tls.key`, so a single
-reference satisfies both `caBundleSecretRef` and `clientCertSecretRef`:
+Set the `tls` block on the `ControlPlane` CR's shared database, **not** on the
+projected Keystone child. The reconciler deep-copies the whole
+`spec.infrastructure.database` block — `tls` included — onto
+`controlplane-keystone` on every reconcile. The minimal TLS-enabled block uses
+`mode: verify-full` (the strongest mode — verifies the server certificate chain
+AND that the server hostname matches the certificate identity). In managed mode,
+the keystone-operator provisions the Secret `controlplane-keystone-db-client`
+carrying `ca.crt`, `tls.crt`, and `tls.key`, so a single reference satisfies both
+`caBundleSecretRef` and `clientCertSecretRef`:
 
 ```yaml
 spec:
-  database:
-    clusterRef:
-      name: openstack-db
-    database: keystone
-    secretRef:
-      name: keystone-db
-    tls:
-      mode: verify-full
-      caBundleSecretRef:
-        name: keystone-db-client
-      clientCertSecretRef:
-        name: keystone-db-client
+  infrastructure:
+    database:
+      clusterRef:
+        name: openstack-db
+      database: keystone
+      secretRef:
+        name: keystone-db
+      tls:
+        mode: verify-full
+        caBundleSecretRef:
+          name: controlplane-keystone-db-client
+        clientCertSecretRef:
+          name: controlplane-keystone-db-client
 ```
 
-Apply via patch or full re-apply:
+Apply via patch:
 
 ```bash
-kubectl -n openstack patch keystone keystone --type merge --patch '
+kubectl -n openstack patch controlplane controlplane --type merge --patch '
 spec:
-  database:
-    tls:
-      mode: verify-full
-      caBundleSecretRef:
-        name: keystone-db-client
-      clientCertSecretRef:
-        name: keystone-db-client
+  infrastructure:
+    database:
+      tls:
+        mode: verify-full
+        caBundleSecretRef:
+          name: controlplane-keystone-db-client
+        clientCertSecretRef:
+          name: controlplane-keystone-db-client
 '
 ```
 
-The mutating webhook does **not** materialize the `tls` block when it is
-omitted — TLS is strictly opt-in. When `tls` is present with an empty `mode`,
-the webhook materializes `mode: "require"` as the documented baseline (a present
-block means "on"). Set `mode: disabled` to keep the block and its certificate
-references while turning TLS off.
+::: warning Do not patch `spec.database.tls` on the projected child
+Setting `spec.database.tls` on the `controlplane-keystone` Keystone CR directly
+is reverted on the next reconcile: the c5c3-operator re-asserts the **entire**
+`spec.database` block from `spec.infrastructure.database`, so any `tls` you write
+on the child that is not present on the `ControlPlane` CR is deep-copied away.
+Always set `tls` on the `ControlPlane` CR.
+:::
+
+The keystone-operator's mutating webhook does **not** materialize the `tls` block
+on the child when it is absent — TLS is strictly opt-in. When `tls` is present
+with an empty `mode`, the webhook materializes `mode: "require"` as the documented
+baseline (a present block means "on"). Set `mode: disabled` to keep the block and
+its certificate references while turning TLS off.
 
 ### 2. Wait for the operator to issue the client `Certificate`
 
-`reconcileDatabaseTLS` creates a cert-manager `Certificate` named
-`<keystone-name>-db-client` with `issuerRef = openstack-db-ca-issuer`
+`reconcileDatabaseTLS` on the child creates a cert-manager `Certificate` named
+`controlplane-keystone-db-client` with `issuerRef = openstack-db-ca-issuer`
 (ClusterIssuer). cert-manager writes the resulting keypair into a Secret of the
 same name. The reconciler reports progress via the `DatabaseTLSReady` status
-condition:
+condition on the child:
 
 | Condition reason | Meaning |
 | --- | --- |
 | `NotRequired` | `tls` is `nil`, its `mode` is empty, or its `mode` is `disabled` — plaintext connection. |
 | `CertificatePending` | Managed mode; cert-manager has not yet issued the leaf. |
 | `CertificateIssued` | Managed mode; client keypair ready and mounted. |
-| `ExternallyManaged` | Brownfield mode (`spec.database.clusterRef` unset / `host` set) — the client keypair must be supplied out-of-band. |
+| `ExternallyManaged` | Brownfield mode (`spec.infrastructure.database.host` set) — the client keypair must be supplied out-of-band. |
 
 ---
 
@@ -148,16 +184,16 @@ condition:
 ### 1. `DatabaseTLSReady=True` with `reason=CertificateIssued`
 
 ```bash
-kubectl -n openstack get keystone keystone \
+kubectl -n openstack get keystone controlplane-keystone \
   -o jsonpath='{range .status.conditions[?(@.type=="DatabaseTLSReady")]}{.status} {.reason} {.message}{"\n"}{end}'
 ```
 
-Expected: `True CertificateIssued Database client Certificate "<name>-db-client" issued into Secret "<name>-db-client"`.
+Expected: `True CertificateIssued Database client Certificate "controlplane-keystone-db-client" issued into Secret "controlplane-keystone-db-client"`.
 
 The Secret should carry the three keys cert-manager writes:
 
 ```bash
-kubectl -n openstack get secret keystone-db-client \
+kubectl -n openstack get secret controlplane-keystone-db-client \
   -o go-template='{{range $k, $_ := .data}}{{$k}}{{"\n"}}{{end}}'
 ```
 
@@ -173,7 +209,7 @@ mounted at `/etc/keystone/db-tls/`, so we can parse the same
 
 ```bash
 POD=$(kubectl -n openstack get pods \
-  -l app.kubernetes.io/instance=keystone,app.kubernetes.io/name=keystone \
+  -l app.kubernetes.io/instance=controlplane-keystone,app.kubernetes.io/name=keystone \
   -o jsonpath='{.items[0].metadata.name}')
 
 kubectl -n openstack exec "$POD" -c keystone -- python3 -c '
@@ -204,16 +240,16 @@ conn.close()
 Expected: a non-empty TLS cipher name (e.g.,
 `TLS_AES_256_GCM_SHA384`). An empty value means the live connection is **not**
 encrypted — re-check `DatabaseTLSReady` and confirm the MariaDB CR has
-`spec.tls.required=true`.
+`spec.tls.required=true` (see prerequisite 3).
 
 ### 3. Plaintext connections are rejected by MariaDB
 
-Because the MariaDB CR sets `spec.tls.required=true`, any
-connection that does not negotiate TLS is rejected at the transport layer
-before authentication. The `probe`/`probe` credentials below are deliberately
-bogus — they are never checked, because the server rejects the plaintext
-handshake before it reaches authentication. Probe from inside the Keystone Pod
-by deliberately omitting the `ssl=` kwarg:
+This check requires the MariaDB from prerequisite 3 to set
+`spec.tls.required=true`, so any connection that does not negotiate TLS is
+rejected at the transport layer before authentication. The `probe`/`probe`
+credentials below are deliberately bogus — they are never checked, because the
+server rejects the plaintext handshake before it reaches authentication. Probe
+from inside the Keystone Pod by deliberately omitting the `ssl=` kwarg:
 
 ```bash
 kubectl -n openstack exec "$POD" -c keystone -- python3 -c '
@@ -233,7 +269,8 @@ Expected: `PLAINTEXT_REJECTED: …` from the server's TLS-required enforcement.
 ### 4. Run the end-to-end chainsaw test (canonical check)
 
 The repository ships a chainsaw E2E suite that pins all three of the above
-verifications:
+verifications against a standalone Keystone CR (whose `openstack-db` ships
+`tls.required=true`):
 
 ```bash
 chainsaw test --test-dir tests/e2e/keystone/database-tls/
@@ -247,18 +284,68 @@ the Keystone CRD reference.
 
 ## Disabling
 
-> **WARNING — data-plane outage if you skip the MariaDB step.** The MariaDB CR
-> in `deploy/flux-system/infrastructure/mariadb.yaml` ships with
-> `spec.tls.required=true`. Disabling TLS on the Keystone side **only** will
-> brick the deployment: MariaDB rejects every plaintext handshake at the
-> transport layer, so Keystone cannot connect to the database. Before applying
-> the Keystone patch below, set `spec.tls.required=false` (or fully disable
-> TLS) on the MariaDB CR — updating MariaDB is out of scope of this guide but
-> is a prerequisite for a working plaintext deployment.
+> **WARNING — data-plane outage if you skip the MariaDB step.** If the MariaDB
+> serving the control plane ships with `spec.tls.required=true`, disabling TLS on
+> the Keystone side **only** will brick the deployment: MariaDB rejects every
+> plaintext handshake at the transport layer, so Keystone cannot connect to the
+> database. Before applying the ControlPlane patch below, set
+> `spec.tls.required=false` (or fully disable TLS) on the MariaDB CR — updating
+> MariaDB is out of scope of this guide but is a prerequisite for a working
+> plaintext deployment.
 
-To revert a CR to plaintext without uninstalling the operator, drop the `tls`
-block. The mutating webhook never re-materializes it, so the
-absence is persistent:
+To revert to plaintext without uninstalling the operator, drop the `tls` block
+from the `ControlPlane` CR. The reconciler then deep-copies a `nil` `tls` onto the
+child and the keystone-operator's mutating webhook never re-materializes it, so
+the absence is persistent:
+
+```bash
+kubectl -n openstack patch controlplane controlplane --type json --patch '[
+  {"op": "remove", "path": "/spec/infrastructure/database/tls"}
+]'
+```
+
+The child's `DatabaseTLSReady` condition transitions to `True` with
+`reason=NotRequired`, the operator deletes the managed
+`controlplane-keystone-db-client` `Certificate` (so cert-manager stops renewing
+it), cert-manager then garbage-collects the issued Secret via the `Certificate`
+owner-reference cascade, and subsequent connections fall back to plaintext TCP —
+but only succeed if MariaDB's `spec.tls.required` is also turned off (see warning
+above).
+
+---
+
+## Standalone Keystone, without a ControlPlane
+
+On the [Quick Start](../quick-start.md) / [Quick Start (Extended)](../quick-start-extended.md)
+devstacks a standalone Keystone CR named `keystone` runs with no ControlPlane
+projecting it, and the shared `openstack-db` MariaDB ships with
+`spec.tls.enabled=true, required=true` — so this flow is fully runnable
+end-to-end without extra MariaDB hardening. Set the `tls` block on the Keystone
+CR's own `spec.database`:
+
+```bash
+kubectl -n openstack patch keystone keystone --type merge --patch '
+spec:
+  database:
+    tls:
+      mode: verify-full
+      caBundleSecretRef:
+        name: keystone-db-client
+      clientCertSecretRef:
+        name: keystone-db-client
+'
+```
+
+The names map as follows; substitute them in every command above:
+
+| ControlPlane devstack | Standalone devstack |
+| --- | --- |
+| CR `controlplane` (patch `spec.infrastructure.database.tls`) | CR `keystone` (patch `spec.database.tls`) |
+| child `controlplane-keystone` | CR `keystone` |
+| Certificate / Secret `controlplane-keystone-db-client` | `keystone-db-client` |
+| pod selector `app.kubernetes.io/instance=controlplane-keystone` | `app.kubernetes.io/instance=keystone` |
+
+To disable, drop the `tls` block from the Keystone CR:
 
 ```bash
 kubectl -n openstack patch keystone keystone --type json --patch '[
@@ -266,12 +353,8 @@ kubectl -n openstack patch keystone keystone --type json --patch '[
 ]'
 ```
 
-The `DatabaseTLSReady` condition transitions to `True` with `reason=NotRequired`,
-the operator deletes the managed `<name>-db-client` `Certificate` (so
-cert-manager stops renewing it), cert-manager then garbage-collects the issued
-Secret via the `Certificate` owner-reference cascade, and subsequent
-connections fall back to plaintext TCP — but only succeed if MariaDB's
-`spec.tls.required` is also turned off (see warning above).
+The `tests/e2e/keystone/database-tls/` chainsaw suite pins the keystone-operator
+mechanics through this standalone flow.
 
 ---
 
@@ -279,6 +362,7 @@ connections fall back to plaintext TCP — but only succeed if MariaDB's
 
 - [Keystone CRD — DatabaseTLSSpec](../reference/keystone/keystone-crd.md#databasetlsspec) — authoritative field reference.
 - [Keystone CRD — Mode → connect-args mapping](../reference/keystone/keystone-crd.md#mode--connect-args-mapping) — DSN parameters per mode.
+- [ControlPlane CRD — InfrastructureSpec](../reference/c5c3/controlplane-crd.md#infrastructurespec) — the `spec.infrastructure.database` block the reconciler projects.
 - [Infrastructure Manifests — OpenStack DB CA Issuer](../reference/infrastructure/infrastructure-manifests.md#openstack-db-ca-issuer) — CA keypair and ClusterIssuer.
 - [Infrastructure Manifests — MariaDB Galera Cluster](../reference/infrastructure/infrastructure-manifests.md#mariadb-galera-cluster) — server-side TLS configuration.
 - [`tests/e2e/keystone/database-tls/`](https://github.com/c5c3/forge/tree/main/tests/e2e/keystone/database-tls) — chainsaw E2E suite.

--- a/docs/guides/keystone-admin-password-scheduled-rotation.md
+++ b/docs/guides/keystone-admin-password-scheduled-rotation.md
@@ -24,44 +24,122 @@ Both flows converge on the same final hop — `reconcileBootstrap` re-runs
 `keystone-manage bootstrap` against the new credential. This guide therefore
 *cross-links* the manual guide's verification steps rather than repeating them.
 
-> **Names.** The examples target the ControlPlane devstack's projected Keystone:
-> the CR is `controlplane-keystone` in the `openstack` namespace, and its admin
-> password lives in the Secret referenced by
-> `spec.bootstrap.adminPasswordSecretRef` — `controlplane-keystone-admin-credentials`,
+## On a ControlPlane deployment
+
+Scheduled admin-password rotation (Model B, `spec.passwordRotation`) is
+**standalone-only**: the `ControlPlane` CRD does not expose it, and the
+`controlplane-keystone` Keystone child is operator-projected. Setting
+`spec.passwordRotation` on that child is **unsupported** — the
+[guide conventions](../contributing/guide-conventions.md) forbid editing
+operator-projected children, and on a ControlPlane the c5c3-operator already owns
+the admin credential's lifecycle (it mints and rotates the K-ORC admin
+application credential and projects the admin password from OpenBao into
+`controlplane-keystone-admin-credentials`). Standing up Model B on the child
+would put two owners on the same `bootstrap/openstack/controlplane-keystone/admin`
+path.
+
+To rotate the admin password on a ControlPlane deployment today, use the manual
+flow, which operates at the OpenBao source without editing the projected child:
+[Rotate the Keystone Admin Password](keystone-admin-password-rotation.md).
+
+The rest of this guide targets a **standalone** Keystone CR you own.
+
+> **Names.** The examples target the standalone Quick Start's Keystone: the CR is
+> `keystone` in the `openstack` namespace, and its admin password lives in the
+> Secret referenced by `spec.bootstrap.adminPasswordSecretRef` — `keystone-admin`,
 > under the key `password`; this guide calls it the *admin Secret*. The Model B
 > resources are named after the CR (e.g. the CronJob is
-> `controlplane-keystone-admin-password-rotate`). If your Keystone CR has a
-> different name, substitute it throughout; for a standalone Keystone, read the
-> per-CR path isolation section.
+> `keystone-admin-password-rotate`) and the per-CR OpenBao path is
+> `bootstrap/openstack/keystone/admin`. If your Keystone CR has a different name,
+> substitute it (and the resource and path names derived from it) throughout.
 
 ---
 
 ## Prerequisites
 
 ::: info Devstack
-This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
+This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
 
 ```bash
-KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+KIND_HOST_PORT=8443 make deploy-infra
 ```
 
-Follow that tutorial through to its final **Verify** step, so the ControlPlane's
-projected `controlplane-keystone` Keystone is `Ready`. Every resource name in the
-examples below is one that devstack produces.
+Follow that tutorial through to its final **Verify** step, so a standalone
+Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
+resource name in the examples below is one that devstack produces.
 :::
 
 - A bootstrapped Keystone CR (`BootstrapReady=True`) with the **manual** admin-password
   flow already working — scheduled rotation reuses the same ESO/OpenBao path and final
   re-bootstrap hop. See [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md).
-- The per-CR OpenBao path `bootstrap/openstack/controlplane-keystone/admin` already seeded **and** stamped with
-  `custom_metadata managed-by=external-secrets`; without that marker ESO refuses the very
-  first PushSecret. `deploy/openbao/bootstrap/write-bootstrap-secrets.sh` stamps it for the
-  default CR (see [Topology](#2-topology-what-the-operator-stands-up) below).
+- `bao` CLI access to the OpenBao KV mount (in kind, OpenBao enforces mTLS, so the
+  CLI needs a client certificate signed by the OpenBao CA).
 - `kubectl` access to the CR's namespace (`openstack`).
 
 ---
 
-## 1. Enable scheduled rotation
+## 1. Wire OpenBao and the admin ExternalSecret to the per-CR path
+
+Model B writes each rotation to the **per-CR** OpenBao path
+`bootstrap/{namespace}/{name}/admin` — for `keystone` in `openstack`, that is
+`bootstrap/openstack/keystone/admin` (hardcoded from the CR's namespace and name;
+there is no knob to change it). Two things must line up with that path before the
+first rotation:
+
+**Seed and stamp the per-CR path.** Seed it with the current admin password so
+ESO's first sync is deterministic, then stamp it `managed-by=external-secrets` so
+the Model B backup PushSecret is allowed to overwrite it. ESO's OpenBao provider
+refuses to overwrite a path it does not own and fails the PushSecret with
+`secret not managed by external-secrets`; a plain `bao kv put` writes no
+custom-metadata, so the marker must be set separately with `bao kv metadata put`:
+
+```bash
+# Prompt without echo, then pipe the value in on stdin so the live admin
+# password never appears on argv (visible in /proc/<pid>/cmdline for the life of
+# the process) or in your shell history file. `password=-` reads the value from
+# stdin — this mirrors the in-pod hardening in
+# deploy/openbao/bootstrap/write-bootstrap-secrets.sh, which likewise keeps
+# cleartext credentials off the command line.
+read -rs -p 'current admin password: ' PW; echo
+printf '%s' "$PW" | bao kv put kv-v2/bootstrap/openstack/keystone/admin password=-
+unset PW
+
+# The metadata marker carries no secret, so a plain argument is fine here.
+bao kv metadata put \
+  -custom-metadata=managed-by=external-secrets \
+  kv-v2/bootstrap/openstack/keystone/admin
+```
+
+**Point the admin ExternalSecret at the per-CR path.** The ExternalSecret feeding
+the admin Secret must read the same per-CR path this rotation writes, or the
+rotated password never reaches Keystone. On the kind Quick Start the admin Secret
+`keystone-admin` is fed by the shim ExternalSecret
+`deploy/kind/infrastructure/keystone-admin-externalsecret.yaml`, which reads the
+**default-identity** path `bootstrap/openstack/controlplane-keystone/admin` — not
+the standalone CR's per-CR path. Repoint it:
+
+```bash
+kubectl -n openstack patch externalsecret keystone-admin --type merge -p '
+spec:
+  data:
+    - secretKey: password
+      remoteRef:
+        key: bootstrap/openstack/keystone/admin
+        property: password
+'
+```
+
+> **Own the ExternalSecret for a durable setup.** If your devstack continuously
+> reconciles `deploy/kind/infrastructure/` (Flux/GitOps), a manual patch to the
+> shim is reverted — own a dedicated ExternalSecret for your CR reading the per-CR
+> path instead, exactly as the `admin-password-scheduled-rotation` chainsaw suite
+> ships its own CR + ExternalSecret (`tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml`).
+> On a non-kind deployment you already own the ExternalSecret, so just set its
+> `remoteRef.key` to `bootstrap/openstack/keystone/admin`.
+
+---
+
+## 2. Enable scheduled rotation
 
 Scheduled rotation is opt-in. Add a `spec.passwordRotation` block to the
 Keystone CR:
@@ -70,13 +148,13 @@ Keystone CR:
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: Keystone
 metadata:
-  name: controlplane-keystone
+  name: keystone
   namespace: openstack
 spec:
   bootstrap:
     adminUser: admin
     adminPasswordSecretRef:
-      name: controlplane-keystone-admin-credentials
+      name: keystone-admin
   passwordRotation:
     enabled: true
     schedule: "0 0 1 * *"   # monthly, midnight on the 1st (default)
@@ -101,26 +179,26 @@ The four fields of `passwordRotation`:
 
 ---
 
-## 2. Topology: what the operator stands up
+## 3. Topology: what the operator stands up
 
 When `enabled: true`, the `reconcilePasswordRotation` sub-reconciler ensures a
 chain of resources. A rotation flows left to right:
 
 ```
-CronJob controlplane-keystone-admin-password-rotate
+CronJob keystone-admin-password-rotate
   │  (mounts only /scripts/admin_password_rotate.sh; never runs keystone-manage)
   │  PATCH password + forge.c5c3.io/rotation-completed-at
   ▼
-staging Secret controlplane-keystone-admin-password-rotation
+staging Secret keystone-admin-password-rotation
   │  operator validates (non-empty, >= min length) and COMMITS
   ▼
-push-source Secret controlplane-keystone-admin-password-next   (operator-owned)
-  │  PushSecret controlplane-keystone-admin-password-backup mirrors it
+push-source Secret keystone-admin-password-next   (operator-owned)
+  │  PushSecret keystone-admin-password-backup mirrors it
   ▼
-OpenBao  bootstrap/openstack/controlplane-keystone/admin   (per-CR path)
-  │  ESO controlplane-keystone-admin-credentials ExternalSecret syncs it
+OpenBao  bootstrap/openstack/keystone/admin   (per-CR path)
+  │  ESO keystone-admin ExternalSecret syncs it
   ▼
-admin Secret controlplane-keystone-admin-credentials
+admin Secret keystone-admin
   │  secretToKeystoneMapper triggers a reconcile
   ▼
 reconcileBootstrap re-runs `keystone-manage bootstrap`  →  credential cut over
@@ -130,17 +208,17 @@ The resources, by name:
 
 | Resource | Name | Role |
 | --- | --- | --- |
-| CronJob | `controlplane-keystone-admin-password-rotate` | Mints a fresh password on `schedule` and PATCHes it onto the staging Secret. Mounts only the rotation script; never runs `keystone-manage`. |
-| Staging Secret | `controlplane-keystone-admin-password-rotation` | Drop box the CronJob writes; the only Secret the CronJob SA may patch. |
-| Push-source Secret | `controlplane-keystone-admin-password-next` | Operator-owned. The operator commits the validated password here; the PushSecret selects it. |
-| PushSecret | `controlplane-keystone-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/openstack/controlplane-keystone/admin` (per-CR path). |
-| RBAC trio | `controlplane-keystone-admin-password-rotate` (ServiceAccount, Role, RoleBinding) | The CronJob's split-RBAC identity. |
-| Script ConfigMap | `controlplane-keystone-admin-password-rotate-script` (content-hash suffixed) | Immutable mount of `admin_password_rotate.sh`. |
+| CronJob | `keystone-admin-password-rotate` | Mints a fresh password on `schedule` and PATCHes it onto the staging Secret. Mounts only the rotation script; never runs `keystone-manage`. |
+| Staging Secret | `keystone-admin-password-rotation` | Drop box the CronJob writes; the only Secret the CronJob SA may patch. |
+| Push-source Secret | `keystone-admin-password-next` | Operator-owned. The operator commits the validated password here; the PushSecret selects it. |
+| PushSecret | `keystone-admin-password-backup` | Mirrors the push-source Secret to OpenBao `bootstrap/openstack/keystone/admin` (per-CR path). |
+| RBAC trio | `keystone-admin-password-rotate` (ServiceAccount, Role, RoleBinding) | The CronJob's split-RBAC identity. |
+| Script ConfigMap | `keystone-admin-password-rotate-script` (content-hash suffixed) | Immutable mount of `admin_password_rotate.sh`. |
 
 Two safety properties are worth calling out:
 
 > **Split RBAC.** The CronJob's Role grants `get` + `patch` on **only** the
-> staging Secret `controlplane-keystone-admin-password-rotation`, and `get` (read-only) on the
+> staging Secret `keystone-admin-password-rotation`, and `get` (read-only) on the
 > push-source Secret. The CronJob can never write the push-source Secret — *the
 > operator* validates the staged value and writes the push-source. Write access to
 > the Secret a PushSecret backs is a token-forgery primitive, and it is kept off
@@ -150,18 +228,13 @@ Two safety properties are worth calling out:
 > Secret actually holds a valid password (non-empty, at least the minimum length).
 > Before the first rotation completes the push-source Secret is empty, so the
 > operator does not push — it would otherwise overwrite the seeded
-> `bootstrap/openstack/controlplane-keystone/admin` value with nothing.
+> `bootstrap/openstack/keystone/admin` value with nothing.
 
 > **ESO-managed source path.** The PushSecret can only write
-> `bootstrap/openstack/controlplane-keystone/admin` if that OpenBao path carries the custom-metadata
-> marker `managed-by=external-secrets`. The ESO Vault/OpenBao provider refuses to
-> overwrite a path it does not own and fails the PushSecret with `secret not
-> managed by external-secrets`. The standard bootstrap
-> (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) stamps the marker when it
-> seeds the path, and re-running it adopts a path written by an older bootstrap
-> that predates this marker. If you seed `bootstrap/openstack/controlplane-keystone/admin` by hand, set
-> the marker too:
-> `bao kv metadata put -custom-metadata=managed-by=external-secrets kv-v2/bootstrap/openstack/controlplane-keystone/admin`.
+> `bootstrap/openstack/keystone/admin` if that OpenBao path carries the custom-metadata
+> marker `managed-by=external-secrets` (Step 1). The ESO Vault/OpenBao provider
+> refuses to overwrite a path it does not own and fails the PushSecret with `secret
+> not managed by external-secrets`.
 
 For the full sub-reconciler contract (validation rules, event reasons, the
 clobber-safe gate, RBAC shape) see
@@ -169,28 +242,28 @@ clobber-safe gate, RBAC shape) see
 
 ---
 
-## 3. Prove a scheduled rotation end-to-end
+## 4. Prove a scheduled rotation end-to-end
 
 The monthly default schedule rarely fires when you want to observe it, so trigger
 a run on demand and follow the evidence chain. Each step below is something you
 can run and confirm.
 
-### 3.1 Confirm the CronJob exists with your schedule
+### 4.1 Confirm the CronJob exists with your schedule
 
 ```bash
-kubectl -n openstack get cronjob controlplane-keystone-admin-password-rotate
+kubectl -n openstack get cronjob keystone-admin-password-rotate
 ```
 
 The `SCHEDULE` column should show your `spec.passwordRotation.schedule`
 (e.g. `0 0 1 * *`).
 
-### 3.2 Trigger a run on demand
+### 4.2 Trigger a run on demand
 
 Instantiate a one-shot Job from the CronJob template and wait for it to finish:
 
 ```bash
-JOB=controlplane-keystone-admin-password-rotate-manual-$(date +%s)
-kubectl -n openstack create job --from=cronjob/controlplane-keystone-admin-password-rotate "$JOB"
+JOB=keystone-admin-password-rotate-manual-$(date +%s)
+kubectl -n openstack create job --from=cronjob/keystone-admin-password-rotate "$JOB"
 
 kubectl -n openstack wait --for=condition=complete job/"$JOB" --timeout=120s
 ```
@@ -199,9 +272,9 @@ The timestamp suffix keeps the Job name unique, so re-running this step never
 collides with a prior manual Job (`AlreadyExists`) before it is cleaned up.
 
 The Job's pod mints a fresh password and PATCHes it onto the staging Secret
-`controlplane-keystone-admin-password-rotation`.
+`keystone-admin-password-rotation`.
 
-### 3.3 Observe the operator commit
+### 4.3 Observe the operator commit
 
 On the next reconcile the operator validates the staged password, copies it onto
 the push-source Secret, deletes staging, and emits a Normal event. Confirm all
@@ -209,15 +282,15 @@ three:
 
 ```bash
 # Push-source Secret now carries a non-empty password and the completion stamp.
-kubectl -n openstack get secret controlplane-keystone-admin-password-next \
+kubectl -n openstack get secret keystone-admin-password-next \
   -o jsonpath="{.metadata.annotations['forge\.c5c3\.io/rotation-completed-at']}{\"\n\"}"
 
 # Staging Secret has been deleted (NotFound is the success signal here).
-kubectl -n openstack get secret controlplane-keystone-admin-password-rotation
+kubectl -n openstack get secret keystone-admin-password-rotation
 
 # The success event.
 kubectl -n openstack get events \
-  --field-selector reason=AdminPasswordRotated,involvedObject.name=controlplane-keystone \
+  --field-selector reason=AdminPasswordRotated,involvedObject.name=keystone \
   --sort-by='.lastTimestamp'
 ```
 
@@ -225,7 +298,7 @@ Expected event:
 
 ```
 LAST SEEN   TYPE     REASON               OBJECT          MESSAGE
-5s          Normal   AdminPasswordRotated keystone/controlplane-keystone   admin password rotation applied from staging secret controlplane-keystone-admin-password-rotation
+5s          Normal   AdminPasswordRotated keystone/keystone   admin password rotation applied from staging secret keystone-admin-password-rotation
 ```
 
 > **Note.** The password value itself is never logged or echoed in an event. If
@@ -234,11 +307,11 @@ LAST SEEN   TYPE     REASON               OBJECT          MESSAGE
 > `AdminPasswordRotationAnnotationInvalid` (malformed completion timestamp), and
 > the staging Secret is retained for inspection.
 
-### 3.4 Confirm the OpenBao value changed and ESO synced it
+### 4.4 Confirm the OpenBao value changed and ESO synced it
 
 The PushSecret mirrors the push-source Secret into OpenBao at
-`bootstrap/openstack/controlplane-keystone/admin`, and the `controlplane-keystone-admin-credentials` ExternalSecret projects it
-back into the admin Secret `controlplane-keystone-admin-credentials`. Use the manual guide's
+`bootstrap/openstack/keystone/admin`, and the `keystone-admin` ExternalSecret projects it
+back into the admin Secret `keystone-admin`. Use the manual guide's
 force-sync + fingerprint technique to confirm the admin Secret carries the new
 value: see
 [step 2 of the manual guide](keystone-admin-password-rotation.md#2-optional-force-eso-to-sync-the-new-value).
@@ -246,22 +319,28 @@ value: see
 The short version:
 
 ```bash
-kubectl -n openstack get secret controlplane-keystone-admin-credentials \
+kubectl -n openstack get secret keystone-admin \
   -o jsonpath='{.data.password}' | base64 -d | sha256sum
 ```
 
 This digest is the same one the operator stamps onto the recreated bootstrap Job
 in the next step.
 
-### 3.5 Watch the re-bootstrap (cross-link to the manual guide)
+### 4.5 Watch the re-bootstrap (cross-link to the manual guide)
 
 From here the flow is *identical* to a manual rotation — the operator's
 `secretToKeystoneMapper` observes the admin Secret change and re-runs the
 idempotent bootstrap Job. Follow the manual guide's steps, which are the
-authoritative walkthrough:
+authoritative walkthrough.
+
+> **Substitute the names.** The manual guide is written against the ControlPlane
+> devstack's `controlplane-keystone`. Reading it for a standalone `keystone` CR,
+> substitute `controlplane-keystone` → `keystone`,
+> `controlplane-keystone-bootstrap` → `keystone-bootstrap`, and
+> `controlplane-keystone-admin-credentials` → `keystone-admin` throughout.
 
 - [Step 3 — Observe the recreated bootstrap Job](keystone-admin-password-rotation.md#3-observe-the-recreated-bootstrap-job)
-  (the `controlplane-keystone-bootstrap` Job is delete+recreated with a fresh UID and the new
+  (the `keystone-bootstrap` Job is delete+recreated with a fresh UID and the new
   `forge.c5c3.io/admin-password-hash`).
 - [Step 4 — Watch the `BootstrapReady` transitions](keystone-admin-password-rotation.md#4-watch-the-bootstrapready-transitions)
   (`False`/`BootstrapInProgress` → `True`/`BootstrapComplete`).
@@ -271,57 +350,48 @@ authoritative walkthrough:
 - [Step 7 — Post-rotation smoke check](keystone-admin-password-rotation.md#7-post-rotation-smoke-check)
   (the new password authenticates `201`; the old one is rejected `401`).
 
-### 3.6 Note the separation from the live credential
+### 4.6 Note the separation from the live credential
 
-The push-source Secret `controlplane-keystone-admin-password-next` is a **distinct object** from
-the live admin Secret `controlplane-keystone-admin-credentials`. The operator commits the new password onto
+The push-source Secret `keystone-admin-password-next` is a **distinct object** from
+the live admin Secret `keystone-admin`. The operator commits the new password onto
 the push-source Secret; the running Keystone keeps using the value in
-`controlplane-keystone-admin-credentials` until ESO has synced the new value back. A scheduled rotation
+`keystone-admin` until ESO has synced the new value back. A scheduled rotation
 never clobbers the credential the running Keystone is using mid-flight.
 
 ---
 
-## 4. Per-CR path isolation
+## 5. Per-CR path isolation
 
 Model B scopes the OpenBao RemoteKey **per Keystone CR** to
-`bootstrap/{namespace}/{name}/admin` — for `controlplane-keystone` in
-`openstack`, that is `bootstrap/openstack/controlplane-keystone/admin`. Each
-Model-B-enabled Keystone CR therefore writes its admin password to its **own**
-OpenBao object, and the matching admin-credentials ExternalSecret reads that same
-per-CR path. Two Model-B-enabled Keystone CRs in the same cluster no longer share
-one OpenBao object — they cannot clobber each other's rotations, so scheduled
-rotation can be enabled on multiple Keystone CRs concurrently.
+`bootstrap/{namespace}/{name}/admin` — for `keystone` in `openstack`, that is
+`bootstrap/openstack/keystone/admin`. Each Model-B-enabled Keystone CR therefore
+writes its admin password to its **own** OpenBao object, and the matching
+admin-credentials ExternalSecret reads that same per-CR path. Two Model-B-enabled
+Keystone CRs in the same cluster no longer share one OpenBao object — they cannot
+clobber each other's rotations, so scheduled rotation can be enabled on multiple
+Keystone CRs concurrently.
 
 > **Path in lockstep.** The admin-credentials ExternalSecret's `remoteRef.key`
-> must match the per-CR path of the Keystone CR whose rotation feeds it. On the
-> ControlPlane devstack that ExternalSecret is the operator-projected
-> `controlplane-keystone-admin-credentials`, reading
-> `bootstrap/openstack/controlplane-keystone/admin`. The bootstrap seed
-> (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) seeds
-> `bootstrap/{namespace}/{name}/admin` for each ControlPlane identity in
-> `KORC_CONTROLPLANES` (default `openstack/controlplane`, whose projected Keystone
-> CR is `controlplane-keystone`, i.e. `bootstrap/openstack/controlplane-keystone/admin`).
-
-> **Standalone Keystone.** For a standalone Keystone (no ControlPlane), the
-> ExternalSecret feeding the admin Secret is one you supply, and its
-> `remoteRef.key` must match the per-CR path this rotation writes —
-> `bootstrap/{namespace}/{name}/admin` for a CR named `{name}` in `{namespace}`.
-> The kind `keystone-admin` shim
-> (`deploy/kind/infrastructure/keystone-admin-externalsecret.yaml`) instead reads
-> the fixed default-identity path `bootstrap/openstack/controlplane-keystone/admin`,
-> so scheduled rotation on the kind Quick Start is exercised against the
-> ControlPlane's `controlplane-keystone`, not a separately named standalone CR.
+> must match the per-CR path of the Keystone CR whose rotation feeds it — this is
+> exactly what Step 1 wired up. For a CR named `{name}` in `{namespace}`, that is
+> `bootstrap/{namespace}/{name}/admin`. On a ControlPlane deployment the
+> operator-projected `controlplane-keystone-admin-credentials` ExternalSecret
+> reads `bootstrap/openstack/controlplane-keystone/admin`, and the bootstrap seed
+> (`deploy/openbao/bootstrap/write-bootstrap-secrets.sh`) seeds that path for each
+> ControlPlane identity in `KORC_CONTROLPLANES` — but scheduled rotation is not
+> configured on the projected child (see
+> [On a ControlPlane deployment](#on-a-controlplane-deployment)).
 
 ---
 
-## 5. Suspend or disable rotation
+## 6. Suspend or disable rotation
 
 There are two ways to stop rotating, with different blast radius.
 
 **Suspend** — keep every resource but stop new runs:
 
 ```bash
-kubectl -n openstack patch keystone controlplane-keystone --type merge \
+kubectl -n openstack patch keystone keystone --type merge \
   -p '{"spec":{"passwordRotation":{"suspend":true}}}'
 ```
 
@@ -331,7 +401,7 @@ resources remain. No new password is minted until you set `suspend: false` again
 **Disable** — tear everything down:
 
 ```bash
-kubectl -n openstack patch keystone controlplane-keystone --type merge \
+kubectl -n openstack patch keystone keystone --type merge \
   -p '{"spec":{"passwordRotation":{"enabled":false}}}'
 ```
 
@@ -342,7 +412,7 @@ Secrets, the RBAC trio, the PushSecret, and the script ConfigMap — and reports
 
 > **Safety note.** Disabling does **not** remove the last-pushed password from
 > OpenBao. The PushSecret uses `DeletionPolicy: None`, so the value already in
-> `bootstrap/openstack/controlplane-keystone/admin` stays put when the PushSecret is deleted. Disabling
+> `bootstrap/openstack/keystone/admin` stays put when the PushSecret is deleted. Disabling
 > rotation can never lock the admin out of Keystone.
 
 ---
@@ -351,6 +421,6 @@ Secrets, the RBAC trio, the PushSecret, and the script ConfigMap — and reports
 
 - [`reconcilePasswordRotation`](../reference/keystone/keystone-reconciler.md#reconcilepasswordrotation) — the authoritative contract for the Model B sub-reconciler: validation rules, event reasons, the clobber-safe PushSecret gate, and the split RBAC.
 - [`reconcileBootstrap`](../reference/keystone/keystone-reconciler.md#reconcilebootstrap) — the bootstrap sub-reconciler and the `admin-password-hash` re-run gate that applies the rotated credential.
-- [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md) — the manual rotation guide whose verification steps (3–7) this guide cross-links.
+- [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md) — the manual rotation guide whose verification steps (3–7) this guide cross-links, and the supported admin-password rotation path on a ControlPlane deployment.
 - [Rotate Keystone Fernet and Credential Keys](keystone-key-rotation.md) — the key-rotation counterpart, which uses an analogous staging→production split.
 - Chainsaw test: `tests/e2e/keystone/admin-password-scheduled-rotation/chainsaw-test.yaml` asserts this guide's evidence chain end-to-end — CronJob run → push-source commit → OpenBao change → ESO sync → re-bootstrap `BootstrapReady=True` → new-password `201` / old-password `401`, and the disable→teardown `RotationDisabled` posture.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -108,7 +108,7 @@ The first `status=False` condition from the top is usually the bottleneck:
 
 ## Upgrade status fields
 
-During an image-tag change, three additional status fields track progress (see [Day 2 Operations — Image upgrade](./day-2-operations.md#image-upgrade-with-upgradephase)):
+During a release upgrade, three additional status fields track progress (see [Day 2 Operations — Upgrade the OpenStack release](./day-2-operations.md#upgrade-the-openstack-release)):
 
 | Field | Outside upgrade | During upgrade |
 |-------|-----------------|----------------|

--- a/docs/guides/oidc-federation.md
+++ b/docs/guides/oidc-federation.md
@@ -24,27 +24,40 @@ For the full field reference, see the
 ## Prerequisites
 
 ::: info Devstack
-This guide is written against the **[Quick Start](../quick-start.md)** devstack. Stand it up first:
+This guide is written against the **[Quick Start (ControlPlane)](../quick-start-controlplane.md)** devstack. Stand it up first:
 
 ```bash
-KIND_HOST_PORT=8443 make deploy-infra
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
-Follow that tutorial through to its final **Verify** step, so a Keystone CR named
-`keystone` is `Ready` in the `openstack` namespace. Every resource name in the
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
+`controlplane-keystone` Keystone child is running. Every resource name in the
 examples below is one that devstack produces.
+:::
+
+::: warning The Keystone child is operator-owned
+On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
+**projected** by the c5c3-operator, which re-asserts the entire
+`spec.federation` block (proxy image and trusted dashboards) on every reconcile.
+Set the federation proxy image on the `ControlPlane` CR (Step 3), and the trusted
+dashboards flow from `spec.services.horizon` — see
+[End-to-End SSO](./end-to-end-sso.md). The `KeystoneIdentityBackend` CR you apply
+in Step 4 is yours to own; only the projected Keystone child's `spec.federation`
+is operator-managed.
 :::
 
 - An OIDC identity provider reachable from the cluster (this guide uses a
   Keycloak realm) with a **confidential client** registered for keystone.
   The client's redirect URIs must cover
   `<keystone endpoint base>/v3/OS-FEDERATION/redirect_uri`.
-- **A federation proxy image.** The managed ControlPlane path projects
-  `ghcr.io/c5c3/keystone-federation-proxy` automatically; standalone
-  Keystone installations set `spec.federation.proxyImage` themselves
-  (mirroring the required `spec.image`). Without it, OIDC backends stay
-  pending with a `FederationProxyImageMissing` Warning — no hidden default
-  is assumed.
+- **A federation proxy image.** On the ControlPlane path the c5c3-operator
+  projects `ghcr.io/c5c3/keystone-federation-proxy:latest` onto the child
+  automatically, overridable via `spec.services.keystone.federationProxyImage`
+  (Step 3); standalone Keystone installations set `spec.federation.proxyImage`
+  themselves (see the [Standalone Keystone](#standalone-keystone-without-a-controlplane)
+  section). Without a proxy image, OIDC backends stay pending with a
+  `FederationProxyImageMissing` Warning — no hidden default is assumed.
 - **Service users stay SQL-backed.** Federated users are ephemeral shadow
   users; OpenStack service accounts and the bootstrap admin remain in the
   SQL-backed `Default` domain, which the CRD hard-rejects federating.
@@ -68,22 +81,37 @@ kubectl create secret generic keycloak-forge-client -n openstack \
 Rotating this Secret later re-renders the federation configuration
 automatically — the operator watches it.
 
-## Step 3 — Configure the proxy image (standalone installations)
+## Step 3 — Pin the federation proxy image (optional)
+
+On the ControlPlane path the c5c3-operator already projects
+`ghcr.io/c5c3/keystone-federation-proxy:latest` onto the `controlplane-keystone`
+child, so OIDC federation works out of the box — this step is only needed to pin
+an immutable digest for production or to test a locally built sidecar. Override
+the default on the `ControlPlane` CR:
 
 ```yaml
-apiVersion: keystone.openstack.c5c3.io/v1alpha1
-kind: Keystone
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
 metadata:
-  name: keystone
+  name: controlplane
+  namespace: openstack
 spec:
-  # ...
-  federation:
-    proxyImage:
-      repository: ghcr.io/c5c3/keystone-federation-proxy
-      tag: latest   # pin a digest for production
+  services:
+    keystone:
+      federationProxyImage:
+        repository: ghcr.io/c5c3/keystone-federation-proxy
+        digest: sha256:<digest>   # pin a digest for production
 ```
 
-This block is inert until an OIDC backend attaches.
+::: warning Do not set `spec.federation.proxyImage` on the projected child
+Editing `spec.federation.proxyImage` (or any `spec.federation` field) on the
+`controlplane-keystone` child directly is reverted on the next reconcile: the
+c5c3-operator re-asserts the whole `spec.federation` block from the ControlPlane.
+Set the override via `spec.services.keystone.federationProxyImage` on the
+`ControlPlane` CR instead.
+:::
+
+The projected image is inert until an OIDC backend attaches.
 
 ## Step 4 — Apply the backend CR
 
@@ -95,7 +123,7 @@ metadata:
   namespace: openstack
 spec:
   keystoneRef:
-    name: keystone
+    name: controlplane-keystone
   domain:
     name: forge
     mode: Manage           # the operator creates the domain
@@ -162,8 +190,8 @@ value (e.g. `{1}` here) makes keystone reject the assertion with a
 
 ```bash
 kubectl get keystoneidentitybackends -n openstack
-NAME             READY   DOMAIN   KEYSTONE   AGE
-keycloak-forge   True    forge    keystone   1m
+NAME             READY   DOMAIN   KEYSTONE               AGE
+keycloak-forge   True    forge    controlplane-keystone  1m
 ```
 
 `kubectl describe` shows the progression: `DomainReady=True`, then
@@ -188,8 +216,12 @@ Browser (WebSSO): navigate to
 You are redirected to the Keycloak login form; after authenticating,
 keystone answers with the auto-submitting token form that hands the token to
 the dashboard. The `origin` must be listed in keystone's
-`[federation] trusted_dashboard` (set it via `spec.extraConfig` until the
-Horizon phase ships the typed field).
+`[federation] trusted_dashboard`. On a ControlPlane deployment the operator
+projects this onto the child's typed `spec.federation.trustedDashboards` from
+the dashboard's `spec.services.horizon` (`publicEndpoint` / `gateway`) — you do
+not set it by hand; see [End-to-End SSO](./end-to-end-sso.md). On a standalone
+Keystone, set `spec.federation.trustedDashboards` directly (see the
+[Standalone Keystone](#standalone-keystone-without-a-controlplane) section).
 
 CLI (bearer token, needs `oauth2Introspection` enabled on exactly one
 backend): obtain an access token from the IdP, then exchange it:
@@ -247,7 +279,7 @@ Declarative groups live inside the domain and follow it.
 
 | Symptom | Likely cause |
 | --- | --- |
-| `IdentityBackendsReady=False` with a `FederationProxyImageMissing` Warning | `spec.federation.proxyImage` is not set on the Keystone CR — configure the sidecar image (Step 3). |
+| `IdentityBackendsReady=False` with a `FederationProxyImageMissing` Warning | The child Keystone CR has no `spec.federation.proxyImage`. On a ControlPlane deployment the operator always projects it, so this points to a **standalone** Keystone with no proxy image — set `spec.federation.proxyImage` on it (see the [Standalone Keystone](#standalone-keystone-without-a-controlplane) section). |
 | `IdentityBackendsSkipped` Warning naming `provider metadata unavailable` | The discovery document could not be fetched from the operator pod, or its `issuer` does not equal `spec.oidc.issuer`. Check egress/DNS, or spell out `spec.oidc.endpoints`. |
 | `FederationObjectsReady=False/NoMappingRules` | `spec.mappings` is empty — keystone cannot represent a rule-less mapping; add at least one rule. |
 | `MappingsReady=False/RoleOrProjectNotFound` | A role assignment references a role or project that does not exist (yet); the backend retries on a bounded poll. |
@@ -258,3 +290,38 @@ Declarative groups live inside the domain and follow it.
 | Bearer-token auth returns 401 with `Access token JWT check failed` in the IdP log | The token's `iss` differs from what the IdP computes at the introspection endpoint (e.g. tokens minted over one hostname/scheme, introspected over another). Pin a fixed frontend URL / hostname on the IdP so the issuer is stable across listeners. |
 | The backend is skipped with `is not https` in the Warning | The IdP publishes an http introspection endpoint, which mod_auth_openidc refuses. Point `endpoints.introspectionEndpoint` at an https listener (and set `oauth2Introspection.tlsVerify: false` if its certificate is not in the system trust store). |
 | Admission rejects the CR | The message names the exact rule: discovery-shape exclusivity, the fixed `clientSecret` data-key contract, mapping-rule completeness, identity-provider-name uniqueness, remote-id uniformity, or the single-introspection limit. |
+
+## Standalone Keystone, without a ControlPlane
+
+On the [Quick Start](../quick-start.md) / [Quick Start (Extended)](../quick-start-extended.md)
+devstacks a standalone Keystone CR named `keystone` runs with no ControlPlane
+projecting it, so there is no operator projecting the federation block onto it —
+you set it directly on the Keystone CR.
+
+**Proxy image.** A standalone Keystone assumes no hidden default, so set
+`spec.federation.proxyImage` yourself (mirroring the required `spec.image`).
+Without it, OIDC backends stay pending with a `FederationProxyImageMissing`
+Warning:
+
+```yaml
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone
+spec:
+  # ...
+  federation:
+    proxyImage:
+      repository: ghcr.io/c5c3/keystone-federation-proxy
+      tag: latest   # pin a digest for production
+```
+
+**Backend `keystoneRef`.** Point the `KeystoneIdentityBackend` from Step 4 at the
+standalone CR by name — `keystoneRef.name: keystone` instead of
+`controlplane-keystone`.
+
+**Trusted dashboards.** Without the ControlPlane there is nothing to project the
+WebSSO origin, so set `spec.federation.trustedDashboards` directly on the Keystone
+CR. It is a list, rendered as one `[federation] trusted_dashboard` line per entry.
+See the standalone section of [End-to-End SSO](./end-to-end-sso.md#standalone-keystone-without-a-controlplane)
+for the full shape and the `spec.extraConfig` conflict rule.


### PR DESCRIPTION
## Summary

Reworks the operator guides so every recipe that touches a Keystone/Horizon resource is anchored on the **ControlPlane devstack** rather than the standalone Quick Start. On a ControlPlane deployment the `c5c3`-operator projects and re-asserts spec fragments onto the operator-owned `controlplane-keystone` / `controlplane-horizon` children on every reconcile, so the old guides — which patched those children or the standalone CR directly — silently had their edits reverted with no error surfaced. Each guide now drives the primary path through the ControlPlane CR's projecting knob, warns against editing the projected child, and moves the standalone-only variants into a dedicated "Standalone Keystone" section.

Closes #612

## Change set (commit order)

1. **`42f5fa16` docs(guides): rework day-2 operations to drive the ControlPlane CR**
   Re-anchors `day-2-operations.md` on the ControlPlane devstack. Scale via `spec.services.keystone.replicas`, release upgrades via `spec.openStackRelease` (instead of an image-tag patch on the child), and the Fernet schedule via `spec.services.keystone.rotationInterval`. Adds an operator-owned/revert warning up front and moves the suspend / maxActiveKeys / autoscaling standalone knobs into a Standalone Keystone section. Also updates the inbound `observability.md` anchor for the renamed upgrade heading.

2. **`efeeb1fc` docs(guides): rework advanced configuration ControlPlane-first**
   Re-anchors `advanced-configuration.md`. Leads with a brownfield database + cache recipe at ControlPlane level (`spec.infrastructure`, a creation-time decision the webhook freezes) and gives the feature pointer table a "ControlPlane path" column naming the projecting knob or marking a field standalone-only. Autoscaling, network-policy, extraConfig, and standalone-brownfield recipes move into the Standalone Keystone section. Keeps the `Autoscaling (HPA)` heading so the inbound `#autoscaling-hpa` anchor survives.

3. **`590a8bec` docs(guides): move database TLS enablement to the ControlPlane CR**
   Drives the primary path in `enable-keystone-database-tls.md` from `spec.infrastructure.database.tls` on the ControlPlane CR (projected, not frozen by the immutability webhook) with a revert warning against editing the child. Ground-truth correction: the managed ControlPlane devstack provisions `openstack-db` without server-side TLS, so a prerequisite now states client DB TLS needs a TLS-capable MariaDB, and the fully-runnable end-to-end flow lives in an appended Standalone Keystone section whose `openstack-db` ships `tls.required=true`.

4. **`eb6092f5` docs(guides): anchor OIDC federation on the ControlPlane devstack**
   Re-anchors `oidc-federation.md`: pins the proxy image via `spec.services.keystone.federationProxyImage` on the ControlPlane CR (with a revert warning), points the `KeystoneIdentityBackend` `keystoneRef` at the `controlplane-keystone` child, and replaces the stale `extraConfig` sentence — the typed `spec.federation.trustedDashboards` field already exists and is projected from `spec.services.horizon` on the ControlPlane path. Adds a Standalone Keystone section and marks `FederationProxyImageMissing` as standalone-only.

5. **`4b04dcb1` docs(guides): make scheduled admin-password rotation standalone-only**
   Scheduled rotation (Model B) is not exposed on the ControlPlane CRD, and configuring it on the projected child is unsupported. Re-anchors `keystone-admin-password-scheduled-rotation.md` on the plain Quick Start against a reader-owned Keystone CR named `keystone` (per-CR OpenBao path `bootstrap/openstack/keystone/admin`), adds an "On a ControlPlane deployment" section pointing ControlPlane readers to the manual rotation flow, and adds a wiring step that seeds/stamps the per-CR OpenBao path and repoints the admin ExternalSecret.

6. **`9d7d591c` docs(guides): verify Horizon NetworkPolicy via the ControlPlane CR**
   The Step 2 verification in `enable-horizon-operator-networkpolicy.md` told readers to bump `spec.deployment.replicas` on the projected `controlplane-horizon` child, which is reverted with no rollout. Now drives the check through `spec.services.horizon.replicas` on the ControlPlane CR, watches `deploy/controlplane-horizon` scale, and reverts — with a note that the child's replica count is operator-owned. The raw helm upgrade step and the kindnet caveat are untouched.

7. **`0bd1fb1c` docs(guides): tighten the day-2 projected-fields warning**
   The child's Fernet rotation schedule is only re-asserted when `spec.services.keystone.rotationInterval` is set, which the bundled devstack ControlPlane CR does not set — so listing "rotation schedule" among the always-reverted fields overstated the projection. Drops it from the parenthetical; the Fernet section already directs the schedule to the `rotationInterval` knob.

## Notes for the reviewer

- Docs-only change: 7 files under `docs/guides/` plus a one-line inbound-anchor fix in `observability.md`. No code, CRD, or webhook changes.
- Divergence from the issue worth flagging: commit `590a8bec` includes a ground-truth correction (the managed devstack `openstack-db` has no server-side TLS), and commit `4b04dcb1` concludes scheduled rotation cannot be made ControlPlane-first at all — it is genuinely standalone-only because the knob is absent from the ControlPlane CRD — so that guide is re-anchored on the Quick Start with a ControlPlane pointer rather than converted.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
