### PR TITLE
feat(skills): add prepare-new-guide scaffold-and-validate skill

### DIFF
--- a/.claude/skills/prepare-new-guide/SKILL.md
+++ b/.claude/skills/prepare-new-guide/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: prepare-new-guide
+description: >-
+  Scaffold and validate a how-to guide under docs/guides/ against the guide
+  conventions — one devstack per guide, ControlPlane-first naming, no
+  projected-child edits without a revert warning, raw helm framed against
+  Flux ownership, a Tested by suite reference, code-import for mirrored
+  fixtures. Use when asked to write a new guide, scaffold a guide skeleton,
+  or check a draft guide for convention violations.
+---
+
+# Prepare a new guide
+
+This skill makes a new guide under `docs/guides/` **conform by
+construction** and turns convention review into a **check**. The contract
+it applies is `docs/contributing/guide-conventions.md` — the standardized
+prerequisites block, ControlPlane-first naming, the projected-children
+rule, the terminal `## Tested by` section, and the code-import discipline.
+Encode the conventions by content; guides never carry internal feature or
+requirement IDs, or issue references.
+
+## Scaffold a new guide
+
+### 1. Settle the devstack anchor with the user
+
+Every guide declares exactly one devstack. Default to the ControlPlane
+Quick Start (`quick-start-controlplane`) — the ControlPlane-first rule —
+and fall back to a standalone devstack only when the knob is
+standalone-only or the guide targets the operator chart itself. Collect
+every `WITH_*` opt-in the guide depends on (Prometheus, Chaos Mesh, ...);
+opt-in flags compose onto the bring-up command.
+
+### 2. Generate the skeleton
+
+```bash
+bash .claude/skills/prepare-new-guide/scripts/scaffold-guide.sh \
+  <slug> --devstack quick-start-controlplane \
+  --title "<Title>" \
+  --opt-in WITH_PROMETHEUS=true \
+  --suite tests/e2e/keystone/<suite> \
+  > docs/guides/<slug>.md
+```
+
+The script prints the skeleton to stdout and never writes to the tree —
+you perform the write. The skeleton carries the `::: info Devstack`
+container with the devstack's verbatim bring-up command, the section
+structure (`## Steps`, `## Verification`, `## See also`), and the terminal
+`## Tested by` fence; the ControlPlane variant additionally carries the
+operator-owned `::: warning` block and a
+`## Standalone Keystone, without a ControlPlane` stub. Until the
+tested-by suite path resolves to a real `chainsaw-test.yaml`, the
+skeleton fails the docs gate — that is intended, not a scaffold bug.
+
+### 3. Register the guide in the sidebar
+
+Add a `{ text: '<Title>', link: '/guides/<slug>' }` entry to the `Guides`
+sidebar section in `docs/.vitepress/config.ts`.
+
+### 4. Author the body with the devstack's real names
+
+Use only the resource names the declared devstack actually produces — the
+table in `docs/contributing/guide-conventions.md` lists them per devstack.
+Standalone differences go in the terminal
+`## Standalone Keystone, without a ControlPlane` section (modeled on
+`docs/guides/end-to-end-sso.md`); never interleave the two naming worlds
+in the primary walkthrough.
+
+### 5. Wire the Tested by section
+
+Point `## Tested by` at the mirroring suite (`chainsaw test --test-dir
+tests/e2e/keystone/<suite>`, one line per suite) and embed mirrored
+fixtures via `<<< @/../tests/e2e/...#<region>` imports instead of
+hand-maintained copies. The walkthrough YAML stays devstack-named; the
+imported fixture is isolation-named and lives as a labelled `::: details`
+exhibit inside `## Tested by`, prefaced by a sentence that states which
+names the exhibit uses and why.
+
+## Validate a draft guide
+
+### 1. Run the deterministic checks
+
+```bash
+bash .claude/skills/prepare-new-guide/scripts/validate-guide.sh [<guide.md>...]
+```
+
+Without arguments it walks every `docs/guides/*.md`. It checks what the
+docs gate does not:
+
+- **V1** — banned placeholder names (`keystone-default`).
+- **V2** — the devstack link and the `WITH_CONTROLPLANE=true` flag agree
+  inside the `::: info Devstack` container.
+- **V3** — a bash fence running raw `helm upgrade`/`helm install` against
+  the published operator chart (`oci://ghcr.io/c5c3/charts/`) requires a
+  `HelmRelease` mention (Flux-ownership framing).
+- **V4** — a mutating kubectl verb on a projected child CR
+  (`controlplane-keystone` / `controlplane-horizon`) requires a
+  `::: warning` container with revert/projected language.
+
+### 2. Run the authoritative gate
+
+```bash
+bash tests/unit/docs/guide_devstack_and_tested_by_test.sh
+```
+
+or `validate-guide.sh --full`, which chains it. The gate owns the
+structural half of the conventions — the `## Prerequisites` heading, the
+`::: info Devstack` container with exactly one tutorial link and a bash
+bring-up fence, the `## Tested by` heading with resolvable `--test-dir`
+suites, and resolvable code-imports with balanced region markers. Trust
+the gate's verdict over the script's.
+
+### 3. Walk the prose checklist
+
+What the scripts cannot decide:
+
+- Every example name exists on the declared devstack — cross-reference the
+  names table in `docs/contributing/guide-conventions.md`.
+- Revert warnings sit adjacent to the operations they cover, not in a
+  distant section.
+- Standalone differences live in a terminal
+  `## Standalone Keystone, without a ControlPlane` section with no
+  interleaved naming worlds.
+- Walkthrough YAML is devstack-named; the imported fixture exhibit is
+  isolation-named and labelled as such.
+- Frontmatter (`title`, `quadrant: operator`) starts on line 1.
+- The guide is registered in the `Guides` sidebar in
+  `docs/.vitepress/config.ts`.
+
+## Findings report
+
+Group findings by severity, with a `file:line` reference on both the
+guide side and the convention side:
+
+- **HIGH** — the reader's cluster cannot execute the guide: a placeholder
+  name no tutorial produces, a devstack/flag mismatch, a projected-child
+  edit with no revert warning.
+- **MEDIUM** — drift and revert traps: raw helm without Flux-ownership
+  framing, interleaved naming worlds, a hand-maintained fixture copy where
+  a code-import belongs.
+- **LOW** — housekeeping: missing sidebar registration, frontmatter not on
+  line 1, a `## Tested by` invocation not in `--test-dir` form.
+
+## Known gotchas (verified 2026-07, re-verify at HEAD)
+
+- **Raw helm against the OCI chart is not itself a violation** — it is the
+  canonical non-kind path for the operator charts. The violation is raw
+  helm with no Flux-ownership framing; the model is the `::: tip On kind`
+  block in `docs/guides/enable-keystone-operator-metrics.md`, which frames
+  the raw-helm sections as the non-kind path and routes kind users through
+  the HelmRelease.
+- **Not every `controlplane-keystone-*` mutation is a projected-CR edit** —
+  Secrets and ExternalSecrets named with that prefix (rotation Secrets,
+  admin-credential ExternalSecrets) are legitimately user-mutable; V4 keys
+  on the resource kind adjacent to the child name for exactly this reason.
+- **The docs gate is structural only** — it checks headings, containers,
+  and paths, and makes no assertions on prose. A guide can pass the gate
+  and still violate the naming or projected-children conventions.
+- **A multi-line `kubectl apply` that overwrites a projected child is not
+  mechanically detectable** — V4 matches single-line mutating verbs; the
+  prose checklist owns the apply-a-manifest case.
+
+## Notes
+
+- The scripts are read-only with respect to the tree: `scaffold-guide.sh`
+  prints the skeleton to stdout (the caller writes the file), and
+  `validate-guide.sh` only reads and reports.
+- The per-devstack bring-up commands and name sets are sourced from the
+  devstack table in `docs/contributing/guide-conventions.md`; the scripts
+  carry a machine copy that must stay in sync with it (both scripts say so
+  in a header note).
+- Pair with [[check-doc-drift]] after guide edits — it audits the wider
+  docs surface against the implementation.

