### PR TITLE
docs(openbao): scope seeding to managed flows and prove the never-seeded External-mode round-trip

### DIFF
--- a/deploy/openbao/bootstrap/setup-database-tenant.sh
+++ b/deploy/openbao/bootstrap/setup-database-tenant.sh
@@ -4,7 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # setup-database-tenant.sh — Provision the per-tenant MariaDB database-engine
-# connection and role for one ControlPlane's Keystone service DB user.
+# connection and role for one MANAGED ControlPlane's Keystone service DB user.
+#
+# MODE: this is a managed-database onboarding step. An External-mode ControlPlane
+# (spec.services.keystone.mode: External) has NO managed database — the c5c3
+# operator's reconcileDBCredentials is skipped for it — so it must not be
+# onboarded here; there is no MariaDB CR to read and no DB credential path to
+# issue.
 #
 # This is the stage-(b) counterpart to the bootstrap engine mount performed by
 # setup-secret-engines.sh (enable_database). The database secrets engine is

--- a/deploy/openbao/bootstrap/setup-eso-tenant.sh
+++ b/deploy/openbao/bootstrap/setup-eso-tenant.sh
@@ -3,16 +3,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# setup-eso-tenant.sh — Provision the in-cluster half of one ControlPlane's
-# per-tenant OpenBao identity: the ServiceAccount, mTLS client Certificate, and
-# namespaced SecretStore that let that tenant's ExternalSecrets and PushSecrets
-# reach OpenBao as the "eso-tenant" role instead of the shared cluster identity.
+# setup-eso-tenant.sh — Provision the in-cluster half of a STANDALONE (non-
+# ControlPlane) Keystone/Horizon namespace's per-tenant OpenBao identity: the
+# ServiceAccount, mTLS client Certificate, and namespaced SecretStore that let
+# that namespace's ExternalSecrets and PushSecrets reach OpenBao as the
+# "eso-tenant" role instead of the shared cluster identity.
 #
-# This is the per-ControlPlane onboarding counterpart to setup-database-tenant.sh
-# (which provisions the tenant's dynamic MariaDB engine role). The OpenBao side —
-# the eso-tenant Kubernetes auth role and the eso-tenant templated policy — is
-# created once at bootstrap by setup-auth.sh / setup-policies.sh; this script
-# creates the objects that come into being when a ControlPlane does:
+# SCOPE: this is the MANUAL onboarding path for standalone Keystone/Horizon CRs
+# (which have no operator above them to provision a tenant store) — for example
+# the standalone dev shims hack/deploy-infra.sh brings up. A ControlPlane —
+# Managed OR External — never needs it: the c5c3 operator provisions the SAME
+# ServiceAccount / Certificate / SecretStore itself and DEFAULTS the control plane
+# onto the store (reconcileESOTenantStore in
+# operators/c5c3/internal/controller/reconcile_esotenant.go, which runs for every
+# ControlPlane regardless of mode). Setting a ControlPlane's spec.secretStoreRef
+# is therefore NOT an onboarding step — it is the opt-OUT override for a
+# ControlPlane that manages its own store (StoreRefOverridden), the opposite of
+# what a standalone CR does. This is the ESO counterpart to setup-database-tenant.sh
+# (the standalone/managed split is analogous there too).
+#
+# The OpenBao side — the eso-tenant Kubernetes auth role and the eso-tenant
+# templated policy — is created once at bootstrap by setup-auth.sh /
+# setup-policies.sh (both provisioning routes converge on it); this script only
+# creates the in-cluster objects a standalone namespace needs:
 #
 #   - ServiceAccount eso-tenant-auth
 #       the identity ESO presents to OpenBao. The eso-tenant role binds this SA
@@ -26,17 +39,15 @@
 #       from the same Secret (mirroring the DB-credential Certificate in
 #       reconcile_dbcredentials.go).
 #   - SecretStore openbao-tenant-store
-#       the namespaced store the ControlPlane selects via
+#       the namespaced store a standalone Keystone/Horizon CR selects via
 #       spec.secretStoreRef: {kind: SecretStore, name: openbao-tenant-store}. It
 #       authenticates as the eso-tenant role with the eso-tenant-auth SA.
 #
-# After this runs and the SecretStore reports Ready, set the ControlPlane's
-# spec.secretStoreRef to the namespaced store to switch it onto the per-tenant
-# identity. On an EXISTING ControlPlane, run this (and, on upgraded clusters,
-# re-run setup-auth.sh / setup-policies.sh so the role and policy exist) BEFORE
-# flipping the ref — otherwise pushes 403 and FernetKeysReady/CredentialKeysReady
-# degrade. The flip updates the PushSecrets in place and never re-creates the
-# irreplaceable fernet/credential key material.
+# After this runs and the SecretStore reports Ready, set the STANDALONE CR's
+# spec.secretStoreRef to the namespaced store to route it through the per-tenant
+# identity. On a cluster bootstrapped before this feature, re-run setup-auth.sh /
+# setup-policies.sh first so the eso-tenant role and policy exist — otherwise
+# pushes 403 and FernetKeysReady/CredentialKeysReady degrade.
 #
 # Idempotent: every object is applied with `kubectl apply`, so re-running
 # refreshes the manifests without disrupting a live tenant.
