### PR TITLE
docs(guides): make guide dependencies reachable on a kind devstack

### DIFF
--- a/deploy/kind/metrics-server/kustomization.yaml
+++ b/deploy/kind/metrics-server/kustomization.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Opt-in kind overlay for metrics-server — applied only when the operator
+# explicitly requests it (WITH_METRICS_SERVER=true make deploy-infra).
+#
+# Bundles everything needed to render a working metrics-server on a kind
+# cluster:
+#   1. The metrics-server HelmRepository source (upstream chart index).
+#   2. The metrics-server HelmRelease with kind-tuned values baked directly
+#      into release.yaml (`--kubelet-insecure-tls`, so the server can scrape
+#      kind's self-signed kubelet certificates).
+#
+# There is NO inline namespace.yaml: the chart installs into the pre-existing
+# `kube-system` Namespace (it defaults to `priorityClassName:
+# system-cluster-critical`, which only resolves in kube-system), so the
+# overlay does not create a Namespace of its own.
+#
+# All resource references are local to this overlay (no parent-directory
+# `../../` paths). The overlay therefore renders cleanly under kustomize's
+# default `LoadRestrictionsRootOnly` security check, which means
+# `kubectl apply -k deploy/kind/metrics-server` works without
+# `--load-restrictor`. kubectl's embedded kustomize does NOT expose
+# `--load-restrictor` (kubernetes/kubectl#948), so keeping the overlay
+# self-contained is the only way to ship `kubectl apply -k` as the production
+# caller in hack/deploy-infra.sh — same constraint that drove the chaos-mesh
+# and kube-prometheus-stack overlays in.
+#
+# Production overlays (deploy/flux-system/kustomization.yaml) do not list any
+# of the resources in this directory — metrics-server is a kind-only
+# convenience for the HPA / autoscaling recipe. Managed distributions ship
+# their own metrics-server; production clusters bring their own.
+#
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # HelmRepository (flux-system) + HelmRelease (kube-system) are local to
+  # this overlay — production overlays do not include them.
+  - source.yaml
+  - release.yaml

--- a/deploy/kind/metrics-server/release.yaml
+++ b/deploy/kind/metrics-server/release.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# metrics-server HelmRelease — opt-in Kubernetes resource-metrics API for the
+# kind Quick Start. Provides the CPU/memory utilisation samples the
+# HorizontalPodAutoscaler in the autoscaling recipe consumes; without it the
+# generated HPA sits at `unknown/80%` and never scales.
+#
+# Deployed to kube-system (the chart defaults to
+# priorityClassName: system-cluster-critical, which only resolves there) and
+# tuned for kind with `--kubelet-insecure-tls`: kind's kubelets serve their
+# metrics endpoint with self-signed certificates the metrics-server cannot
+# verify against the cluster CA, so scrapes fail with an x509 error until TLS
+# verification is skipped. This replaces the runtime `kubectl patch` the
+# autoscaling guide previously documented — the flag is baked into the
+# release values so a single `kubectl apply -k` yields a working server.
+#
+# Production overlays never install this release: managed distributions ship
+# their own metrics-server, and production clusters bring their own.
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: metrics-server
+      version: ">=3.12.0 <4.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    args:
+      # kind kubelets serve /metrics/resource with a self-signed cert that
+      # metrics-server cannot verify against the cluster CA; skip verification
+      # so scrapes succeed on the devstack. Never set this on a production
+      # cluster with properly issued kubelet certificates.
+      - --kubelet-insecure-tls

--- a/deploy/kind/metrics-server/source.yaml
+++ b/deploy/kind/metrics-server/source.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/metrics-server/

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -226,21 +226,34 @@ spec:
 - At least one of `targetCPUUtilization` or `targetMemoryUtilization` is required.
 - `minReplicas` defaults to `spec.deployment.replicas` if unset — omitting it will floor the HPA at your current hand-set replica count, not at 1.
 - The generated HPA references `deploy/keystone` and uses the Kubernetes standard
-  `metrics-server`. The Quick Start kind cluster does **not** ship one — the HPA will
-  sit at `unknown/80%` until you install it:
+  `metrics-server`. The Quick Start kind cluster does **not** ship one by default —
+  the HPA will sit at `unknown/80%` until a resource-metrics API is available.
+
+  On the kind devstack, opt in with the `WITH_METRICS_SERVER` flag. Bring the
+  devstack up with it set (the recipe here also needs the ControlPlane, so the
+  flags compose):
 
   ```bash
-  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+  KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_METRICS_SERVER=true make deploy-infra
   ```
 
-  On kind (and most development clusters that use self-signed kubelet certs) patch
-  the Deployment to skip TLS verification, otherwise `metrics-server` will fail to
-  scrape the kubelet:
+  Or, if the devstack is already running, apply the kind overlay additively and
+  wait for it to reconcile:
 
   ```bash
-  kubectl patch -n kube-system deploy/metrics-server --type=json \
-    -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+  kubectl apply -k deploy/kind/metrics-server
+  kubectl wait helmrelease/metrics-server -n kube-system --for=condition=Ready --timeout=5m
+  kubectl top pods -n openstack   # sanity check: real utilisation, not an error
   ```
+
+  The overlay pins the chart to a single major range and bakes in
+  `--kubelet-insecure-tls`, which kind requires because its kubelets serve the
+  metrics endpoint with self-signed certificates — no runtime patch needed.
+
+  On non-kind clusters, `metrics-server` is usually already present: most managed
+  Kubernetes distributions ship it. If yours does not, install it per the
+  [upstream project](https://github.com/kubernetes-sigs/metrics-server) rather
+  than copy-pasting an unpinned manifest.
 
 Inspect the HPA:
 

--- a/docs/guides/enable-horizon-operator-metrics.md
+++ b/docs/guides/enable-horizon-operator-metrics.md
@@ -32,8 +32,11 @@ CRDs, Prometheus, and Grafana are already wrapped behind opt-in flags:
 KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra
 ```
 
-The rest of this guide is the canonical path for non-kind clusters that run
-their own Prometheus.
+`WITH_PROMETHEUS=true` also flips the horizon-operator `ServiceMonitor` for
+you at bring-up (`deploy-infra` patches the horizon-operator HelmRelease), so
+on a fresh kind devstack none of the manual steps below are required. Step 1
+is the path for a devstack that is **already running** without
+`WITH_PROMETHEUS`, or for non-kind clusters that run their own Prometheus.
 :::
 
 ## Prerequisites
@@ -56,14 +59,43 @@ Follow that tutorial through to its final **Verify** step, so the horizon-operat
 
 ## Step 1 — Enable the ServiceMonitor
 
+On the tutorial devstacks the `horizon-operator` release is owned by Flux (a
+`HelmRelease`), so set the chart value by patching that HelmRelease rather than
+running a raw `helm upgrade` — Flux's helm-controller reverts any out-of-band
+Helm revision on its next reconcile:
+
+```bash
+kubectl patch helmrelease horizon-operator -n horizon-system --type=merge \
+  -p '{"spec":{"values":{"monitoring":{"serviceMonitor":{"enabled":true}}}}}'
+
+kubectl wait helmrelease/horizon-operator -n horizon-system \
+  --for=condition=Ready --timeout=5m
+```
+
+Confirm the `ServiceMonitor` was rendered:
+
+```bash
+kubectl -n horizon-system get servicemonitor \
+  -l app.kubernetes.io/name=horizon-operator
+```
+
+The chart renders a `ServiceMonitor` scraping the operator's metrics Service
+on the `https`-less metrics port with the shared operator-library labels.
+
+::: details Helm-managed installations (non-Flux)
+If you installed the operator directly with Helm (not through Flux), set the
+value with a rolling `helm upgrade` instead:
+
 ```bash
 helm upgrade horizon-operator oci://ghcr.io/c5c3/charts/horizon-operator \
   --namespace horizon-system --reuse-values \
   --set monitoring.serviceMonitor.enabled=true
 ```
 
-The chart renders a `ServiceMonitor` scraping the operator's metrics Service
-on the `https`-less metrics port with the shared operator-library labels.
+Do **not** run this on the tutorial devstacks: there the release is
+Flux-owned, and the helm-controller reverts out-of-band revisions on its next
+reconcile. Use the HelmRelease patch above instead.
+:::
 
 ## Step 2 — Import the Grafana dashboard
 

--- a/docs/guides/enable-horizon-operator-networkpolicy.md
+++ b/docs/guides/enable-horizon-operator-networkpolicy.md
@@ -39,10 +39,27 @@ is running (namespace `horizon-system`) alongside the projected
 
 ## Step 1 — Enable the policy
 
+The chart guards `networkPolicy.enabled=true` with a fail-closed check:
+`networkPolicy.kubeApiServer.cidrs` and `ports` must both be non-empty, or the
+template refuses to render. Gather the API server CIDR and port from the
+in-cluster `kubernetes` Service (on kind this is `10.96.0.1/32` port `6443`):
+
 ```bash
-helm upgrade horizon-operator oci://ghcr.io/c5c3/charts/horizon-operator \
-  --namespace horizon-system --reuse-values \
-  --set networkPolicy.enabled=true
+kubectl get endpoints kubernetes -n default -o json \
+  | jq -r '.subsets[] | (.addresses[].ip) as $ip | (.ports[].port) as $p | "\($ip)/32 port=\($p)"'
+```
+
+On the tutorial devstacks the `horizon-operator` release is owned by Flux (a
+`HelmRelease`), so set the values by patching its `spec.values` — not with a
+raw `helm upgrade`, which the Flux helm-controller reverts on its next
+reconcile. Substitute the CIDRs and ports from above:
+
+```bash
+kubectl patch helmrelease horizon-operator -n horizon-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"enabled":true,"kubeApiServer":{"cidrs":["10.96.0.1/32"],"ports":[6443]}}}}}'
+
+kubectl wait helmrelease/horizon-operator -n horizon-system \
+  --for=condition=Ready --timeout=5m
 ```
 
 The chart-level policy allows exactly what the operator needs: egress to the
@@ -52,6 +69,24 @@ the workload namespace; when the workload namespace itself runs a per-CR
 NetworkPolicy, the operator's namespace is admitted automatically by the
 sub-reconciler (an operator-namespace ingress peer is appended to every
 rendered policy).
+
+::: details Helm-managed installations (non-Flux)
+If you installed the operator directly with Helm (not through Flux), set the
+values with a rolling `helm upgrade` — remember the fail-closed guard requires
+`kubeApiServer.cidrs` and `ports`:
+
+```bash
+helm upgrade horizon-operator oci://ghcr.io/c5c3/charts/horizon-operator \
+  --namespace horizon-system --reuse-values \
+  --set networkPolicy.enabled=true \
+  --set 'networkPolicy.kubeApiServer.cidrs[0]=10.96.0.1/32' \
+  --set 'networkPolicy.kubeApiServer.ports[0]=6443'
+```
+
+Do **not** run this on the tutorial devstacks: there the release is
+Flux-owned, and the helm-controller reverts out-of-band revisions on its next
+reconcile. Use the HelmRelease patch above instead.
+:::
 
 ## Step 2 — Verify
 

--- a/docs/guides/enable-horizon-operator-networkpolicy.md
+++ b/docs/guides/enable-horizon-operator-networkpolicy.md
@@ -32,9 +32,21 @@ is running (namespace `horizon-system`) alongside the projected
 `controlplane-horizon` dashboard.
 :::
 
-1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy.** Confirm with
-   your platform team — kindnet (the kind default) does NOT enforce policies,
-   so on a kind cluster the object is created but has no effect.
+1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy — for real
+   enforcement.** Confirm with your platform team (Calico, Cilium, and Antrea
+   enforce).
+
+   ::: warning Enforcement cannot be verified on the default devstack CNI
+   The ControlPlane Quick Start kind devstack uses the default `kindnet` CNI,
+   which **silently ignores** NetworkPolicy objects, and kind fixes the CNI at
+   cluster creation so it cannot be swapped in afterwards. The policy object
+   is still created and the operator keeps reconciling, so Step 2 below
+   confirms only the policy's **shape** and that enabling it does **not
+   break** reconciliation — it does **not** prove that packets outside the
+   allow-list are dropped. Real enforcement requires a cluster whose CNI
+   enforces NetworkPolicy — typically your production platform, not the kind
+   devstack.
+   :::
 2. A running `horizon-operator` Helm release (namespace `horizon-system`).
 
 ## Step 1 — Enable the policy
@@ -89,6 +101,10 @@ reconcile. Use the HelmRelease patch above instead.
 :::
 
 ## Step 2 — Verify
+
+On the kind devstack this verifies the policy's **shape** and that enabling it
+does **not break** reconciliation — not traffic enforcement, which the default
+`kindnet` CNI does not apply (see the prerequisite above).
 
 ```bash
 kubectl -n horizon-system get networkpolicy

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -52,9 +52,12 @@ NetworkPolicy — see item 1 below to make the policy effective on kind.)
    kubectl auth can-i get endpoints/kubernetes -n default
    ```
 
-3. **Existing operator deployment managed by Helm.** If you installed the
-   operator via `hack/ci-deploy-operator.sh` or a raw manifest, first
-   migrate to Helm — this feature is gated by chart values.
+3. **Operator deployment whose chart values you can set.** This feature is
+   gated by chart values. On the tutorial devstacks the operator is a Flux
+   `HelmRelease`, so you set the values on its `spec.values` (section 3); a
+   directly Helm-managed install uses `helm upgrade`. If you installed the
+   operator via `hack/ci-deploy-operator.sh` or a raw manifest, first migrate
+   to one of those chart-value paths.
 
 ---
 
@@ -154,7 +157,31 @@ Optional overrides:
 
 ## 3. Roll out
 
-Apply the values change with a rolling `helm upgrade`:
+On the tutorial devstacks the `keystone-operator` release is owned by Flux (a
+`HelmRelease`), so apply the values change by patching that HelmRelease's
+`spec.values` — not with a raw `helm upgrade`, which the Flux helm-controller
+reverts on its next reconcile. Substitute the CIDRs and ports you gathered in
+step 1:
+
+```bash
+kubectl patch helmrelease keystone-operator -n keystone-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"enabled":true,"kubeApiServer":{"cidrs":["10.96.0.1/32"],"ports":[6443]}}}}}'
+
+kubectl wait helmrelease/keystone-operator -n keystone-system \
+  --for=condition=Ready --timeout=5m
+```
+
+The optional overrides from section 2 (`dns`, `allowMetricsFrom`,
+`webhookClients`) go into the same `spec.values.networkPolicy` patch — merge
+them into the JSON above.
+
+Flux reconciles the HelmRelease, which creates the `NetworkPolicy` object and
+rolls the operator Deployment. Existing reconciliations queue during the
+rollout and resume once the new pod reaches `Ready`.
+
+::: details Helm-managed installations (non-Flux)
+If you installed the operator directly with Helm (not through Flux), apply the
+`values.yaml` from section 2 with a rolling `helm upgrade` instead:
 
 ```bash
 helm upgrade keystone-operator oci://ghcr.io/c5c3/charts/keystone-operator \
