### PR TITLE
chore: remove leftover references to the architecture submodule

### DIFF
--- a/.claude/skills/check-condition-coverage/SKILL.md
+++ b/.claude/skills/check-condition-coverage/SKILL.md
@@ -39,7 +39,7 @@ an `UNKNOWN` Prometheus label:
 | Set in code | `operators/<op>/internal/controller/reconcile_*.go` (`conditions.SetCondition` with `Type: "<Name>Ready"` or `Type: conditionType<X>Ready`) | the sub-reconciler that actually computes the status |
 | Instrumentation map | `operators/<op>/internal/controller/instrumentation.go` (`subReconcilerConditionTypes`) | the canonical sub-reconciler → condition-type label binding for Prometheus |
 | Unit tests | `operators/<op>/internal/controller/reconcile_*_test.go` plus the drift-guard test `TestSubReconcilerConditionTypesCoversAllNames` (in `instrumentation_test.go`) | test functions named after the sub-reconciler |
-| Docs | `docs/reference/<op>/*.md` (the reconciler and CRD reference pages); keystone additionally `architecture/docs/09-implementation/03-crd-implementation.md` when the submodule is checked out | the condition tables / sections in the reference docs |
+| Docs | `docs/reference/<op>/*.md` (the reconciler and CRD reference pages) | the condition tables / sections in the reference docs |
 
 The authoritative gate is the per-operator drift-guard test
 `TestSubReconcilerConditionTypesCoversAllNames` in
@@ -188,9 +188,8 @@ These recurring shapes are worth grepping for first:
   parser — the per-operator `TestSubReconcilerConditionTypesCoversAllNames`
   drift-guard test does the map-side check with full Go AST awareness.
   Treat K1 as a smoke check and the test as the authoritative gate.
-- The `architecture/` submodule is usually not checked out; the
-  keystone architecture chapter is consulted only when present. The
-  operator's `docs/reference/<op>/` pages are the primary doc corpus.
+- The operator's `docs/reference/<op>/` pages are the doc corpus for
+  K4/K5.
 - Pair this with [[check-doc-drift]] — that skill confirms the prose
   reference matches the code (sub-reconciler chain, OPERATORS list);
   this skill drills into the condition-type wiring specifically.

--- a/.claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh
+++ b/.claude/skills/check-condition-coverage/scripts/audit-condition-coverage.sh
@@ -14,10 +14,8 @@
 #   K4  every condition type in the instrumentation map is documented
 #   K5  every condition type referenced in docs is set in code
 #
-# The per-operator doc corpus is docs/reference/<op>/*.md; keystone
-# additionally consults architecture/docs/09-implementation/03-crd-implementation.md
-# when the architecture/ submodule is checked out. Operators without a
-# reference-doc directory skip K4/K5 with [INFO].
+# The per-operator doc corpus is docs/reference/<op>/*.md. Operators
+# without a reference-doc directory skip K4/K5 with [INFO].
 #
 # Defers Go-AST-aware checks to the existing per-operator drift-guard test:
 #   TestSubReconcilerConditionTypesCoversAllNames
@@ -70,9 +68,6 @@ for op in "${OPERATORS[@]}"; do
     for d in "docs/reference/${op}"/*.md; do
       [[ -f "${d}" ]] && DOC_FILES+=("${d}")
     done
-  fi
-  if [[ "${op}" == "keystone" && -f "architecture/docs/09-implementation/03-crd-implementation.md" ]]; then
-    DOC_FILES+=("architecture/docs/09-implementation/03-crd-implementation.md")
   fi
 
   # Build the union of condition types declared in the map (right-hand side).

--- a/.claude/skills/check-doc-drift/SKILL.md
+++ b/.claude/skills/check-doc-drift/SKILL.md
@@ -2,8 +2,8 @@
 name: check-doc-drift
 description: >-
   Audit the forge documentation for drift against the implementation —
-  the architecture/docs/ chapters vs the operator code, the docs/
-  user-facing reference vs the deploy/ infrastructure stack. Use when
+  the docs/reference/ pages vs the operator code, the guides and
+  quick-starts vs the deploy/ infrastructure stack. Use when
   asked to check documentation drift, after adding or
   removing a sub-reconciler, status condition, operator binary, or
   infrastructure component, or before tagging a release.
@@ -14,7 +14,7 @@ description: >-
 This skill verifies that the forge documentation still **describes what
 the code actually does**: every sub-reconciler, status condition,
 operator binary, CRD field, and FluxCD component
-named in `architecture/docs/` or `docs/` (and `README.md`) is checked
+named in `docs/` (and `README.md`) is checked
 against its source of truth, so a reader is never handed a reference
 page that contradicts the implementation.
 
@@ -28,9 +28,9 @@ splits the corpus into three areas, each with a single source of truth:
 
 | Doc area | Files | Source of truth |
 |---|---|---|
-| Operator architecture | `architecture/docs/09-implementation/04-keystone-reconciler.md`, `architecture/docs/09-implementation/02-shared-library.md`, `architecture/docs/04-architecture/*.md` | `operators/keystone/internal/controller/reconcile_*.go` + `operators/keystone/api/v1alpha1/keystone_types.go` + `internal/common/` |
-| CRD reference | `architecture/docs/09-implementation/03-crd-implementation.md` | `operators/keystone/api/v1alpha1/keystone_types.go` and the generated CRD under `operators/keystone/config/crd/bases/` |
-| Infrastructure stack | `architecture/docs/09-implementation/01-project-setup.md`, `architecture/docs/09-implementation/05-keystone-dependencies.md`, `architecture/docs/09-implementation/09-openbao-deployment.md`, `docs/guides/`, `docs/quick-start*.md` | `deploy/` kustomize tree + `hack/deploy-infra.sh` + `releases/<version>/source-refs.yaml` |
+| Operator reference | `docs/reference/<op>/` reconciler pages (e.g. `keystone-reconciler.md`, `controlplane-reconciler.md`, `horizon-reconciler.md`) | `operators/<op>/internal/controller/reconcile_*.go` + `operators/<op>/api/v1alpha1/*_types.go` + `internal/common/` |
+| CRD reference | `docs/reference/<op>/*-crd.md` | `operators/<op>/api/v1alpha1/*_types.go` and the generated CRDs under `operators/<op>/config/crd/bases/` |
+| Infrastructure stack | `docs/guides/`, `docs/quick-start*.md`, `docs/reference/infrastructure/` | `deploy/` kustomize tree + `hack/deploy-infra.sh` + `releases/<version>/source-refs.yaml` |
 
 A doc that contradicts its source is a defect even when the build is
 green: the compiler never reads prose. The audit's job is to surface
@@ -49,56 +49,50 @@ bash .claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
 The script catches the mechanically-checkable drift and prints an
 inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
 
-- **D1** — `OPERATORS ?=` default in `Makefile` vs the actual
-  `operators/*/` directories. An operator added under `operators/` but
-  not added to the Makefile default (or vice versa) means the new
-  binary never gets built/tested by `make build` / `make test` /
-  `make lint`.
-- **D2** — count of `reconcile_*.go` files under
-  `operators/keystone/internal/controller/` vs the count of
-  `### reconcile…()` sections in
-  `architecture/docs/09-implementation/04-keystone-reconciler.md`. A
-  delta means a new sub-reconciler shipped without a doc section, or
-  a section names a sub-reconciler that was removed.
-- **D3** — every `### reconcile…()` heading in the reconciler doc
-  names a function that exists in the controller package. A renamed
-  reconciler leaves the heading stranded.
-- **D4** — every condition type set in the sub-reconcilers (literal
-  string in `meta.SetStatusCondition` / `conditions.SetCondition`
-  calls) is documented under
-  `architecture/docs/09-implementation/03-crd-implementation.md`.
-- **D5** — retired. The audit used to cross-reference internal feature-ID
-  markers in the code against `architecture/docs/`; those IDs have been
-  removed repo-wide (a gate, `scripts/check-no-feature-ids.sh`, now forbids
-  them), so the check is obsolete and reports nothing.
-- **D6** — every `deploy/<component>/` directory mentioned by name in
-  `architecture/docs/09-implementation/` exists. A renamed or removed
-  infra component leaves the doc page pointing at nothing.
+- **D1** — `OPERATORS ?=` default in `Makefile` vs the operator modules
+  under `operators/` (directories with a `go.mod`; `operators/shared/`
+  is a helm library, not an operator). An operator added under
+  `operators/` but not added to the Makefile default (or vice versa)
+  means the new binary never gets built/tested by `make build` /
+  `make test` / `make lint`.
+- **D2** — every `### reconcile…` heading under `docs/reference/`
+  names a function that exists in an
+  `operators/*/internal/controller/` package. A renamed or removed
+  sub-reconciler leaves the heading stranded.
+- **D3** — every `deploy/<component>/` directory mentioned by name in
+  `docs/` or `README.md` exists. A renamed or removed infra component
+  leaves the doc page pointing at nothing.
 - The **inventories** are review aids, not pass/fail: every spelled-out
   numeric claim in the docs ("11 sub-conditions", "8-step deployment",
   "three states"), every FluxCD release name documented vs declared.
   Cross-reference each by hand in step 2.
 
