### PR TITLE
docs: brownfield phase-1 adoption guide, ControlPlane reference true-up, future-page graduation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           { text: 'Enable Horizon Operator Metrics', link: '/guides/enable-horizon-operator-metrics' },
           { text: 'Enable Horizon Operator NetworkPolicy', link: '/guides/enable-horizon-operator-networkpolicy' },
           { text: 'Migrate Keystone DB to Dynamic Credentials', link: '/guides/migrate-keystone-db-to-dynamic-credentials' },
+          { text: 'Adopt an External Keystone', link: '/guides/adopt-external-keystone' },
         ],
       },
       {

--- a/docs/future/brownfield-keystone-adoption.md
+++ b/docs/future/brownfield-keystone-adoption.md
@@ -5,22 +5,27 @@ quadrant: operator
 
 # Brownfield Keystone Adoption
 
-> **Status: idea sketch.** Nothing on this page is implemented or scheduled.
-> It analyzes what a phased takeover of an existing Keystone installation
-> would require, using the current codebase as the baseline.
+> **Status: phase 1 is implemented.** The service-less, External-mode
+> ControlPlane described below now exists. Use the
+> [Adopt an External Keystone](../guides/adopt-external-keystone.md) guide to run
+> it, and the [ControlPlane CRD](../reference/c5c3/controlplane-crd.md#externalkeystonespec)
+> and [reconciler](../reference/c5c3/controlplane-reconciler.md) references for
+> the authoritative behavior. **Phases 2–4 remain idea sketches** — nothing beyond
+> phase 1 is implemented or scheduled.
 
 ## Motivation
 
-Today a `ControlPlane` CR always ends in a running, operator-deployed Keystone:
-the reconciler chain provisions infrastructure, projects a Keystone CR, runs
-the bootstrap job, and only then wires up K-ORC credentials and the catalog.
-For an existing (brownfield) OpenStack installation this is a big-bang
-proposition — the operator cannot add value before it owns the whole stack.
+In **Managed** mode a `ControlPlane` CR always ends in a running,
+operator-deployed Keystone: the reconciler chain provisions infrastructure,
+projects a Keystone CR, runs the bootstrap job, and only then wires up K-ORC
+credentials and the catalog. For an existing (brownfield) OpenStack installation
+that alone would be a big-bang proposition — the operator could not add value
+before it owned the whole stack.
 
-The idea: invert the adoption order. In a first step, a **service-less
-ControlPlane** deploys *nothing* — no Keystone, no MariaDB, no cache — and
-takes over only the **identity-plane management** that K-ORC provides against
-the existing, externally running Keystone API:
+Phase 1 inverts the adoption order. A **service-less ControlPlane** deploys
+*nothing* — no Keystone, no MariaDB, no cache — and takes over only the
+**identity-plane management** that K-ORC provides against the existing,
+externally running Keystone API:
 
 - minting and rotating the admin **application credential**,
 - managing **service accounts** (service users, projects, role assignments)
@@ -35,14 +40,15 @@ seeds via `keystone-manage bootstrap`. On a brownfield the admin password is
 supplied by the platform owner and rotated out-of-band.
 
 The actual takeover of MariaDB, messaging, and the Keystone deployment itself
-then happens in later, individually reversible phases on the **same CR**.
+would then happen in later, individually reversible phases on the **same CR**.
+Those phases are still sketches.
 
-## Baseline: what exists today
+## Baseline: what phase 1 built on
 
-The building blocks are further along than one might expect — brownfield is
-already a first-class concept, just not for the service layer.
+The building blocks were further along than one might expect — brownfield was
+already a first-class concept, just not yet for the service layer.
 
-**Already in place:**
+**Already in place before phase 1:**
 
 - **Brownfield infrastructure modes.** `spec.infrastructure.database` accepts
   either a `clusterRef` (managed MariaDB) or a `host` (existing external
@@ -55,10 +61,11 @@ already a first-class concept, just not for the service layer.
   sub-reconciler detects a pre-existing MariaDB or Memcached CR it does not
   control and adopts it as-is instead of re-projecting defaults.
 - **K-ORC imports for pre-existing identity resources.** The admin user and
-  the `Default` domain are created as *unmanaged* K-ORC resources — imports of
-  objects that already exist in Keystone. This is exactly the mechanism a
-  brownfield needs; today it merely happens to import objects the operator's
-  own bootstrap job created moments earlier.
+  the domain are created as *unmanaged* K-ORC resources — imports of objects that
+  already exist in Keystone. This was exactly the mechanism a brownfield needs; in
+  Managed mode it merely happens to import objects the operator's own bootstrap
+  job created moments earlier. Phase 1 points the same mechanism at objects the
+  operator never created.
 - **Credential lifecycle machinery.** The admin application credential is
   minted by a managed K-ORC `ApplicationCredential`, backed up to OpenBao via
   PushSecret, re-materialized via ExternalSecret, and re-minted
@@ -66,29 +73,37 @@ already a first-class concept, just not for the service layer.
   `CredentialRotation` CR nudges it. None of this logic cares *where* the
   Keystone API lives — only the endpoint URL does.
 
-**Gaps that block a service-less mode** (all in `operators/c5c3`):
+**Gaps that blocked a service-less mode** (all in `operators/c5c3`) — **all five
+are closed by phase 1**:
 
-1. **`services.keystone` is a required struct.** There is no way to express
-   "manage identity, deploy nothing". The `Keystone` sub-reconciler always
-   projects a child Keystone CR.
-2. **The auth URL is hardwired to the in-cluster Service.** Both clouds.yaml
-   builders (password-based and application-credential-based) use
-   `http://{name}-keystone.{namespace}.svc:5000/v3` with
-   `endpoint_type: internal`. No spec field, env var, or Secret can point
-   K-ORC at an external Keystone; the only configurable URL today,
-   `services.keystone.publicEndpoint`, affects catalog advertisement and the
-   bootstrap job — never the auth path.
-3. **`spec.infrastructure` is required.** Even in brownfield database mode the
-   CR must carry database coordinates, because the projected Keystone consumes
-   them. A service-less ControlPlane needs neither database nor cache.
-4. **The catalog sub-reconciler only creates.** It manages a K-ORC `Service`
-   (type `identity`) and `Endpoint` (interface `public`) as *managed*
-   resources. Pointed at an existing installation this would duplicate catalog
-   entries — Keystone does not enforce unique service names.
-5. **The bootstrap seed assumes the managed flow.** The write-if-empty
-   password clouds.yaml seed and the OpenBao bootstrap path
-   (`bootstrap/{namespace}/{keystone}/admin`) are built around the
-   operator-generated admin password.
+1. **No way to say "manage identity, deploy nothing".** `services.keystone` is
+   already an *optional pointer* (`*ServiceKeystoneSpec`); when it is nil the
+   ControlPlane manages no identity plane and reports `KeystoneNotManaged`. But
+   nil is deliberately **not** "external": absence carries no endpoint
+   configuration, and an omitted field reads like an authoring mistake rather
+   than intent. That is exactly why phase 1 added a `mode` discriminator
+   (`Managed` | `External`) with an `external` block, rather than overloading
+   absence. **Closed:** `mode: External` projects no Keystone child and reports
+   `KeystoneReady=True/ExternallyManaged`.
+2. **The auth URL was hardwired to the in-cluster Service.** Both clouds.yaml
+   builders used `http://{name}-keystone.{namespace}.svc:5000/v3` with
+   `endpoint_type: internal`; nothing could point K-ORC at an external Keystone.
+   **Closed:** `external.authURL` plus a configurable `external.endpointType`
+   (default `public`) and an optional `external.caBundleSecretRef`, projected
+   into both credentials Secrets.
+3. **`spec.infrastructure` was required.** **Closed:** it is now optional, and
+   the validating webhook *forbids* it in External mode — a service-less
+   ControlPlane needs neither database nor cache.
+4. **The catalog sub-reconciler only created.** Pointed at an existing
+   installation it would have duplicated catalog entries, since Keystone does not
+   enforce unique service names. **Closed:** External mode is **import-first** —
+   the existing identity service and its endpoints are imported as unmanaged
+   K-ORC resources, and managed entries are created only on explicit opt-in. An
+   ambiguous catalog fails loudly rather than guessing.
+5. **The bootstrap seed assumed the managed flow.** **Closed:** External mode
+   **never seeds** the OpenBao bootstrap path — the admin password is read only
+   from the referenced Secret. Only the application-credential and service-account
+   paths exist.
 
 ## Phase model
 
@@ -96,12 +111,12 @@ Each phase is a spec transition on the same `ControlPlane` CR, forward-only,
 and leaves the system in a supported steady state. A brownfield operator can
 stop at any phase indefinitely.
 
-| Phase | Name | Operator manages | Existing installation keeps |
-|-------|------|------------------|------------------------------|
-| 1 | Identity-only (service-less) | App credentials, service accounts, catalog entries, secret rotation via K-ORC + OpenBao | Keystone API, database, admin password, all data |
-| 2 | Infrastructure attach | Phase 1 + database/cache coordinates (brownfield `host`/`servers` mode), later managed replacements with data migration | Keystone API, admin password |
-| 3 | Service takeover | Phase 2 + the Keystone deployment itself (fernet/credential keys imported, bootstrap skipped, endpoint cutover) | — |
-| 4 | Steady state | Everything — indistinguishable from a greenfield ControlPlane | — |
+| Phase | Name | Status | Operator manages | Existing installation keeps |
+|-------|------|--------|------------------|------------------------------|
+| 1 | Identity-only (service-less) | **Implemented** | App credentials, service accounts, catalog entries, secret rotation via K-ORC + OpenBao | Keystone API, database, admin password, all data |
+| 2 | Infrastructure attach | Sketch | Phase 1 + database/cache coordinates (brownfield `host`/`servers` mode), later managed replacements with data migration | Keystone API, admin password |
+| 3 | Service takeover | Sketch | Phase 2 + the Keystone deployment itself (fernet/credential keys imported, bootstrap skipped, endpoint cutover) | — |
+| 4 | Steady state | Sketch | Everything — indistinguishable from a greenfield ControlPlane | — |
 
 Messaging (RabbitMQ) is not modeled in the ControlPlane CRD at all today —
 Keystone needs none. The phase model reserves its takeover for the point where
@@ -111,128 +126,91 @@ replacement with migration later.
 
 ## Phase 1: the service-less ControlPlane
 
-### API sketch
+**Implemented.** This section summarizes what shipped and how each of the
+sketch's open questions was resolved. For the authoritative material see the
+[Adopt an External Keystone](../guides/adopt-external-keystone.md) guide, the
+[ControlPlane CRD reference](../reference/c5c3/controlplane-crd.md#externalkeystonespec),
+and the [reconciler reference](../reference/c5c3/controlplane-reconciler.md).
 
-A mode discriminator on the service entry, mirroring the existing
-managed-vs-brownfield split of the infrastructure specs:
+### What shipped
+
+A `mode` discriminator on the Keystone service entry, with an `external` block:
 
 ```yaml
-apiVersion: c5c3.io/v1alpha1
-kind: ControlPlane
-metadata:
-  name: brownfield
-  namespace: openstack
 spec:
-  openStackRelease: "2025.1"        # advisory in this mode — no images are deployed
-  region: RegionOne
-  # infrastructure: omitted — must become optional (forbidden in External mode)
   services:
     keystone:
-      mode: External                 # new discriminator; default Managed
+      mode: External                 # default Managed
       external:
         authURL: https://keystone.example.com/v3
-        endpointType: public         # interface K-ORC selects from the catalog
+        endpointType: public         # default; the catalog interface K-ORC authenticates against
         caBundleSecretRef:           # optional, for private CAs
           name: brownfield-keystone-ca
+        catalog:
+          identityServiceName: keystone   # only needed to disambiguate duplicates
   korc:
     adminCredential:
       passwordSecretRef:
         name: brownfield-admin-password   # user-supplied, from the existing installation
+    serviceAccounts:
+      - name: nova
+        project:
+          name: service-nova
+          create: true
 ```
 
-Alternative shapes considered:
+`spec.infrastructure` became optional and is **forbidden** in External mode, as is
+`services.horizon`. `mode` transitions are rejected in **both** directions, so
+adoption is always a new CR — `External → Managed` is reserved for the phase-3
+takeover, and `Managed → External` has no meaning.
 
-- **Make `services.keystone` a pointer** (absent = not deployed). Rejected:
-  absence cannot carry the external endpoint configuration, and an omitted
-  required-feeling field reads like an authoring mistake rather than intent.
-- **A separate CRD** (e.g. `IdentityPlane`). Rejected: the whole point of the
-  phase model is that adoption is a sequence of spec transitions on one CR;
-  a CRD migration in the middle of it would break ownership, status history,
-  and the one-ControlPlane-per-namespace invariant.
+The baseline analysis held up: the two heaviest sub-reconcilers (KORC,
+AdminCredential) needed almost no change, because their logic is
+endpoint-agnostic. The bulk of the work was API surface, the import-first catalog,
+and the failure-classification vocabulary.
 
-The `mode: External` → `mode: Managed` transition is precisely the phase 3
-takeover and must therefore be *gated*, not immutable — unlike the existing
-infrastructure mode fields, which are immutable today and would need the same
-relaxation for phase 2. The reverse transition (`Managed` → `External`) should
-be rejected outright.
+Sub-reconcilers that would deploy something short-circuit with
+`Status=True, Reason=ExternallyManaged` (Infrastructure, DBCredentials,
+AdminPassword, Keystone), so the condition schema is identical across modes. The
+conditions that carry signal are `KORCReady`, `AdminCredentialReady`,
+`CatalogReady`, and `ServiceAccountsReady`.
 
-### Sub-reconciler behavior in External mode
+Beyond the original sketch, phase 1 also delivered **declarative service
+accounts** (`korc.serviceAccounts`): managed K-ORC users and projects with
+operator-generated, OpenBao-backed, rotatable passwords, collision-gated against
+pre-existing users and adoptable on explicit consent. This is the operational win
+the sketch predicted, and it landed in phase 1 rather than later.
 
-The chain keeps its order; External mode changes what each link does:
+### How the open questions resolved
 
-| Sub-reconciler | Managed (today) | External mode (proposed) |
-|----------------|-----------------|--------------------------|
-| Infrastructure | Creates MariaDB / Memcached CRs | Skipped — `InfrastructureReady` with a dedicated reason (e.g. `ExternallyManaged`) |
-| DBCredentials | Projects ExternalSecret from OpenBao | Skipped — no database involvement at all |
-| AdminPassword | Projects ExternalSecret from the OpenBao bootstrap path | Skipped — the user-supplied `passwordSecretRef` Secret is the source, exactly as in today's brownfield database mode |
-| Keystone | Creates the child Keystone CR | Skipped — no child CR; `KeystoneReady` reports `ExternallyManaged` |
-| KORC | Builds clouds.yaml against the in-cluster Service URL | Builds clouds.yaml against `spec…external.authURL` with the configured `endpointType`; admin user/domain imports, application-credential mint, OpenBao round-trip all unchanged |
-| AdminCredential | Assembles app-credential clouds.yaml, force-push/force-sync | Unchanged — the assembled clouds.yaml simply carries the external `auth_url` |
-| Catalog | Creates managed Service + Endpoint | Import-first: unmanaged imports of the existing identity service and endpoints; managed creation only as an explicit opt-in for genuinely new entries |
-
-The striking observation from the baseline analysis: **the two heaviest
-sub-reconcilers (KORC, AdminCredential) need almost no change.** Their logic
-is endpoint-agnostic; only the two clouds.yaml builders take a different
-`auth_url` and `endpoint_type`. The bulk of the work is API surface
-(mode/external fields, optionality of `infrastructure`, webhook rules) and the
-catalog import semantics.
-
-### What phase 1 delivers on a brownfield
-
-- **Admin application credential under management.** Minted by K-ORC against
-  the existing Keystone, stored per-CR in OpenBao, re-minted automatically
-  when the admin password changes (hash-driven) or on demand via a
-  `CredentialRotation` CR. Consumers read it from OpenBao / the materialized
-  Secret instead of sharing long-lived admin passwords.
-- **A home for service accounts.** The `bootstrapResources` field already
-  reserved in the CRD (kinds `Project` and `Role`, currently not reconciled)
-  grows into the service-account story: K-ORC `User`, `Project`, and role
-  assignment resources for the service users of other OpenStack services
-  (nova, glance, …), with passwords generated into OpenBao and rotated on
-  schedule. For an existing installation this is the single biggest
-  operational win of phase 1.
-- **Catalog stewardship.** Existing services and endpoints become visible as
-  imports; endpoint changes (new URLs, TLS migrations) become declarative
-  once entries are promoted to managed.
-- **Zero blast radius.** No database connection, no message queue, no running
-  service is touched. Deleting the ControlPlane in phase 1 tears down only the
-  K-ORC-managed application credential (its finalizer revokes it) and the
-  OpenBao-backed Secrets — imports are left untouched by definition.
-
-### Open questions for phase 1
-
-- **Reachability and trust.** K-ORC runs in-cluster and must reach the
-  external API: egress/NetworkPolicy posture, and CA-bundle delivery for
-  private CAs. gophercloud honors a `cacert` key, but how a bundle travels
-  from a Secret into K-ORC's credential resolution needs verification —
-  possibly a documented constraint of the first iteration.
-- **`endpoint_type` semantics.** In-cluster the operator deliberately forces
-  `internal`; against an external installation the reachable interface is
-  usually `public`. Making it configurable per External spec (as sketched)
-  seems right, but the interplay with catalog entries that also list internal
-  endpoints unreachable from the cluster needs a test matrix.
-- **Readiness semantics.** What does `Ready` mean when nothing is deployed?
-  The natural proxy is the K-ORC import conditions (a failed admin-user import
-  means the external Keystone is unreachable or the credential is wrong).
-  An active health probe would require an OpenStack client in the operator,
-  which it deliberately does not have today — everything is K-ORC-mediated,
-  and phase 1 should keep it that way.
-- **Admin password rotation stays out.** The scheduled password rotation
-  (rotation CronJob, staging/commit, push to OpenBao) lives in the Keystone
-  operator and presumes the managed deployment. On a brownfield the password
-  rotates out-of-band; updating the referenced Secret already triggers the
-  hash-driven application-credential re-mint. Whether the ControlPlane should
-  *validate* freshness (e.g. warn on stale seeds) is open.
-- **Release skew.** `openStackRelease` drives image selection, which External
-  mode doesn't use. Should the field validate against the actual version of
-  the external Keystone (discoverable via the root endpoint), or is it purely
-  advisory until phase 3? At takeover time it *must* match the existing
-  database schema.
-- **OpenBao path layout.** The per-CR scoped paths carry over unchanged, but
-  the admin-password seed path is bootstrap-oriented; External mode reads the
-  password only from the referenced Secret and never seeds, so the OpenBao
-  seeding scripts and policies need an audit for assumptions about the
-  managed flow.
+- **Reachability and trust.** The CA bundle travels from a Secret into K-ORC as
+  the inline `cacert` key beside `clouds.yaml` — which gophercloud reads natively,
+  so no mount and no upstream change were needed. Egress remains the operator's
+  responsibility: nothing restricts it by default, and a restrictive-egress cluster
+  must allow K-ORC to reach the endpoint. A *rotated* bundle only takes effect
+  after K-ORC's provider cache expires — a documented constraint, not a bug.
+- **`endpoint_type` semantics.** Configurable per External spec, defaulting to
+  `public`. The hazard the sketch worried about — a catalog whose entries point at
+  interfaces unreachable from the cluster — is handled by failing **loudly**:
+  a mismatch surfaces as `CatalogEndpointMismatch`, and a silently-empty import is
+  caught by a stall detector that reports `ImportStalled` naming `endpoint_type`
+  and `region`. Nothing waits forever.
+- **Readiness semantics.** As the sketch proposed: K-ORC-proxied, with no
+  OpenStack client in the operator. The failure classes (`AuthenticationFailed`,
+  `EndpointUnreachable`, `TLSVerificationFailed`, `CatalogEndpointMismatch`,
+  `CredentialDrift`, `ImportStalled`) are recovered from K-ORC's message, since
+  K-ORC collapses every hard API failure into one transient condition.
+- **Admin password rotation stays out.** Confirmed: it rotates out-of-band at the
+  installation, and updating the referenced Secret drives the hash-driven
+  application-credential re-mint. Freshness is **not** validated; a stale Secret
+  surfaces as drift (`AuthenticationFailed`), which the operator reports and never
+  remediates.
+- **Release skew.** `openStackRelease` stays required but is **advisory** in
+  External mode — no images are deployed. It must match the existing database
+  schema only at the phase-3 takeover.
+- **OpenBao path layout.** External mode **never seeds**. The bootstrap path does
+  not exist for it; only the per-CR application-credential and service-account
+  paths do, created on first push.
 
 ## Phase 2: infrastructure attach
 
@@ -286,31 +264,41 @@ the (now historical) spec transitions.
 
 ## Risks
 
+The phase-1 risks are **addressed by the implemented posture**; they are kept
+here because phases 2–4 inherit them.
+
 - **Catalog duplication.** Keystone happily stores duplicate service entries;
-  a bug in import-vs-create logic pollutes the production catalog. Import
-  semantics must be conservative (never create unless explicitly told to).
+  a bug in import-vs-create logic would pollute the production catalog.
+  *Addressed:* External mode is import-first and never creates unless explicitly
+  told to; an ambiguous catalog fails loudly instead of guessing.
 - **Re-mint revokes.** The application-credential re-mint is delete + recreate;
   the old credential is revoked at the Keystone level the moment the K-ORC
-  finalizer runs. Anything in the existing installation that was handed the
-  minted credential must consume it from OpenBao (or the materialized Secret),
-  never from a copy.
-- **Spec/reality drift.** A service-less ControlPlane describes an
-  installation it does not control; the external Keystone can change under it
-  (endpoints edited by hand, admin password rotated without updating the
-  Secret). Conditions must surface drift loudly rather than fighting it.
-- **Scope creep in phase 1.** The temptation is to "just add" a health probe,
-  a schema check, a password rotator. Phase 1 stays credible exactly because
-  it is K-ORC-only and touches nothing stateful.
+  finalizer runs. *Addressed:* the consumer contract — always read the credential
+  from the materialized Secret or its OpenBao path, never from a copy — is stated
+  in the [adoption guide](../guides/adopt-external-keystone.md).
+- **Spec/reality drift.** A service-less ControlPlane describes an installation it
+  does not control; the external Keystone can change under it (endpoints edited by
+  hand, admin password rotated without updating the Secret). *Addressed:* drift is
+  surfaced as dedicated conditions (`AuthenticationFailed`, `CredentialDrift`,
+  `ImportStalled`) and never fought — the operator does not write to the external
+  installation.
+- **Scope creep in phase 1.** The temptation was to "just add" a health probe, a
+  schema check, a password rotator. *Held:* phase 1 stayed K-ORC-only and touches
+  nothing stateful; readiness is K-ORC-proxied and the operator carries no
+  OpenStack client.
 
 ## Suggested next steps
 
-1. **Spike:** run K-ORC from a kind cluster against an external Keystone
-   (clouds.yaml with an external `auth_url`, `endpoint_type: public`, private
-   CA) and confirm imports, application-credential mint, and revoke-on-delete
-   behave as assumed above.
-2. **API design review:** settle the `mode`/`external` shape (or an
-   alternative) and the optionality/immutability matrix for
-   `infrastructure` — this decides how painful phases 2–3 become.
-3. **Triage:** open a GitHub issue for phase 1 following the usual
-   feature-triage flow; phases 2–4 remain sketches until phase 1 proves the
-   model.
+Phases 2–4 remain sketches. The natural next step is to triage **phase 2**
+(infrastructure attach) through the usual feature-triage flow, now that phase 1
+has proven the model — in particular that the mode discriminator, the import-first
+catalog, and the K-ORC-proxied readiness hold up against a real external
+installation.
+
+The two hard problems phase 2 and phase 3 still owe a design:
+
+- **Data migration** for the database cutover (phase 2b) — replication or
+  dump/restore with a maintenance window; no tooling exists.
+- **Key material import** (fernet and credential encryption keys) before the first
+  operator-managed pod starts, plus an explicit bootstrap skip/adopt gate
+  (phase 3).

--- a/docs/future/index.md
+++ b/docs/future/index.md
@@ -23,6 +23,8 @@ Pages in this section are explicitly **not**:
 ## Current sketches
 
 - [Brownfield Keystone Adoption](./brownfield-keystone-adoption.md) — adopt an
-  existing OpenStack Keystone installation incrementally, starting with a
-  service-less ControlPlane that only manages credentials, service accounts,
-  and catalog entries via K-ORC.
+  existing OpenStack Keystone installation incrementally. **Phase 1 has
+  graduated**: the service-less, External-mode ControlPlane is implemented, and
+  running it is documented in
+  [Adopt an External Keystone](../guides/adopt-external-keystone.md). The page
+  keeps the later phases (infrastructure attach, service takeover) as sketches.

--- a/docs/guides/adopt-external-keystone.md
+++ b/docs/guides/adopt-external-keystone.md
@@ -1,0 +1,427 @@
+---
+title: Adopt an External Keystone
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Adopt an External Keystone
+
+This guide walks a platform owner through putting an **existing** Keystone
+installation under operator management without deploying anything into it.
+
+A ControlPlane in **External mode** is service-less: it projects no MariaDB, no
+Memcached, and no Keystone workload. It manages the *identity plane* against the
+Keystone API you already run — minting and rotating the admin **application
+credential**, provisioning declarative **service accounts**, and importing your
+existing **service catalog** rather than writing to it. Your installation keeps
+serving tokens throughout, and deleting the ControlPlane leaves it untouched.
+
+This is the first step of a staged adoption. Taking over the database and the
+Keystone deployment itself are later, separate phases — see
+[Brownfield Keystone Adoption](../future/brownfield-keystone-adoption.md).
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the
+[Quick Start (ControlPlane)](../quick-start-controlplane.md).
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow it through its final **Verify** step, so the operators and the shared
+infrastructure (OpenBao, External Secrets, K-ORC) are running. This guide adds a
+**second, External-mode** ControlPlane in its own namespace; the managed
+`controlplane` the tutorial creates in `openstack` stays as it is.
+:::
+
+Beyond the devstack, adopting a real installation needs:
+
+- **A reachable Keystone API.** K-ORC dials it from inside the cluster. Nothing
+  restricts the operator's egress by default, but on a cluster that enforces a
+  restrictive egress policy you must explicitly allow traffic from the K-ORC
+  namespace to the endpoint and port.
+- **The admin password, as a Secret** in the ControlPlane's namespace. The
+  operator never invents it and never rotates it — you supply it and rotate it at
+  the installation (see [step 6](#_6-rotating-the-admin-password-out-of-band)).
+- **A CA bundle Secret**, if the endpoint uses a private CA. The key defaults to
+  `ca.crt`. An IP-based `authURL` needs an IP SAN in the certificate; a hostname
+  resolves through cluster DNS.
+- **A `spec.region` that matches your catalog.** The region and the selected
+  interface must both exist in the external catalog, or the control plane fails
+  loudly rather than importing nothing.
+
+### Standing in a brownfield Keystone on kind
+
+On kind there is no pre-existing installation to adopt, so create one. These are
+the same fixtures the e2e suite uses: a plain, operator-free Keystone in
+namespace `brownfield-keystone`, serving
+`http://keystone.brownfield-keystone.svc:5000/v3`.
+
+```bash
+kubectl apply -f tests/e2e/c5c3/external-keystone/00-fixture-keystone.yaml
+kubectl -n brownfield-keystone rollout status deploy/keystone --timeout=5m
+
+kubectl apply -f tests/e2e/c5c3/external-keystone/01-fixture-catalog-setup-job.yaml
+kubectl -n brownfield-keystone wait --for=condition=Complete \
+  job/keystone-fixture-setup --timeout=5m
+```
+
+The setup Job deliberately makes this look like a *real* installation rather than
+a fresh bootstrap:
+
+- a **non-default admin identity** — user `brownfield-admin`, project
+  `platform-admin`, domain `heimdall` — so nothing relies on the `admin`/`Default`
+  names a bootstrap would leave behind;
+- a **duplicate identity-type service** (`keystone-legacy` alongside `keystone`),
+  which is what forces the catalog disambiguation in
+  [step 2](#_2-apply-the-external-mode-controlplane).
+
+Against a real installation, skip this section entirely.
+
+## Steps
+
+### 1. Create the namespace and the admin-password Secret
+
+The ControlPlane needs its own namespace (one ControlPlane per namespace), and
+the admin password of the existing installation as a Secret in it.
+
+```bash
+kubectl create namespace brownfield
+
+# Prompt without echo, then pipe the value in on stdin so the admin password
+# never appears on argv (visible in /proc/<pid>/cmdline for the life of the
+# process) or in your shell history file.
+read -rs -p 'Keystone admin password: ' PW; echo
+printf '%s' "$PW" | kubectl -n brownfield create secret generic brownfield-admin-password \
+  --from-file=password=/dev/stdin
+unset PW
+```
+
+Type your installation's real admin password at the prompt. On the kind devstack
+it is the fixture password `brownfield_admin_fixture_pw_0`, which the setup Job
+of the previous section gave `brownfield-admin`.
+
+Nothing else in this guide reads the password directly — everything downstream
+authenticates with the application credential the operator mints from it.
+
+### 2. Apply the External-mode ControlPlane
+
+This is the manifest the e2e suite applies, imported from the suite itself. The
+walkthrough and the suite share the namespace `brownfield`, the ControlPlane name
+`controlplane-external`, and the admin-password Secret from step 1, so there is one
+manifest here rather than a hand-kept copy of one — see [Tested by](#tested-by).
+
+<<< @/../tests/e2e/c5c3/external-keystone/02-controlplane-external.yaml#controlplane-external
+
+That ControlPlane is the only thing in the file — the suite keeps its fixture
+admin-password Secret in a sibling file precisely so applying this one cannot
+overwrite the Secret you filled in step 1 — so on the devstack apply it as it
+stands:
+
+```bash
+kubectl apply -f tests/e2e/c5c3/external-keystone/02-controlplane-external.yaml
+```
+
+Against a real installation, copy it out and set `external.authURL`, `spec.region`,
+and the admin identity to yours.
+
+Field by field:
+
+| Field | Why |
+| --- | --- |
+| `mode: External` | Selects the service-less path. No Keystone workload is deployed and no child CR is projected. |
+| `external.authURL` | The identity endpoint the operator manages against. |
+| `external.endpointType` | Which catalog interface to authenticate against. Omitted here, so it defaults to `public` — the interface that is normally reachable from outside the installation. |
+| `external.caBundleSecretRef` | The private-CA bundle, when the endpoint needs one. Omitted here: the kind fixture is plain HTTP — devstack only, see the warning below. |
+| `external.catalog.identityServiceName` | Disambiguates the identity-service import. Only needed when your catalog holds **more than one** `identity`-type service — as the fixture deliberately does. |
+| `korc.adminCredential.cloudCredentialsRef` | Where the minted credential is materialized — the `clouds.yaml` Secret and cloud entry read back in [step 4](#_4-verify). Spelled out here, but `k-orc-clouds-yaml` / `admin` are the defaults. |
+| `korc.adminCredential.passwordSecretRef` | The Secret from step 1. |
+| `userName` / `projectName` / `domainName` | The admin identity to authenticate as. They default to `admin` / `admin` / `Default`; the fixture uses a non-default identity, so all three are set. |
+| `applicationCredential.restricted` | Keeps the minted credential least-privilege — it cannot mint further application credentials. Spelled out here, but `true` is the default. |
+| `applicationCredential.rotation.mode` | `PasswordDriven` keys the re-mint on a hash of the admin password — see [step 6](#_6-rotating-the-admin-password-out-of-band). Spelled out here, but it is the default. |
+| `korc.serviceAccounts` | Declarative service accounts — see [step 5](#_5-declare-service-accounts). |
+
+`spec.openStackRelease` stays required but is **advisory** in this mode: no images
+are deployed, so it only has to match your installation at a future managed
+takeover.
+
+::: danger `authURL` must be `https://` against a real installation
+The CRD admits `http://` so the kind fixture can run without certificates. It is
+the *only* reason. Over plain HTTP the admin password travels in the clear on
+every mint — and the minted application credential's id and secret come back in
+the clear — to anything on the path between K-ORC and the endpoint. There is no
+handshake to fail, so `TLSVerificationFailed` never fires: the failure mode is a
+silent success.
+
+Against anything but a throwaway devstack, use `https://` and supply the private
+CA via `external.caBundleSecretRef`. Pairing that ref with an `http://` authURL is
+rejected at admission — a CA bundle a plaintext endpoint never consults would only
+manufacture false confidence.
+:::
+
+::: warning Adoption means a *new* CR, never a flipped one
+The webhook **forbids** `spec.infrastructure`, `services.horizon`, and every
+managed-only Keystone knob in External mode — it names the offending field. It
+also rejects `mode` transitions **in both directions**: `Managed → External` is
+refused, and `External → Managed` is reserved for the phase-3 takeover. So you
+adopt an installation by creating a *new* External-mode ControlPlane, never by
+flipping an existing managed one.
+:::
+
+### 3. What `Ready` means in this mode
+
+Nothing is deployed, so the sub-reconcilers that would deploy something report
+`Status=True` with reason `ExternallyManaged` — `InfrastructureReady`,
+`DBCredentialsReady`, `AdminPasswordReady`, and `KeystoneReady`. They are *not*
+evidence that anything converged.
+
+The conditions that carry real signal are `KORCReady`, `AdminCredentialReady`,
+`CatalogReady`, and `ServiceAccountsReady`. All of them are proxied through K-ORC:
+the operator holds no OpenStack client of its own, so "can we reach and
+authenticate against your Keystone?" is answered by whether the imports and the
+application-credential mint succeed.
+
+```bash
+kubectl -n brownfield get controlplane controlplane-external
+kubectl -n brownfield get controlplane controlplane-external \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
+```
+
+When something is wrong, `KORCReady` names the failure class:
+
+| Reason | What it means | What to do |
+| --- | --- | --- |
+| `AuthenticationFailed` | Keystone rejected the admin credential (HTTP 401). | The password in the Secret is not (or is no longer) the installation's admin password. |
+| `EndpointUnreachable` | `authURL` could not be dialled — DNS, connection refused, timeout. | Check the URL, cluster DNS, and your egress policy. |
+| `TLSVerificationFailed` | The endpoint's certificate did not verify. | Supply the private CA via `external.caBundleSecretRef`. A **rotated** bundle only takes effect after K-ORC's provider cache expires (roughly half the token lifetime). |
+| `CatalogEndpointMismatch` | Authentication worked, but the requested interface/region is absent from the catalog. | Correct `external.endpointType` or `spec.region`. |
+| `ImportStalled` | An import is waiting for a resource that "will be created externally" — but in this mode every import target already exists, so it never resolves. | The operator is looking in the wrong place; the message names `endpoint_type` and `region`. |
+| `CredentialDrift` | The installation changed underneath the CR. | Reconcile the CR with reality. Drift is **surfaced, never remediated** — the operator does not write to your installation. |
+
+Imports resolve **once**. If an imported object is later replaced in Keystone, that
+surfaces as drift rather than the operator silently re-pointing at the new one.
+
+The full reason vocabulary for every condition is in the
+[ControlPlane CRD reference](../reference/c5c3/controlplane-crd.md#status-conditions).
+
+### 4. Verify
+
+First, converge:
+
+```bash
+kubectl -n brownfield wait --for=condition=Ready \
+  controlplane/controlplane-external --timeout=10m
+```
+
+Then prove the ControlPlane deployed **nothing** — this is the whole point of the
+mode:
+
+```bash
+kubectl -n brownfield get mariadbs,memcacheds,keystones,deployments
+# No resources found in brownfield namespace.
+```
+
+Finally, prove the minted credential actually authenticates against your
+installation — not merely that the operator called itself Ready. Read it from the
+materialized Secret:
+
+```bash
+kubectl -n brownfield get secret k-orc-clouds-yaml \
+  -o jsonpath='{.data.clouds\.yaml}' | base64 -d
+```
+
+Use that `clouds.yaml` with an OpenStack client (`openstack token issue`,
+`openstack catalog list`). The e2e suite does exactly this in a Job; see
+[Tested by](#tested-by).
+
+::: tip Read the credential from Kubernetes, not the OpenBao UI
+On kind, OpenBao enforces mTLS, so browsing to it or using the `bao` CLI needs a
+client certificate. The materialized Secret above is the supported handle.
+:::
+
+### 5. Declare service accounts
+
+`korc.serviceAccounts` gives the service users of other OpenStack services
+(nova, glance, …) a managed home: a Keystone user and project with an
+operator-generated, OpenBao-backed, rotatable password.
+
+The entry in [step 2](#_2-apply-the-external-mode-controlplane) declares user
+`nova` with a **created** project `service-nova`. The semantics that matter:
+
+- **`project.create: false`** references an existing project via an unmanaged
+  import — it is never created, and never deleted.
+- **`adopt: true`** is explicit consent to take over a **pre-existing** Keystone
+  user of that name. Without it, a name collision fails loudly
+  (`ServiceAccountCollision`) rather than silently hijacking the account. Note an
+  adopted user becomes operator-owned, so it *is* deleted at teardown.
+- **`roles`** is accepted but **deferred** — K-ORC ships no RoleAssignment yet, so
+  the operator emits a `RoleAssignmentsDeferred` event rather than silently
+  dropping them. Bind roles yourself for now.
+
+Each account's password is generated into OpenBao at
+`openstack/keystone/{namespace}/{controlplane}/service-accounts/{name}` and
+materialized as a stable consumer Secret:
+
+```bash
+kubectl -n brownfield get secret controlplane-external-service-account-nova-credentials \
+  -o jsonpath='{.data.clouds\.yaml}' | base64 -d
+```
+
+Per-account readiness is reported individually in
+`status.serviceAccounts[].ready`, so one lagging account is attributable without
+decoding the aggregate condition.
+
+### 6. Rotating the admin password, out-of-band
+
+The admin password belongs to your installation, so it rotates **there** — the
+operator has no database access and no rotation job in this mode.
+
+After rotating it at the installation, **update the referenced Secret** — again
+off the command line, since this one carries the *fresh* production password.
+
+Writing that Secret is not bookkeeping: it *is* the trigger. The operator keys the
+mint on a hash of the admin password, so the write re-mints the application
+credential — and a re-mint is **destructive-first**: K-ORC deletes and revokes the
+credential that is currently working *before* it tries the fresh one. So the value
+has to be proven against Keystone **before** it is written. Type it twice, then
+issue a token with it; the Secret is only written if both readings agree *and* your
+installation accepts the password.
+
+```bash
+read -rs -p 'new Keystone admin password: ' PW; echo
+read -rs -p 'confirm: ' PW2; echo
+
+# The admin identity the ControlPlane authenticates as (spec.korc.adminCredential).
+export OS_IDENTITY_API_VERSION=3
+export OS_AUTH_URL=http://keystone.brownfield-keystone.svc:5000/v3
+export OS_USERNAME=brownfield-admin
+export OS_PROJECT_NAME=platform-admin
+export OS_USER_DOMAIN_NAME=heimdall OS_PROJECT_DOMAIN_NAME=heimdall
+
+if [ "$PW" != "$PW2" ]; then
+  echo 'passwords do not match — Secret left untouched, nothing rotated' >&2
+elif ! OS_PASSWORD="$PW" openstack token issue >/dev/null 2>&1; then
+  echo 'password does not authenticate — Secret left untouched, credential intact' >&2
+else
+  printf '%s' "$PW" | kubectl -n brownfield create secret generic brownfield-admin-password \
+    --from-file=password=/dev/stdin --dry-run=client -o yaml | kubectl -n brownfield replace -f -
+fi
+unset PW PW2
+```
+
+Run the token check from wherever `authURL` is reachable — that is the network
+position K-ORC dials from, so a pass there answers the same question the operator
+is about to ask. On the kind devstack the endpoint is a cluster-internal Service,
+so run it in a pod (`kubectl run --rm -i --image=… -- openstack token issue`), as
+the suite does.
+
+**Neither gate is ceremony, and equality alone is not enough.** Comparing two
+readings catches a *divergent* typo and nothing else. It passes just as happily
+when you mistype the same thing twice, when you type the old password from muscle
+memory, and when you update the Secret before you actually rotated at the
+installation. Each of those changes the hash, so the re-mint fires all the same —
+revoking the working credential and then failing `401` against a password Keystone
+never accepted. You are left with no valid admin credential at all, `KORCReady` on
+`AuthenticationFailed`, and every import and service-account projection driven by
+it broken until a human notices and redoes the step. Asking Keystone first is the
+difference between a rotation and an outage.
+
+**Forgetting the Secret update is the classic drift.** The old password stops
+authenticating, `KORCReady` goes to `AuthenticationFailed`, and the operator
+reports it — it will not go hunting for the new password.
+
+To force a re-mint without a password change, request one. `reMint: true` is what
+makes it a rotation: without it the reconciler falls back to the password-hash
+check, finds the hash unchanged, and reports `Ready=True` with reason
+`NoRotationNeeded` having rotated nothing. The CR binds to the ControlPlane by
+**namespace** — one ControlPlane per namespace — so there is no reference field:
+
+```yaml
+apiVersion: c5c3.io/v1alpha1
+kind: CredentialRotation
+metadata:
+  name: rotate-admin
+  namespace: brownfield
+spec:
+  target: adminApplicationCredential
+  reMint: true
+```
+
+The nudge is one-shot per spec generation, so a `reMint: true` left in the spec
+fires once per edit rather than on every resync.
+
+A service-account password rotates the same way, with
+`target: serviceAccountPassword` and `serviceAccount: nova` — and there `reMint`
+is not merely advisable but **required**: that path has no password-hash
+auto-detect at all, so without it the request is a guaranteed no-op.
+
+::: warning The minted credential must never be copied
+A re-mint is **delete + recreate**, and the previous credential is revoked at the
+Keystone level the moment it happens — any client still holding it starts getting
+`404 Could not find Application Credential`, with no grace period.
+
+So every consumer must read the credential from the materialized Secret (or its
+OpenBao path) **at use time**. A copy pasted into another Secret, a config file, or
+an environment variable dies without warning on the next rotation.
+:::
+
+### 7. OpenBao paths in this mode
+
+External mode **never seeds** a bootstrap path: there is no operator-generated
+admin password to seed. Only the application-credential and service-account paths
+exist, and both are created on first push — there is no per-ControlPlane OpenBao
+preparation to do, because the operator provisions the per-tenant store itself.
+
+The full per-mode path catalog is in
+[OpenBao paths per ControlPlane mode](../reference/infrastructure/openbao-bootstrap.md#openbao-paths-per-controlplane-mode).
+
+### 8. Deletion — zero blast radius
+
+Deleting the ControlPlane tears down **only what it created or adopted**:
+
+```bash
+kubectl -n brownfield delete controlplane controlplane-external
+```
+
+- The admin **application credential is revoked** (K-ORC's finalizer), and the
+  OpenBao-backed Secrets are removed.
+- **Managed** service-account users and projects are deleted from Keystone —
+  including any you marked `adopt: true`.
+- **Every unmanaged import is untouched**: the admin user, the domain, the catalog
+  services and endpoints, and any project referenced with `project.create: false`.
+- Your Keystone keeps serving tokens throughout.
+
+Ordering is held by the `c5c3.io/orc-teardown` finalizer, so the credential is
+revoked against a still-reachable Keystone before the CR leaves etcd.
+
+## See also
+
+- [ControlPlane CRD reference](../reference/c5c3/controlplane-crd.md#externalkeystonespec) —
+  `ExternalKeystoneSpec` and the full [status-condition catalog](../reference/c5c3/controlplane-crd.md#status-conditions).
+- [ControlPlane reconciler reference](../reference/c5c3/controlplane-reconciler.md) —
+  what each sub-reconciler does in External mode.
+- [OpenBao bootstrap reference](../reference/infrastructure/openbao-bootstrap.md#openbao-paths-per-controlplane-mode) —
+  which paths exist per mode.
+- [Brownfield Keystone Adoption](../future/brownfield-keystone-adoption.md) —
+  the later phases (infrastructure attach, service takeover).
+
+## Tested by
+
+```bash
+chainsaw test --test-dir tests/e2e/c5c3/external-keystone
+```
+
+or `make e2e-external-keystone`. The suite stands up the brownfield Keystone,
+adopts it with an External-mode ControlPlane, authenticates an OpenStack client
+with the minted credential, rotates it, and asserts the imports survive deletion.
+
+The suite runs in namespace `brownfield` with the ControlPlane
+`controlplane-external` — exactly the names this walkthrough uses — so
+[step 2](#_2-apply-the-external-mode-controlplane) imports the suite's own
+manifest rather than restating it.

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -193,7 +193,7 @@ status:
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.\d$`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. Upgrades are allowed on update, but **downgrades are rejected** (Keystone DB migrations are forward-only). Stays required in **both** keystone modes; in **External** mode it is **advisory** — no images are deployed, so the value only needs to match the external installation's release at the phase-3 managed takeover. |
+| `openStackRelease` | `string` | Yes | — | OpenStack release the control plane targets (e.g. `"2025.2"`). The reconciler (L2) projects this into each service CR's image tag. Must match the date-based release pattern `^\d{4}\.[12]$`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. Upgrades are allowed on update, but **downgrades are rejected** (Keystone DB migrations are forward-only). Stays required in **both** keystone modes; in **External** mode it is **advisory** — no images are deployed, so the value only needs to match the external installation's release at the phase-3 managed takeover. |
 | `region` | `string` | No | `"RegionOne"` | OpenStack region name applied across the control plane. Projected into the Keystone CR's `bootstrap.region`. Defaulted to `RegionOne` by **both** the `+kubebuilder:default` marker (normal admission) and the defaulting webhook (callers that bypass the CRD default). Immutable after create (the projected `bootstrap.region` is itself immutable). |
 | `infrastructure` | [`*InfrastructureSpec`](#infrastructurespec) | Conditional | managed-mode defaulted | Shared backing services (database, cache) the control plane's services connect to. **Required** when `services.keystone.mode` is `Managed` (or unset, or `services.keystone` unset) — the defaulting webhook materializes a managed-mode `database`/`cache` when omitted, and the validating webhook rejects a non-External ControlPlane without it. **Forbidden** in **External** mode (an External ControlPlane provisions no backing services; phase 2 relaxes this to optional). The mode-conditional required/forbidden rule is webhook-enforced because CEL cannot span `spec.infrastructure` and `spec.services.keystone`; see [InfrastructureSpec](#infrastructurespec) and [Validation Rules](#validation-rules). |
 | `services` | [`ServicesSpec`](#servicesspec) | Yes | — | Per-service configuration projected into the individual service CRs. |
@@ -305,12 +305,13 @@ that adopts a pre-existing MariaDB/Memcached leaves its topology untouched.
 ## ServicesSpec
 
 Declares the per-service configuration of the control plane. Today
-only Keystone is modeled; additional services are added as fields as the
-operator grows.
+Keystone and the Horizon dashboard are modeled; additional services are added as
+fields as the operator grows.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `keystone` | [`*ServiceKeystoneSpec`](#servicekeystonespec) | No | `nil` | Configuration for the Keystone service projected by the reconciler. Optional: when unset, this ControlPlane manages no Keystone service (staged adoption, or an externally-managed Keystone) and `KeystoneReady` is reported as not-managed. Flipping it from set to `nil` **preserves** the previously-projected Keystone child by default — deleting it would cascade to the child's irreplaceable `<name>-credential-keys` Secret (and its OpenBao backup), so an accidental unset is fail-safe. Set the `c5c3.io/allow-keystone-deletion: "true"` annotation on the ControlPlane to opt in to deleting the child on unset. |
+| `horizon` | [`*ServiceHorizonSpec`](#servicehorizonspec) | No | `nil` | Configuration for the Horizon dashboard projected by the reconciler. Optional: when unset, this ControlPlane manages no dashboard and `HorizonReady` is reported as not-managed (`HorizonNotManaged`), so the aggregate `Ready` is not blocked. **Forbidden in External mode** — the dashboard needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Horizon child by default; set the `c5c3.io/allow-horizon-deletion: "true"` annotation to opt in to deleting the child on unset. |
 
 ---
 
@@ -403,7 +404,7 @@ identity against that endpoint rather than deploying a Keystone workload.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `authURL` | `string` | Yes | — | Identity endpoint of the external Keystone (e.g. `https://keystone.example.com/v3`). Must match the HTTP(S) URL pattern `^https?://`, enforced by both the CRD `+kubebuilder:validation:Pattern` marker and the validating webhook. |
+| `authURL` | `string` | Yes | — | Identity endpoint of the external Keystone (e.g. `https://keystone.example.com/v3`). Must match the HTTP(S) URL pattern `^https?://[^\s/]+` — an HTTP(S) shape with a **non-empty host**, so a hostless endpoint is rejected at admission — and be at most **2048** characters. Both are enforced by the CRD `+kubebuilder:validation:Pattern` / `MaxLength` markers and mirrored by the validating webhook with a full `net/url` parse. The cap bounds the one unbounded input the reconciler interpolates into `status.conditions[].message`: the pattern is end-unanchored, so without it a multi-kilobyte path could push the assembled message past the apiserver's 32768-byte cap and fail the **whole** `status.conditions` write. Neither gate is an SSRF control — admission cannot resolve where the host points, so egress restrictions remain the operator's responsibility. |
 | `endpointType` | `string` (`public` \| `internal` \| `admin`) | No | `public` | Which Keystone catalog interface to authenticate against. Defaulted to `public` by both the `+kubebuilder:default` marker and the defaulting webhook. Rendered as the clouds.yaml `endpoint_type` key of **both** generated credentials Secrets. Named `endpointType` (not `interface`) because K-ORC drops gophercloud's `Interface` field and only honours `endpoint_type` (the authoritative note lives on `buildAppCredCloudsYAML` in the reconciler's `korc_cloudsyaml.go`). The selected interface must exist in the external catalog for `spec.region` — otherwise the control plane fails loud with `KORCReady=False/CatalogEndpointMismatch`. |
 | `caBundleSecretRef` | [`*commonv1.SecretRefSpec`](../keystone/keystone-crd.md#secretrefspec) | No | `nil` | References a Secret carrying a private CA bundle the client trusts when verifying the external endpoint. The bundle is projected verbatim as the inline `cacert` key into **both** generated K-ORC credentials Secrets — K-ORC reads that key natively from the same Secret that carries `clouds.yaml`, so no mount and no upstream change are needed. `key` defaults to `ca.crt`; this default is **webhook-only** because the shared `SecretRefSpec` carries no c5c3-specific marker (the same discipline as `passwordSecretRef.key`). When the ref is set its `name` must be non-empty (CRD `MinLength` marker + webhook). A missing Secret, a missing key, or a present-but-empty key defers the mint with `KORCReady=False/WaitingForCABundle` — the last shape is the normal transient of a two-step "create the Secret, then populate it" flow. |
 | `catalog` | [`*ExternalCatalogSpec`](#externalcatalogspec) | No | `nil` | Tunes how the control plane stewards the external Keystone's service catalog. Omitting it selects the conservative default: the existing identity service and all three of its endpoint interfaces are **imported** as unmanaged K-ORC CRs, and **zero** catalog entries are created. |
@@ -989,11 +990,11 @@ Keystone discipline:
 
 | Field | Rule |
 | --- | --- |
-| `spec.openStackRelease` | Pattern `^\d{4}\.\d$` |
+| `spec.openStackRelease` | Pattern `^\d{4}\.[12]$` |
 | `spec.services.keystone.publicEndpoint` | Pattern `^https?://`; MaxLength 512 (the Horizon child's bound on `websso.keystoneURL`, which this value is projected onto) |
 | `spec.services.horizon.publicEndpoint` | Pattern `^https?://`; MaxLength 499 (the Keystone child's 512-character bound on `trustedDashboards[]` minus `/auth/websso/`) |
 | `spec.services.keystone.mode` | Enum: `Managed`, `External`; schema default `Managed` |
-| `spec.services.keystone.external.authURL` | Pattern `^https?://` |
+| `spec.services.keystone.external.authURL` | Pattern `^https?://[^\s/]+`; MaxLength 2048 (bounds the one unbounded input interpolated into `status.conditions[].message`) |
 | `spec.services.keystone.external.endpointType` | Enum: `public`, `internal`, `admin`; schema default `public` |
 | `spec.services.keystone.external.caBundleSecretRef.name` | MinLength 1 (shared `SecretRefSpec` marker) |
 | `spec.korc.adminCredential.applicationCredential.accessRules[].method` | Enum: `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE` |
@@ -1033,7 +1034,7 @@ short-circuit on the first error.
 
 | Rule | Field Path | Error Type | Condition |
 | --- | --- | --- | --- |
-| Release pattern | `spec.openStackRelease` | `field.Invalid` | Value does not match `^\d{4}\.\d$`. Defense-in-depth alongside the CRD `+kubebuilder:validation:Pattern` marker. |
+| Release pattern | `spec.openStackRelease` | `field.Invalid` | Value does not match `^\d{4}\.[12]$`. Defense-in-depth alongside the CRD `+kubebuilder:validation:Pattern` marker. |
 | Database mutual exclusivity | `spec.infrastructure.database` | `field.Invalid` | Both `clusterRef` and `host` set, or neither (`(clusterRef != nil) == (host != "")`). Defense-in-depth alongside the CEL `XValidation` rule on `commonv1.DatabaseSpec`. |
 | Cache mutual exclusivity | `spec.infrastructure.cache` | `field.Invalid` | Both `clusterRef` and `servers` set, or neither (`(clusterRef != nil) == (len(servers) > 0)`). Defense-in-depth alongside the CEL `XValidation` rule on `commonv1.CacheSpec`. |
 | Database replicas quorum | `spec.infrastructure.database.replicas` | `field.Invalid` | Value is exactly `2`. The managed-mode projection turns any `replicas > 1` into a Galera cluster, and a two-node Galera cluster cannot hold a majority — a single pod disruption then loses quorum. Replicas must be 1 (standalone) or >=3. The CRD marker enforces only `Minimum=1` (the shared `commonv1.DatabaseSpec` must not carry a c5c3-specific CEL rule the keystone operator, which ignores `replicas`, would inherit), so this check is **webhook-only**; a zero value (defaulting bypassed) is left to the reconciler's floor. |
@@ -1042,7 +1043,7 @@ short-circuit on the first error.
 | Empty policy rule name | `spec.globalPolicyOverrides.rules[<key>]`, `spec.services.keystone.policyOverrides.rules[<key>]` | `field.Required` | A rule name (map key) is the empty string. Enforced via the shared `policy.ValidatePolicyRules`, mirrored by the CEL rule on `commonv1.PolicySpec`. |
 | Empty policy rule value | `spec.globalPolicyOverrides.rules[<key>]`, `spec.services.keystone.policyOverrides.rules[<key>]` | `field.Required` | A rule value is the empty string. Enforced via the shared `policy.ValidatePolicyRules`, mirrored by the CEL rule on `commonv1.PolicySpec`. |
 | External block required | `spec.services.keystone.external` | `field.Required` | `mode: External` but `external` unset. Defense-in-depth mirror of the CEL rule. |
-| External authURL required/URL | `spec.services.keystone.external.authURL` | `field.Required` / `field.Invalid` | In External mode, `authURL` empty (Required) or not matching `^https?://` (Invalid). Mirrors the CRD required/pattern markers. |
+| External authURL required/URL | `spec.services.keystone.external.authURL` | `field.Required` / `field.Invalid` | In External mode, `authURL` empty (Required), or not matching `^https?://[^\s/]+` / failing a full `net/url` parse / exceeding 2048 characters (Invalid). Mirrors the CRD required/pattern/maxLength markers. |
 | External caBundle name required | `spec.services.keystone.external.caBundleSecretRef.name` | `field.Required` | `caBundleSecretRef` set with an empty `name`. Mirrors the shared `SecretRefSpec` MinLength marker. |
 | Managed-only field forbidden in External mode | `spec.services.keystone.{replicas,image,policyOverrides,rotationInterval,gateway,publicEndpoint,federationProxyImage}` | `field.Forbidden` | The field is set while `mode: External`. Defense-in-depth mirror of the per-field CEL rules. |
 | Federation proxy image resolvable | `spec.services.keystone.federationProxyImage` | `field.Required` / `field.Invalid` | Empty `repository`, or neither/both of `tag` and `digest`. Surfaces on the ControlPlane the operator edits rather than as an opaque `KeystoneProjectionRejected` condition on the child. |
@@ -1216,6 +1217,7 @@ markers' documented values where a marker also exists.
 | `spec.korc.adminCredential.userName` | `== ""` | `"admin"` | Marker + webhook |
 | `spec.korc.adminCredential.projectName` | `== ""` | `"admin"` | Marker + webhook |
 | `spec.korc.adminCredential.domainName` | `== ""` | `"Default"` | Marker + webhook |
+| `spec.korc.serviceAccounts[].userName` | `== ""` | the entry's `name` | Webhook-only |
 
 <a id="secretref-default-note"></a>
 > **† `database.secretRef.name` default — managed-mode convenience name only.**
@@ -1288,22 +1290,31 @@ func (w *ControlPlaneWebhook) ValidateDelete(_ context.Context, _ *ControlPlane)
 
 ## Status Conditions
 
-The ControlPlane status is driven by eight sub-reconcilers, each owning one
+The ControlPlane status is driven by ten sub-reconcilers, each owning one
 condition type, plus an aggregate `Ready` condition. The condition-type
-constants in `controlplane_controller.go` are the single source of truth; call
-sites reference the constants rather than inline literals.
+constants in `controlplane_controller.go` (`subConditionTypes`) are the single
+source of truth; call sites reference the constants rather than inline literals.
 
 The sub-reconcilers run in dependency order; a stage that has not converged
 requeues and stops the chain, so later conditions are never computed against a
-half-built earlier stage. Three stages additionally gate **explicitly** on an
+half-built earlier stage. Four stages additionally gate **explicitly** on an
 earlier condition being `True` (`reconcileKeystone` on `InfrastructureReady`,
-`reconcileAdminCredential` on `KORCReady`, `reconcileCatalog` on
-`AdminCredentialReady`):
+`reconcileHorizon` on `KeystoneReady`, `reconcileAdminCredential` on `KORCReady`,
+`reconcileCatalog` and `reconcileServiceAccounts` on `AdminCredentialReady`):
 
 ```
-InfrastructureReady → DBCredentialsReady → AdminPasswordReady → KeystoneReady
-  → KORCReady → AdminCredentialReady → CatalogReady → ServiceAccountsReady
+InfrastructureReady → ESOTenantStoreReady → DBCredentialsReady → AdminPasswordReady
+  → KeystoneReady → HorizonReady → KORCReady → AdminCredentialReady
+  → CatalogReady → ServiceAccountsReady
 ```
+
+`ESOTenantStoreReady` runs ahead of every store-consuming stage because it
+provisions the per-tenant `SecretStore` they route their ExternalSecrets and
+PushSecrets through. It is **mode-independent**: an External-mode ControlPlane
+provisions the same tenant store (it just never seeds a bootstrap path through
+it), so both `ESOTenantStoreReady` and `HorizonReady` appear on an External-mode
+CR's status — the latter as `HorizonNotManaged`, since the dashboard is forbidden
+in External mode.
 
 `ServiceAccountsReady` gates explicitly on `AdminCredentialReady` (like
 `CatalogReady`): the admin credential must be minted before K-ORC can project
@@ -1332,6 +1343,21 @@ Set by `reconcileInfrastructure`.
 | `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: identity is managed against `services.keystone.external.authURL`, so no MariaDB/Memcached is provisioned. |
 | `False` | `InfrastructureNotConfigured` | `spec.infrastructure` is unset on a **non**-External ControlPlane. The validating webhook requires the block outside External mode, so this only fires for a webhook-bypassed CR; it fails closed rather than dereferencing the nil block. |
 
+### ESOTenantStoreReady
+
+Set by `reconcileESOTenantStore`. It provisions the per-tenant `SecretStore` (plus
+its ServiceAccount and mTLS certificate) that every store-consuming stage routes
+its ExternalSecrets and PushSecrets through, which is why it runs ahead of them.
+It is **mode-independent** — an External-mode ControlPlane provisions the same
+store.
+
+| Status | Reason | When |
+| --- | --- | --- |
+| `True` | `ESOTenantStoreReady` | The operator-provisioned per-tenant `SecretStore` is Ready. |
+| `True` | `StoreRefOverridden` | An explicit `spec.secretStoreRef` opts out of the operator-provisioned store: the ControlPlane owns the referenced store's lifecycle, so nothing is provisioned. The selected store's readiness is still gated by each store-consuming sub-reconciler. |
+| `False` | `SecretStoreNotReady` | The per-tenant `SecretStore` is not Ready yet; waiting on cert issuance and the OpenBao backend. |
+| `False` | `ProvisioningError` | Error ensuring the per-tenant secret-store objects (SecretStore, ServiceAccount, certificate). |
+
 ### DBCredentialsReady
 
 Set by `reconcileDBCredentials`. In managed mode (`database.clusterRef` set) it
@@ -1348,6 +1374,7 @@ ExternalSecret's stale per-object Ready cache.
 | `True` | `BrownfieldUserSuppliedCredential` | Brownfield database (`clusterRef` unset): the user supplies the DB-credential Secret out-of-band, so no ExternalSecret is projected and the chain proceeds immediately. |
 | `True` | `ExternallyManaged` | `services.keystone.mode` is `External`: the ControlPlane manages no database at all, so nothing is projected and neither OpenBao nor the `ClusterSecretStore` is consulted. |
 | `False` | `SecretStoreNotReady` | The store selected by `spec.secretStoreRef` (a ClusterSecretStore or a namespaced SecretStore) is not Ready; the secret backend is unreachable. |
+| `False` | `GeneratorError` | Error ensuring the dynamic DB-credential objects (the MariaDB `database` engine-backed generator that issues short-lived credentials). |
 | `False` | `ExternalSecretError` | Error ensuring or checking the DB-credential ExternalSecret. |
 | `False` | `WaitingForDBCredentialSecret` | The ExternalSecret is ensured but ESO has not yet synced it to Ready. |
 
@@ -1383,7 +1410,24 @@ Set by `reconcileKeystone` (gated on `InfrastructureReady`).
 | `False` | `WaitingForInfrastructure` | `InfrastructureReady` is not `True`; Keystone projection deferred. |
 | `False` | `WaitingForKeystone` | The Keystone CR is ensured but not yet Ready. |
 | `False` | `InvalidRotationInterval` | `services.keystone.rotationInterval` could not be converted to a cron schedule. |
+| `False` | `KeystoneProjectionRejected` | The Keystone API server rejected the projected spec (HTTP 422) — almost always a now-immutable db/bootstrap field that diverged from the frozen Keystone child. Reconcile the ControlPlane spec back to the child's values, or recreate the child, to recover. Distinct from `KeystoneError` so the wedge is diagnosable from the condition. |
 | `False` | `KeystoneError` | Error create-or-updating the Keystone CR. |
+
+### HorizonReady
+
+Set by `reconcileHorizon` (gated on `KeystoneReady` — the dashboard authenticates
+against the Keystone child). The dashboard is **forbidden in External mode**, so
+an External-mode ControlPlane always reports `HorizonNotManaged`.
+
+| Status | Reason | When |
+| --- | --- | --- |
+| `True` | `HorizonReady` | The projected Horizon CR reports Ready. |
+| `True` | `HorizonNotManaged` | `services.horizon` is unset (or the ControlPlane is in External mode): no dashboard is managed, so the aggregate `Ready` is not blocked. Any previously-projected Horizon child is **preserved** unless the `c5c3.io/allow-horizon-deletion: "true"` annotation opts in to its deletion. |
+| `False` | `WaitingForKeystone` | `KeystoneReady` is not `True`; Horizon projection deferred. |
+| `False` | `WaitingForHorizon` | The Horizon CR is ensured but not yet Ready. |
+| `False` | `IdentityBackendsUnavailable` | Listing the Keystone child's identity backends for the Horizon projection failed. The chain stops rather than projecting an empty `websso` block, which would silently remove a working SSO button from the login page. |
+| `False` | `HorizonProjectionRejected` | The Horizon API server rejected the projected spec (HTTP 422) — the projection violates a CRD/webhook rule. Reconcile the ControlPlane spec to a valid projection to recover. |
+| `False` | `HorizonError` | Error create-or-updating the Horizon CR. |
 
 ### KORCReady
 
@@ -1393,10 +1437,21 @@ Set by `reconcileKORC`.
 | --- | --- | --- |
 | `True` | `ApplicationCredentialMinted` | The K-ORC admin `ApplicationCredential` is minted and reports `Available=True`. |
 | `False` | `WaitingForAdminPassword` | The admin password Secret/key is not yet available; minting deferred. |
+| `False` | `WaitingForCABundle` | **External mode only.** The Secret referenced by `external.caBundleSecretRef` does not exist yet, or exists with a missing/empty key; the mint is deferred rather than attempted against an endpoint whose certificate cannot be verified. The present-but-empty shape is the normal transient of a two-step "create the Secret, then populate it" flow. |
+| `False` | `CABundleError` | **External mode only.** Non-missing error reading the external CA bundle. |
 | `False` | `ApplicationCredentialFailed` | The `ApplicationCredential` reports a terminal K-ORC error (`GetTerminalError` — an unrecoverable/invalid-config reason such as K-ORC being unable to authenticate); the message folds in any stuck admin Domain/User import. |
 | `False` | `WaitingForApplicationCredential` | The `ApplicationCredential` CR is ensured but not yet `Available`; the message folds in any stuck admin Domain/User import. |
+| `False` | `ReMinting` | The admin application credential is being re-minted (delete + recreate) after an admin-password change or a `CredentialRotation` request; awaiting K-ORC's revoke of the previous credential. The old credential is **already revoked** at the Keystone level — see the [consumption contract](#admincredentialspec). |
+| `False` | `ReMintStalled` | The `ApplicationCredential` has been `Terminating` longer than `remintStallTimeout`; K-ORC may be unable to reach Keystone to revoke the previous credential. Escalated from `ReMinting` so a stuck finalizer is alertable instead of looping silently. |
 | `False` | `AdminPasswordError` | Non-missing error reading the admin password. |
-| `False` | `ApplicationCredentialError` | Error create-or-updating the `ApplicationCredential` CR. |
+| `False` | `PasswordCloudError` | Error ensuring the operator-owned password-based `clouds.yaml` Secret the mint authenticates with. |
+| `False` | `AdminImportError` | Error create-or-updating the K-ORC admin `User`/`Domain` imports. |
+| `False` | `SecretError` | Error ensuring the application-credential Secret, or regenerating its `value` for a re-mint. |
+| `False` | `SeedCloudsYamlError` | Error seeding the bootstrap `clouds.yaml`. |
+| `False` | `PushSecretError` | Error ensuring the admin app-credential `PushSecret`, or forcing its CA-bundle re-push. |
+| `False` | `ExternalSecretError` | Error ensuring the K-ORC `clouds.yaml` `ExternalSecret`. |
+| `False` | `ApplicationCredentialError` | Error create-or-updating (or deleting, for a re-mint) the `ApplicationCredential` CR. |
+| `False` | `FinalizingORC` | The ControlPlane is being deleted and the operator is waiting for the owned K-ORC CRs and PushSecrets to finish their teardown (K-ORC's finalizer revokes the credential against Keystone) before releasing the `c5c3.io/orc-teardown` finalizer. Set by `reconcileDelete`; see the [reconciler reference](./controlplane-reconciler.md). |
 | `False` | `AuthenticationFailed` | **External mode only.** The external Keystone rejected the admin credential (HTTP 401) — typically the password was rotated out-of-band and `passwordSecretRef` is stale. K-ORC's message is relayed verbatim. |
 | `False` | `EndpointUnreachable` | **External mode only.** `services.keystone.external.authURL` could not be dialled (DNS failure, connection refused, timeout). |
 | `False` | `TLSVerificationFailed` | **External mode only.** The external endpoint's certificate did not verify; supply the private CA via `external.caBundleSecretRef`. |
@@ -1419,6 +1474,8 @@ application-credential id+secret) the freshly assembled credential).
 | `False` | `CredentialDrift` | **External mode only.** `KORCReady` reports drift in the external installation (`AuthenticationFailed` or `CredentialDrift`). The operator never remediates the external Keystone; update the `passwordSecretRef` Secret to drive a re-mint. |
 | `False` | `SecretStoreNotReady` | The store selected by `spec.secretStoreRef` (a ClusterSecretStore or a namespaced SecretStore) is not Ready; the secret backend is unreachable. |
 | `False` | `WaitingForCloudsYaml` | The operator-created per-ControlPlane `k-orc-clouds-yaml` ExternalSecret in the control-plane namespace (co-located with the K-ORC CRs per C1; created and owned by `reconcileKORC`) is not yet Ready. |
+| `False` | `WaitingForCredentialID` | K-ORC has not yet reported the minted application credential's id; the assembly is deferred until it does. |
+| `False` | `WaitingForAppCredentialSecret` | The operator-owned app-credential Secret does not exist yet, or carries no credential key — the mint is not complete. |
 | `False` | `WaitingForPushSecret` | The admin app-credential `PushSecret` has not synced the assembled `clouds.yaml` to OpenBao yet. `AdminCredentialReady` is gated on the PushSecret's `Ready` condition — not merely on the CR existing — so a backend permission failure (e.g. the ESO role missing the push policy) cannot yield a false-positive Ready while OpenBao still serves the password-based bootstrap `clouds.yaml`. |
 | `False` | `WaitingForCloudsYamlSync` | The materialised `k-orc-clouds-yaml` Secret is absent or still holds a stale credential (a re-mint revoked the old one but ESO has not re-synced yet). `reconcileAdminCredential` stamps the `external-secrets.io/force-sync` annotation to force an immediate re-sync and compares the materialised Secret semantically (parsed application-credential id+secret) against the assembled credential before reporting Ready, so the condition never reads `True` against a revoked credential. |
 | `False` | `CloudsYamlSyncStuck` | The materialised `k-orc-clouds-yaml` Secret has failed to match the assembled credential for longer than `cloudsYamlSyncStuckTimeout` (measured from the credential's `LastRotation`); the ESO ExternalSecret or OpenBao backend may be unable to sync. Escalated from `WaitingForCloudsYamlSync` so a never-converging sync is alertable and distinguishable from a transient miss. |

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -1383,11 +1383,21 @@ Per declared entry it, in order:
    the **materialized password matching the current generation**, so a rotated-away
    password never reads Ready.
 
+**Per-account status.** Each declared entry is projected onto a
+`status.serviceAccounts[]` entry keyed by `name`. Its `ready` field mirrors that
+account's own convergence — user, project, and a materialized password Secret
+matching the current generation — so a single lagging account is attributable
+without reading the aggregate `ServiceAccountsReady` message. The entry also
+carries the resolved `userID` / `projectID`, the applied `passwordGeneration`, and
+`lastPasswordRotation`, alongside the `secretName` handle below.
+
 **Consumption contract.** Consumers read from the materialized Secret
 `{controlplane.Name}-service-account-{name}-credentials` (keys `password` and a
 ready-to-use `clouds.yaml`), named in `status.serviceAccounts[].secretName`. The
 credentials are always read from that Secret (or the OpenBao path directly); after
-a rotation, one reload picks up the new password.
+a rotation, one reload picks up the new password. For which OpenBao paths exist in
+each Keystone mode, see
+[OpenBao paths per ControlPlane mode](../infrastructure/openbao-bootstrap.md#openbao-paths-per-controlplane-mode).
 
 **Deletion.** A managed `User`/`Project` (created **or adopted** — adoption makes
 it operator-owned) is deleted from Keystone at teardown, sequenced through the

--- a/docs/reference/testing/controlplane-e2e-tests.md
+++ b/docs/reference/testing/controlplane-e2e-tests.md
@@ -253,6 +253,7 @@ tests/e2e/c5c3/
 │   ├── chainsaw-test.yaml              External mode vs a plain, operator-free Keystone
 │   ├── 00-fixture-keystone.yaml        Plain SQLite Keystone fixture (no operator)
 │   ├── 01-fixture-catalog-setup-job.yaml  Non-default identities + duplicate service
+│   ├── 02-admin-password-secret.yaml   Fixture admin password for the main CR
 │   ├── 02-controlplane-external.yaml   Main External CR + service account
 │   ├── 03-controlplane-wrong-password.yaml  Wrong-password negative case
 │   ├── 04-controlplane-stalled.yaml    Unreachable-internal-endpoint case

--- a/tests/e2e/c5c3/external-keystone/01-fixture-catalog-setup-job.yaml
+++ b/tests/e2e/c5c3/external-keystone/01-fixture-catalog-setup-job.yaml
@@ -48,7 +48,7 @@ spec:
                   name: keystone-fixture-admin
                   key: password
             # SYNC: must equal the password in the brownfield-admin-password
-            # Secret in 02-controlplane-external.yaml — the main ControlPlane
+            # Secret in 02-admin-password-secret.yaml — the main ControlPlane
             # authenticates as brownfield-admin with exactly this value.
             - name: BROWNFIELD_ADMIN_PASSWORD
               value: brownfield_admin_fixture_pw_0

--- a/tests/e2e/c5c3/external-keystone/02-admin-password-secret.yaml
+++ b/tests/e2e/c5c3/external-keystone/02-admin-password-secret.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The brownfield Keystone's admin password, as the ControlPlane's namespace sees
+# it. Deliberately its OWN file rather than a second document inside
+# 02-controlplane-external.yaml: the adoption guide imports that manifest and
+# tells the reader to apply the file it comes from, and the reader's copy of this
+# Secret holds their installation's REAL admin password. A fixture password
+# riding along in the same file would silently overwrite it — and because the
+# ControlPlane re-mints on a password-hash change, and a re-mint is
+# destructive-first, that would revoke a working admin credential.
+#
+# SYNC: must equal BROWNFIELD_ADMIN_PASSWORD in 01-fixture-catalog-setup-job.yaml
+# — that Job creates user brownfield-admin with exactly this password.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: brownfield-admin-password
+  namespace: brownfield
+stringData:
+  password: brownfield_admin_fixture_pw_0
+type: Opaque

--- a/tests/e2e/c5c3/external-keystone/02-controlplane-external.yaml
+++ b/tests/e2e/c5c3/external-keystone/02-controlplane-external.yaml
@@ -21,18 +21,14 @@
 #     project "service-nova", both in the admin domain heimdall. rotation defaults
 #     to Manual; roles is omitted (K-ORC v2.6.0 ships no RoleAssignment, so only
 #     unscoped-token usability is assertable at this level).
+#
+# The admin-password Secret this CR references lives in its own file
+# (02-admin-password-secret.yaml), NOT here: the adoption guide imports the region
+# below and tells the reader to apply this file, and their copy of
+# brownfield-admin-password holds a real admin password that a fixture Secret
+# riding along in the same file must not overwrite.
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: brownfield-admin-password
-  namespace: brownfield
-# SYNC: must equal BROWNFIELD_ADMIN_PASSWORD in 01-fixture-catalog-setup-job.yaml
-# — that Job creates user brownfield-admin with exactly this password.
-stringData:
-  password: brownfield_admin_fixture_pw_0
-type: Opaque
----
+# region controlplane-external
 apiVersion: c5c3.io/v1alpha1
 kind: ControlPlane
 metadata:
@@ -67,3 +63,4 @@ spec:
         project:
           name: service-nova
           create: true
+# endregion controlplane-external

--- a/tests/e2e/c5c3/external-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/external-keystone/chainsaw-test.yaml
@@ -358,6 +358,11 @@ spec:
           # The stall grace (2m) and the negative auth/ambiguity clocks run while
           # the main CP converges, so the negative assertions later just read
           # already-settled conditions.
+          # The main CP's admin-password Secret is a separate file (the three
+          # negative CPs carry theirs inline): the adoption guide has readers apply
+          # 02-controlplane-external.yaml against a namespace whose
+          # brownfield-admin-password holds a REAL admin password.
+          kubectl apply -f 02-admin-password-secret.yaml
           kubectl apply -f 02-controlplane-external.yaml
           kubectl apply -f 03-controlplane-wrong-password.yaml
           kubectl apply -f 04-controlplane-stalled.yaml


### PR DESCRIPTION
## Summary

Closes #591

Docs and guard coverage for brownfield phase 1: an adoption guide that takes a platform owner from an existing Keystone installation to a `Ready` External-mode ControlPlane, a ControlPlane reference that matches the code again, and a future page that no longer contradicts `main`.

The change set is documentation plus one e2e fixture split that exists to serve the guide. No operator code is touched.

## Commits, in order

**`8f4c5e83` docs(c5c3): true up the ControlPlane reference for External mode**

The condition catalog in `docs/reference/c5c3/controlplane-crd.md` had drifted behind the sub-reconcilers: 19 reason strings were undocumented, and two of the ten sub-condition types (`ESOTenantStoreReady`, `HorizonReady`) had no subsection at all — both of which an External-mode ControlPlane surfaces, so its status was not readable from the reference alone. Every reason is now documented with the wording the code uses, the two missing condition types are added in chain order, and the section intro and chain diagram are corrected (ten sub-reconcilers, not eight).

Three marker mismatches found while auditing reference against types are fixed in the same pass: `authURL`'s pattern is `^https?://[^\s/]+` with a 2048 `MaxLength` (not a bare `^https?://`), `openStackRelease`'s is `^\d{4}\.[12]$` (not `^\d{4}\.\d$`), and `ServicesSpec` was missing its `horizon` row. Per-account service-account readiness is projected into `controlplane-reconciler.md`, and the per-mode OpenBao path catalog is cross-linked.

**`2fd95fe8` test(e2e): anchor the external-keystone fixture for docs code-import**

The guide embeds the e2e ControlPlane manifest as its `Tested by` exhibit via VitePress `code-import` rather than hand-maintaining a second copy that drifts, which requires column-0 region markers in the fixture.

Being an exhibit the guide tells a reader to *apply* means the file must contain nothing but the ControlPlane. The fixture admin-password Secret therefore moves out into `02-admin-password-secret.yaml`: it shares name and namespace with the Secret the guide has the reader fill with their installation's real admin password, and overwriting that with a fixture constant would change the password hash, fire a destructive-first re-mint, and revoke a working admin credential. The chainsaw script now applies both files; the three negative ControlPlanes keep their Secret inline.

**`4d9daddb` docs(guides): add the external Keystone adoption guide**

`docs/guides/adopt-external-keystone.md` — prerequisites and a kind standing-in brownfield Keystone, the minimal External CR, what `Ready` means when nothing is deployed (the skipped stages report `ExternallyManaged`, so `Ready` is proxied through K-ORC), verification, service accounts, out-of-band admin-password rotation, the per-mode OpenBao paths (app-credential family only, no bootstrap seed), and deletion semantics.

It leads with the parts that are only learnable the hard way: adoption means a *new* CR, because mode transitions are rejected in both directions; an out-of-band password rotation must be followed by a Secret update or it surfaces as drift; and a re-mint revokes the previous credential instantly, so consumers must read the credential from the materialized Secret rather than copying it.

**`a767ee2d` docs(future): mark brownfield phase 1 implemented, fix stale baseline**

The page still opened with "nothing here is implemented or scheduled" and still called `services.keystone` "a required struct" — it is an optional pointer on `main`, and nil reports `KeystoneNotManaged`. Phase 1 is graduated per the rule the future index sets (a sketch is replaced by a pointer once implemented): banner, motivation, baseline and phase table say phase 1 shipped, and the phase-1 body is now a summary that resolves each former open question and points at the guide and the reference. It also records why nil was *not* reused as the external discriminator — absence carries no endpoint configuration. Phases 2–4 stay sketches; the phase-1 risks are marked addressed but kept, because the later phases inherit them.

## Divergences from the issue

- The issue's **CRD reference** bullet asks for "updates for every new field (`mode`, `external.*`, optional `infrastructure`, service-account surface)". Those field tables already landed on `main` with the workstreams that introduced them — this PR found them present and correct, and closes what was actually still open: the condition/reason catalog, the two missing condition subsections, and the three marker mismatches.
- The **OpenBao path documentation per mode** is delivered as a guide section (step 7) plus a cross-link from the reference, rather than as a separate page.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