--- a/.claude/skills/prepare-new-guide/scripts/scaffold-guide.sh
+++ b/.claude/skills/prepare-new-guide/scripts/scaffold-guide.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# scaffold-guide.sh — print a convention-conform how-to guide skeleton for a
+# chosen devstack anchor to stdout. The script never writes to the tree; the
+# caller redirects stdout into docs/guides/<slug>.md.
+#
+# The skeleton carries the standardized prerequisites block (the
+# "::: info Devstack" container with the devstack's verbatim bring-up command
+# and completion pointer), the section structure, and the terminal
+# "## Tested by" section. Until the tested-by suite path resolves to a real
+# chainsaw-test.yaml the skeleton fails
+# tests/unit/docs/guide_devstack_and_tested_by_test.sh — that is intended.
+#
+# NOTE: bring-up commands, completion pointers, and name sets MUST stay in
+# sync with the devstack table in docs/contributing/guide-conventions.md —
+# that page is the prose source of truth; this script is the machine copy.
+#
+# Usage: scaffold-guide.sh <slug> --devstack <devstack> [options]
+#   <slug>                guide file slug ([a-z0-9-]+, becomes docs/guides/<slug>.md)
+#   --devstack <name>     quick-start | quick-start-extended | quick-start-controlplane
+#   --title <title>       guide title (default: title-cased slug)
+#   --opt-in WITH_X=true  compose a WITH_* opt-in flag onto the bring-up command
+#                         (repeatable; WITH_CONTROLPLANE is a devstack, not an opt-in)
+#   --suite <path>        tests/e2e/... suite for '## Tested by' (default: TODO placeholder)
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <slug> --devstack <quick-start|quick-start-extended|quick-start-controlplane> [--title <title>] [--opt-in WITH_X=true]... [--suite tests/e2e/...]" >&2
+  exit 2
+}
+
+SLUG=""
+DEVSTACK=""
+TITLE=""
+SUITE=""
+OPT_INS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --devstack)
+      [[ $# -ge 2 ]] || usage
+      DEVSTACK="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || usage
+      TITLE="$2"
+      shift 2
+      ;;
+    --opt-in)
+      [[ $# -ge 2 ]] || usage
+      if [[ ! "$2" =~ ^WITH_[A-Z0-9_]+= ]]; then
+        echo "error: --opt-in must be a WITH_*=... flag, got '$2'" >&2
+        exit 2
+      fi
+      if [[ "$2" == WITH_CONTROLPLANE=* ]]; then
+        echo "error: WITH_CONTROLPLANE is not an opt-in — use --devstack quick-start-controlplane" >&2
+        exit 2
+      fi
+      OPT_INS="${OPT_INS}${OPT_INS:+ }$2"
+      shift 2
+      ;;
+    --suite)
+      [[ $# -ge 2 ]] || usage
+      if [[ ! "$2" =~ ^tests/ ]]; then
+        echo "error: --suite must be a tests/... path, got '$2'" >&2
+        exit 2
+      fi
+      SUITE="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      [[ -z "${SLUG}" ]] || usage
+      SLUG="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${SLUG}" ]] || usage
+if [[ ! "${SLUG}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "error: slug must match [a-z0-9][a-z0-9-]*, got '${SLUG}'" >&2
+  exit 2
+fi
+case "${DEVSTACK}" in
+  quick-start | quick-start-extended | quick-start-controlplane) ;;
+  *) usage ;;
+esac
+
+if [[ -z "${TITLE}" ]]; then
+  TITLE="$(printf '%s' "${SLUG}" | awk -F- '{
+    for (i = 1; i <= NF; i++) $i = toupper(substr($i, 1, 1)) substr($i, 2)
+    print
+  }' OFS=' ')"
+fi
+
+# Warn (stderr only — stdout is the skeleton) when the suite does not resolve
+# yet; the docs gate stays red until it does.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+if [[ -n "${SUITE}" && ! -f "${REPO_ROOT}/${SUITE}/chainsaw-test.yaml" ]]; then
+  echo "note: ${SUITE}/chainsaw-test.yaml does not exist yet — the docs gate fails until it does" >&2
+fi
+if [[ -z "${SUITE}" ]]; then
+  SUITE="tests/e2e/keystone/<TODO-suite>"
+  echo "note: no --suite given — '## Tested by' carries a TODO placeholder the docs gate rejects" >&2
+fi
+
+# Bring-up command per devstack, with opt-ins composed onto the
+# 'make deploy-infra' line (guide-conventions.md: "Opt-in flags compose").
+OPT_SUFFIX=""
+[[ -n "${OPT_INS}" ]] && OPT_SUFFIX="${OPT_INS} "
+case "${DEVSTACK}" in
+  quick-start)
+    DEVSTACK_LABEL="Quick Start"
+    BRING_UP="KIND_HOST_PORT=8443 ${OPT_SUFFIX}make deploy-infra"
+    ;;
+  quick-start-extended)
+    DEVSTACK_LABEL="Quick Start (Extended)"
+    BRING_UP="kind create cluster --name forge --config hack/kind-config.yaml
+${OPT_SUFFIX}make deploy-infra"
+    ;;
+  quick-start-controlplane)
+    DEVSTACK_LABEL="Quick Start (ControlPlane)"
+    BRING_UP="KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true ${OPT_SUFFIX}make deploy-infra"
+    ;;
+esac
+
+# --- Skeleton ---------------------------------------------------------------
+
+cat <<EOF
+---
+title: ${TITLE}
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# How-to: ${TITLE}
+
+TODO: one paragraph — what this guide accomplishes on a running cluster and
+why an operator reaches for it.
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[${DEVSTACK_LABEL}](../${DEVSTACK}.md)** devstack. Stand it up first:
+
+\`\`\`bash
+${BRING_UP}
+\`\`\`
+
+EOF
+
+case "${DEVSTACK}" in
+  quick-start-controlplane)
+    cat <<'EOF'
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
+`controlplane-keystone` Keystone child is running. Every resource name in the
+examples below is one that devstack produces.
+:::
+
+::: warning The Keystone child is operator-owned
+On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
+**projected** by the c5c3-operator, so a knob you set directly on the child is
+reverted on the next reconcile. Set operational knobs on the `ControlPlane` CR
+and let the operator project them down. Where the `ControlPlane` CRD does not
+expose a knob, this guide points to the
+[Standalone Keystone](#standalone-keystone-without-a-controlplane) section,
+which drives a Keystone CR you own.
+:::
+EOF
+    ;;
+  quick-start-extended)
+    cat <<'EOF'
+Follow that tutorial through to its final **Verify the deployment** step, so a
+Keystone CR named `keystone` is `Ready` in the `openstack` namespace. Every
+resource name in the examples below is one that devstack produces.
+:::
+EOF
+    ;;
+  quick-start)
+    cat <<'EOF'
+Follow that tutorial through to its final **Verify** step, so a Keystone CR named
+`keystone` is `Ready` in the `openstack` namespace. Every resource name in the
+examples below is one that devstack produces.
+:::
+EOF
+    ;;
+esac
+
+cat <<EOF
+
+1. **TODO guide-specific prerequisite.** Anything the devstack does not
+   provide (an external LDAP server, a Keycloak realm, a CNI that enforces
+   NetworkPolicy, ...). Delete this list if there is none.
+
+---
+
+## Steps
+
+### 1. TODO first step
+
+TODO: every command uses only the resource names the declared devstack
+produces (see the devstack table in docs/contributing/guide-conventions.md).
+
+## Verification
+
+TODO: how the reader confirms the change took effect.
+EOF
+
+if [[ "${DEVSTACK}" == "quick-start-controlplane" ]]; then
+  cat <<'EOF'
+
+## Standalone Keystone, without a ControlPlane
+
+TODO: where a standalone (non-ControlPlane) installation differs, describe it
+here against a Keystone CR the reader owns — do not interleave the two naming
+worlds in the primary walkthrough above.
+EOF
+fi
+
+cat <<EOF
+
+## See also
+
+- TODO: related guides and reference pages.
+
+## Tested by
+
+The flow above mirrors the following end-to-end suite:
+
+\`\`\`bash
+chainsaw test --test-dir ${SUITE}
+\`\`\`
+EOF

--- a/.claude/skills/prepare-new-guide/scripts/validate-guide.sh
+++ b/.claude/skills/prepare-new-guide/scripts/validate-guide.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# validate-guide.sh — mechanical guide-convention checks for docs/guides/.
+# Verifies the conventions from docs/contributing/guide-conventions.md that
+# the docs gate (tests/unit/docs/guide_devstack_and_tested_by_test.sh) does
+# not cover:
+#   V1  no banned placeholder name ('keystone-default') — the general
+#       "example names no tutorial produces" judgment is prose-level and
+#       belongs to the SKILL.md checklist
+#   V2  devstack link and WITH_CONTROLPLANE=true flag agree inside the
+#       '::: info Devstack' container
+#   V3  a bash fence running 'helm upgrade'/'helm install' against the
+#       published operator chart (oci://ghcr.io/c5c3/charts/) requires the
+#       guide to frame Flux ownership (a 'HelmRelease' mention)
+#   V4  a mutating kubectl verb on an operator-projected child CR
+#       (kind keystone/horizon, name controlplane-keystone/-horizon)
+#       requires a '::: warning' container with revert/projected language
+#
+# The missing-devstack-block / missing-tested-by half of the conventions is
+# owned by the docs gate; pass --full to chain it and trust its verdict.
+# A multi-line 'kubectl apply' that overwrites a projected child is not
+# mechanically detectable — the SKILL.md prose checklist owns that case.
+#
+# NOTE: the devstack/flag mapping in V2 MUST stay in sync with the devstack
+# table in docs/contributing/guide-conventions.md — that page is the prose
+# source of truth; this script is the machine copy.
+#
+# Usage: validate-guide.sh [--full] [<guide.md>...]
+# Defaults to every docs/guides/*.md. Exit code 1 on any [FAIL].
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+GATE="tests/unit/docs/guide_devstack_and_tested_by_test.sh"
+
+FULL=0
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full)
+      FULL=1
+      ;;
+    -*)
+      echo "usage: $0 [--full] [<guide.md>...]" >&2
+      exit 2
+      ;;
+    *)
+      if [[ ! -f "$1" ]]; then
+        echo "error: no such guide: $1" >&2
+        exit 2
+      fi
+      FILES+=("$1")
+      ;;
+  esac
+  shift
+done
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  FILES=("${REPO_ROOT}"/docs/guides/*.md)
+fi
+
+FAIL_COUNT=0
+fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "[PASS] $*"; }
+info() { echo "[INFO] $*"; }
+
+# Body of the first "::: info Devstack" container (same extractor as the
+# docs gate), including the fence lines.
+devstack_container() {
+  awk '
+    /^::: info Devstack/ { f = 1; print; next }
+    f && /^:::[[:space:]]*$/ { print; exit }
+    f { print }
+  ' "$1"
+}
+
+check_guide() {
+  local file="$1"
+
+  # V1 — banned placeholder names (guide-conventions.md "ControlPlane-first
+  # naming"): 'keystone-default' is the retired placeholder no tutorial
+  # produces.
+  local hits h
+  hits="$(grep -n 'keystone-default' "${file}" || true)"
+  if [[ -n "${hits}" ]]; then
+    while IFS= read -r h; do
+      fail "V1 ${file}:${h%%:*}: banned placeholder name 'keystone-default' — no tutorial produces it"
+    done <<< "${hits}"
+  else
+    pass "V1 ${file}: no banned placeholder names"
+  fi
+
+  # V2 — devstack link and bring-up flag agree (guide-conventions.md "One
+  # devstack per guide"): the ControlPlane devstack link and the
+  # WITH_CONTROLPLANE=true flag imply each other.
+  local container links_cp=0 has_flag=0
+  container="$(devstack_container "${file}")"
+  if [[ -z "${container}" ]]; then
+    info "V2 ${file}: no '::: info Devstack' container — structure is owned by ${GATE} (run --full)"
+  else
+    printf '%s\n' "${container}" | grep -qF '](../quick-start-controlplane.md' && links_cp=1
+    printf '%s\n' "${container}" | grep -qF 'WITH_CONTROLPLANE=true' && has_flag=1
+    if [[ "${links_cp}" -eq 1 && "${has_flag}" -eq 0 ]]; then
+      fail "V2 ${file}: devstack links quick-start-controlplane.md but the bring-up command lacks WITH_CONTROLPLANE=true"
+    elif [[ "${links_cp}" -eq 0 && "${has_flag}" -eq 1 ]]; then
+      fail "V2 ${file}: bring-up command names WITH_CONTROLPLANE=true but the devstack link is not quick-start-controlplane.md"
+    else
+      pass "V2 ${file}: devstack link and WITH_CONTROLPLANE flag agree"
+    fi
+  fi
+
+  # V3 — raw helm against Flux-owned releases (guide-conventions.md via the
+  # deployment model): a bash fence that runs helm upgrade/install against
+  # the published OCI operator chart is the canonical non-kind path ONLY when
+  # the guide frames Flux ownership — on the kind devstacks the operator is a
+  # Flux-owned HelmRelease and a raw helm upgrade is reverted. An oci://
+  # mention in prose (outside a helm fence) does not trigger.
+  local fence_lines line
+  fence_lines="$(awk '
+    /^```bash/ { infence = 1; start = NR; helm = 0; oci = 0; next }
+    infence && /^```[[:space:]]*$/ {
+      if (helm && oci) print start
+      infence = 0
+      next
+    }
+    infence && /helm (upgrade|install)/ { helm = 1 }
+    infence && /oci:\/\/ghcr\.io\/c5c3\/charts\// { oci = 1 }
+  ' "${file}")"
+  if [[ -z "${fence_lines}" ]]; then
+    pass "V3 ${file}: no raw-helm fence against the published operator chart"
+  elif grep -q 'HelmRelease' "${file}"; then
+    pass "V3 ${file}: raw-helm fence(s) present and the guide frames Flux ownership (mentions HelmRelease)"
+  else
+    while IFS= read -r line; do
+      fail "V3 ${file}:${line}: bash fence runs raw helm against oci://ghcr.io/c5c3/charts/ but the guide never mentions HelmRelease (Flux-ownership framing)"
+    done <<< "${fence_lines}"
+  fi
+
+  # V4 — projected-child edits need a revert warning (guide-conventions.md
+  # "Never edit operator-projected children"): a mutating kubectl verb on the
+  # projected keystone/horizon CR requires a '::: warning' container with
+  # projected/revert language. The kind token must sit adjacent to the child
+  # name so Secrets/ExternalSecrets named controlplane-keystone-* do not
+  # trigger.
+  local mut_re='kubectl[^`]*[[:space:]](patch|edit|scale|set|annotate|label|delete)[[:space:]](.*[[:space:]])?(keystone|horizon)s?(\.[a-z0-9.]*)?[[:space:]]+(controlplane-keystone|controlplane-horizon)([^a-z0-9-]|$)'
+  hits="$(grep -nE "${mut_re}" "${file}" || true)"
+  if [[ -z "${hits}" ]]; then
+    pass "V4 ${file}: no mutating kubectl command on a projected child CR"
+  elif grep -qE '^::: warning' "${file}" && grep -qiE '(revert|projected)' "${file}"; then
+    pass "V4 ${file}: projected-child mutation(s) covered by a '::: warning' container with revert/projected language"
+  else
+    while IFS= read -r h; do
+      fail "V4 ${file}:${h%%:*}: mutating kubectl on a projected child CR without a '::: warning' revert warning"
+    done <<< "${hits}"
+  fi
+}
+
+for f in "${FILES[@]}"; do
+  echo "== ${f} =="
+  check_guide "${f}"
+done
+
+if [[ "${FULL}" -eq 1 ]]; then
+  echo
+  echo "== authoritative gate: ${GATE} =="
+  if bash "${REPO_ROOT}/${GATE}"; then
+    pass "authoritative gate green"
+  else
+    fail "authoritative gate red — trust its verdict over this script's"
+  fi
+fi
+
+echo
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+  echo "Result: ${FAIL_COUNT} FAIL"
+  exit 1
+fi
+echo "Result: all checks passed"
+exit 0

