### PR TITLE
feat(infra): deploy Garage via the garage-operator as the kind/CI S3 object store

### DIFF
--- a/deploy/flux-system/infrastructure/garage.yaml
+++ b/deploy/flux-system/infrastructure/garage.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Garage object store for the CI/e2e stack — an in-cluster, S3-compatible
+# backend for the Glance multi-store e2e suites. The garage-operator manages
+# these CRs the same way the mariadb-operator/memcached-operator manage their
+# instance CRs; cluster layout, buckets, and keys are all declarative (no
+# `garage layout assign/apply` scripting).
+#
+# CI-ONLY posture (decided 2026-07-15): plain HTTP in-cluster (the glance S3
+# driver's s3_store_cacert covers TLS when a suite later needs it) and a single
+# storage tier. The kind overlay (deploy/kind/infrastructure/kustomization.yaml)
+# patches this to a single node with small PVCs.
+#
+# Credential flow — OpenBao stays the single source of truth, no read-back from
+# Garage and no cross-namespace Secret plumbing:
+#   1. write-bootstrap-secrets.sh seeds a GK-prefixed access/secret pair at
+#      bootstrap/openstack/garage/s3-credentials and an admin token at
+#      bootstrap/openstack/garage/admin-token.
+#   2. Two kind-only ExternalSecrets materialize them into the `openstack`
+#      namespace as Secrets garage-s3-credentials / garage-admin-token.
+#   3. The GarageCluster reads the admin token via admin.adminTokenSecretRef;
+#      the GarageKey IMPORTS the pre-existing S3 pair via importKey.secretRef
+#      (rather than the operator minting a fresh key), so the key material never
+#      diverges from OpenBao. Glance later reads the identical OpenBao path from
+#      its own namespace through its tenant store.
+---
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: garage
+  namespace: openstack
+spec:
+  # No spec.image: the Garage version rides the operator/chart releases Renovate
+  # already tracks, so pinning our own image would add a customManager for no CI
+  # benefit.
+  replication:
+    factor: 1
+  # Storage tier — a long-lived StatefulSet with PVCs. Sized for a small
+  # multi-node baseline; the kind overlay patches replicas/PVC sizes down to a
+  # single node (mirroring the MariaDB/Memcached single-node kind patches).
+  storage:
+    replicas: 3
+    metadata:
+      size: 1Gi
+    data:
+      size: 10Gi
+  network:
+    service:
+      type: ClusterIP
+  s3Api:
+    # Path-style addressing on the default S3 port; the SigV4 region is "garage"
+    # (Garage's default) — the e2e probe and any consumer must sign with it.
+    bindPort: 3900
+    region: garage
+  admin:
+    # The operator authenticates to Garage's Admin API with this token to manage
+    # buckets, keys, and layout. Seeded in OpenBao and materialized by the
+    # kind-only garage-admin-token ExternalSecret.
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: token
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: glance-images
+  namespace: openstack
+spec:
+  clusterRef:
+    name: garage
+  # Explicit global alias so the S3 bucket name is deterministic for consumers
+  # (no reliance on s3_store_create_bucket_on_put). A second bucket for the
+  # multi-store suite is a two-line addition here (#656).
+  globalAlias: glance-images
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: glance-s3
+  namespace: openstack
+spec:
+  clusterRef:
+    name: garage
+  # Import the pre-seeded OpenBao key pair rather than minting a new one. The
+  # secretRef namespace defaults to this GarageKey's namespace (openstack); the
+  # data-key names are pinned to match the garage-s3-credentials Secret.
+  importKey:
+    secretRef:
+      name: garage-s3-credentials
+    accessKeyIdKey: access-key-id
+    secretAccessKeyKey: secret-access-key
+  bucketPermissions:
+    - globalAlias: glance-images
+      read: true
+      write: true

--- a/deploy/flux-system/infrastructure/kustomization.yaml
+++ b/deploy/flux-system/infrastructure/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - db-ca-issuer.yaml
   - mariadb.yaml
   - memcached.yaml
+  - garage.yaml
   - openbao-ca-issuer.yaml
   - openbao-tls-cert.yaml
   - openbao-client-tls-cert.yaml

--- a/deploy/flux-system/kustomization.yaml
+++ b/deploy/flux-system/kustomization.yaml
@@ -35,6 +35,8 @@ resources:
   - sources/c5c3-charts.yaml
   - sources/k-orc.yaml
   - sources/prometheus-community.yaml
+  # First third-party OCI-type HelmRepository (see sources/garage-operator.yaml).
+  - sources/garage-operator.yaml
 
   # HelmRelease operators (deployed via FluxCD).
   # Chaos Mesh is intentionally absent: opt-in via deploy/kind/chaos-mesh/
@@ -49,3 +51,5 @@ resources:
   - releases/horizon-operator.yaml
   - releases/k-orc.yaml
   - releases/c5c3-operator.yaml
+  # Garage object store operator (S3 backend for the CI/e2e stack).
+  - releases/garage-operator.yaml

--- a/deploy/flux-system/namespaces.yaml
+++ b/deploy/flux-system/namespaces.yaml
@@ -73,6 +73,13 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  # garage-system hosts the garage-operator controller (S3 object store for the
+  # CI/e2e stack), mirroring the mariadb-system / memcached-system operators.
+  name: garage-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: orc-system
 # The chaos-mesh Namespace lives in the opt-in overlay deploy/kind/chaos-mesh/,
 # not here, so the privileged PodSecurity label is created only when Chaos Mesh

--- a/deploy/flux-system/releases/garage-operator.yaml
+++ b/deploy/flux-system/releases/garage-operator.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# garage-operator — deploys Garage, an S3-compatible object store, as the
+# in-cluster S3 backend for the kind/CI stack (the Glance e2e suites need an S3
+# endpoint before any glance-operator lands). Delivered as operator + instance
+# CRs, the same pattern the stack uses for MariaDB and Memcached.
+#
+# The operator ships admission/conversion webhooks that are on by default and
+# need cert-manager (first in the stack, Phase 1), so this release dependsOn
+# cert-manager.
+#
+# ACCEPTED RISK (decided 2026-07-15): garage-operator is a young,
+# single-maintainer, pre-1.0 (v0.6.x) project. It is accepted for TEST
+# INFRASTRUCTURE ONLY — it is never a production dependency of the operators,
+# and the consuming surface is deliberately thin (three instance CRs + two
+# ExternalSecrets), so a later provider swap stays local to this layer.
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: garage-operator
+  namespace: garage-system
+spec:
+  interval: 30m
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+  chart:
+    spec:
+      chart: garage-operator
+      version: ">=0.6.26 <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: garage-operator
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3

--- a/deploy/flux-system/sources/garage-operator.yaml
+++ b/deploy/flux-system/sources/garage-operator.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# First THIRD-PARTY OCI-type HelmRepository in the repo. The url is the OCI
+# registry namespace (the chart name lives in the HelmRelease's chart.spec.chart,
+# exactly like the c5c3-charts source that memcached-operator consumes). The
+# garage-operator chart is semver-released in lockstep with the operator, so the
+# HelmRelease version range is resolved by Flux and needs no Renovate custom rule.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: garage-operator
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/rajsinghtech/charts

--- a/deploy/kind/infrastructure/garage-admin-token-externalsecret.yaml
+++ b/deploy/kind/infrastructure/garage-admin-token-externalsecret.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# kind-only ExternalSecret for the Garage Admin API token.
+#
+# The garage-operator reads this token (referenced from the GarageCluster's
+# spec.admin.adminTokenSecretRef) to authenticate to Garage's Admin API when it
+# manages buckets, keys, and layout. The value is seeded by
+# deploy/openbao/bootstrap/write-bootstrap-secrets.sh at the OpenBao path
+# "bootstrap/openstack/garage/admin-token" — readable through the shared
+# openbao-cluster-store, which allow-lists the openstack namespace.
+#
+# Like the other deploy/kind/infrastructure/ shims this is CI/dev-only; the
+# production stack (deploy/eso/) ships none of these static ExternalSecrets.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-admin-token
+  namespace: openstack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: garage-admin-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: bootstrap/openstack/garage/admin-token
+        property: token