+Condition-type doc coverage (every condition set in code appears in the
+`docs/reference/<op>/` pages, and vice versa) is audited by
+[[check-condition-coverage]] (K4/K5) — do not duplicate it here.
+
 ### 2. Cross-reference the three areas by hand
 
 The script cannot read prose meaning. For each area, open the doc and
 its source of truth and confirm they agree. This is the real work —
-delegate the four areas to parallel sub-agents for a large corpus.
+delegate the areas to parallel sub-agents for a large corpus.
 
-- **Operator architecture** — for each `### reconcile…()` section in
-  `04-keystone-reconciler.md`, confirm the description matches the
-  current implementation under `operators/keystone/internal/controller/`
-  (what it touches, what condition it sets, what it requeues on).
+- **Operator reference** — for each `### reconcile…` section in the
+  `docs/reference/<op>/` reconciler page, confirm the description
+  matches the current implementation under
+  `operators/<op>/internal/controller/` (what it touches, what
+  condition it sets, what it requeues on).
 - **CRD reference** — for each Spec field listed in
-  `03-crd-implementation.md`, confirm the type, JSON tag, default,
-  required-ness, and CEL validation rule match
-  `keystone_types.go`. Then walk the generated CRD under
-  `operators/keystone/config/crd/bases/` and confirm no Spec field is
+  `docs/reference/<op>/*-crd.md`, confirm the type, JSON tag, default,
+  required-ness, and CEL validation rule match the
+  `*_types.go` source. Then walk the generated CRD under
+  `operators/<op>/config/crd/bases/` and confirm no Spec field is
   undocumented.
 - **Infrastructure stack** — for each component named in
-  `01-project-setup.md` and `05-keystone-dependencies.md`, confirm a
-  matching directory exists under `deploy/` and that
-  `hack/deploy-infra.sh` still installs it in the documented order.
+  `docs/guides/`, `docs/quick-start*.md`, and
+  `docs/reference/infrastructure/`, confirm a matching directory
+  exists under `deploy/` and that `hack/deploy-infra.sh` still
+  installs it in the documented order.
 Flag any pair where the doc and the source disagree.
 
 ### 3. Report
@@ -106,15 +100,16 @@ Flag any pair where the doc and the source disagree.
 Produce a concise summary grouped by severity:
 
 - **HIGH** — `OPERATORS` Makefile default disagrees with the
-  `operators/` tree; a `### reconcile…()` doc heading names a function
+  `operators/` tree; a `### reconcile…` doc heading names a function
   that does not exist; a documented condition type is never set by
   any sub-reconciler; an infrastructure component named in the docs
   has no matching `deploy/` directory.
-- **MEDIUM** — sub-reconciler count drift; a condition type set in
-  the code that is not documented; a Spec field with a `+kubebuilder`
-  marker that is not described in the CRD reference doc; a numeric
-  claim ("11 sub-conditions") that no longer matches the code count.
-- **LOW** — a stale link target inside `architecture/docs/`; a typo or
+- **MEDIUM** — a sub-reconciler with no doc section; a condition type
+  set in the code that is not documented; a Spec field with a
+  `+kubebuilder` marker that is not described in the CRD reference
+  page; a numeric claim ("11 sub-conditions") that no longer matches
+  the code count.
+- **LOW** — a stale link target inside `docs/`; a typo or
   formatting drift.
 
 For each finding give one line with a `file:line` reference for both
@@ -126,16 +121,16 @@ health verdict per doc area.
 These recurring shapes are worth grepping for first:
 
 1. **New sub-reconciler, no doc section.** A `reconcile_<thing>.go`
-   was added but `04-keystone-reconciler.md` still lists the old
-   sub-reconciler set. The new condition type is then set by the
-   controller but not described under `03-crd-implementation.md`
-   either.
+   was added but the `docs/reference/<op>/` reconciler page still
+   describes the old sub-reconciler set. The new condition type is
+   then set by the controller but not described in the CRD reference
+   page either.
 2. **Renamed condition type.** A condition was renamed in
-   `keystone_types.go` and the sub-reconciler code, but the docs
+   `*_types.go` and the sub-reconciler code, but the docs
    still use the old type name in a table row. Operators looking up
    the new name in the docs find nothing.
-3. **Removed Spec field.** A field was deleted from `keystone_types.go`
-   but the CRD reference doc still lists it. CR fixtures that use the
+3. **Removed Spec field.** A field was deleted from `*_types.go`
+   but the CRD reference page still lists it. CR fixtures that use the
    field then fail with an obscure unknown-field error and the doc
    is the only place that knew what it meant.
 4. **OPERATORS drift.** A new operator binary was added under
@@ -143,9 +138,9 @@ These recurring shapes are worth grepping for first:
    originals. `make test` / `make lint` silently skip the new
    operator until someone notices a CI gap.
 5. **Renamed infra release.** `deploy/<component>/` was renamed
-   (e.g. `cert-manager` ⇢ `cert-manager-istio`) but
-   `01-project-setup.md` or `05-keystone-dependencies.md` still uses
-   the old name. New operators copy the wrong reference.
+   (e.g. `cert-manager` ⇢ `cert-manager-istio`) but a guide or
+   quick-start still uses the old name. New operators copy the wrong
+   reference.
 
 ## Notes
 
@@ -157,4 +152,4 @@ These recurring shapes are worth grepping for first:
   reference still mirrors both.
 - Pair this with [[check-condition-coverage]] — that skill confirms
   every condition type set in the code is wired to the instrumentation
