### PR TITLE
fix(glance): load the default metadefs and make the tempest legs pass the full image suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1775,6 +1775,7 @@ jobs:
         run: |
           kubectl apply -f ${{ matrix.config-dir }}/02-glance-cr.yaml
           kubectl apply -f ${{ matrix.config-dir }}/03-glancebackend-cr.yaml
+          kubectl apply -f ${{ matrix.config-dir }}/04-glancebackend2-cr.yaml
           kubectl wait glance/${{ matrix.glance-cr-name }} -n openstack \
             --for=condition=Ready --timeout=300s
       # Use shared Tempest wrapper script.

--- a/docs/reference/testing/tempest-test-infrastructure.md
+++ b/docs/reference/testing/tempest-test-infrastructure.md
@@ -23,7 +23,7 @@ and `build-images.yaml` dynamically discovers releases for the Tempest image pip
 | `releases/<release>/test-refs.yaml` | PyPI version pins for test tooling (single source of truth), per release |
 | `tests/tempest/keystone-2025-2/` | Keystone 2025.2 Tempest configuration (`tempest.conf`, `include-tests.txt`, `exclude-tests.txt`) |
 | `tests/tempest/keystone-2026-1/` | Keystone 2026.1 Tempest configuration |
-| `tests/tempest/glance-2025-2/` | Glance 2025.2 Tempest configuration: the `tempest.conf` / `include-tests.txt` / `exclude-tests.txt` triplet, a `00-keystone-cr.yaml` identity CR named `keystone-glance-tempest-2025-2`, and three extra fixtures the CI job applies — `01-catalog-setup-job.yaml` (image-catalog bootstrap Job), `02-glance-cr.yaml` (Glance CR), `03-glancebackend-cr.yaml` (GlanceBackend CR) |
+| `tests/tempest/glance-2025-2/` | Glance 2025.2 Tempest configuration: the `tempest.conf` / `include-tests.txt` / `exclude-tests.txt` triplet, a `00-keystone-cr.yaml` identity CR named `keystone-glance-tempest-2025-2`, and four extra fixtures the CI job applies — `01-catalog-setup-job.yaml` (image-catalog bootstrap Job), `02-glance-cr.yaml` (Glance CR), `03-glancebackend-cr.yaml` (default GlanceBackend CR), `04-glancebackend2-cr.yaml` (second, non-default store so the copy-image import test has a copy target) |
 | `tests/tempest/glance-2026-1/` | Glance 2026.1 Tempest configuration (same file set; identity CR `keystone-glance-tempest-2026-1`) |
 | `tests/container-images/verify_tempest.sh` | Image verification script (PASS/FAIL counters) |
 | `hack/run-tempest.sh` | Local orchestration script for running Tempest against a kind cluster |
@@ -74,9 +74,16 @@ tooling versions can evolve independently.
 **Format:**
 
 ```yaml
-tempest: "45.0.0"
-keystone-tempest-plugin: "0.19.0"
+tempest: "46.3.0"
+keystone-tempest-plugin: "0.21.0"
 ```
+
+The tempest pin may run ahead of the release line a directory represents:
+tempest is branchless (released tags never receive fixes) and upstream
+validates current plus recent stable releases with the latest tag. Both
+release directories currently pin tempest `46.3.0` — the glance legs need
+`>= 46.2.0`, where the web-download bad-URL negative test accepts the
+synchronous 400 that glance's DNS-based URI filtering returns.
 
 Each key is a PyPI package name. Values are quoted strings representing exact version
 pins. CI workflows resolve versions from this file via `yq`:
@@ -147,7 +154,7 @@ in three ways: (1) it installs from PyPI instead of mounting a git source tree,
 
 | Arg | Default | Source |
 | --- | --- | --- |
-| `TEMPEST_VERSION` | `45.0.0` | `test-refs.yaml` → `.tempest` |
+| `TEMPEST_VERSION` | `46.3.0` | `test-refs.yaml` → `.tempest` |
 | `KEYSTONE_TEMPEST_PLUGIN_VERSION` | `0.19.0` | `test-refs.yaml` → `.["keystone-tempest-plugin"]` |
 
 ### Local Build
@@ -350,7 +357,10 @@ not a single directory. To add another service:
    missing the directory. A service with its own operator payload also ships the
    CRs the job applies before Tempest runs — glance carries
    `01-catalog-setup-job.yaml` (registers the image service + endpoints in
-   Keystone), `02-glance-cr.yaml`, and `03-glancebackend-cr.yaml`.
+   Keystone), `02-glance-cr.yaml`, `03-glancebackend-cr.yaml`, and
+   `04-glancebackend2-cr.yaml` (a second, non-default store: the copy-image
+   import test only executes a real copy when there is a store the image is
+   not already in).
 2. Set `[service_available]` flags to match the deployed services and point
    `[identity]` `uri_v3` at the leg's identity CR (glance authenticates against
    its own `keystone-glance-tempest-<slug>` CR, not the shared keystone leg's CR).