--- a/deploy/kind/infrastructure/garage-s3-credentials-externalsecret.yaml
+++ b/deploy/kind/infrastructure/garage-s3-credentials-externalsecret.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# kind-only ExternalSecret for the Garage S3 access/secret key pair.
+#
+# The GarageKey "glance-s3" IMPORTS this pair (via spec.importKey.secretRef)
+# instead of the operator minting a fresh key, so OpenBao stays the single
+# source of truth. The access-key-id / secret-access-key data-key names match
+# the GarageKey's importKey.accessKeyIdKey / secretAccessKeyKey, and the value
+# is seeded by deploy/openbao/bootstrap/write-bootstrap-secrets.sh at
+# "bootstrap/openstack/garage/s3-credentials" (a GK-prefixed access key, as
+# Garage requires). Glance later reads the identical path from its own
+# namespace through its tenant store.
+#
+# CI/dev-only shim, like every other deploy/kind/infrastructure/ ExternalSecret.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-s3-credentials
+  namespace: openstack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: garage-s3-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: access-key-id
+      remoteRef:
+        key: bootstrap/openstack/garage/s3-credentials
+        property: access-key-id
+    - secretKey: secret-access-key
+      remoteRef:
+        key: bootstrap/openstack/garage/s3-credentials
+        property: secret-access-key

--- a/deploy/kind/infrastructure/kustomization.yaml
+++ b/deploy/kind/infrastructure/kustomization.yaml
@@ -36,6 +36,13 @@ resources:
   # horizon-secret-key is the Django SECRET_KEY shim for standalone Horizon
   # flows (per-CR OpenBao path; survives the WITH_CONTROLPLANE shim drop).
   - horizon-secret-key-externalsecret.yaml
+  # kind-only: materialize the Garage admin token and the imported S3 key pair
+  # (seeded in OpenBao) so the GarageCluster/GarageKey can consume them. Both
+  # sit in the openstack namespace and survive the WITH_CONTROLPLANE shim drop
+  # (they are not among the keystone-admin/keystone-db/mariadb-root-password
+  # names that hack/deploy-infra.sh filters out on the ControlPlane path).
+  - garage-admin-token-externalsecret.yaml
+  - garage-s3-credentials-externalsecret.yaml
 
 patches:
   # MariaDB: single replica, no Galera, no MaxScale, standard storage.
@@ -94,3 +101,27 @@ patches:
         namespace: openstack
       spec:
         replicas: 1
+
+  # Garage: single storage node with small PVCs on the kind default storage
+  # class (mirrors the MariaDB/Memcached single-node kind footprint).
+  - target:
+      group: garage.rajsingh.info
+      version: v1beta2
+      kind: GarageCluster
+      name: garage
+      namespace: openstack
+    patch: |
+      apiVersion: garage.rajsingh.info/v1beta2
+      kind: GarageCluster
+      metadata:
+        name: garage
+        namespace: openstack
+      spec:
+        storage:
+          replicas: 1
+          metadata:
+            size: 512Mi
+            storageClassName: standard
+          data:
+            size: 2Gi
+            storageClassName: standard

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -75,6 +75,13 @@ KORC_CONTROLPLANES="${KORC_CONTROLPLANES:-openstack/controlplane}"
 # argument lists.
 readonly GENERATED_PASSWORD="@generate"
 
+# Marker value: like GENERATED_PASSWORD but generates a Garage-format S3 access
+# key ID — the literal prefix "GK" followed by 24 hex characters (12 random
+# bytes). Garage's key import REQUIRES the GK prefix, so a plain @generate value
+# would be rejected. The random part is generated in-pod for the same reason as
+# @generate (no cleartext in host process argument lists).
+readonly GENERATED_GK_ACCESS_KEY="@generate-gk"
+
 # Write a secret only if it does not already exist in the KV-v2 store.
 #
 # Usage: write_secret_if_missing <kv_path> <key1>=<value1> [<key2>=<value2> ...]
@@ -102,6 +109,9 @@ write_secret_if_missing() {
     local val="${arg#*=}"
     if [[ "${val}" == "${GENERATED_PASSWORD}" ]]; then
       put_args+=" ${key}=\"\$(bao write -field=random_bytes sys/tools/random/32 format=hex)\""
+    elif [[ "${val}" == "${GENERATED_GK_ACCESS_KEY}" ]]; then
+      # Garage access-key ID: literal "GK" + 24 hex chars (12 random bytes).
+      put_args+=" ${key}=\"GK\$(bao write -field=random_bytes sys/tools/random/12 format=hex)\""
     else
       # Quote non-generated values to guard against shell metacharacters
       # (spaces, equals signs in values, etc.) in the sh -c command string.
@@ -162,6 +172,26 @@ main() {
 
   write_secret_if_missing "kv-v2/infrastructure/mariadb" \
     "root-password=${GENERATED_PASSWORD}"
+
+  # Garage object store (S3 backend for the CI/e2e stack) — seeded
+  # unconditionally, independent of KORC_CONTROLPLANES, because Garage is a
+  # base infrastructure component (not per-ControlPlane). Both paths sit under
+  # bootstrap/openstack/garage/ so they are readable today through the shared
+  # cluster store (the eso-management policy grants read on bootstrap/*) AND by
+  # an openstack-namespace tenant store later, which is what lets a same-
+  # namespace Glance read the identical s3-credentials path (per-dedicated-
+  # namespace delivery for Glance is deferred to the Glance onboarding, not
+  # this seed). No mark_eso_managed: no PushSecret targets these paths.
+  #
+  # The admin token authenticates the operator to Garage's Admin API. The S3
+  # pair is IMPORTED by the GarageKey, so the access key must be GK-prefixed
+  # (@generate-gk); the secret is a 32-byte hex value like every other
+  # generated credential.
+  write_secret_if_missing "kv-v2/bootstrap/openstack/garage/admin-token" \
+    "token=${GENERATED_PASSWORD}"
+  write_secret_if_missing "kv-v2/bootstrap/openstack/garage/s3-credentials" \
+    "access-key-id=${GENERATED_GK_ACCESS_KEY}" \
+    "secret-access-key=${GENERATED_PASSWORD}"
 
   # per-ControlPlane bootstrap seeding. For each MANAGED-mode
   # "<namespace>/<controlplane>" identity in KORC_CONTROLPLANES (default

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -275,6 +275,20 @@ The test asserts readiness of all deployed components:
 
 Assert timeout is ~5 minutes to account for operator startup time.
 
+The `e2e-infra` job auto-discovers every `chainsaw-test.yaml` under
+`tests/e2e/infrastructure/`, so sibling suites run in the same job with no CI wiring.
+
+**File:** `tests/e2e/infrastructure/garage-health/chainsaw-test.yaml`
+
+Covers the Garage object store (the S3 backend for the Glance e2e suites):
+
+| # | Assertion | Namespace | Resource |
+| --- | --- | --- | --- |
+| 1 | garage-operator Deployment ready + HelmRelease Ready | `garage-system` | `Deployment`, `HelmRelease` |
+| 2 | Credential ExternalSecrets SecretSynced | `openstack` | `ExternalSecret` (x2) |
+| 3 | GarageCluster `Running`; GarageBucket / GarageKey `Ready` | `openstack` | `GarageCluster`, `GarageBucket`, `GarageKey` |
+| 4 | S3 put + list with the imported key over path-style HTTP | `openstack` | `script` (throwaway `aws-cli` pod) |
+
 ## Pinned Tool Versions
 
 `hack/install-test-deps.sh` installs these pinned versions with SHA256 checksum

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -53,7 +53,7 @@ comment, license identifier).
 
 ## Namespaces
 
-Ten `Namespace` resources are defined in `namespaces.yaml` and included as the first
+Eleven `Namespace` resources are defined in `namespaces.yaml` and included as the first
 entry in the base kustomization. Kustomize applies `Namespace` resources before other
 resource kinds, ensuring target namespaces exist before any namespaced resources are
 created.
@@ -65,8 +65,9 @@ created.
 | `external-secrets` | External Secrets Operator |
 | `monitoring` | Prometheus Operator CRDs (consumed by the optional kube-prometheus-stack kind overlay) |
 | `memcached-system` | Memcached Operator |
+| `garage-system` | Garage Operator (S3 object store for the CI/e2e stack) |
 | `keystone-system` | Keystone Operator controller (workload CRs continue to live in `openstack`) |
-| `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster) |
+| `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster, Garage cluster) |
 | `openbao-system` | OpenBao HA Raft cluster |
 | `c5c3-system` | c5c3-operator controller; the `ControlPlane` and its child CRs are created in the `ControlPlane`'s own namespace |
 | `orc-system` | K-ORC (OpenStack Resource Controller) and its installer resources |
