### PR TITLE
docs(guides): couple every guide to the e2e suite that tests it

### DIFF
--- a/docs/contributing/guide-conventions.md
+++ b/docs/contributing/guide-conventions.md
@@ -85,24 +85,43 @@ section, applied to a Keystone CR the reader owns.
 ## Every guide is testable
 
 A guide describes behaviour the project also asserts in an end-to-end suite.
-Where a mirroring suite exists under `tests/e2e/`, the guide closes with a
-pointer to it and its invocation, so a reader can run the same flow the guide
-walks through:
+Every guide closes with a terminal section titled exactly `## Tested by` that
+names its mirroring suite(s) and the local invocation, so a reader can run the
+same flow the guide walks through. The invocation uses the `--test-dir` form,
+one line per suite:
 
 ```bash
 chainsaw test --test-dir tests/e2e/keystone/<suite>
 ```
 
+`tests/unit/docs/guide_devstack_and_tested_by_test.sh` enforces this per guide:
+the `## Tested by` section must exist, and every path it names with
+`chainsaw test --test-dir` must resolve to a real `chainsaw-test.yaml`.
+
 ## Single source of truth for manifests
 
-Where a guide mirrors an e2e suite, embed the CR manifests from the suite's
-fixture files rather than hand-maintaining a second copy that drifts. VitePress
-snippet imports keep the rendered YAML in lockstep with the fixture the suite
-actually applies:
+Where a guide mirrors an e2e suite, embed the fixture the suite applies rather
+than hand-maintaining a second copy that drifts. A VitePress snippet import
+keeps the rendered YAML in lockstep with the tested fixture; mark the region to
+import with column-0 `# region <name>` / `# endregion <name>` YAML comments
+around the CR document in the fixture:
 
 ```md
-<<< @/../tests/e2e/keystone/<suite>/00-keystone-cr.yaml
+<<< @/../tests/e2e/keystone/<suite>/00-keystone-cr.yaml#<region>
 ```