@@ -377,7 +387,7 @@ PASS/FAIL counter pattern as other `verify_*.sh` scripts and sources
 
 ```bash
 bash tests/container-images/verify_tempest.sh [image_name]
-# Default image: c5c3/tempest:45.0.0
+# Default image: c5c3/tempest:46.3.0
 ```
 
 **Test cases:**
@@ -501,7 +511,7 @@ port-forwards on 9292).
 | Deploy Glance operator *(glance leg only)* | `hack/ci-deploy-operator.sh` with `OPERATOR=glance`, `NAMESPACE=glance-system` (before the Keystone CR reconciles) |
 | Deploy Keystone CR | Applies `matrix.config-dir/00-keystone-cr.yaml`, waits for `matrix.cr-name` Ready |
 | Bootstrap image catalog *(glance leg only)* | Applies `matrix.config-dir/01-catalog-setup-job.yaml`, waits for the `glance-tempest-catalog-setup` Job to complete (registers the image service + endpoints in Keystone that the Glance CR needs to reconcile) |
-| Deploy Glance CR *(glance leg only)* | Applies `matrix.config-dir/02-glance-cr.yaml` and `03-glancebackend-cr.yaml`, waits for `matrix.glance-cr-name` Ready |
+| Deploy Glance CR *(glance leg only)* | Applies `matrix.config-dir/02-glance-cr.yaml`, `03-glancebackend-cr.yaml`, and `04-glancebackend2-cr.yaml`, waits for `matrix.glance-cr-name` Ready |
 | Run Tempest API tests | `hack/ci-run-tempest.sh` with `CONFIG_DIR`, `TEMPEST_IMAGE`, and `SERVICE_K8S_NAME` from matrix; the glance leg also passes `GLANCE_K8S_NAME` (empty on keystone legs, which disables the 9292 port-forward) |
 | Upload Tempest results | Uploads `_output/tempest/` (minus the rendered `tempest.conf`, which carries the substituted admin password) as artifact with 14-day retention |
 
@@ -574,7 +584,7 @@ security. The job is parameterized by release via the `generate-matrix` job.
 | Tag | Example | Description |
 | --- | --- | --- |
 | `<release>` | `ghcr.io/<owner>/tempest:2025.2` | Release series tag |
-| `<tempest-version>` | `ghcr.io/<owner>/tempest:45.0.0` | Tempest PyPI version (main branch only) |
+| `<tempest-version>` | `ghcr.io/<owner>/tempest:46.3.0` | Tempest PyPI version (main branch only) |
 | `<release>-<commit-sha>` | `ghcr.io/<owner>/tempest:2025.2-<sha>` | Release + git commit for traceability |
 
 **Supply chain security steps:**

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -11,7 +11,7 @@
 FROM venv-builder AS build
 
 # PyPI versions passed by CI from releases/<release>/test-refs.yaml.
-ARG TEMPEST_VERSION=45.0.0
+ARG TEMPEST_VERSION=46.3.0
 ARG KEYSTONE_TEMPEST_PLUGIN_VERSION=0.19.0
 
 # Install Tempest and plugins into the shared virtualenv.

--- a/operators/glance/internal/controller/reconcile_database.go
+++ b/operators/glance/internal/controller/reconcile_database.go
@@ -125,6 +125,14 @@ func (r *GlanceReconciler) reconcileDatabase(ctx context.Context, glance *glance
 	})
 }
 
+// glanceMetadefsSourcePath is the directory the glance image ships the default
+// metadata-definition JSON files at. Glance's setup.cfg installs etc/metadefs/*
+// to <prefix>/etc/glance/metadefs, and the image installs glance with
+// --prefix /var/lib/openstack (images/glance/Dockerfile); the two paths must
+// stay in lockstep. The oslo default (/etc/glance/metadefs/) does not exist in
+// the config-free image, so the db-sync Job passes this path explicitly.
+const glanceMetadefsSourcePath = "/var/lib/openstack/etc/glance/metadefs"
+
 // glanceJobSetParams derives the shared migration-Job inputs from the Glance CR:
 // the config mount, the DB-connection env override, and the glance-manage db
 // sync command. The steady-state sync flow (database.ReconcileSyncJobs) consumes