@@ -124,7 +125,7 @@ applied via `kubectl apply -f install.yaml`) before this kustomization is applie
 
 ## HelmRepository Sources
 
-Six HelmRepository CRs define the Helm chart registries that FluxCD pulls from. All
+Seven HelmRepository CRs define the Helm chart registries that FluxCD pulls from. All
 use `apiVersion: source.toolkit.fluxcd.io/v1`, are deployed to the `flux-system`
 namespace, and poll at `interval: 1h`.
 
@@ -136,6 +137,7 @@ namespace, and poll at `interval: 1h`.
 | `sources/openbao.yaml` | `openbao` | `https://openbao.github.io/openbao-helm` | HTTPS |
 | `sources/c5c3-charts.yaml` | `c5c3-charts` | `oci://ghcr.io/c5c3/charts` | OCI |
 | `sources/prometheus-community.yaml` | `prometheus-community` | `oci://ghcr.io/prometheus-community/charts` | OCI |
+| `sources/garage-operator.yaml` | `garage-operator` | `oci://ghcr.io/rajsinghtech/charts` | OCI |
 
 **K-ORC is sourced from Git, not Helm.** K-ORC publishes no Helm chart (its
 `github.io` page serves no Helm index), so `sources/k-orc.yaml` is a `GitRepository`