@@ -163,9 +190,10 @@ helm upgrade keystone-operator oci://ghcr.io/c5c3/charts/keystone-operator \
   -f values.yaml
 ```
 
-The upgrade creates the `NetworkPolicy` object and rolls the operator
-Deployment. Existing reconciliations queue during the rollout and resume
-once the new pod reaches `Ready`.
+Do **not** run this on the tutorial devstacks: there the release is
+Flux-owned, and the helm-controller reverts out-of-band revisions on its next
+reconcile. Use the HelmRelease patch above instead.
+:::
 
 ---
 
@@ -318,9 +346,17 @@ opt-in via `networkPolicy.allowMetricsFrom`.
 ## Rolling back
 
 If enablement causes production regressions that cannot be resolved
-immediately, roll back by setting `networkPolicy.enabled=false` and
-re-running `helm upgrade`. The NetworkPolicy object is removed on the
-next reconcile and the operator reverts to unrestricted pod networking
+immediately, roll back by setting `networkPolicy.enabled=false`. On the Flux
+devstacks patch the HelmRelease:
+
+```bash
+kubectl patch helmrelease keystone-operator -n keystone-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"enabled":false}}}}'
+```
+
+(On a directly Helm-managed install, re-run `helm upgrade` with
+`networkPolicy.enabled=false` instead.) The NetworkPolicy object is removed on
+the next reconcile and the operator reverts to unrestricted pod networking
 without a pod restart.
 
 ---

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -30,20 +30,30 @@ KIND_HOST_PORT=8443 make deploy-infra
 ```
 
 Follow that tutorial through to its final **Verify** step, so the keystone-operator
-is running and a `keystone` CR is `Ready` in `openstack`. (kindnet does not enforce
-NetworkPolicy — see item 1 below to make the policy effective on kind.)
+is running and a `keystone` CR is `Ready` in `openstack`. (The devstack's default
+`kindnet` CNI does not enforce NetworkPolicy — item 1 below explains what you can
+and cannot verify on kind.)
 :::
 
