### PR TITLE
docs(guides): fix mechanical errors the guide audit surfaced

### DIFF
--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -85,6 +85,20 @@ operator projects the new image tag (`ghcr.io/c5c3/keystone:<release>`) onto the
 expand-migrate-contract pipeline. The API stays available throughout — old and
 new schemas coexist while data is migrated.
 
+Before you patch, make the target-release images node-local. The devstack
+pre-loads only the `2025.2` Keystone image, and the projected Horizon child
+follows `spec.openStackRelease` too — so pull and `kind load` both the Keystone
+and Horizon images for the target release, or the rollout stalls on an image
+pull:
+
+```bash
+docker pull ghcr.io/c5c3/keystone:2026.1
+kind load docker-image ghcr.io/c5c3/keystone:2026.1 --name forge
+
+docker pull ghcr.io/c5c3/horizon:2026.1
+kind load docker-image ghcr.io/c5c3/horizon:2026.1 --name forge
+```
+
 ```bash
 kubectl patch controlplane controlplane -n openstack \
   --type merge \
@@ -243,9 +257,18 @@ kubectl patch keystone keystone -n openstack \
 ```
 
 The same sequential-only constraint, the four-phase pipeline, and the
-forward-only recovery path apply. The target tag must be pullable by the cluster
-(`ghcr.io/c5c3/keystone:<tag>`), or the `RollingUpdate` phase stalls on an image
-pull error.
+forward-only recovery path apply. Make the target image node-local first, or the
+upgrade stalls at its first phase that needs it — `Expanding`, which runs
+`db_sync --expand` with the new image:
+
+```bash
+docker pull ghcr.io/c5c3/keystone:2026.1
+kind load docker-image ghcr.io/c5c3/keystone:2026.1 --name forge
+```
+
+On the [Quick Start (Extended)](../quick-start-extended.md) local-build path,
+rebuild the service image with `RELEASE=2026.1` per that tutorial's Step 6
+instead of pulling it.
 
 **Rotate Fernet keys** against the `keystone-fernet-rotate` /
 `keystone-credential-rotate` CronJobs, and tune or pause scheduled rotation with

--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -120,7 +120,7 @@ kubectl get controlplane controlplane -n openstack -w
 
 ```bash
 kubectl get keystone controlplane-keystone -n openstack -w \
-  -o custom-columns=NAME:.metadata.name,PHASE:.status.upgradePhase,FROM:.status.installedRelease,TO:.status.targetRelease,READY:.status.conditions[?(@.type=='Ready')].status
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.upgradePhase,FROM:.status.installedRelease,TO:.status.targetRelease,READY:.status.conditions[?(@.type=="Ready")].status'
 ```
 
 Expected timeline on the child:

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -206,7 +206,15 @@ server itself, so they hold even with the webhook disabled.
 
 ## Example: namespace-scoped install
 
-Deploy the operator into the `team-alpha` namespace with namespace-scoped RBAC:
+Deploy the operator into the `team-alpha` namespace with namespace-scoped RBAC.
+Build the operator image and load it into the kind cluster first — this mirrors
+the install form of the guide's namespace-scoped-rbac chainsaw suite (a local
+`dev` image with `pullPolicy=Never`, no registry needed):
+
+```bash
+make docker-build OPERATOR=keystone IMG=ghcr.io/c5c3/keystone-operator:dev
+kind load docker-image ghcr.io/c5c3/keystone-operator:dev --name forge
+```
 
 ```bash
 helm install keystone-operator \
@@ -215,7 +223,8 @@ helm install keystone-operator \
   --set rbac.namespaceScoped=true \
   --set webhook.enabled=false \
   --set image.repository=ghcr.io/c5c3/keystone-operator \
-  --set image.tag=v0.1.0 \
+  --set image.tag=dev \
+  --set image.pullPolicy=Never \
   --wait --timeout 120s
 ```
 