@@ -149,15 +151,18 @@ The `chaos-mesh` HelmRepository ships in the kind-only opt-in overlay at
 from `deploy/flux-system/{sources,kustomization.yaml}`. See
 [Chaos Mesh (kind-only opt-in)](#chaos-mesh-kind-only-opt-in).
 
-The `c5c3-charts` and `prometheus-community` repositories are OCI-type sources
-(`spec.type: oci`). `c5c3-charts` hosts internally-built operator charts (e.g.,
-memcached-operator) in the GitHub Container Registry. `prometheus-community` hosts
-Prometheus community charts (e.g., prometheus-operator-crds). All other repositories
-use standard HTTPS Helm registries.
+The `c5c3-charts`, `prometheus-community`, and `garage-operator` repositories are
+OCI-type sources (`spec.type: oci`). `c5c3-charts` hosts internally-built operator
+charts (e.g., memcached-operator) in the GitHub Container Registry;
+`prometheus-community` hosts Prometheus community charts (e.g.,
+prometheus-operator-crds); `garage-operator` is the first **third-party** OCI-type
+source and hosts the upstream garage-operator chart. For every OCI-type source the
+registry URL is the chart *namespace* and the chart name lives in the HelmRelease's
+`chart.spec.chart`. All other repositories use standard HTTPS Helm registries.
 
 ## HelmRelease Operators
 
-Nine HelmRelease CRs deploy the infrastructure operators and CRD charts (K-ORC is
+Ten HelmRelease CRs deploy the infrastructure operators and CRD charts (K-ORC is
 applied separately via a Flux `Kustomization` — see
 [K-ORC (OpenStack Resource Controller)](#k-orc-openstack-resource-controller)). All use
 `apiVersion: helm.toolkit.fluxcd.io/v2` and share these common settings:
@@ -184,6 +189,7 @@ mariadb-operator-crds     (no dependencies)
 ├── mariadb-operator      dependsOn: cert-manager, mariadb-operator-crds
 ├── external-secrets      dependsOn: cert-manager
 ├── memcached-operator    dependsOn: cert-manager, prometheus-operator-crds
+├── garage-operator       dependsOn: cert-manager
 ├── openbao               dependsOn: cert-manager
 ├── keystone-operator     dependsOn: cert-manager, mariadb-operator, memcached-operator, external-secrets
 └── c5c3-operator         dependsOn: keystone-operator, external-secrets, mariadb-operator, memcached-operator
@@ -333,6 +339,34 @@ OCI registry (`oci://ghcr.io/c5c3/charts`), not a dedicated HelmRepository. The
 | --- | --- | --- |
 | `metrics.enabled` | `true` | Expose Prometheus metrics |
 | `webhook.enabled` | `true` | Enable admission webhooks for Memcached CRDs |
+
+### Garage Operator
+
+**File:** `deploy/flux-system/releases/garage-operator.yaml`
+
+| Property | Value |
+| --- | --- |
+| Target namespace | `garage-system` |
+| Chart | `garage-operator` |
+| Version constraint | `>=0.6.26 <1.0.0` |
+| Source | `garage-operator` HelmRepository (third-party OCI registry) |
+| Dependencies | `cert-manager` in `cert-manager` namespace |
+
+The [garage-operator](https://github.com/rajsinghtech/garage-operator) deploys
+[Garage](https://garagehq.deuxfleurs.fr), a lightweight S3-compatible object store, as
+the in-cluster S3 backend for the CI/e2e stack (the Glance multi-store e2e suites need an
+S3 endpoint before any glance-operator lands). Its instance CRs are described under
+[Garage Object Store](#garage-object-store) below.
+
+No Helm values are overridden. The Garage image rides the operator/chart releases (no
+custom `GarageCluster.spec.image` pin), and the operator's admission/conversion webhooks
+are on by default — hence the `dependsOn: cert-manager` edge.
+
+**Accepted risk (decided 2026-07-15):** garage-operator is a young, single-maintainer,
+pre-1.0 (v0.6.x) project. It is accepted for **test infrastructure only** — never a
+production dependency of the operators — and the consuming surface is deliberately thin
+(three instance CRs plus two ExternalSecrets), so a later provider swap stays local to
+this layer.
 
 ### OpenBao
 
@@ -529,6 +563,7 @@ Each HelmRelease `sourceRef.name` must match a HelmRepository `metadata.name` in
 | `external-secrets` | `external-secrets` | `sources/external-secrets.yaml` |
 | `memcached-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `openbao` | `openbao` | `sources/openbao.yaml` |
+| `garage-operator` | `garage-operator` | `sources/garage-operator.yaml` |
 | `keystone-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `c5c3-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 
@@ -709,6 +744,46 @@ service discovery for operator consumers.
 **API group:** The API group is `memcached.c5c3.io`, matching the CRD definition
 shipped by the [memcached-operator](https://github.com/C5C3/memcached-operator) Helm chart.
 
+### Garage Object Store
+
+**File:** `deploy/flux-system/infrastructure/garage.yaml`
+
+Three instance CRs (API group `garage.rajsingh.info`) declare the S3 object store the
+[garage-operator](#garage-operator) manages. All live in the `openstack` namespace:
+
+| Kind | API version | Name | Purpose |
+| --- | --- | --- | --- |
+| `GarageCluster` | `garage.rajsingh.info/v1beta2` | `garage` | Storage tier StatefulSet, config, and cluster layout — declarative, no manual `garage layout assign/apply` |
+| `GarageBucket` | `garage.rajsingh.info/v1beta1` | `glance-images` | Pre-created bucket with an explicit `globalAlias` (deterministic S3 name) |
+| `GarageKey` | `garage.rajsingh.info/v1beta1` | `glance-s3` | Imported S3 credentials with read/write on the `glance-images` bucket |
+
+`GarageCluster` is written against the `v1beta2` storage version with
+`replication.factor: 1`, a single storage tier, `network.service.type: ClusterIP`, and
+the S3 API on `:3900` with SigV4 region `garage` (path-style addressing — virtual-host
+style would need wildcard DNS). No `spec.image` is set, so the Garage version rides the
+operator/chart releases. The kind overlay
+(`deploy/kind/infrastructure/kustomization.yaml`) patches the storage tier to a single
+node with small PVCs on the `standard` storage class, mirroring the MariaDB/Memcached
+single-node kind footprint. This is a **CI/dev fixture** — plain HTTP in-cluster, single
+tier; production-grade multi-node/zone-aware guidance is out of scope.
+
+**Credential flow — OpenBao stays the single source of truth.** No key material is read
+back from Garage and there is no cross-namespace Secret plumbing:
+
+1. `write-bootstrap-secrets.sh` seeds an admin token at
+   `bootstrap/openstack/garage/admin-token` and a `GK`-prefixed S3 access/secret pair at
+   `bootstrap/openstack/garage/s3-credentials` (see the
+   [OpenBao bootstrap reference](./openbao-bootstrap.md#write-bootstrap-secretssh)).
+2. Two kind-only ExternalSecrets
+   (`deploy/kind/infrastructure/garage-{admin-token,s3-credentials}-externalsecret.yaml`)
+   materialize them into the `openstack` namespace through the shared
+   `openbao-cluster-store`.
+3. The `GarageCluster` reads the admin token via `spec.admin.adminTokenSecretRef`; the
+   `GarageKey` **imports** the pre-existing S3 pair via `spec.importKey.secretRef` (rather
+   than the operator minting a fresh key), so the key material never diverges from
+   OpenBao. Glance later reads the identical `s3-credentials` path from its own namespace
+   through its tenant store.
+
 ### Admin Credential Chain
 
 The c5c3-operator mints a single restricted admin Application Credential per cluster and
@@ -807,17 +882,17 @@ The base kustomization uses `apiVersion: kustomize.config.k8s.io/v1beta1` and in
 namespaces, the FluxInstance CR, HelmRepository sources, and HelmRelease operators.
 These resources do not depend on any custom CRDs.
 
-**Resource count:** 19 files producing 28 Kubernetes resources.
+**Resource count:** 21 files producing 31 Kubernetes resources.
 
 | Category | Count | Resources |
 | --- | --- | --- |
-| Namespace | 10 | cert-manager, mariadb-system, external-secrets, monitoring, memcached-system, keystone-system, openstack, openbao-system, c5c3-system, orc-system |
+| Namespace | 11 | cert-manager, mariadb-system, external-secrets, monitoring, memcached-system, garage-system, keystone-system, openstack, openbao-system, c5c3-system, orc-system |
 | FluxInstance | 1 | flux (drives the flux-operator) |
-| HelmRepository | 6 | cert-manager, mariadb-operator, external-secrets, openbao, c5c3-charts, prometheus-community |
+| HelmRepository | 7 | cert-manager, mariadb-operator, external-secrets, openbao, c5c3-charts, prometheus-community, garage-operator |
 | GitRepository | 1 | k-orc |
-| HelmRelease | 9 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, openbao, keystone-operator, c5c3-operator |
+| HelmRelease | 10 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, garage-operator, openbao, keystone-operator, c5c3-operator |
 | Kustomization | 1 | k-orc |
-| **Total** | **28** | |
+| **Total** | **31** | |
 
 The `chaos-mesh` HelmRepository, HelmRelease, and Namespace ship in the
 kind-only opt-in overlay at `deploy/kind/chaos-mesh/` and are not
@@ -831,9 +906,9 @@ The infrastructure kustomization includes CRD-dependent resources that require t
 operator CRDs to be installed first. This kustomization must be applied after the base
 kustomization and after operators have finished installing their CRDs.
 
-**Resource count:** 4 manifests producing 6 Kubernetes resources (the
+**Resource count:** 5 manifests producing 9 Kubernetes resources (the
 `db-ca-issuer.yaml` manifest declares two resources: a CA Certificate and the
-CA-type ClusterIssuer that signs from it).
+CA-type ClusterIssuer that signs from it; `garage.yaml` declares three).
 
 | Category | Count | Resources |
 | --- | --- | --- |
@@ -841,7 +916,8 @@ CA-type ClusterIssuer that signs from it).
 | Certificate | 2 | `openstack-db-ca`, `openbao-ca` — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
 | MariaDB | 1 | `openstack-db` (requires mariadb-operator CRDs; TLS enabled per [MariaDB Galera Cluster](#mariadb-galera-cluster)) |
 | Memcached | 1 | `openstack-memcached` (requires memcached-operator CRDs) |
-| **Total** | **6** | |
+| GarageCluster / GarageBucket / GarageKey | 3 | `garage`, `glance-images`, `glance-s3` (require garage-operator CRDs; see [Garage Object Store](#garage-object-store)) |
+| **Total** | **9** | |
 
 <!-- NOTE: count excludes openbao-tls-cert.yaml and the ../../eso overlay that
 the infrastructure kustomization also references. Those resources are documented
@@ -858,8 +934,8 @@ of scope here. -->
 kubectl apply -k deploy/flux-system/
 ```
 
-This applies 28 resources: 10 namespaces, 1 FluxInstance, 7 sources
-(6 HelmRepository + 1 GitRepository for K-ORC), 9 HelmRelease operators, and
+This applies 31 resources: 11 namespaces, 1 FluxInstance, 8 sources
+(7 HelmRepository + 1 GitRepository for K-ORC), 10 HelmRelease operators, and
 1 Kustomization (K-ORC). FluxCD resolves the dependency graph between
 HelmReleases and installs operators in the correct order. Wait for all operators to
 finish installing before proceeding to step 2.
@@ -873,8 +949,9 @@ kubectl apply -k deploy/flux-system/infrastructure/
 This applies the CRD-dependent resources: the `selfsigned-cluster-issuer`
 ClusterIssuer, the `openstack-db-ca-issuer` ClusterIssuer plus its backing CA
 `Certificate`, the `openbao-ca-issuer` ClusterIssuer plus
-its backing CA `Certificate`, the MariaDB Galera cluster, and the
-Memcached cluster. These resources require CRDs that are installed by the operator
+its backing CA `Certificate`, the MariaDB Galera cluster, the
+Memcached cluster, and the Garage object store (`GarageCluster` / `GarageBucket` /
+`GarageKey`). These resources require CRDs that are installed by the operator
 HelmReleases in step 1. If CRDs are not yet available, the apply will fail — wait
 for the operators to finish installing and retry.
 
@@ -924,9 +1001,18 @@ The manifest structure is designed for straightforward extension. Adding a new o
 4. **Add the operator namespace** to `namespaces.yaml` (e.g., `openbao-system`) so the
    namespace exists before `kubectl apply -k` creates the namespaced HelmRelease CR
 
-Infrastructure instance CRs (e.g., a new database or cache cluster) follow the same
-pattern: add a file in `infrastructure/` and list it in
-`infrastructure/kustomization.yaml`.
+The [garage-operator](#garage-operator) is the worked example of an **OCI-type
+third-party** operator following this recipe: step 1 adds an OCI HelmRepository
+(`sources/garage-operator.yaml`, `spec.type: oci`, the registry namespace as `url`); the
+release (`releases/garage-operator.yaml`) references it by `sourceRef.name` and carries
+the chart name in `chart.spec.chart`. The OCI variant changes nothing else in the recipe
+— Renovate's native Flux handling resolves the HelmRelease version range with no custom
+rule, exactly as for the HTTPS sources.
+
+Infrastructure instance CRs (e.g., a new database, cache, or object-store cluster) follow
+the same pattern: add a file in `infrastructure/` and list it in
+`infrastructure/kustomization.yaml` (see [Garage Object Store](#garage-object-store) and
+its single-node kind patch for a multi-CR example).
 
 ## Design Decisions
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -506,6 +506,8 @@ into the KV v2 secret engine.
 | `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | Keystone admin user password, scoped per **Managed-mode** ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default `openstack/controlplane` seeds `kv-v2/bootstrap/openstack/controlplane-keystone/admin`. |
 | `kv-v2/bootstrap/<namespace>/<horizon>/secret-key` | `secret-key` | Horizon Django `SECRET_KEY`, scoped per **Managed-mode** ControlPlane. One entry per `KORC_CONTROLPLANES` identity; the default seeds `kv-v2/bootstrap/openstack/controlplane-horizon/secret-key`, read by the kind-only `horizon-secret-key` ExternalSecret. |
 | `kv-v2/infrastructure/mariadb` | `root-password` | MariaDB root password |
+| `kv-v2/bootstrap/openstack/garage/admin-token` | `token` | Garage Admin API token — the operator authenticates to Garage's Admin API with it. Read by the kind-only `garage-admin-token` ExternalSecret (`GarageCluster.spec.admin.adminTokenSecretRef`). Seeded unconditionally (Garage is base infrastructure, not per-ControlPlane). |
+| `kv-v2/bootstrap/openstack/garage/s3-credentials` | `access-key-id`, `secret-access-key` | Garage S3 key pair, **imported** by the `GarageKey` (not minted by the operator). `access-key-id` is `GK`-prefixed (`@generate-gk`), as Garage requires. Read by the kind-only `garage-s3-credentials` ExternalSecret; Glance later reads the same path from its own namespace. |
 | `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | Static Keystone DB credential for **standalone** (non-ControlPlane) Keystone demos only (username is `keystone`), read by the kind-only `keystone-db` ExternalSecret. Brownfield-only. |
 
 **Mode note:** `KORC_CONTROLPLANES` lists **Managed-mode** ControlPlane
@@ -529,6 +531,12 @@ remains.
 (256-bit) cryptographically secure random value encoded as base64 (44 characters).
 Generating passwords inside the pod prevents cleartext passwords from appearing in
 host `/proc/<pid>/cmdline` process argument lists.
+
+**Generated-value markers:** A key whose value is the marker `@generate` is replaced
+with a freshly generated random value in-pod (as above). The `@generate-gk` marker is a
+variant for Garage S3 access-key IDs: it emits the literal prefix `GK` followed by 24 hex
+characters (12 random bytes), the format Garage's key import requires. Both markers keep
+the cleartext off the host process argument list.
 
 **Security:** Generated passwords are never echoed to stdout or stderr and never
 appear as command-line arguments visible to host process listings. The script
@@ -615,6 +623,8 @@ All secrets are stored under the `kv-v2/` mount point (KV version 2 engine).
 | `kv-v2/bootstrap/<namespace>/<keystone>/admin` | `password` | `write-bootstrap-secrets.sh` (per **Managed-mode** ControlPlane; default `.../openstack/controlplane-keystone/admin`) | Operator-created ExternalSecret `{controlplane.Name}-keystone-admin-credentials` (default `controlplane-keystone-admin-credentials`); on kind additionally the overlay's `keystone-admin` ExternalSecret (default identity) |
 | `kv-v2/bootstrap/<namespace>/<horizon>/secret-key` | `secret-key` | `write-bootstrap-secrets.sh` (per **Managed-mode** ControlPlane; default `.../openstack/controlplane-horizon/secret-key`) | On kind the overlay's `horizon-secret-key` ExternalSecret (default identity); per-CR ExternalSecrets in test namespaces |
 | `kv-v2/infrastructure/mariadb` | `root-password` | `write-bootstrap-secrets.sh` | On kind the overlay's `mariadb-root-password` ExternalSecret; in production a non-kind Flux MariaDB baseline provides the `mariadb-root-password` Secret itself |
+| `kv-v2/bootstrap/openstack/garage/admin-token` | `token` | `write-bootstrap-secrets.sh` (unconditional; Garage is base infra) | The kind overlay's `garage-admin-token` ExternalSecret → `GarageCluster.spec.admin.adminTokenSecretRef` |
+| `kv-v2/bootstrap/openstack/garage/s3-credentials` | `access-key-id` (`GK`-prefixed), `secret-access-key` | `write-bootstrap-secrets.sh` (unconditional) | The kind overlay's `garage-s3-credentials` ExternalSecret → `GarageKey.spec.importKey.secretRef`; Glance later reads the same path from its own namespace |
 | `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | `write-bootstrap-secrets.sh` (standalone/brownfield only) | The kind overlay's `keystone-db` ExternalSecret, serving standalone (non-ControlPlane) Keystone demos |
 
 **Note:** The stage-(a) per-ControlPlane static path

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -1658,14 +1658,15 @@ main() {
   log "Phase 3: Waiting for remaining HelmReleases..."
   # Build the release list dynamically so chaos-mesh is only awaited when the
   # opt-in overlay was applied. The surviving non-chaos order is
-  # preserved exactly as before; chaos-mesh is appended last to avoid moving
-  # any other release's relative position.
-  local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway)
+  # preserved exactly as before; garage-operator is appended as the last base
+  # release, and chaos-mesh after it, to avoid moving any other release's
+  # relative position.
+  local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)
   if [[ "${WITH_CHAOS_MESH}" == "true" ]]; then
     helm_releases+=(chaos-mesh)
   fi
   # kube-prometheus-stack is appended last so the relative
-  # ordering of the seven base releases (and chaos-mesh) is preserved exactly.
+  # ordering of the eight base releases (and chaos-mesh) is preserved exactly.
   local release_wait_timeout="${HELMRELEASE_TIMEOUT}"
   if [[ "${WITH_PROMETHEUS}" == "true" ]]; then
     helm_releases+=(kube-prometheus-stack)
@@ -1678,7 +1679,7 @@ main() {
     fi
   fi
   # metrics-server is appended last (after chaos-mesh and kube-prometheus-stack)
-  # so the relative ordering of the seven base releases is preserved exactly.
+  # so the relative ordering of the eight base releases is preserved exactly.
   if [[ "${WITH_METRICS_SERVER}" == "true" ]]; then
     helm_releases+=(metrics-server)
   fi
@@ -1711,7 +1712,10 @@ main() {
     clustersecretstores.external-secrets.io \
     externalsecrets.external-secrets.io \
     mariadbs.k8s.mariadb.com \
-    envoyproxies.gateway.envoyproxy.io
+    envoyproxies.gateway.envoyproxy.io \
+    garageclusters.garage.rajsingh.info \
+    garagebuckets.garage.rajsingh.info \
+    garagekeys.garage.rajsingh.info
 
   # Invalidate kubectl's client-side discovery cache so that the newly
   # registered CRDs are visible to kubectl apply.
@@ -1842,6 +1846,39 @@ main() {
     wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
       keystone-admin keystone-db mariadb-root-password
   fi
+
+  # Garage object store (S3 backend for the Glance e2e suites). Its
+  # GarageCluster/GarageBucket/GarageKey CRs and the two ESO ExternalSecrets are
+  # applied on BOTH paths — they are not among the MariaDB/Memcached/standalone-
+  # shim resources the WITH_CONTROLPLANE overlay filter drops — so this
+  # readiness block runs unconditionally. The two ExternalSecrets read the
+  # OpenBao paths bootstrap/openstack/garage/{admin-token,s3-credentials} through
+  # the shared cluster store (re-validated above on both paths); force a re-sync
+  # now that OpenBao is up, the same reason as the standalone shims above.
+  log "Forcing Garage ExternalSecret re-sync..."
+  for es in garage-admin-token garage-s3-credentials; do
+    kubectl annotate "externalsecret/${es}" -n openstack \
+      "force-sync=${now}" --overwrite || true
+  done
+  wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
+    garage-admin-token garage-s3-credentials
+
+  # The GarageCluster CR was applied in Step 5, before its admin-token Secret
+  # existed (that Secret is materialized by the ExternalSecret above). The
+  # operator may have stopped retrying; patch an annotation to force a new
+  # reconciliation now that the Secret is available, then wait for the cluster to
+  # reach its terminal healthy phase. "Running" is the operator's fully-
+  # operational phase (set once the Admin API is reachable); a storage-backed
+  # GarageCluster never advances to the "Ready" phase value, and the operator
+  # sets no "Ready" status condition (only health conditions such as
+  # QuorumAtRisk), so the wait keys on status.phase rather than a condition.
+  log "Triggering GarageCluster re-reconciliation..."
+  kubectl patch garagecluster garage -n openstack --type merge \
+    -p "{\"metadata\":{\"annotations\":{\"deploy.c5c3.io/reconcile-trigger\":\"${now}\"}}}" || true
+  log "Waiting for the GarageCluster CR to become Running..."
+  kubectl wait garagecluster/garage -n openstack \
+    --for=jsonpath='{.status.phase}'=Running --timeout="${POD_TIMEOUT}s"
+  log "GarageCluster CR is Running."
 
   if [[ "${WITH_CONTROLPLANE}" != "true" ]]; then
     # Trigger MariaDB operator re-reconciliation.

--- a/renovate.json
+++ b/renovate.json
@@ -243,6 +243,17 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/tests/e2e/infrastructure/garage-health/chainsaw-test\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image=(?<depName>public\\.ecr\\.aws/aws-cli/aws-cli):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -467,6 +478,22 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "keycloak e2e fixture"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["tests/e2e/infrastructure/garage-health/chainsaw-test.yaml"],
+      "matchPackageNames": ["public.ecr.aws/aws-cli/aws-cli"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["tests/e2e/infrastructure/garage-health/chainsaw-test.yaml"],
+      "matchPackageNames": ["public.ecr.aws/aws-cli/aws-cli"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "aws-cli e2e fixture"
     },
     {
       "matchDatasources": ["docker", "go"],

--- a/tests/e2e/infrastructure/garage-health/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/garage-health/chainsaw-test.yaml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the Garage object store (S3 backend for the Glance e2e
+# suites). Auto-discovered by the e2e-infra job, which runs
+# `chainsaw test tests/e2e/infrastructure/` after `make deploy-infra`.
+#
+# Covers:
+#   - garage-operator Deployment available + its HelmRelease Ready
+#   - The two credential ExternalSecrets (admin token, S3 key pair) SecretSynced
+#   - GarageCluster Running (terminal healthy phase — a storage-backed cluster
+#     never advances to the "Ready" phase value and the operator sets no "Ready"
+#     status condition, only health conditions such as QuorumAtRisk), and the
+#     GarageBucket / GarageKey Ready
+#   - The S3 endpoint answers and the IMPORTED key can put and list an object in
+#     the bucket over path-style HTTP — the end-to-end proof that the seeded
+#     OpenBao credentials flow through ESO into a working S3 grant
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: garage-health
+spec:
+  # Extended assert timeout (~5min) for operator startup, CRD reconciliation,
+  # and the StatefulSet/PVC provisioning the GarageCluster drives.
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Operator Deployment + HelmRelease ───────────────────────────
+  # The chart's fullname helper renders the Deployment as "garage-operator" for
+  # a release of that name.
+  - try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: garage-operator
+            namespace: garage-system
+          status:
+            (availableReplicas > `0`): true
+    - assert:
+        resource:
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: garage-operator
+            namespace: garage-system
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+  # ── Step 2: Credential ExternalSecrets ──────────────────────────────────
+  # Both read bootstrap/openstack/garage/{admin-token,s3-credentials} from
+  # OpenBao through the shared cluster store. SecretSynced proves the seed +
+  # ESO materialization end-to-end.
+  - try:
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: garage-admin-token
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: SecretSynced
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: garage-s3-credentials
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: SecretSynced
+  # ── Step 3: Garage instance CRs ─────────────────────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: garage.rajsingh.info/v1beta2
+          kind: GarageCluster
+          metadata:
+            name: garage
+            namespace: openstack
+          status:
+            (phase == 'Running'): true
+    - assert:
+        resource:
+          apiVersion: garage.rajsingh.info/v1beta1
+          kind: GarageBucket
+          metadata:
+            name: glance-images
+            namespace: openstack
+          status:
+            (phase == 'Ready'): true
+    - assert:
+        resource:
+          apiVersion: garage.rajsingh.info/v1beta1
+          kind: GarageKey
+          metadata:
+            name: glance-s3
+            namespace: openstack
+          status:
+            (phase == 'Ready'): true
+  # ── Step 4: S3 put + list with the imported key ─────────────────────────
+  # Decode the imported key pair and drive a put-object + list-objects-v2 from a
+  # throwaway aws-cli pod against the ClusterIP S3 endpoint. addressing_style is
+  # forced to "path" (Garage has no wildcard DNS for virtual-host style) and the
+  # SigV4 region is "garage" (the GarageCluster's s3Api.region). Success is the
+  # listing echoing the key we just wrote.
+  - try:
+    - script:
+        timeout: 3m
+        content: |
+          set -eu
+          AKID="$(kubectl get secret garage-s3-credentials -n openstack \
+            -o 'jsonpath={.data.access-key-id}' | base64 -d)"
+          SAK="$(kubectl get secret garage-s3-credentials -n openstack \
+            -o 'jsonpath={.data.secret-access-key}' | base64 -d)"
+          OUT="$(kubectl run garage-s3-probe -n openstack \
+            --image=public.ecr.aws/aws-cli/aws-cli:2.35.23@sha256:0425835c7c9e33a747dfd499dcd3603ec802662f7f7ded42d8fc81ce7b712bf9 \
+            --rm -i --restart=Never --pod-running-timeout=2m \
+            --env "AWS_ACCESS_KEY_ID=${AKID}" \
+            --env "AWS_SECRET_ACCESS_KEY=${SAK}" \
+            --env "AWS_DEFAULT_REGION=garage" \
+            --env "AWS_CONFIG_FILE=/tmp/aws-cfg" \
+            --command -- sh -c 'set -e; printf "[default]\ns3 =\n    addressing_style = path\n" > /tmp/aws-cfg; echo probe > /tmp/p; aws --endpoint-url http://garage.openstack.svc.cluster.local:3900 s3api put-object --bucket glance-images --key garage-health/probe.txt --body /tmp/p; aws --endpoint-url http://garage.openstack.svc.cluster.local:3900 s3api list-objects-v2 --bucket glance-images --prefix garage-health/')"
+          echo "${OUT}"
+          echo "${OUT}" | grep -q 'garage-health/probe.txt'
+          echo "OK: imported key put and listed garage-health/probe.txt in glance-images"

--- a/tests/unit/deploy/kind_base_flux_web_test.sh
+++ b/tests/unit/deploy/kind_base_flux_web_test.sh
@@ -220,10 +220,10 @@ test_production_overlay_has_no_flux_web() {
   assert_eq "production overlay renders no flux-web string" "0" "$fw_count"
 }
 
-# --- Test 6: production kustomization + fluxinstance are unchanged vs. origin/main
-#             ---
+# --- Test 6: production fluxinstance frozen; kustomization carries no flux-web
+#             leakage ---
 test_production_kustomization_unchanged() {
-  echo "Test: deploy/flux-system/{kustomization.yaml,fluxinstance.yaml} have no diff vs. origin/main"
+  echo "Test: deploy/flux-system/fluxinstance.yaml unchanged vs. origin/main and kustomization.yaml carries no flux-web leakage"
 
   if ! git -C "$PROJECT_ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
     echo "  SKIP: origin/main ref is not available in this checkout (1 check skipped)"
@@ -231,13 +231,24 @@ test_production_kustomization_unchanged() {
     return
   fi
 
+  # The FluxInstance spec is frozen — the kind-only flux-web addon must not
+  # touch it.
   local diff_rc=0
   git -C "$PROJECT_ROOT" diff --quiet origin/main -- \
-    deploy/flux-system/kustomization.yaml \
     deploy/flux-system/fluxinstance.yaml \
     || diff_rc=$?
+  assert_eq "fluxinstance.yaml diff against origin/main is empty" "0" "$diff_rc"
 
-  assert_eq "git diff against origin/main is empty" "0" "$diff_rc"
+  # The production kustomization legitimately grows as operators are added (the
+  # documented Extensibility recipe adds each operator's source + release to the
+  # resources list — mariadb, memcached, c5c3-operator, k-orc, garage-operator,
+  # …), so it is NOT byte-frozen. The flux-web guard here is that the kind-only
+  # Web UI overlay never leaks a flux-web ResourceSet into it; Test 5 renders the
+  # overlay and asserts the same absence semantically.
+  assert_file_not_contains \
+    "production kustomization.yaml references no flux-web resource" \
+    "$FLUX_SYSTEM_KUSTOMIZATION" \
+    "flux-web"
 }
 
 # --- Run ---

--- a/tests/unit/deploy/production_posture_test.sh
+++ b/tests/unit/deploy/production_posture_test.sh
@@ -89,11 +89,11 @@ test_production_overlay_unchanged() {
   # remain byte-identical.
   local groups_label=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml releases added)"
+    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml/garage-operator.yaml releases added)"
   )
   local groups_specs=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml"
+    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/garage-operator.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml"
   )
 
   local diff_output=""

--- a/tests/unit/hack/deploy_infra_chaos_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_chaos_flag_test.sh
@@ -168,12 +168,12 @@ test_chaos_mesh_not_in_default_helm_releases() {
     "$DEPLOY_INFRA_SH" \
     'memcached-operator chaos-mesh envoy-gateway'
 
-  # The new dynamic array must include the seven non-chaos releases in order
+  # The new dynamic array must include the eight non-chaos releases in order
   # and append chaos-mesh inside the gate.
   assert_file_contains \
-    "helm_releases array preserves the seven non-chaos releases in the documented order" \
+    "helm_releases array preserves the eight non-chaos releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
 
   assert_file_contains \
     "chaos-mesh is appended only inside the WITH_CHAOS_MESH gate" \

--- a/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
@@ -175,11 +175,11 @@ test_metrics_server_appended_dynamically() {
     "$DEPLOY_INFRA_SH" \
     'envoy-gateway metrics-server'
 
-  # The base array must preserve the seven non-opt-in releases in order.
+  # The base array must preserve the eight non-opt-in releases in order.
   assert_file_contains \
-    "helm_releases array preserves the seven non-opt-in releases in the documented order" \
+    "helm_releases array preserves the eight non-opt-in releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
 
   # The dynamic append must be guarded by WITH_METRICS_SERVER.
   assert_file_contains \

--- a/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
@@ -205,11 +205,11 @@ test_kube_prometheus_stack_appended_dynamically() {
     "$DEPLOY_INFRA_SH" \
     'envoy-gateway kube-prometheus-stack'
 
-  # The base array must preserve the seven non-opt-in releases in order.
+  # The base array must preserve the eight non-opt-in releases in order.
   assert_file_contains \
-    "helm_releases array preserves the seven non-opt-in releases in the documented order" \
+    "helm_releases array preserves the eight non-opt-in releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
 
   # The dynamic append must be guarded by WITH_PROMETHEUS.
   assert_file_contains \

--- a/tests/unit/renovate/awscli_fixture_custommanager_test.sh
+++ b/tests/unit/renovate/awscli_fixture_custommanager_test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json declares a customManagers entry that targets the
+# public.ecr.aws/aws-cli/aws-cli image pin in the garage-health e2e fixture,
+# plus the paired packageRules:
+#   - the docker-datasource matchStrings regex captures the image's depName,
+#     tag (currentValue) AND digest (currentDigest)
+#   - packageRules disable major bumps and automerge minor/patch/digest with a
+#     3-day minimumReleaseAge
+#
+# This is the regression test the check-renovate-coverage skill requires for
+# every customManager. It does NOT run renovate-config-validator itself — the
+# sibling fluxoperator_custommanager_test.sh already exercises that
+# authoritative gate over the whole file.
+#
+# Usage: bash tests/unit/renovate/awscli_fixture_custommanager_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+FIXTURE_FILE="$PROJECT_ROOT/tests/e2e/infrastructure/garage-health/chainsaw-test.yaml"
+
+AWSCLI_PACKAGE="public.ecr.aws/aws-cli/aws-cli"
+FIXTURE_PATH="tests/e2e/infrastructure/garage-health/chainsaw-test.yaml"
+
+# --- Test 1: customManager targets the fixture and captures depName/tag/digest ---
+test_custom_manager_captures_image() {
+  echo "Test: customManagers regex captures the aws-cli fixture depName/tag/digest"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (6 checks skipped)"
+    SKIP=$((SKIP + 6))
+    return
+  fi
+
+  # The aws-cli-fixture manager is the docker-datasource customManager on the
+  # garage-health fixture file.
+  local entry
+  entry="$(jq -c '.customManagers[]
+    | select(.datasourceTemplate == "docker")
+    | select((.managerFilePatterns // []) | join(",") | contains("garage-health"))' \
+    "$RENOVATE_FILE")"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no docker-datasource customManagers entry for $FIXTURE_PATH"
+    FAIL=$((FAIL + 6))
+    return
+  fi
+
+  assert_eq "customManagers.datasourceTemplate is docker" \
+    "docker" "$(jq -r '.datasourceTemplate' <<<"$entry")"
+
+  local patterns
+  patterns="$(jq -r '.managerFilePatterns | join(",")' <<<"$entry")"
+  assert_contains "managerFilePatterns targets the fixture file" "$patterns" "garage-health"
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local line match_string
+  line="$(grep -E 'image=public\.ecr\.aws/aws-cli/aws-cli' "$FIXTURE_FILE" | head -1)"
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+  assert_not_empty "aws-cli image line present in the fixture" "$line"
+
+  # Confirm the matchStrings regex captures depName/currentValue/currentDigest
+  # from the actual line (perl speaks the same PCRE named-group syntax Renovate
+  # uses for the regex customManager).
+  local captured
+  captured="$(REGEX="$match_string" LINE="$line" perl -e '
+    my $re = $ENV{REGEX}; my $l = $ENV{LINE};
+    if ($l =~ /$re/) {
+      print "depName=$+{depName}\n";
+      print "currentValue=$+{currentValue}\n";
+      print "currentDigest=$+{currentDigest}\n";
+    }
+  ')"
+
+  assert_contains "regex captures the depName" "$captured" "depName=${AWSCLI_PACKAGE}"
+  assert_contains "regex captures the tag as currentValue" "$captured" "currentValue="
+  assert_contains "regex captures the sha256 digest" "$captured" "currentDigest=sha256:"
+}
+
+# --- Test 2: packageRules disable major, automerge minor/patch/digest ---
+test_package_rules() {
+  echo "Test: packageRules disable major bumps and automerge minor/patch/digest"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c --arg p "$AWSCLI_PACKAGE" --arg f "$FIXTURE_PATH" '.packageRules[]
+    | select(((.matchPackageNames // []) | index($p)) != null
+             and ((.matchFileNames // []) | index($f)) != null
+             and ((.matchUpdateTypes // []) | index("major")) != null)' "$RENOVATE_FILE" | head -1)"
+  minor_rule="$(jq -c --arg p "$AWSCLI_PACKAGE" --arg f "$FIXTURE_PATH" '.packageRules[]
+    | select(((.matchPackageNames // []) | index($p)) != null
+             and ((.matchFileNames // []) | index($f)) != null
+             and ((.matchUpdateTypes // []) | index("minor")) != null)' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule scoping major updates for the aws-cli fixture image"
+    FAIL=$((FAIL + 1))
+  else
+    assert_eq "major aws-cli fixture image updates are disabled" \
+      "false" "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule scoping minor/patch updates for the aws-cli fixture image"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  assert_eq "minor/patch aws-cli fixture image updates are automerged" \
+    "true" "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "the rule also covers digest refreshes" \
+    "true" "$(jq -r '(.matchUpdateTypes // []) | index("digest") != null' <<<"$minor_rule")"
+  assert_eq "minor/patch aws-cli fixture image rule waits minimumReleaseAge=3 days" \
+    "3 days" "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+}
+
+# --- Run ---
+test_custom_manager_captures_image
+test_package_rules
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Deploys [Garage](https://garagehq.deuxfleurs.fr/) via the `garage-operator` as the in-cluster, S3-compatible object store of the kind/CI stack, so the upcoming Glance e2e suites have an S3 endpoint to target. Garage is delivered the same way the stack already ships MariaDB and Memcached — an OCI `HelmRepository` source plus a Flux `HelmRelease` — and OpenBao stays the single source of truth for its credentials, materialized into the cluster through ESO.

Closes #653

## Change set (in commit order)

1. **`2bbf89ea` feat(deploy): add the garage-operator Flux source and HelmRelease**
   Adds the `garage-system` namespace, the third-party OCI-type `HelmRepository` source (`sources/garage-operator.yaml`), and the `HelmRelease` (`releases/garage-operator.yaml`). This is the first *third-party* OCI-type `HelmRepository` in the repo — the `url` is the registry namespace and the chart name lives on the `HelmRelease`, mirroring the `c5c3-charts` source. The release `dependsOn` cert-manager because the operator's admission/conversion webhooks are on by default. The accepted risk (young, single-maintainer, pre-1.0 project — CI-only by decision) is recorded in the release header, and the production-posture byte-identity exclusion is extended so the net-new release file reads as a deliberate addition, like `c5c3-operator` and `k-orc` before it.

2. **`ffa64320` feat(deploy): declare the Garage instance CRs and their credentials**
   Declares the `GarageCluster` / `GarageBucket` / `GarageKey` instance CRs under the Flux base (single storage tier, `replication.factor 1`, admin token via `adminTokenSecretRef`) plus a single-node kind patch with small PVCs on the default storage class, mirroring the MariaDB/Memcached kind footprint. `write-bootstrap-secrets.sh` seeds an admin token and a `GK`-prefixed S3 access/secret pair under `bootstrap/openstack/garage/`, via a new `@generate-gk` marker that emits the `GK`-prefixed access-key ID that Garage's key import requires. Two kind-only `ExternalSecret`s materialize them into the `openstack` namespace, and the `GarageKey` **imports** the pair via `importKey.secretRef` rather than minting a fresh key — so the key material never diverges from OpenBao and Glance can later read the identical path from its own namespace.

3. **`09c7bdd4` feat(deploy): await the Garage release, CRDs, and cluster readiness**
   Appends `garage-operator` to the Phase 3 `helm_releases` wait list, extends `wait_for_crds` with the three `garage.rajsingh.info` CRDs so the Step-5 overlay apply cannot race their registration, and adds an unconditional readiness block after Step 8: force-sync the two Garage `ExternalSecret`s, wait for them to sync, then nudge and wait for the `GarageCluster` to reach its terminal healthy phase. The wait keys on `status.phase == Running` (a storage-backed cluster never advances to a `Ready` phase and the operator sets no `Ready` condition, only health conditions like `QuorumAtRisk`). It runs on both the default and `WITH_CONTROLPLANE` paths because the Garage resources survive the ControlPlane overlay filter. The three `deploy_infra` flag unit tests that pin the exact `helm_releases` literal are updated to the new eight-release array.

4. **`892344f2` test(e2e): add the garage-health infrastructure chainsaw suite**
   Adds `tests/e2e/infrastructure/garage-health/`, auto-discovered by the e2e-infra job (runs after `make deploy-infra`, no CI wiring). It asserts the operator `Deployment`/`HelmRelease` are up, both credential `ExternalSecret`s are `SecretSynced`, the `GarageCluster` is `Running` and the `GarageBucket`/`GarageKey` are `Ready`, then drives an authenticated put+list from a throwaway aws-cli pod using the **imported** key (path-style addressing, SigV4 region `garage`) — proving the OpenBao-seeded credentials flow through ESO into a working S3 grant. The aws-cli probe image is pinned by tag+digest and covered by a Renovate `customManager` + paired `packageRules` (disable major, automerge minor/patch/digest after 3 days) plus the regression test the `check-renovate-coverage` gate requires. The garage-operator chart range needs no rules — Flux resolves it like any other `HelmRelease` range.

5. **`6f1c9989` docs(infra): document the Garage object store and credential flow**
   Extends the infrastructure reference: the `garage-system` namespace, the OCI source and its release, the dependency-graph edge, a component entry with the accepted CI-only risk, a *Garage Object Store* section covering the three instance CRs and the OpenBao → ESO → import credential flow, and the OCI-source variant of the extensibility recipe. Documents the two seeded OpenBao paths and the `@generate-gk` marker in the OpenBao bootstrap reference, adds the garage-health suite to the e2e-infra reference, and bumps the affected kustomization counts by the garage delta.

6. **`124db07a` test(deploy): let the flux-web guard allow operator kustomization edits**
   `kind_base_flux_web_test.sh` Test 6 byte-froze `deploy/flux-system/kustomization.yaml` against `origin/main`, but that file legitimately grows with every added operator (the documented Extensibility recipe appends each operator's source + release). The garage wiring trips that freeze. Since the test's real concern is only that the kind-only flux-web overlay never leaks into production, this keeps `fluxinstance.yaml` byte-frozen and replaces the `kustomization.yaml` byte-identity check with an explicit no-flux-web assertion; Test 5 still renders the overlay and asserts the same absence semantically, so the guard stays intact.

## Notes for the reviewer

- No divergence from the issue is apparent in the commits: the branch delivers exactly the garage-operator-based S3 store the issue asks for, wired through the existing MariaDB/Memcached delivery pattern and the OpenBao→ESO credential flow.
- The imported-key design (`importKey.secretRef` rather than an operator-minted key) is a deliberate choice so the S3 credential lives only in OpenBao and can be re-read verbatim from Glance's namespace later — worth a look during review.
- The garage-operator is a young, single-maintainer, pre-1.0 project; adopting it is a **CI-only** decision, recorded in the release header and the docs.

This branch was implemented, simplified, and self-reviewed by earlier automated sessions; this PR only publishes it.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