@@ -51,8 +62,12 @@ set -euo pipefail
 ###############################################################################
 TENANT_NS="${1:?usage: setup-eso-tenant.sh <namespace>}"
 
-# Fixed names — the eso-tenant OpenBao role binds this SA name, and the
-# ControlPlane selects this SecretStore name via spec.secretStoreRef.
+# Fixed names — the eso-tenant OpenBao role binds this SA name, and a standalone
+# Keystone/Horizon CR selects this SecretStore name via spec.secretStoreRef. They
+# MUST match the constants the c5c3 operator uses (esoTenantStoreName /
+# esoTenantServiceAccountName / esoTenantClientCertName in reconcile_esotenant.go)
+# so the manual standalone route and the operator-provisioned ControlPlane route
+# converge on the same objects.
 SA_NAME="eso-tenant-auth"
 CERT_NAME="eso-tenant-client-tls"
 STORE_NAME="openbao-tenant-store"
@@ -157,9 +172,10 @@ spec:
         key: "ca.crt"
 EOF
 
-  echo "=== Done. Set the ControlPlane's spec.secretStoreRef to"
-  echo "    {kind: SecretStore, name: ${STORE_NAME}} to switch it onto the"
-  echo "    per-tenant identity. ==="
+  echo "=== Done. Set the STANDALONE Keystone/Horizon CR's spec.secretStoreRef to"
+  echo "    {kind: SecretStore, name: ${STORE_NAME}} to route it through the"
+  echo "    per-tenant identity. A ControlPlane needs no such flip — the c5c3"
+  echo "    operator provisions this store and defaults onto it. ==="
 }
 
 main "$@"

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -21,14 +21,28 @@ BAO_TOKEN="${BAO_TOKEN:?BAO_TOKEN must be set}"
 
 # KORC_CONTROLPLANES: whitespace-separated list of "<namespace>/<controlplane>"
 # identities to seed per-ControlPlane bootstrap secrets.
-# For each identity the script seeds ONLY:
+#
+# MODE CONTRACT: entries are MANAGED-mode ControlPlane identities only. An
+# External-mode ControlPlane (spec.services.keystone.mode: External) must NOT be
+# listed here — nothing is seeded for it, and a listed entry would MIS-SEED it.
+# In External mode the admin password of the pre-existing Keystone is owned
+# out-of-band in the user-supplied passwordSecretRef Secret, and the c5c3
+# operator's reconcileAdminPassword short-circuits (IsExternalKeystone) without
+# projecting an ExternalSecret or reading any bootstrap path; the operator also
+# rejects services.horizon in External mode, so the seeded Horizon secret-key
+# would go unconsumed. Seeding an External-mode identity here would therefore
+# write a generated admin password at bootstrap/<namespace>/<controlplane>-keystone/admin
+# unrelated to the external installation's real one — a path nothing reads.
+#
+# For each MANAGED-mode identity the script seeds:
 #   - the Model B admin password at  kv-v2/bootstrap/<namespace>/<controlplane>-keystone/admin
+#   - the Horizon Django SECRET_KEY at kv-v2/bootstrap/<namespace>/<controlplane>-horizon/secret-key
 # The stage-(a) per-ControlPlane static DB credential seed is RETIRED (#439):
 # managed-mode Keystone draws engine-issued short-lived DB credentials from the
 # OpenBao database engine (see setup-database-tenant.sh), so no static DB
 # password is seeded at rest. A single static credential for standalone
 # (non-ControlPlane) Keystone demos is still seeded at
-# kv-v2/openstack/keystone/standalone/db (brownfield-only).
+# kv-v2/openstack/keystone/openstack/standalone/db (brownfield-only).
 # The K-ORC bootstrap clouds.yaml is no longer seeded here: the operator now seeds
 # it from reconcileKORC (seedBootstrapCloudsYAML).
 # The default is the single canonical ControlPlane the Quick Start brings up