+
+The fixture and the walkthrough serve different masters, so they carry different
+names. A suite fixture is **isolation-named** — a distinct CR name, its own
+logical database, `deletionPolicy: Delete`, dev-tag image pins — so the suite
+runs safely in the parallel suite pool. The walkthrough is **devstack-named** —
+it uses the resource names the guide's declared devstack actually produces (see
+[ControlPlane-first naming](#controlplane-first-naming)), so a reader can copy a
+command and have it hit a resource that exists. Reconcile the two by keeping the
+walkthrough YAML devstack-named and embedding the isolation-named fixture as a
+labelled `::: details` exhibit inside `## Tested by`, prefaced by a sentence
+that states which names the exhibit uses and why. The import is real, so the
+exhibit cannot drift from the tested fixture, and the walkthrough keeps the
+names the reader's devstack can actually copy.
 
 ## Housekeeping
 

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -337,3 +337,14 @@ A change to `extraConfig` triggers a ConfigMap rehash and a rolling Deployment u
 - [ControlPlane CRD API Reference](../reference/c5c3/controlplane-crd.md) — the `spec.*` fields the ControlPlane exposes, including `spec.infrastructure`
 - [Observability & Diagnostics](./observability.md) — how to verify a new configuration took effect
 - [Day 2 Operations](./day-2-operations.md) — scale, upgrade, rotate using the configured CR
+
+## Tested by
+
+The recipes above are exercised on the CI e2e kind cluster — the operator
+installed with a dev image — by these chainsaw suites:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/brownfield-database
+chainsaw test --test-dir tests/e2e/keystone/autoscaling
+chainsaw test --test-dir tests/e2e/keystone/network-policy
+```

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -273,3 +273,15 @@ scheduled rotation during an incident without deleting the CronJob, and
 - [Keystone Upgrade Flow](../reference/keystone/keystone-upgrade-flow.md) — state machine, job names, retry behavior
 - [Keystone Controller Events](../reference/keystone/keystone-events.md) — full event catalogue for upgrade, rotation, and scale events
 - [Advanced Configuration](./advanced-configuration.md) — brownfield DB, autoscaling, network policy, and more
+
+## Tested by
+
+Scale, release upgrade, image upgrade, zero-downtime rollout, and manual Fernet
+rotation are each asserted on the CI e2e kind cluster by these chainsaw suites:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/release-upgrade
+chainsaw test --test-dir tests/e2e/keystone/image-upgrade
+chainsaw test --test-dir tests/e2e/keystone/rolling-update-zero-downtime
+chainsaw test --test-dir tests/e2e/keystone/fernet-rotation
+```

--- a/docs/guides/enable-horizon-operator-metrics.md
+++ b/docs/guides/enable-horizon-operator-metrics.md
@@ -122,3 +122,18 @@ curl -s 'http://localhost:9090/api/v1/query?query=horizon_operator_reconcile_dur
 
 A non-zero result count means the operator has reconciled at least one
 Horizon CR since the scrape began.
+
+## Tested by
+
+The chart's ServiceMonitor render-and-remove lifecycle is asserted on the CI
+e2e kind cluster by the chainsaw suite below (install with
+`monitoring.serviceMonitor.enabled=true`, assert the `ServiceMonitor` shape,
+uninstall, assert removal). The end-to-end scrape path — a live Prometheus
+that discovers the ServiceMonitor and marks the target Up — is the
+`WITH_PROMETHEUS=true` kind bring-up shown in the tip above, not this suite:
+the e2e cluster ships only the prometheus-operator CRDs, not a Prometheus
+instance.
+
+```bash
+chainsaw test --test-dir tests/e2e/horizon-operator/metrics
+```

--- a/docs/guides/enable-horizon-operator-networkpolicy.md
+++ b/docs/guides/enable-horizon-operator-networkpolicy.md
@@ -130,3 +130,15 @@ Set the replica count on the `ControlPlane` CR, not on the projected
 reverted. If the operator loses apiserver connectivity after enabling the policy,
 your CNI maps the apiserver behind a different port — compare the policy's egress
 ports with `kubectl get endpoints kubernetes -n default`.
+
+## Tested by
+
+Both operator charts carry an equivalent chart-level NetworkPolicy template
+(each chart ships its own copy — it is not a shared operator-library helper).
+The keystone chart's copy is exercised end-to-end on the CI e2e kind cluster by
+the chainsaw suite below; the horizon chart's copy is pinned by its helm-unittest
+(`operators/horizon/helm/horizon-operator/tests/networkpolicy_test.yaml`).
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone-operator/network-policy-egress
+```

--- a/docs/guides/enable-keystone-database-tls.md
+++ b/docs/guides/enable-keystone-database-tls.md
@@ -266,20 +266,6 @@ except Exception as exc:
 
 Expected: `PLAINTEXT_REJECTED: …` from the server's TLS-required enforcement.
 
-### 4. Run the end-to-end chainsaw test (canonical check)
-
-The repository ships a chainsaw E2E suite that pins all three of the above
-verifications against a standalone Keystone CR (whose `openstack-db` ships
-`tls.required=true`):
-
-```bash
-chainsaw test --test-dir tests/e2e/keystone/database-tls/
-```
-
-The suite is also listed in the
-[E2E inventory](../reference/keystone/keystone-crd.md#chainsaw-e2e-tests) of
-the Keystone CRD reference.
-
 ---
 
 ## Disabling
@@ -366,3 +352,18 @@ mechanics through this standalone flow.
 - [Infrastructure Manifests — OpenStack DB CA Issuer](../reference/infrastructure/infrastructure-manifests.md#openstack-db-ca-issuer) — CA keypair and ClusterIssuer.
 - [Infrastructure Manifests — MariaDB Galera Cluster](../reference/infrastructure/infrastructure-manifests.md#mariadb-galera-cluster) — server-side TLS configuration.
 - [`tests/e2e/keystone/database-tls/`](https://github.com/c5c3/forge/tree/main/tests/e2e/keystone/database-tls) — chainsaw E2E suite.
+
+## Tested by
+
+The canonical check pins all three verifications above — `DatabaseTLSReady=True`,
+the encrypted live connection, and the plaintext rejection — against a standalone
+Keystone CR whose `openstack-db` ships `tls.required=true`. Run it on the CI e2e
+kind cluster:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/database-tls
+```
+
+The suite is also listed in the
+[E2E inventory](../reference/keystone/keystone-crd.md#chainsaw-e2e-tests) of the
+Keystone CRD reference.

--- a/docs/guides/enable-keystone-operator-metrics.md
+++ b/docs/guides/enable-keystone-operator-metrics.md
@@ -288,3 +288,15 @@ ServiceMonitor (and therefore the Prometheus scrape) is removed.
 - [Keystone Reconciler — Metrics Instrumentation](../reference/keystone/keystone-reconciler.md#metrics-instrumentation) — how sub-reconcilers are instrumented.
 - [Observability & Diagnostics](../guides/observability.md) — conditions, events, and logs.
 - [`operators/keystone/dashboards/keystone-operator.json`](https://github.com/c5c3/forge/blob/main/operators/keystone/dashboards/keystone-operator.json) — reference Grafana dashboard.
+
+## Tested by
+
+The chart's ServiceMonitor render-and-remove lifecycle is asserted on the CI
+e2e kind cluster by `tests/e2e/keystone/metrics`; the end-to-end
+`WITH_PROMETHEUS` scrape-and-dashboard path is asserted by
+`tests/e2e/keystone/prometheus-stack`:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/metrics
+chainsaw test --test-dir tests/e2e/keystone/prometheus-stack
+```

--- a/docs/guides/enable-keystone-operator-networkpolicy.md
+++ b/docs/guides/enable-keystone-operator-networkpolicy.md
@@ -256,22 +256,6 @@ kubectl -n keystone-system logs deploy/keystone-operator -f \
   | grep -Ei 'apiserver|leader|timeout|refused|deadline'
 ```
 
-### 4.4 Chart-level E2E guardrail
-
-The repository ships a Chainsaw E2E that exercises this exact code path —
-operator installed with `networkPolicy.enabled=true`, one Keystone CR
-reaches `Ready=True`:
-
-```bash
-chainsaw test tests/e2e/keystone-operator/network-policy-egress
-```
-
-Like the verification steps above, this suite runs on the default `kindnet`
-CI cluster, so it validates that the chart **renders** the policy and that
-the operator **reconciles to Ready** while the (unenforced) policy is present
-— it does **not** assert that blocked egress is actually dropped. Enforcement
-coverage would require a CI job with a NetworkPolicy-enforcing CNI.
-
 ---
 
 ## Troubleshooting
@@ -382,3 +366,19 @@ without a pod restart.
   the CR-scoped `reconcileNetworkPolicy` sub-reconciler for the
   Keystone API pod NetworkPolicy (different scope from this guide).
 - [Kubernetes NetworkPolicy concepts](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
+
+## Tested by
+
+The operator installed with `networkPolicy.enabled=true` and one Keystone CR
+reaching `Ready=True` is exercised on the CI e2e kind cluster by this chainsaw
+suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone-operator/network-policy-egress
+```
+
+Like the verification steps above, this suite runs on the default `kindnet` CI
+cluster, so it validates that the chart **renders** the policy and that the
+operator **reconciles to Ready** while the (unenforced) policy is present — it
+does **not** assert that blocked egress is actually dropped. Enforcement
+coverage would require a CI job with a NetworkPolicy-enforcing CNI.

--- a/docs/guides/end-to-end-sso.md
+++ b/docs/guides/end-to-end-sso.md
@@ -229,11 +229,7 @@ host cannot resolve. Clicking the SSO button through to a session needs an
 through the gateway with matching redirect URIs and a host-resolvable issuer).
 The full WebSSO hand-off against the in-cluster fixture — including the
 Envoy-routed gateway redirect URIs this guide's fixtures register — is
-exercised headlessly by the mirroring e2e suite:
-
-```bash
-chainsaw test --test-dir tests/e2e-controlplane-sso
-```
+exercised headlessly by the mirroring e2e suite (see [Tested by](#tested-by)).
 
 For a copy-pasteable devstack login that does not need a browser, use the CLI
 bearer flow in [Attach an OIDC Federation Backend](./oidc-federation.md#step-6-log-in-as-a-federated-user).
@@ -369,3 +365,30 @@ Then check the two rules from Step 1: the port must be present when it is not
 is projected from `services.keystone.publicEndpoint`. If that is unset, Horizon
 falls back to `spec.keystoneEndpoint` — the cluster-local Service URL, which the
 browser cannot resolve. Set `publicEndpoint`.
+
+## Tested by
+
+The full ControlPlane-driven SSO chain — both services published through the
+shared gateway, the OIDC and LDAP backends attached, and a headless WebSSO
+hand-off — is asserted end-to-end on its own CI e2e kind cluster by this
+chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e-controlplane-sso
+```
+
+::: details The ControlPlane CR the suite applies
+The suite runs a second full ControlPlane in its own CI job (the webhook permits
+only one ControlPlane per namespace), so its CR name (`controlplane-sso`)
+deliberately differs from the `controlplane` devstack name used in the
+walkthrough above.
+
+<<< @/../tests/e2e-controlplane-sso/02-controlplane-cr.yaml#controlplane-cr
+:::
+
+::: details The identity backends the suite applies
+Both backends reference the suite's projected Keystone child
+(`controlplane-sso-keystone`) rather than the walkthrough's `controlplane-keystone`.
+
+<<< @/../tests/e2e-controlplane-sso/04-backends.yaml#backends
+:::

--- a/docs/guides/keystone-admin-password-rotation.md
+++ b/docs/guides/keystone-admin-password-rotation.md
@@ -358,4 +358,13 @@ so write to whatever path it reads.
 - [Labels and Annotations](../reference/keystone/keystone-reconciler.md#labels-and-annotations) — stable metadata keys, including `forge.c5c3.io/admin-password-hash` and `forge.c5c3.io/pod-spec-hash`.
 - See also [Schedule Keystone Admin Password Rotation](keystone-admin-password-scheduled-rotation.md) — the Model B scheduled flow, where a CronJob mints the password instead of an operator writing OpenBao by hand.
 - See also [Rotate Keystone Fernet and Credential Keys](keystone-key-rotation.md) — the key-rotation counterpart to this admin-password rotation.
-- Chainsaw test: `tests/e2e/keystone/admin-password-rotation/chainsaw-test.yaml` asserts this guide's happy path end-to-end — re-bootstrap on Secret change, old-password `401` / new-password `201` cutover, and unchanged API pod UIDs.
+
+## Tested by
+
+This guide's happy path is asserted end-to-end on the CI e2e kind cluster —
+re-bootstrap on Secret change, old-password `401` / new-password `201` cutover,
+and unchanged API pod UIDs — by this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/admin-password-rotation
+```

--- a/docs/guides/keystone-admin-password-scheduled-rotation.md
+++ b/docs/guides/keystone-admin-password-scheduled-rotation.md
@@ -423,4 +423,23 @@ Secrets, the RBAC trio, the PushSecret, and the script ConfigMap — and reports
 - [`reconcileBootstrap`](../reference/keystone/keystone-reconciler.md#reconcilebootstrap) — the bootstrap sub-reconciler and the `admin-password-hash` re-run gate that applies the rotated credential.
 - [Rotate the Keystone Admin Password](keystone-admin-password-rotation.md) — the manual rotation guide whose verification steps (3–7) this guide cross-links, and the supported admin-password rotation path on a ControlPlane deployment.
 - [Rotate Keystone Fernet and Credential Keys](keystone-key-rotation.md) — the key-rotation counterpart, which uses an analogous staging→production split.
-- Chainsaw test: `tests/e2e/keystone/admin-password-scheduled-rotation/chainsaw-test.yaml` asserts this guide's evidence chain end-to-end — CronJob run → push-source commit → OpenBao change → ESO sync → re-bootstrap `BootstrapReady=True` → new-password `201` / old-password `401`, and the disable→teardown `RotationDisabled` posture.
+
+## Tested by
+
+This guide's evidence chain is asserted end-to-end on the CI e2e kind cluster —
+CronJob run → push-source commit → OpenBao change → ESO sync → re-bootstrap
+`BootstrapReady=True` → new-password `201` / old-password `401`, and the
+disable→teardown `RotationDisabled` posture — by this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/admin-password-scheduled-rotation
+```
+
+::: details The Keystone CR the suite applies
+The suite isolates its Keystone instance from the parallel suite pool, so its
+CR name (`keystone-adminpw-sched`) and logical database
+(`keystone_adminpw_sched`) deliberately differ from the devstack names used in
+the walkthrough above.
+
+<<< @/../tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml#keystone-cr
+:::

--- a/docs/guides/keystone-key-rotation.md
+++ b/docs/guides/keystone-key-rotation.md
@@ -313,4 +313,13 @@ identical.
 - [Key Rotation RBAC Split](../reference/keystone/keystone-reconciler.md#key-rotation-rbac-split) — the authoritative contract for the Fernet sub-reconciler.
 - [Labels and Annotations](../reference/keystone/keystone-reconciler.md#labels-and-annotations) — stable metadata keys observable by consumers.
 - [Rotation Scripts](../reference/backend/rotation-scripts.md) — the embedded `fernet_rotate.sh` / `credential_rotate.sh` contract.
-- Chainsaw tests: `tests/e2e/keystone/fernet-rotation/chainsaw-test.yaml` and `tests/e2e/keystone/credential-rotation/chainsaw-test.yaml` assert this guide's happy path and the RBAC verb split end-to-end.
+
+## Tested by
+
+This guide's happy path and the RBAC verb split are asserted end-to-end on the
+CI e2e kind cluster by these chainsaw suites:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/fernet-rotation
+chainsaw test --test-dir tests/e2e/keystone/credential-rotation
+```

--- a/docs/guides/ldap-domain-backend.md
+++ b/docs/guides/ldap-domain-backend.md
@@ -189,3 +189,22 @@ applies `spec.domain.deletionPolicy`:
 | LDAP users not listed | Check the tree/attribute mapping against your directory (`user_tree_dn`, `user_objectclass`, `user_id_attribute`) — unset fields fall back to keystone's defaults, which may not match your schema. |
 | `GET /v3/users` returns HTTP 400 `'enabled' is a required property` | The projected `user_enabled_invert`/`user_enabled_default` fallback was suppressed by a `user_enabled_*` key in `extraOptions` that does not match the directory — with no matching attribute, keystone omits `enabled` from the user model and its own response validation rejects the reply. Align the `user_enabled_*` options with the directory schema (or drop them to restore the fallback). |
 | Admission rejects the CR | The message names the exact rule: Default-domain protection, domain-name uniqueness per Keystone, the `extraOptions` denylist, or the fixed Secret data-key contract. |
+
+## Tested by
+
+Attaching the LDAP domain, watching the conditions converge, and authenticating
+an LDAP user against the seeded `dc=planetexpress,dc=com` directory are asserted
+end-to-end on the CI e2e kind cluster by this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/ldap-domain-backend
+```
+
+::: details The backend CR the suite applies
+The suite isolates its Keystone instance from the parallel suite pool, so its
+backend CR name (`planetexpress-ldap`) and `keystoneRef` (`keystone-ldap`)
+deliberately differ from the `corp-ldap` / `keystone` names used in the
+walkthrough above.
+
+<<< @/../tests/e2e/keystone/ldap-domain-backend/02-backend-cr.yaml#backend-cr
+:::

--- a/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
+++ b/docs/guides/migrate-keystone-db-to-dynamic-credentials.md
@@ -201,3 +201,15 @@ to remove the generator objects.
   engines, auth roles, policies, and secret paths.
 - [ControlPlane reconciler reference](/reference/c5c3/controlplane-reconciler) —
   `reconcileDBCredentials` projection flow.
+
+## Tested by
+
+The dynamic, engine-issued per-ControlPlane database credential this guide
+migrates to — the `VaultDynamicSecret`, the owned
+`controlplane-keystone-db-credentials` ExternalSecret, and the transient
+engine-issued login — is asserted on the CI e2e kind cluster by this chainsaw
+suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/c5c3/db-credential-scoping
+```

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -302,3 +302,14 @@ For deployments off a checkout, use the published OCI chart instead —
 - [ControlPlane Quick Start](../quick-start-controlplane.md) — standing up a tenant as a `ControlPlane` CR (the one-per-namespace tenancy aggregate).
 - [Enable the Keystone Operator NetworkPolicy](./enable-keystone-operator-networkpolicy.md) — confine the namespace-scoped operator's egress.
 - [Helm Values Schema](../reference/backend/helm-values-schema.md) — the full `rbac.*` / `webhook.*` value reference.
+
+## Tested by
+
+The namespace-scoped install and the two-ControlPlanes-in-two-namespaces tenancy
+this guide describes are asserted on the CI e2e kind cluster by these chainsaw
+suites:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/namespace-scoped-rbac
+chainsaw test --test-dir tests/e2e/c5c3/multi-controlplane
+```

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -229,3 +229,14 @@ kubectl logs -n keystone-system -l app.kubernetes.io/name=keystone-operator --ta
 - [Enable the Keystone operator metrics endpoint](./enable-keystone-operator-metrics.md) — ServiceMonitor enablement and Grafana import walk-through
 - [Keystone Upgrade Flow](../reference/keystone/keystone-upgrade-flow.md) — state machine that drives upgrade conditions
 - [Day 2 Operations](./day-2-operations.md) — putting this observability into practice during scale, upgrade, rotation
+
+## Tested by
+
+Lifecycle event emission and `spec.logging` → oslo.log propagation — the two
+observable surfaces this guide reads — are asserted on the CI e2e kind cluster
+by these chainsaw suites:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/events
+chainsaw test --test-dir tests/e2e/keystone/logging
+```

--- a/docs/guides/oidc-federation.md
+++ b/docs/guides/oidc-federation.md
@@ -315,9 +315,8 @@ your workstation cannot complete the login form against it — the browser
 WebSSO flow needs an **externally reachable** IdP (your production Keycloak, or
 a fixture published through the gateway with matching redirect URIs). The
 headless authorization-code round trip against the in-cluster fixture is
-exercised end-to-end by the mirroring e2e suite
-(`tests/e2e/keystone/oidc-federation/`); the CLI bearer flow above is the
-copy-pasteable devstack path.
+exercised end-to-end by the mirroring e2e suite (see [Tested by](#tested-by));
+the CLI bearer flow above is the copy-pasteable devstack path.
 :::
 
 ## Multiple identity providers
@@ -403,3 +402,22 @@ WebSSO origin, so set `spec.federation.trustedDashboards` directly on the Keysto
 CR. It is a list, rendered as one `[federation] trusted_dashboard` line per entry.
 See the standalone section of [End-to-End SSO](./end-to-end-sso.md#standalone-keystone-without-a-controlplane)
 for the full shape and the `spec.extraConfig` conflict rule.
+
+## Tested by
+
+Attaching the OIDC backend, watching the conditions converge, and the headless
+CLI bearer flow are asserted end-to-end on the CI e2e kind cluster by this
+chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/oidc-federation
+```
+
+::: details The backend CR the suite applies
+The suite isolates its Keystone instance from the parallel suite pool, so its
+backend CR points `keystoneRef` at `keystone-oidc` (and enables
+`oauth2Introspection` for the CLI bearer flow) — deliberately differing from the
+`controlplane-keystone` reference used in the walkthrough above.
+
+<<< @/../tests/e2e/keystone/oidc-federation/02-backend-cr.yaml#backend-cr
+:::

--- a/docs/guides/saml-federation.md
+++ b/docs/guides/saml-federation.md
@@ -10,8 +10,8 @@ identity provider using the `KeystoneIdentityBackend` CRD: supply the IdP
 metadata, apply one CR, watch the conditions converge, export the generated
 service-provider (SP) metadata, register it at the IdP out of band, and
 verify a federated user can log in. The worked example uses Keycloak — the
-same fixture the e2e suite deploys — so every value is adaptable to a kind
-cluster.
+same IdP the mirroring e2e suite ([Tested by](#tested-by)) deploys — so every
+value is adaptable to a kind cluster.
 
 SAML reuses almost all of the OIDC federation machinery: the same
 federation sidecar (which now also ships `mod_auth_mellon`), the same
@@ -246,3 +246,22 @@ the last federation backend restores the plain uWSGI-only pod.
 | Backend stays pending, `FederationProxyImageMissing` | `spec.federation.proxyImage` is not set on the Keystone CR. |
 | Second SAML backend rejected at admission | At most one SAML backend per Keystone is supported. |
 | IdP rejects the AuthnRequest | The SP was not registered, or its `clientId`/`entityID` at the IdP does not match the exported SP `entityID`. |
+
+## Tested by
+
+Attaching the SAML backend, watching the conditions converge, exporting the SP
+metadata, and a WebSSO login are asserted end-to-end on the CI e2e kind cluster
+by this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone/saml-federation
+```
+
+::: details The backend CR the suite applies
+The suite isolates its Keystone instance from the parallel suite pool, so its
+backend CR name (`keycloak-saml`) and `keystoneRef` (`keystone-saml`)
+deliberately differ from the `corp-saml` / `keystone` names used in the
+walkthrough above.
+
+<<< @/../tests/e2e/keystone/saml-federation/02-backend-cr.yaml#backend-cr
+:::

--- a/tests/e2e-controlplane-sso/02-controlplane-cr.yaml
+++ b/tests/e2e-controlplane-sso/02-controlplane-cr.yaml
@@ -36,6 +36,7 @@
 # Single-replica topology across database, cache, Keystone and Horizon so the
 # fresh-create chain schedules on a single-node kind cluster; storageSize is
 # pinned to 512Mi rather than the 100Gi CRD production default.
+# region controlplane-cr
 apiVersion: c5c3.io/v1alpha1
 kind: ControlPlane
 metadata:
@@ -95,3 +96,4 @@ spec:
         restricted: true
         rotation:
           mode: PasswordDriven
+# endregion controlplane-cr

--- a/tests/e2e-controlplane-sso/04-backends.yaml
+++ b/tests/e2e-controlplane-sso/04-backends.yaml
@@ -13,6 +13,7 @@
 # The OIDC backend provisions its own "forge" domain: the CRD forbids backing
 # the Default domain — which hosts the SQL-backed service users and the
 # bootstrap admin — with an external identity backend.
+# region backends
 ---
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: KeystoneIdentityBackend
@@ -92,3 +93,4 @@ spec:
       idAttribute: uid
       nameAttribute: uid
       mailAttribute: mail
+# endregion backends

--- a/tests/e2e/horizon-operator/metrics/chainsaw-test.yaml
+++ b/tests/e2e/horizon-operator/metrics/chainsaw-test.yaml
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the horizon-operator metrics ServiceMonitor.
+# Verifies that the horizon-operator chart renders (and later removes) a
+# monitoring.coreos.com/v1 ServiceMonitor pointing at the operator's
+# /metrics endpoint when monitoring.serviceMonitor.enabled is toggled.
+#
+# This mirrors tests/e2e/keystone/metrics/chainsaw-test.yaml so the
+# metrics guide's flow (docs/guides/enable-horizon-operator-metrics.md) is
+# asserted on a real cluster rather than only by the chart's helm-unittest.
+#
+# DEPLOYMENT NOTE — why this test installs its own Helm release:
+# The horizon-operator HelmRelease at horizon-system/horizon-operator is
+# intentionally suspended in the kind CI overlay (see
+# deploy/kind/base/kustomization.yaml: "horizon-operator: suspend Flux
+# management in kind"). The operator that actually runs in the cluster is
+# installed by hack/ci-deploy-operator.sh, which `helm install`s the chart
+# into the default namespace with a locally built dev image. Patching the
+# suspended HelmRelease therefore has no observable effect. Mirroring the
+# pattern in tests/e2e/keystone/metrics, this test installs a dedicated
+# release ("horizon-operator-metrics") whose lifecycle directly produces and
+# tears down the ServiceMonitor under assertion.
+#
+# DECISION: Prometheus target-Up polling is intentionally NOT implemented here.
+# The end-to-end scrape path (a live Prometheus that discovers the
+# ServiceMonitor and marks the target Up) is exercised by the WITH_PROMETHEUS
+# kind bring-up documented in the guide, not by this suite: the e2e cluster
+# only installs prometheus-operator-crds (see
+# deploy/flux-system/releases/prometheus-operator-crds.yaml) and does NOT run a
+# Prometheus instance, so there is no /api/v1/targets endpoint to poll. The
+# structural ServiceMonitor assertion below (CRD shape, labels, selector,
+# endpoints port/path/interval) is what this cluster can honestly verify.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: horizon-operator-metrics
+spec:
+  namespace: horizon-system
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Install horizon-operator chart with monitoring enabled ───────
+  # webhook.enabled=false avoids the cluster-scoped MutatingWebhookConfiguration
+  # registered by the primary horizon-operator deployed by
+  # hack/ci-deploy-operator.sh (same rationale as the keystone metrics twin).
+  - try:
+    - script:
+        timeout: 120s
+        content: |
+          helm install horizon-operator-metrics \
+            ${GITHUB_WORKSPACE:-.}/operators/horizon/helm/horizon-operator/ \
+            --namespace horizon-system --create-namespace \
+            --set image.repository=ghcr.io/c5c3/horizon-operator \
+            --set image.tag=dev \
+            --set image.pullPolicy=Never \
+            --set replicas=1 \
+            --set webhook.enabled=false \
+            --set monitoring.serviceMonitor.enabled=true \
+            --set monitoring.serviceMonitor.interval=30s \
+            --wait --timeout 90s
+    catch:
+    - script:
+        content: |
+          echo "=== Helm status ==="
+          helm status horizon-operator-metrics -n horizon-system 2>&1 || true
+          echo "=== Pod status ==="
+          kubectl get pods -n horizon-system -l app.kubernetes.io/instance=horizon-operator-metrics -o wide 2>&1 || true
+          echo "=== Operator pod logs ==="
+          for pod in $(kubectl get pods -n horizon-system -l app.kubernetes.io/instance=horizon-operator-metrics -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n horizon-system "$pod" --all-containers --tail=120 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n horizon-system --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 2: Assert the ServiceMonitor exists with the expected spec ──────
+  # Mirrors operators/shared/helm/operator-library/templates/_servicemonitor.tpl.
+  # With release name "horizon-operator-metrics" the helper
+  # "operator-library.fullname" resolves to "horizon-operator-metrics" (the
+  # chart name "horizon-operator" is a substring of the release name; see
+  # operators/shared/helm/operator-library/templates/_helpers.tpl).
+  - try:
+    - assert:
+        resource:
+          apiVersion: monitoring.coreos.com/v1
+          kind: ServiceMonitor
+          metadata:
+            name: horizon-operator-metrics
+            namespace: horizon-system
+            labels:
+              app.kubernetes.io/name: horizon-operator
+              app.kubernetes.io/instance: horizon-operator-metrics
+              app.kubernetes.io/managed-by: Helm
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: horizon-operator
+                app.kubernetes.io/instance: horizon-operator-metrics
+            endpoints:
+            - port: metrics
+              path: /metrics
+              interval: 30s
+    catch:
+    - script:
+        content: |
+          echo "=== ServiceMonitor list ==="
+          kubectl get servicemonitor -n horizon-system -o wide 2>&1 || true
+          echo "=== ServiceMonitor yaml ==="
+          kubectl get servicemonitor horizon-operator-metrics -n horizon-system -o yaml 2>&1 || true
+          echo "=== Helm values ==="
+          helm get values horizon-operator-metrics -n horizon-system 2>&1 || true
+  # ── Step 3: Uninstall the test release (cleanup) ─────────────────────────
+  - try:
+    - script:
+        timeout: 120s
+        content: |
+          helm uninstall horizon-operator-metrics -n horizon-system --wait --timeout 60s 2>&1 || true
+  # ── Step 4: Assert the ServiceMonitor is removed ─────────────────────────
+  - try:
+    - script:
+        content: |
+          # Verify the ServiceMonitor is gone after helm uninstall
+          for i in $(seq 1 12); do
+            if ! kubectl get servicemonitor horizon-operator-metrics -n horizon-system >/dev/null 2>&1; then
+              echo "PASS: ServiceMonitor correctly removed"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "FAIL: ServiceMonitor still present after helm uninstall"
+          kubectl get servicemonitor horizon-operator-metrics -n horizon-system -o yaml 2>&1 || true
+          exit 1

--- a/tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/admin-password-scheduled-rotation/00-keystone-cr.yaml
@@ -67,6 +67,7 @@ spec:
         key: bootstrap/openstack/keystone-adminpw-sched/admin
         property: password
 ---
+# region keystone-cr
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: Keystone
 metadata:
@@ -117,3 +118,4 @@ spec:
   extraConfig:
     cache:
       enabled: "false"
+# endregion keystone-cr

--- a/tests/e2e/keystone/ldap-domain-backend/02-backend-cr.yaml
+++ b/tests/e2e/keystone/ldap-domain-backend/02-backend-cr.yaml
@@ -9,6 +9,7 @@
 # objectClass inetOrgPerson, uid as both ID and name, mail for email.
 # readOnly: true (the default, spelled out for readers) forces the
 # user_allow_*/group_allow_* write options to false.
+# region backend-cr
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: KeystoneIdentityBackend
 metadata:
@@ -35,3 +36,4 @@ spec:
       idAttribute: uid
       nameAttribute: uid
       mailAttribute: mail
+# endregion backend-cr

--- a/tests/e2e/keystone/oidc-federation/02-backend-cr.yaml
+++ b/tests/e2e/keystone/oidc-federation/02-backend-cr.yaml
@@ -13,6 +13,7 @@
 # attribute the proxy passes) and maps the preferred username into an
 # ephemeral user plus the declarative federated-users group, whose member
 # role on the domain is what authorizes domain-scoped tokens.
+# region backend-cr
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: KeystoneIdentityBackend
 metadata:
@@ -71,3 +72,4 @@ spec:
     roleAssignments:
     - role: member
       domain: true
+# endregion backend-cr

--- a/tests/e2e/keystone/saml-federation/02-backend-cr.yaml
+++ b/tests/e2e/keystone/saml-federation/02-backend-cr.yaml
@@ -15,6 +15,7 @@
 # (HTTP_MELLON_USERNAME) into an ephemeral user plus the declarative
 # federated-users group, whose member role on the domain authorizes
 # domain-scoped tokens.
+# region backend-cr
 apiVersion: keystone.openstack.c5c3.io/v1alpha1
 kind: KeystoneIdentityBackend
 metadata:
@@ -60,3 +61,4 @@ spec:
     roleAssignments:
     - role: member
       domain: true
+# endregion backend-cr

--- a/tests/e2e/keystone/saml-federation/chainsaw-test.yaml
+++ b/tests/e2e/keystone/saml-federation/chainsaw-test.yaml
@@ -45,6 +45,14 @@ spec:
   timeouts:
     apply: 2m
     assert: 6m
+    # Step 6 detaches both federation backends, which rewrites the
+    # content-hashed federation Secret and rolls the replicas:1 Keystone pod
+    # (the mellon sidecar is removed). Each backend's finalizer deprovisions its
+    # domain THROUGH that same Keystone, so its first attempt races the rollout
+    # and fails (EOF), then a requeue retries and succeeds ~30s later — past the
+    # 30s global delete bound. 2m covers one failed attempt plus the retry with
+    # margin for a slow rollout (mirrors the oidc-federation suite).
+    delete: 2m
     exec: 3m
   steps:
   # ── Step 1: Deploy the Keycloak fixture and Keystone; both become ready ──

--- a/tests/unit/docs/guide_devstack_and_tested_by_test.sh
+++ b/tests/unit/docs/guide_devstack_and_tested_by_test.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Enforce the guide↔suite coupling contract per guide under docs/guides/:
+#
+#   (a) a "## Prerequisites" heading exists;
+#   (b) its section contains a "::: info Devstack" container;
+#   (c) that container names exactly one Getting-Started tutorial
+#       ("](../quick-start...") and holds at least one ```bash fence with the
+#       devstack bring-up command;
+#   (d) a "## Tested by" heading exists;
+#   (e) the "## Tested by" section names at least one suite via
+#       "chainsaw test --test-dir tests/...", and every referenced suite
+#       directory resolves to a real chainsaw-test.yaml;
+#   (f) every VitePress code-import ("<<< @/../...") in the guide resolves to a
+#       file that exists, and when a "#region" is named the fixture carries the
+#       matching "# region <name>" / "# endregion <name>" markers.
+#
+# VitePress does not fail the build on a dead snippet path, so (e) and (f) are
+# the enforcing gate for the tested-by references and the code-import wiring.
+# This check is purely structural (headings, containers, paths) — it makes no
+# assertions on the guides' prose.
+#
+# Usage: bash tests/unit/docs/guide_devstack_and_tested_by_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+GUIDES_DIR="$PROJECT_ROOT/docs/guides"
+
+# Body of the "## <title>" section: lines after the heading up to (but not
+# including) the next level-2 heading or EOF.
+section_body() {
+  local file="$1" heading="$2"
+  awk -v h="^## ${heading}[[:space:]]*\$" '
+    $0 ~ h { f = 1; next }
+    f && /^## / { exit }
+    f { print }
+  ' "$file"
+}
+
+# Body of the first "::: info Devstack" container, including the opening and
+# closing fence lines, up to the first line that is exactly ":::".
+devstack_container() {
+  local file="$1"
+  awk '
+    /^::: info Devstack/ { f = 1; print; next }
+    f && /^:::[[:space:]]*$/ { print; exit }
+    f { print }
+  ' "$file"
+}
+
+check_guide() {
+  local file="$1"
+  local name
+  name="$(basename "$file")"
+  echo "Guide: $name"
+
+  # (a) Prerequisites heading.
+  if ! grep -qE '^## Prerequisites[[:space:]]*$' "$file"; then
+    echo "  FAIL: $name has no '## Prerequisites' heading"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $name has a '## Prerequisites' heading"
+  PASS=$((PASS + 1))
+
+  local prereq devstack
+  prereq="$(section_body "$file" "Prerequisites")"
+
+  # (b) Devstack container inside Prerequisites.
+  if [[ "$prereq" != *"::: info Devstack"* ]]; then
+    echo "  FAIL: $name Prerequisites section has no '::: info Devstack' container"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $name Prerequisites has a '::: info Devstack' container"
+  PASS=$((PASS + 1))
+
+  devstack="$(devstack_container "$file")"
+
+  # (c1) Exactly one Getting-Started link in the devstack container. Count
+  # occurrences (grep -o, one match per line) rather than matching lines, so a
+  # second link on the same line cannot slip past.
+  local link_count
+  link_count="$(printf '%s\n' "$devstack" | grep -oE '\]\(\.\./quick-start' | wc -l | tr -d '[:space:]')"
+  assert_eq "$name devstack names exactly one Getting-Started tutorial" \
+    "1" "$link_count"
+
+  # (c2) At least one bash bring-up fence in the devstack container.
+  local bash_count
+  bash_count="$(printf '%s\n' "$devstack" | grep -cE '^```bash')"
+  assert_gte "$name devstack holds a bash bring-up fence" "$bash_count" "1"
+
+  # (d) Tested by heading.
+  if ! grep -qE '^## Tested by[[:space:]]*$' "$file"; then
+    echo "  FAIL: $name has no '## Tested by' heading"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $name has a '## Tested by' heading"
+  PASS=$((PASS + 1))
+
+  # (e) Tested by names at least one resolvable suite.
+  local tested paths
+  tested="$(section_body "$file" "Tested by")"
+  paths="$(printf '%s\n' "$tested" \
+    | grep -oE 'chainsaw test --test-dir tests/[^ )]+' \
+    | awk '{print $4}' | sed 's:/*$::')"
+  if [[ -z "$paths" ]]; then
+    echo "  FAIL: $name '## Tested by' has no 'chainsaw test --test-dir tests/...' invocation"
+    FAIL=$((FAIL + 1))
+  else
+    local p
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      if [[ -f "$PROJECT_ROOT/$p/chainsaw-test.yaml" ]]; then
+        echo "  PASS: $name tested-by suite $p resolves"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL: $name tested-by suite $p has no chainsaw-test.yaml"
+        FAIL=$((FAIL + 1))
+      fi
+    done <<< "$paths"
+  fi
+
+  # (f) Every code-import resolves (file + region markers).
+  local spec importfile region
+  while IFS= read -r spec; do
+    [[ -z "$spec" ]] && continue
+    spec="${spec#<<< @/../}"
+    importfile="${spec%%#*}"
+    if [[ ! -f "$PROJECT_ROOT/$importfile" ]]; then
+      echo "  FAIL: $name code-import target $importfile does not exist"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+    if [[ "$spec" == *"#"* ]]; then
+      region="${spec#*#}"
+      if grep -qE "^# region ${region}\$" "$PROJECT_ROOT/$importfile" \
+        && grep -qE "^# endregion ${region}\$" "$PROJECT_ROOT/$importfile"; then
+        echo "  PASS: $name code-import $importfile#$region resolves with balanced markers"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL: $name code-import $importfile#$region is missing '# region'/'# endregion $region' markers"
+        FAIL=$((FAIL + 1))
+      fi
+    else
+      echo "  PASS: $name code-import $importfile resolves (whole file)"
+      PASS=$((PASS + 1))
+    fi
+  done < <(grep -E '^<<< @/\.\./' "$file")
+}
+
+# --- Run ---
+if [[ ! -d "$GUIDES_DIR" ]]; then
+  echo "FAIL: guides directory $GUIDES_DIR does not exist"
+  exit 1
+fi
+
+shopt -s nullglob
+guide_files=("$GUIDES_DIR"/*.md)
+shopt -u nullglob
+
+if [[ "${#guide_files[@]}" -eq 0 ]]; then
+  echo "FAIL: no guides found under $GUIDES_DIR"
+  exit 1
+fi
+
+for guide in "${guide_files[@]}"; do
+  check_guide "$guide"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #614

## Why

Nearly every guide under `docs/guides/` already has a mirroring chainsaw e2e suite that exercises the same feature (rotation, database TLS, NetworkPolicy, LDAP, OIDC/SAML federation, multi-ControlPlane SSO), but the guide YAML and the suite fixtures were maintained by hand in parallel and could drift silently. Today only the quick-start CR is structurally cross-checked against its fixture. This branch couples each guide to the suite that tests it so the e2e run exercises exactly the manifests the docs show.

## What changed (in commit order)

**`test(e2e): add the horizon-operator metrics ServiceMonitor suite` (1c3fc055)**
The horizon-operator chart ships a `ServiceMonitor` (via the shared operator-library template) but no e2e suite exercised it, unlike its keystone twin. Adds `tests/e2e/horizon-operator/metrics/chainsaw-test.yaml`, mirroring `tests/e2e/keystone/metrics`: install a dedicated horizon-operator release with `monitoring.serviceMonitor.enabled=true`, assert the rendered ServiceMonitor shape (labels, selector, endpoints), uninstall, and poll for removal. It installs its own release because the flux-managed HelmRelease is suspended in the kind overlay, and lives under `tests/e2e/horizon-operator/` so the `e2e-operator` horizon leg picks it up.

**`test(e2e): mark guide-exhibit snippet regions in suite fixtures` (1c6aa498)**
Adds column-0 `# region <name>` / `# endregion <name>` YAML-comment markers around the CR document(s) that the federation, scheduled-rotation, and SSO guides embed. The markers are comments — inert to chainsaw, keeping each fixture a valid YAML document — and let a guide pull the exact manifest its suite applies via `<<< @/../<fixture>#<region>`. Touches the SSO, LDAP, OIDC, SAML, scheduled-rotation, and controlplane-sso fixtures.

**`docs(guides): close every guide with a standard Tested by section` (52d5d50e)**
Every guide under `docs/guides/` now ends with a terminal `## Tested by` section that names its mirroring chainsaw suite(s) and the `chainsaw test --test-dir <dir>` invocation. Pre-existing scattered pointers (database-tls step 4, the operator-networkpolicy guardrail subsection, the SSO warning fence, the rotation guides' Related-reference bullets) are normalized into that section. The five guides whose walkthrough mirrors a suite CR (scheduled admin-password rotation, LDAP, OIDC, SAML, end-to-end SSO) embed the exact fixture as a labelled `::: details` exhibit via VitePress code-import. `docs/contributing/guide-conventions.md` records the resolution and pins the `## Tested by` contract.

**`test(docs): enforce the devstack and tested-by blocks per guide` (152c226b)**
Adds `tests/unit/docs/guide_devstack_and_tested_by_test.sh`, a purely structural shell test gating every `docs/guides/*.md` on the coupling contract: a `## Prerequisites` section with a `::: info Devstack` container naming exactly one Getting-Started tutorial and a bash bring-up fence; a terminal `## Tested by` section whose `chainsaw test --test-dir tests/...` invocations each resolve to a real `chainsaw-test.yaml`; and every `<<< @/../` code-import target and its `#region` markers (VitePress does not fail the build on a dead snippet path, so this check owns that validation). Picked up by `make test-shell` with no CI wiring change; it makes no prose assertions.

## Note on divergence from the issue

The issue framed the coupling as embedding guide manifests "instead of hand-maintained inline YAML." The implementation refines this rather than replacing inline YAML wholesale: a suite fixture is **isolation-named** (distinct CR name, own database, `deletionPolicy: Delete`, dev-tag pins) so it runs safely in the parallel suite pool, while a walkthrough must be **devstack-named** so a reader's copy-pasted command hits a resource that exists. The two are reconciled by keeping the walkthrough YAML devstack-named and embedding the isolation-named fixture as a labelled `::: details` exhibit inside `## Tested by`, prefaced by a sentence explaining which names it uses and why. The import is live, so the exhibit cannot drift from the tested fixture while the walkthrough stays copy-pasteable. This resolution is documented in `guide-conventions.md`.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