-  map; this skill adds the doc-side check.
+  map and documented; this skill covers the remaining doc surface.

--- a/.claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
+++ b/.claude/skills/check-doc-drift/scripts/audit-doc-drift.sh
@@ -4,15 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # audit-doc-drift.sh — mechanical doc-drift checks for the forge repo.
-# Verifies that architecture/docs/ + docs/ still describe the operator code
+# Verifies that docs/ (and README.md) still describe the operator code
 # and infrastructure stack accurately:
-#   D1  Makefile OPERATORS default matches operators/*/
-#   D2  count of reconcile_*.go matches doc-side sub-reconciler section count
-#   D3  every doc-side reconcileX() heading names a real function
-#   D4  every condition type literal set in reconcile_*.go is documented
-#   D5  retired (internal feature/requirement IDs removed repo-wide)
-#   D6  every deploy/<component>/ named in architecture/docs/09-implementation/
-#       still exists
+#   D1  Makefile OPERATORS default matches the operator modules under operators/
+#       (directories with a go.mod; operators/shared/ is a helm library, not
+#       an operator)
+#   D2  every ### reconcile… heading under docs/reference/ names a real
+#       Go function in an operators/*/internal/controller/ package
+#   D3  every deploy/<component>/ named in docs/ or README.md still exists
+#
+# Condition-type doc coverage is audited by check-condition-coverage (K4/K5);
+# internal feature/requirement-ID cross-referencing is retired repo-wide
+# (scripts/check-no-feature-ids.sh forbids the IDs).
 #
 # Defers prose-meaning checks to a human reviewer. Exit code 1 on any [FAIL].
 
@@ -27,101 +30,43 @@ pass() { echo "[PASS] $*"; }
 info() { echo "[INFO] $*"; }
 hdr()  { echo; echo "=== $* ==="; }
 
-RECONCILER_DOC="architecture/docs/09-implementation/04-keystone-reconciler.md"
-CRD_DOC="architecture/docs/09-implementation/03-crd-implementation.md"
-CONTROLLER_DIR="operators/keystone/internal/controller"
-
 # ---------------------------------------------------------------------------
-# D1 — Makefile OPERATORS default matches operators/*/
+# D1 — Makefile OPERATORS default matches the operator modules under operators/
 # ---------------------------------------------------------------------------
-hdr "D1: Makefile OPERATORS default matches operators/*/"
+hdr "D1: Makefile OPERATORS default matches operator modules under operators/"
 makefile_ops=$(grep -E '^OPERATORS \?=' Makefile | head -1 | sed -E 's/^OPERATORS \?= *//' | tr ' ' '\n' | sort)
-fs_ops=$(for d in operators/*/; do basename "${d}"; done | sort)
+fs_ops=$(for d in operators/*/; do if [[ -f "${d}go.mod" ]]; then basename "${d}"; fi; done | sort)
 if diff <(echo "${makefile_ops}") <(echo "${fs_ops}") >/dev/null 2>&1; then
-  pass "Makefile OPERATORS default matches operators/* (${fs_ops//$'\n'/, })"
+  pass "Makefile OPERATORS default matches operator modules (${fs_ops//$'\n'/, })"
 else
   fail "OPERATORS drift — Makefile: $(echo "${makefile_ops}" | tr '\n' ',' | sed 's/,$//') vs filesystem: $(echo "${fs_ops}" | tr '\n' ',' | sed 's/,$//')"
 fi
 
 # ---------------------------------------------------------------------------
-# D2 — count of reconcile_*.go matches doc heading count
+# D2 — every ### reconcile… heading under docs/reference/ names a real function
 # ---------------------------------------------------------------------------
-hdr "D2: reconcile_*.go file count vs ### reconcileX() heading count in ${RECONCILER_DOC}"
-recon_files=$(find "${CONTROLLER_DIR}" -maxdepth 1 -name 'reconcile_*.go' -not -name '*_test.go' | wc -l | tr -d ' ')
-if [[ -f "${RECONCILER_DOC}" ]]; then
-  doc_headings=$(grep -cE '^### reconcile[A-Z][A-Za-z]*\(\)' "${RECONCILER_DOC}" || true)
-  info "reconcile_*.go files: ${recon_files}; ### reconcileX() headings: ${doc_headings}"
-  if [[ "${recon_files}" -ne "${doc_headings}" ]]; then
-    fail "sub-reconciler count drift: ${recon_files} files vs ${doc_headings} doc headings (delta=$((recon_files - doc_headings)))"
+hdr "D2: every ### reconcile… heading under docs/reference/ names a real Go function"
+heading_count=0
+while IFS=: read -r file heading; do
+  fn=$(echo "${heading}" | sed -nE 's/^### (reconcile[A-Za-z]+).*/\1/p')
+  [[ -z "${fn}" ]] && continue
+  heading_count=$((heading_count + 1))
+  if grep -rqE "func .*\) ${fn}\(" operators/*/internal/controller/; then
+    pass "${file}: ### ${fn} resolves to a Go function"
   else
-    pass "sub-reconciler count consistent"
+    fail "${file}: ### ${fn} has no matching func under operators/*/internal/controller/ — renamed/removed?"
   fi
-else
-  fail "missing reconciler doc: ${RECONCILER_DOC}"
-fi
+done < <(grep -rE --include='*.md' '^### reconcile[A-Z]' docs/reference/ 2>/dev/null)
+info "reconcile headings checked: ${heading_count}"
 
 # ---------------------------------------------------------------------------
-# D3 — every ### reconcileX() heading names a real Go function
+# D3 — every deploy/<component> named in docs/ or README.md exists on disk
 # ---------------------------------------------------------------------------