@@ -138,8 +146,18 @@ func glanceJobSetParams(glance *glancev1alpha1.Glance, configMapName string) dat
 		ConfigMountPath: glanceConfigDir,
 		// Override [database].connection via the oslo.config env-var so db-sync
 		// reads the DB URL from the derived Secret instead of the ConfigMap.
-		Env:         []corev1.EnvVar{database.ConnectionEnvVar(glance.Name)},
-		SyncCommand: []string{"glance-manage", "--config-dir", glanceConfigDir, "db", "sync"},
+		Env: []corev1.EnvVar{database.ConnectionEnvVar(glance.Name)},
+		// After the schema migration, load the default metadata-definitions
+		// catalog — the managed counterpart of the classic deployment's
+		// `glance-manage db_load_metadefs` step. Without it GET
+		// /v2/metadefs/resource_types serves an empty catalog. The load is
+		// idempotent: namespaces already in the database are skipped (no
+		// --merge), so re-runs and release upgrades only insert new files.
+		SyncCommand: []string{
+			"/bin/sh", "-eu", "-c",
+			"glance-manage --config-dir " + glanceConfigDir + " db sync && " +
+				"glance-manage --config-dir " + glanceConfigDir + " db load_metadefs --path " + glanceMetadefsSourcePath,
+		},
 		// No schema-check: glance-manage db sync is idempotent and applies all
 		// pending migrations in one pass, unlike keystone's expand/migrate split.
 		SchemaCheckCommand: nil,

--- a/operators/glance/internal/controller/reconcile_database_test.go
+++ b/operators/glance/internal/controller/reconcile_database_test.go
@@ -167,7 +167,10 @@ func TestReconcileDatabase_SyncJobCommandAndEnv(t *testing.T) {
 
 	container := syncJob.Spec.Template.Spec.Containers[0]
 	g.Expect(container.Command).To(Equal([]string{
-		"glance-manage", "--config-dir", "/etc/glance/glance-api.conf.d/", "db", "sync",
+		"/bin/sh", "-eu", "-c",
+		"glance-manage --config-dir /etc/glance/glance-api.conf.d/ db sync && " +
+			"glance-manage --config-dir /etc/glance/glance-api.conf.d/ db load_metadefs " +
+			"--path /var/lib/openstack/etc/glance/metadefs",
 	}))
 
 	var connEnv *corev1.EnvVar

--- a/releases/2025.2/test-refs.yaml
+++ b/releases/2025.2/test-refs.yaml
@@ -6,5 +6,12 @@
 # This file is the single source of truth for what version of each test tool
 # is installed in test container images. CI workflows resolve versions via yq.
 # Separate from source-refs.yaml which tracks git refs for OpenStack services.
-tempest: "45.0.0"
+#
+# tempest is deliberately ahead of the 45.x line that shipped with 2025.2:
+# tempest is branchless (old tags never receive fixes) and upstream validates
+# current + recent stable releases with the latest tag. The glance leg needs
+# ≥ 46.2.0, where test_image_web_download_import_with_bad_url accepts the
+# synchronous 400 that glance ≥ 31.x's DNS-based URI filtering returns for
+# unresolvable hosts; tempest 45.x still demands the legacy async failure.
+tempest: "46.3.0"
 keystone-tempest-plugin: "0.21.0"

--- a/tests/container-images/verify_tempest.sh
+++ b/tests/container-images/verify_tempest.sh
@@ -5,12 +5,12 @@
 
 # Verify tempest container image meets requirements
 # Usage: bash tests/container-images/verify_tempest.sh [image_name]
-# Default image: c5c3/tempest:45.0.0
+# Default image: c5c3/tempest:46.3.0
 # Requires: Docker daemon running
 
 set -euo pipefail
 
-IMAGE="${1:-c5c3/tempest:45.0.0}"
+IMAGE="${1:-c5c3/tempest:46.3.0}"
 
 PASS=0
 FAIL=0

--- a/tests/tempest/glance-2025-2/04-glancebackend2-cr.yaml
+++ b/tests/tempest/glance-2025-2/04-glancebackend2-cr.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Second, non-default S3 store for the glance-tempest-2025-2 CR, backing the
+# independent, pre-created glance-images-2 bucket (same Garage cluster and
+# credentials as the default store in 03-glancebackend-cr.yaml). The copy-image
+# tempest test (ImportCopyImagesTest.test_image_copy_image_import) needs a
+# second store to be meaningful: with a single store the image is already
+# present everywhere, glance exits the copy workflow before stamping
+# os_glance_importing_to_stores, and the tempest waiter polls that property
+# until timeout. With this store attached, the copy actually executes
+# (default store → staging → this store) and the test verifies it end-to-end.
+apiVersion: glance.openstack.c5c3.io/v1alpha1
+kind: GlanceBackend
+metadata:
+  name: glance-tempest-2025-2-s3-b
+  namespace: openstack
+spec:
+  glanceRef:
+    name: glance-tempest-2025-2
+  type: S3
+  isDefault: false
+  s3:
+    host: http://garage.openstack.svc.cluster.local:3900
+    bucket: glance-images-2
+    region: garage
+    credentialsSecretRef:
+      name: garage-s3-credentials

--- a/tests/tempest/glance-2026-1/04-glancebackend2-cr.yaml
+++ b/tests/tempest/glance-2026-1/04-glancebackend2-cr.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Second, non-default S3 store for the glance-tempest-2026-1 CR, backing the
+# independent, pre-created glance-images-2 bucket (same Garage cluster and
+# credentials as the default store in 03-glancebackend-cr.yaml). The copy-image
+# tempest test (ImportCopyImagesTest.test_image_copy_image_import) needs a
+# second store to be meaningful: with a single store the image is already
+# present everywhere, glance exits the copy workflow before stamping
+# os_glance_importing_to_stores, and the tempest waiter polls that property
+# until timeout. With this store attached, the copy actually executes
+# (default store → staging → this store) and the test verifies it end-to-end.
+apiVersion: glance.openstack.c5c3.io/v1alpha1
+kind: GlanceBackend
+metadata:
+  name: glance-tempest-2026-1-s3-b
+  namespace: openstack
+spec:
+  glanceRef:
+    name: glance-tempest-2026-1
+  type: S3
+  isDefault: false
+  s3:
+    host: http://garage.openstack.svc.cluster.local:3900
+    bucket: glance-images-2
+    region: garage
+    credentialsSecretRef:
+      name: garage-s3-credentials


### PR DESCRIPTION
Closes #671.

Both glance tempest legs now pass the complete `tempest.api.image` suite with the exclude lists empty. The five deterministic failures fell into three classes; investigation against the pinned upstream sources showed only one of them was a service defect.

## Empty metadata-definitions catalog (3 tests, both releases)

The managed database-sync flow ran only `glance-manage db sync`, so a freshly reconciled Glance served an empty metadefs catalog — the classic deployment's `glance-manage db_load_metadefs` step had no managed counterpart. The db-sync Job now chains `db load_metadefs --path /var/lib/openstack/etc/glance/metadefs` (the image's `--prefix` install location; the oslo default `/etc/glance/metadefs/` does not exist in the config-free image) after the schema migration. The load is idempotent — existing namespaces are skipped — so config-hash re-runs and release upgrades only insert new definitions.