--- a/docs/guides/saml-federation.md
+++ b/docs/guides/saml-federation.md
@@ -101,7 +101,20 @@ spec:
   federation:
     proxyImage:
       repository: ghcr.io/c5c3/keystone-federation-proxy
-      tag: v0.1.0
+      digest: sha256:<64-hex-digest>   # pin by immutable digest, never a mutable tag
+```
+
+The sidecar terminates SAML on the authentication path, so pin it by immutable
+`digest` rather than a tag. `latest` re-pulls on every restart (its default
+`pullPolicy` is `Always`), so a silently re-published image would land
+unreviewed in the auth path with no version to roll back to. The proxy image is
+released under the base-image scheme (`:latest` and per-commit `:<sha>`, not the
+`spec.openStackRelease` cadence), so resolve the digest of the build you intend
+to run and pin that:
+
+```bash
+docker buildx imagetools inspect ghcr.io/c5c3/keystone-federation-proxy:latest \
+  --format '{{.Manifest.Digest}}'
 ```
 
 ## Step 4 — Apply the backend CR


### PR DESCRIPTION
Closes #615

## What

Fixes the mechanical, deployment-model-independent errors the guide audit flagged: copy-paste commands whose image reference, shell quoting, or preloading assumptions do not match the cluster the tutorials tell the reader to build. Docs-only — no operator or chart code changes.

## Change set (commit order)

1. **`a2edba61` docs(guides): preload the upgrade-target images in day-2 examples**
   The image-upgrade examples patch `spec.openStackRelease` to a target tag the devstack never loads onto the kind nodes, so the rollout stalls on an `ImagePullBackOff`. Adds explicit `docker pull` + `kind load` steps for the target-release images before each upgrade patch:
   - ControlPlane path: preload both the Keystone **and** the projected Horizon child images (the Horizon child follows `spec.openStackRelease` too).
   - Standalone Keystone path: preload the target Keystone image, with a note that the `Expanding` phase (`db_sync --expand`) is the first phase that needs it, plus a pointer to the Quick Start (Extended) local-build path (`RELEASE=2026.1`) as the alternative to pulling.

2. **`f0530d7a` docs(guides): shell-quote the day-2 upgrade watch custom-columns**
   The upgrade-watch `kubectl get keystone ... -o custom-columns=...` uses `[?(@.type=='Ready')]`, whose parentheses and brackets the shell tries to expand, so the pasted command fails. Wraps the whole `custom-columns` spec in single quotes and switches the inner JSONPath filter to double quotes (`=="Ready"`).

3. **`e3fd4869` docs(guides): replace unpublished v0.1.0 image pins with real tags**
   Two guides pinned `v0.1.0`, a tag that was never published, so the pasted install fails to pull:
   - `multi-tenant-deployment.md` namespace-scoped install: swaps `image.tag=v0.1.0` for a locally-built `dev` image with `image.pullPolicy=Never`, and adds the `make docker-build` + `kind load` steps ahead of the `helm install` — mirroring the install form of the guide's namespace-scoped-rbac chainsaw suite.
   - `saml-federation.md` federation proxy: swaps `tag: v0.1.0` for a `digest:` pin (the sidecar terminates SAML on the auth path, so it should be pinned by immutable digest, not a mutable/`latest` tag), and documents resolving the digest with `docker buildx imagetools inspect`.

## Divergence from the issue

The issue's first concrete example — the scale example patching `replicas` at the top level of the spec instead of under the deployment block — was **already correct on `main`** and needed no change: the ControlPlane example nests `spec.services.keystone.replicas` and the standalone example nests `spec.deployment.replicas`, both matching their prose. This branch therefore addresses the issue's second concrete example (image-upgrade preloading) plus the same-class mechanical errors found while verifying: the unquoted watch command and the unpublished `v0.1.0` image pins.

## Verification

Docs-only change; no code paths affected. The corrected commands were checked against the CR shapes and image cadences the tutorials actually produce.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_