-hdr "D3: every ### reconcileX() heading names a real Go function"
-if [[ -f "${RECONCILER_DOC}" ]]; then
-  while IFS= read -r heading; do
-    fn=$(echo "${heading}" | sed -nE 's/^### (reconcile[A-Z][A-Za-z]*)\(\).*/\1/p')
-    [[ -z "${fn}" ]] && continue
-    if grep -rqE "^func .*\) ${fn}\(" "${CONTROLLER_DIR}"; then
-      pass "doc heading ### ${fn}() resolves to a Go function"
-    else
-      fail "doc heading ### ${fn}() has no matching func in ${CONTROLLER_DIR} — renamed/removed?"
-    fi
-  done < <(grep -E '^### reconcile[A-Z]' "${RECONCILER_DOC}")
-fi
-
-# ---------------------------------------------------------------------------
-# D4 — every condition type literal set in reconcile_*.go is documented
-# ---------------------------------------------------------------------------
-hdr "D4: condition types set in code are documented in ${CRD_DOC}"
-# Extract condition type literals from instrumentation.go map (the canonical set).
-INSTRUMENTATION="${CONTROLLER_DIR}/instrumentation.go"
-if [[ -f "${INSTRUMENTATION}" && -f "${CRD_DOC}" ]]; then
-  # Map values in the form `"<Name>Ready"` or `conditionType<X>Ready` (constant).
-  # We take the literal-quoted ones directly; the const ones require resolving in code.
-  literal_types=$(grep -oE '"[A-Z][A-Za-z]+Ready"' "${INSTRUMENTATION}" | tr -d '"' | sort -u)
-  for t in ${literal_types}; do
-    if grep -q "${t}" "${CRD_DOC}"; then
-      pass "condition type ${t} documented in ${CRD_DOC}"
-    else
-      fail "condition type ${t} set in code but not documented in ${CRD_DOC}"
-    fi
-  done
-  # Also list constant-referenced types for the human to cross-check.
-  const_refs=$(grep -oE 'conditionType[A-Z][A-Za-z]+Ready' "${INSTRUMENTATION}" | sort -u)
-  for c in ${const_refs}; do
-    info "condition type constant ${c} — confirm doc coverage by hand"
-  done
-else
-  info "skipping D4: missing ${INSTRUMENTATION} or ${CRD_DOC}"
-fi
-
-# ---------------------------------------------------------------------------
-# D5 — RETIRED. This check cross-referenced internal CC-NNNN feature-ID markers
-# in the code against the architecture docs. Those internal IDs have been
-# removed from the repository (a repo-wide gate, scripts/check-no-feature-ids.sh,
-# now forbids them), so there are no code anchors left to cross-reference.
-# ---------------------------------------------------------------------------
-hdr "D5: code-anchor cross-reference (retired)"
-info "D5 retired: internal feature/requirement IDs were removed repo-wide, so there are no code markers to cross-reference"
-pass "D5 skipped (retired)"
-
-# ---------------------------------------------------------------------------
-# D6 — every deploy/<component> named in architecture/docs/09-implementation/
-#       exists on disk
-# ---------------------------------------------------------------------------
-hdr "D6: deploy/<component>/ references in architecture/docs/09-implementation/ exist"
-if [[ -d architecture/docs/09-implementation && -d deploy ]]; then
-  refs=$(grep -rhoE 'deploy/[a-z][a-z0-9-]+/' architecture/docs/09-implementation/ 2>/dev/null \
-    | sort -u || true)
+hdr "D3: deploy/<component>/ references in docs/ and README.md exist"
+if [[ -d docs && -d deploy ]]; then
+  refs=$(grep -rhoE --include='*.md' --exclude-dir=.vitepress 'deploy/[a-z][a-z0-9-]+/' docs/ README.md 2>/dev/null | sort -u || true)
   for ref in ${refs}; do
-    # ref is like "deploy/cert-manager/"; strip trailing slash for stat
+    # ref is like "deploy/openbao/"; strip trailing slash for the dir test
     path="${ref%/}"
     if [[ -d "${path}" ]]; then
       pass "doc reference ${ref} exists on disk"
@@ -135,10 +80,13 @@ fi
 # Inventory — spelled-out numeric claims (review aid)
 # ---------------------------------------------------------------------------
 hdr "Inventory — numeric claims in docs (review aid)"
-if [[ -d architecture/docs ]]; then
+if [[ -d docs ]]; then
   # Match common patterns like "11 sub-conditions", "8-step", "three states".
-  grep -rEn '[0-9]+[- ](sub-condition|step|reconciler|operator|condition|phase|version)' \
-    architecture/docs/ 2>/dev/null | head -20 || true
+  # Markdown sources only — .vitepress/ holds build output and cache. The
+  # leading class keeps product names like "c5c3-operator" out of the matches.
+  grep -rEn --include='*.md' --exclude-dir=.vitepress \
+    '(^|[^a-z0-9-])[0-9]+[- ](sub-condition|step|reconciler|operator|condition|phase|version)' \
+    docs/ 2>/dev/null | head -20 || true
 fi
 
 hdr "Inventory — FluxCD HelmReleases declared under deploy/"

--- a/.claude/skills/check-spdx-reuse/SKILL.md
+++ b/.claude/skills/check-spdx-reuse/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Audit SPDX / REUSE compliance across the forge source tree — every
   *.go, *.sh, hand-authored YAML, and CI workflow file should carry
   matching SPDX-FileCopyrightText and SPDX-License-Identifier headers,
-  every license referenced in a header has a corresponding text under
-  LICENSES/, and architecture/REUSE.toml stays well-formed. Use when
+  and every license referenced in a header has a corresponding text
+  under LICENSES/. Use when
   asked to check SPDX or REUSE coverage, after adding a new source
   file, or before tagging a release where SAP supply-chain audits
   require clean REUSE output.
@@ -14,10 +14,8 @@ description: >-
 # Check SPDX / REUSE coverage
 
 This skill verifies that the forge source tree stays **REUSE-compliant**:
-every file that needs a copyright/licence header has one, every header
-references a licence that ships under `LICENSES/`, and the
-`architecture/REUSE.toml` rules cover the prose corpus that lives
-without inline headers.
+every file that needs a copyright/licence header has one, and every
+header references a licence that ships under `LICENSES/`.
 
 It is repeatable — run it any time, especially after adding a new file
 type or directory, or before cutting a release.
@@ -30,8 +28,11 @@ There are two ways a file can carry a licence statement:
 | Mechanism | Where it applies | Source of truth |
 |---|---|---|
 | Inline header | Every hand-authored `*.go`, `*.sh`, `*.py`, `Dockerfile`, `Makefile`, `*.yaml` (excluding controller-gen / sqlc output and Helm chart copies) | Two adjacent comment lines: `SPDX-FileCopyrightText: …` and `SPDX-License-Identifier: …` |
-| `REUSE.toml` annotation | The `docs/` prose corpus, vendored chart copies, and a few well-known asset paths | `architecture/REUSE.toml` (top-level `[[annotations]]` blocks with `path` globs) |
 | Licence text inventory | Every licence identifier used anywhere | A matching file under `LICENSES/` (e.g. `Apache-2.0.txt`) |