--- a/deploy/kind/base/flux-web.yaml
+++ b/deploy/kind/base/flux-web.yaml
@@ -46,7 +46,7 @@
 #
 # Version pin: `spec.inputs[0].version` is a SemVer range locked to the
 # minor track of `FLUX_OPERATOR_VERSION` in hack/deploy-infra.sh (today
-# v0.53.0 → 0.53.x). Bump both together when upgrading the operator.
+# v0.54.1 → 0.54.x). Bump both together when upgrading the operator.
 #
 ---
 apiVersion: fluxcd.controlplane.io/v1
@@ -63,7 +63,7 @@ spec:
   # This keeps the kind-only addon self-contained — no extra
   # ResourceSetInputProvider CR to maintain.
   inputs:
-    - version: "0.53.x"
+    - version: "0.54.x"
   resources:
     - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository

--- a/docs/contributing/claude-skills.md
+++ b/docs/contributing/claude-skills.md
@@ -17,10 +17,11 @@ codebase against its source of truth — the operator CRDs, the
 sub-reconciler chains, the validation rules, the release wiring, the
 FluxCD infrastructure stack, the Renovate configuration, the e2e
 fixture corpus, the SPDX/REUSE coverage, the Go workspace — and report
-drift before it reaches a release. The suite also carries two
-**planners** (`prepare-new-service`, `prepare-new-release`) that turn
-an onboarding task into a phased checklist, and a **runbook**
-(`debug-e2e-failure`) for diagnosing failing chainsaw e2e jobs.
+drift before it reaches a release. The suite also carries three
+**planners** (`prepare-new-service`, `prepare-new-release`,
+`prepare-new-guide`) that turn an onboarding or authoring task into a
+phased checklist, and a **runbook** (`debug-e2e-failure`) for diagnosing
+failing chainsaw e2e jobs.
 
 The skills complement the CI gates configured in
 [`.github/workflows/`](https://github.com/c5c3/forge/tree/main/.github/workflows)
@@ -60,11 +61,13 @@ repository's `.claude/` directory. There are two ways to run one:
 
 Every audit skill ships a `scripts/audit-<name>.sh` companion that runs
 the deterministic part of the audit and exits non-zero on a `[FAIL]`;
-the planners ship `inventory-*` scripts and the e2e runbook ships a log
-collector (`collect-e2e-failure.sh`). Audit and inventory scripts are
-safe to run by hand from a shell — they read files and print
-inventories; they never write to the tree. The collector downloads CI
-evidence into the untracked `_output/` directory.
+the planners ship `inventory-*` scripts (the guide planner a
+`scaffold-guide.sh` / `validate-guide.sh` pair) and the e2e runbook
+ships a log collector (`collect-e2e-failure.sh`). Audit, inventory,
+scaffold, and validation scripts are safe to run by hand from a shell —
+they read files and print to stdout; they never write to the tree (the
+scaffold prints a skeleton the caller redirects into a file). The
+collector downloads CI evidence into the untracked `_output/` directory.
 
 ```bash
 bash .claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
@@ -80,7 +83,7 @@ the gate commands to run alongside the audit, and the report format.
 
 ## Catalogue
 
-The thirteen skills are grouped by the surface they cover. Each entry
+The skills are grouped by the surface they cover. Each entry
 links to the skill's `SKILL.md` (the procedure); every skill also ships
 a companion Bash script (the deterministic part).
 
@@ -120,6 +123,7 @@ a companion Bash script (the deterministic part).
 |---|---|---|
 | [`prepare-new-service`](https://github.com/c5c3/forge/blob/main/.claude/skills/prepare-new-service/SKILL.md) | Plans the onboarding of a new OpenStack service across the five layers against the keystone reference — inventories what already exists, checks what keystone scaffolding must be generalized into `internal/common` first, and drafts the phased meta issue. | When asked to onboard a new OpenStack service (Glance, Nova, Neutron, Placement, …); when assessing readiness for the next service operator. |
 | [`prepare-new-release`](https://github.com/c5c3/forge/blob/main/.claude/skills/prepare-new-release/SKILL.md) | Plans the addition of a new OpenStack release — inventories the touch points auto-discovery does not cover (release config files, the Tempest config directory, per-release e2e variants, constraint overrides) and walks the decision points: moving the default release, extending the upgrade-path tests, retiring an old release. | When asked to add a new OpenStack release, bump the release matrix, or remove an old release. |
+| [`prepare-new-guide`](https://github.com/c5c3/forge/blob/main/.claude/skills/prepare-new-guide/SKILL.md) | Scaffolds a new how-to guide skeleton under `docs/guides/` for a chosen devstack anchor and validates draft guides against the guide conventions — placeholder names no tutorial produces, devstack↔flag consistency, raw-helm instructions against Flux-owned releases, projected-child edits without a revert warning. Defers to `tests/unit/docs/guide_devstack_and_tested_by_test.sh` as the authoritative gate. | When writing a new guide under `docs/guides/`; when checking a draft guide for convention violations. |
 | [`debug-e2e-failure`](https://github.com/c5c3/forge/blob/main/.claude/skills/debug-e2e-failure/SKILL.md) | Diagnoses a failing chainsaw e2e job — resolves the failed run, pulls the failed-step logs and JUnit/diagnostic evidence, maps the failure back to the suite directory under `tests/`, classifies it against the known flake patterns, and reproduces it locally against a kind cluster. | When any CI e2e job fails (`e2e-operator`, `e2e-chaos`, `e2e-controlplane`, …); when reproducing an e2e failure locally. |
 
 ## What a skill is, structurally
@@ -134,7 +138,8 @@ Every skill in this suite follows the same layout:
 ```
 
 Audit skills name the script `audit-<name>.sh`; the planners ship
-`inventory-*` scripts, and the e2e runbook ships
+`inventory-*` scripts (the guide planner a `scaffold-guide.sh` /
+`validate-guide.sh` pair), and the e2e runbook ships
 `collect-e2e-failure.sh`.
 
 `SKILL.md` opens with a YAML frontmatter block carrying `name` and

--- a/docs/contributing/guide-conventions.md
+++ b/docs/contributing/guide-conventions.md
@@ -19,6 +19,13 @@ names that name a resource the reader's cluster never created.
 This page is the contract. New guides follow it from the start; existing guides
 are being brought into conformance.
 
+The `prepare-new-guide` Claude Code skill applies this contract: its
+`scaffold-guide.sh` prints a conforming skeleton for a chosen devstack anchor,
+and its `validate-guide.sh` checks a draft against the conventions the docs
+gate does not cover (see
+[Claude Code skills](./claude-skills.md) for how to invoke it, and
+`.claude/skills/prepare-new-guide/` for the scripts).
+
 ## One devstack per guide
 
 A reader arriving at a guide has to know exactly which cluster to build before

--- a/tests/unit/deploy/kind_base_flux_web_test.sh
+++ b/tests/unit/deploy/kind_base_flux_web_test.sh
@@ -133,7 +133,7 @@ test_kustomize_build_emits_resourceset() {
 # --- Test 3: chart version pin is a SemVer range locked to the minor
 #             track shipped by hack/deploy-infra.sh ---
 test_chart_version_pin_is_semver_range() {
-  echo "Test: ResourceSet spec.inputs[0].version is 0.53.x and matches FLUX_OPERATOR_VERSION minor track"
+  echo "Test: ResourceSet spec.inputs[0].version is 0.54.x and matches FLUX_OPERATOR_VERSION minor track"
 
   if [[ ! -f "$FLUX_WEB_FILE" ]]; then
     echo "  FAIL: $FLUX_WEB_FILE does not exist"
@@ -147,12 +147,12 @@ test_chart_version_pin_is_semver_range() {
   else
     local version
     version="$(yq -r '.spec.inputs[0].version' "$FLUX_WEB_FILE" 2>/dev/null | head -n1)"
-    assert_eq "spec.inputs[0].version pins the 0.53.x SemVer range" "0.53.x" "$version"
+    assert_eq "spec.inputs[0].version pins the 0.54.x SemVer range" "0.54.x" "$version"
   fi
 
-  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.53.0\"" \
+  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.54.1\"" \
     "$DEPLOY_INFRA_SH" \
-    'FLUX_OPERATOR_VERSION="v0.53.0"'
+    'FLUX_OPERATOR_VERSION="v0.54.1"'
 }
 
 # --- Test 4: kind kustomization lists flux-web.yaml after headlamp.yaml ---


### PR DESCRIPTION
## Summary

Adds `prepare-new-guide`, a guide-authoring skill in the `prepare-*` family, that scaffolds a convention-conform how-to guide skeleton and mechanically validates draft guides against the guide conventions the docs gate does not cover. No product code is touched — this is a `.claude/` skill plus its registration in the contributing docs.

Closes #616

## Change set (in commit order)

### `078ecbea` feat(skills): add prepare-new-guide skill with scaffold and validator

Adds the skill and its two read-only companion scripts, encoding the contract from `docs/contributing/guide-conventions.md`:

- **`.claude/skills/prepare-new-guide/SKILL.md`** — the guide-authoring planner procedure.
- **`scripts/scaffold-guide.sh`** — prints a convention-conform guide skeleton to stdout for a chosen devstack anchor (`quick-start`, `quick-start-extended`, or `quick-start-controlplane`), composing `WITH_*` opt-in flags onto the verbatim bring-up command and emitting the standardized prerequisites block, the section structure, and the terminal `Tested by` section. The ControlPlane variant additionally carries the operator-owned warning block and a standalone stub. It only prints; the caller redirects the output into a file.
- **`scripts/validate-guide.sh`** — checks a draft guide for the violations the docs gate misses: banned placeholder names (V1), devstack-link ↔ `WITH_CONTROLPLANE`-flag consistency (V2), raw-helm fences against the published operator chart without Flux-ownership framing (V3), and mutating `kubectl` commands on projected child CRs without a revert warning (V4). `--full` chains `tests/unit/docs/guide_devstack_and_tested_by_test.sh` as the authoritative gate for the structural half.

Per the commit message, both scripts were reported to run clean over the existing 17-guide corpus with zero false positives (including the Secret/ExternalSecret near-misses in the rotation guides and the prose-only OCI-chart mention in the multi-tenant guide).

### `30764bb4` docs(contributing): register prepare-new-guide in the skills docs

- `docs/contributing/claude-skills.md` — adds the `prepare-new-guide` catalogue row to the planners table, bumps the planner count to three, drops the hardcoded skill count from the catalogue intro, and extends the layout/script-naming prose to cover the `scaffold-guide.sh` / `validate-guide.sh` pair.
- `docs/contributing/guide-conventions.md` — cross-references the skill from the conventions page so contributors arriving at the contract find the tooling that applies it.

## Divergence from the issue

None visible from the commits. Issue #616 asks for a skill that both scaffolds and validates new guides; the two scripts (`scaffold-guide.sh`, `validate-guide.sh`) cover exactly those two halves, and the validator defers structural checks to the existing `guide_devstack_and_tested_by_test.sh` gate rather than duplicating them.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