## copy-image import timeout (1 test, both releases)

Not a service defect: `ImportCopyImagesTest` imports with `all_stores=true` and polls `os_glance_importing_to_stores`. With a single store the image is already present everywhere, glance exits the copy workflow before stamping that property ("available in all configured stores"), and the tempest waiter times out — upstream behaves identically. Each glance leg now attaches a second, non-default S3 store (`04-glancebackend2-cr.yaml`, backed by the pre-created `glance-images-2` bucket), so the copy executes for real: default store → staging → second store. `copy-image` stays advertised — it works.

## web-download bad-URL rejection (1 test, 2025.2 only)

Also not a config defect: glance ≥ 31.x rejects import URIs whose host does not resolve synchronously with 400 (DNS-based SSRF filtering in `normalize_hostname`, not configurable), on both releases. Only tempest ≥ 46.2.0 accepts that 400 in `test_image_web_download_import_with_bad_url`; tempest is branchless, so 45.x will never receive the fix. The 2025.2 pin moves to 46.3.0, aligning both releases on one tempest version. The positive web-download test passes on both releases, so dropping the method for parity would have removed working, covered functionality. (Renovate intentionally leaves major bumps of the test tooling to humans; the `test-refs.yaml` comment records why the pin runs ahead of the release line.)

## Verification (local kind cluster)

- glance 2025.2 leg: 69 tests, 0 failures — all five previously failing tests pass, copy-image performs a real cross-store copy
- glance 2026.1 leg: 69 tests, 0 failures
- keystone 2025.2 leg under tempest 46.3.0: 505 tests, 0 failures; the test-ID set and skip counts are byte-identical to the CI baseline under 45.0.0, so the bump changes no keystone coverage
- metadefs idempotency observed live: the db-sync Job ran twice (config-hash change when the second store joined) and the second run skipped every namespace cleanly
- unit tests, golangci-lint, shellcheck, and `verify_glance_ci_pipeline.sh` green; the tempest 46.3.0 image builds cleanly under the 2025.2 upper-constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)