+
+The `docs/` prose corpus (VitePress pages) carries no inline headers —
+frontmatter must sit on line 1, so an SPDX comment would render as body
+text — and has no REUSE enforcement.
 
 The authoritative gate is `reuse lint` from the
 [reuse-tool](https://github.com/fsfe/reuse-tool) Python package. This
@@ -59,8 +60,9 @@ inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
   `tests/` has both `SPDX-FileCopyrightText` and `SPDX-License-Identifier`
   headers in the first 5 lines. Generated files
   (`zz_generated.*.go`, `// Code generated … DO NOT EDIT.` banner)
-  are exempted from the inline check — they are expected to be
-  REUSE.toml-covered.
+  are exempted from the inline check — the generator boilerplate
+  carries its own SPDX headers, but not always within the first 5
+  lines the heuristic scans.
 - **S2** — every `*.sh` under `hack/`, `scripts/`, `tests/scripts/`,
   `tests/unit/`, `tests/lib/` has both headers.
 - **S3** — every hand-authored YAML / TOML under `deploy/`,
@@ -70,8 +72,6 @@ inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
   header has a matching `<id>.txt` under `LICENSES/`.
 - **S5** — every `<id>.txt` under `LICENSES/` is referenced by at
   least one file (no unused licence inventory).
-- **S6** — `architecture/REUSE.toml` is valid TOML (parses with
-  `python3 -c 'import tomllib; tomllib.load(open(…, "rb"))'`).
 - The **inventory** lists, per check, the number of files scanned,
   the number that passed, and the per-extension breakdown of
   failures.
@@ -84,9 +84,8 @@ For each `[FAIL]`, confirm by hand:
 
 1. The flagged file is genuinely hand-authored (not a vendored copy,
    not generated, not a binary blob).
-2. The fix is either (a) add the SPDX header inline, or (b) add a
-   matching `[[annotations]]` block to `architecture/REUSE.toml` that
-   covers the path.
+2. The fix is to add the SPDX header inline (copy the two comment
+   lines from a sibling file of the same type).
 3. For S4 failures, add the missing licence text to `LICENSES/`
    (most often by running `reuse download <SPDX-ID>` to fetch the
    canonical text).
@@ -102,7 +101,7 @@ pipx install reuse  # one-time
 reuse lint
 ```
 
-`reuse lint` is the authoritative gate — trust it over the S1–S6
+`reuse lint` is the authoritative gate — trust it over the S1–S5
 smoke checks when they disagree. It understands every comment style
 the spec recognises and walks the full file tree.
 
@@ -111,13 +110,12 @@ the spec recognises and walks the full file tree.
 Produce a concise summary grouped by severity:
 
 - **HIGH** — `reuse lint` fails; an SPDX header references a licence
-  that ships no text under `LICENSES/`; a `REUSE.toml` parse error.
-- **MEDIUM** — a hand-authored source file with no SPDX header that
-  is also not covered by `REUSE.toml`; a `LICENSES/<id>.txt` referenced
+  that ships no text under `LICENSES/`.
+- **MEDIUM** — a hand-authored source file with no SPDX header; a
+  `LICENSES/<id>.txt` referenced
   by zero files (unused licence inventory).
 - **LOW** — a header on the wrong line (S1–S3 expect first-five-lines
-  placement but the spec is more flexible); a `[[annotations]]` block
-  whose `path` glob does not match any current file (over-broad cover).
+  placement but the spec is more flexible).
 
 For each finding give one line with a `file:line` reference. End with
 a two- to three-sentence verdict per file type (Go / shell / YAML).
@@ -137,21 +135,16 @@ These recurring shapes are worth grepping for first:
    files are byte-mirrors of `config/crd/bases/`. They carry SPDX in
    comment form because `sync-crds` prepends a `#`-comment block; if
    that step is skipped, the copies fail S3.
-4. **REUSE.toml over-broad path glob.** A `[[annotations]]` block
-   uses `**` and accidentally covers a file that *should* carry its
-   own inline header. The lint silently passes; the file's
-   provenance is wrong.
-5. **Generated file picks up an inline header.** A controller-gen
-   regeneration overwrites a file that previously carried a manual
-   header. Counter-intuitively, the regeneration removes the SPDX
-   line because the generator's template does not include it. The
-   REUSE.toml exemption is what is supposed to cover it; check the
-   path glob still matches after the rename.
+4. **Generated file loses its header.** A generator's output template
+   changes and no longer emits the SPDX boilerplate. The audit
+   script's generated-file exemption hides it from S1, so only
+   `reuse lint` catches the gap — another reason to always run the
+   authoritative gate in step 3.
 
 ## Notes
 
 - This skill is read-only; the deterministic script edits nothing.
-  Apply fixes (add the header, extend REUSE.toml, fetch the licence
+  Apply fixes (add the header, fetch the licence
   text) as a separate, explicitly-scoped task.
 - The S1–S3 checks are coarse heuristics. `reuse lint` is the
   authoritative source for compliance and is what the SAP supply-chain

--- a/.claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh
+++ b/.claude/skills/check-spdx-reuse/scripts/audit-spdx-reuse.sh
@@ -12,7 +12,6 @@
 #       are exempted)
 #   S4  every SPDX-License-Identifier value has a matching LICENSES/<id>.txt
 #   S5  every LICENSES/<id>.txt is referenced by at least one file
-#   S6  architecture/REUSE.toml parses as valid TOML
 #
 # Defers full compliance to `reuse lint`. Exit code 1 on [FAIL].
 
@@ -145,24 +144,6 @@ if [[ -d LICENSES ]]; then
       info "${id} in LICENSES/ but no file references it — unused inventory"
     fi
   done
-fi
-
-# ---------------------------------------------------------------------------
-# S6 — REUSE.toml parses
-# ---------------------------------------------------------------------------
-hdr "S6: architecture/REUSE.toml parses as valid TOML"
-if [[ -f architecture/REUSE.toml ]]; then
-  if command -v python3 >/dev/null 2>&1; then
-    if python3 -c 'import tomllib,sys; tomllib.load(open("architecture/REUSE.toml","rb"))' 2>/dev/null; then
-      pass "architecture/REUSE.toml parses"
-    else
-      fail "architecture/REUSE.toml does not parse as TOML"
-    fi
-  else
-    info "python3 not on PATH — S6 skipped"
-  fi
-else
-  info "no architecture/REUSE.toml — S6 skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/prepare-new-service/SKILL.md
+++ b/.claude/skills/prepare-new-service/SKILL.md
@@ -32,7 +32,7 @@ Every service in forge threads through five layers. Keystone
 | 2. Service operator | `operators/<svc>/` (api, controller, webhook, helm chart on `operators/shared/helm/operator-library`), `go.work`, `Makefile` `OPERATORS` | **no** — module + enumerations by hand |
 | 3. CI / e2e / deploy | `ci.yaml` paths-filter + `ALL_OPERATORS` + matrices, `tests/e2e/<svc>/`, `tests/e2e/<svc>-operator/`, `tests/e2e-chaos/`, `tests/tempest/<svc>-*/`, `deploy/flux-system/releases/<svc>-operator.yaml` | chainsaw suites: **yes** (auto-discovered); ci.yaml wiring: **no** (3-step procedure in `hack/ci-resolve-changes.sh` header) |
 | 4. ControlPlane (c5c3) | `ServicesSpec` in `operators/c5c3/api/v1alpha1/controlplane_types.go`, `reconcile_<svc>.go`, condition/instrumentation maps, RBAC markers + helm `_helpers.tpl`, scheme, webhook | **no** — ~10 enumeration points |
-| 5. Documentation | `docs/reference/<svc>/` (hand-written, `quadrant: operator` frontmatter), VitePress sidebar, guides, `tests/unit/docs/` conventions; `architecture/` **submodule** (separate repo C5C3/C5C3) | **no** — no doc generator exists |
+| 5. Documentation | `docs/reference/<svc>/` (hand-written, `quadrant: operator` frontmatter), VitePress sidebar, guides, `tests/unit/docs/` conventions | **no** — no doc generator exists |
 
 ## Procedure
 
@@ -160,9 +160,6 @@ sub-issues use them as gates): [[check-crd-drift]], [[check-fixture-drift]],
 - **Operator Dockerfiles are coupled to `go.work`:** each copies every
   module's go.mod, so adding a module edits all existing operator
   Dockerfiles (until a parameterized `ARG OPERATOR` Dockerfile lands).
-- **`architecture/` is a git submodule** of a separate repo — architecture
-  chapters (esp. `docs/09-implementation/`) are planned there, not here,
-  and need `git submodule update --init architecture` to even read.
 - **Tempest matrix naming** (`hack/ci-generate-tempest-matrix.sh`) and the
   chaos CI job's image list are keystone-specific today.
 - **WSGI entry points:** `uv pip install --prefix` skips PBR

--- a/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
+++ b/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
@@ -98,9 +98,6 @@ for uc in releases/*/upper-constraints.txt; do
       "${uc}" "${pin}"
   fi
 done
-if [[ ! -f "architecture/docs/index.md" && ! -d "architecture/docs" ]]; then
-  printf '  [WARN] architecture/ submodule not initialized — architecture chapters live in a separate repo (git submodule update --init architecture)\n'
-fi
 
 printf '\nSummary: %d done, %d todo (inventory only — todo is expected for a fresh service)\n' \
   "${DONE_COUNT}" "${TODO_COUNT}"

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@
 .github
 .planwerk
 
-architecture/
 deploy/
 docs/
 hack/

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,8 @@
 # Makefile for Go Workspace
 # Manages build, test, lint, and deployment operations for operators and common modules
 #
-# DEVIATION from architecture/01-project-setup.md
-# - Architecture doc lists 9 targets; this Makefile defines 12 (adds deploy-infra,
-#   teardown-infra, install-test-deps) for completeness.
-# - generate/manifests use controller-gen to produce deepcopy functions and CRD/webhook
-#   manifests for each operator module that has an api/ directory.
+# generate/manifests use controller-gen to produce deepcopy functions and CRD/webhook
+# manifests for each operator module that has an api/ directory.
 
 # Default operators to build and test
 OPERATORS ?= keystone c5c3 horizon glance

--- a/README.md
+++ b/README.md
@@ -23,5 +23,4 @@ Chainsaw E2E).
 
 Outstanding work is tracked in [GitHub Issues](https://github.com/c5c3/forge/issues) — the issue
 tracker is the single source of truth for planned features (`CC-NNNN` labels), production-hardening
-gaps, and release milestones. See the architecture handbook under [`architecture/docs/`](architecture/docs/)
-for the design context behind individual feature IDs.
+gaps, and release milestones.

--- a/deploy/flux-system/releases/openbao.yaml
+++ b/deploy/flux-system/releases/openbao.yaml
@@ -4,7 +4,6 @@
 
 # OpenBao HelmRelease — HA 3-replica Raft cluster with TLS.
 # Deployed to openbao-system namespace, depends on cert-manager for TLS certificates.
-# See architecture/docs/09-implementation/09-openbao-deployment.md for design rationale.
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/deploy/kind/chaos-mesh/release.yaml
+++ b/deploy/kind/chaos-mesh/release.yaml
@@ -4,7 +4,6 @@
 
 # Chaos Mesh HelmRelease — fault injection platform for chaos engineering.
 # Deployed to chaos-mesh namespace, depends on cert-manager for webhook TLS certificates.
-# See architecture/docs/09-implementation/10-chaos-e2e-testing.md for design rationale.
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/docs/contributing/claude-skills.md
+++ b/docs/contributing/claude-skills.md
@@ -114,8 +114,8 @@ a companion Bash script (the deterministic part).
 
 | Skill | Audits | Use when |
 |---|---|---|
-| [`check-doc-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-drift/SKILL.md) | The forge documentation against the implementation — the `architecture/docs/` chapters vs the operator code, and the `docs/` user-facing reference vs the `deploy/` infrastructure stack. | After adding or removing a sub-reconciler, status condition, operator binary, or infrastructure component, before tagging a release. |
-| [`check-spdx-reuse`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-spdx-reuse/SKILL.md) | SPDX / REUSE compliance across the source tree — every `*.go`, `*.sh`, hand-authored YAML, and CI workflow file should carry matching `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers; every licence referenced has a corresponding text under `LICENSES/`; `architecture/REUSE.toml` stays well-formed. Defers to `reuse lint` as the authoritative gate. | After adding a new source file; before tagging a release where SAP supply-chain audits require clean REUSE output. |
+| [`check-doc-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-drift/SKILL.md) | The forge documentation against the implementation — the `docs/reference/` pages vs the operator code, and the guides and quick-starts vs the `deploy/` infrastructure stack. | After adding or removing a sub-reconciler, status condition, operator binary, or infrastructure component, before tagging a release. |
+| [`check-spdx-reuse`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-spdx-reuse/SKILL.md) | SPDX / REUSE compliance across the source tree — every `*.go`, `*.sh`, hand-authored YAML, and CI workflow file should carry matching `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers; every licence referenced has a corresponding text under `LICENSES/`. Defers to `reuse lint` as the authoritative gate. | After adding a new source file; before tagging a release where SAP supply-chain audits require clean REUSE output. |
 
 ### Planners and runbooks
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -2261,21 +2261,3 @@ bao kv metadata delete kv-v2/openstack/keystone/<name>/credential-keys
 path — the canonical KV-v2 purge and the right inverse of the now-superseded write.
 (The Fernet / credential families were previously migrated flat→per-name in an
 earlier release, and the boundary-4 change layers the namespace segment on top.)
-
-## Architecture references
-
-The `ControlPlane` reconciler and the K-ORC self-credentialing chain implement
-the following upstream architecture chapters (in the `architecture/` submodule,
-[github.com/C5C3/C5C3](https://github.com/C5C3/C5C3)). They are the authoritative
-design source for this reconciler:
-
-- `architecture/docs/09-implementation/08-c5c3-operator.md` — the c5c3-operator
-  `ControlPlane` reconciler contract and sub-reconciler ordering.
-- `architecture/docs/03-components/01-control-plane/05-korc.md` — the K-ORC
-  component, the per-resource `cloudCredentialsRef` resolution model (resolved in
-  the resource's own namespace, the basis for the C1 co-location fix), and the
-  chart constraint.
-- `architecture/docs/05-deployment/01-gitops-fluxcd/01-credential-lifecycle.md` —
-  the restricted, password-driven admin Application Credential lifecycle and the
-  operator bootstrap-seed → mint → PushSecret → operator-owned per-CR
-  ExternalSecret round-trip.

--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -555,13 +555,12 @@ bash tests/container-images/verify_horizon.sh c5c3/horizon:25.5.1
 
 ## Design Deviations
 
-The implementation deviates from the architecture document
-(`architecture/docs/08-container-images/01-build-pipeline.md`) in one area, documented
-with `# DEVIATION` comments in the affected Dockerfiles:
+The implementation deviates from the original design document in one area,
+documented with `# DEVIATION` comments in the affected Dockerfiles:
 
 **Generic `openstack` user instead of per-service users:**
 
-The architecture document's Keystone Dockerfile example creates a per-service user
+The original design's Keystone Dockerfile example creates a per-service user
 (e.g., `groupadd keystone` / `useradd keystone`). The implementation uses a single
 generic `openstack` user (UID/GID 42424) defined in `python-base` and shared by all
 service images. This reduces complexity and image layers — each service image inherits

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -396,9 +396,7 @@ whether from a Raft peer, the in-pod bootstrap script, or
 `ClusterSecretStore/openbao-cluster-store` — must present a client certificate
 that chains to the same self-signed CA bundle as the server cert; the
 Kubernetes-token auth method (`auth.kubernetes`) is unchanged and runs
-*after* the transport-layer admission gate. See
-`architecture/docs/09-implementation/09-openbao-deployment.md` for design
-rationale.
+*after* the transport-layer admission gate.
 
 **Helm values:**
 
@@ -536,8 +534,7 @@ the catalog and rotate the admin credential, but K-ORC is the separate Flux
 is a hard dependency the manager requires at startup rather than tolerating). The
 operator child CRs are created
 in the `ControlPlane`'s own namespace, not a hard-coded one. For the reconciliation
-contract see the upstream design chapter
-`architecture/docs/09-implementation/08-c5c3-operator.md`.
+contract see the [`ControlPlane` reconciler reference](../c5c3/controlplane-reconciler.md).
 
 **Helm values:**
 
@@ -1058,23 +1055,7 @@ which provisions secrets from an external vault into the cluster.
 
 The Memcached Operator chart is sourced from the shared `c5c3-charts` OCI registry
 rather than a dedicated HelmRepository. This follows the project convention of publishing
-internally-built charts to `oci://ghcr.io/c5c3/charts` (see
-`architecture/docs/09-implementation/07-ci-cd-and-packaging.md`).
-
-### c5c3-operator and K-ORC design source
-
-The upstream design for the c5c3-operator, K-ORC, and the admin-credential lifecycle
-documented above lives in the `architecture/` git submodule:
-
-- `architecture/docs/09-implementation/08-c5c3-operator.md` — the c5c3-operator `ControlPlane` reconciler contract
-- `architecture/docs/03-components/01-control-plane/05-korc.md` — the K-ORC component and chart constraint
-- `architecture/docs/05-deployment/01-gitops-fluxcd/01-credential-lifecycle.md` — the restricted admin Application Credential lifecycle
-
-These chapters are the authoritative design source. They are **updated upstream only**
-and reach this repository through a submodule pointer bump — they are **not** edited from
-this repository or worktree. Treat any divergence between these chapters and
-the manifests above as a drift to reconcile at the source, not by editing the submodule
-in place.
+internally-built charts to `oci://ghcr.io/c5c3/charts`.
 
 ## Kind Overlay Demo Addons
 

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -179,7 +179,7 @@ Groups the pod-level knobs for the Keystone API Deployment under `spec.deploymen
 | `resources` | [`*corev1.ResourceRequirements`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) | No | See below | CPU and memory requests and limits for the Keystone API container. When unset, the defaulting webhook injects sensible defaults to ensure Burstable QoS class and enable HPA utilization calculations. |
 | `topologySpreadConstraints` | [`[]corev1.TopologySpreadConstraint`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) | No | See [below](#topologyspreadconstraints) | Scheduler hints for spreading pods across zones and nodes. `nil` injects two defaults (zone + hostname, MaxSkew=1, `ScheduleAnyway`); a non-nil value (including `[]`) is used verbatim. |
 | `priorityClassName` | `*string` | No | `nil` | PriorityClass attached to the Keystone API pod spec. When set, the webhook verifies the class exists; when unset, no priority class is configured. |
-| `terminationGracePeriodSeconds` | `*int64` | No | `nil` | Grace period (seconds) granted to Keystone API pods between SIGTERM and SIGKILL during rolling updates. When `nil`, the reconciler applies `30` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `10`. Must be strictly greater than `preStopSleepSeconds`. Drives the PodSpec `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields) and the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
+| `terminationGracePeriodSeconds` | `*int64` | No | `nil` | Grace period (seconds) granted to Keystone API pods between SIGTERM and SIGKILL during rolling updates. When `nil`, the reconciler applies `30` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `10`. Must be strictly greater than `preStopSleepSeconds`. Drives the PodSpec `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields). |
 | `preStopSleepSeconds` | `*int64` | No | `nil` | Sleep duration (seconds) of the preStop lifecycle hook, covering the window between EndpointSlice removal and kube-proxy/ingress propagation. When `nil`, the reconciler applies `5` (the CRD schema emits no `default:` so pre-existing CRs are not mutated on operator upgrade). Minimum: `0`. Must be strictly less than `terminationGracePeriodSeconds`. See [Graceful-termination fields](#graceful-termination-fields). |
 | `strategy` | [`*appsv1.DeploymentStrategy`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) | No | `RollingUpdate(maxSurge=1, maxUnavailable=0)` | Overrides the Deployment rollout strategy. When `nil`, the reconciler injects `RollingUpdate` with `maxUnavailable=0` and `maxSurge=1` so available capacity never drops below `spec.deployment.replicas` during an image-tag patch. Set to customize surge/unavailable counts or switch to `Recreate`. |
 
@@ -316,8 +316,8 @@ from the spec.
 | `processes` | `int32` | No | `2` | Number of uWSGI worker processes. Minimum: 1. Maps to `--processes` in the container command. |
 | `threads` | `int32` | No | `1` | Number of threads per uWSGI worker process. Minimum: 1. Maps to `--threads` in the container command. |
 | `httpKeepAlive` | `*bool` | No | `true` | Enables the `--http-keepalive` flag on the uWSGI process. When `false`, the flag is omitted. A nil-preserving pointer: unset means the documented default (`true`) is restored by the webhook. See [HTTPKeepAlive defaulting](#httpkeepalive-defaulting). |
-| `harakiri` | `*int32` | No | `nil` (flag omitted) | Caps the per-request worker lifetime (seconds) via `--harakiri`. Minimum: `1`. The webhook additionally enforces `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` so the worst-case per-request kill fits inside the shutdown drain window. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
-| `httpKeepAliveTimeout` | `*int32` | No | `nil` (flag omitted) | Idle timeout (seconds) for keep-alive connections via `--http-keepalive-timeout`. Minimum: `1`. Emitted only when `httpKeepAlive=true` (the webhook rejects a non-nil timeout combined with `httpKeepAlive=false`). Recommended to set `≤ preStopSleepSeconds` so idle sockets close before SIGTERM reaches uWSGI. See the HA rollout sequence in `architecture/docs/04-architecture/04-high-availability.md`. |
+| `harakiri` | `*int32` | No | `nil` (flag omitted) | Caps the per-request worker lifetime (seconds) via `--harakiri`. Minimum: `1`. The webhook additionally enforces `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds` so the worst-case per-request kill fits inside the shutdown drain window. See [Graceful-termination fields](#graceful-termination-fields). |
+| `httpKeepAliveTimeout` | `*int32` | No | `nil` (flag omitted) | Idle timeout (seconds) for keep-alive connections via `--http-keepalive-timeout`. Minimum: `1`. Emitted only when `httpKeepAlive=true` (the webhook rejects a non-nil timeout combined with `httpKeepAlive=false`). Recommended to set `≤ preStopSleepSeconds` so idle sockets close before SIGTERM reaches uWSGI. See [Graceful-termination fields](#graceful-termination-fields). |
 
 ### Deployment Command Mapping
 
@@ -387,10 +387,6 @@ updates — `spec.deployment.terminationGracePeriodSeconds`, `spec.deployment.pr
 Each field is listed in its owning section (top-level `KeystoneSpec` or
 `UWSGISpec`); this section consolidates their semantics, interaction rules,
 and defaulting behavior.
-
-For the rollout sequence diagram and tunable-selection guidance, see
-`architecture/docs/04-architecture/04-high-availability.md` (section
-"Keystone Rolling Update").
 
 ### Field Summary
 

--- a/images/glance/Dockerfile
+++ b/images/glance/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target
 # hadolint ignore=DL3006
 FROM python-base
 
-# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:
+# DEVIATION from the original build-pipeline design:
 # Uses the generic 'openstack' user (UID/GID 42424) from python-base instead
 # of a per-service user. See python-base/Dockerfile for rationale.
 

--- a/images/horizon/Dockerfile
+++ b/images/horizon/Dockerfile
@@ -62,7 +62,7 @@ RUN SITE_PKG="$(/var/lib/openstack/bin/python -c 'import os, openstack_dashboard
 # hadolint ignore=DL3006
 FROM python-base
 
-# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:
+# DEVIATION from the original build-pipeline design:
 # Uses the generic 'openstack' user (UID/GID 42424) from python-base instead
 # of a per-service user. See python-base/Dockerfile for rationale.
 

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -38,7 +38,7 @@ application = initialize_public_application()\n' \
 # hadolint ignore=DL3006
 FROM python-base
 
-# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:
+# DEVIATION from the original build-pipeline design:
 # Uses the generic 'openstack' user (UID/GID 42424) from python-base instead
 # of a per-service user. See python-base/Dockerfile for rationale.
 

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -32,8 +32,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-# DEVIATION from architecture/docs/08-container-images/01-build-pipeline.md:
-# The architecture doc's Keystone Dockerfile example creates a per-service user
+# DEVIATION from the original build-pipeline design:
+# The original design's Keystone Dockerfile example creates a per-service user
 # (e.g., groupadd keystone / useradd keystone). We use a generic 'openstack'
 # user/group (UID/GID 42424) shared by all service images to reduce complexity
 # and image layers. Each service image inherits this user via USER openstack.

--- a/operators/c5c3/main.go
+++ b/operators/c5c3/main.go
@@ -4,7 +4,7 @@
 
 // Package main is the entrypoint for the C5C3 operator.
 //
-// DEVIATION from architecture/01-project-setup.md
+// DEVIATION from the original project-setup design:
 // Hand-crafted instead of `operator-sdk init` — the SDK scaffolds config/,
 // internal/controller/, Dockerfile, and a per-module Makefile that would be
 // immediately deleted for this minimal scaffolding phase. The manager setup

--- a/operators/keystone/main.go
+++ b/operators/keystone/main.go
@@ -4,7 +4,7 @@
 
 // Package main is the entrypoint for the Keystone operator.
 //
-// DEVIATION from architecture/01-project-setup.md
+// DEVIATION from the original project-setup design:
 // Hand-crafted instead of `operator-sdk init` — the SDK scaffolds config/,
 // internal/controller/, Dockerfile, and a per-module Makefile that would be
 // immediately deleted for this minimal scaffolding phase. The manager setup

--- a/scripts/check-no-feature-ids.sh
+++ b/scripts/check-no-feature-ids.sh
@@ -19,10 +19,7 @@
 #
 # Scope is git-tracked files (git ls-files). This automatically excludes
 # git-ignored build output (node_modules/, bin/, docs/.vitepress/{dist,cache}/,
-# coverage *.out) and the architecture/ submodule, which git lists as a single
-# gitlink entry rather than its contents — that directory is the upstream
-# C5C3/C5C3 repository and is read-only from this worktree, so any IDs there are
-# fixed upstream and pulled in via a submodule bump.
+# coverage *.out).
 #
 # Additional excludes:
 #   - .planwerk/  internal planning/review tool records keyed by the IDs (the

--- a/scripts/check-no-review-markers.sh
+++ b/scripts/check-no-review-markers.sh
@@ -24,8 +24,7 @@
 #
 # Scope is git-tracked files (git ls-files). This automatically excludes
 # git-ignored build output (node_modules/, bin/, docs/.vitepress/{dist,cache}/,
-# coverage *.out) and the architecture/ submodule, which git lists as a single
-# gitlink entry rather than its contents.
+# coverage *.out).
 #
 # Additional excludes:
 #   - .planwerk/  internal planning/review tool records; they quote the

--- a/scripts/grep-keystone-api-residue.sh
+++ b/scripts/grep-keystone-api-residue.sh
@@ -28,11 +28,6 @@
 # scan misses stale doc tables that contradict the current naming convention;
 # this scanner catches both.
 #
-# Architecture docs (`architecture/`) are intentionally excluded from the scan:
-# that directory is a git submodule pointing at the upstream C5C3 repository
-# and is read-only from this worktree. Stale references inside `architecture/`
-# must be fixed upstream and pulled in via a submodule SHA bump.
-#
 # This script itself is excluded from BOTH scans because its description
 # mentions the literal and templated forms verbatim and would otherwise
 # self-trip if `scripts/` is ever added to the search roots.
@@ -59,8 +54,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
-# Search roots, minus the `architecture/` submodule (see header comment for
-# rationale).
 SEARCH_ROOTS=(
   "operators"
   "tests"
@@ -74,7 +67,6 @@ SEARCH_ROOTS=(
 # instead of treating it as opaque. Adding a new top-level directory without
 # also adding it to SEARCH_ROOTS or here causes the script to exit 2.
 EXCLUDED_ROOTS=(
-  "architecture"  # git submodule; residue must be fixed upstream
   "internal"      # shared Go libs; verified clean of `keystone-api`
   "scripts"       # contains this script, which references the patterns by design
   "releases"      # generated install manifests; sourced from operators/ which is scanned


### PR DESCRIPTION
## Summary

The `architecture/` submodule (the upstream C5C3/C5C3 repository) was removed in 6679a98a, but the Claude skills, the docs, several gate scripts, and a handful of comments kept pointing at it. This PR removes every remaining reference; `operators/c5c3` (the ControlPlane operator) is unrelated and untouched.

- **`.claude/skills/`** — `check-doc-drift` is reworked to audit `docs/reference/` instead of the removed architecture chapters: the heading-to-function and deploy-reference checks are retargeted, condition-doc coverage is delegated to `check-condition-coverage`, and the `.vitepress/` build output is excluded from the greps. `check-spdx-reuse` drops the `architecture/REUSE.toml` check (S6), `check-condition-coverage` and `prepare-new-service` lose their submodule special cases.
- **`docs/`** — the architecture cross-references are removed from the reference pages (`controlplane-reconciler.md` "Architecture references" section, `infrastructure-manifests.md` design-source section, `keystone-crd.md` HA-rollout pointers, `container-images.md`), the contributing skill catalog, and the README roadmap.
- **Comments** — the `# DEVIATION` headers in the service Dockerfiles and the operator `main.go` files are reworded (the `verify_deviation_comments.sh` contract — `# DEVIATION` + `openstack` — is preserved), and the design-rationale pointers are dropped from the OpenBao and Chaos Mesh HelmReleases.
- **`scripts/`** — the submodule exclusions and rationale comments are removed from `check-no-feature-ids.sh`, `check-no-review-markers.sh`, and `grep-keystone-api-residue.sh`.
- **Housekeeping** — the empty leftover `.gitmodules` and the dead `.dockerignore` entry are deleted.

`check-doc-drift` also fixes a pre-existing false positive: operator modules are now discovered via their `go.mod`, so `operators/shared/` (the helm library) no longer counts as an operator binary.

## Verification

- `audit-doc-drift.sh` runs green end-to-end (it previously hard-failed on the missing architecture doc); all 27 `### reconcile…` headings under `docs/reference/` resolve to real Go functions.
- `verify_deviation_comments.sh` passes 8/8; the feature-ids and review-markers gates pass.
- `audit-condition-coverage.sh` and `audit-spdx-reuse.sh` report only pre-existing findings (verified identical against `main`), e.g. `GlanceReady` undocumented in `docs/reference/c5c3/` and the webhook `manifests.yaml` files without SPDX headers.
- A repo-wide grep finds no remaining `architecture/` or `C5C3/C5C3` references (the `sig-architecture` URLs in generated CRDs are upstream Kubernetes links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YAhbqosZg7FFNMYRm8MeZ