-1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy.** Confirm with
-   your platform team. Common CNIs that enforce:
+1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy — for real
+   enforcement.** Confirm with your platform team. Common CNIs that enforce:
 
    - [Calico](https://docs.tigera.io/calico/latest/network-policy/policy-rules/kubernetes)
    - [Cilium](https://docs.cilium.io/en/stable/network/kubernetes/policy/)
    - [Antrea](https://antrea.io/docs/main/docs/network-policy/)
 
-   On kind, the default `kindnet` CNI does **not** enforce NetworkPolicy.
-   Install a supported CNI (Calico or Cilium) before proceeding — otherwise
-   the policy is rendered but has no effect.
+   ::: warning Enforcement cannot be verified on the default devstack CNI
+   The Quick Start kind devstack uses the default `kindnet` CNI, which
+   **silently ignores** NetworkPolicy objects. kind fixes the CNI at cluster
+   creation, so it cannot be swapped in afterwards on a running devstack. The
+   policy object is still rendered and the operator keeps reconciling
+   normally, so this guide's verification steps (§4.1–4.3) confirm only that
+   the policy has the right **shape** and that enabling it does **not break**
+   the operator — they do **not** prove that packets outside the allow-list
+   are dropped. Real enforcement requires a cluster whose CNI enforces
+   NetworkPolicy (Calico, Cilium, Antrea) — typically your production
+   platform, not the kind devstack.
+   :::
 
 2. **Permission to read the `kubernetes` default Service's endpoints** in
    order to discover the API server CIDR:
@@ -256,8 +266,11 @@ reaches `Ready=True`:
 chainsaw test tests/e2e/keystone-operator/network-policy-egress
 ```
 
-This should be green on any CI environment that provisions a kind cluster
-with a NetworkPolicy-enforcing CNI.
+Like the verification steps above, this suite runs on the default `kindnet`
+CI cluster, so it validates that the chart **renders** the policy and that
+the operator **reconciles to Ready** while the (unenforced) policy is present
+— it does **not** assert that blocked egress is actually dropped. Enforcement
+coverage would require a CI job with a NetworkPolicy-enforcing CNI.
 
 ---
 

--- a/docs/guides/end-to-end-sso.md
+++ b/docs/guides/end-to-end-sso.md
@@ -33,6 +33,27 @@ projected `controlplane-keystone` and `controlplane-horizon` children are
 running. Every resource name in the examples below is one that devstack produces.
 :::
 
+On the kind devstack, stand up the fixture IdP and LDAP directory this guide
+federates against. These are the same fixtures the two backend guides use, with
+the WebSSO gateway redirect URIs added for the token hand-off:
+
+```bash
+kubectl apply -f tests/e2e-controlplane-sso/00-keycloak.yaml \
+              -f tests/e2e-controlplane-sso/01-openldap.yaml
+kubectl -n openstack rollout status deploy/keycloak
+kubectl -n openstack rollout status deploy/openldap
+```
+
+::: tip Already applied the oidc-federation fixture?
+Keycloak imports its realms at pod start, so if you previously applied the
+`oidc-federation` guide's copy of the Keycloak fixture, re-apply the manifest
+above and restart the pod so the gateway redirect URIs are picked up:
+
+```bash
+kubectl -n openstack rollout restart deploy/keycloak
+```
+:::
+
 - [Attach an OIDC Federation Backend](./oidc-federation.md) — how to stand up the
   federation backend this guide projects onto the login page.
 - [Attach an LDAP Domain Backend](./ldap-domain-backend.md) — how to stand up the
@@ -134,10 +155,24 @@ spec:
     name: federated
   type: OIDC
   oidc:
-    issuer: https://keycloak.example.com/realms/corp
+    # Fixture-true values from the two-fixture apply in Prerequisites. Explicit
+    # endpoints are required because the operator's metadata-fetch SSRF guard
+    # blocks .well-known discovery against the in-cluster Keycloak — see
+    # [Attach an OIDC Federation Backend](./oidc-federation.md) Step 4 for the
+    # full worked example (mappings, groups, and why introspection is https).
+    issuer: http://keycloak.openstack.svc.cluster.local:8080/realms/forge
     clientID: keystone
     clientSecretRef:
-      name: keycloak-client
+      name: keycloak-forge-client
+    endpoints:
+      authorizationEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/auth
+      tokenEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/token
+      jwksURI: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/certs
+      userinfoEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/userinfo
+      introspectionEndpoint: https://keycloak.openstack.svc.cluster.local:8443/realms/forge/protocol/openid-connect/token/introspect
+    oauth2Introspection:
+      enabled: true
+      tlsVerify: false
 ```
 
 ::: tip The Default domain is off limits
@@ -184,6 +219,25 @@ Under the hood the dashboard redirects the browser to
 passing its own origin. Keystone authenticates you through the provider and
 POSTs a token back to that origin — but only if the origin appears in its
 trusted list, which is what Step 1 configured.
+
+::: warning The fixture IdP is not reachable from a host browser
+On the kind devstack the fixture Keycloak issuer is a cluster-internal Service
+name, so a browser on your workstation cannot complete the login form: it is
+redirected to `http://keycloak.openstack.svc.cluster.local:8080/...`, which the
+host cannot resolve. Clicking the SSO button through to a session needs an
+**externally reachable** IdP (your production Keycloak, or a fixture published
+through the gateway with matching redirect URIs and a host-resolvable issuer).
+The full WebSSO hand-off against the in-cluster fixture — including the
+Envoy-routed gateway redirect URIs this guide's fixtures register — is
+exercised headlessly by the mirroring e2e suite:
+
+```bash
+chainsaw test --test-dir tests/e2e-controlplane-sso
+```
+
+For a copy-pasteable devstack login that does not need a browser, use the CLI
+bearer flow in [Attach an OIDC Federation Backend](./oidc-federation.md#step-6-log-in-as-a-federated-user).
+:::
 
 ## Step 4 — Multi-domain login for LDAP users
 

--- a/docs/guides/ldap-domain-backend.md
+++ b/docs/guides/ldap-domain-backend.md
@@ -33,14 +33,38 @@ examples below is one that devstack produces.
 - A Keystone CR that reaches `Ready=True`; backends can be applied before the
   Keystone exists, but nothing is provisioned until its API is up.
 - An LDAP server reachable from the cluster, plus a bind DN allowed to
-  search the user/group trees.
+  search the user/group trees. On the kind devstack, Step 1 stands up the
+  seeded fixture directory; on other clusters, substitute your own directory.
 - **Service users stay SQL-backed.** The backend is read-only by default,
   so OpenStack service accounts (and the bootstrap admin) must remain in the
   SQL-backed `Default` domain — the CRD hard-rejects attaching a backend to
   `Default` for exactly this reason. Plan for humans in the LDAP domain and
   services in `Default`.
 
-## Step 1 — Create the bind credentials Secret
+## Step 1 — Deploy the seeded OpenLDAP fixture (kind devstack)
+
+On the kind devstack, stand up the same OpenLDAP directory the e2e suite uses.
+It is a plain namespace-pinned manifest, so `kubectl apply` runs it verbatim:
+
+```bash
+kubectl apply -f tests/e2e/keystone/ldap-domain-backend/00-openldap.yaml
+kubectl -n openstack rollout status deploy/openldap
+```
+
+This ships, all in the `openstack` namespace:
+
+- a seeded `dc=planetexpress,dc=com` tree (users under `ou=people` with
+  `objectClass: inetOrgPerson`, `uid`/`mail` attributes, and `userPassword`
+  equal to the `uid`);
+- a Service `openldap` on port `10389`
+  (`ldap://openldap.openstack.svc.cluster.local:10389`);
+- a bind-credentials Secret `openldap-bind` holding
+  `cn=admin,dc=planetexpress,dc=com` / `GoodNewsEveryone`.
+
+On a non-kind cluster, skip this step and point the CR (Step 3) at your own
+directory instead — every value below is one this fixture produces.
+
+## Step 2 — Create the bind credentials Secret
 
 The projection reads two fixed data keys: `username` (the bind DN) and
 `password`:
@@ -54,7 +78,14 @@ kubectl create secret generic corp-ldap-bind -n openstack \
 Rotating this Secret later re-renders the per-domain config automatically —
 the operator watches it.
 
-## Step 2 — Apply the backend CR
+::: tip On the kind devstack
+Step 1's fixture already ships an `openldap-bind` Secret with these exact
+credentials (it is the one the e2e suite's own backend CR binds through), so
+you can skip this `kubectl create` and set
+`bindCredentialsSecretRef.name: openldap-bind` in Step 3 instead.
+:::
+
+## Step 3 — Apply the backend CR
 
 ```yaml
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
@@ -96,7 +127,7 @@ For `ldaps://` endpoints, add certificate verification:
         name: corp-ldap-ca   # data key must be "ca.crt"
 ```
 
-## Step 3 — Watch the conditions converge
+## Step 4 — Watch the conditions converge
 
 ```bash
 kubectl get keystoneidentitybackends -n openstack
@@ -116,7 +147,7 @@ The domains Secret is content-hashed, so the attach rolls the Keystone
 Deployment once; subsequent reconciles are no-ops until the spec or the bind
 credentials change.
 
-## Step 4 — Verify an LDAP user can authenticate
+## Step 5 — Verify an LDAP user can authenticate
 
 ```bash
 # List the LDAP-backed users through the Keystone API (admin credentials):

--- a/docs/guides/oidc-federation.md
+++ b/docs/guides/oidc-federation.md
@@ -8,9 +8,9 @@ quadrant: operator
 This guide walks through federating a running Keystone with an OpenID
 Connect identity provider using the `KeystoneIdentityBackend` CRD: create
 the client-secret Secret, apply one CR, watch the conditions converge, and
-verify a federated user can log in. The worked example uses Keycloak — the
-same fixture the e2e suite deploys — so every value is adaptable to a kind
-cluster.
+verify a federated user can log in. The worked example uses the same Keycloak
+fixture the e2e suite deploys, and every value below is one that fixture
+produces — so the whole flow is reproducible on the kind devstack.
 
 When at least one OIDC backend attaches, the operator injects an
 Apache/`mod_auth_openidc` reverse-proxy sidecar into the Keystone pod, binds
@@ -62,12 +62,39 @@ is operator-managed.
   users; OpenStack service accounts and the bootstrap admin remain in the
   SQL-backed `Default` domain, which the CRD hard-rejects federating.
 
-## Step 1 — Register the client at the identity provider
+## Step 1 — Deploy the fixture IdP (kind devstack)
 
-In Keycloak: create (or pick) a realm — say `forge` — and add a confidential
-client `keystone` with *Standard flow* enabled and a client secret. Note the
-realm's issuer URL (`https://keycloak.example.com/realms/forge`); it must
-match the `iss` claim the IdP asserts, byte for byte.
+On the kind devstack, stand up the same Keycloak the e2e suite uses. It is a
+plain namespace-pinned manifest, so `kubectl apply` runs it verbatim:
+
+```bash
+kubectl apply -f tests/e2e/keystone/oidc-federation/00-keycloak.yaml
+kubectl -n openstack rollout status deploy/keycloak
+```
+
+This provides, all in the `openstack` namespace:
+
+| What | Value |
+| --- | --- |
+| Realm | `forge` |
+| Issuer | `http://keycloak.openstack.svc.cluster.local:8080/realms/forge` |
+| Confidential client | `keystone` (direct access grants + standard flow enabled) |
+| Client secret | `keystone-forge-secret` (also shipped as Secret `keycloak-forge-client`) |
+| Test user | `fry` / `fry-password` (group `/engineers`) |
+| Keycloak admin | `admin` / `admin-password` |
+
+The fixture pins `KC_HOSTNAME` to the cluster-internal issuer above, so tokens
+carry a stable `iss` regardless of how you reach the pod. It also serves an
+https listener on `8443` with a throwaway self-signed cert for the
+introspection endpoint (mod_auth_openidc requires https there).
+
+::: details Registering a client at your own IdP (non-kind)
+On a non-kind cluster, skip the fixture and use your own Keycloak (or any OIDC
+IdP): create (or pick) a realm, add a **confidential** client `keystone` with
+*Standard flow* enabled and a client secret, and note the realm's issuer URL —
+it must match the `iss` claim the IdP asserts, byte for byte. Substitute your
+issuer, endpoints, and client secret for the fixture values below.
+:::
 
 ## Step 2 — Create the client-secret Secret
 
@@ -80,6 +107,12 @@ kubectl create secret generic keycloak-forge-client -n openstack \
 
 Rotating this Secret later re-renders the federation configuration
 automatically — the operator watches it.
+
+::: tip On the kind devstack
+Step 1's fixture already ships the `keycloak-forge-client` Secret with the
+fixed `clientSecret: keystone-forge-secret` key, so you can skip this
+`kubectl create` — the backend CR in Step 4 references it as-is.
+:::
 
 ## Step 3 — Pin the federation proxy image (optional)
 
@@ -130,17 +163,32 @@ spec:
     deletionPolicy: Retain # keep the domain when this CR is deleted
   type: OIDC
   oidc:
-    issuer: https://keycloak.example.com/realms/forge
+    issuer: http://keycloak.openstack.svc.cluster.local:8080/realms/forge
     clientID: keystone
     clientSecretRef:
       name: keycloak-forge-client
+    # Explicit endpoints are required against the fixture: the operator's
+    # metadata-fetch SSRF guard blocks discovery against the in-cluster
+    # Keycloak's private ClusterIP, so the .well-known auto-discovery
+    # (bare `issuer:` alone) does not run here. Everything speaks the fixture's
+    # plain-http :8080 listener EXCEPT introspection, which mod_auth_openidc
+    # requires to be https — the fixture serves it on the self-signed :8443
+    # listener, and tlsVerify opts out of verifying that throwaway cert.
+    # A publicly resolvable IdP can drop this block and rely on discovery.
+    endpoints:
+      authorizationEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/auth
+      tokenEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/token
+      jwksURI: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/certs
+      userinfoEndpoint: http://keycloak.openstack.svc.cluster.local:8080/realms/forge/protocol/openid-connect/userinfo
+      introspectionEndpoint: https://keycloak.openstack.svc.cluster.local:8443/realms/forge/protocol/openid-connect/token/introspect
     oauth2Introspection:
       enabled: true        # CLI clients may present IdP-issued bearer tokens
+      tlsVerify: false     # the fixture's :8443 cert is a throwaway self-signed cert
   mappings:
   - remote:
     - type: HTTP_OIDC_ISS
       anyOneOf:
-      - https://keycloak.example.com/realms/forge
+      - http://keycloak.openstack.svc.cluster.local:8080/realms/forge
     - type: HTTP_OIDC_PREFERRED_USERNAME
     local:
     - user:
@@ -207,7 +255,45 @@ unchanged.
 
 ## Step 6 — Log in as a federated user
 
-Browser (WebSSO): navigate to
+### CLI (bearer token) — reproducible on the kind devstack
+
+This flow needs `oauth2Introspection` enabled on exactly one backend (Step 4
+sets it). The fixture's `keystone` client has direct-access-grants enabled, so
+you can mint a token with a username/password and exchange it — no browser
+required. Port-forward Keycloak and obtain an access token:
+
+```bash
+kubectl -n openstack port-forward svc/keycloak 8080:8080 &
+
+TOKEN=$(curl -s http://localhost:8080/realms/forge/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=keystone \
+  -d client_secret=keystone-forge-secret \
+  -d username=fry -d password=fry-password \
+  -d scope=openid | jq -r .access_token)
+```
+
+`KC_HOSTNAME` pins the realm issuer to
+`http://keycloak.openstack.svc.cluster.local:8080/realms/forge`, so a token
+minted through the port-forward still carries the cluster-internal `iss` the
+in-cluster proxy expects. Exchange the bearer for an unscoped Keystone token
+against the devstack's published Keystone endpoint (`-k` for the devstack's
+self-signed gateway cert, matching the Quick Start):
+
+```bash
+# The proxy introspects the bearer (in-cluster, over :8443) and keystone maps
+# it to an unscoped token:
+curl -sik -H "Authorization: Bearer $TOKEN" \
+  "https://keystone.127-0-0-1.nip.io:8443/v3/OS-FEDERATION/identity_providers/keycloak-forge/protocols/openid/auth" \
+  | grep -i x-subject-token
+```
+
+The unscoped token exchanges for a domain- or project-scoped one through the
+regular `POST /v3/auth/tokens` — authorized by the roles the mapped group
+carries.
+
+### Browser (WebSSO)
+
+Navigate to
 
 ```
 <keystone endpoint base>/v3/auth/OS-FEDERATION/identity_providers/keycloak-forge/protocols/openid/websso?origin=<dashboard origin>
@@ -223,24 +309,16 @@ not set it by hand; see [End-to-End SSO](./end-to-end-sso.md). On a standalone
 Keystone, set `spec.federation.trustedDashboards` directly (see the
 [Standalone Keystone](#standalone-keystone-without-a-controlplane) section).
 
-CLI (bearer token, needs `oauth2Introspection` enabled on exactly one
-backend): obtain an access token from the IdP, then exchange it:
-
-```bash
-TOKEN=$(curl -s https://keycloak.example.com/realms/forge/protocol/openid-connect/token \
-  -d grant_type=password -d client_id=keystone \
-  -d client_secret=<secret> -d username=<user> -d password=<pw> \
-  -d scope=openid | jq -r .access_token)
-
-# The proxy introspects the bearer and keystone maps it to an unscoped token:
-curl -si -H "Authorization: Bearer $TOKEN" \
-  "<keystone endpoint base>/v3/OS-FEDERATION/identity_providers/keycloak-forge/protocols/openid/auth" \
-  | grep -i x-subject-token
-```
-
-The unscoped token exchanges for a domain- or project-scoped one through the
-regular `POST /v3/auth/tokens` — authorized by the roles the mapped group
-carries.
+::: warning The fixture IdP is not reachable from a host browser
+The fixture Keycloak issuer is a cluster-internal Service name, so a browser on
+your workstation cannot complete the login form against it — the browser
+WebSSO flow needs an **externally reachable** IdP (your production Keycloak, or
+a fixture published through the gateway with matching redirect URIs). The
+headless authorization-code round trip against the in-cluster fixture is
+exercised end-to-end by the mirroring e2e suite
+(`tests/e2e/keystone/oidc-federation/`); the CLI bearer flow above is the
+copy-pasteable devstack path.
+:::
 
 ## Multiple identity providers
 

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -233,6 +233,7 @@ headlamp-system       headlamp-*             Starting (kind-only demo UI, not wa
 monitoring            kube-prometheus-stack-prometheus-*   Ready (kind-only; WITH_PROMETHEUS=true; see Step 4c)
 monitoring            kube-prometheus-stack-grafana-*      Ready (kind-only; WITH_PROMETHEUS=true; see Step 4c)
 monitoring            kube-prometheus-stack-operator-*     Ready (kind-only; WITH_PROMETHEUS=true; see Step 4c)
+kube-system           metrics-server-*                     Ready (kind-only; WITH_METRICS_SERVER=true)
 ```
 
 Headlamp is deployed asynchronously and is **not** part of the `deploy-infra` wait list — a
@@ -291,6 +292,25 @@ keystone-operator HelmRelease to enable its `ServiceMonitor`. Use it when you
 want to visualise the keystone-operator metrics live (reconcile p95,
 error rate) — see [Step 4c — Open the Grafana UI](#step-4c-grafana-ui) for the
 port-forward and the bundled `Keystone Operator` dashboard.
+:::
+
+::: tip Enabling metrics-server
+`metrics-server` is **not installed by default** in the kind Quick Start. The
+default `make deploy-infra` flow leaves the `kube-system` metrics-server absent
+so first-run deployments stay lean. Production overlays (`deploy/flux-system/`)
+also omit it — managed distributions ship their own.
+
+Opt in by setting `WITH_METRICS_SERVER=true` before `make deploy-infra`:
+
+```bash
+WITH_METRICS_SERVER=true make deploy-infra
+```
+
+This applies the kind-only overlay at `deploy/kind/metrics-server/` and waits
+for the `metrics-server` HelmRelease to become Ready. It is the prerequisite
+for the [Autoscaling (HPA) recipe](./guides/advanced-configuration.md#autoscaling-hpa):
+without it the generated HorizontalPodAutoscaler reports `unknown/80%` and never
+scales.
 :::
 
 ::: tip Enabling the local registry pull-through cache

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -736,7 +736,8 @@ of the operator metrics endpoint.
 The `setup-e2e-infra` composite action is invoked with `WITH_PROMETHEUS: "true"`
 in its step `env`, which threads through to `hack/deploy-infra.sh` and gates the
 `kube-prometheus-stack` overlay (`deploy/kind/prometheus/`) plus the
-post-deploy `enable_keystone_operator_servicemonitor` patch. The Deploy
+post-deploy `enable_operator_servicemonitor` patch (applied to both the
+keystone-operator and horizon-operator HelmReleases). The Deploy
 operator step runs `hack/ci-deploy-operator.sh` with `WITH_PROMETHEUS: "true"`
 in its step `env`, which adds `--set monitoring.serviceMonitor.enabled=true`
 to the Helm install command — without this flag the chart's gated

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -1215,3 +1215,60 @@ under `deploy/kind/prometheus/` so the production kustomization root is
 untouched. The
 [`document-intentional-environment-divergence-in-overlays`](https://github.com/c5c3/forge/blob/main/.planwerk/review_patterns/document-intentional-environment-divergence-in-overlays.md)
 review pattern catalogues the full surface area.
+
+### metrics-server (kind-only opt-in)
+
+**File:** `deploy/kind/metrics-server/kustomization.yaml`
+
+[`metrics-server`](https://github.com/kubernetes-sigs/metrics-server) ships as
+a separate **opt-in** kind overlay. The default `make deploy-infra` flow does
+**not** install it — the `kube-system` metrics-server stays absent so the
+default Quick Start does not spend the kind node's budget on a component most
+tutorials do not need. The production `deploy/flux-system/` overlay also does
+not install it: managed distributions ship their own metrics-server, and
+production clusters bring their own.
+
+The overlay's sole consumer is the
+[Autoscaling (HPA) recipe](../../guides/advanced-configuration.md#autoscaling-hpa):
+the operator-generated `HorizontalPodAutoscaler` reads CPU/memory utilisation
+from the resource-metrics API, and without a metrics-server it reports
+`unknown/80%` and never scales.
+
+The overlay is self-contained: the `HelmRepository` and `HelmRelease` live in
+`deploy/kind/metrics-server/source.yaml` and
+`deploy/kind/metrics-server/release.yaml`. Unlike the chaos-mesh and
+kube-prometheus-stack overlays it ships **no** `Namespace` — the chart defaults
+to `priorityClassName: system-cluster-critical`, which only resolves in the
+pre-existing `kube-system` Namespace, so the HelmRelease targets `kube-system`
+directly.
+
+| Property | Value |
+| --- | --- |
+| Target namespace | `kube-system` (pre-existing; no inline Namespace) |
+| Chart | `metrics-server` |
+| Version constraint | `>=3.12.0 <4.0.0` |
+| Source | `metrics-server` HelmRepository (`https://kubernetes-sigs.github.io/metrics-server/`) |
+| Dependencies | none |
+
+**Kind-tuned values:**
+
+| Helm value | Override | Purpose |
+| --- | --- | --- |
+| `args` | `["--kubelet-insecure-tls"]` | kind's kubelets serve `/metrics/resource` with a self-signed certificate metrics-server cannot verify against the cluster CA; skipping verification lets scrapes succeed. This replaces the runtime `kubectl patch` the autoscaling recipe previously documented — never set it on a production cluster with properly issued kubelet certificates |
+
+When `WITH_METRICS_SERVER=true`, `hack/deploy-infra.sh` runs
+`kubectl apply -k deploy/kind/metrics-server` in Step 3 and appends
+`metrics-server` to the Phase 3 HelmRelease wait list. Both actions are gated
+strictly on the flag; the chart values are never modified, which keeps the
+production posture unchanged.
+
+**Opt-in usage:**
+
+```bash
+WITH_METRICS_SERVER=true make deploy-infra
+```
+
+**Posture summary.** Same shape as the two entries above: the production
+omission is explicit, the opt-in flag has a single documented name
+(`WITH_METRICS_SERVER`), and the kind overlay is self-contained under
+`deploy/kind/metrics-server/` so the production kustomization root is untouched.

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -765,20 +765,21 @@ load_chaos_mesh_kernel_modules() {
 }
 
 # ---------------------------------------------------------------------------
-# enable_keystone_operator_servicemonitor — Toggle the operator chart's
-# `monitoring.serviceMonitor.enabled` value to true so the kube-prometheus-stack
-# Prometheus instance can scrape the operator metrics endpoint via the
-# rendered ServiceMonitor (/).
+# enable_operator_servicemonitor RELEASE NAMESPACE [TIMEOUT] — Toggle the given
+# operator chart's `monitoring.serviceMonitor.enabled` value to true so the
+# kube-prometheus-stack Prometheus instance can scrape the operator metrics
+# endpoint via the rendered ServiceMonitor. Used for both keystone-operator
+# (keystone-system) and horizon-operator (horizon-system).
 #
 # Callable only when WITH_PROMETHEUS=true. Patches spec.values via
 # strategic-merge so any other values set on the HelmRelease (including the
 # kind-base suspend patch) are preserved.
 #
 # DECISION: handle suspended HelmRelease in kind
-# Ambiguity: deploy/kind/base/kustomization.yaml suspends the keystone-operator
-#   HelmRelease (lines 87-106) so CI can `helm install` it manually with a
-#   locally built image. A suspended HelmRelease never reconciles, so a
-#   wait-for-Ready against it would always time out.
+# Ambiguity: deploy/kind/base/kustomization.yaml suspends the operator
+#   HelmReleases so CI can `helm install` them manually with a locally built
+#   image (and the ControlPlane path un-suspends them). A suspended HelmRelease
+#   never reconciles, so a wait-for-Ready against it would always time out.
 # Chose: patch spec.values regardless of suspend state, then read the current
 #   spec.suspend; skip the wait when suspended (logging the rationale) and
 #   wait for Ready otherwise. The patch remains durable: when ci-deploy-
@@ -789,25 +790,27 @@ load_chaos_mesh_kernel_modules() {
 #   keeping the kind path green; the suspend semantics are owned by Flux, not
 #   by this script.
 # ---------------------------------------------------------------------------
-enable_keystone_operator_servicemonitor() {
-  local timeout="${1:-${HELMRELEASE_TIMEOUT}}"
+enable_operator_servicemonitor() {
+  local release="$1"
+  local namespace="$2"
+  local timeout="${3:-${HELMRELEASE_TIMEOUT}}"
 
-  log "Enabling keystone-operator ServiceMonitor..."
-  kubectl patch helmrelease keystone-operator -n keystone-system --type=merge \
+  log "Enabling ${release} ServiceMonitor..."
+  kubectl patch helmrelease "${release}" -n "${namespace}" --type=merge \
     -p '{"spec":{"values":{"monitoring":{"serviceMonitor":{"enabled":true}}}}}'
 
   local suspended
-  suspended=$(kubectl get helmrelease keystone-operator -n keystone-system \
+  suspended=$(kubectl get helmrelease "${release}" -n "${namespace}" \
     -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
   if [[ "${suspended}" == "true" ]]; then
-    log "keystone-operator HelmRelease is suspended (kind base patch); skipping reconcile wait."
+    log "${release} HelmRelease is suspended (kind base patch); skipping reconcile wait."
     log "  spec.values patch is durable — re-enable Flux management or run ci-deploy-operator.sh"
     log "  with monitoring.serviceMonitor.enabled=true to render the ServiceMonitor."
     return 0
   fi
 
-  wait_for_helmreleases "${timeout}" keystone-operator
-  log "keystone-operator HelmRelease reconciled with monitoring.serviceMonitor.enabled=true."
+  wait_for_helmreleases "${timeout}" "${release}"
+  log "${release} HelmRelease reconciled with monitoring.serviceMonitor.enabled=true."
 }
 
 # ---------------------------------------------------------------------------
@@ -1681,12 +1684,17 @@ main() {
   fi
   wait_for_helmreleases "${release_wait_timeout}" "${helm_releases[@]}"
 
-  # with kube-prometheus-stack Ready, flip the operator
-  # chart's monitoring.serviceMonitor.enabled to true so Prometheus picks up
-  # the metrics target. Runs only when WITH_PROMETHEUS=true to keep the
-  # default Quick Start free of monitoring-coreos-com CRD lookups.
+  # with kube-prometheus-stack Ready, flip both operator charts'
+  # monitoring.serviceMonitor.enabled to true so Prometheus picks up the
+  # metrics targets. Runs only when WITH_PROMETHEUS=true to keep the default
+  # Quick Start free of monitoring-coreos-com CRD lookups. The horizon-operator
+  # HelmRelease exists on every path: suspended on the default kind base
+  # (durable-but-inert patch + skipped wait) and un-suspended under
+  # WITH_CONTROLPLANE (patch + Ready wait), which is what makes the horizon
+  # metrics guide's kind tip true.
   if [[ "${WITH_PROMETHEUS}" == "true" ]]; then
-    enable_keystone_operator_servicemonitor "${HELMRELEASE_TIMEOUT}"
+    enable_operator_servicemonitor keystone-operator keystone-system "${HELMRELEASE_TIMEOUT}"
+    enable_operator_servicemonitor horizon-operator horizon-system "${HELMRELEASE_TIMEOUT}"
   fi
 
   # Step 5: Apply infrastructure kustomize overlay (CRD-dependent resources)

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -85,6 +85,13 @@ WITH_CHAOS_MESH="${WITH_CHAOS_MESH:-false}"
 # WITH_PROMETHEUS=true to install the monitoring stack.
 WITH_PROMETHEUS="${WITH_PROMETHEUS:-false}"
 
+# Gates the opt-in metrics-server kind overlay (deploy/kind/metrics-server)
+# required by the HPA/autoscaling recipe: without a resource-metrics API the
+# generated HorizontalPodAutoscaler reports `unknown/80%` and never scales.
+# Defaults to false so the kind Quick Start stays minimal; set
+# WITH_METRICS_SERVER=true to install it.
+WITH_METRICS_SERVER="${WITH_METRICS_SERVER:-false}"
+
 # Gates the opt-in transparent registry pull-through cache (#564). When true,
 # deploy-infra brings up one small distribution-registry (registry:2/3) proxy
 # per upstream registry on the `kind` Docker network (start_registry_cache),
@@ -1382,6 +1389,7 @@ main() {
   log "Node RLIMIT_NOFILE  : ${NODE_NOFILE_LIMIT:-<unset — skip cap>} (override via NODE_NOFILE_LIMIT)"
   log "Chaos Mesh         : ${WITH_CHAOS_MESH} (set WITH_CHAOS_MESH=true to install)"
   log "Prometheus stack    : ${WITH_PROMETHEUS} (set WITH_PROMETHEUS=true to install)"
+  log "metrics-server      : ${WITH_METRICS_SERVER} (set WITH_METRICS_SERVER=true to install)"
   log "Registry cache      : ${WITH_REGISTRY_CACHE} (set WITH_REGISTRY_CACHE=true for a local pull-through cache; local-dev only)"
   log "ControlPlane stack  : ${WITH_CONTROLPLANE} (set WITH_CONTROLPLANE=true to provision infra via the c5c3 ControlPlane)"
   if [[ "${WITH_CONTROLPLANE}" == "true" ]]; then
@@ -1536,6 +1544,18 @@ main() {
     log "Prometheus kind overlay applied (WITH_PROMETHEUS=true)."
   fi
 
+  # Opt-in metrics-server overlay. Layered on top of the base so the default
+  # Quick Start stays minimal; enable with WITH_METRICS_SERVER=true. The
+  # overlay is self-contained (no `../../` parent-dir references), so kubectl's
+  # embedded kustomize renders it under the default LoadRestrictionsRootOnly
+  # security check — same contract as the chaos-mesh and prometheus overlays
+  # (no `--load-restrictor` flag required, kubernetes/kubectl#948). It installs
+  # the resource-metrics API the autoscaling recipe's HPA depends on.
+  if [[ "${WITH_METRICS_SERVER}" == "true" ]]; then
+    kubectl apply -k "${REPO_ROOT}/deploy/kind/metrics-server"
+    log "metrics-server kind overlay applied (WITH_METRICS_SERVER=true)."
+  fi
+
   # the c5c3 ControlPlane stack (c5c3-operator + image and the K-ORC
   # GitRepository/Kustomization) is published and valid, so it would reconcile —
   # but running the full chain is opt-in. WITH_CONTROLPLANE=true deploys it; the
@@ -1653,6 +1673,11 @@ main() {
     if [[ "${release_wait_timeout}" -lt 1200 ]]; then
       release_wait_timeout=1200
     fi
+  fi
+  # metrics-server is appended last (after chaos-mesh and kube-prometheus-stack)
+  # so the relative ordering of the seven base releases is preserved exactly.
+  if [[ "${WITH_METRICS_SERVER}" == "true" ]]; then
+    helm_releases+=(metrics-server)
   fi
   wait_for_helmreleases "${release_wait_timeout}" "${helm_releases[@]}"
 

--- a/tests/e2e/infrastructure/no-metrics-server-when-disabled/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/no-metrics-server-when-disabled/chainsaw-test.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test pinning the default-state non-regression invariant for the
+# metrics-server kind opt-in: when WITH_METRICS_SERVER is unset (or set to
+# anything other than the literal string "true"), `make deploy-infra` MUST NOT
+# install the metrics-server HelmRepository, HelmRelease, or Deployment.
+#
+# Why this test exists
+#   The shell unit tests
+#   (tests/unit/hack/deploy_infra_metrics_server_flag_test.sh,
+#   tests/unit/deploy/metrics_server_overlay_test.sh) exercise the gating logic
+#   and overlay render at the source level. Neither positively asserts "default
+#   cluster has no metrics-server footprint", so a regression that accidentally
+#   installs it (a stray `kubectl apply -k deploy/kind/metrics-server` outside
+#   the WITH_METRICS_SERVER gate, or a future kustomize merge that pulls the
+#   overlay into the base) would slip through. This suite closes that gap by
+#   asserting absence end-to-end against the running cluster, mirroring the
+#   sibling no-prometheus-when-disabled suite.
+#
+# Lane wiring:
+#   This test runs in the default e2e-infra lane (which exercises
+#   `make deploy-infra` without WITH_METRICS_SERVER), so the absence
+#   assertions hold. There is no CI lane that opts the flag on today, so this
+#   negative gate is the primary end-to-end coverage of the default posture.
+#
+# Scope gating — none. This absence invariant is also true on production
+# overlays (deploy/flux-system/ does not install metrics-server), so the test
+# is environment-agnostic like no-prometheus-when-disabled.
+#
+# Why a single script and not declarative `error` blocks: asserting "no
+# HelmRelease named metrics-server in any namespace" requires a
+# list-and-filter, which is more naturally expressed in shell. Consolidating
+# into one script also keeps the catch-block dump aligned with the assertion
+# sequence.
+#
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: no-metrics-server-when-disabled
+spec:
+  # Three kubectl gets (helmrepository, helmrelease list, deployment) plus a
+  # diagnostic dump on failure. Realistic worst case is sub-second; budget 2m
+  # for cluster slowness margin.
+  timeouts:
+    assert: 2m
+    exec: 2m
+  steps:
+  - try:
+    - script:
+        timeout: 2m
+        # Chainsaw defaults to `sh`, which rejects `set -o pipefail`. Pin bash
+        # to match the rest of the infra/keystone e2e scripts.
+        shell: bash
+        content: |
+          set -euo pipefail
+
+          # ── Assertion 1: no metrics-server HelmRepository in flux-system ──
+          # The only producer is deploy/kind/metrics-server/source.yaml, applied
+          # solely inside the WITH_METRICS_SERVER=true gate.
+          if kubectl get helmrepository.source.toolkit.fluxcd.io metrics-server \
+                -n flux-system >/dev/null 2>&1; then
+            echo "FAIL: HelmRepository 'metrics-server' exists in 'flux-system' on a default cluster."
+            echo "      Source of regression: hack/deploy-infra.sh ran the metrics-server"
+            echo "      overlay apply outside the WITH_METRICS_SERVER gate, or the overlay was"
+            echo "      pulled into deploy/kind/base."
+            exit 1
+          fi
+          echo "OK: no HelmRepository 'metrics-server' in 'flux-system'"
+
+          # ── Assertion 2: no metrics-server HelmRelease anywhere ──
+          # `kubectl get -A -o name` returns 0 even when the list is empty; we
+          # count lines rather than relying on exit codes.
+          hr_count=$(kubectl get helmrelease.helm.toolkit.fluxcd.io --all-namespaces \
+            --field-selector=metadata.name=metrics-server \
+            -o name 2>/dev/null | wc -l | tr -d '[:space:]')
+          if [ "${hr_count}" != "0" ]; then
+            echo "FAIL: HelmRelease 'metrics-server' exists (count=${hr_count}) on a default cluster."
+            kubectl get helmrelease.helm.toolkit.fluxcd.io --all-namespaces \
+              --field-selector=metadata.name=metrics-server -o wide 2>&1 || true
+            exit 1
+          fi
+          echo "OK: no HelmRelease 'metrics-server' exists"
+
+          # ── Assertion 3: no metrics-server Deployment in kube-system ──
+          # The chart installs its Deployment into kube-system; its absence is
+          # the default steady state.
+          if kubectl get deployment metrics-server -n kube-system >/dev/null 2>&1; then
+            echo "FAIL: Deployment 'metrics-server' exists in 'kube-system' on a default cluster."
+            echo "      Source of regression: the metrics-server overlay was applied"
+            echo "      without WITH_METRICS_SERVER=true."
+            exit 1
+          fi
+          echo "OK: no Deployment 'metrics-server' in 'kube-system'"
+
+          echo "PASS: default kind deploy footprint matches the WITH_METRICS_SERVER=false contract."
+    catch:
+    # On failure, dump the cluster's metrics-server footprint for triage. Each
+    # block is independently scoped so a missing resource does not
+    # short-circuit the rest of the dump.
+    - script:
+        content: |
+          echo "=== HelmRepositories named metrics-server (flux-system) ==="
+          kubectl get helmrepository.source.toolkit.fluxcd.io -n flux-system \
+            --field-selector=metadata.name=metrics-server -o wide 2>&1 || true
+          echo "=== HelmReleases named metrics-server (any namespace) ==="
+          kubectl get helmrelease.helm.toolkit.fluxcd.io --all-namespaces \
+            --field-selector=metadata.name=metrics-server -o wide 2>&1 || true
+          echo "=== Deployments named metrics-server (kube-system) ==="
+          kubectl get deployment metrics-server -n kube-system -o wide 2>&1 || true

--- a/tests/e2e/infrastructure/no-prometheus-when-disabled/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/no-prometheus-when-disabled/chainsaw-test.yaml
@@ -6,7 +6,9 @@
 # kind opt-in: when WITH_PROMETHEUS is unset (or set to anything
 # other than the literal string "true"), `make deploy-infra` MUST NOT install
 # the kube-prometheus-stack HelmRelease or render a
-# `ServiceMonitor/keystone-operator` in `keystone-system` (the operator's dedicated Namespace).
+# `ServiceMonitor/keystone-operator` in `keystone-system` or a
+# `ServiceMonitor/horizon-operator` in `horizon-system` (the operators'
+# dedicated Namespaces).
 #
 # Why this test exists
 #   The shell unit test (tests/unit/hack/deploy_infra_prometheus_flag_test.sh)
@@ -107,10 +109,10 @@ spec:
           echo "OK: no HelmRelease 'kube-prometheus-stack' exists"
 
           # ── Assertion 3: no ServiceMonitor/keystone-operator in keystone-system ──
-          # The deploy script's enable_keystone_operator_servicemonitor
-          # helper patches monitoring.serviceMonitor.enabled=true only inside
-          # the WITH_PROMETHEUS=true gate. On a default cluster the
-          # rendered chart's monitoring.serviceMonitor.enabled stays false
+          # The deploy script's enable_operator_servicemonitor helper patches
+          # monitoring.serviceMonitor.enabled=true only inside the
+          # WITH_PROMETHEUS=true gate. On a default cluster the rendered chart's
+          # monitoring.serviceMonitor.enabled stays false
           # (chart default at operators/keystone/helm/keystone-operator/values.yaml),
           # so the ServiceMonitor must not exist.
           # Post-, the keystone-operator HelmRelease lives in
@@ -121,12 +123,29 @@ spec:
                 -n keystone-system >/dev/null 2>&1; then
             echo "FAIL: ServiceMonitor/keystone-operator exists in 'keystone-system' on a default cluster."
             echo "      Source of regression: hack/deploy-infra.sh ran"
-            echo "      enable_keystone_operator_servicemonitor outside the WITH_PROMETHEUS gate,"
+            echo "      enable_operator_servicemonitor outside the WITH_PROMETHEUS gate,"
             echo "      or the keystone-operator chart default monitoring.serviceMonitor.enabled"
             echo "      flipped to true."
             exit 1
           fi
           echo "OK: no ServiceMonitor/keystone-operator in 'keystone-system'"
+
+          # ── Assertion 4: no ServiceMonitor/horizon-operator in horizon-system ──
+          # enable_operator_servicemonitor also flips the horizon-operator
+          # ServiceMonitor under the WITH_PROMETHEUS gate, so on a default
+          # cluster the horizon-operator ServiceMonitor must be absent too. On
+          # the default kind base the horizon-operator HelmRelease is suspended,
+          # so this also guards against a stray patch or a chart-default flip.
+          if kubectl get servicemonitor.monitoring.coreos.com horizon-operator \
+                -n horizon-system >/dev/null 2>&1; then
+            echo "FAIL: ServiceMonitor/horizon-operator exists in 'horizon-system' on a default cluster."
+            echo "      Source of regression: hack/deploy-infra.sh ran"
+            echo "      enable_operator_servicemonitor outside the WITH_PROMETHEUS gate,"
+            echo "      or the horizon-operator chart default monitoring.serviceMonitor.enabled"
+            echo "      flipped to true."
+            exit 1
+          fi
+          echo "OK: no ServiceMonitor/horizon-operator in 'horizon-system'"
 
           echo "PASS: default kind deploy footprint matches the WITH_PROMETHEUS=false contract."
     catch:
@@ -142,6 +161,11 @@ spec:
             --field-selector=metadata.name=kube-prometheus-stack -o wide 2>&1 || true
           echo "=== ServiceMonitors in keystone-system ==="
           kubectl get servicemonitor.monitoring.coreos.com -n keystone-system -o wide 2>&1 || true
+          echo "=== ServiceMonitors in horizon-system ==="
+          kubectl get servicemonitor.monitoring.coreos.com -n horizon-system -o wide 2>&1 || true
           echo "=== keystone-operator HelmRelease values (effective) ==="
           kubectl get helmrelease.helm.toolkit.fluxcd.io keystone-operator -n keystone-system \
+            -o jsonpath='{.spec.values}' 2>&1 || true
+          echo "=== horizon-operator HelmRelease values (effective) ==="
+          kubectl get helmrelease.helm.toolkit.fluxcd.io horizon-operator -n horizon-system \
             -o jsonpath='{.spec.values}' 2>&1 || true

--- a/tests/unit/deploy/metrics_server_overlay_test.sh
+++ b/tests/unit/deploy/metrics_server_overlay_test.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the metrics-server opt-in overlay:
+#   - deploy/kind/metrics-server/{kustomization,source,release}.yaml exist
+#     with SPDX headers, the kustomization references the local
+#     source/release files (no parent-directory paths), and the overlay does
+#     NOT create a Namespace (the chart installs into the pre-existing
+#     kube-system Namespace).
+#   - kustomize build of the overlay renders the expected document set under
+#     the default LoadRestrictionsRootOnly security check (no
+#     --load-restrictor flag): HelmRepository/metrics-server in flux-system at
+#     the upstream chart index, and HelmRelease/metrics-server in kube-system
+#     whose chart version stays within major 3 and whose values carry
+#     `--kubelet-insecure-tls`.
+#   - kustomize build of deploy/flux-system and deploy/kind/base renders ZERO
+#     metrics-server resources (production / default posture).
+# Usage: bash tests/unit/deploy/metrics_server_overlay_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+FLUX_SYSTEM_DIR="$PROJECT_ROOT/deploy/flux-system"
+KIND_BASE_DIR="$PROJECT_ROOT/deploy/kind/base"
+KIND_MS_DIR="$PROJECT_ROOT/deploy/kind/metrics-server"
+KIND_MS_KUSTOMIZATION="$KIND_MS_DIR/kustomization.yaml"
+KIND_MS_SOURCE="$KIND_MS_DIR/source.yaml"
+KIND_MS_RELEASE="$KIND_MS_DIR/release.yaml"
+
+# Count resources of a given kind named metrics-server in a rendered stream.
+# Reads the stream on stdin; prints the match count.
+count_metrics_server_resources() {
+  local kind="$1"
+  awk -v want="$kind" '
+      /^---$/ { k=""; }
+      $0 ~ "^kind:[[:space:]]+" want "[[:space:]]*$" { k=want }
+      /^[[:space:]]*name:[[:space:]]+metrics-server[[:space:]]*$/ {
+        if (k == want) { print; k="" }
+      }
+    ' | wc -l
+}
+
+# --- Test 1: overlay files exist with SPDX headers ---
+test_overlay_files_exist_with_spdx() {
+  echo "Test: deploy/kind/metrics-server/{kustomization,source,release}.yaml exist with SPDX headers"
+
+  local f
+  for f in "$KIND_MS_KUSTOMIZATION" "$KIND_MS_SOURCE" "$KIND_MS_RELEASE"; do
+    if [[ ! -f "$f" ]]; then
+      echo "  FAIL: $f does not exist"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+    assert_file_contains "$(basename "$f") has SPDX FileCopyrightText header" \
+      "$f" "SPDX-FileCopyrightText: Copyright 2026 SAP SE"
+    assert_file_contains "$(basename "$f") has SPDX-License-Identifier: Apache-2.0" \
+      "$f" "SPDX-License-Identifier: Apache-2.0"
+  done
+}
+
+# --- Test 2: kustomization references local source/release, no parent dirs,
+#             and creates no Namespace ---
+test_kustomization_is_self_contained() {
+  echo "Test: kustomization references local source/release and is self-contained"
+
+  if [[ ! -f "$KIND_MS_KUSTOMIZATION" ]]; then
+    echo "  FAIL: $KIND_MS_KUSTOMIZATION does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_file_contains "kustomization.yaml references the local source.yaml" \
+    "$KIND_MS_KUSTOMIZATION" "source.yaml$"
+  assert_file_contains "kustomization.yaml references the local release.yaml" \
+    "$KIND_MS_KUSTOMIZATION" "release.yaml$"
+
+  # Pin the no-parent-dir contract: a `../../` reference would re-introduce
+  # the kubectl#948 load-restrictor failure.
+  local parent_refs
+  parent_refs="$( { grep -E '^[[:space:]]*-[[:space:]]+\.\./\.\.' "$KIND_MS_KUSTOMIZATION" || true; } | wc -l)"
+  assert_eq "kustomization.yaml has no '../../' parent-directory resource entries" \
+    "0" "${parent_refs// /}"
+
+  # The overlay must NOT ship an inline namespace.yaml — the chart installs
+  # into the pre-existing kube-system Namespace.
+  local ns_entry
+  ns_entry="$( { grep -E '^[[:space:]]*-[[:space:]]+namespace\.yaml[[:space:]]*$' "$KIND_MS_KUSTOMIZATION" || true; } | wc -l)"
+  assert_eq "kustomization.yaml does not list a namespace.yaml resource" \
+    "0" "${ns_entry// /}"
+}
+
+# --- Test 3: kustomize build renders the metrics-server bundle with kind
+#             tuning under the default LoadRestrictionsRootOnly check ---
+test_kustomize_build_renders_bundle() {
+  echo "Test: kustomize build deploy/kind/metrics-server renders HelmRepository + HelmRelease with kind tuning"
+
+  if ! command -v kustomize >/dev/null 2>&1; then
+    echo "  SKIP: kustomize not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  # Mirror the production invocation: NO --load-restrictor flag. kubectl's
+  # embedded kustomize (used by hack/deploy-infra.sh) does not expose one.
+  local rendered
+  if ! rendered="$(kustomize build "$KIND_MS_DIR" 2>&1)"; then
+    echo "  FAIL: kustomize build $KIND_MS_DIR failed (default LoadRestrictionsRootOnly):"
+    echo "$rendered" | head -20
+    FAIL=$((FAIL + 5))
+    return
+  fi
+
+  # HelmRepository in flux-system at the upstream chart index.
+  local repo_ns repo_url
+  repo_ns="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "HelmRepository" and .metadata.name == "metrics-server") | .metadata.namespace // ""' \
+    2>/dev/null | head -n1)"
+  repo_url="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "HelmRepository" and .metadata.name == "metrics-server") | .spec.url // ""' \
+    2>/dev/null | head -n1)"
+  assert_eq "HelmRepository/metrics-server lives in flux-system" "flux-system" "$repo_ns"
+  assert_eq "HelmRepository/metrics-server points at the upstream chart index" \
+    "https://kubernetes-sigs.github.io/metrics-server/" "$repo_url"
+
+  # HelmRelease in kube-system with a major-3 version range and the
+  # kubelet-insecure-tls arg.
+  local rel_ns version arg
+  rel_ns="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "HelmRelease" and .metadata.name == "metrics-server") | .metadata.namespace // ""' \
+    2>/dev/null | head -n1)"
+  version="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "HelmRelease" and .metadata.name == "metrics-server") | .spec.chart.spec.version // ""' \
+    2>/dev/null | head -n1)"
+  arg="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "HelmRelease" and .metadata.name == "metrics-server") | .spec.values.args[] | select(. == "--kubelet-insecure-tls")' \
+    2>/dev/null | head -n1)"
+
+  assert_eq "HelmRelease/metrics-server lives in kube-system" "kube-system" "$rel_ns"
+  assert_eq "HelmRelease/metrics-server passes --kubelet-insecure-tls" \
+    "--kubelet-insecure-tls" "$arg"
+
+  # The version range must be pinned within major 3 so in-range updates need
+  # no Renovate pin (mirrors the chaos-mesh / kube-prometheus-stack posture).
+  if printf '%s' "$version" | grep -qE '>=3\.[0-9]+\.[0-9]+ <4\.0\.0'; then
+    echo "  PASS: chart version range '$version' stays within major 3"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: chart version range '$version' is not a '>=3.x.y <4.0.0' single-major range"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test 4: production flux-system renders zero metrics-server resources ---
+test_flux_system_renders_no_metrics_server() {
+  echo "Test: kustomize build deploy/flux-system renders no metrics-server resources"
+
+  if ! command -v kustomize >/dev/null 2>&1; then
+    echo "  SKIP: kustomize not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local rendered
+  if ! rendered="$(kustomize build "$FLUX_SYSTEM_DIR" 2>&1)"; then
+    echo "  FAIL: kustomize build $FLUX_SYSTEM_DIR failed:"
+    echo "$rendered" | head -20
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  local repo_count release_count
+  repo_count="$(printf '%s\n' "$rendered" | count_metrics_server_resources HelmRepository)"
+  release_count="$(printf '%s\n' "$rendered" | count_metrics_server_resources HelmRelease)"
+  assert_eq "production overlay renders zero HelmRepository/metrics-server" "0" "${repo_count// /}"
+  assert_eq "production overlay renders zero HelmRelease/metrics-server" "0" "${release_count// /}"
+}
+
+# --- Test 5: kind/base renders zero metrics-server resources ---
+test_kind_base_renders_no_metrics_server() {
+  echo "Test: kustomize build deploy/kind/base renders no metrics-server resources"
+
+  if ! command -v kustomize >/dev/null 2>&1; then
+    echo "  SKIP: kustomize not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local rendered
+  if ! rendered="$(kustomize build "$KIND_BASE_DIR" 2>&1)"; then
+    echo "  FAIL: kustomize build $KIND_BASE_DIR failed:"
+    echo "$rendered" | head -20
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local resource_count
+  resource_count="$(printf '%s\n' "$rendered" \
+    | grep -cE '^[[:space:]]*name:[[:space:]]+metrics-server[[:space:]]*$' || true)"
+  assert_eq "kind/base output contains no resource named metrics-server" "0" "${resource_count// /}"
+}
+
+# --- Run ---
+test_overlay_files_exist_with_spdx
+test_kustomization_is_self_contained
+test_kustomize_build_renders_bundle
+test_flux_system_renders_no_metrics_server
+test_kind_base_renders_no_metrics_server
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify hack/deploy-infra.sh gates metrics-server behind WITH_METRICS_SERVER
+# so the kind Quick Start stays minimal by default and only installs the
+# resource-metrics API (required by the HPA/autoscaling recipe) when
+# explicitly requested.
+#
+# Implementation: bash + tests/lib/assertions.sh — mirrors the sibling
+# tests/unit/hack/deploy_infra_prometheus_flag_test.sh pattern. The repo has
+# zero .bats files and no shellspec runner; introducing one would add an
+# undeclared test dependency.
+#
+# Strategy: hybrid — source the script (the `BASH_SOURCE[0] == ${0}` guard at
+# the bottom of deploy-infra.sh keeps main() from auto-running) to assert the
+# runtime default of WITH_METRICS_SERVER for each env scenario, and grep the
+# script source to lock in the two gate locations:
+#   1. kustomize apply (deploy/kind/metrics-server)
+#   2. Phase 3 helm-release wait list append (metrics-server)
+# Unlike the prometheus flag there is NO dashboard copy and NO servicemonitor
+# patch, so the strict gate count is 2, not 3. The configuration-banner line
+# is asserted via grep so the user-visible summary stays in lockstep with the
+# runtime value.
+#
+# Usage: bash tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEPLOY_INFRA_SH="$PROJECT_ROOT/hack/deploy-infra.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# resolve_with_metrics_server [env_var=value...]
+# Sources deploy-infra.sh in a subshell with the supplied env overrides and
+# echoes the resolved value of WITH_METRICS_SERVER after the configuration
+# block runs. The `BASH_SOURCE[0] == ${0}` guard at the bottom of
+# deploy-infra.sh keeps main() from auto-running when the script is sourced.
+resolve_with_metrics_server() {
+  (
+    for assignment in "$@"; do
+      export "${assignment?}"
+    done
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    printf '%s' "${WITH_METRICS_SERVER}"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: WITH_METRICS_SERVER defaults to false
+# ---------------------------------------------------------------------------
+test_default_is_false() {
+  echo "Test: WITH_METRICS_SERVER defaults to false"
+
+  # Unset any inherited value so we observe the script's own default.
+  local resolved
+  resolved="$(unset WITH_METRICS_SERVER; resolve_with_metrics_server)"
+  assert_eq "WITH_METRICS_SERVER defaults to false" "false" "$resolved"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: explicit WITH_METRICS_SERVER=true
+# ---------------------------------------------------------------------------
+test_explicit_true() {
+  echo "Test: WITH_METRICS_SERVER=true is preserved"
+
+  local resolved
+  resolved="$(resolve_with_metrics_server WITH_METRICS_SERVER=true)"
+  assert_eq "WITH_METRICS_SERVER=true is preserved" "true" "$resolved"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: explicit WITH_METRICS_SERVER=false
+# ---------------------------------------------------------------------------
+test_explicit_false() {
+  echo "Test: WITH_METRICS_SERVER=false is preserved"
+
+  local resolved
+  resolved="$(resolve_with_metrics_server WITH_METRICS_SERVER=false)"
+  assert_eq "WITH_METRICS_SERVER=false is preserved" "false" "$resolved"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: defensive non-true value
+# A typo like WITH_METRICS_SERVER=yes must NOT enable the overlay; every gate
+# uses the strict `== "true"` comparison. We assert the value passes through
+# verbatim AND that all gate sites use exact-match.
+# ---------------------------------------------------------------------------
+test_non_true_value_does_not_trigger_install() {
+  echo "Test: WITH_METRICS_SERVER=yes passes through but does not trigger install"
+
+  local resolved
+  resolved="$(resolve_with_metrics_server WITH_METRICS_SERVER=yes)"
+  assert_eq "WITH_METRICS_SERVER=yes is preserved verbatim" "yes" "$resolved"
+
+  # Every gate must compare with the exact string "true" so "yes" takes the
+  # skip branch at every gate. There are exactly two runtime gates:
+  #   - kustomize apply (Step 3)
+  #   - helm_releases append (Phase 3)
+  local gate_count
+  gate_count="$(grep -cE '"\$\{WITH_METRICS_SERVER\}" == "true"' "$DEPLOY_INFRA_SH" || true)"
+  assert_eq "deploy-infra.sh has exactly 2 strict WITH_METRICS_SERVER==true gates" "2" "$gate_count"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: configuration banner line
+# The user-visible summary must surface the WITH_METRICS_SERVER state next to
+# WITH_PROMETHEUS so operators can spot accidental opt-ins / opt-outs at a
+# glance. The expected line shape mirrors the prometheus banner exactly.
+# ---------------------------------------------------------------------------
+test_banner_includes_metrics_server_line() {
+  echo "Test: configuration banner surfaces WITH_METRICS_SERVER state"
+
+  assert_file_contains \
+    "deploy-infra.sh banner mentions metrics-server" \
+    "$DEPLOY_INFRA_SH" \
+    'metrics-server'
+
+  assert_file_contains \
+    "deploy-infra.sh banner shows the WITH_METRICS_SERVER value and remediation hint" \
+    "$DEPLOY_INFRA_SH" \
+    'set WITH_METRICS_SERVER=true to install'
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: metrics-server overlay apply is conditional
+# The kustomize apply for deploy/kind/metrics-server must live inside the
+# WITH_METRICS_SERVER gate so the default Quick Start does not install it.
+# ---------------------------------------------------------------------------
+test_metrics_server_kustomize_is_gated() {
+  echo "Test: metrics-server kustomize apply is gated by WITH_METRICS_SERVER"
+
+  # The apply line itself exists.
+  assert_file_contains \
+    "deploy-infra.sh references the deploy/kind/metrics-server overlay" \
+    "$DEPLOY_INFRA_SH" \
+    'deploy/kind/metrics-server'
+
+  # The line must be preceded by a WITH_METRICS_SERVER gate. Use awk to confirm
+  # the most recent if-line above the apply tests WITH_METRICS_SERVER.
+  local apply_line gate_line
+  apply_line="$(grep -n 'kubectl apply -k "${REPO_ROOT}/deploy/kind/metrics-server"' "$DEPLOY_INFRA_SH" | head -1 | cut -d: -f1)"
+  gate_line="$(grep -n '"${WITH_METRICS_SERVER}" == "true"' "$DEPLOY_INFRA_SH" | awk -F: -v target="${apply_line:-0}" '$1 < target { last = $1 } END { print last }')"
+
+  assert_not_empty "kustomize apply line for metrics-server is found" "$apply_line"
+  assert_not_empty "WITH_METRICS_SERVER gate precedes the kustomize apply" "$gate_line"
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: metrics-server appended to helm-release wait list
+# The Phase 3 wait list must NOT statically include metrics-server; it must be
+# appended dynamically inside the WITH_METRICS_SERVER gate, after the
+# kube-prometheus-stack append, so the relative ordering of the seven base
+# releases is preserved.
+# ---------------------------------------------------------------------------
+test_metrics_server_appended_dynamically() {
+  echo "Test: metrics-server is appended dynamically to the helm-release wait list"
+
+  # The base array must NOT include metrics-server inline.
+  assert_file_not_contains \
+    "deploy-infra.sh does not hard-code metrics-server in the helm-release wait list" \
+    "$DEPLOY_INFRA_SH" \
+    'envoy-gateway metrics-server'
+
+  # The base array must preserve the seven non-opt-in releases in order.
+  assert_file_contains \
+    "helm_releases array preserves the seven non-opt-in releases in the documented order" \
+    "$DEPLOY_INFRA_SH" \
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway)'
+
+  # The dynamic append must be guarded by WITH_METRICS_SERVER.
+  assert_file_contains \
+    "metrics-server is appended only inside the WITH_METRICS_SERVER gate" \
+    "$DEPLOY_INFRA_SH" \
+    'helm_releases+=(metrics-server)'
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: production-caller contract — the metrics-server apply mirrors the
+# chaos-mesh / prometheus contract under kubectl's embedded kustomize.
+#
+# kubectl apply -k uses the embedded kustomize, which does NOT expose
+# --load-restrictor (kubernetes/kubectl#948). We hold the metrics-server
+# overlay to the same standard:
+#
+#   (a) deploy-infra.sh's metrics-server apply line uses plain
+#       `kubectl apply -k` (no `--load-restrictor`, no pipe through
+#       `kustomize build` to `kubectl apply -f -`); and
+#   (b) deploy/kind/metrics-server/kustomization.yaml has zero `../../`
+#       parent-directory resource entries, so the default
+#       LoadRestrictionsRootOnly check is satisfied and the apply succeeds
+#       without any flag.
+# ---------------------------------------------------------------------------
+test_production_caller_matches_self_contained_overlay() {
+  echo "Test: production caller and overlay agree on the no-load-restrictor contract"
+
+  # (a) The apply line is the bare kubectl form — no pipe, no flag.
+  local raw
+  raw="$(grep -E 'kubectl apply -k "\$\{REPO_ROOT\}/deploy/kind/metrics-server"' "$DEPLOY_INFRA_SH" | head -1)"
+  assert_not_empty "deploy-infra.sh has the metrics-server kubectl apply line" "$raw"
+
+  if printf '%s' "$raw" | grep -q -- '--load-restrictor'; then
+    echo "  FAIL: deploy-infra.sh's metrics-server apply line passes --load-restrictor (kubectl's embedded kustomize does not accept it)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: metrics-server apply line uses no --load-restrictor flag"
+    PASS=$((PASS + 1))
+  fi
+
+  # (b) The overlay must have zero `../../` parent-directory resource entries.
+  local kust="$PROJECT_ROOT/deploy/kind/metrics-server/kustomization.yaml"
+  if [[ ! -f "$kust" ]]; then
+    echo "  FAIL: $kust does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local parent_refs
+  parent_refs="$( { grep -E '^[[:space:]]*-[[:space:]]+\.\./\.\.' "$kust" || true; } | wc -l)"
+  assert_eq "deploy/kind/metrics-server/kustomization.yaml has no '../../' resource entries" \
+    "0" "${parent_refs// /}"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_default_is_false
+test_explicit_true
+test_explicit_false
+test_non_true_value_does_not_trigger_install
+test_banner_includes_metrics_server_line
+test_metrics_server_kustomize_is_gated
+test_metrics_server_appended_dynamically
+test_production_caller_matches_self_contained_overlay
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
@@ -19,7 +19,7 @@
 #   1. kustomize apply (deploy/kind/prometheus)
 #   2. dashboard JSON copy (operators/keystone/dashboards → overlay root)
 #   3. Phase 3 helm-release wait list append (kube-prometheus-stack)
-#   4. enable_keystone_operator_servicemonitor call site
+#   4. enable_operator_servicemonitor call sites (keystone + horizon)
 # The configuration-banner line is asserted via grep so the user-visible
 # summary stays in lockstep with the runtime value.
 #
@@ -109,7 +109,7 @@ test_non_true_value_does_not_trigger_install() {
   # skip branch at every gate. There are four runtime gates:
   #   - dashboard copy + kustomize apply (Step 3)
   #   - helm_releases append (Phase 3)
-  #   - enable_keystone_operator_servicemonitor call (post Phase 3)
+  #   - enable_operator_servicemonitor calls, keystone + horizon (post Phase 3)
   local gate_count
   gate_count="$(grep -cE '"\$\{WITH_PROMETHEUS\}" == "true"' "$DEPLOY_INFRA_SH" || true)"
   assert_eq "deploy-infra.sh has exactly 3 strict WITH_PROMETHEUS==true gates" "3" "$gate_count"
@@ -219,32 +219,45 @@ test_kube_prometheus_stack_appended_dynamically() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 9: enable_keystone_operator_servicemonitor exists and is gated
+# Test 9: enable_operator_servicemonitor exists and is gated for both operators
 #
-# The helper must (a) be defined as a function in the script and (b) be
-# called from main() only when WITH_PROMETHEUS=true so the default Quick
-# Start does not poke the operator HelmRelease.
+# The helper must (a) be defined as a parameterized function in the script and
+# (b) be called from main() for BOTH keystone-operator and horizon-operator,
+# each only when WITH_PROMETHEUS=true so the default Quick Start does not poke
+# the operator HelmReleases. The horizon call is what makes the horizon
+# metrics guide's kind tip true.
 # ---------------------------------------------------------------------------
 test_servicemonitor_helper_is_defined_and_gated() {
-  echo "Test: enable_keystone_operator_servicemonitor is defined and gated"
+  echo "Test: enable_operator_servicemonitor is defined and gated for keystone + horizon"
 
   assert_file_contains \
-    "enable_keystone_operator_servicemonitor function is defined" \
+    "enable_operator_servicemonitor function is defined" \
     "$DEPLOY_INFRA_SH" \
-    '^enable_keystone_operator_servicemonitor()'
+    '^enable_operator_servicemonitor()'
 
+  # The patch is parameterized (release/namespace), so assert the parameterized
+  # patch line inside the function rather than a hard-coded release name — the
+  # literal 'kubectl patch helmrelease keystone-operator -n keystone-system'
+  # also matches the un-suspend patch elsewhere in the script and would be
+  # ambiguous.
   assert_file_contains \
-    "helper patches the keystone-operator HelmRelease values" \
+    "helper patches the operator HelmRelease values via parameterized release/namespace" \
     "$DEPLOY_INFRA_SH" \
-    'kubectl patch helmrelease keystone-operator -n keystone-system'
+    'kubectl patch helmrelease "${release}" -n "${namespace}" --type=merge'
 
-  # The call site must be inside a WITH_PROMETHEUS gate.
-  local call_line gate_line
-  call_line="$(grep -nE '^[[:space:]]+enable_keystone_operator_servicemonitor[[:space:]]' "$DEPLOY_INFRA_SH" | head -1 | cut -d: -f1)"
-  gate_line="$(grep -n '"${WITH_PROMETHEUS}" == "true"' "$DEPLOY_INFRA_SH" | awk -F: -v target="${call_line:-0}" '$1 < target { last = $1 } END { print last }')"
+  # Both call sites must exist and each must be inside a WITH_PROMETHEUS gate.
+  local ks_line hz_line gate_line
+  ks_line="$(grep -nE '^[[:space:]]+enable_operator_servicemonitor keystone-operator keystone-system' "$DEPLOY_INFRA_SH" | head -1 | cut -d: -f1)"
+  hz_line="$(grep -nE '^[[:space:]]+enable_operator_servicemonitor horizon-operator horizon-system' "$DEPLOY_INFRA_SH" | head -1 | cut -d: -f1)"
 
-  assert_not_empty "enable_keystone_operator_servicemonitor call site is found" "$call_line"
-  assert_not_empty "WITH_PROMETHEUS gate precedes the helper call" "$gate_line"
+  assert_not_empty "keystone-operator ServiceMonitor call site is found" "$ks_line"
+  assert_not_empty "horizon-operator ServiceMonitor call site is found" "$hz_line"
+
+  gate_line="$(grep -n '"${WITH_PROMETHEUS}" == "true"' "$DEPLOY_INFRA_SH" | awk -F: -v target="${ks_line:-0}" '$1 < target { last = $1 } END { print last }')"
+  assert_not_empty "WITH_PROMETHEUS gate precedes the keystone-operator helper call" "$gate_line"
+
+  gate_line="$(grep -n '"${WITH_PROMETHEUS}" == "true"' "$DEPLOY_INFRA_SH" | awk -F: -v target="${hz_line:-0}" '$1 < target { last = $1 } END { print last }')"
+  assert_not_empty "WITH_PROMETHEUS gate precedes the horizon-operator helper call" "$gate_line"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Issue #613 asked to make the documentation guides' dependencies actually reachable on a kind devstack. Several guides pointed at services that no devstack stands up (a placeholder `keycloak.example.com` IdP, an unspecified LDAP server), told readers to fight Flux with raw `helm upgrade`, or promised NetworkPolicy enforcement that the default kindnet CNI silently ignores. This branch wires the guides to the fixtures the e2e suites already deploy, adds the two devstack opt-ins the guides need, and corrects the claims that were never true on kind.

The e2e fixtures stay the single source of truth throughout — the guides reference them, they are never forked.

## Change set (commit order)

1. **`33b594dc` feat(deploy): add `WITH_METRICS_SERVER` opt-in kind overlay**
   The Autoscaling (HPA) recipe needs a resource-metrics API that the kind devstack shipped none of. Adds a self-contained overlay under `deploy/kind/metrics-server` (HelmRepository + HelmRelease, pinned to a single-major `>=3.12.0 <4.0.0` chart range with `--kubelet-insecure-tls` baked into the values), gated behind `WITH_METRICS_SERVER=true`, mirroring the chaos-mesh / kube-prometheus-stack opt-in shape. Installs into the pre-existing `kube-system` namespace (no `namespace.yaml`). Production overlays never install it. Covered by a flag unit test, an overlay render test, and a `no-metrics-server-when-disabled` negative e2e suite.

2. **`6f725787` feat(deploy): flip horizon-operator ServiceMonitor with `WITH_PROMETHEUS`**
   The horizon metrics guide claimed `WITH_PROMETHEUS` wires the horizon-operator ServiceMonitor, but `deploy-infra` only ever patched keystone-operator. Generalizes `enable_keystone_operator_servicemonitor` into a parameterized `enable_operator_servicemonitor RELEASE NAMESPACE [TIMEOUT]` and calls it for both keystone-operator and horizon-operator inside the existing `WITH_PROMETHEUS` gate. The suspended-HelmRelease contract is unchanged (strict gate count stays 3). Reworks the prometheus flag test's Test 9 and adds a fourth `no-prometheus-when-disabled` assertion.

3. **`1c132550` docs(guides): document the metrics-server opt-in for autoscaling**
   Rewires the Autoscaling (HPA) recipe off the unpinned upstream `components.yaml` + hand-patch onto the `WITH_METRICS_SERVER` opt-in from commit 1 — bring-up flag (composed with `WITH_CONTROLPLANE`) and an additive `kubectl apply -k` + wait for a running devstack. Adds a matching tip block and a kube-system row to the Extended Quick Start, and a metrics-server subsection to the infrastructure reference.

4. **`44300348` docs(guides): patch Flux HelmReleases instead of raw helm upgrade**
   The horizon metrics guide and both operator NetworkPolicy guides told readers to run raw `helm upgrade` against releases that every tutorial devstack installs through Flux — reverted on the next reconcile. Makes the HelmRelease-`spec.values`-patch pattern the primary devstack path in all three (horizon metrics, keystone NetworkPolicy, horizon NetworkPolicy — the latter now also patches the chart-required `kubeApiServer.cidrs/ports` its fail-closed guard demands). Each keeps a corrected raw-`helm upgrade` command under an explicitly-scoped "Helm-managed installations (non-Flux)" note.

5. **`9b02d1ab` docs(guides): state the kind NetworkPolicy enforcement limits honestly**
   Both NetworkPolicy guides told kind readers to install an enforcing CNI, but kind fixes the CNI at cluster creation and the default kindnet silently ignores NetworkPolicy objects. Replaces that unactionable instruction with the shape-only SCOPE CAVEAT the mirroring e2e suites already carry, and corrects the keystone guide's §4.4 claim that the e2e suite proves enforcement (it runs on kindnet CI and validates render + reconcile only).

6. **`cdcd9ee1` docs(guides): deploy the OpenLDAP e2e fixture in the LDAP guide**
   The LDAP guide used the `docker-test-openldap` fixture's real values but never stood the fixture up. Adds a first step that applies `tests/e2e/keystone/ldap-domain-backend/00-openldap.yaml` verbatim, documenting the `dc=planetexpress,dc=com` tree, the `openldap:10389` Service, and the `openldap-bind` Secret it ships (which lets kind readers skip the manual bind-Secret create). Renumbers the subsequent steps.

7. **`0b5181a7` docs(guides): wire federation guides to the Keycloak e2e fixtures**
   The OIDC federation and SSO guides pointed at a placeholder `keycloak.example.com` IdP no devstack runs. Wires both to the Keycloak fixtures the e2e suites already deploy — `oidc-federation` applies `tests/e2e/keystone/oidc-federation/00-keycloak.yaml` (realm `forge`, user `fry`, client `keystone`) with a fixture-true issuer + explicit endpoints block (the operator's metadata-fetch SSRF guard blocks discovery against the in-cluster ClusterIP), and Step 6 becomes a copy-pasteable CLI bearer flow; `end-to-end-sso` applies the `tests/e2e-controlplane-sso/` fixtures. Both carry an honest note that the fixture IdP is not host-browser reachable — the headless WebSSO round trip lives in the e2e suite.

## Notes for the reviewer

- Commits 1–2 (`feat(deploy)`) add the two devstack capabilities the guides then consume; commits 3–7 (`docs(guides)`) rewire the guides onto real, reproducible dependencies. Each infra change lands with its unit/e2e coverage before the guide that relies on it.
- Nothing in the diff diverges from the issue's intent: the theme throughout is "reference the e2e fixtures, don't fork them" and "make kind's real limits (kindnet, Flux ownership, SSRF guard) explicit rather than pretend them away."

Closes #613

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