@@ -133,11 +147,14 @@ main() {
   write_secret_if_missing "kv-v2/infrastructure/mariadb" \
     "root-password=${GENERATED_PASSWORD}"
 
-  # per-ControlPlane bootstrap seeding. For each
+  # per-ControlPlane bootstrap seeding. For each MANAGED-mode
   # "<namespace>/<controlplane>" identity in KORC_CONTROLPLANES (default
-  # "openstack/controlplane"), seed ONLY the per-CR Model B admin password on the
-  # per-CR OpenBao path so two ControlPlanes never collide on the cluster-global
-  # OpenBao backend. The K-ORC bootstrap clouds.yaml is now seeded by the
+  # "openstack/controlplane"), seed the per-CR Model B admin password and Horizon
+  # secret-key on the per-CR OpenBao paths so two ControlPlanes never collide on
+  # the cluster-global OpenBao backend. An External-mode ControlPlane is NEVER
+  # seeded here (see the KORC_CONTROLPLANES contract above): its admin password is
+  # user-supplied and reconcileAdminPassword short-circuits without reading any
+  # bootstrap path. The K-ORC bootstrap clouds.yaml is now seeded by the
   # operator's reconcileKORC (seedBootstrapCloudsYAML) rather than here.
   # The legacy flat writes (bootstrap/keystone-admin,
   # openstack/keystone/admin/app-credential) are gone: the keystone-operator Model

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -160,7 +160,7 @@ on the successful completion of the previous step:
 3. setup-auth.sh            Configure Kubernetes auth + AppRole
        │
        ▼
-4. setup-policies.sh        Apply 8 HCL least-privilege policies
+4. setup-policies.sh        Apply 9 HCL least-privilege policies
        │
        ▼
 5. write-bootstrap-secrets.sh  Generate and seed initial passwords
@@ -342,10 +342,15 @@ idempotent.
 
 ### setup-eso-tenant.sh
 
-**Purpose:** Provision the in-cluster half of one ControlPlane's per-tenant
-OpenBao identity — the objects that let that tenant's ExternalSecrets and
-PushSecrets reach OpenBao as the `eso-tenant` role instead of the shared
-cluster identity. It is the ESO counterpart to `setup-database-tenant.sh`.
+**Purpose:** Provision the in-cluster half of a **standalone** (non-ControlPlane)
+Keystone/Horizon namespace's per-tenant OpenBao identity — the objects that let
+that namespace's ExternalSecrets and PushSecrets reach OpenBao as the
+`eso-tenant` role instead of the shared cluster identity. It is the **manual**
+onboarding path for standalone CRs; a ControlPlane of **any** mode (Managed or
+External) never needs it, because the c5c3 operator provisions the same
+ServiceAccount, Certificate, and SecretStore itself and defaults the control
+plane onto the store (`reconcileESOTenantStore`). It is the ESO counterpart to
+`setup-database-tenant.sh`.
 
 **File:** `deploy/openbao/bootstrap/setup-eso-tenant.sh`
 
@@ -368,12 +373,13 @@ tenant namespace:
 The SecretStore authenticates as the `eso-tenant` role with the
 `eso-tenant-auth` ServiceAccount and sources its client cert, key, and CA from
 the `eso-tenant-client-tls` Secret (same namespace). After the SecretStore
-reports `Ready`, set the ControlPlane's `spec.secretStoreRef` to
-`{kind: SecretStore, name: openbao-tenant-store}` to switch it onto the
-per-tenant identity. On an **existing** ControlPlane, run this (and, on a
-cluster bootstrapped before this feature, re-run `setup-auth.sh` /
-`setup-policies.sh`) **before** flipping the ref — otherwise ESO's pushes 403
-and `FernetKeysReady` / `CredentialKeysReady` degrade. See the
+reports `Ready`, set the **standalone** Keystone/Horizon CR's
+`spec.secretStoreRef` to `{kind: SecretStore, name: openbao-tenant-store}` to
+route it through the per-tenant identity. On a cluster bootstrapped before this
+feature, re-run `setup-auth.sh` / `setup-policies.sh` first so the `eso-tenant`
+role and policy exist — otherwise ESO's pushes 403 and `FernetKeysReady` /
+`CredentialKeysReady` degrade. Setting `spec.secretStoreRef` on a **ControlPlane**
+is the opt-out override for a self-managed store, not an onboarding step. See the
 [multi-tenant deployment guide](../../guides/multi-tenant-deployment.md#per-controlplane-secret-stores-and-openbao-identities)
 for the full procedure.
 
@@ -497,9 +503,19 @@ into the KV v2 secret engine.
 
 | KV v2 Path | Secret Keys | Description |
 | --- | --- | --- |
-| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | Keystone admin user password, scoped per ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default `openstack/controlplane` seeds `kv-v2/bootstrap/openstack/controlplane-keystone/admin`. |
+| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | Keystone admin user password, scoped per **Managed-mode** ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default `openstack/controlplane` seeds `kv-v2/bootstrap/openstack/controlplane-keystone/admin`. |
+| `kv-v2/bootstrap/<namespace>/<horizon>/secret-key` | `secret-key` | Horizon Django `SECRET_KEY`, scoped per **Managed-mode** ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default seeds `kv-v2/bootstrap/openstack/controlplane-horizon/secret-key`, read by the kind-only `horizon-secret-key` ExternalSecret. |
 | `kv-v2/infrastructure/mariadb` | `root-password` | MariaDB root password |
-| `kv-v2/openstack/keystone/standalone/db` | `username`, `password` | Static Keystone DB credential for **standalone** (non-ControlPlane) Keystone demos only (username is `keystone`), read by the kind-only `keystone-db` ExternalSecret. Brownfield-only. |
+| `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | Static Keystone DB credential for **standalone** (non-ControlPlane) Keystone demos only (username is `keystone`), read by the kind-only `keystone-db` ExternalSecret. Brownfield-only. |
+
+**Mode note:** `KORC_CONTROLPLANES` lists **Managed-mode** ControlPlane
+identities only. An **External-mode** ControlPlane
+(`spec.services.keystone.mode: External`) is **never** seeded here — its admin
+password is owned out-of-band in the user-supplied `passwordSecretRef` Secret, the
+c5c3 operator's `reconcileAdminPassword` short-circuits without reading any
+bootstrap path, and `services.horizon` is rejected in External mode. Listing an
+External identity would write a generated admin password that nothing reads. See
+[OpenBao paths per ControlPlane mode](#openbao-paths-per-controlplane-mode).
 
 **Retired (#439):** the stage-(a) per-ControlPlane static DB seed
 `kv-v2/openstack/keystone/{ns}/{name}/db` is **no longer written**. Managed-mode
@@ -596,9 +612,10 @@ All secrets are stored under the `kv-v2/` mount point (KV version 2 engine).
 
 | Path | Keys | Provisioned By | Consumed By |
 | --- | --- | --- | --- |
-| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | `write-bootstrap-secrets.sh` (per ControlPlane; default `.../openstack/controlplane-keystone/admin`) | Operator-created ExternalSecret `{controlplane.Name}-keystone-admin-credentials` (default `controlplane-keystone-admin-credentials`); on kind additionally the overlay's `keystone-admin` ExternalSecret (default identity) |
+| `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | `write-bootstrap-secrets.sh` (per **Managed-mode** ControlPlane; default `.../openstack/controlplane-keystone/admin`) | Operator-created ExternalSecret `{controlplane.Name}-keystone-admin-credentials` (default `controlplane-keystone-admin-credentials`); on kind additionally the overlay's `keystone-admin` ExternalSecret (default identity) |
+| `kv-v2/bootstrap/<namespace>/<horizon>/secret-key` | `secret-key` | `write-bootstrap-secrets.sh` (per **Managed-mode** ControlPlane; default `.../openstack/controlplane-horizon/secret-key`) | On kind the overlay's `horizon-secret-key` ExternalSecret (default identity); per-CR ExternalSecrets in test namespaces |
 | `kv-v2/infrastructure/mariadb` | `root-password` | `write-bootstrap-secrets.sh` | On kind the overlay's `mariadb-root-password` ExternalSecret; in production a non-kind Flux MariaDB baseline provides the `mariadb-root-password` Secret itself |
-| `kv-v2/openstack/keystone/standalone/db` | `username`, `password` | `write-bootstrap-secrets.sh` (standalone/brownfield only) | The kind overlay's `keystone-db` ExternalSecret, serving standalone (non-ControlPlane) Keystone demos |
+| `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | `write-bootstrap-secrets.sh` (standalone/brownfield only) | The kind overlay's `keystone-db` ExternalSecret, serving standalone (non-ControlPlane) Keystone demos |
 
 **Note:** The stage-(a) per-ControlPlane static path
 `openstack/keystone/{ns}/{name}/db` (c5c3 operator helper
@@ -608,6 +625,52 @@ ControlPlanes draw short-lived, engine-issued credentials from
 retained only for the `credentialsMode: Static` opt-out (brownfield migration),
 whose KV path must then be seeded manually — see
 `docs/guides/migrate-keystone-db-to-dynamic-credentials.md`.
+
+### OpenBao paths per ControlPlane mode
+
+Which OpenBao paths exist for a ControlPlane depends on its Keystone identity
+mode (`spec.services.keystone.mode`). Seeding is a **Managed-mode** concern only;
+an **External-mode** ControlPlane wraps a pre-existing Keystone whose credentials
+were never minted by this operator, so no seeding script runs for it. In both
+modes the per-tenant `openbao-tenant-store` SecretStore the c5c3 operator
+provisions for the ControlPlane (`reconcileESOTenantStore`) is what reaches these
+paths, authenticating as the namespace-templated `eso-tenant` identity.
+
+**Both modes** — created on demand by ESO, never seeded. ESO's first PushSecret
+CREATES the KV leaf and stamps `custom_metadata.managed-by=external-secrets`
+itself (the managed-by guard only rejects a *pre-existing* leaf lacking that
+marker, so a first push to a never-seeded path always succeeds):
+
+| Path (under the `kv-v2` mount) | Written by | Read back by |
+| --- | --- | --- |
+| `openstack/keystone/{ns}/{cp}/admin/app-credential` | c5c3 operator admin-AC backup PushSecret (`adminAppCredentialRemoteKeyFor`, `DeletionPolicy: Delete`) | per-CR `k-orc-clouds-yaml` ExternalSecret (`ensureKORCCloudsYAMLExternalSecret`) |
+| `openstack/keystone/{ns}/{cp}/service-accounts/{account}` | c5c3 operator per-service-account backup PushSecret (`serviceAccountRemoteKeyFor`, one per declared `korc.serviceAccounts` entry) | the matching per-service-account ExternalSecret |
+
+**Managed mode additionally** — seeded and/or backed up because the operator owns
+the Keystone lifecycle:
+
+| Path (under the `kv-v2` mount) | Provisioned |
+| --- | --- |
+| `bootstrap/{ns}/{cp}-keystone/admin` | seeded by `write-bootstrap-secrets.sh` (ESO-adoption-marked), later overwritten by the keystone-operator Model B rotation PushSecret |
+| `bootstrap/{ns}/{cp}-horizon/secret-key` | seeded by `write-bootstrap-secrets.sh` |
+| `openstack/keystone/{ns}/{cp}-keystone/fernet-keys` | keystone-operator backup PushSecret (`reconcile_fernet.go`) |
+| `openstack/keystone/{ns}/{cp}-keystone/credential-keys` | keystone-operator backup PushSecret (`reconcile_credential.go`) |
+| `database/mariadb/creds/keystone-{ns}` (database engine, not KV) | dynamic, short-lived leases issued by the `database` engine role provisioned by `setup-database-tenant.sh` |
+
+**External mode** — no seeding script runs for the ControlPlane and no bootstrap
+path is created for it. The **only** OpenBao-side prerequisites are the one-time
+cluster bootstrap:
+
+- the secret engines (`setup-secret-engines.sh`),
+- the `eso-tenant` Kubernetes-auth role (`setup-auth.sh`),
+- the templated `eso-tenant` policy (`setup-policies.sh`),
+
+plus the infra-stack `openbao-ca-issuer` ClusterIssuer that signs the tenant
+store's mTLS client certificate. Neither `setup-eso-tenant.sh` nor
+`setup-database-tenant.sh` is needed: the c5c3 operator provisions the per-tenant
+store itself, and an External-mode ControlPlane has no managed database. The
+app-credential and declared service-account paths above are still created on the
+operator's first push, exactly as in Managed mode.
 
 ### ESO Integration
 
@@ -630,7 +693,7 @@ deployment-specific.
 | `{controlplane.Name}-keystone-db-credentials` | `openstack` | Dynamic (default): generator-backed via `VaultDynamicSecret` reading `database/mariadb/creds/keystone-{ns}` (no KV remote path); Static opt-out: `openstack/keystone/{ns}/{name}/db` | `username`, `password` | `{controlplane.Name}-keystone-db-credentials` | `username`, `password` |
 | `keystone-admin` (kind only) | `openstack` | `bootstrap/openstack/controlplane-keystone/admin` | `password` | `keystone-admin` | `password` |
 | `mariadb-root-password` (kind only) | `openstack` | `infrastructure/mariadb` | `root-password` | `mariadb-root-password` | `password` |
-| `keystone-db` (kind only) | `openstack` | `openstack/keystone/standalone/db` | `username`, `password` | `keystone-db` | `username`, `password` |
+| `keystone-db` (kind only) | `openstack` | `openstack/keystone/openstack/standalone/db` | `username`, `password` | `keystone-db` | `username`, `password` |
 
 **Note:** The static `deploy/eso/externalsecrets/` directory has been removed, so
 the production stack ships **no** ExternalSecret resources — its ESO

--- a/docs/reference/testing/controlplane-e2e-tests.md
+++ b/docs/reference/testing/controlplane-e2e-tests.md
@@ -167,7 +167,23 @@ cross-tenant isolation. Running in the ephemeral test namespace, the suite:
 3. mints a token from the tenant's `eso-tenant-auth` ServiceAccount, logs in as
    the `eso-tenant` role, and proves the token can read **its own** namespace's
    Keystone key path but is **denied** on a foreign namespace's path — the
-   templated-policy isolation that replaces the naming convention.
+   templated-policy isolation that replaces the naming convention;
+4. logs in as the shared `eso-management` role and proves it is **denied** both
+   read and write on a Keystone key path (#606 retired the `push-*` write
+   policies and dropped `eso-management`'s `openstack/keystone/*` read) while
+   still reading the retained shared `bootstrap/*` subtree;
+5. applies an `ExternalSecret` referencing the shared `openbao-cluster-store`
+   from the non-allow-listed ephemeral namespace and proves it never goes
+   `Ready`, because #606 restricted the cluster store with `spec.conditions`;
+6. drives the **never-seeded first-push** round-trip on a per-CP app-credential
+   path (`openstack/keystone/{ns}/{cp}/admin/app-credential`, the shape the
+   External-mode round-trip uses) through the operator-default tenant store:
+   the first `PushSecret` creates the leaf and ESO stamps
+   `managed-by=external-secrets` itself (the managed-by guard's inverse), a
+   read-back `ExternalSecret` materialises the exact value, and
+   `DeletionPolicy: Delete` purges the leaf via the `eso-tenant` delete grant —
+   with zero seeded state and nothing per-CP beyond the one-time cluster
+   bootstrap.
 
 The ControlPlane→Keystone/Horizon projection and the `SecretsReady` gating are
 covered by the c5c3 operator integration test

--- a/tests/e2e/c5c3/secret-store-scoping/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/secret-store-scoping/chainsaw-test.yaml
@@ -29,7 +29,14 @@
 #      shared bootstrap subtree — the confused-deputy grants are gone;
 #   5. an ExternalSecret referencing the shared openbao-cluster-store from this
 #      non-allow-listed namespace never goes Ready, because #606 restricted the
-#      cluster store with spec.conditions to the static-manifest namespace(s).
+#      cluster store with spec.conditions to the static-manifest namespace(s);
+#   6. a FIRST PushSecret through the operator-default tenant store to a
+#      NEVER-SEEDED per-CP app-credential path (the External-mode app-credential
+#      round-trip runs on exactly this shape) creates the leaf and lets ESO stamp
+#      managed-by=external-secrets ITSELF (the managed-by guard's inverse), the
+#      read-back materialises the exact value, and DeletionPolicy: Delete purges
+#      the leaf via the eso-tenant delete grant — with zero seeded state and
+#      nothing per-CP beyond the one-time cluster bootstrap.
 #
 # ── Presence + capability guard ──────────────────────────────────────────────
 # Like the sibling db-credential-scoping / multi-controlplane suites, the
@@ -52,11 +59,14 @@ spec:
   # tenant namespace, so the eso-tenant policy templates the tenant token to it.
   timeouts:
     assert: 5m
-    exec: 10m
+    # 15m exec/script budget: checks 1-5 worst-case ~5-6m (240s store-Ready +
+    # 30s cluster-store window + probes) and check 6 adds ~5-6m (120s push-Ready
+    # + 120s read-back-Ready + 90s purge), so ~12m worst case with margin.
+    exec: 15m
   steps:
   - try:
     - script:
-        timeout: 10m
+        timeout: 15m
         shell: bash
         content: |
           set -euo pipefail
@@ -269,6 +279,162 @@ spec:
           fi
           echo "OK: openbao-cluster-store rejected the reference from the non-allow-listed namespace"
 
+          # ── 6. First push to a NEVER-SEEDED per-CP path (ESO managed-by guard
+          #       inverse) ─────────────────────────────────────────────────────
+          # The External-mode app-credential round-trip runs on a per-CP path no
+          # seeding script ever writes: openstack/keystone/{ns}/{cp}/admin/
+          # app-credential (adminAppCredentialRemoteKeyFor in korc_eso.go). This
+          # check proves the OpenBao-side half of that round-trip on a path with
+          # ZERO seeded state, reusing the operator-default tenant store check 1
+          # provisioned: ESO's FIRST PushSecret CREATES the leaf and stamps
+          # custom_metadata.managed-by=external-secrets ITSELF (the managed-by guard
+          # only rejects a pre-existing UNMARKED leaf, so a first push always
+          # succeeds — the inverse of write-bootstrap-secrets.sh's mark_eso_managed),
+          # the read-back ExternalSecret materialises the exact value, and
+          # DeletionPolicy: Delete drives the eso-tenant delete grant to purge it.
+          # Nothing per-CP beyond the one-time cluster bootstrap is required.
+          #
+          # wait_ready <kind> <name> <timeout-seconds>: poll the namespaced
+          # resource in the tenant namespace until its Ready condition is True,
+          # or fail the step once the deadline passes (a still-unset condition
+          # counts as a timeout, never a pass). Callers print their own "OK:" line.
+          wait_ready() {
+            local kind="$1" name="$2" timeout="$3" deadline status
+            deadline=$(( $(date +%s) + timeout ))
+            while true; do
+              status="$(kubectl get "${kind}" "${name}" -n "${TENANT_NS}" \
+                -o "jsonpath={.status.conditions[?(@.type=='Ready')].status}" 2>/dev/null || true)"
+              [ "${status}" = "True" ] && return 0
+              if [ "$(date +%s)" -ge "${deadline}" ]; then
+                echo "ERROR: ${kind}/${name} Ready not True within ${timeout}s (last: '${status:-<none>}')"
+                exit 1
+              fi
+              sleep 5
+            done
+          }
+
+          PROBE_KV="openstack/keystone/${TENANT_NS}/probe-cp/admin/app-credential"
+          PROBE_SRC=probe-app-credential
+          PROBE_PUSH=probe-app-credential-backup
+          PROBE_ES=probe-app-credential-readback
+          # Fixed marker: the never-seeded precondition below proves nothing was at
+          # this path before, so an exact-match read-back can only observe THIS
+          # value if the full push -> materialise round-trip worked.
+          MARKER="unseeded-first-push-probe-value"
+
+          # (a) Never-seeded precondition: the path MUST NOT exist yet, else the
+          #     round-trip below would be a vacuous false-positive on stale state.
+          if bao_exec bao kv get -mount=kv-v2 "${PROBE_KV}" >/dev/null 2>&1; then
+            echo "ERROR: ${PROBE_KV} already exists; the never-seeded precondition is violated"
+            exit 1
+          fi
+          echo "OK: ${PROBE_KV} is never-seeded — first push starts from zero state"
+
+          # (b) Source Secret whose whole content the PushSecret mirrors (the c5c3
+          #     admin-AC PushSecret pushes the source Secret WHOLE, no Match.SecretKey).
+          kubectl create secret generic "${PROBE_SRC}" -n "${TENANT_NS}" \
+            --from-literal=clouds.yaml="${MARKER}"
+
+          # (c) First push through the operator-default per-tenant store.
+          #     deletionPolicy Delete + whole-secret match mirror adminAppCredentialPushSecret.
+          kubectl apply -f - <<EOF
+          apiVersion: external-secrets.io/v1alpha1
+          kind: PushSecret
+          metadata:
+            name: ${PROBE_PUSH}
+            namespace: ${TENANT_NS}
+          spec:
+            deletionPolicy: Delete
+            refreshInterval: 10s
+            secretStoreRefs:
+              - name: ${STORE_NAME}
+                kind: SecretStore
+            selector:
+              secret:
+                name: ${PROBE_SRC}
+            data:
+              - match:
+                  remoteRef:
+                    remoteKey: ${PROBE_KV}
+          EOF
+          wait_ready pushsecret "${PROBE_PUSH}" 120
+          echo "OK: first PushSecret to the never-seeded path reached Ready=True"
+
+          # (d) ESO must have CREATED the path and stamped the managed-by guard
+          #     marker ITSELF — the inverse of the pre-seed mark_eso_managed stamp.
+          if ! bao_exec bao kv metadata get -format=json -mount=kv-v2 "${PROBE_KV}" \
+               | jq -e '.data.custom_metadata."managed-by" == "external-secrets"' >/dev/null; then
+            echo "ERROR: ESO did not stamp managed-by=external-secrets on the first push to ${PROBE_KV}"
+            exit 1
+          fi
+          echo "OK: ESO stamped custom_metadata.managed-by=external-secrets on the first push"
+
+          # (e) Read-back through the same tenant store must materialise the EXACT
+          #     pushed value (mirrors the k-orc-clouds-yaml ExternalSecret, property
+          #     clouds.yaml).
+          kubectl apply -f - <<EOF
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: ${PROBE_ES}
+            namespace: ${TENANT_NS}
+          spec:
+            refreshInterval: 10s
+            secretStoreRef:
+              name: ${STORE_NAME}
+              kind: SecretStore
+            target:
+              name: ${PROBE_ES}
+            data:
+              - secretKey: clouds.yaml
+                remoteRef:
+                  key: ${PROBE_KV}
+                  property: clouds.yaml
+          EOF
+          wait_ready externalsecret "${PROBE_ES}" 120
+          got="$(kubectl get secret "${PROBE_ES}" -n "${TENANT_NS}" \
+            -o "jsonpath={.data.clouds\.yaml}" 2>/dev/null | base64 -d || true)"
+          if [ "${got}" != "${MARKER}" ]; then
+            echo "ERROR: read-back materialised '${got}', expected '${MARKER}' — round-trip broken"
+            exit 1
+          fi
+          echo "OK: read-back materialised the exact pushed value — full round-trip verified"
+
+          # (f) DeletionPolicy: Delete teardown. Deleting the PushSecret drives ESO's
+          #     finalizer to remove the data leaf via the eso-tenant delete grant.
+          #     For the app-credential shape the eso-tenant policy grants delete on
+          #     the DATA leaf but NOT the metadata path, so ESO soft-deletes the data
+          #     (the leaf then reports data:null); a hypothetical hard delete would
+          #     make kv get fail outright. Either outcome proves the delete grant
+          #     drove the purge, so accept both — a leaf still holding the pushed
+          #     value fails the poll and surfaces a real regression.
+          kubectl delete externalsecret "${PROBE_ES}" -n "${TENANT_NS}" --ignore-not-found >/dev/null 2>&1 || true
+          kubectl delete pushsecret "${PROBE_PUSH}" -n "${TENANT_NS}" --ignore-not-found >/dev/null 2>&1 || true
+          deadline=$(( $(date +%s) + 90 ))
+          purged=0
+          while [ "$(date +%s)" -lt "${deadline}" ]; do
+            if json="$(bao_exec bao kv get -format=json -mount=kv-v2 "${PROBE_KV}" 2>/dev/null)"; then
+              if echo "${json}" | jq -e '.data.data == null' >/dev/null 2>&1; then
+                purged=1
+                break
+              fi
+            else
+              purged=1
+              break
+            fi
+            sleep 3
+          done
+          if [ "${purged}" -ne 1 ]; then
+            echo "ERROR: ${PROBE_KV} still holds a live value 90s after PushSecret deletion; DeletionPolicy: Delete / the eso-tenant delete grant did not purge it"
+            exit 1
+          fi
+          echo "OK: DeletionPolicy: Delete purged the never-seeded leaf via the eso-tenant delete grant"
+
+          # Best-effort teardown of the probe source Secret + the KV metadata the
+          # soft-delete leaves behind (a root metadata delete clears it).
+          kubectl delete secret "${PROBE_SRC}" -n "${TENANT_NS}" --ignore-not-found >/dev/null 2>&1 || true
+          bao_exec bao kv metadata delete -mount=kv-v2 "${PROBE_KV}" >/dev/null 2>&1 || true
+
           # Best-effort cleanup of the probe secrets (KV-v2 hard delete).
           bao_exec bao kv metadata delete -mount=kv-v2 "${OWN_KV}" >/dev/null 2>&1 || true
           bao_exec bao kv metadata delete -mount=kv-v2 "${FOREIGN_KV}" >/dev/null 2>&1 || true
@@ -283,6 +449,12 @@ spec:
           kubectl describe secretstore openbao-tenant-store -n "$NAMESPACE" 2>&1 || true
           echo "=== Certificate eso-tenant-client-tls ==="
           kubectl describe certificate eso-tenant-client-tls -n "$NAMESPACE" 2>&1 || true
+          echo "=== PushSecret probe-app-credential-backup (check 6) ==="
+          kubectl describe pushsecret probe-app-credential-backup -n "$NAMESPACE" 2>&1 || true
+          echo "=== ExternalSecret probe-app-credential-readback (check 6) ==="
+          kubectl describe externalsecret probe-app-credential-readback -n "$NAMESPACE" 2>&1 || true
+          echo "=== Secret probe-app-credential-readback (check 6; dummy values) ==="
+          kubectl get secret probe-app-credential-readback -n "$NAMESPACE" -o yaml 2>&1 || true
           echo "=== external-secrets controller logs (last 100 lines) ==="
           kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=100 --all-containers 2>&1 || true
           echo "=== OpenBao logs (last 100 lines) ==="


### PR DESCRIPTION
## Summary

Audit of the OpenBao seeding scripts and rebuilt policy set for managed-flow assumptions that would break an **External-mode** ControlPlane (#582). External mode reads the admin password only from the user-referenced Secret and **never seeds** an OpenBao bootstrap path, yet the seeding scripts and their docs were written as if every ControlPlane has a seeded `bootstrap/{ns}/{keystone}/admin` path and a projected Keystone/Horizon.

**Audit outcome: no runtime bug.** The rebuilt `eso-tenant` templated-policy path (#605/#606) already covers an External-mode ControlPlane end-to-end — its per-CP app-credential paths are created on ESO's first push, never seeded. The gaps were in the scripts' and docs' *contracts*: they invited an operator to mis-seed or manually onboard an External-mode ControlPlane. This branch closes those with comment/doc scoping and adds an e2e test that proves the never-seeded first-push round-trip. Runtime behaviour of the scripts is unchanged (comment-only edits).

Closes #589

## Change set (commit order)

**1. `a16830e0` docs(openbao): scope seeding and tenant onboarding to managed flows** — comment-only edits to three bootstrap scripts:
- `write-bootstrap-secrets.sh`: documents that `KORC_CONTROLPLANES` entries are **Managed-mode identities only** and why an External-mode ControlPlane must not be listed (user-supplied admin password, `reconcileAdminPassword` short-circuits, `services.horizon` rejected → a listed entry would write a generated password nothing reads). Also corrects the seeds list (it also seeds the Horizon secret-key) and the stale standalone/db path.
- `setup-eso-tenant.sh`: re-scoped to **standalone** (non-ControlPlane) Keystone/Horizon namespaces. A ControlPlane of any mode never needs it — the c5c3 operator provisions the same store via `reconcileESOTenantStore` and defaults onto it; `spec.secretStoreRef` on a ControlPlane is the opt-out override, not an onboarding step.
- `setup-database-tenant.sh`: notes it is a managed-database onboarding step an External-mode ControlPlane (no managed database) must not use.

**2. `a0b8985a` docs(openbao): state per-mode OpenBao paths in the bootstrap reference** — adds an "OpenBao paths per ControlPlane mode" subsection to `docs/reference/infrastructure/openbao-bootstrap.md` (the explicit per-mode path statement the W9 adoption guide, #591, consumes): both modes get the on-demand app-credential / service-account paths (created by ESO's first push, never seeded); Managed additionally gets the seeded admin + horizon paths, the keystone-operator fernet/credential backups, and dynamic DB leases; External needs nothing beyond the one-time cluster bootstrap. Also corrects drift the audit surfaced: the standalone DB path carries the `openstack/` namespace segment (`openstack/keystone/openstack/standalone/db`), the seeded Horizon secret-key path was undocumented, and `setup-policies.sh` applies 9 (not 8) policies.

**3. `9316c3a1` test(e2e): prove first push to a never-seeded per-CP OpenBao path** — extends the `tests/e2e/c5c3/secret-store-scoping` suite with the OpenBao-side half of the External-mode app-credential round-trip (check 6). On the per-CP path shape `openstack/keystone/{ns}/{cp}/admin/app-credential` — which no seeding script writes — it asserts the path starts never-seeded, a first `PushSecret` through the operator-default tenant store creates the leaf and lets ESO stamp `custom_metadata.managed-by=external-secrets` itself (the managed-by guard's inverse), a read-back `ExternalSecret` materialises the exact pushed value, and `DeletionPolicy: Delete` purges the leaf via the `eso-tenant` delete grant. The purge assertion tolerates both the soft-delete the app-credential policy shape produces and a hypothetical hard delete, since either proves the delete grant fired. The exec/script timeout is bumped to 15m for the added round-trip and the catch block dumps the probe objects.

## Divergence from the issue

None material. The issue's scope checklist called for "fixes to scripts/policies where an External-mode CP would be denied or mis-seeded" — the audit found **no denial or runtime mis-seed** (the #605/#606 policy rebuild already covers External mode), so the deliverable is contract-scoping comments + the per-mode path statement + a regression test proving the never-seeded round-trip, rather than a behavioural code fix. The `docs/reference/testing/controlplane-e2e-tests.md` update documents the new check 6 and the checks 4–5 the suite already carried.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
