### PR TITLE
feat(c5c3): issue dynamic Glance DB credentials from the OpenBao database engine

### DIFF
--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -132,6 +132,32 @@ main() {
     token_max_ttl=72h
   log "keystone-db role written."
 
+  # glance-db role on the management cluster's Kubernetes auth mount — the Glance
+  # analogue of the keystone-db role above, and fully keystone-independent. The
+  # c5c3 operator's per-ControlPlane VaultDynamicSecret generator authenticates
+  # with the "glance-db-creds" ServiceAccount to read short-lived DB credentials
+  # at database/mariadb/creds/glance-<namespace>.
+  # bound_service_account_namespaces="*" lets any ControlPlane namespace
+  # authenticate; the fixed SA name is what tells this role apart from keystone-db
+  # (a glance-db-creds token can never read a keystone creds path), and the
+  # cross-tenant boundary is enforced by the glance-db-dynamic policy, which
+  # templates the readable creds path to the caller's OWN service_account_namespace
+  # (an exact match).
+  #
+  # Token TTLs are pinned to DB_CREDS_MAX_TTL (72h, setup-database-tenant.sh) for
+  # the same reason spelled out on the keystone-db role above: OpenBao revokes a
+  # dynamic-secret lease together with the token that minted it, so the token must
+  # outlive the lease or the issued DB credential dies early under a running
+  # Glance.
+  log "Writing glance-db role on kubernetes/management..."
+  bao_exec bao write "auth/kubernetes/management/role/glance-db" \
+    bound_service_account_names=glance-db-creds \
+    bound_service_account_namespaces="*" \
+    token_policies=glance-db-dynamic \
+    token_ttl=72h \
+    token_max_ttl=72h
+  log "glance-db role written."
+
   # eso-tenant role on the management cluster's Kubernetes auth mount. This is
   # the per-ControlPlane ESO identity a namespaced SecretStore authenticates
   # with (created per tenant by setup-eso-tenant.sh with the "eso-tenant-auth"

--- a/deploy/openbao/bootstrap/setup-database-tenant.sh
+++ b/deploy/openbao/bootstrap/setup-database-tenant.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # setup-database-tenant.sh — Provision the per-tenant MariaDB database-engine
-# connection and role for one MANAGED ControlPlane's Keystone service DB user.
+# connection and role for one MANAGED ControlPlane's per-service DB users
+# (Keystone always; Glance when it shares the managed database).
 #
 # MODE: this is a managed-database onboarding step. An External-mode ControlPlane
 # (spec.services.keystone.mode: External) has NO managed database — the c5c3
@@ -17,13 +18,21 @@
 # mounted at database/mariadb during bootstrap, but per-tenant connection and
 # role configuration cannot happen there: the managed MariaDB instances do not
 # exist at bootstrap time. This script is therefore run once per ControlPlane,
-# after its MariaDB is Ready, to configure:
+# after its MariaDB is Ready, to configure — per service (see
+# provision_service_tenant) — one connection+role pair:
 #
-#   - database/mariadb/config/keystone-<keystone-namespace>
-#       the connection to the ControlPlane's MariaDB, authenticated as root.
-#   - database/mariadb/roles/keystone-<keystone-namespace>
+#   - database/mariadb/config/<service>-<service-namespace>
+#       the connection to the service's MariaDB, authenticated as root.
+#   - database/mariadb/roles/<service>-<service-namespace>
 #       a role that issues short-lived MySQL users with ALL PRIVILEGES on the
-#       Keystone database and auto-revokes them at lease end.
+#       service database and auto-revokes them at lease end.
+#
+# It ALWAYS provisions the Keystone pair. It also provisions a Glance pair when
+# the ControlPlane declares spec.services.glance on the SHARED managed database;
+# a Glance that declares a dedicated database
+# (spec.services.glance.dedicatedBackingServices.database) is Static-only and is
+# skipped here. Each service's pair is keyed and root-resolved independently in
+# ITS OWN service namespace, so Glance's engine plumbing is keystone-independent.
 #
 # The role is keyed on the KEYSTONE SERVICE NAMESPACE alone — the namespace the
 # MariaDB lives in and the generator's ServiceAccount authenticates from. That is
@@ -108,50 +117,30 @@ get_controlplane_field() {
 }
 
 ###############################################################################
-# Main
+# provision_service_tenant <service> <svc_ns> <mariadb_name> <database_name>
 ###############################################################################
-main() {
-  log "=== Provisioning MariaDB database-engine tenant '${CP_NS}/${CP_NAME}' ==="
-  log "Namespace : ${NAMESPACE}"
-  log "BAO_ADDR  : ${BAO_ADDR}"
+# Write the database-engine connection+role pair for one service tenant:
+#   database/mariadb/config/<service>-<svc_ns>
+#   database/mariadb/roles/<service>-<svc_ns>
+# resolving the MariaDB root credential from the <mariadb_name> CR in <svc_ns>
+# and issuing short-lived users with ALL PRIVILEGES on <database_name>. Fails
+# loudly if that namespace's MariaDB root Secret is missing.
+provision_service_tenant() {
+  local service="$1"
+  local svc_ns="$2"
+  local mariadb_name="$3"
+  local database_name="$4"
 
-  # Fail loudly if the ControlPlane CR cannot be read. get_controlplane_field
-  # below falls back to the projection defaults (openstack-db / keystone) on an
-  # empty result, which is correct for a genuinely-unset field but would silently
-  # mask a missing CR or an unreachable cluster — the script would then provision
-  # a database-engine tenant against those defaults for a ControlPlane that does
-  # not exist. Verifying existence up front keeps the empty-vs-absent fallback
-  # unambiguous.
-  if ! kubectl get controlplane "${CP_NAME}" -n "${CP_NS}" >/dev/null 2>&1; then
-    log "ERROR: ControlPlane '${CP_NAME}' not found in namespace '${CP_NS}' (or the cluster is unreachable)."
-    exit 1
-  fi
-
-  # Resolve the KEYSTONE SERVICE NAMESPACE: the namespace the MariaDB, the
-  # credential generator, and its ServiceAccount all live in. It defaults to the
-  # ControlPlane's own namespace, and is spec.services.keystone.namespace.name
-  # when the Keystone service is placed in a namespace of its own.
-  local svc_ns
-  svc_ns="$(get_controlplane_field '{.spec.services.keystone.namespace.name}' "${CP_NS}")"
-
-  # Keyed on the Keystone service namespace alone (see header): unique +
-  # collision-free, and matched exactly by the keystone-db-dynamic templated
-  # policy, whose ACL template resolves to the caller's own namespace — the
-  # generator's ServiceAccount in exactly this namespace.
-  local role_name="keystone-${svc_ns}"
+  # Keyed on the service namespace alone (see header): unique + collision-free,
+  # and matched exactly by the <service>-db-dynamic templated policy, whose ACL
+  # template resolves to the caller's own namespace — the generator's
+  # ServiceAccount in exactly this namespace.
+  local role_name="${service}-${svc_ns}"
   local config_name="${role_name}"
 
+  log "Service   : ${service}"
   log "Service NS: ${svc_ns}"
   log "Role      : database/mariadb/roles/${role_name}"
-
-  # Resolve the MariaDB cluster name and Keystone database name from the live
-  # ControlPlane spec. Defaults mirror the c5c3 operator's projection defaults
-  # (openstack-db / keystone) so a ControlPlane that leaves them unset resolves
-  # to the same values the operator projects.
-  local mariadb_name database_name
-  mariadb_name="$(get_controlplane_field '{.spec.infrastructure.database.clusterRef.name}' 'openstack-db')"
-  database_name="$(get_controlplane_field '{.spec.infrastructure.database.database}' 'keystone')"
-
   log "MariaDB   : ${mariadb_name}.${svc_ns}.svc:3306"
   log "Database  : ${database_name}"
 
@@ -198,7 +187,7 @@ main() {
   log "Connection config written."
 
   # Write the role. creation_statements creates a short-lived MySQL user with
-  # ALL PRIVILEGES on the Keystone database; revocation_statements drops it at
+  # ALL PRIVILEGES on the service database; revocation_statements drops it at
   # lease end. The database identifier is backtick-quoted (escaped \` for the
   # bash double-quoted string) so a hyphenated database name is valid MySQL.
   local creation_stmt revocation_stmt
@@ -213,6 +202,71 @@ main() {
     default_ttl="${DB_CREDS_DEFAULT_TTL}" \
     max_ttl="${DB_CREDS_MAX_TTL}"
   log "Role written."
+}
+
+###############################################################################
+# Main
+###############################################################################
+main() {
+  log "=== Provisioning MariaDB database-engine tenant '${CP_NS}/${CP_NAME}' ==="
+  log "Namespace : ${NAMESPACE}"
+  log "BAO_ADDR  : ${BAO_ADDR}"
+
+  # Fail loudly if the ControlPlane CR cannot be read. get_controlplane_field
+  # below falls back to the projection defaults (openstack-db / keystone) on an
+  # empty result, which is correct for a genuinely-unset field but would silently
+  # mask a missing CR or an unreachable cluster — the script would then provision
+  # a database-engine tenant against those defaults for a ControlPlane that does
+  # not exist. Verifying existence up front keeps the empty-vs-absent fallback
+  # unambiguous.
+  if ! kubectl get controlplane "${CP_NAME}" -n "${CP_NS}" >/dev/null 2>&1; then
+    log "ERROR: ControlPlane '${CP_NAME}' not found in namespace '${CP_NS}' (or the cluster is unreachable)."
+    exit 1
+  fi
+
+  # --- Keystone (always) ------------------------------------------------------
+  # Resolve the KEYSTONE SERVICE NAMESPACE: the namespace the MariaDB, the
+  # credential generator, and its ServiceAccount all live in. It defaults to the
+  # ControlPlane's own namespace, and is spec.services.keystone.namespace.name
+  # when the Keystone service is placed in a namespace of its own. The MariaDB
+  # cluster name and Keystone database name resolve from the live ControlPlane
+  # spec; defaults mirror the c5c3 operator's projection defaults (openstack-db /
+  # keystone) so a ControlPlane that leaves them unset resolves to the same values
+  # the operator projects. The role name derivation MUST stay in sync with
+  # dbDynamicRoleFor in operators/c5c3/internal/controller/reconcile_dbcredentials.go.
+  local keystone_ns keystone_mariadb keystone_db
+  keystone_ns="$(get_controlplane_field '{.spec.services.keystone.namespace.name}' "${CP_NS}")"
+  keystone_mariadb="$(get_controlplane_field '{.spec.infrastructure.database.clusterRef.name}' 'openstack-db')"
+  keystone_db="$(get_controlplane_field '{.spec.infrastructure.database.database}' 'keystone')"
+  provision_service_tenant keystone "${keystone_ns}" "${keystone_mariadb}" "${keystone_db}"
+
+  # --- Glance (only on the shared managed database) ---------------------------
+  # Glance gets its OWN keystone-independent engine pair when the ControlPlane
+  # declares spec.services.glance. A Glance that declares a dedicated database
+  # (spec.services.glance.dedicatedBackingServices.database) is Static-only —
+  # there is no engine role for a dedicated glance DB — so it is skipped.
+  #
+  # MUST STAY IN SYNC: the glance-<namespace> role name below is the derivation
+  # glanceDBDynamicRoleFor asserts in
+  # operators/c5c3/internal/controller/reconcile_glance_dbcredentials.go, and the
+  # fixed 'glance' database name mirrors defaultGlanceDatabaseName in
+  # operators/c5c3/internal/controller/reconcile_glance.go.
+  if [[ -n "$(get_controlplane_field '{.spec.services.glance}' '')" ]]; then
+    if [[ -n "$(get_controlplane_field '{.spec.services.glance.dedicatedBackingServices.database}' '')" ]]; then
+      log "ControlPlane declares a dedicated glance database (Static-only) — skipping the glance database-engine tenant."
+    else
+      # The glance service namespace defaults to the ControlPlane's own namespace
+      # and is spec.services.glance.namespace.name when Glance is placed in a
+      # namespace of its own; its MariaDB is the shared managed cluster resolved
+      # in THAT namespace, and its database name is the fixed 'glance' schema.
+      local glance_ns glance_mariadb
+      glance_ns="$(get_controlplane_field '{.spec.services.glance.namespace.name}' "${CP_NS}")"
+      glance_mariadb="$(get_controlplane_field '{.spec.infrastructure.database.clusterRef.name}' 'openstack-db')"
+      provision_service_tenant glance "${glance_ns}" "${glance_mariadb}" "glance"
+    fi
+  else
+    log "ControlPlane declares no spec.services.glance — skipping the glance database-engine tenant."
+  fi
 
   log "=== Done ==="
 }

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -258,27 +258,14 @@ main() {
     # mark_eso_managed.
     mark_eso_managed "${admin_path}"
 
-    # Per-ControlPlane, namespace-scoped STATIC KV source read by the
-    # OPERATOR-PROJECTED glance DB-credential ExternalSecret
-    # ({cp}-glance-db-credentials, c5c3-operator reconcileGlance) in
-    # ControlPlane deployments. The glance DB credential is always Static
-    # because no OpenBao database-engine role exists for the glance schema
-    # (the dynamic engine role is keystone-schema-scoped).
-    #
-    # The path segment is the GLANCE service namespace: this loop seeds it as
-    # ${cp_ns} (the ControlPlane's namespace, the co-located default). A
-    # ControlPlane that places Glance in a DEDICATED namespace needs a manual
-    # seed under that namespace instead — the same caveat as the
-    # Keystone-namespace admin path segment above.
-    #
-    # The username value is a gate-satisfying placeholder: in managed-Static
-    # mode the glance-operator derives the MySQL username from the Glance CR
-    # name (internal/common/database ResolveUsername), so only the password
-    # property is load-bearing. No PushSecret targets this path, so no
-    # mark_eso_managed is needed.
-    write_secret_if_missing "kv-v2/openstack/glance/${cp_ns}/${cp_name}/db" \
-      "username=glance" \
-      "password=${GENERATED_PASSWORD}"
+    # The per-ControlPlane STATIC glance DB credential seed
+    # (kv-v2/openstack/glance/{ns}/{cp}/db) is RETIRED here: managed-mode Glance
+    # now draws short-lived, engine-issued DB credentials from the OpenBao
+    # database engine (database/mariadb/creds/glance-{ns}, provisioned by
+    # setup-database-tenant.sh), so no long-lived static DB password is seeded at
+    # rest. A ControlPlane that explicitly opts back into credentialsMode: Static
+    # must have its KV path (kv-v2/openstack/glance/{glance-ns}/{cp}/db) seeded
+    # manually (see docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md).
 
     # The stage-(a) per-ControlPlane STATIC DB credential seed
     # (kv-v2/openstack/keystone/{ns}/{cp}/db) is RETIRED here (#439): managed-mode

--- a/deploy/openbao/policies/glance-db-dynamic.hcl
+++ b/deploy/openbao/policies/glance-db-dynamic.hcl
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# glance-db-dynamic policy — grants read on the per-tenant dynamic MariaDB
+# database-engine credentials path for the Glance service DB user. Bound to the
+# "glance-db" role on the kubernetes/management auth mount (see setup-auth.sh),
+# which the c5c3 operator's per-ControlPlane VaultDynamicSecret generator uses to
+# issue short-lived Glance service-DB users at database/mariadb/creds/glance-<namespace>.
+#
+# TENANT ISOLATION: the read path is scoped by OpenBao ACL identity templating to
+# the caller's OWN service-account namespace — {{...service_account_namespace}}
+# resolves, at request time, to the namespace of the glance-db-creds SA token
+# that authenticated. Per-tenant roles are named glance-<namespace> (one
+# ControlPlane per namespace, so the namespace is a unique, collision-free tenant
+# key), so this is an EXACT match with no wildcard: a token minted in namespace A
+# can read only database/mariadb/creds/glance-A and cannot read another tenant's
+# glance-B path. The glance-db role deliberately keeps
+# bound_service_account_namespaces="*" (any ControlPlane namespace may
+# authenticate); it is this templated policy — not the role binding — that
+# enforces the cross-tenant boundary (the client cert only gates transport).
+#
+# SERVICE ISOLATION: this policy and its glance-db role are entirely separate
+# from the keystone-db pair. Both roles bind bound_service_account_namespaces="*"
+# and are told apart by the ServiceAccount NAME the token carries —
+# glance-db-creds here versus keystone-db-creds for keystone-db-dynamic — so a
+# Glance credential generator can never read a Keystone creds path (or vice
+# versa), even for two services co-located in one namespace.
+#
+# The KUBERNETES_MANAGEMENT_ACCESSOR placeholder is substituted with the live
+# kubernetes/management auth-mount accessor at apply time by setup-policies.sh —
+# the accessor is generated when the mount is enabled (setup-auth.sh, run first)
+# and is not known until runtime.
+#
+# READ-ONLY by design: a dynamic secrets engine has no long-lived static
+# password to push back, so there is no write/push grant here.
+path "database/mariadb/creds/glance-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}" {
+  capabilities = ["read"]
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
               { text: 'Attach S3 Multi-Store Backends to Glance', link: '/guides/glance/glance-s3-multistore' },
               { text: 'Enable Glance Operator Metrics', link: '/guides/glance/enable-glance-operator-metrics' },
               { text: 'Enable Glance Operator NetworkPolicy', link: '/guides/glance/enable-glance-operator-networkpolicy' },
+              { text: 'Migrate Glance DB to Dynamic Credentials', link: '/guides/glance/migrate-glance-db-to-dynamic-credentials' },
             ],
           },
         ],

--- a/docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md
+++ b/docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md
@@ -1,0 +1,252 @@
+---
+title: Migrate Glance DB to Dynamic Credentials
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Migrate Glance DB to Dynamic Credentials
+
+This guide takes a managed-mode ControlPlane from a long-lived **static** Glance
+database credential to **dynamic**, engine-issued credentials, without database
+downtime. It is the operator-facing side of the OpenBao MariaDB database secrets
+engine wired for the Glance service DB user.
+
+## What changes
+
+- **Before:** the Glance DB password is a long-lived value materialised from an
+  OpenBao KV path (`openstack/glance/{namespace}/{name}/db`) into the
+  `{name}-glance-db-credentials` Secret. It is only rotated when an operator
+  rotates it.
+- **After:** the c5c3 operator projects a per-ControlPlane
+  [`VaultDynamicSecret`](https://external-secrets.io/) generator that reads
+  short-lived credentials from the OpenBao database engine
+  (`database/mariadb/creds/glance-{namespace}`, where `{namespace}` is the Glance
+  service namespace — the ControlPlane's own namespace unless Glance runs in a
+  dedicated one). The External Secrets Operator re-issues a fresh lease before
+  the previous one expires and materialises the current username and password
+  into the same Secret. No long-lived static DB password remains at rest.
+
+The engine issues an ephemeral MySQL user per lease (for example `v-kube-...`)
+with `ALL PRIVILEGES` on the Glance database and drops it at lease end.
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step. On this devstack the
+ControlPlane is `controlplane` in `openstack`, so its projected Glance is
+`controlplane-glance` and its DB-credential Secret is
+`controlplane-glance-db-credentials` — the names the migration below manages.
+:::
+
+- The OpenBao `database` secrets engine is mounted at `database/mariadb` (the
+  `setup-secret-engines.sh` bootstrap step). On a greenfield cluster this is
+  already in place; on a brownfield cluster, re-apply the bootstrap scripts (see
+  below).
+- cert-manager and its `openbao-ca-issuer` ClusterIssuer are installed (they
+  issue the per-ControlPlane mTLS client certificate the generator presents to
+  the OpenBao listener).
+- The External Secrets Operator can request ServiceAccount tokens
+  (`serviceaccounts/token` `create`) so the generator can authenticate to OpenBao
+  as the per-ControlPlane `glance-db-creds` ServiceAccount.
+
+## Migration steps
+
+### 1. Re-apply the OpenBao bootstrap on brownfield clusters
+
+The database engine mount, the `glance-db` Kubernetes-auth role, and the
+`glance-db-dynamic` policy are added by the (idempotent) bootstrap scripts.
+Re-apply them so a cluster provisioned before this change picks them up:
+
+```bash
+# From the repo root, with BAO_TOKEN exported (the OpenBao root token).
+bash deploy/openbao/bootstrap/setup-secret-engines.sh
+bash deploy/openbao/bootstrap/setup-auth.sh
+bash deploy/openbao/bootstrap/setup-policies.sh
+```
+
+`make deploy-infra` runs these for you on a fresh kind cluster.
+
+### 2. Onboard the per-tenant database-engine role
+
+The engine role for a tenant only exists once its MariaDB is Ready and
+`setup-database-tenant.sh` has configured the connection and role against it:
+
+```bash
+# BAO_TOKEN must be exported; <namespace>/<controlplane> identify the tenant.
+bash deploy/openbao/bootstrap/setup-database-tenant.sh <namespace> <controlplane>
+```
+
+When the ControlPlane declares `spec.services.glance` on the shared managed
+database, the script provisions the Glance leg:
+
+- `database/mariadb/config/glance-<glance-namespace>` — the connection to the
+  tenant's MariaDB, authenticated as root.
+- `database/mariadb/roles/glance-<glance-namespace>` — the role that issues
+  short-lived users (`default_ttl` 48h, `max_ttl` 72h by default; override with
+  `DB_CREDS_DEFAULT_TTL` / `DB_CREDS_MAX_TTL`).
+
+When Glance lives in a dedicated service namespace, that namespace's MariaDB must
+be Ready first — the script resolves that namespace's root secret and fails
+loudly otherwise. A ControlPlane whose Glance declares a *dedicated* database is
+skipped: a dedicated Glance database is Static-only.
+
+`make deploy-infra WITH_CONTROLPLANE=true WITH_CONTROLPLANE_CR=true` runs this
+automatically for the bundled ControlPlane after its MariaDB becomes Ready.
+
+### 3. (Optional) Stage the cutover with `databaseCredentialsMode: Static`
+
+Dynamic is the default effective mode for a managed ControlPlane on the shared
+database. To keep Glance on the static credential — for example while Keystone
+already runs Dynamic — pin the per-service override so the blast radius stays on
+Glance:
+
+```yaml
+spec:
+  services:
+    glance:
+      databaseCredentialsMode: Static
+```
+
+The shared `spec.infrastructure.database.credentialsMode: Static` opts out
+ControlPlane-wide instead; the per-service override scopes the opt-out to Glance
+alone. A ControlPlane staged on `Static` after this change no longer has its
+static KV path seeded automatically (the per-ControlPlane seed is retired), so
+you must seed `kv-v2/openstack/glance/<namespace>/<controlplane>/db` (`username`,
+`password`) by hand while staging. Remove the override (or set it to `Dynamic`)
+to cut over.
+
+### 4. Upgrade the operators and observe the cutover
+
+Upgrade the c5c3 and glance operators to a build that includes the dynamic engine
+wiring. On the next reconcile the c5c3 operator projects the generator,
+ServiceAccount, and Certificate, and the ExternalSecret switches to drawing from
+the generator.
+
+On a cluster that ran the static path, delete the materialised credential Secret
+once so the engine-issued value is the only thing that can ever be read from it:
+
+```bash
+kubectl delete secret <controlplane>-glance-db-credentials -n <namespace>
+```
+
+The ExternalSecret switches to the generator in place — same name, same target
+Secret — so until ESO's first generator-backed sync lands, the Secret still holds
+whatever the previous static sync wrote, including the retired `username=glance`
+placeholder the old bootstrap seeded. That name is a *syntactically valid*
+username naming a MySQL user that has never existed (the static login is the
+Glance CR name, `<controlplane>-glance`). Deleting the Secret forces ESO to
+re-materialise it from the generator immediately instead of at the next refresh.
+
+You do not have to get this right for Glance to stay up: the c5c3 operator will
+not project `credentialsMode: Dynamic` onto the Glance child until that
+ExternalSecret reports Ready **and** the Secret behind it carries an engine-issued
+username. While either is outstanding, `GlanceReady` is `False` with reason
+`WaitingForGlanceDBCredential`, the running child keeps its current mode, and the
+message names either the `database/mariadb/creds/glance-<namespace>` path from
+step 2 or the stale username it found. A ControlPlane stuck on the path message
+has not been onboarded; re-run step 2. One stuck on the username message is
+waiting for the sync this deletion shortcuts.
+
+Watch for:
+
+- The `controlplane-glance-db-credentials` ExternalSecret spec changing from
+  static `data[].remoteRef` to `dataFrom[].sourceRef.generatorRef` (kind
+  `VaultDynamicSecret`).
+- The materialised Secret's `username` becoming an engine-issued login (not
+  `glance`).
+- A Glance Deployment rollout: the operator stamps a
+  `glance.c5c3.io/db-connection-hash` pod-template annotation in Dynamic mode, so
+  a rotated credential rolls the Deployment (the DSN is consumed via an
+  environment variable, which only takes effect on a Pod restart).
+
+Because the engine's GRANT overlaps any pre-existing operator-provisioned
+`User`/`Grant` from the static deployment, Glance keeps serving throughout — the
+rolling restart (protected by the Glance PodDisruptionBudget) simply moves it
+onto an engine-issued login. This is the no-downtime property.
+
+### 5. Retire the static credential
+
+Once the ControlPlane reports `DBCredentialsReady=True` on the dynamic path and
+Glance is Ready:
+
+1. Delete the leftover static MariaDB `User` and `Grant` CRs (they carry the
+   long-lived `glance` login the engine no longer uses):
+
+   ```bash
+   kubectl delete user,grant <glance-cr-name> -n <namespace> --ignore-not-found
+   ```
+
+2. Remove the retired static KV secret:
+
+   ```bash
+   # Inside the OpenBao pod, or with a bao client configured for it.
+   bao kv metadata delete kv-v2/openstack/glance/<namespace>/<controlplane>/db
+   ```
+
+## Rollback
+
+To revert to the static credential, set the mode back to `Static` (the
+per-service `spec.services.glance.databaseCredentialsMode` override, or the shared
+`spec.infrastructure.database.credentialsMode`), re-seed the KV path (step 3), and
+let the next Static-mode reconcile re-create the `User`/`Grant`. Roll back the
+operators if you also need to remove the generator objects.
+
+## Operational considerations
+
+- **Rotation churn vs. lease headroom:** because the DSN is consumed via an
+  environment variable, a rotated engine credential only takes effect on a Pod
+  restart, so Glance rolls each time the ExternalSecret re-issues the credential
+  (a rotating dynamic credential means every refresh is a *new* credential — there
+  is no stable value to renew in place). The defaults balance two concerns: the
+  24h refresh interval keeps the roll cadence to at most once a day, while the 48h
+  `default_ttl` keeps a 24h gap (`default_ttl` − refresh) so the operator has a
+  full day to roll the pods before the previous, still-in-use lease is revoked —
+  long enough that a stalled rollout pages on-call before it can become an outage.
+  Raise `DB_CREDS_DEFAULT_TTL` / `DB_CREDS_MAX_TTL` (and the operator's refresh
+  interval) further to trade churn against lease headroom; the PodDisruptionBudget
+  and the surge-before-remove rollout strategy keep each roll zero-downtime.
+- **Auth-token TTL bounds the lease:** OpenBao revokes a dynamic-secret lease
+  together with the auth token that minted it, so the effective credential
+  lifetime is `min(lease TTL, minting token TTL)`. The `glance-db` auth role
+  therefore pins its token TTLs to `DB_CREDS_MAX_TTL` (72h). When raising
+  `DB_CREDS_*` beyond that, raise the role's `token_ttl`/`token_max_ttl` in
+  lockstep — a shorter token silently drops the ephemeral MySQL user under a
+  running Glance long before the advertised lease end.
+- **Revocation semantics:** revoking a lease runs `DROP USER`, which rejects
+  *new* connections. Already-open sessions of a dropped user may persist until
+  they disconnect.
+- **ESO/OpenBao outage longer than the lease:** the materialised credential
+  expires before a refresh lands; running Pods keep pooled connections but new
+  connections fail until ESO recovers. This surfaces as `DBCredentialsReady=False`
+  via the ClusterSecretStore gate.
+
+## See also
+
+- [OpenBao Bootstrap reference](/reference/infrastructure/openbao-bootstrap) —
+  engines, auth roles, policies, and secret paths.
+- [ControlPlane reconciler reference](/reference/c5c3/controlplane-reconciler) —
+  `reconcileDBCredentials` projection flow.
+- [Migrate Keystone DB to Dynamic Credentials](/guides/keystone/migrate-keystone-db-to-dynamic-credentials) —
+  the sibling migration for the Keystone service DB user.
+
+## Tested by
+
+The dynamic, engine-issued per-ControlPlane database credential this guide
+migrates to — the projected Dynamic mode, the `VaultDynamicSecret`, the
+generator-backed `controlplane-glance-db-credentials` ExternalSecret, and the
+transient engine-issued login — is asserted on the live CI e2e kind cluster by
+this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/c5c3/full-controlplane-keystone
+```

--- a/docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md
+++ b/docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md
@@ -176,8 +176,7 @@ onto an engine-issued login. This is the no-downtime property.
 
 ### 5. Retire the static credential
 
-Once the ControlPlane reports `DBCredentialsReady=True` on the dynamic path and
-Glance is Ready:
+Once the ControlPlane reports `GlanceReady=True` on the dynamic path:
 
 1. Delete the leftover static MariaDB `User` and `Grant` CRs (they carry the
    long-lived `glance` login the engine no longer uses):
@@ -227,15 +226,15 @@ operators if you also need to remove the generator objects.
   they disconnect.
 - **ESO/OpenBao outage longer than the lease:** the materialised credential
   expires before a refresh lands; running Pods keep pooled connections but new
-  connections fail until ESO recovers. This surfaces as `DBCredentialsReady=False`
-  via the ClusterSecretStore gate.
+  connections fail until ESO recovers. This surfaces through the Glance child's
+  own database readiness and, ControlPlane-side, as `GlanceReady=False`.
 
 ## See also
 
 - [OpenBao Bootstrap reference](/reference/infrastructure/openbao-bootstrap) —
   engines, auth roles, policies, and secret paths.
 - [ControlPlane reconciler reference](/reference/c5c3/controlplane-reconciler) —
-  `reconcileDBCredentials` projection flow.
+  `reconcileGlance` DB-credential projection flow.
 - [Migrate Keystone DB to Dynamic Credentials](/guides/keystone/migrate-keystone-db-to-dynamic-credentials) —
   the sibling migration for the Keystone service DB user.
 

--- a/docs/guides/keystone/migrate-keystone-db-to-dynamic-credentials.md
+++ b/docs/guides/keystone/migrate-keystone-db-to-dynamic-credentials.md
@@ -114,6 +114,14 @@ seed `kv-v2/openstack/keystone/<namespace>/<controlplane>/db` (`username`,
 `password`) by hand while staging. Remove the field (or set it to `Dynamic`) to
 cut over.
 
+The shared `spec.infrastructure.database.credentialsMode: Static` above stages
+**every** service on the shared database at once. To scope the staging to
+Keystone alone, set `spec.services.keystone.databaseCredentialsMode: Static`
+instead — the per-service variant of the same opt-out, so another service (for
+example Glance) can already run Dynamic while Keystone stays Static. An empty
+override inherits the shared mode; clear it (or set it to `Dynamic`) to cut
+Keystone over.
+
 ### 4. Upgrade the operators and observe the cutover
 
 Upgrade the c5c3 and keystone operators to a build that includes the dynamic

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -190,7 +190,10 @@ of the default-443 form the operator would otherwise derive from the gateway
 hostname. The defaulting webhook injects a `glance` service account (user
 `glance`, project `service`, role `service`) into `spec.korc.serviceAccounts` so
 Glance can validate the Keystone tokens it receives; its database and cache
-derive from `spec.infrastructure`, exactly like Keystone's. A `GlanceReady`
+derive from `spec.infrastructure`, exactly like Keystone's. On the managed
+shared database its DB credential is engine-issued and auto-rotated exactly like
+Keystone's — short-lived leases from the OpenBao database engine, and the Step 4
+onboarding provisions the engine tenant for both services. A `GlanceReady`
 condition joins the chain — gating on `KeystoneReady` plus that injected service
 account — and `status.services` gains a third entry.
 

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -84,6 +84,10 @@ spec:
       # VaultDynamicSecret generator (Dynamic) or the stage-(a) KV-backed
       # ExternalSecret (Static). Dynamic requires clusterRef (managed mode).
       # credentialsMode: Dynamic
+      # Per-service override: services.<svc>.databaseCredentialsMode (Static |
+      # Dynamic) overrides this ControlPlane-wide mode for one service on the
+      # shared database, so a staged migration can run one service Dynamic while
+      # another stays Static; empty (the default) inherits the mode above.
       # In managed mode (clusterRef set) database.secretRef is
       # operator-owned — reconcileDBCredentials materialises a per-ControlPlane
       # Secret and the projected Keystone CR's secretRef is overridden to
@@ -313,7 +317,7 @@ additional services are added as fields as the operator grows.
 | --- | --- | --- | --- | --- |
 | `keystone` | [`*ServiceKeystoneSpec`](#servicekeystonespec) | No | `nil` | Configuration for the Keystone service projected by the reconciler. Optional: when unset, this ControlPlane manages no Keystone service (staged adoption, or an externally-managed Keystone) and `KeystoneReady` is reported as not-managed. Flipping it from set to `nil` **preserves** the previously-projected Keystone child by default — deleting it would cascade to the child's irreplaceable `<name>-credential-keys` Secret (and its OpenBao backup), so an accidental unset is fail-safe. Set the `c5c3.io/allow-keystone-deletion: "true"` annotation on the ControlPlane to opt in to deleting the child on unset. |
 | `horizon` | [`*ServiceHorizonSpec`](#servicehorizonspec) | No | `nil` | Configuration for the Horizon dashboard projected by the reconciler. Optional: when unset, this ControlPlane manages no dashboard and `HorizonReady` is reported as not-managed (`HorizonNotManaged`), so the aggregate `Ready` is not blocked. **Forbidden in External mode** — the dashboard needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Horizon child by default; set the `c5c3.io/allow-horizon-deletion: "true"` annotation to opt in to deleting the child on unset. |
-| `glance` | [`*ServiceGlanceSpec`](#serviceglancespec) | No | `nil` | Configuration for the Glance image service projected by the reconciler. Optional: when unset, this ControlPlane manages no image service and `GlanceReady` is reported as not-managed (`GlanceNotManaged`), so the aggregate `Ready` is not blocked. The projection is **gated on `KeystoneReady`** — Glance validates every token against the ControlPlane's Keystone child. **Forbidden in External mode** — Glance needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Glance child by default; set the `c5c3.io/allow-glance-deletion: "true"` annotation to opt in to deleting the child (and its `GlanceBackend` children and DB-credential ExternalSecret) on unset. |
+| `glance` | [`*ServiceGlanceSpec`](#serviceglancespec) | No | `nil` | Configuration for the Glance image service projected by the reconciler. Optional: when unset, this ControlPlane manages no image service and `GlanceReady` is reported as not-managed (`GlanceNotManaged`), so the aggregate `Ready` is not blocked. The projection is **gated on `KeystoneReady`** — Glance validates every token against the ControlPlane's Keystone child. **Forbidden in External mode** — Glance needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Glance child by default; set the `c5c3.io/allow-glance-deletion: "true"` annotation to opt in to deleting the child (and its `GlanceBackend` children and DB-credential ExternalSecret) on unset. The dynamic DB-credential generator is torn down on unset regardless of the annotation — preserving a running service does not imply preserving a credential minter. |
 
 ---
 
@@ -361,6 +365,7 @@ validating webhook is bypassed) and mirrored by the validating webhook; see
 | `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Keystone API externally via a Gateway API HTTPRoute. When `nil`, no HTTPRoute is projected and the Keystone API is reachable in-cluster only (its ClusterIP Service). When set, the reconciler projects it onto the Keystone CR's `spec.gateway`, so the Keystone operator attaches an HTTPRoute to the referenced Gateway. When a `gateway` is set its `hostname` must be non-empty — enforced at admission by the validating webhook (see [Validation Rules](#validation-rules)). |
 | `publicEndpoint` | `string` | No | `""` | Externally routable Keystone identity endpoint URL (e.g. `https://keystone.example.com/v3`). Projected into the Keystone bootstrap (`--bootstrap-public-url`) and used for the K-ORC identity catalog Endpoint, so external clients resolve the same URL Keystone advertises. When set, it must be an HTTP(S) URL (`+kubebuilder:validation:Pattern=^https?://`), so a malformed endpoint fails at admission rather than wedging the projected Keystone CR. When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}/v3` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
 | `federationProxyImage` | [`*commonv1.ImageSpec`](../keystone/keystone-crd.md#imagespec) | No | `nil` | Overrides the `mod_auth_openidc` sidecar image projected onto the Keystone child's `spec.federation.proxyImage`. When `nil` the reconciler projects `ghcr.io/c5c3/keystone-federation-proxy:latest`. That default is a **mutable tag**: every node re-pulls it on each pod start, and a locally built sidecar cannot be exercised. Override it with a digest-carrying `ImageSpec` for the immutable pin published images are expected to carry. Inert until a federation-typed `KeystoneIdentityBackend` attaches. Forbidden in External mode (CEL + webhook). |
+| `databaseCredentialsMode` | `string` (`Static` \| `Dynamic`) | No | `""` (inherits `spec.infrastructure.database.credentialsMode`) | Per-service override of the ControlPlane-wide credentials mode for the managed **shared** database, so a staged migration can run Keystone on one mode while another service (e.g. Glance) stays on the other. Empty (the default) **inherits** the shared mode — deliberately **not** materialized by the defaulting webhook, so "inherit" stays distinguishable from an explicit override. A `Dynamic` override is **rejected** when the Keystone service declares a [dedicated](#dedicatedbackingservices) database (dedicated is `Static`-only — set `dedicatedBackingServices.database.credentialsMode` instead; see [Credential modes](#credential-modes)) and when the shared database is **brownfield** (`clusterRef` unset); `Static` is always admitted. **Forbidden in External mode (CEL + webhook)** — no managed database is provisioned there, so there is no credentials mode to override. |
 | `dedicatedBackingServices` | [`*KeystoneDedicatedBackingServicesSpec`](#dedicatedbackingservices) | No | `nil` (shares the ControlPlane-wide instances) | Opts the Keystone service **out** of the shared `spec.infrastructure` instances and gives it backing services of its own. Forbidden in External mode (CEL + webhook): no backing services are provisioned at all there. |
 | `namespace` | [`*ServiceNamespaceSpec`](#service-namespaces) | No | `nil` (placed in the ControlPlane's namespace) | Places the Keystone service — and the backing services, secret store, and credential material that follow it — in a namespace of its own. Create-only. Forbidden in External mode (CEL + webhook): no Keystone workload is deployed, so there is nothing to place. See [Service Namespaces](#service-namespaces). |
 
@@ -421,6 +426,7 @@ carry per-field External-mode forbid-rules.
 | `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Glance API externally via a Gateway API HTTPRoute. When `nil` (the default) no HTTPRoute is projected and the Glance API is reachable in-cluster only. When a `gateway` is set its `hostname` must be non-empty — enforced at admission by the validating webhook (see [Validation Rules](#validation-rules)). |
 | `publicEndpoint` | `string` | No | `""` | Externally routable Glance image endpoint URL (e.g. `https://glance.127-0-0-1.nip.io:8443`). Used **only** for the K-ORC public image catalog Endpoint; it is projected into no child CR, so the validating webhook is the only gate on it. When set, it must match `^https?://`, parse to a bare origin with a host (no path, query, or fragment — the Glance API is served at the root), and be at most 512 characters. When a `gateway` is configured the scheme must be `https` and the host must equal `gateway.hostname` (the port may differ) — see [Validation Rules](#validation-rules). When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
 | `backends` | [`[]GlanceBackendEntry`](#glancebackendentry) | Yes | — | The curated list of image stores, projected one-to-one into [`GlanceBackend`](../glance/glance-backend-crd.md) child CRs. **Exactly one** entry must set `isDefault`, promoting its store to the Glance `default_backend`. A `listType=map` list keyed on `name` (the API server rejects duplicate names); `MinItems` 1 and `MaxItems` 32 (every entry amplifies into one `GlanceBackend` CR). The single-default invariant holds at the CRD schema layer via a CEL `XValidation` rule and is mirrored by the validating webhook. |
+| `databaseCredentialsMode` | `string` (`Static` \| `Dynamic`) | No | `""` (inherits `spec.infrastructure.database.credentialsMode`) | Per-service override of the ControlPlane-wide credentials mode for the managed **shared** database, so a staged migration can run Glance on one mode while another service (e.g. Keystone) stays on the other. Empty (the default) **inherits** the shared mode — deliberately **not** materialized by the defaulting webhook, so "inherit" stays distinguishable from an explicit override. A `Dynamic` override is **rejected** when Glance declares a [dedicated](#dedicatedbackingservices) database (dedicated is `Static`-only — set `dedicatedBackingServices.database.credentialsMode` instead; see [Credential modes](#credential-modes)) and when the shared database is **brownfield** (`clusterRef` unset); `Static` is always admitted. |
 | `dedicatedBackingServices` | [`*GlanceDedicatedBackingServicesSpec`](#dedicatedbackingservices) | No | `nil` (shares the ControlPlane-wide instances) | Opts Glance **out** of the shared `spec.infrastructure` instances and gives it a database and/or cache of its own. Glance consumes both classes, so it can take either or both dedicated. |
 | `namespace` | [`*ServiceNamespaceSpec`](#service-namespaces) | No | `nil` (placed in the ControlPlane's namespace) | Places the Glance service — and the database, cache, secret store, and object-store credential material that follow it — in a namespace of its own. Create-only. See [Service Namespaces](#service-namespaces). |
 
@@ -556,30 +562,60 @@ same path as a shared instance:
 
 ### Credential modes
 
+On the managed **shared** database, `credentialsMode: Dynamic` — short-lived,
+engine-issued credentials from the OpenBao database engine — is the **default**
+for **both** Keystone and Glance. Glance is no longer forced onto `Static`: it
+now carries its own glance-scoped engine role, `glance-db-dynamic` policy, and
+`glance-db` auth role (`deploy/openbao/bootstrap/setup-database-tenant.sh` /
+`setup-auth.sh` / `deploy/openbao/policies/glance-db-dynamic.hcl`), exactly the
+way Keystone does.
+
+The mode is resolved from ControlPlane-wide to per-service:
+
+1. `spec.infrastructure.database.credentialsMode` is the ControlPlane-wide
+   default for the shared database — `Dynamic` unless you opt out to `Static`
+   (migration staging / brownfield). `Dynamic` requires `clusterRef` (managed
+   mode).
+2. `spec.services.<svc>.databaseCredentialsMode` **overrides** it for one
+   service. Empty (the default) **inherits** the shared mode — deliberately not
+   materialized by the defaulting webhook, so "inherit" stays distinguishable
+   from an explicit override — so a staged migration can run one service (say
+   Keystone) on `Dynamic` while another (Glance) stays `Static`, or the reverse.
+   A `Dynamic` override is rejected on a service that declares a dedicated
+   database or when the shared database is brownfield; `Static` is always
+   admitted.
+
+In the shared **Static** branch — the ControlPlane-wide opt-out or a per-service
+`Static` override — the operator projects a KV-backed ExternalSecret reading the
+per-service path (`openstack/keystone/{namespace}/{name}/db` for Keystone,
+`openstack/glance/{namespace}/{name}/db` for Glance), and the credential is
+**seeded and rotated at the OpenBao source** (ESO refreshes it within the hour).
+
 A dedicated **managed** database uses `credentialsMode: Static`. The defaulting
 webhook materializes it, and an explicit `Dynamic` is **rejected at admission**:
 the OpenBao database engine carries exactly one connection and one role **per
 namespace** (`deploy/openbao/bootstrap/setup-database-tenant.sh`), bootstrapped
 against the *shared* cluster, so no engine role exists that could issue
 credentials for a dedicated instance — an admitted `Dynamic` dedicated database
-would wedge on an ExternalSecret that can never sync.
-
-`Static` is the same contract the shared block's own Static opt-out carries: the
-operator projects a KV-backed ExternalSecret reading
-`openstack/keystone/{namespace}/{name}/db`, and the credential is **seeded and
-rotated at the OpenBao source** (ESO refreshes it within the hour). A brownfield
-dedicated database keeps the user-supplied `secretRef` Secret, exactly as a
-brownfield shared one does.
+would wedge on an ExternalSecret that can never sync. It reads the same
+per-service KV path a shared `Static` opt-out does, and a brownfield dedicated
+database keeps the user-supplied `secretRef` Secret, exactly as a brownfield
+shared one does.
 
 > **Seed the KV path before you expect `Ready`.** It is seeded by **neither the
 > operator nor the bootstrap** — the per-ControlPlane static seed was retired when
-> managed mode moved to engine-issued credentials. A dedicated managed database
-> therefore reaches `Ready` only once you have seeded
-> `kv-v2/openstack/keystone/{namespace}/{name}/db` (`username`, `password`)
-> yourself; see
+> managed mode moved to engine-issued credentials. A service on the `Static`
+> branch (a dedicated managed database, or the shared database opted out)
+> therefore reaches `Ready` only once you have seeded its per-service KV path —
+> `kv-v2/openstack/keystone/{namespace}/{name}/db` for Keystone,
+> `kv-v2/openstack/glance/{namespace}/{name}/db` for Glance — with `username` and
+> `password` yourself; see
 > [Migrate the Keystone DB to dynamic credentials](../../guides/keystone/migrate-keystone-db-to-dynamic-credentials.md)
-> for the exact `bao kv put`. Until then `DBCredentialsReady` stays `False` with
-> reason `WaitingForDBCredentialSecret` and a message naming the path.
+> and [Migrate the Glance DB to dynamic credentials](../../guides/glance/migrate-glance-db-to-dynamic-credentials.md)
+> for the exact `bao kv put`. Until then Keystone's `DBCredentialsReady` stays
+> `False` with reason `WaitingForDBCredentialSecret` and a message naming the
+> path, and Glance's projected child cannot resolve its DB secret, so
+> `GlanceReady` stays `False`.
 
 ### Name collisions
 
@@ -1230,6 +1266,7 @@ Keystone discipline:
 | `spec.services.keystone.external.authURL` | Pattern `^https?://[^\s/]+`; MaxLength 2048 (bounds the one unbounded input interpolated into `status.conditions[].message`) |
 | `spec.services.keystone.external.endpointType` | Enum: `public`, `internal`, `admin`; schema default `public` |
 | `spec.services.keystone.external.caBundleSecretRef.name` | MinLength 1 (shared `SecretRefSpec` marker) |
+| `spec.services.keystone.databaseCredentialsMode` | Enum: `Static`, `Dynamic` |
 | `spec.korc.adminCredential.applicationCredential.accessRules[].method` | Enum: `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE` |
 | `spec.korc.adminCredential.applicationCredential.accessRules[].path` | Pattern `^/` |
 | `spec.korc.adminCredential.bootstrapResources[].kind` | Enum: `Project`, `Role` |
@@ -1257,8 +1294,9 @@ Keystone discipline:
 | `spec.globalPolicyOverrides`, `spec.services.keystone.policyOverrides` (CEL) | `!has(self.rules) \|\| self.rules.all(k, size(self.rules[k]) > 0)` → "policy rule value must not be empty" |
 | `spec.services.keystone` (CEL) | `mode == 'External'` ⇒ `has(self.external)` → "external is required when services.keystone.mode is External" |
 | `spec.services.keystone` (CEL) | `has(self.external)` ⇒ `mode == 'External'` → "external may only be set when services.keystone.mode is External" |
-| `spec.services.keystone` (CEL) | `mode == 'External'` ⇒ each managed-only field (`replicas`, `image`, `policyOverrides`, `rotationInterval`, `gateway`, `publicEndpoint`, `federationProxyImage`) absent → "services.keystone.\<field\> is forbidden when services.keystone.mode is External" (one rule per field) |
+| `spec.services.keystone` (CEL) | `mode == 'External'` ⇒ each managed-only field (`replicas`, `image`, `policyOverrides`, `rotationInterval`, `gateway`, `publicEndpoint`, `federationProxyImage`, `databaseCredentialsMode`) absent → "services.keystone.\<field\> is forbidden when services.keystone.mode is External" (one rule per field) |
 | `spec.services.glance.replicas` | Minimum: 1 |
+| `spec.services.glance.databaseCredentialsMode` | Enum: `Static`, `Dynamic` |
 | `spec.services.glance.gateway.hostname` | MinLength 1 (shared `GatewaySpec` marker) |
 | `spec.services.glance.publicEndpoint` | Pattern `^https?://`; MaxLength 512 (mirrors `services.keystone.publicEndpoint`; the value feeds the K-ORC image Endpoint URL) |
 | `spec.services.glance.backends` | listType=map keyed by `name`; MinItems 1; MaxItems 32 |
@@ -1292,6 +1330,9 @@ short-circuit on the first error.
 | External authURL required/URL | `spec.services.keystone.external.authURL` | `field.Required` / `field.Invalid` | In External mode, `authURL` empty (Required), or not matching `^https?://[^\s/]+` / failing a full `net/url` parse / exceeding 2048 characters (Invalid). Mirrors the CRD required/pattern/maxLength markers. |
 | External caBundle name required | `spec.services.keystone.external.caBundleSecretRef.name` | `field.Required` | `caBundleSecretRef` set with an empty `name`. Mirrors the shared `SecretRefSpec` MinLength marker. |
 | Managed-only field forbidden in External mode | `spec.services.keystone.{replicas,image,policyOverrides,rotationInterval,gateway,publicEndpoint,federationProxyImage}` | `field.Forbidden` | The field is set while `mode: External`. Defense-in-depth mirror of the per-field CEL rules. |
+| Keystone credentials-mode override forbidden in External mode | `spec.services.keystone.databaseCredentialsMode` | `field.Forbidden` | The per-service override is set while `mode: External` — no managed database is provisioned, so there is no credentials mode to override. Defense-in-depth mirror of the per-field CEL rule. |
+| Dynamic credentials-mode override on a dedicated database | `spec.services.{keystone,glance}.databaseCredentialsMode` | `field.Forbidden` | The override is `Dynamic` while that service declares a dedicated database: the override retargets the shared database the service does not use, and a dedicated database is `Static`-only (set `dedicatedBackingServices.database.credentialsMode` instead). `Static` stays admitted. **Cross-field, webhook-only.** |
+| Dynamic credentials-mode override on a brownfield shared database | `spec.services.{keystone,glance}.databaseCredentialsMode` | `field.Forbidden` | The override is `Dynamic` while the shared database is brownfield (`clusterRef` unset): the dynamic engine issues per-tenant DB users only against a cluster the operator provisions. **Cross-field, webhook-only.** |
 | Federation proxy image resolvable | `spec.services.keystone.federationProxyImage` | `field.Required` / `field.Invalid` | Empty `repository`, or neither/both of `tag` and `digest`. Surfaces on the ControlPlane the operator edits rather than as an opaque `KeystoneProjectionRejected` condition on the child. |
 | Dashboard public endpoint is a URL | `spec.services.horizon.publicEndpoint` | `field.Invalid` | Not an absolute HTTP(S) URL with a host. Keystone matches the derived WebSSO origin verbatim, so an unusable endpoint could never match any dashboard. |
 | Dashboard public endpoint is a bare origin | `spec.services.horizon.publicEndpoint` | `field.Invalid` | Carries a path, query, or fragment (a single trailing `/` is trimmed and allowed). The `^https?://` pattern anchors only the prefix, so `https://horizon.example.com?utm=1` is schema-legal and would render the trusted origin `https://horizon.example.com?utm=1/auth/websso/` — accepted by Keystone, matched by nothing. **Webhook-only.** |
@@ -1709,11 +1750,12 @@ against a Managed-mode Keystone.
 | Status | Reason | When |
 | --- | --- | --- |
 | `True` | `GlanceReady` | The projected Glance CR reports Ready. |
-| `True` | `GlanceNotManaged` | `spec.services.glance` is unset: no image service is managed, so the aggregate `Ready` is not blocked. Any previously-projected Glance child (and its `GlanceBackend` children and DB-credential ExternalSecret) is **preserved** unless the `c5c3.io/allow-glance-deletion: "true"` annotation opts in to its deletion. |
+| `True` | `GlanceNotManaged` | `spec.services.glance` is unset: no image service is managed, so the aggregate `Ready` is not blocked. Any previously-projected Glance child (and its `GlanceBackend` children and DB-credential ExternalSecret) is **preserved** unless the `c5c3.io/allow-glance-deletion: "true"` annotation opts in to its deletion. The dynamic DB-credential generator, its ServiceAccount, and its client Certificate are torn down **either way** — preserving a running service does not imply preserving the generator that keeps minting its credentials. |
 | `False` | `WaitingForKeystone` | `KeystoneReady` is not `True`; Glance projection deferred. |
 | `False` | `ServiceAccountNotDeclared` | No `spec.korc.serviceAccounts` entry named `glance` is declared — the defaulting webhook injects it whenever `services.glance` is set, so a ControlPlane reaching here bypassed admission. Fails loud rather than projecting a Glance with no Keystone user. |
 | `False` | `WaitingForServiceAccount` | The `glance` service account is declared but not yet Ready; projection deferred until its Keystone user and password are provisioned. |
 | `False` | `GlanceDBCredentialError` | Error ensuring the Glance DB-credential ExternalSecret (managed database only). |
+| `False` | `WaitingForGlanceDBCredential` | `credentialsMode: Dynamic` is in effect but no engine-issued credential has materialised yet — either the generator-backed DB-credential ExternalSecret has not synced, or (on a Static→Dynamic migration, where the ExternalSecret is updated in place and keeps reporting the previous Static sync's `Ready`) the Secret it targets still carries the retired static username. No Glance CR is projected, and an existing child keeps its current mode, until one does. The message names the `database/mariadb/creds/glance-<namespace>` path, which only exists once `setup-database-tenant.sh` has onboarded the tenant, or the stale username it found. |
 | `False` | `GlanceBackendProjectionRejected` | The Glance API server rejected a projected `GlanceBackend` (HTTP 422). Reconcile the `services.glance.backends` entries to a valid projection to recover. |
 | `False` | `GlanceBackendError` | Error projecting or pruning a `GlanceBackend` child. |
 | `False` | `WaitingForGlance` | The Glance CR is ensured but not yet Ready. |

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -1057,7 +1057,7 @@ an empty websso block, which would silently remove a working SSO button.
 | File | `reconcile_glance.go` |
 | Condition | `GlanceReady` |
 | Gate | `KeystoneReady == True` (Glance validates every token against the Keystone child) **and** the injected `glance` service account being Ready |
-| Projects / Owns | one `Glance` child named `{controlplane.Name}-glance` (`glanceNameSuffix`) in `cp.GlanceNamespace()`; one `GlanceBackend` child per `services.glance.backends` entry, named `{controlplane.Name}-glance-{entry}`; and — managed database only — a DB-credential `ExternalSecret` named `{controlplane.Name}-glance-db-credentials` reading OpenBao KV path `openstack/glance/{glance-namespace}/{controlplane.Name}/db` (properties `username`, `password`). Only when `spec.services.glance` is set |
+| Projects / Owns | one `Glance` child named `{controlplane.Name}-glance` (`glanceNameSuffix`) in `cp.GlanceNamespace()`; one `GlanceBackend` child per `services.glance.backends` entry, named `{controlplane.Name}-glance-{entry}`; and — managed database only — the per-ControlPlane DB-credential objects in the Glance service namespace: in **Dynamic** mode (the managed-shared default) a ServiceAccount `glance-db-creds`, an mTLS client Certificate `{controlplane.Name}-glance-db-openbao-client`, a `VaultDynamicSecret` generator reading `database/mariadb/creds/glance-{glance-namespace}` (auth role `glance-db`), and a generator-backed `ExternalSecret` `{controlplane.Name}-glance-db-credentials`; in the **Static** opt-out a KV-backed `ExternalSecret` of the same name reading `openstack/glance/{glance-namespace}/{controlplane.Name}/db` (properties `username`, `password`). Only when `spec.services.glance` is set |
 | Requeue | `keystoneInfraGateRequeueAfter` = **5s** while gated on Keystone; `korcRequeueAfter` = **10s** while the `glance` service account is not yet Ready; `infraRequeueAfter` = **15s** while the child is not Ready |
 
 `reconcileGlance` runs **last** in the pipeline (after `reconcileServiceAccounts`),
@@ -1065,8 +1065,10 @@ because it gates on the per-account readiness that stage computes into status in
 the same pass. It is optional: `spec.services.glance` unset means this ControlPlane
 manages no image service, and the sub-reconciler reports `GlanceReady=True` /
 `GlanceNotManaged` so the aggregate is not blocked (staged adoption). A
-previously-projected child — and its `GlanceBackend` children and DB-credential
-ExternalSecret — is **preserved** unless the ControlPlane opts in with
+previously-projected child — and its `GlanceBackend` children, DB-credential
+ExternalSecret, and (from a prior Dynamic deployment) the `VaultDynamicSecret`
+generator, its client Certificate, and the `glance-db-creds` ServiceAccount — is
+**preserved** unless the ControlPlane opts in with
 `c5c3.io/allow-glance-deletion: "true"` (then the orphans, plus the image catalog
 K-ORC CRs, are deleted). Cross-namespace children are ownership-checked, so a
 hand-created `GlanceBackend` sharing the namespace is never touched.
@@ -1082,12 +1084,21 @@ reusing the ControlPlane's own specs so Glance points at the same backing servic
   when it opted into one, the shared `spec.infrastructure.database` otherwise) with
   its logical database name forced to `glance` so Glance's schema stays isolated
   from Keystone's on a shared cluster. In managed mode (`clusterRef` set) the
-  `secretRef` is repointed at the operator-owned `{controlplane.Name}-glance-db-credentials`
-  Secret and `credentialsMode` is forced to `Static`: there is **no** OpenBao
-  dynamic-engine role for the glance schema (the engine role is keystone-scoped and
-  bootstrapped once per namespace), so the credential is always read from the KV
-  path above and seeded/rotated at the OpenBao source. A brownfield database keeps
-  the user-supplied `secretRef`.
+  `secretRef` is repointed at the operator-owned
+  `{controlplane.Name}-glance-db-credentials` Secret, and the projected
+  `credentialsMode` is the **effective** mode: `Dynamic` (engine-issued) by
+  default on the managed shared database — Glance now has its own engine role
+  `glance-{glance-ns}`, provisioned by `setup-database-tenant.sh` — flipped to
+  `Static` by the shared-block opt-out or the per-service
+  `services.glance.databaseCredentialsMode` override, and always `Static` for a
+  dedicated glance database (fail-closed even when the stored mode says
+  otherwise). In `Dynamic` mode the generator objects above (the
+  `glance-db-creds` ServiceAccount, the client Certificate, the
+  `VaultDynamicSecret`, and the generator-backed ExternalSecret) are ensured
+  before the child; in `Static` mode they are torn down and the KV-backed
+  ExternalSecret is projected, reading a path seeded **out-of-band** (see
+  [Migrate the Glance DB to dynamic credentials](../../guides/glance/migrate-glance-db-to-dynamic-credentials.md)).
+  A brownfield database keeps the user-supplied `secretRef` and `credentialsMode`.
 - **Cache:** a DeepCopy of the **effective** cache (`effectiveGlanceCache`).
 - **Keystone endpoint:** `keystoneEndpoint` is derived top-down via
   `glanceKeystoneEndpoint(cp)` — **always** the cluster-local `{controlplane.Name}-keystone`
@@ -1125,11 +1136,12 @@ unowned, and the finalizer sweeps it by those labels.
 
 | Path | Status | Reason | Notes |
 | --- | --- | --- | --- |
-| `spec.services.glance` unset | True | `GlanceNotManaged` | staged adoption; a previously-projected child is preserved unless `c5c3.io/allow-glance-deletion: "true"` is set |
+| `spec.services.glance` unset | True | `GlanceNotManaged` | staged adoption; a previously-projected child is preserved unless `c5c3.io/allow-glance-deletion: "true"` is set — but its dynamic DB-credential generator, ServiceAccount, and client Certificate are torn down either way, so no credential minter outlives the service |
 | `KeystoneReady` not True | False | `WaitingForKeystone` | requeue 5s; no Glance CR is projected while Keystone is unready |
 | no `glance` service account declared | False | `ServiceAccountNotDeclared` | admission was bypassed (the defaulting webhook injects it); fails loud rather than projecting a Glance with no Keystone user |
 | `glance` service account not yet Ready | False | `WaitingForServiceAccount` | requeue 10s; deferred until its Keystone user and password are provisioned |
-| DB-credential ExternalSecret ensure fails | False | `GlanceDBCredentialError` | returns the error (managed database only) |
+| DB-credential ensure fails (Dynamic generator objects or Static ExternalSecret) | False | `GlanceDBCredentialError` | returns the error (managed database only) |
+| Dynamic DB credential not yet materialised | False | `WaitingForGlanceDBCredential` | requeue 10s; no Glance CR is projected and an existing child keeps its current mode until the generator-backed ExternalSecret reports Ready **and** the Secret it targets carries an engine-issued username. The message names the `database/mariadb/creds/glance-<namespace>` path, which only exists after `setup-database-tenant.sh` has onboarded the tenant, or — on a Static→Dynamic migration, where the in-place ExternalSecret update leaves the previous Static sync's `Ready` in place over a stale Secret — the non-engine-issued username it found |
 | projected `GlanceBackend` rejected (HTTP 422 Invalid) | False | `GlanceBackendProjectionRejected` | returns the error; reconcile the `services.glance.backends` entries to a valid projection to recover |
 | `GlanceBackend` project/prune fails | False | `GlanceBackendError` | returns the error |
 | Glance child not yet Ready | False | `WaitingForGlance` | requeue 15s |

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -312,7 +312,8 @@ one ControlPlane per namespace makes it a unique, collision-free tenant key).
 ### setup-database-tenant.sh
 
 **Purpose:** Provision the per-tenant `database` engine connection and role for one
-managed ControlPlane's Keystone service DB user.
+managed ControlPlane's per-service DB users — Keystone always, and Glance when it
+shares the managed database.
 
 **File:** `deploy/openbao/bootstrap/setup-database-tenant.sh`
 
@@ -320,25 +321,39 @@ managed ControlPlane's Keystone service DB user.
 
 **Usage:** `setup-database-tenant.sh <namespace> <controlplane>`
 
-It resolves the MariaDB name, database name, and root credential from the live
-ControlPlane and MariaDB CRs, then writes:
+It resolves each service leg's MariaDB name, database name, and root credential
+from the live ControlPlane and MariaDB CRs — independently and in that service's
+own namespace, so Glance's engine plumbing is keystone-independent — then writes
+one connection+role pair per leg. The **Keystone** leg is **always** provisioned:
 
 | Object | Path |
 | --- | --- |
 | Connection | `database/mariadb/config/keystone-{namespace}` |
 | Role | `database/mariadb/roles/keystone-{namespace}` |
 
-The role's `creation_statements` create a short-lived MySQL user with `ALL
-PRIVILEGES` on the Keystone database; `revocation_statements` drop it at lease
+The **Glance** leg is provisioned **only** when the live ControlPlane declares
+`spec.services.glance` on the shared managed database; a Glance that declares a
+dedicated database (`spec.services.glance.dedicatedBackingServices.database`) is
+`Static`-only and is **skipped** here. Its glance service namespace defaults to
+the ControlPlane's own:
+
+| Object | Path |
+| --- | --- |
+| Connection | `database/mariadb/config/glance-{namespace}` |
+| Role | `database/mariadb/roles/glance-{namespace}` |
+
+Each role's `creation_statements` create a short-lived MySQL user with `ALL
+PRIVILEGES` on that service's database; `revocation_statements` drop it at lease
 end. `default_ttl` (48h) and `max_ttl` (72h) are tunable via `DB_CREDS_DEFAULT_TTL`
 / `DB_CREDS_MAX_TTL`; `default_ttl` stays a full day above the operator's
 ExternalSecret refresh interval (24h) so the operator has a wide window to roll
 pods onto a fresh credential before the previous, still-in-use lease is revoked —
 long enough that a stalled rollout pages on-call before it can become an outage.
-The role name is keyed on the
-namespace alone and stays in sync with `dbDynamicRoleFor` in the c5c3 operator's
-`reconcile_dbcredentials.go`. Config and role writes are upserts, so re-running is
-idempotent.
+Each role name is keyed on its own service namespace alone (`{namespace}` above is
+that service's namespace) and stays in sync with `dbDynamicRoleFor` /
+`glanceDBDynamicRoleFor` in the c5c3 operator (`reconcile_dbcredentials.go` /
+`reconcile_glance_dbcredentials.go`). Config and role writes are upserts, so
+re-running is idempotent.
 
 ### setup-eso-tenant.sh
 
@@ -405,29 +420,33 @@ Each Kubernetes auth mount creates a role named `eso-<cluster>` that binds to th
 `external-secrets` service account in the `external-secrets` namespace. The role is
 linked to the corresponding `eso-<cluster>` policy.
 
-The management mount additionally carries a `keystone-db` role bound to the
-per-ControlPlane `keystone-db-creds` ServiceAccount (any namespace), linked to the
-`keystone-db-dynamic` policy. The c5c3 operator's per-ControlPlane
-`VaultDynamicSecret` generator authenticates with it to read short-lived DB
-credentials at `database/mariadb/creds/keystone-{namespace}`. The role
-deliberately binds `namespaces="*"` so any ControlPlane namespace may
-authenticate; cross-tenant isolation is enforced by the `keystone-db-dynamic`
-policy, which templates the readable path to the caller's own
+The management mount additionally carries a `keystone-db` and a `glance-db` role,
+each bound to a fixed per-ControlPlane ServiceAccount (`keystone-db-creds` /
+`glance-db-creds`, any namespace) and linked to its own dynamic-credential policy
+(`keystone-db-dynamic` / `glance-db-dynamic`). The c5c3 operator's per-ControlPlane
+`VaultDynamicSecret` generators authenticate with them to read short-lived DB
+credentials at `database/mariadb/creds/keystone-{namespace}` and
+`database/mariadb/creds/glance-{namespace}` respectively. Both roles deliberately
+bind `namespaces="*"` so any ControlPlane namespace may authenticate; the fixed
+SA name is what tells the two roles apart (a `glance-db-creds` token can never
+read a Keystone creds path, or vice versa), and cross-tenant isolation is
+enforced by each policy, which templates the readable path to the caller's own
 `service_account_namespace` (an exact match — a token minted in one namespace
 cannot read another namespace's path).
 
-Unlike the `eso-<cluster>` roles, the `keystone-db` token TTLs are pinned to the
-database engine's `max_ttl` (72h): OpenBao revokes a dynamic-secret lease
-together with the auth token that minted it, so a token shorter than the lease
-silently caps the effective credential lifetime at the token's — with an
-eso-style 1h token, every issued DB credential died after ~1h while the
-ExternalSecret refresh only re-mints every 24h, dropping the ephemeral MySQL
-user under a running Keystone. The longer-lived token is bounded by the
-read-only `keystone-db-dynamic` policy.
+Unlike the `eso-<cluster>` roles, the `keystone-db` and `glance-db` token TTLs are
+pinned to the database engine's `max_ttl` (`DB_CREDS_MAX_TTL`, 72h): OpenBao
+revokes a dynamic-secret lease together with the auth token that minted it, so a
+token shorter than the lease silently caps the effective credential lifetime at
+the token's — with an eso-style 1h token, every issued DB credential died after
+~1h while the ExternalSecret refresh only re-mints every 24h, dropping the
+ephemeral MySQL user under a running service. The longer-lived token is bounded by
+the read-only `keystone-db-dynamic` / `glance-db-dynamic` policy.
 
 | Mount Path | Role | Bound SA | Bound NS | Policy | TTL | Max TTL |
 | --- | --- | --- | --- | --- | --- | --- |
 | `kubernetes/management` | `keystone-db` | `keystone-db-creds` | `*` | `keystone-db-dynamic` | 72h | 72h |
+| `kubernetes/management` | `glance-db` | `glance-db-creds` | `*` | `glance-db-dynamic` | 72h | 72h |
 | `kubernetes/management` | `eso-tenant` | `eso-tenant-auth` | `*` | `eso-tenant` | 1h | 4h |
 
 The management mount also carries an `eso-tenant` role — the per-ControlPlane
@@ -474,10 +493,11 @@ change. The `KUBERNETES_MANAGEMENT_ACCESSOR` placeholder in the templated
 policies is substituted with the live `kubernetes/management` auth-mount accessor
 at apply time.
 
-Two policies are **namespace-templated** rather than statically scoped, so a
+Three policies are **namespace-templated** rather than statically scoped, so a
 single policy backs every tenant while confining each token to its own namespace:
 
-- `keystone-db-dynamic` — read on the caller's own dynamic DB-credential path.
+- `keystone-db-dynamic` — read on the caller's own dynamic Keystone DB-credential path.
+- `glance-db-dynamic` — read on the caller's own dynamic Glance DB-credential path.
 - `eso-tenant` — the per-ControlPlane ESO identity and the **sole write path**
   for per-ControlPlane Keystone key material: read on the caller's own
   `openstack/keystone/{ns}/*` and `bootstrap/{ns}/*` subtrees, and
@@ -561,7 +581,7 @@ password versions untouched.
 
 ## HCL Access Control Policies
 
-Nine HCL policies enforce least-privilege access for each consumer type. All policy
+Ten HCL policies enforce least-privilege access for each consumer type. All policy
 paths under the KV v2 engine include the `data/` prefix, which is required by the
 OpenBao/Vault KV v2 API for read and write operations.
 
@@ -592,6 +612,7 @@ Ceph client key for Nova and Nova compute configuration, not broader secret path
 | `ci-cd-provisioner` | `kv-v2/data/*` (create/update/read), `kv-v2/metadata/*` (read/list) | `create`, `update`, `read`, `list` | CI/CD pipeline secret provisioning |
 | `pki-issuer` | `pki/issue/*`, `pki/sign/*` | `create`, `update` | cert-manager PKI certificate issuing |
 | `keystone-db-dynamic` | <code v-pre>database/mariadb/creds/keystone-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}</code> | `read` | Per-tenant dynamic Keystone DB credential reads (bound to the `keystone-db` role). The path is scoped by ACL identity templating to the caller's own service-account namespace (exact match, no wildcard), so a token minted in one namespace cannot read another tenant's creds path. Read-only: a dynamic engine has no static password to push, so the deferred `push-keystone-db.hcl` is unnecessary and not created (#439). |
+| `glance-db-dynamic` | <code v-pre>database/mariadb/creds/glance-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}</code> | `read` | Per-tenant dynamic Glance DB credential reads (bound to the `glance-db` role) — the Glance analogue of `keystone-db-dynamic`, and fully keystone-independent. The path is scoped by ACL identity templating to the caller's own service-account namespace (exact match, no wildcard), so a token minted in one namespace cannot read another tenant's creds path. Read-only: a dynamic engine has no static password to push. |
 
 **Note:** `ci-cd-provisioner` intentionally lacks `delete` capability. The CI/CD
 pipeline can create, update, and read secrets but cannot delete them, preventing
@@ -701,6 +722,7 @@ deployment-specific.
 | --- | --- | --- | --- | --- | --- |
 | `{controlplane.Name}-keystone-admin-credentials` | `openstack` | `bootstrap/{ns}/{name}-keystone/admin` (default `bootstrap/openstack/controlplane-keystone/admin`) | `password` | `{controlplane.Name}-keystone-admin-credentials` | `password` |
 | `{controlplane.Name}-keystone-db-credentials` | `openstack` | Dynamic (default): generator-backed via `VaultDynamicSecret` reading `database/mariadb/creds/keystone-{ns}` (no KV remote path); Static opt-out: `openstack/keystone/{ns}/{name}/db` | `username`, `password` | `{controlplane.Name}-keystone-db-credentials` | `username`, `password` |
+| `{controlplane.Name}-glance-db-credentials` | `openstack` | Dynamic (default): generator-backed via `VaultDynamicSecret` reading `database/mariadb/creds/glance-{ns}` (no KV remote path); Static opt-out: `openstack/glance/{ns}/{name}/db` | `username`, `password` | `{controlplane.Name}-glance-db-credentials` | `username`, `password` |
 | `keystone-admin` (kind only) | `openstack` | `bootstrap/openstack/controlplane-keystone/admin` | `password` | `keystone-admin` | `password` |
 | `mariadb-root-password` (kind only) | `openstack` | `infrastructure/mariadb` | `root-password` | `mariadb-root-password` | `password` |
 | `keystone-db` (kind only) | `openstack` | `openstack/keystone/openstack/standalone/db` | `username`, `password` | `keystone-db` | `username`, `password` |

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -964,6 +964,9 @@ openbao_bootstrap() {
 # Ready. This is the stage-(b) tenant-onboarding step (#439): managed-mode
 # Keystone draws engine-issued credentials from database/mariadb/creds/keystone-
 # <ns>-<cp>, which only exist after setup-database-tenant.sh configures the role.
+# setup-database-tenant.sh now ALSO provisions the glance engine connection+role
+# (database/mariadb/creds/glance-<ns>) when the ControlPlane declares Glance on
+# the shared managed database, so this single call onboards both services.
 #
 # Arguments:
 #   $1 — ControlPlane namespace
@@ -977,23 +980,65 @@ openbao_onboard_database_tenant() {
 
   log "--- Onboarding OpenBao database-engine tenant '${cp_ns}/${cp_name}' ---"
 
+  # Wait on the MariaDB in EVERY namespace setup-database-tenant.sh will read a
+  # root credential from, not just the ControlPlane's. Each service leg of that
+  # script resolves its own service namespace and hard-exits when that namespace's
+  # MariaDB root Secret is missing, so a ControlPlane that places Keystone or
+  # Glance in a namespace of its own provisions a SECOND openstack-db there on an
+  # independent timeline. Waiting only on the ControlPlane's namespace lets the
+  # Keystone leg succeed and the Glance leg exit 1 — a partially applied
+  # onboarding, with the operator already primed to flip Glance to Dynamic.
+  #
+  # The namespaces are resolved from the live CR with the same defaults the
+  # operator projects (an unset namespace block means the ControlPlane's own) and
+  # under the same conditions the script applies, so the wait set matches the read
+  # set exactly. The Glance leg in particular is SKIPPED for a dedicated glance
+  # database (Static-only, no engine role), which also has its own clusterRef name
+  # — waiting for the shared one in that namespace would block until timeout.
+  #
+  # Seeded with the ControlPlane's own namespace (the default every unset service
+  # namespace resolves to), which also keeps the dedup test below from expanding
+  # an empty array under `set -u`.
+  local svc_ns_list=("${cp_ns}")
+  local ns candidates=()
+
+  candidates+=("$(kubectl get controlplane "${cp_name}" -n "${cp_ns}" \
+    -o 'jsonpath={.spec.services.keystone.namespace.name}' 2>/dev/null || true)")
+
+  if [[ -n "$(kubectl get controlplane "${cp_name}" -n "${cp_ns}" \
+      -o 'jsonpath={.spec.services.glance}' 2>/dev/null || true)" &&
+    -z "$(kubectl get controlplane "${cp_name}" -n "${cp_ns}" \
+      -o 'jsonpath={.spec.services.glance.dedicatedBackingServices.database}' 2>/dev/null || true)" ]]; then
+    candidates+=("$(kubectl get controlplane "${cp_name}" -n "${cp_ns}" \
+      -o 'jsonpath={.spec.services.glance.namespace.name}' 2>/dev/null || true)")
+  fi
+
+  for ns in "${candidates[@]}"; do
+    [[ -z "${ns}" ]] && continue
+    if [[ ! " ${svc_ns_list[*]} " == *" ${ns} "* ]]; then
+      svc_ns_list+=("${ns}")
+    fi
+  done
+
   # The ControlPlane projects the MariaDB after it reconciles; wait for the CR to
   # appear before waiting on its Ready condition (kubectl wait errors on a
   # not-yet-existent resource).
-  log "Waiting for MariaDB '${mariadb_name}' to be projected in namespace '${cp_ns}'..."
   local i
-  for i in $(seq 1 30); do
-    if kubectl get "mariadb/${mariadb_name}" -n "${cp_ns}" >/dev/null 2>&1; then
-      break
+  for ns in "${svc_ns_list[@]}"; do
+    log "Waiting for MariaDB '${mariadb_name}' to be projected in namespace '${ns}'..."
+    for i in $(seq 1 30); do
+      if kubectl get "mariadb/${mariadb_name}" -n "${ns}" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 10
+    done
+    log "Waiting for MariaDB '${mariadb_name}' in namespace '${ns}' to become Ready..."
+    if ! kubectl wait "mariadb/${mariadb_name}" -n "${ns}" \
+      --for=condition=Ready --timeout="${POD_TIMEOUT}s"; then
+      log "ERROR: MariaDB '${mariadb_name}' in namespace '${ns}' did not become Ready; cannot onboard the database-engine tenant."
+      exit 1
     fi
-    sleep 10
   done
-  log "Waiting for MariaDB '${mariadb_name}' to become Ready..."
-  if ! kubectl wait "mariadb/${mariadb_name}" -n "${cp_ns}" \
-    --for=condition=Ready --timeout="${POD_TIMEOUT}s"; then
-    log "ERROR: MariaDB '${mariadb_name}' in namespace '${cp_ns}' did not become Ready; cannot onboard the database-engine tenant."
-    exit 1
-  fi
 
   export BAO_TOKEN
   trap 'unset BAO_TOKEN' EXIT
@@ -1984,9 +2029,10 @@ main() {
       log "  It provisions MariaDB/Memcached, projects Keystone, mints the K-ORC admin"
       log "  credential, and registers the identity catalog (not awaited here)."
 
-      # Onboard the OpenBao database-engine tenant so managed-mode Keystone can
-      # draw engine-issued (Dynamic) DB credentials (#439). The ControlPlane CR
-      # always lives in the openstack namespace; its MariaDB defaults to
+      # Onboard the OpenBao database-engine tenant so managed-mode Keystone — and
+      # Glance, when the ControlPlane declares it on the shared managed database —
+      # can draw engine-issued (Dynamic) DB credentials (#439). The ControlPlane
+      # CR always lives in the openstack namespace; its MariaDB defaults to
       # openstack-db. Idempotent, so it is safe even if a downstream suite also
       # onboards. The e2e-controlplane CI job uses WITH_CONTROLPLANE_CR=false and
       # runs setup-database-tenant.sh from its own chainsaw suite instead.

--- a/operators/c5c3/api/v1alpha1/controlplane_types.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_types.go
@@ -214,6 +214,7 @@ type ServicesSpec struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'External') || !has(self.federationProxyImage)",message="services.keystone.federationProxyImage is forbidden when services.keystone.mode is External"
 // +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'External') || !has(self.dedicatedBackingServices)",message="services.keystone.dedicatedBackingServices is forbidden when services.keystone.mode is External"
 // +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'External') || !has(self.namespace)",message="services.keystone.namespace is forbidden when services.keystone.mode is External"
+// +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'External') || !has(self.databaseCredentialsMode)",message="services.keystone.databaseCredentialsMode is forbidden when services.keystone.mode is External"
 type ServiceKeystoneSpec struct {
 	// Mode selects whether the Keystone service is Managed (the reconciler
 	// deploys and owns a full Keystone workload, today's behavior) or External
@@ -303,6 +304,25 @@ type ServiceKeystoneSpec struct {
 	// is deployed, so there is no sidecar to image.
 	// +optional
 	FederationProxyImage *commonv1.ImageSpec `json:"federationProxyImage,omitempty"`
+
+	// DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+	// for THIS service on the managed SHARED database, so a staged migration can run
+	// Keystone on one mode while another service stays on the other. Empty (the
+	// default) inherits the ControlPlane-wide mode; it is deliberately NOT
+	// materialized by the defaulting webhook, so "inherit" stays distinguishable
+	// from an explicit override. A dedicated per-service database is Static-only
+	// (its own credentialsMode lives in dedicatedBackingServices.database, where the
+	// webhook already rejects Dynamic), so a Dynamic override on a service that
+	// declares one is rejected; Dynamic also requires the shared database to be
+	// managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+	// Dynamic override on a brownfield shared database is rejected too. A Static
+	// override is always admitted.
+	//
+	// Forbidden when services.keystone.mode is External (CEL + webhook enforced): no
+	// managed database is provisioned, so there is no credentials mode to override.
+	// +optional
+	// +kubebuilder:validation:Enum=Static;Dynamic
+	DatabaseCredentialsMode string `json:"databaseCredentialsMode,omitempty"`
 
 	// DedicatedBackingServices opts the Keystone service out of the
 	// ControlPlane-wide shared instances declared in spec.infrastructure and gives
@@ -800,6 +820,22 @@ type ServiceGlanceSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:XValidation:rule="self.filter(b, has(b.isDefault) && b.isDefault).size() == 1",message="exactly one backends entry must set isDefault"
 	Backends []GlanceBackendEntry `json:"backends"`
+
+	// DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+	// for THIS service on the managed SHARED database, so a staged migration can run
+	// Glance on one mode while another service stays on the other. Empty (the
+	// default) inherits the ControlPlane-wide mode; it is deliberately NOT
+	// materialized by the defaulting webhook, so "inherit" stays distinguishable
+	// from an explicit override. A dedicated per-service database is Static-only
+	// (its own credentialsMode lives in dedicatedBackingServices.database, where the
+	// webhook already rejects Dynamic), so a Dynamic override on a service that
+	// declares one is rejected; Dynamic also requires the shared database to be
+	// managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+	// Dynamic override on a brownfield shared database is rejected too. A Static
+	// override is always admitted.
+	// +optional
+	// +kubebuilder:validation:Enum=Static;Dynamic
+	DatabaseCredentialsMode string `json:"databaseCredentialsMode,omitempty"`
 
 	// DedicatedBackingServices opts the Glance service out of the ControlPlane-wide
 	// shared instances declared in spec.infrastructure and gives it backing

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook.go
@@ -1400,6 +1400,7 @@ func (w *ControlPlaneWebhook) validate(cp *ControlPlane) field.ErrorList {
 	allErrs = append(allErrs, validateKeystoneMode(cp)...)
 	allErrs = append(allErrs, validateServiceAccounts(cp)...)
 	allErrs = append(allErrs, validateDedicatedBackingServices(cp)...)
+	allErrs = append(allErrs, validateServiceCredentialsModeOverrides(cp)...)
 	allErrs = append(allErrs, validateServiceNamespaces(cp)...)
 
 	return allErrs
@@ -1709,6 +1710,66 @@ func validateDedicatedBackingServices(cp *ControlPlane) field.ErrorList {
 	return allErrs
 }
 
+// validateServiceCredentialsModeOverrides enforces the rules on the per-service
+// spec.services.<svc>.databaseCredentialsMode override, which overrides the
+// ControlPlane-wide spec.infrastructure.database.credentialsMode for one service
+// on the managed SHARED database. The Enum marker already bounds the value to
+// Static|Dynamic at the schema layer; the two rejections below are the cross-field
+// invariants CEL cannot express, so they live in the webhook (per the established
+// CEL-vs-webhook split):
+//
+//   - A Dynamic override is rejected on a service that declares a DEDICATED
+//     database. The override targets the shared database, which that service does
+//     not use; its dedicated database has its own credentialsMode (Static-only —
+//     validateDedicatedBackingServices already rejects Dynamic there), so a Dynamic
+//     override on such a service is meaningless. Static stays admissible.
+//   - A Dynamic override is rejected when the shared database is brownfield
+//     (clusterRef unset), mirroring the commonv1.DatabaseSpec Dynamic-requires-
+//     clusterRef contract one level up: the dynamic engine issues per-tenant DB
+//     users only against a cluster the operator provisions.
+//
+// A Static override is always admitted, and an empty override (inherit) is a no-op.
+// The External-mode forbid on services.keystone.databaseCredentialsMode lives in
+// validateKeystoneMode with the rest of the External-mode matrix (glance is
+// forbidden entirely in External mode, so it needs no such rule).
+func validateServiceCredentialsModeOverrides(cp *ControlPlane) field.ErrorList {
+	var allErrs field.ErrorList
+	svcPath := field.NewPath("spec", "services")
+
+	// The shared database is managed exactly when it names a clusterRef. A nil
+	// infrastructure block (only reachable in External mode, which forbids the
+	// keystone override via CEL and forbids glance entirely) counts as not managed.
+	sharedManaged := cp.Spec.Infrastructure != nil && cp.Spec.Infrastructure.Database.ClusterRef != nil
+
+	check := func(svc string, mode string, dedicatedDB *commonv1.DatabaseSpec) {
+		if mode != commonv1.CredentialsModeDynamic {
+			return
+		}
+		modePath := svcPath.Child(svc, "databaseCredentialsMode")
+		switch {
+		case dedicatedDB != nil:
+			allErrs = append(allErrs, field.Forbidden(modePath,
+				"credentialsMode Dynamic is not supported as an override on a service with a dedicated database: "+
+					"the override retargets the shared database this service does not use, and a dedicated database is "+
+					"Static-only (set dedicatedBackingServices.database.credentialsMode instead)"))
+		case !sharedManaged:
+			allErrs = append(allErrs, field.Forbidden(modePath,
+				"credentialsMode Dynamic requires the shared database to be managed (clusterRef): the dynamic engine "+
+					"issues per-tenant DB users only against a cluster the operator provisions, so it cannot run against "+
+					"a brownfield database"))
+		}
+	}
+
+	if ks := cp.Spec.Services.Keystone; ks != nil {
+		check("keystone", ks.DatabaseCredentialsMode, cp.DedicatedKeystoneDatabase())
+	}
+	if gl := cp.Spec.Services.Glance; gl != nil {
+		check("glance", gl.DatabaseCredentialsMode, cp.DedicatedGlanceDatabase())
+	}
+
+	return allErrs
+}
+
 // validateKeystoneMode enforces the External-mode validation matrix. It mirrors
 // the type-level CEL rules on ServiceKeystoneSpec as defense-in-depth for callers
 // that bypass CRD schema admission (the same discipline as the release/database
@@ -1830,6 +1891,10 @@ func validateKeystoneMode(cp *ControlPlane) field.ErrorList {
 		if ks.Namespace != nil {
 			allErrs = append(allErrs, field.Forbidden(ksPath.Child("namespace"),
 				"forbidden when services.keystone.mode is External (no Keystone workload is deployed, so there is nothing to place)"))
+		}
+		if ks.DatabaseCredentialsMode != "" {
+			allErrs = append(allErrs, field.Forbidden(ksPath.Child("databaseCredentialsMode"),
+				"forbidden when services.keystone.mode is External (no managed database is provisioned, so there is no credentials mode to override)"))
 		}
 
 		// Cross-field rules CEL cannot express.

--- a/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
+++ b/operators/c5c3/api/v1alpha1/controlplane_webhook_test.go
@@ -4099,3 +4099,148 @@ func TestValidateUpdate_RejectsGlanceDedicatedPresenceFlip(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("switching a service between shared and dedicated backing services"))
 	g.Expect(err.Error()).To(ContainSubstring("glance.dedicatedBackingServices"))
 }
+
+// --- per-service databaseCredentialsMode override (issue #683) ---
+
+// TestValidateCreate_RejectsKeystoneCredentialsModeOverrideDynamicOnDedicated pins
+// that a Dynamic override on the Keystone service is rejected when Keystone
+// declares a dedicated database: the override retargets the shared database the
+// service does not use, and a dedicated database is Static-only. CEL cannot catch
+// it — the value passes the Enum, and no CEL rule spans the dedicated block.
+func TestValidateCreate_RejectsKeystoneCredentialsModeOverrideDynamicOnDedicated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane()
+	cp.Name = "cp"
+	cp.Spec.Services.Keystone.DatabaseCredentialsMode = commonv1.CredentialsModeDynamic
+	cp.Spec.Services.Keystone.DedicatedBackingServices = &KeystoneDedicatedBackingServicesSpec{
+		Database: &commonv1.DatabaseSpec{
+			ClusterRef: &corev1.LocalObjectReference{Name: "cp-keystone-db"},
+			Database:   "keystone",
+			SecretRef:  commonv1.SecretRefSpec{Name: "keystone-db"},
+		},
+	}
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("services.keystone.databaseCredentialsMode"))
+	g.Expect(err.Error()).To(ContainSubstring(
+		"Dynamic is not supported as an override on a service with a dedicated database",
+	))
+}
+
+// TestValidateCreate_RejectsGlanceCredentialsModeOverrideDynamicOnDedicated is the
+// glance mirror of the keystone dedicated-database rejection above.
+func TestValidateCreate_RejectsGlanceCredentialsModeOverrideDynamicOnDedicated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeDynamic
+	cp.Spec.Services.Glance.DedicatedBackingServices = &GlanceDedicatedBackingServicesSpec{
+		Database: &commonv1.DatabaseSpec{
+			ClusterRef: &corev1.LocalObjectReference{Name: "cp-glance-db"},
+			Database:   "glance",
+			SecretRef:  commonv1.SecretRefSpec{Name: "glance-db"},
+		},
+	}
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("services.glance.databaseCredentialsMode"))
+	g.Expect(err.Error()).To(ContainSubstring(
+		"Dynamic is not supported as an override on a service with a dedicated database",
+	))
+}
+
+// TestValidateCreate_RejectsCredentialsModeOverrideDynamicOnBrownfieldShared pins
+// that a Dynamic override on a service using the SHARED database is rejected when
+// that shared database is brownfield (host set, no clusterRef), mirroring the
+// commonv1.DatabaseSpec Dynamic-requires-clusterRef contract one level up.
+func TestValidateCreate_RejectsCredentialsModeOverrideDynamicOnBrownfieldShared(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane() // shared database is brownfield (host set, no clusterRef)
+	cp.Spec.Services.Keystone.DatabaseCredentialsMode = commonv1.CredentialsModeDynamic
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("services.keystone.databaseCredentialsMode"))
+	g.Expect(err.Error()).To(ContainSubstring(
+		"Dynamic requires the shared database to be managed (clusterRef)",
+	))
+}
+
+// TestValidateCreate_RejectsKeystoneCredentialsModeOverrideInExternalMode pins the
+// webhook mirror of the CEL forbid rule: databaseCredentialsMode is forbidden on
+// the Keystone service in External mode (even a Static value), because no managed
+// database is provisioned. The webhook is the enforcement point a direct validate()
+// call exercises (CEL runs only against a live apiserver).
+func TestValidateCreate_RejectsKeystoneCredentialsModeOverrideInExternalMode(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := externalControlPlane()
+	cp.Spec.Services.Keystone.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("services.keystone.databaseCredentialsMode"))
+	g.Expect(err.Error()).To(ContainSubstring("forbidden when services.keystone.mode is External"))
+}
+
+// TestValidateCreate_AcceptsStaticCredentialsModeOverrideOnDedicated pins that a
+// Static override is always admitted, even on a service that declares a dedicated
+// database (only Dynamic is rejected there).
+func TestValidateCreate_AcceptsStaticCredentialsModeOverrideOnDedicated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+	cp := validControlPlane()
+	cp.Name = "cp"
+	cp.Spec.Services.Keystone.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+	cp.Spec.Services.Keystone.DedicatedBackingServices = &KeystoneDedicatedBackingServicesSpec{
+		Database: &commonv1.DatabaseSpec{
+			ClusterRef: &corev1.LocalObjectReference{Name: "cp-keystone-db"},
+			Database:   "keystone",
+			SecretRef:  commonv1.SecretRefSpec{Name: "keystone-db"},
+		},
+	}
+
+	_, err := w.ValidateCreate(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"a Static override is always admitted, even on a service with a dedicated database")
+}
+
+// TestValidateCreate_AcceptsCredentialsModeOverridesOnManagedShared pins that a
+// Static or Dynamic override on a MANAGED shared database is admitted for both
+// services, in every combination — the staged-migration shape the field exists for.
+func TestValidateCreate_AcceptsCredentialsModeOverridesOnManagedShared(t *testing.T) {
+	g := NewGomegaWithT(t)
+	w := &ControlPlaneWebhook{}
+
+	tests := []struct {
+		name         string
+		keystoneMode string
+		glanceMode   string
+	}{
+		{"keystone-dynamic-glance-static", commonv1.CredentialsModeDynamic, commonv1.CredentialsModeStatic},
+		{"keystone-static-glance-dynamic", commonv1.CredentialsModeStatic, commonv1.CredentialsModeDynamic},
+		{"both-dynamic", commonv1.CredentialsModeDynamic, commonv1.CredentialsModeDynamic},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := managedControlPlane() // shared database is managed (clusterRef)
+			cp.Name = "cp"
+			cp.Spec.Services.Keystone.DatabaseCredentialsMode = tc.keystoneMode
+			cp.Spec.Services.Glance = validGlanceSpec()
+			cp.Spec.Services.Glance.DatabaseCredentialsMode = tc.glanceMode
+			cp.Spec.KORC.ServiceAccounts = []ServiceAccountSpec{{
+				Name:    "glance",
+				Project: ServiceAccountProjectSpec{Name: "service", Create: true},
+				Roles:   []string{"service"},
+			}}
+
+			_, err := w.ValidateCreate(context.Background(), cp)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"a Static/Dynamic override on a managed shared database must be admitted for both services")
+		})
+	}
+}

--- a/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/config/crd/bases/c5c3.io_controlplanes.yaml
@@ -896,6 +896,24 @@ spec:
                         - message: exactly one backends entry must set isDefault
                           rule: self.filter(b, has(b.isDefault) && b.isDefault).size()
                             == 1
+                      databaseCredentialsMode:
+                        description: |-
+                          DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+                          for THIS service on the managed SHARED database, so a staged migration can run
+                          Glance on one mode while another service stays on the other. Empty (the
+                          default) inherits the ControlPlane-wide mode; it is deliberately NOT
+                          materialized by the defaulting webhook, so "inherit" stays distinguishable
+                          from an explicit override. A dedicated per-service database is Static-only
+                          (its own credentialsMode lives in dedicatedBackingServices.database, where the
+                          webhook already rejects Dynamic), so a Dynamic override on a service that
+                          declares one is rejected; Dynamic also requires the shared database to be
+                          managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+                          Dynamic override on a brownfield shared database is rejected too. A Static
+                          override is always admitted.
+                        enum:
+                        - Static
+                        - Dynamic
+                        type: string
                       dedicatedBackingServices:
                         description: |-
                           DedicatedBackingServices opts the Glance service out of the ControlPlane-wide
@@ -1583,6 +1601,27 @@ spec:
                       reconciler reports KeystoneReady as not-managed. Flipping this from set to
                       nil deletes the previously-projected Keystone child.
                     properties:
+                      databaseCredentialsMode:
+                        description: |-
+                          DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+                          for THIS service on the managed SHARED database, so a staged migration can run
+                          Keystone on one mode while another service stays on the other. Empty (the
+                          default) inherits the ControlPlane-wide mode; it is deliberately NOT
+                          materialized by the defaulting webhook, so "inherit" stays distinguishable
+                          from an explicit override. A dedicated per-service database is Static-only
+                          (its own credentialsMode lives in dedicatedBackingServices.database, where the
+                          webhook already rejects Dynamic), so a Dynamic override on a service that
+                          declares one is rejected; Dynamic also requires the shared database to be
+                          managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+                          Dynamic override on a brownfield shared database is rejected too. A Static
+                          override is always admitted.
+
+                          Forbidden when services.keystone.mode is External (CEL + webhook enforced): no
+                          managed database is provisioned, so there is no credentials mode to override.
+                        enum:
+                        - Static
+                        - Dynamic
+                        type: string
                       dedicatedBackingServices:
                         description: |-
                           DedicatedBackingServices opts the Keystone service out of the
@@ -2350,6 +2389,9 @@ spec:
                     - message: services.keystone.namespace is forbidden when services.keystone.mode
                         is External
                       rule: '!(has(self.mode) && self.mode == ''External'') || !has(self.namespace)'
+                    - message: services.keystone.databaseCredentialsMode is forbidden
+                        when services.keystone.mode is External
+                      rule: '!(has(self.mode) && self.mode == ''External'') || !has(self.databaseCredentialsMode)'
                 type: object
             required:
             - korc

--- a/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
+++ b/operators/c5c3/helm/c5c3-operator/crds/c5c3.io_controlplanes.yaml
@@ -899,6 +899,24 @@ spec:
                         - message: exactly one backends entry must set isDefault
                           rule: self.filter(b, has(b.isDefault) && b.isDefault).size()
                             == 1
+                      databaseCredentialsMode:
+                        description: |-
+                          DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+                          for THIS service on the managed SHARED database, so a staged migration can run
+                          Glance on one mode while another service stays on the other. Empty (the
+                          default) inherits the ControlPlane-wide mode; it is deliberately NOT
+                          materialized by the defaulting webhook, so "inherit" stays distinguishable
+                          from an explicit override. A dedicated per-service database is Static-only
+                          (its own credentialsMode lives in dedicatedBackingServices.database, where the
+                          webhook already rejects Dynamic), so a Dynamic override on a service that
+                          declares one is rejected; Dynamic also requires the shared database to be
+                          managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+                          Dynamic override on a brownfield shared database is rejected too. A Static
+                          override is always admitted.
+                        enum:
+                        - Static
+                        - Dynamic
+                        type: string
                       dedicatedBackingServices:
                         description: |-
                           DedicatedBackingServices opts the Glance service out of the ControlPlane-wide
@@ -1586,6 +1604,27 @@ spec:
                       reconciler reports KeystoneReady as not-managed. Flipping this from set to
                       nil deletes the previously-projected Keystone child.
                     properties:
+                      databaseCredentialsMode:
+                        description: |-
+                          DatabaseCredentialsMode overrides spec.infrastructure.database.credentialsMode
+                          for THIS service on the managed SHARED database, so a staged migration can run
+                          Keystone on one mode while another service stays on the other. Empty (the
+                          default) inherits the ControlPlane-wide mode; it is deliberately NOT
+                          materialized by the defaulting webhook, so "inherit" stays distinguishable
+                          from an explicit override. A dedicated per-service database is Static-only
+                          (its own credentialsMode lives in dedicatedBackingServices.database, where the
+                          webhook already rejects Dynamic), so a Dynamic override on a service that
+                          declares one is rejected; Dynamic also requires the shared database to be
+                          managed (clusterRef set), mirroring the commonv1.DatabaseSpec contract, so a
+                          Dynamic override on a brownfield shared database is rejected too. A Static
+                          override is always admitted.
+
+                          Forbidden when services.keystone.mode is External (CEL + webhook enforced): no
+                          managed database is provisioned, so there is no credentials mode to override.
+                        enum:
+                        - Static
+                        - Dynamic
+                        type: string
                       dedicatedBackingServices:
                         description: |-
                           DedicatedBackingServices opts the Keystone service out of the
@@ -2353,6 +2392,9 @@ spec:
                     - message: services.keystone.namespace is forbidden when services.keystone.mode
                         is External
                       rule: '!(has(self.mode) && self.mode == ''External'') || !has(self.namespace)'
+                    - message: services.keystone.databaseCredentialsMode is forbidden
+                        when services.keystone.mode is External
+                      rule: '!(has(self.mode) && self.mode == ''External'') || !has(self.databaseCredentialsMode)'
                 type: object
             required:
             - korc

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -790,6 +790,40 @@ func simulateAdminPasswordExternalSecretSyncWhenPresent(
 		To(Succeed(), "simulate per-CP admin password ExternalSecret sync")
 }
 
+// simulateGlanceDBCredentialSyncWhenPresent waits for the operator-created Glance
+// DB-credential ExternalSecret, simulates the ESO sync, and materialises the
+// Secret behind it with an ENGINE-ISSUED username.
+//
+// Both halves are required: reconcileGlance gates the Dynamic projection on the
+// ExternalSecret being Ready AND on the Secret it targets carrying a username the
+// database engine minted, because a Static->Dynamic flip updates the
+// ExternalSecret in place and its Ready can otherwise still be the retired Static
+// sync's. SimulateExternalSecretSync patches only the ExternalSecret .status, and
+// envtest runs no ESO, so the Secret is created here the way ESO would create it.
+func simulateGlanceDBCredentialSyncWhenPresent(
+	t testing.TB, ctx context.Context, c client.Client, cp *c5c3v1alpha1.ControlPlane,
+) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	glanceNS, name := cp.GlanceNamespace(), glanceDBCredentialSecretName(cp)
+	g.Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: glanceNS, Name: name}, &esov1.ExternalSecret{})
+	}, itEventuallyTimeout, itPollInterval).Should(Succeed(),
+		"operator must create the per-CP Glance DB-credential ExternalSecret")
+
+	g.Expect(c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: glanceNS},
+		Data: map[string][]byte{
+			"username": []byte(engineIssuedUsernamePrefix + "kubernetes-glance-abc123-1750000000"),
+			"password": []byte("engine-issued-password"),
+		},
+	})).To(Succeed(), "materialise the engine-issued Glance DB credential ESO would have written")
+
+	g.Expect(simulators.SimulateExternalSecretSync(ctx, c, client.ObjectKey{Namespace: glanceNS, Name: name})).
+		To(Succeed(), "simulate per-CP Glance DB credential ExternalSecret sync")
+}
+
 // TestIntegration_FullReconcile_ManagedToReady drives a managed-mode ControlPlane
 // through every sub-reconciler to the aggregate Ready=True, simulating each
 // external dependency's readiness in dependency order. It is the single primary
@@ -984,6 +1018,12 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	// per-account readiness (driven in Phase 5.5), so the child — and its
 	// GlanceBackend and DB-credential ExternalSecret — only appear now. Assert their
 	// operator-derived shape before simulating readiness. ---
+	//
+	// The Dynamic-default credential is a THIRD gate on top of those two: no child
+	// is projected until the glance-scoped ExternalSecret has synced and the Secret
+	// behind it carries an engine-issued username, so open it first.
+	simulateGlanceDBCredentialSyncWhenPresent(t, ctx, c, cp)
+
 	glanceKey := client.ObjectKey{Name: glanceName(cp), Namespace: ns.Name}
 	projectedGlance := &glancev1alpha1.Glance{}
 	g.Eventually(func() error {
@@ -996,16 +1036,16 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g.Expect(projectedGlance.Spec.Image.Tag).To(Equal("2025.2"), "Glance image tag must derive from openStackRelease")
 
 	// Database: the shared managed cluster, the fixed "glance" logical schema, and
-	// the operator-owned static KV-backed DB credential (there is no OpenBao engine
-	// role for the glance schema, so the credential is never engine-issued).
+	// the operator-owned engine-issued DB credential (Dynamic is the default on the
+	// managed shared database, mirroring Keystone with glance-scoped objects).
 	g.Expect(projectedGlance.Spec.Database.ClusterRef).NotTo(BeNil(), "Glance database clusterRef must be wired")
 	g.Expect(projectedGlance.Spec.Database.ClusterRef.Name).To(Equal("openstack-db"))
 	g.Expect(projectedGlance.Spec.Database.Database).To(Equal("glance"))
 	g.Expect(projectedGlance.Spec.Database.SecretRef.Name).To(Equal(glanceDBCredentialSecretName(cp)),
 		"managed Glance DB secretRef must point at the operator-owned per-CP Glance DB-credential Secret")
 	g.Expect(projectedGlance.Spec.Database.SecretRef.Key).To(Equal("password"))
-	g.Expect(projectedGlance.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeStatic),
-		"the projected Glance DB credential is forced Static (KV-backed)")
+	g.Expect(projectedGlance.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeDynamic),
+		"the projected Glance DB credential defaults to Dynamic (engine-issued)")
 
 	// Cache: the shared managed Memcached.
 	g.Expect(projectedGlance.Spec.Cache.ClusterRef).NotTo(BeNil(), "Glance cache clusterRef must be wired")
@@ -1050,21 +1090,39 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g.Expect(backendOwner).NotTo(BeNil(), "GlanceBackend child must be controller-owned by the ControlPlane")
 	g.Expect(backendOwner.Name).To(Equal(cp.Name))
 
-	// The static, KV-backed Glance DB-credential ExternalSecret: two Data entries
-	// (username/password) read from this CR's namespace-scoped OpenBao KV path.
+	// The Dynamic-mode Glance DB-credential ExternalSecret draws from the per-CP
+	// VaultDynamicSecret generator (dataFrom.sourceRef.generatorRef) and carries no
+	// static Data refs.
 	glanceDBCredES := &esov1.ExternalSecret{}
 	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: glanceDBCredentialSecretName(cp)}, glanceDBCredES)).
 		To(Succeed(), "operator must create the per-CP Glance DB-credential ExternalSecret")
-	g.Expect(glanceDBCredES.Spec.Data).To(HaveLen(2), "Glance DB-credential ExternalSecret carries username + password")
-	g.Expect(glanceDBCredES.Spec.Data[0].SecretKey).To(Equal("username"))
-	g.Expect(glanceDBCredES.Spec.Data[1].SecretKey).To(Equal("password"))
-	for _, d := range glanceDBCredES.Spec.Data {
-		g.Expect(d.RemoteRef.Key).To(Equal(glanceDBCredentialRemoteKeyFor(cp)),
-			"Glance DB-credential ExternalSecret must read this CR's namespace-scoped OpenBao KV path")
-	}
+	g.Expect(glanceDBCredES.Spec.Data).To(BeEmpty(), "the Dynamic Glance DB-credential ExternalSecret carries no static Data refs")
+	g.Expect(glanceDBCredES.Spec.DataFrom).NotTo(BeEmpty(), "the Dynamic Glance DB-credential ExternalSecret must declare a generatorRef")
+	g.Expect(glanceDBCredES.Spec.DataFrom[0].SourceRef).NotTo(BeNil())
+	g.Expect(glanceDBCredES.Spec.DataFrom[0].SourceRef.GeneratorRef).NotTo(BeNil())
+	g.Expect(glanceDBCredES.Spec.DataFrom[0].SourceRef.GeneratorRef.Kind).To(Equal("VaultDynamicSecret"))
 	glanceESOwner := metav1.GetControllerOf(glanceDBCredES)
 	g.Expect(glanceESOwner).NotTo(BeNil(), "Glance DB-credential ExternalSecret must be controller-owned by the ControlPlane")
 	g.Expect(glanceESOwner.Name).To(Equal(cp.Name))
+
+	// The per-CP Glance VaultDynamicSecret generator reads this tenant's glance
+	// creds path with role glance-db, authenticating with the glance-db-creds SA and
+	// the mTLS client Certificate — all in the glance namespace.
+	glanceVDS := &esgenv1alpha1.VaultDynamicSecret{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: glanceDBCredentialSecretName(cp)}, glanceVDS)).
+		To(Succeed(), "operator must create the per-CP Glance VaultDynamicSecret generator")
+	g.Expect(glanceVDS.Spec.Path).To(Equal(glanceDBDynamicCredsPathFor(cp)))
+	g.Expect(glanceVDS.Spec.Provider.Auth.Kubernetes.Role).To(Equal(glanceDBDynamicVaultRole))
+	g.Expect(metav1.GetControllerOf(glanceVDS)).NotTo(BeNil(), "Glance VaultDynamicSecret must be owned by the ControlPlane")
+
+	glanceDBCredSA := &corev1.ServiceAccount{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: glanceDBCredentialServiceAccountName}, glanceDBCredSA)).
+		To(Succeed(), "operator must create the Glance generator's ServiceAccount in the glance namespace")
+
+	glanceDBCredCert := &unstructured.Unstructured{}
+	glanceDBCredCert.SetGroupVersionKind(certificateGVK)
+	g.Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: glanceDBCredentialClientCertName(cp)}, glanceDBCredCert)).
+		To(Succeed(), "operator must create the Glance generator's mTLS client Certificate in the glance namespace")
 
 	simulateGlanceReadyWhenPresent(t, ctx, c, glanceKey)
 	waitForControlPlaneCondition(t, ctx, c, cpKey, conditionTypeGlanceReady, metav1.ConditionTrue, itEventuallyTimeout)

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials.go
@@ -7,12 +7,15 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esgenv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
 	esmetav1 "github.com/external-secrets/external-secrets/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,6 +67,16 @@ const (
 	// leaves (openbao-client-tls-cert.yaml) so client-cert rotation cadences align.
 	dbCredentialClientCertDuration    = "8760h"
 	dbCredentialClientCertRenewBefore = "720h"
+	// engineIssuedUsernamePrefix is the prefix every username the OpenBao MariaDB
+	// database engine mints carries. The mysql-database-plugin derives usernames
+	// from its default username_template ("v-<display>-<role>-<random>-<timestamp>",
+	// truncated to MySQL's 32-character limit) and setup-database-tenant.sh does not
+	// override that template, so the prefix is what tells an engine-issued login
+	// apart from the hand-seeded static one a retired Static deployment leaves
+	// behind. A template override there would have to keep the prefix, or the gate
+	// below stalls the credentials-mode flip (fail CLOSED — a diagnosable
+	// GlanceReady=False, never a DSN naming a login that was never created).
+	engineIssuedUsernamePrefix = "v-"
 )
 
 // dbCredentialRefreshInterval is how often ESO re-issues the engine-issued
@@ -178,20 +191,80 @@ func dbCredentialClientCertName(cp *c5c3v1alpha1.ControlPlane) string {
 	return keystoneName(cp) + dbCredentialClientCertSuffix
 }
 
+// dbCredentialTarget carries everything that distinguishes one service's
+// DB-credential concern from another's. The projected objects, their ordering,
+// and their teardown are identical across services, so the builders and the
+// ensure/delete pair below take a target rather than being transliterated once
+// per service (see keystoneDBCredentialTarget / glanceDBCredentialTarget in
+// reconcile_glance_dbcredentials.go).
+type dbCredentialTarget struct {
+	// qualifier is the service name the error and log messages this concern emits
+	// prefix themselves with, so each service names itself in the ControlPlane
+	// condition it surfaces through: empty for Keystone ("ensuring DB credential
+	// ServiceAccount"), "Glance" for Glance ("ensuring Glance DB credential
+	// ServiceAccount"). Message sites splice it through prefix(), never directly.
+	qualifier string
+	// namespace is the SERVICE namespace every object lands in, beside the
+	// database it issues against and the child that consumes it.
+	namespace string
+	// secretName names the DB-credential Secret, its ExternalSecret, and the
+	// VaultDynamicSecret generator behind it (all three share the name).
+	secretName string
+	// certName names the mTLS client Certificate and the Secret it materialises.
+	certName string
+	// saName is the ServiceAccount whose token the generator presents to OpenBao.
+	saName string
+	// vaultRole is the OpenBao Kubernetes-auth role the generator authenticates
+	// against; credsPath is the database-engine path it reads from.
+	vaultRole string
+	credsPath string
+	// kvPath is the KV path the Static opt-out branch reads instead.
+	kvPath string
+	// storeRef is the store the ControlPlane selected, used by the Static
+	// ExternalSecret and to resolve the OpenBao connection config.
+	storeRef commonv1.SecretStoreRefSpec
+}
+
+// prefix returns qualifier as a message prefix: the service name plus the
+// separating space, or "" for the unqualified (Keystone) concern. Keeping the
+// separator here rather than inside the qualifier literal means no message
+// depends on an invisible trailing space surviving every future edit.
+func (t dbCredentialTarget) prefix() string {
+	if t.qualifier == "" {
+		return ""
+	}
+	return t.qualifier + " "
+}
+
+// keystoneDBCredentialTarget describes the Keystone DB-credential concern.
+func keystoneDBCredentialTarget(cp *c5c3v1alpha1.ControlPlane) dbCredentialTarget {
+	return dbCredentialTarget{
+		namespace:  cp.KeystoneNamespace(),
+		secretName: dbCredentialSecretName(cp),
+		certName:   dbCredentialClientCertName(cp),
+		saName:     dbCredentialServiceAccountName,
+		vaultRole:  dbDynamicVaultRole,
+		credsPath:  dbDynamicCredsPathFor(cp),
+		kvPath:     dbCredentialRemoteKeyFor(cp),
+		storeRef:   effectiveControlPlaneStoreRef(cp),
+	}
+}
+
 // dbCredentialServiceAccount builds the per-ControlPlane ServiceAccount whose
 // token the VaultDynamicSecret generator presents to OpenBao. PURE builder: the
 // reconciler sets the owner reference in the CreateOrUpdate mutate closure.
-func dbCredentialServiceAccount(cp *c5c3v1alpha1.ControlPlane) *corev1.ServiceAccount {
+func dbCredentialServiceAccount(t dbCredentialTarget) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Name: dbCredentialServiceAccountName, Namespace: cp.KeystoneNamespace()},
+		ObjectMeta: metav1.ObjectMeta{Name: t.saName, Namespace: t.namespace},
 	}
 }
 
 // applyDBCredentialCertificateSpec sets the desired spec fields on the client
-// Certificate. Extracted so the CreateOrUpdate mutate closure can re-assert the
-// spec on an existing object without clobbering cert-manager-managed status.
-func applyDBCredentialCertificateSpec(u *unstructured.Unstructured, cp *c5c3v1alpha1.ControlPlane) {
-	name := dbCredentialClientCertName(cp)
+// Certificate named name in namespace. Extracted so the CreateOrUpdate mutate
+// closure can re-assert the spec on an existing object without clobbering
+// cert-manager-managed status, and generalized over name/namespace so both the
+// Keystone and the Glance DB-credential concerns can drive their own client cert.
+func applyDBCredentialCertificateSpec(u *unstructured.Unstructured, name, namespace string) {
 	// SetNested* only errors on a type conflict at an existing path; on a
 	// freshly-built or Certificate-typed object the writes cannot fail, so the
 	// errors are intentionally ignored here.
@@ -199,7 +272,7 @@ func applyDBCredentialCertificateSpec(u *unstructured.Unstructured, cp *c5c3v1al
 	_ = unstructured.SetNestedField(u.Object, dbCredentialClientCertDuration, "spec", "duration")
 	_ = unstructured.SetNestedField(u.Object, dbCredentialClientCertRenewBefore, "spec", "renewBefore")
 	_ = unstructured.SetNestedStringSlice(u.Object, []string{"client auth"}, "spec", "usages")
-	_ = unstructured.SetNestedField(u.Object, name+"."+cp.KeystoneNamespace()+".svc", "spec", "commonName")
+	_ = unstructured.SetNestedField(u.Object, name+"."+namespace+".svc", "spec", "commonName")
 	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
 		"name": openBaoCAIssuerName,
 		"kind": "ClusterIssuer",
@@ -213,12 +286,12 @@ func applyDBCredentialCertificateSpec(u *unstructured.Unstructured, cp *c5c3v1al
 // Certificate's Secret, and the SA token from the per-CP ServiceAccount. server
 // and mountPath are copied from the live openbao-cluster-store so the connection
 // config cannot drift from the store the rest of the stack uses.
-func dbCredentialVaultDynamicSecret(cp *c5c3v1alpha1.ControlPlane, server, mountPath string) *esgenv1alpha1.VaultDynamicSecret {
-	certSecret := dbCredentialClientCertName(cp)
+func dbCredentialVaultDynamicSecret(t dbCredentialTarget, server, mountPath string) *esgenv1alpha1.VaultDynamicSecret {
+	certSecret := t.certName
 	return &esgenv1alpha1.VaultDynamicSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: dbCredentialSecretName(cp), Namespace: cp.KeystoneNamespace()},
+		ObjectMeta: metav1.ObjectMeta{Name: t.secretName, Namespace: t.namespace},
 		Spec: esgenv1alpha1.VaultDynamicSecretSpec{
-			Path:   dbDynamicCredsPathFor(cp),
+			Path:   t.credsPath,
 			Method: "GET",
 			Provider: &esov1.VaultProvider{
 				Server: server,
@@ -231,8 +304,8 @@ func dbCredentialVaultDynamicSecret(cp *c5c3v1alpha1.ControlPlane, server, mount
 				Auth: &esov1.VaultAuth{
 					Kubernetes: &esov1.VaultKubernetesAuth{
 						Path:              mountPath,
-						Role:              dbDynamicVaultRole,
-						ServiceAccountRef: &esmetav1.ServiceAccountSelector{Name: dbCredentialServiceAccountName},
+						Role:              t.vaultRole,
+						ServiceAccountRef: &esmetav1.ServiceAccountSelector{Name: t.saName},
 					},
 				},
 				CAProvider: &esov1.CAProvider{
@@ -250,15 +323,17 @@ func dbCredentialVaultDynamicSecret(cp *c5c3v1alpha1.ControlPlane, server, mount
 }
 
 // dbCredentialGeneratorExternalSecret builds the Dynamic-mode ExternalSecret that
-// materialises the engine-issued username+password into the KEYSTONE service
-// namespace (beside the child that consumes it) via the per-CP VaultDynamicSecret
+// materialises the engine-issued username+password into the SERVICE namespace
+// (beside the child that consumes it) via the per-CP VaultDynamicSecret
 // generator. It carries no static Data refs and no
 // SecretStoreRef — the generatorRef is the sole source. RefreshInterval is below
-// the engine role's default_ttl so ESO renews the lease before it expires.
-func dbCredentialGeneratorExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
-	name := dbCredentialSecretName(cp)
+// the engine role's default_ttl so ESO renews the lease before it expires. The
+// materialised Secret carries the same username/password keys the static
+// ExternalSecret produces, so the projected DB secretRef is mode-agnostic.
+func dbCredentialGeneratorExternalSecret(t dbCredentialTarget) *esov1.ExternalSecret {
+	name := t.secretName
 	return &esov1.ExternalSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cp.KeystoneNamespace()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: t.namespace},
 		Spec: esov1.ExternalSecretSpec{
 			RefreshInterval: &metav1.Duration{Duration: dbCredentialRefreshInterval},
 			Target:          esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner},
@@ -279,14 +354,16 @@ func dbCredentialGeneratorExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.E
 // ExternalSecret used by the Static opt-out branch (migration staging /
 // brownfield). It reads username+password from the per-ControlPlane KV path via
 // the store the ControlPlane selected (default: the shared openbao-cluster-store).
-func dbCredentialStaticExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
-	name := dbCredentialSecretName(cp)
-	remoteKey := dbCredentialRemoteKeyFor(cp)
+// It materialises the same target Secret shape the Dynamic generator does, so the
+// projected DB secretRef is mode-agnostic.
+func dbCredentialStaticExternalSecret(t dbCredentialTarget) *esov1.ExternalSecret {
+	name := t.secretName
+	remoteKey := t.kvPath
 	return &esov1.ExternalSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cp.KeystoneNamespace()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: t.namespace},
 		Spec: esov1.ExternalSecretSpec{
 			RefreshInterval: &metav1.Duration{Duration: time.Hour},
-			SecretStoreRef:  secrets.ESOSecretStoreRef(effectiveControlPlaneStoreRef(cp)),
+			SecretStoreRef:  secrets.ESOSecretStoreRef(t.storeRef),
 			Target:          esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner},
 			Data: []esov1.ExternalSecretData{
 				{SecretKey: "username", RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: "username"}},
@@ -299,7 +376,10 @@ func dbCredentialStaticExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.Exte
 // dbCredentialsDynamicEnabled reports the effective credentials mode of the
 // database Keystone actually connects to: Dynamic (engine-issued) is the default
 // for a managed SHARED database; a ControlPlane opts out by setting
-// credentialsMode: Static (migration staging / brownfield).
+// credentialsMode: Static (migration staging / brownfield). A non-empty
+// per-service services.keystone.databaseCredentialsMode override wins over the
+// shared credentialsMode, so a staged migration can run Keystone on one mode
+// while another service stays on the other.
 //
 // A DEDICATED database is never Dynamic. The OpenBao database engine carries one
 // connection and one role per NAMESPACE (deploy/openbao/bootstrap/
@@ -311,14 +391,34 @@ func dbCredentialStaticExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.Exte
 // stored mode keeps a webhook-bypassed CR failing closed onto Static rather than
 // projecting a generator that could never sync.
 func dbCredentialsDynamicEnabled(cp *c5c3v1alpha1.ControlPlane) bool {
-	if cp.DedicatedKeystoneDatabase() != nil {
+	var override string
+	if ks := cp.Spec.Services.Keystone; ks != nil {
+		override = ks.DatabaseCredentialsMode
+	}
+	return dbCredentialModeIsDynamic(cp.DedicatedKeystoneDatabase(), effectiveKeystoneDatabase(cp), override)
+}
+
+// dbCredentialModeIsDynamic decides the effective credentials mode shared by
+// every service's *DynamicEnabled predicate: dedicated declarations and
+// databases without a managed cluster fail closed onto Static, and a non-empty
+// per-service override wins over the shared credentialsMode.
+func dbCredentialModeIsDynamic(dedicated, effective *commonv1.DatabaseSpec, override string) bool {
+	if dedicated != nil {
 		return false
 	}
 	// The effective database is nil for an External-mode (or webhook-bypassed) CR,
 	// and brownfield when it carries no ClusterRef: neither has a managed database
 	// to issue credentials for.
-	db := effectiveKeystoneDatabase(cp)
-	return db != nil && db.ClusterRef != nil && db.CredentialsMode != commonv1.CredentialsModeStatic
+	if effective == nil || effective.ClusterRef == nil {
+		return false
+	}
+	// The per-service override takes precedence over the shared credentialsMode
+	// when set; an empty override inherits the shared mode (Dynamic by default).
+	mode := effective.CredentialsMode
+	if override != "" {
+		mode = override
+	}
+	return mode != commonv1.CredentialsModeStatic
 }
 
 // reconcileDBCredentials projects (in managed mode) the per-ControlPlane service
@@ -407,8 +507,9 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 		return ctrl.Result{RequeueAfter: dbCredentialsRequeueAfter}, nil
 	}
 
+	target := keystoneDBCredentialTarget(cp)
 	if dbCredentialsDynamicEnabled(cp) {
-		if err := r.ensureDynamicDBCredentialObjects(ctx, cp); err != nil {
+		if err := r.ensureDynamicDBCredentialObjects(ctx, cp, target); err != nil {
 			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 				Type:               conditionTypeDBCredentialsReady,
 				Status:             metav1.ConditionFalse,
@@ -424,8 +525,8 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 		// a KV path nothing seeds (see dbCredentialRemoteKeyFor), so it only syncs
 		// once that path has been seeded out-of-band — dbCredentialNotReadyMessage
 		// says so in the condition while it has not.
-		r.deleteDynamicDBCredentialObjects(ctx, cp)
-		if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialStaticExternalSecret(cp)); err != nil {
+		r.deleteDynamicDBCredentialObjects(ctx, cp, target)
+		if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialStaticExternalSecret(target)); err != nil {
 			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 				Type:               conditionTypeDBCredentialsReady,
 				Status:             metav1.ConditionFalse,
@@ -443,16 +544,16 @@ func (r *ControlPlaneReconciler) reconcileDBCredentials(ctx context.Context, cp 
 // ensureDynamicDBCredentialObjects create-or-updates the ServiceAccount, mTLS
 // client Certificate, VaultDynamicSecret generator, and generator-backed
 // ExternalSecret that materialise engine-issued DB credentials — all in the
-// KEYSTONE service namespace, beside the database they issue against and the child
+// target's SERVICE namespace, beside the database they issue against and the child
 // that consumes them. Ordering (SA → Certificate → generator → ExternalSecret)
 // makes the auth identity and TLS material exist before the generator that
 // references them. In the ControlPlane's own namespace they are owner-referenced;
 // in a service namespace they carry the ownership labels instead.
-func (r *ControlPlaneReconciler) ensureDynamicDBCredentialObjects(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) error {
-	server, mountPath := r.openBaoConnection(ctx, cp, effectiveControlPlaneStoreRef(cp))
+func (r *ControlPlaneReconciler) ensureDynamicDBCredentialObjects(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, t dbCredentialTarget) error {
+	server, mountPath := r.openBaoConnection(ctx, cp, t.storeRef)
 
-	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialServiceAccount(cp)); err != nil {
-		return fmt.Errorf("ensuring DB credential ServiceAccount: %w", err)
+	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialServiceAccount(t)); err != nil {
+		return fmt.Errorf("ensuring %sDB credential ServiceAccount: %w", t.prefix(), err)
 	}
 
 	// The cert-manager Certificate is handled as an unstructured object (no Go
@@ -461,55 +562,100 @@ func (r *ControlPlaneReconciler) ensureDynamicDBCredentialObjects(ctx context.Co
 	// typed sibling objects around it use Server-Side Apply.
 	live := &unstructured.Unstructured{}
 	live.SetGroupVersionKind(certificateGVK)
-	live.SetName(dbCredentialClientCertName(cp))
-	live.SetNamespace(cp.KeystoneNamespace())
+	live.SetName(t.certName)
+	live.SetNamespace(t.namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, live, func() error {
 		if err := refuseForeignAdoption(cp, live, r.Scheme); err != nil {
 			return err
 		}
-		applyDBCredentialCertificateSpec(live, cp)
+		applyDBCredentialCertificateSpec(live, t.certName, t.namespace)
 		return claimChildOwnership(cp, live, r.Scheme)
 	}); err != nil {
-		return fmt.Errorf("ensuring DB credential Certificate: %w", err)
+		return fmt.Errorf("ensuring %sDB credential Certificate: %w", t.prefix(), err)
 	}
 
-	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialVaultDynamicSecret(cp, server, mountPath)); err != nil {
-		return fmt.Errorf("ensuring VaultDynamicSecret generator: %w", err)
+	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialVaultDynamicSecret(t, server, mountPath)); err != nil {
+		return fmt.Errorf("ensuring %sVaultDynamicSecret generator: %w", t.prefix(), err)
 	}
 
-	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialGeneratorExternalSecret(cp)); err != nil {
-		return fmt.Errorf("ensuring DB credential ExternalSecret: %w", err)
+	if err := r.ensureUnownedOrOwned(ctx, cp, dbCredentialGeneratorExternalSecret(t)); err != nil {
+		return fmt.Errorf("ensuring %sDB credential ExternalSecret: %w", t.prefix(), err)
 	}
 	return nil
 }
 
 // deleteDynamicDBCredentialObjects best-effort deletes the dynamic-mode
 // ServiceAccount, client Certificate, and VaultDynamicSecret so a Dynamic→Static
-// flip leaves no orphaned generator. Uses minimal-object Delete + IgnoreNotFound
-// (the Get-less delete pattern); a non-NotFound error is logged rather than
-// blocking the Static reconcile of a superseded object. The generator-backed
-// ExternalSecret is not deleted — it is create-or-updated in place to the static
-// shape (same name).
-func (r *ControlPlaneReconciler) deleteDynamicDBCredentialObjects(ctx context.Context, cp *c5c3v1alpha1.ControlPlane) {
+// flip leaves no orphaned generator. The generator-backed ExternalSecret is not
+// deleted — it is create-or-updated in place to the static shape (same name).
+//
+// Every object is read live and gated on isControlPlaneChild before the Delete,
+// mirroring sweepExternalNamespaceResidue: the names here are fixed and
+// non-CP-derived (keystone-db-creds / glance-db-creds), and a service namespace
+// need not belong to this ControlPlane, so a same-named object belonging to
+// somebody else must be left alone. Deleting it would be the teardown-side twin of
+// the adoption ensureUnownedOrOwned already refuses. Reads and deletes are
+// best-effort: an unreadable or undeletable object is logged rather than blocking
+// the Static reconcile of a superseded object, and an absent CRD
+// (meta.IsNoMatchError) reads as nothing-to-clean.
+func (r *ControlPlaneReconciler) deleteDynamicDBCredentialObjects(ctx context.Context, cp *c5c3v1alpha1.ControlPlane, t dbCredentialTarget) {
 	logger := log.FromContext(ctx)
-	ns := cp.KeystoneNamespace()
 
 	cert := &unstructured.Unstructured{}
 	cert.SetGroupVersionKind(certificateGVK)
-	cert.SetName(dbCredentialClientCertName(cp))
-	cert.SetNamespace(ns)
+	cert.SetName(t.certName)
+	cert.SetNamespace(t.namespace)
 
 	objs := []client.Object{
-		&esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{Name: dbCredentialSecretName(cp), Namespace: ns}},
+		&esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{Name: t.secretName, Namespace: t.namespace}},
 		cert,
-		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dbCredentialServiceAccountName, Namespace: ns}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: t.saName, Namespace: t.namespace}},
 	}
 	for _, obj := range objs {
+		key := client.ObjectKeyFromObject(obj)
+		switch err := r.Get(ctx, key, obj); {
+		case apierrors.IsNotFound(err) || meta.IsNoMatchError(err):
+			continue
+		case err != nil:
+			logger.V(1).Info(fmt.Sprintf("best-effort delete of dynamic %sDB credential object could not read it",
+				t.prefix()), "object", key, "error", err.Error())
+			continue
+		}
+		if !isControlPlaneChild(obj, cp) {
+			continue
+		}
 		if err := client.IgnoreNotFound(r.Delete(ctx, obj)); err != nil {
-			logger.V(1).Info("best-effort delete of dynamic DB credential object failed",
-				"kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "error", err.Error())
+			logger.V(1).Info(fmt.Sprintf("best-effort delete of dynamic %sDB credential object failed", t.prefix()),
+				"object", key, "error", err.Error())
 		}
 	}
+}
+
+// dbCredentialEngineIssuedUsername reads the MATERIALISED DB-credential Secret
+// behind t and reports the username it carries plus whether the database engine
+// issued that username (see engineIssuedUsernamePrefix).
+//
+// It exists because an ExternalSecret's Ready condition is not a statement about
+// its target Secret's current CONTENTS. A Static->Dynamic flip create-or-updates
+// the ExternalSecret in place — same name, same target Secret — so the Ready it
+// reports can still be the one the retired STATIC sync left behind, over a Secret
+// that still holds the static seed's username. Callers gate the credentials-mode
+// flip on this in addition to WaitForExternalSecret, so the flip waits for the
+// generator's first sync instead of for a prose migration step.
+//
+// A missing Secret reads as "not engine-issued yet", not as an error: it is the
+// expected state between deleting the stale Secret and ESO re-materialising it
+// from the generator. Only an unexpected client failure returns an error.
+func (r *ControlPlaneReconciler) dbCredentialEngineIssuedUsername(ctx context.Context, t dbCredentialTarget) (string, bool, error) {
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: t.namespace, Name: t.secretName}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("reading %sDB credential Secret: %w", t.prefix(), err)
+	}
+	username := string(secret.Data["username"])
+	return username, strings.HasPrefix(username, engineIssuedUsernamePrefix), nil
 }
 
 // openBaoConnection returns the OpenBao server URL and Kubernetes-auth mount

--- a/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
+++ b/operators/c5c3/internal/controller/reconcile_dbcredentials_test.go
@@ -99,7 +99,7 @@ func readyClusterSecretStore() *esov1.ClusterSecretStore {
 // name/namespace (Dynamic default shape), so WaitForExternalSecret reports Ready
 // without an ESO controller in the fake client.
 func readyDBCredES(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
-	es := dbCredentialGeneratorExternalSecret(cp)
+	es := dbCredentialGeneratorExternalSecret(keystoneDBCredentialTarget(cp))
 	es.Status = esov1.ExternalSecretStatus{
 		Conditions: []esov1.ExternalSecretStatusCondition{
 			{Type: esov1.ExternalSecretReady, Status: corev1.ConditionTrue},
@@ -287,8 +287,10 @@ func TestReconcileDBCredentials_StaticAfterDynamic_TearsDownGenerator(t *testing
 	s := korcTestScheme(t)
 	cp := dbCredManagedControlPlane()
 	cp.Spec.Infrastructure.Database.CredentialsMode = commonv1.CredentialsModeStatic
-	// Pre-seed a leftover VaultDynamicSecret from a prior Dynamic deployment.
-	leftover := dbCredentialVaultDynamicSecret(cp, openBaoDefaultServer, openBaoDefaultKubernetesMount)
+	// Pre-seed a leftover VaultDynamicSecret from a prior Dynamic deployment,
+	// carrying the ownership a live projection stamps — the teardown gates on it.
+	leftover := dbCredentialVaultDynamicSecret(keystoneDBCredentialTarget(cp), openBaoDefaultServer, openBaoDefaultKubernetesMount)
+	g.Expect(claimChildOwnership(cp, leftover, s)).To(Succeed())
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, readyClusterSecretStore(), readyTenantStoreFor(cp), leftover).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s}
 
@@ -633,6 +635,81 @@ func TestReconcileDBCredentials_StaticNotReady_NamesTheUnseededKVPath(t *testing
 	g.Expect(sharedCond).NotTo(BeNil())
 	g.Expect(sharedCond.Message).NotTo(ContainSubstring("seed"),
 		"an engine-issued credential has nothing to seed")
+}
+
+// TestReconcileDBCredentials_KeystoneOverrideStatic_TearsDownGenerator pins the
+// per-service override: services.keystone.databaseCredentialsMode: Static opts
+// Keystone out of the shared Dynamic default, so the sub-reconciler projects the
+// stage-(a) KV-backed ExternalSecret and tears down any leftover generator.
+func TestReconcileDBCredentials_KeystoneOverrideStatic_TearsDownGenerator(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := dbCredManagedControlPlane()
+	// The shared database defaults to Dynamic; the per-service override opts out.
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		DatabaseCredentialsMode: commonv1.CredentialsModeStatic,
+	}
+	g.Expect(dbCredentialsDynamicEnabled(cp)).To(BeFalse(),
+		"a Static per-service override must resolve to Static even on a Dynamic-default shared database")
+
+	// Pre-seed a leftover generator from a prior Dynamic deployment, carrying the
+	// ownership a live projection stamps — the teardown gates on it.
+	leftover := dbCredentialVaultDynamicSecret(keystoneDBCredentialTarget(cp), openBaoDefaultServer, openBaoDefaultKubernetesMount)
+	g.Expect(claimChildOwnership(cp, leftover, s)).To(Succeed())
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyTenantStoreFor(cp), leftover).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	if _, err := r.reconcileDBCredentials(context.Background(), cp); err != nil {
+		t.Fatalf("reconcileDBCredentials: %v", err)
+	}
+
+	es, err := getDBCredES(t, r, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(es.Spec.DataFrom).To(BeEmpty(), "the override Static branch must project the KV ExternalSecret")
+	g.Expect(es.Spec.Data).To(HaveLen(2))
+	g.Expect(es.Spec.Data[0].RemoteRef.Key).To(Equal(dbCredentialRemoteKeyFor(cp)))
+
+	_, vdsErr := getVDS(t, r, cp)
+	g.Expect(apierrors.IsNotFound(vdsErr)).To(BeTrue(),
+		"the override Static branch must tear down the leftover VaultDynamicSecret")
+}
+
+// TestReconcileDBCredentials_KeystoneOverrideDynamic_WinsOverSharedStatic is the
+// mirror: a Dynamic per-service override wins over a shared credentialsMode:
+// Static, so Keystone gets the generator-backed ExternalSecret while the shared
+// default would have projected the KV one.
+func TestReconcileDBCredentials_KeystoneOverrideDynamic_WinsOverSharedStatic(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	s := korcTestScheme(t)
+	cp := dbCredManagedControlPlane()
+	cp.Spec.Infrastructure.Database.CredentialsMode = commonv1.CredentialsModeStatic
+	cp.Spec.Services.Keystone = &c5c3v1alpha1.ServiceKeystoneSpec{
+		DatabaseCredentialsMode: commonv1.CredentialsModeDynamic,
+	}
+	g.Expect(dbCredentialsDynamicEnabled(cp)).To(BeTrue(),
+		"a Dynamic per-service override must win over a shared Static mode")
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(cp, readyClusterSecretStore(), readyTenantStoreFor(cp)).Build()
+	r := &ControlPlaneReconciler{Client: c, Scheme: s}
+
+	if _, err := r.reconcileDBCredentials(context.Background(), cp); err != nil {
+		t.Fatalf("reconcileDBCredentials: %v", err)
+	}
+
+	es, err := getDBCredES(t, r, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(es.Spec.DataFrom).To(HaveLen(1),
+		"the override Dynamic branch must project the generator-backed ExternalSecret")
+	g.Expect(es.Spec.Data).To(BeEmpty(), "the override Dynamic ExternalSecret carries no static Data")
+
+	vds, vdsErr := getVDS(t, r, cp)
+	g.Expect(vdsErr).NotTo(HaveOccurred(),
+		"the override Dynamic branch must project a VaultDynamicSecret generator")
+	g.Expect(vds.Spec.Path).To(Equal(dbDynamicCredsPathFor(cp)))
 }
 
 // TestReconcileDBCredentials_DedicatedManagedIsStaticEvenWhenModeBypassed is the

--- a/operators/c5c3/internal/controller/reconcile_delete.go
+++ b/operators/c5c3/internal/controller/reconcile_delete.go
@@ -876,11 +876,24 @@ func (r *ControlPlaneReconciler) sweepExternalNamespaceResidue(
 			}},
 		)
 	}
-	// The Glance DB-credential ExternalSecret, which follows the Glance service.
+	// The Glance credential material, which follows the Glance service: the
+	// DB-credential ExternalSecret plus, in Dynamic mode, the VaultDynamicSecret
+	// generator, its mTLS client Certificate, and the ServiceAccount whose token it
+	// authenticates with.
 	if cp.GlanceNamespace() == namespace {
-		objs = append(objs, &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{
-			Name: glanceDBCredentialSecretName(cp), Namespace: namespace,
-		}})
+		objs = append(
+			objs,
+			&esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{
+				Name: glanceDBCredentialSecretName(cp), Namespace: namespace,
+			}},
+			&esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{
+				Name: glanceDBCredentialSecretName(cp), Namespace: namespace,
+			}},
+			unstructuredIn(certificateGVK, glanceDBCredentialClientCertName(cp)),
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name: glanceDBCredentialServiceAccountName, Namespace: namespace,
+			}},
+		)
 	}
 	// Any service-account credential delivered into this namespace: its source
 	// Secret and consumer ExternalSecret, both operator-owned by label here. The

--- a/operators/c5c3/internal/controller/reconcile_delete_test.go
+++ b/operators/c5c3/internal/controller/reconcile_delete_test.go
@@ -19,12 +19,14 @@ import (
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
+	esgenv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -1346,6 +1348,19 @@ func TestTeardownDedicatedNamespaces_SweepsExternalNamespaceResidue(t *testing.T
 	glanceDB := &esov1.ExternalSecret{ObjectMeta: metav1.ObjectMeta{
 		Name: glanceDBCredentialSecretName(cp), Namespace: "shared-ns", Labels: controlPlaneChildLabels(cp),
 	}}
+	// The Dynamic-mode Glance DB-credential objects: the generator, its mTLS client
+	// Certificate, and the generator's ServiceAccount are label-owned residue too.
+	glanceDBVDS := &esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{
+		Name: glanceDBCredentialSecretName(cp), Namespace: "shared-ns", Labels: controlPlaneChildLabels(cp),
+	}}
+	glanceDBCert := &unstructured.Unstructured{}
+	glanceDBCert.SetGroupVersionKind(certificateGVK)
+	glanceDBCert.SetName(glanceDBCredentialClientCertName(cp))
+	glanceDBCert.SetNamespace("shared-ns")
+	glanceDBCert.SetLabels(controlPlaneChildLabels(cp))
+	glanceDBSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: glanceDBCredentialServiceAccountName, Namespace: "shared-ns", Labels: controlPlaneChildLabels(cp),
+	}}
 	saSource := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name: serviceAccountSourceSecretName(cp, sa), Namespace: "shared-ns", Labels: controlPlaneChildLabels(cp),
 	}}
@@ -1358,7 +1373,9 @@ func TestTeardownDedicatedNamespaces_SweepsExternalNamespaceResidue(t *testing.T
 	}}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "shared-ns"}}
 
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cp, ns, ours, adminPw, glanceDB, saSource, saES, foreignSA).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(
+		cp, ns, ours, adminPw, glanceDB, glanceDBVDS, glanceDBCert, glanceDBSA, saSource, saES, foreignSA,
+	).Build()
 	r := &ControlPlaneReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 
 	done, err := r.teardownDedicatedNamespaces(context.Background(), cp)
@@ -1392,6 +1409,23 @@ func TestTeardownDedicatedNamespaces_SweepsExternalNamespaceResidue(t *testing.T
 		Name: glanceDBCredentialSecretName(cp), Namespace: "shared-ns",
 	}, &esov1.ExternalSecret{})
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the Glance DB-credential ExternalSecret must be swept")
+
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name: glanceDBCredentialSecretName(cp), Namespace: "shared-ns",
+	}, &esgenv1alpha1.VaultDynamicSecret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the Glance VaultDynamicSecret generator must be swept")
+
+	sweptGlanceCert := &unstructured.Unstructured{}
+	sweptGlanceCert.SetGroupVersionKind(certificateGVK)
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name: glanceDBCredentialClientCertName(cp), Namespace: "shared-ns",
+	}, sweptGlanceCert)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the Glance DB-credential Certificate must be swept")
+
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name: glanceDBCredentialServiceAccountName, Namespace: "shared-ns",
+	}, &corev1.ServiceAccount{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the Glance DB-credential ServiceAccount must be swept")
 
 	g.Expect(c.Get(context.Background(), types.NamespacedName{
 		Name: esoTenantServiceAccountName, Namespace: "shared-ns",

--- a/operators/c5c3/internal/controller/reconcile_glance.go
+++ b/operators/c5c3/internal/controller/reconcile_glance.go
@@ -9,12 +9,15 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esgenv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -102,23 +105,6 @@ func glanceEndpointURL(cp *c5c3v1alpha1.ControlPlane) string {
 	return managedServiceURL(glanceName(cp), cp.GlanceNamespace(), 9292, "")
 }
 
-// glanceDBCredentialSecretName returns the deterministic name of the
-// per-ControlPlane Glance DB-credential Secret/ExternalSecret. It tracks the
-// projected Glance CR, mirroring dbCredentialSecretName's derivation from the
-// Keystone child.
-func glanceDBCredentialSecretName(cp *c5c3v1alpha1.ControlPlane) string {
-	return glanceName(cp) + dbCredentialSecretNameSuffix
-}
-
-// glanceDBCredentialRemoteKeyFor returns the per-ControlPlane, namespace-scoped
-// OpenBao KV path the static Glance DB credential is read from (keys username,
-// password). The eso-tenant.hcl policy already grants this path shape; the seed
-// lands in a later package (nothing seeds it yet), so the ExternalSecret only
-// syncs once the path has been seeded out-of-band.
-func glanceDBCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string {
-	return "openstack/glance/" + cp.GlanceNamespace() + "/" + cp.Name + "/db"
-}
-
 // glanceBackendName returns the deterministic name of the GlanceBackend child
 // projected for a backends[] entry: the Glance child name, a hyphen, and the
 // entry name — so the prune sweep recognises projected backends by the
@@ -151,29 +137,6 @@ func glanceServiceAccountReady(cp *c5c3v1alpha1.ControlPlane) bool {
 	return false
 }
 
-// glanceDBCredentialStaticExternalSecret builds the static, KV-backed
-// ExternalSecret that materialises the Glance DB user's username+password into
-// the Glance service namespace via the store the ControlPlane selected. It
-// mirrors dbCredentialStaticExternalSecret: there is no OpenBao database-engine
-// role for the glance schema (see the DECISION on the projected Database below),
-// so the credential is always read from a KV path, never engine-issued.
-func glanceDBCredentialStaticExternalSecret(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
-	name := glanceDBCredentialSecretName(cp)
-	remoteKey := glanceDBCredentialRemoteKeyFor(cp)
-	return &esov1.ExternalSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cp.GlanceNamespace()},
-		Spec: esov1.ExternalSecretSpec{
-			RefreshInterval: &metav1.Duration{Duration: time.Hour},
-			SecretStoreRef:  secrets.ESOSecretStoreRef(effectiveControlPlaneStoreRef(cp)),
-			Target:          esov1.ExternalSecretTarget{Name: name, CreationPolicy: esov1.CreatePolicyOwner},
-			Data: []esov1.ExternalSecretData{
-				{SecretKey: "username", RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: "username"}},
-				{SecretKey: "password", RemoteRef: esov1.ExternalSecretDataRemoteRef{Key: remoteKey, Property: "password"}},
-			},
-		},
-	}
-}
-
 // reconcileGlance projects spec.services.glance into an owned Glance CR (and its
 // GlanceBackend children) and drives the GlanceReady condition.
 //
@@ -198,8 +161,24 @@ func (r *ControlPlaneReconciler) reconcileGlance(ctx context.Context, cp *c5c3v1
 				return ctrl.Result{}, err
 			}
 		} else {
+			// Preserve the child — but NEVER the credential minter. A live
+			// VaultDynamicSecret keeps issuing a fresh MySQL user with ALL PRIVILEGES
+			// on the glance schema at every refresh interval, indefinitely, for a
+			// service this ControlPlane has been told it no longer manages: no
+			// consumer, no revocation, and a GlanceReady=True/GlanceNotManaged
+			// condition that surfaces none of it. Preserving a running service does
+			// not imply preserving the generator behind its credentials, so the
+			// dynamic objects come down either way.
+			//
+			// GlanceNamespace() still resolves correctly here: removing a
+			// services.glance.namespace assignment is rejected by
+			// validateServiceNamespacesImmutable, so the only admissible way to reach
+			// this branch with a live generator is the co-located one, where the
+			// generator sits in the ControlPlane's own namespace.
+			r.deleteDynamicDBCredentialObjects(ctx, cp, glanceDBCredentialTarget(cp))
 			message += fmt.Sprintf("; any previously-projected Glance child is preserved "+
-				"(set annotation %s=true to allow deletion)", glanceDeletionAllowedAnnotation)
+				"(set annotation %s=true to allow deletion), but its dynamic DB-credential generator is torn down",
+				glanceDeletionAllowedAnnotation)
 		}
 		conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeGlanceReady,
@@ -270,20 +249,128 @@ func (r *ControlPlaneReconciler) reconcileGlance(ctx context.Context, cp *c5c3v1
 		return ctrl.Result{RequeueAfter: korcRequeueAfter}, nil
 	}
 
-	// Ensure the DB-credential ExternalSecret BEFORE the child so the Secret it
-	// references exists when the glance-operator resolves it. Managed only: a
-	// brownfield database (ClusterRef nil) carries a user-supplied credential
-	// out-of-band, so there is nothing for the operator to project.
+	// The EFFECTIVE credentials mode of the database Glance connects to, resolved
+	// once so the credential projection below, its readiness gate, and the mode
+	// stamped onto the child further down can never disagree.
+	dynamic := database.ClusterRef != nil && glanceDBCredentialsDynamicEnabled(cp)
+
+	// Ensure the DB-credential objects BEFORE the child so the Secret it references
+	// exists when the glance-operator resolves it. Managed only: a brownfield
+	// database (ClusterRef nil) carries a user-supplied credential out-of-band, so
+	// there is nothing for the operator to project. The effective mode decides the
+	// projection: Dynamic (the managed-shared default) provisions the ESO
+	// VaultDynamicSecret generator plus its ServiceAccount and mTLS client
+	// Certificate and an ExternalSecret that draws from the generator; Static
+	// (opt-out) projects the KV-backed ExternalSecret and tears down any dynamic
+	// objects left from a prior Dynamic deployment.
 	if database.ClusterRef != nil {
-		if err := r.ensureUnownedOrOwned(ctx, cp, glanceDBCredentialStaticExternalSecret(cp)); err != nil {
+		var err error
+		target := glanceDBCredentialTarget(cp)
+		if dynamic {
+			err = r.ensureDynamicDBCredentialObjects(ctx, cp, target)
+		} else {
+			r.deleteDynamicDBCredentialObjects(ctx, cp, target)
+			err = r.ensureUnownedOrOwned(ctx, cp, dbCredentialStaticExternalSecret(target))
+		}
+		if err != nil {
 			conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
 				Type:               conditionTypeGlanceReady,
 				Status:             metav1.ConditionFalse,
 				ObservedGeneration: cp.Generation,
 				Reason:             "GlanceDBCredentialError",
-				Message:            fmt.Sprintf("ensuring Glance DB credential ExternalSecret: %v", err),
+				Message:            fmt.Sprintf("ensuring Glance DB credential: %v", err),
 			})
 			return ctrl.Result{}, err
+		}
+
+		// DYNAMIC READINESS GATE. Projecting credentialsMode: Dynamic onto the
+		// child tells the glance-operator to read its MySQL username from the
+		// materialised Secret and to stop asserting the static User/Grant — so it
+		// must not happen until an engine-issued credential actually exists. Without
+		// this gate the flip is unattended and fails OPEN: an operator upgrade rolls
+		// out on its own (Flux), while the engine role behind the generator is only
+		// provisioned by setup-database-tenant.sh, a manual onboarding step. Glance
+		// would then be pointed at a credential that never lands — and, on a
+		// migration, at whatever stale username the retired Static seed left in the
+		// Secret. Gating here keeps a not-yet-onboarded ControlPlane stalled with a
+		// diagnosable GlanceReady=False instead: the child is left untouched, so an
+		// existing one keeps running on Static until the credential lands.
+		//
+		// Keystone reaches the same outcome through reconcileDBCredentials, whose
+		// wait halts the whole pipeline before reconcileGlance can run; Glance has no
+		// equivalent upstream gate because its credential is keystone-independent.
+		if dynamic {
+			exists, ready, err := secrets.WaitForExternalSecret(ctx, r.Client,
+				types.NamespacedName{Namespace: target.namespace, Name: target.secretName})
+			if err != nil {
+				conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+					Type:               conditionTypeGlanceReady,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: cp.Generation,
+					Reason:             "GlanceDBCredentialError",
+					Message:            fmt.Sprintf("checking Glance DB credential ExternalSecret: %v", err),
+				})
+				return ctrl.Result{}, err
+			}
+			if !ready {
+				logger.Info("Glance DB credential ExternalSecret not ready, deferring Glance projection",
+					"exists", exists)
+				conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+					Type:               conditionTypeGlanceReady,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: cp.Generation,
+					Reason:             "WaitingForGlanceDBCredential",
+					Message: fmt.Sprintf("Glance DB credential ExternalSecret %q is not yet Ready: credentialsMode "+
+						"Dynamic draws engine-issued credentials from OpenBao path %q, which only exists once the "+
+						"database-engine tenant has been onboarded (deploy/openbao/bootstrap/setup-database-tenant.sh); "+
+						"Glance projection deferred until the credential lands",
+						target.secretName, glanceDBDynamicCredsPathFor(cp)),
+				})
+				return ctrl.Result{RequeueAfter: dbCredentialsRequeueAfter}, nil
+			}
+
+			// Ready is a statement about ESO's LAST SYNC, not about what the target
+			// Secret holds right now. The Static->Dynamic flip create-or-updates the
+			// ExternalSecret in place (same name, same target Secret), so on a
+			// migrated cluster the Ready it reports can still be the one the retired
+			// Static sync left behind — over a Secret that still carries the static
+			// seed's username. Flipping the child on that signal stops the
+			// glance-operator asserting the static User/Grant Glance was running on
+			// and hands it a DSN for a login the engine never issued (the retired
+			// bootstrap seeded username=glance, while the static login is the Glance
+			// CR name): an outage behind GlanceReady=True, recoverable only by the
+			// manual Secret deletion the migration guide prescribes. Requiring an
+			// engine-issued username makes the operator hold the flip until the
+			// generator's first sync actually lands, so that guide step is a shortcut
+			// rather than the only thing standing between a migration and an outage.
+			username, engineIssued, err := r.dbCredentialEngineIssuedUsername(ctx, target)
+			if err != nil {
+				conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+					Type:               conditionTypeGlanceReady,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: cp.Generation,
+					Reason:             "GlanceDBCredentialError",
+					Message:            fmt.Sprintf("reading Glance DB credential Secret: %v", err),
+				})
+				return ctrl.Result{}, err
+			}
+			if !engineIssued {
+				logger.Info("Glance DB credential Secret carries no engine-issued username, deferring Glance projection",
+					"username", username)
+				conditions.SetCondition(&cp.Status.Conditions, metav1.Condition{
+					Type:               conditionTypeGlanceReady,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: cp.Generation,
+					Reason:             "WaitingForGlanceDBCredential",
+					Message: fmt.Sprintf("Glance DB credential Secret %q does not carry an engine-issued username "+
+						"(found %q); credentialsMode Dynamic needs one minted at OpenBao path %q. On a Static->Dynamic "+
+						"migration the ExternalSecret is updated in place and can keep reporting Ready from its previous "+
+						"Static sync, leaving the retired static seed in the Secret — delete the Secret so ESO "+
+						"re-materialises it from the generator. Glance projection deferred until the credential lands",
+						target.secretName, username, glanceDBDynamicCredsPathFor(cp)),
+				})
+				return ctrl.Result{RequeueAfter: dbCredentialsRequeueAfter}, nil
+			}
 		}
 	}
 
@@ -323,17 +410,22 @@ func (r *ControlPlaneReconciler) reconcileGlance(ctx context.Context, cp *c5c3v1
 	// would alias cp.Spec.
 	glance.Spec.Database = *database.DeepCopy()
 	glance.Spec.Database.Database = defaultGlanceDatabaseName
-	// DECISION (phase-0 D10): there is NO OpenBao dynamic-engine role for the
-	// glance schema — the database engine role is bootstrapped once per namespace
-	// and is keystone-scoped, so no role can mint credentials for the glance user.
-	// In managed mode the operator therefore OWNS the glance DB credential as a
-	// STATIC KV-backed ExternalSecret (ensured above) and forces credentialsMode
-	// Static; the KV path (glanceDBCredentialRemoteKeyFor) is seeded at the OpenBao
-	// source out-of-band. Brownfield (ClusterRef nil) leaves the user-supplied
-	// secretRef in place.
+	// In managed mode the operator OWNS the glance DB credential —
+	// reconcileGlance materialises it (above) into a per-ControlPlane Secret named
+	// glanceDBCredentialSecretName(cp). Override the projected Glance CR's
+	// database.secretRef to that operator-owned Secret (key "password"), and
+	// project the EFFECTIVE credentials mode: Dynamic (engine-issued) is the
+	// default on the managed shared database, a per-service override or the shared
+	// Static opt-out flips it to Static, and a dedicated glance database stays
+	// Static (no engine role can mint its credentials). Brownfield (ClusterRef nil)
+	// leaves the user-supplied secretRef and credentialsMode in place.
 	if database.ClusterRef != nil {
 		glance.Spec.Database.SecretRef = commonv1.SecretRefSpec{Name: glanceDBCredentialSecretName(cp), Key: "password"}
-		glance.Spec.Database.CredentialsMode = commonv1.CredentialsModeStatic
+		if dynamic {
+			glance.Spec.Database.CredentialsMode = commonv1.CredentialsModeDynamic
+		} else {
+			glance.Spec.Database.CredentialsMode = commonv1.CredentialsModeStatic
+		}
 	}
 
 	glance.Spec.Cache = *cache.DeepCopy()
@@ -477,6 +569,27 @@ func (r *ControlPlaneReconciler) deleteOrphanedGlance(ctx context.Context, cp *c
 		return isControlPlaneChild(live, cp)
 	}); err != nil {
 		return err
+	}
+
+	// The Dynamic-mode DB-credential objects: the VaultDynamicSecret generator, its
+	// mTLS client Certificate, and the ServiceAccount whose token it authenticates
+	// with. Each is ownership-checked, so a foreign object colliding on a name is
+	// left alone.
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	cert.SetName(glanceDBCredentialClientCertName(cp))
+	cert.SetNamespace(glanceNS)
+	dynamicChildren := []client.Object{
+		&esgenv1alpha1.VaultDynamicSecret{ObjectMeta: metav1.ObjectMeta{Name: glanceDBCredentialSecretName(cp), Namespace: glanceNS}},
+		cert,
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: glanceDBCredentialServiceAccountName, Namespace: glanceNS}},
+	}
+	for _, child := range dynamicChildren {
+		if err := commonreconcile.DeleteOrphanedChildFunc(ctx, r.Client, child, func(live client.Object) bool {
+			return isControlPlaneChild(live, cp)
+		}); err != nil {
+			return err
+		}
 	}
 
 	// The Glance catalog K-ORC CRs: the image Service and its internal/public

--- a/operators/c5c3/internal/controller/reconcile_glance_dbcredentials.go
+++ b/operators/c5c3/internal/controller/reconcile_glance_dbcredentials.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// The Glance DB-credential concern mirrors the Keystone one in
+// reconcile_dbcredentials.go, glance-scoped and keystone-independent: Dynamic
+// (engine-issued) is the default on a managed SHARED database, and every dynamic
+// object — the ServiceAccount, the mTLS client Certificate, the VaultDynamicSecret
+// generator, and the generator-backed ExternalSecret — lands in the GLANCE service
+// namespace, beside the database it issues against and the child that consumes it.
+//
+// Only the diverging inputs live here: the names, the OpenBao role and paths, and
+// the mode predicate. The object builders and the ensure/delete pair are the
+// service-agnostic ones in reconcile_dbcredentials.go, driven by the
+// dbCredentialTarget this file constructs.
+
+const (
+	// glanceDBDynamicVaultRole is the OpenBao Kubernetes-auth role the Glance
+	// generator authenticates against (see deploy/openbao/bootstrap/setup-auth.sh);
+	// it is bound to the glance-db-dynamic policy scoping reads to the per-tenant
+	// creds path.
+	glanceDBDynamicVaultRole = "glance-db"
+	// glanceDBCredentialServiceAccountName is the fixed name of the per-ControlPlane
+	// ServiceAccount whose token the Glance VaultDynamicSecret generator presents to
+	// OpenBao. A fixed name is safe because a namespace belongs to at most one
+	// ControlPlane: the one-ControlPlane-per-namespace webhook guarantees it for the
+	// ControlPlane's own namespace, and the namespace-claim webhook guarantees it
+	// for every service namespace.
+	glanceDBCredentialServiceAccountName = "glance-db-creds" //nolint:gosec // G101 false positive: ServiceAccount name, not a credential.
+)
+
+// glanceDBCredentialSecretName returns the deterministic name of the
+// per-ControlPlane Glance DB-credential Secret/ExternalSecret. It tracks the
+// projected Glance CR, mirroring dbCredentialSecretName's derivation from the
+// Keystone child.
+func glanceDBCredentialSecretName(cp *c5c3v1alpha1.ControlPlane) string {
+	return glanceName(cp) + dbCredentialSecretNameSuffix
+}
+
+// glanceDBCredentialClientCertName returns the name of the per-ControlPlane
+// cert-manager Certificate and the Secret it materialises (client mTLS keypair
+// plus the CA under ca.crt) for the Glance generator, mirroring
+// dbCredentialClientCertName.
+func glanceDBCredentialClientCertName(cp *c5c3v1alpha1.ControlPlane) string {
+	return glanceName(cp) + dbCredentialClientCertSuffix
+}
+
+// glanceDBCredentialRemoteKeyFor returns the per-ControlPlane, namespace-scoped
+// OpenBao KV path the STATIC Glance DB credential is read from (keys username,
+// password). It is retained only for the Static opt-out / brownfield-migration
+// path; the default managed mode reads engine-issued credentials from
+// glanceDBDynamicCredsPathFor instead. The eso-tenant.hcl policy already grants
+// this path shape; nothing seeds it, so a ControlPlane on the Static branch must
+// have the path seeded out-of-band before ESO can sync the credential.
+func glanceDBCredentialRemoteKeyFor(cp *c5c3v1alpha1.ControlPlane) string {
+	return "openstack/glance/" + cp.GlanceNamespace() + "/" + cp.Name + "/db"
+}
+
+// glanceDBDynamicRoleFor returns the per-tenant OpenBao database-engine role name
+// for this ControlPlane's Glance service. It is keyed on the GLANCE SERVICE
+// NAMESPACE alone — the namespace the database and the generator that reads from
+// it actually live in — so it is collision-free (namespaces are cluster-unique)
+// and the glance-db-dynamic policy can scope reads by the caller's
+// service_account_namespace with an EXACT match. It MUST stay in sync with the
+// role-name derivation in deploy/openbao/bootstrap/setup-database-tenant.sh —
+// the operator reads credentials from a role that script provisions as
+// glance-<glance-ns>.
+func glanceDBDynamicRoleFor(cp *c5c3v1alpha1.ControlPlane) string {
+	return "glance-" + cp.GlanceNamespace()
+}
+
+// glanceDBDynamicCredsPathFor returns the OpenBao path the Glance
+// VaultDynamicSecret generator reads short-lived credentials from
+// (database/mariadb/creds/<role>).
+func glanceDBDynamicCredsPathFor(cp *c5c3v1alpha1.ControlPlane) string {
+	return "database/mariadb/creds/" + glanceDBDynamicRoleFor(cp)
+}
+
+// glanceDBCredentialTarget describes the Glance DB-credential concern for the
+// service-agnostic builders and the ensure/delete pair in
+// reconcile_dbcredentials.go.
+func glanceDBCredentialTarget(cp *c5c3v1alpha1.ControlPlane) dbCredentialTarget {
+	return dbCredentialTarget{
+		qualifier:  "Glance ",
+		namespace:  cp.GlanceNamespace(),
+		secretName: glanceDBCredentialSecretName(cp),
+		certName:   glanceDBCredentialClientCertName(cp),
+		saName:     glanceDBCredentialServiceAccountName,
+		vaultRole:  glanceDBDynamicVaultRole,
+		credsPath:  glanceDBDynamicCredsPathFor(cp),
+		kvPath:     glanceDBCredentialRemoteKeyFor(cp),
+		storeRef:   effectiveControlPlaneStoreRef(cp),
+	}
+}
+
+// glanceDBCredentialsDynamicEnabled reports the effective credentials mode of the
+// database Glance actually connects to: Dynamic (engine-issued) is the default
+// for a managed SHARED database; a ControlPlane opts out by setting
+// credentialsMode: Static (migration staging / brownfield). A non-empty
+// per-service services.glance.databaseCredentialsMode override wins over the
+// shared credentialsMode, so a staged migration can run Glance on one mode while
+// another service stays on the other.
+//
+// A DEDICATED glance database is never Dynamic. The OpenBao database engine
+// carries one connection and one role per NAMESPACE bootstrapped against the
+// SHARED cluster, so no engine role exists that could issue credentials for a
+// dedicated instance — it takes the Static branch. Glance is never External-mode
+// (services.glance is forbidden in External ControlPlanes), so no External
+// short-circuit is needed here; keying the decision on the dedicated declaration
+// rather than only on the stored mode keeps a webhook-bypassed CR failing closed
+// onto Static rather than projecting a generator that could never sync.
+func glanceDBCredentialsDynamicEnabled(cp *c5c3v1alpha1.ControlPlane) bool {
+	var override string
+	if gl := cp.Spec.Services.Glance; gl != nil {
+		override = gl.DatabaseCredentialsMode
+	}
+	return dbCredentialModeIsDynamic(cp.DedicatedGlanceDatabase(), effectiveGlanceDatabase(cp), override)
+}

--- a/operators/c5c3/internal/controller/reconcile_glance_dbcredentials_test.go
+++ b/operators/c5c3/internal/controller/reconcile_glance_dbcredentials_test.go
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Glance DB-credentials concern (reconcile_glance_dbcredentials.go):
+// the dynamic engine objects mirror the Keystone ones, glance-scoped, and the
+// per-service databaseCredentialsMode override plus the Static opt-out decide the
+// projection. The fixtures reuse glanceControlPlane / newGlanceTestReconciler from
+// reconcile_glance_test.go.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esgenv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
+)
+
+// getGlanceVDS fetches the projected Glance VaultDynamicSecret generator at its
+// derived name/namespace.
+func getGlanceVDS(t *testing.T, r *ControlPlaneReconciler, cp *c5c3v1alpha1.ControlPlane) (*esgenv1alpha1.VaultDynamicSecret, error) {
+	t.Helper()
+	vds := &esgenv1alpha1.VaultDynamicSecret{}
+	err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialSecretName(cp)}, vds)
+	return vds, err
+}
+
+// getGlanceDBCredES fetches the projected Glance DB-credential ExternalSecret at
+// its derived name/namespace.
+func getGlanceDBCredES(t *testing.T, r *ControlPlaneReconciler, cp *c5c3v1alpha1.ControlPlane) (*esov1.ExternalSecret, error) {
+	t.Helper()
+	es := &esov1.ExternalSecret{}
+	err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialSecretName(cp)}, es)
+	return es, err
+}
+
+// TestGlanceDBDynamicKeys_FollowTheGlanceNamespace pins the re-keying of the two
+// OpenBao handles onto the GLANCE service namespace: the engine role name, the
+// dynamic creds path, and the static KV path all track it, so glance's engine
+// plumbing is keystone-independent. The role name MUST stay in sync with
+// setup-database-tenant.sh.
+func TestGlanceDBDynamicKeys_FollowTheGlanceNamespace(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cp := glanceControlPlane() // no namespace assignment; glance shares "default"
+	g.Expect(glanceDBDynamicRoleFor(cp)).To(Equal("glance-default"),
+		"an unassigned Glance keeps the ControlPlane-namespace-derived role name")
+	g.Expect(glanceDBDynamicCredsPathFor(cp)).To(Equal("database/mariadb/creds/glance-default"))
+	g.Expect(glanceDBCredentialRemoteKeyFor(cp)).To(Equal("openstack/glance/default/cp/db"))
+
+	cp.Spec.Services.Glance.Namespace = &c5c3v1alpha1.ServiceNamespaceSpec{Name: "images"}
+	g.Expect(glanceDBDynamicRoleFor(cp)).To(Equal("glance-images"))
+	g.Expect(glanceDBDynamicCredsPathFor(cp)).To(Equal("database/mariadb/creds/glance-images"))
+	g.Expect(glanceDBCredentialRemoteKeyFor(cp)).To(Equal("openstack/glance/images/cp/db"))
+}
+
+// TestReconcileGlance_DynamicDefaultProjectsEngineObjects verifies a managed
+// shared glance database (default Dynamic) projects the generator-backed
+// ExternalSecret (no static Data), the VaultDynamicSecret with role glance-db and
+// the per-tenant creds path, the glance-db-creds ServiceAccount, and the mTLS
+// client Certificate named <glance-name>-db-openbao-client.
+func TestReconcileGlance_DynamicDefaultProjectsEngineObjects(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	r := newGlanceTestReconciler(t, cp)
+	ctx := context.Background()
+
+	g.Expect(glanceDBCredentialsDynamicEnabled(cp)).To(BeTrue(),
+		"a managed shared glance database defaults to Dynamic")
+
+	_, err := r.reconcileGlance(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// ExternalSecret: generator-backed, no static KV Data, no SecretStoreRef.
+	es, err := getGlanceDBCredES(t, r, cp)
+	g.Expect(err).NotTo(HaveOccurred(), "operator must create the Glance DB-credential ExternalSecret")
+	g.Expect(es.Spec.Data).To(BeEmpty(), "the Dynamic ExternalSecret must carry no static Data refs")
+	g.Expect(es.Spec.SecretStoreRef.Name).To(BeEmpty(),
+		"a generator-backed ExternalSecret must not reference a SecretStore")
+	g.Expect(es.Spec.DataFrom).To(HaveLen(1))
+	g.Expect(es.Spec.DataFrom[0].SourceRef).NotTo(BeNil())
+	g.Expect(es.Spec.DataFrom[0].SourceRef.GeneratorRef).NotTo(BeNil())
+	g.Expect(es.Spec.DataFrom[0].SourceRef.GeneratorRef.Kind).To(Equal("VaultDynamicSecret"))
+	g.Expect(es.Spec.DataFrom[0].SourceRef.GeneratorRef.Name).To(Equal(glanceDBCredentialSecretName(cp)))
+
+	// VaultDynamicSecret: role glance-db, per-tenant creds path, same-namespace refs.
+	vds, err := getGlanceVDS(t, r, cp)
+	g.Expect(err).NotTo(HaveOccurred(), "operator must create the Glance VaultDynamicSecret generator")
+	g.Expect(vds.Spec.Path).To(Equal("database/mariadb/creds/glance-default"))
+	g.Expect(vds.Spec.Method).To(Equal("GET"))
+	g.Expect(vds.Spec.Provider).NotTo(BeNil())
+	g.Expect(vds.Spec.Provider.Version).To(Equal(esov1.VaultKVStoreV2),
+		"version must be set explicitly — no omitempty, so \"\" fails the CRD enum")
+	g.Expect(vds.Spec.Provider.Auth.Kubernetes.Role).To(Equal(glanceDBDynamicVaultRole))
+	g.Expect(vds.Spec.Provider.Auth.Kubernetes.Role).To(Equal("glance-db"))
+	g.Expect(vds.Spec.Provider.Auth.Kubernetes.ServiceAccountRef.Name).To(Equal(glanceDBCredentialServiceAccountName))
+	g.Expect(vds.Spec.Provider.CAProvider.Name).To(Equal(glanceDBCredentialClientCertName(cp)))
+	g.Expect(vds.Spec.Provider.ClientTLS.CertSecretRef.Name).To(Equal(glanceDBCredentialClientCertName(cp)))
+	g.Expect(vds.Spec.Provider.ClientTLS.KeySecretRef.Name).To(Equal(glanceDBCredentialClientCertName(cp)))
+
+	// ServiceAccount glance-db-creds.
+	g.Expect(glanceDBCredentialServiceAccountName).To(Equal("glance-db-creds"))
+	sa := &corev1.ServiceAccount{}
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialServiceAccountName,
+	}, sa)).To(Succeed())
+
+	// Certificate <glance-name>-db-openbao-client with the CA issuer.
+	g.Expect(glanceDBCredentialClientCertName(cp)).To(Equal("cp-glance-db-openbao-client"))
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialClientCertName(cp),
+	}, cert)).To(Succeed())
+	issuer, _, _ := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name")
+	g.Expect(issuer).To(Equal(openBaoCAIssuerName))
+	commonName, _, _ := unstructured.NestedString(cert.Object, "spec", "commonName")
+	g.Expect(commonName).To(Equal(glanceDBCredentialClientCertName(cp) + ".default.svc"))
+
+	// The projected child carries Dynamic.
+	gl := getProjectedGlance(t, r.Client, cp)
+	g.Expect(gl.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeDynamic))
+}
+
+// TestReconcileGlance_StaticOptOutProjectsKVAndTearsDownDynamic verifies that both
+// opt-out routes — the shared credentialsMode: Static and the per-service
+// services.glance.databaseCredentialsMode: Static — project the KV-backed
+// ExternalSecret, tear down any leftover generator objects, and stamp the child
+// Static.
+func TestReconcileGlance_StaticOptOutProjectsKVAndTearsDownDynamic(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		apply func(cp *c5c3v1alpha1.ControlPlane)
+	}{
+		{
+			name: "shared credentialsMode Static",
+			apply: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Infrastructure.Database.CredentialsMode = commonv1.CredentialsModeStatic
+			},
+		},
+		{
+			name: "per-service databaseCredentialsMode Static",
+			apply: func(cp *c5c3v1alpha1.ControlPlane) {
+				cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cp := glanceControlPlane()
+			tt.apply(cp)
+			g.Expect(glanceDBCredentialsDynamicEnabled(cp)).To(BeFalse())
+
+			// Pre-seed the leftover generator, SA and mTLS client Certificate from a
+			// prior Dynamic deployment, each carrying the ownership a live projection
+			// stamps — the teardown is gated on it.
+			s := glanceTestScheme(t)
+			target := glanceDBCredentialTarget(cp)
+			leftovers := []client.Object{
+				dbCredentialVaultDynamicSecret(target, openBaoDefaultServer, openBaoDefaultKubernetesMount),
+				dbCredentialServiceAccount(target),
+				glanceLeftoverClientCert(cp),
+			}
+			for _, obj := range leftovers {
+				g.Expect(claimChildOwnership(cp, obj, s)).To(Succeed())
+			}
+			r := newGlanceTestReconciler(t, append([]client.Object{cp}, leftovers...)...)
+			ctx := context.Background()
+
+			_, err := r.reconcileGlance(ctx, cp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			es, err := getGlanceDBCredES(t, r, cp)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(es.Spec.DataFrom).To(BeEmpty(), "the Static opt-out must project the KV ExternalSecret")
+			g.Expect(es.Spec.Data).To(HaveLen(2))
+			g.Expect(es.Spec.Data[0].RemoteRef.Key).To(Equal(glanceDBCredentialRemoteKeyFor(cp)))
+
+			_, vdsErr := getGlanceVDS(t, r, cp)
+			g.Expect(apierrors.IsNotFound(vdsErr)).To(BeTrue(),
+				"the Static opt-out must delete the leftover VaultDynamicSecret")
+
+			saErr := r.Get(ctx, types.NamespacedName{
+				Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialServiceAccountName,
+			}, &corev1.ServiceAccount{})
+			g.Expect(apierrors.IsNotFound(saErr)).To(BeTrue(),
+				"the Static opt-out must delete the generator's ServiceAccount")
+
+			sweptCert := &unstructured.Unstructured{}
+			sweptCert.SetGroupVersionKind(certificateGVK)
+			certErr := r.Get(ctx, types.NamespacedName{
+				Namespace: cp.GlanceNamespace(), Name: glanceDBCredentialClientCertName(cp),
+			}, sweptCert)
+			g.Expect(apierrors.IsNotFound(certErr)).To(BeTrue(),
+				"the Static opt-out must delete the leftover mTLS client Certificate")
+
+			gl := getProjectedGlance(t, r.Client, cp)
+			g.Expect(gl.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeStatic))
+		})
+	}
+}
+
+// TestReconcileGlance_StaticOptOutLeavesForeignObjectsAlone is the ownership twin
+// of the teardown test above: the Static branch's names are fixed and
+// non-CP-derived (glance-db-creds, <glance>-db-openbao-client), so in a
+// pre-existing service namespace the operator does not own they can collide with
+// somebody else's objects. The mode flip must leave those alone — the operator
+// already refuses to ADOPT a foreign object here, so deleting one would be the
+// same clobber from the teardown side, and on every reconcile pass.
+func TestReconcileGlance_StaticOptOutLeavesForeignObjectsAlone(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+	cp.Spec.Services.Glance.Namespace = &c5c3v1alpha1.ServiceNamespaceSpec{
+		Name: "images", Lifecycle: c5c3v1alpha1.ServiceNamespaceLifecycleExternal,
+	}
+
+	// Same names, no ownership: the platform team's own objects in a namespace
+	// that happens to host Glance.
+	target := glanceDBCredentialTarget(cp)
+	foreign := []client.Object{
+		dbCredentialVaultDynamicSecret(target, openBaoDefaultServer, openBaoDefaultKubernetesMount),
+		dbCredentialServiceAccount(target),
+		glanceLeftoverClientCert(cp),
+	}
+	r := newGlanceTestReconciler(t, append([]client.Object{cp}, foreign...)...)
+
+	_, err := r.reconcileGlance(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialSecretName(cp)},
+		&esgenv1alpha1.VaultDynamicSecret{})).To(Succeed(),
+		"a foreign VaultDynamicSecret colliding on the name must survive the Static flip")
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialServiceAccountName},
+		&corev1.ServiceAccount{})).To(Succeed(),
+		"a foreign glance-db-creds ServiceAccount must survive the Static flip")
+	survivingCert := &unstructured.Unstructured{}
+	survivingCert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialClientCertName(cp)},
+		survivingCert)).To(Succeed(),
+		"a foreign mTLS client Certificate colliding on the name must survive the Static flip")
+}
+
+// glanceLeftoverClientCert builds the Glance mTLS client Certificate at its
+// derived name/namespace, as a prior Dynamic deployment left it.
+func glanceLeftoverClientCert(cp *c5c3v1alpha1.ControlPlane) *unstructured.Unstructured {
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	cert.SetName(glanceDBCredentialClientCertName(cp))
+	cert.SetNamespace(cp.GlanceNamespace())
+	return cert
+}
+
+// TestGlanceDBCredentialsDynamicEnabled_DedicatedIsStaticEvenWhenModeBypassed is
+// the fail-safe twin: the validating webhook rejects a Dynamic override / mode on
+// a dedicated glance database, but a webhook-bypassed CR must still fall closed
+// onto Static rather than projecting a generator that could never sync (no engine
+// role exists for a dedicated instance).
+func TestGlanceDBCredentialsDynamicEnabled_DedicatedIsStaticEvenWhenModeBypassed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DedicatedBackingServices = &c5c3v1alpha1.GlanceDedicatedBackingServicesSpec{
+		Database: &commonv1.DatabaseSpec{
+			ClusterRef:      &corev1.LocalObjectReference{Name: "cp-glance-db"},
+			CredentialsMode: commonv1.CredentialsModeDynamic,
+			Database:        "glance",
+			SecretRef:       commonv1.SecretRefSpec{Name: "glance-db"},
+		},
+	}
+
+	g.Expect(glanceDBCredentialsDynamicEnabled(cp)).To(BeFalse(),
+		"a dedicated glance database is never Dynamic, even with the mode written directly into the spec")
+}
+
+// TestReconcileGlance_DynamicObjectsLandInTheGlanceNamespace verifies every dynamic
+// object lands beside the Glance child in a namespace of its own — the
+// ServiceAccount whose token OpenBao authenticates, the mTLS client Certificate,
+// the generator, and the ExternalSecret — carrying the ownership labels rather
+// than an owner reference, and nothing is left in the ControlPlane's namespace.
+func TestReconcileGlance_DynamicObjectsLandInTheGlanceNamespace(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.Namespace = &c5c3v1alpha1.ServiceNamespaceSpec{
+		Name: "images", Lifecycle: c5c3v1alpha1.ServiceNamespaceLifecycleManaged,
+	}
+	r := newGlanceTestReconciler(t, cp)
+	ctx := context.Background()
+
+	_, err := r.reconcileGlance(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	es := &esov1.ExternalSecret{}
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialSecretName(cp)}, es)).To(Succeed())
+	g.Expect(es.OwnerReferences).To(BeEmpty(), "a cross-namespace object cannot carry an owner reference")
+	g.Expect(es.Labels).To(HaveKeyWithValue(controlPlaneNameLabel, "cp"))
+
+	vds := &esgenv1alpha1.VaultDynamicSecret{}
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialSecretName(cp)}, vds)).To(Succeed())
+	g.Expect(vds.Spec.Path).To(Equal("database/mariadb/creds/glance-images"),
+		"the generator's per-tenant path follows the glance namespace")
+
+	sa := &corev1.ServiceAccount{}
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialServiceAccountName}, sa)).
+		To(Succeed(), "the generator's SA must authenticate from the namespace the policy grants")
+
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "images", Name: glanceDBCredentialClientCertName(cp)}, cert)).To(Succeed())
+
+	// Nothing may be left in the ControlPlane's own namespace.
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "default", Name: glanceDBCredentialSecretName(cp)},
+		&esov1.ExternalSecret{})).NotTo(Succeed())
+	g.Expect(r.Get(ctx, types.NamespacedName{Namespace: "default", Name: glanceDBCredentialSecretName(cp)},
+		&esgenv1alpha1.VaultDynamicSecret{})).NotTo(Succeed())
+}

--- a/operators/c5c3/internal/controller/reconcile_glance_test.go
+++ b/operators/c5c3/internal/controller/reconcile_glance_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	esgenv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -46,6 +48,9 @@ func glanceTestScheme(t *testing.T) *runtime.Scheme {
 	}
 	if err := esov1.AddToScheme(s); err != nil {
 		t.Fatalf("adding external-secrets scheme: %v", err)
+	}
+	if err := esgenv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("adding external-secrets generators scheme: %v", err)
 	}
 	return s
 }
@@ -115,10 +120,76 @@ func glanceControlPlane() *c5c3v1alpha1.ControlPlane {
 	return cp
 }
 
+// readyGlanceDBCredES builds a Ready Glance DB-credential ExternalSecret at the
+// derived name/namespace (Dynamic default shape), so WaitForExternalSecret reports
+// Ready and the projection clears its dynamic readiness gate. Mirrors
+// readyDBCredES on the Keystone side.
+func readyGlanceDBCredES(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
+	es := notReadyGlanceDBCredES(cp)
+	es.Status = esov1.ExternalSecretStatus{
+		Conditions: []esov1.ExternalSecretStatusCondition{
+			{Type: esov1.ExternalSecretReady, Status: corev1.ConditionTrue},
+		},
+	}
+	return es
+}
+
+// materialisedGlanceDBCredSecret builds the Secret an ESO sync of the
+// generator-backed ExternalSecret would materialise: an ENGINE-ISSUED username
+// (the OpenBao mysql-database-plugin prefix) plus its password. The Dynamic gate
+// checks the username, not just the ExternalSecret's Ready condition, so a Secret
+// carrying a static seed's username reads as "not yet issued".
+func materialisedGlanceDBCredSecret(cp *c5c3v1alpha1.ControlPlane) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      glanceDBCredentialSecretName(cp),
+			Namespace: cp.GlanceNamespace(),
+		},
+		Data: map[string][]byte{
+			"username": []byte(engineIssuedUsernamePrefix + "kubernetes-glance-abc123-1750000000"),
+			"password": []byte("engine-issued-password"),
+		},
+	}
+}
+
+// withReadyGlanceDBCred seeds a Ready Glance DB-credential ExternalSecret AND the
+// engine-issued Secret an ESO sync of it would materialise, for the ControlPlane
+// in objs, unless an ExternalSecret was already seeded explicitly.
+//
+// The Dynamic-default projection gates the child on both — the ExternalSecret
+// having synced and the Secret behind it carrying an engine-issued username — and
+// a fake client never runs ESO, so without this every projection test would stall
+// on the gate and assert against a child that was deliberately not projected.
+// Seeding both here is the fake-client stand-in for "ESO has materialised the
+// engine-issued credential"; the tests that exercise the gate itself seed their
+// own ExternalSecret (and, where the gate under test is the username one, their
+// own Secret), which is kept.
+func withReadyGlanceDBCred(objs []client.Object) []client.Object {
+	var cp *c5c3v1alpha1.ControlPlane
+	for _, o := range objs {
+		if c, ok := o.(*c5c3v1alpha1.ControlPlane); ok {
+			cp = c
+			break
+		}
+	}
+	// Only the Dynamic path has a readiness gate; a Static ControlPlane projects a
+	// KV-backed ExternalSecret of a different shape and must be left to build it.
+	if cp == nil || !glanceDBCredentialsDynamicEnabled(cp) {
+		return objs
+	}
+	name, ns := glanceDBCredentialSecretName(cp), cp.GlanceNamespace()
+	for _, o := range objs {
+		if _, ok := o.(*esov1.ExternalSecret); ok && o.GetName() == name && o.GetNamespace() == ns {
+			return objs
+		}
+	}
+	return append(objs, readyGlanceDBCredES(cp), materialisedGlanceDBCredSecret(cp))
+}
+
 func newGlanceTestReconciler(t *testing.T, objs ...client.Object) *ControlPlaneReconciler {
 	t.Helper()
 	s := glanceTestScheme(t)
-	cb := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).
+	cb := fake.NewClientBuilder().WithScheme(s).WithObjects(withReadyGlanceDBCred(objs)...).
 		WithStatusSubresource(&c5c3v1alpha1.ControlPlane{}, &glancev1alpha1.Glance{})
 	return &ControlPlaneReconciler{Client: cb.Build(), Scheme: s}
 }
@@ -174,10 +245,202 @@ func TestReconcileGlance_UnsetPreservesChildByDefault(t *testing.T) {
 	g.Expect(cond.Message).To(ContainSubstring(glanceDeletionAllowedAnnotation))
 }
 
+// notReadyGlanceDBCredES builds the Glance DB-credential ExternalSecret with NO
+// Ready condition, so WaitForExternalSecret reports not-Ready and the Dynamic
+// readiness gate engages. Seeding it explicitly is what keeps
+// withReadyGlanceDBCred from substituting a Ready one.
+func notReadyGlanceDBCredES(cp *c5c3v1alpha1.ControlPlane) *esov1.ExternalSecret {
+	es := dbCredentialGeneratorExternalSecret(glanceDBCredentialTarget(cp))
+	// Stamped as this ControlPlane's child so the cross-namespace projection path
+	// re-applies it instead of refusing to adopt a same-named foreign object.
+	stampControlPlaneChildLabels(es, cp)
+	return es
+}
+
+// TestReconcileGlance_DynamicCredentialNotReady_DefersProjection is the gate that
+// keeps the Dynamic default from failing OPEN. The engine role behind the
+// generator is provisioned by a MANUAL onboarding step
+// (setup-database-tenant.sh), while the operator rolls out on its own, so a
+// ControlPlane can reach here with no role to mint against. Until the credential
+// materialises no Glance child may be projected at all — projecting one would
+// point Glance at a credential that never lands.
+func TestReconcileGlance_DynamicCredentialNotReady_DefersProjection(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	r := newGlanceTestReconciler(t, cp, notReadyGlanceDBCredES(cp))
+
+	res, err := r.reconcileGlance(context.Background(), cp)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0), "must requeue while the DB credential has not landed")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeGlanceReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForGlanceDBCredential"))
+	g.Expect(cond.Message).To(ContainSubstring(glanceDBDynamicCredsPathFor(cp)),
+		"the condition must name the engine path an operator has to onboard")
+
+	var list glancev1alpha1.GlanceList
+	g.Expect(r.Client.List(context.Background(), &list)).To(Succeed())
+	g.Expect(list.Items).To(BeEmpty(), "no Glance child may be projected before the credential lands")
+}
+
+// TestReconcileGlance_DynamicCredentialNotReady_LeavesExistingChildStatic is the
+// migration half of the same gate: a Static->Dynamic flip must not move a RUNNING
+// Glance onto credentialsMode Dynamic before the engine-issued credential exists.
+// Flipping early points the child at whatever the materialised Secret happens to
+// hold — on a migrated deployment, the retired static seed's stale username — and
+// stops the glance-operator asserting the static User/Grant that was working.
+func TestReconcileGlance_DynamicCredentialNotReady_LeavesExistingChildStatic(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+	r := newGlanceTestReconciler(t, cp, notReadyGlanceDBCredES(cp))
+
+	// Static deployment: the child is projected and runs on the static credential.
+	_, err := r.reconcileGlance(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getProjectedGlance(t, r.Client, cp).Spec.Database.CredentialsMode).
+		To(Equal(commonv1.CredentialsModeStatic))
+
+	// Flip to Dynamic while the generator-backed ExternalSecret has not synced.
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeDynamic
+	res, err := r.reconcileGlance(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+	g.Expect(getProjectedGlance(t, r.Client, cp).Spec.Database.CredentialsMode).
+		To(Equal(commonv1.CredentialsModeStatic),
+			"the running child must stay Static until the engine-issued credential lands")
+}
+
+// staleStaticGlanceDBCredSecret builds the Secret a MIGRATED cluster is left with
+// right after the Static->Dynamic flip: materialised by the last STATIC sync, so
+// it still carries the retired bootstrap's username=glance seed. That name is a
+// syntactically valid username, so a gate that only checks for a non-empty
+// username would wave it through — but no MySQL user was ever created under it
+// (the static login is the Glance CR name).
+func staleStaticGlanceDBCredSecret(cp *c5c3v1alpha1.ControlPlane) *corev1.Secret {
+	secret := materialisedGlanceDBCredSecret(cp)
+	secret.Data["username"] = []byte("glance")
+	return secret
+}
+
+// TestReconcileGlance_DynamicCredentialStaleStaticUsername_LeavesExistingChildStatic
+// is the regression guard for the failure the ExternalSecret-only gate let
+// through. A Static->Dynamic flip create-or-updates the ExternalSecret IN PLACE,
+// so on a migrated cluster it keeps reporting Ready from its last Static sync
+// while the Secret behind it still holds the retired static seed. Flipping the
+// child on that Ready alone stops the glance-operator asserting the static
+// User/Grant Glance was serving on and points it at a login that never existed —
+// an outage behind GlanceReady=True. The operator must hold the flip until the
+// Secret carries an engine-issued username.
+func TestReconcileGlance_DynamicCredentialStaleStaticUsername_LeavesExistingChildStatic(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
+	// A Ready ExternalSecret over a Secret still holding the static seed: exactly
+	// what a cluster upgraded from the Static path presents to the reconciler.
+	r := newGlanceTestReconciler(t, cp, readyGlanceDBCredES(cp), staleStaticGlanceDBCredSecret(cp))
+
+	// Static deployment: the child is projected and runs on the static credential.
+	_, err := r.reconcileGlance(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getProjectedGlance(t, r.Client, cp).Spec.Database.CredentialsMode).
+		To(Equal(commonv1.CredentialsModeStatic))
+
+	// Flip to Dynamic. The ExternalSecret is Ready, but only from the Static sync.
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeDynamic
+	res, err := r.reconcileGlance(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0), "must requeue while the credential is not engine-issued")
+
+	g.Expect(getProjectedGlance(t, r.Client, cp).Spec.Database.CredentialsMode).
+		To(Equal(commonv1.CredentialsModeStatic),
+			"a Ready ExternalSecret over a stale static username must not flip the running child to Dynamic")
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeGlanceReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForGlanceDBCredential"))
+	g.Expect(cond.Message).To(ContainSubstring(`"glance"`),
+		"the condition must name the non-engine-issued username it found")
+	g.Expect(cond.Message).To(ContainSubstring(glanceDBCredentialSecretName(cp)),
+		"the condition must name the Secret an operator has to delete")
+}
+
+// TestReconcileGlance_DynamicCredentialSecretAbsent_DefersProjection covers the
+// window the migration guide's `kubectl delete secret` step opens: the
+// ExternalSecret is Ready but its target Secret is gone until ESO re-materialises
+// it from the generator. An absent Secret is "not issued yet", not an error — no
+// child may be projected against it.
+func TestReconcileGlance_DynamicCredentialSecretAbsent_DefersProjection(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	// A Ready ExternalSecret with no materialised Secret behind it.
+	r := newGlanceTestReconciler(t, cp, readyGlanceDBCredES(cp))
+
+	res, err := r.reconcileGlance(context.Background(), cp)
+
+	g.Expect(err).NotTo(HaveOccurred(), "an absent Secret is an expected state, not a client failure")
+	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+	cond := conditions.GetCondition(cp.Status.Conditions, conditionTypeGlanceReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal("WaitingForGlanceDBCredential"))
+
+	var list glancev1alpha1.GlanceList
+	g.Expect(r.Client.List(context.Background(), &list)).To(Succeed())
+	g.Expect(list.Items).To(BeEmpty(), "no Glance child may be projected before the credential is materialised")
+}
+
+// TestReconcileGlance_UnsetTearsDownDynamicGeneratorWithoutOptIn covers the
+// preserve-by-default branch: dropping spec.services.glance keeps the child
+// (an accidental block drop must not remove a running service) but must NOT keep
+// the credential minter. A retained VaultDynamicSecret mints a fresh MySQL user
+// with ALL PRIVILEGES every refresh interval, forever, for a service the operator
+// was told it no longer manages — with no consumer, no revocation, and a
+// GlanceReady=True condition that surfaces none of it.
+func TestReconcileGlance_UnsetTearsDownDynamicGeneratorWithoutOptIn(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := glanceControlPlane()
+	r := newGlanceTestReconciler(t, cp)
+	ctx := context.Background()
+
+	_, err := r.reconcileGlance(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
+	}, &esgenv1alpha1.VaultDynamicSecret{})).To(Succeed(), "the generator was projected alongside the child")
+
+	// No opt-in annotation: the child is preserved.
+	cp.Spec.Services.Glance = nil
+	_, err = r.reconcileGlance(ctx, cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(getProjectedGlance(t, r.Client, cp)).NotTo(BeNil(), "the child must still be preserved")
+
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
+	}, &esgenv1alpha1.VaultDynamicSecret{})).NotTo(Succeed(),
+		"the credential minter must be torn down even though the child is preserved")
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialServiceAccountName, Namespace: cp.GlanceNamespace(),
+	}, &corev1.ServiceAccount{})).NotTo(Succeed(), "the generator's ServiceAccount must be torn down too")
+	orphanCert := &unstructured.Unstructured{}
+	orphanCert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialClientCertName(cp), Namespace: cp.GlanceNamespace(),
+	}, orphanCert)).NotTo(Succeed(), "the generator's mTLS client Certificate must be torn down too")
+}
+
 // TestReconcileGlance_UnsetDeletesChildWithOptIn verifies the opt-in deletion
-// sweep removes the child AND the DB-credential ExternalSecret, and — the
-// ownership guard — never touches a hand-created Glance child the ControlPlane
-// does not own.
+// sweep removes the child AND every DB-credential object — the (generator-backed)
+// ExternalSecret plus the Dynamic-mode VaultDynamicSecret, Certificate, and
+// ServiceAccount — and, the ownership guard, never touches a hand-created Glance
+// child the ControlPlane does not own.
 func TestReconcileGlance_UnsetDeletesChildWithOptIn(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cp := glanceControlPlane()
@@ -186,11 +449,22 @@ func TestReconcileGlance_UnsetDeletesChildWithOptIn(t *testing.T) {
 
 	_, err := r.reconcileGlance(ctx, cp)
 	g.Expect(err).NotTo(HaveOccurred())
-	// The DB-credential ExternalSecret was projected alongside the child.
+	// The Dynamic-default DB-credential objects were projected alongside the child.
 	var es esov1.ExternalSecret
 	g.Expect(r.Get(ctx, types.NamespacedName{
 		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
 	}, &es)).To(Succeed())
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
+	}, &esgenv1alpha1.VaultDynamicSecret{})).To(Succeed())
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialServiceAccountName, Namespace: cp.GlanceNamespace(),
+	}, &corev1.ServiceAccount{})).To(Succeed())
+	glanceCert := &unstructured.Unstructured{}
+	glanceCert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialClientCertName(cp), Namespace: cp.GlanceNamespace(),
+	}, glanceCert)).To(Succeed())
 
 	cp.Spec.Services.Glance = nil
 	cp.Annotations = map[string]string{glanceDeletionAllowedAnnotation: "true"}
@@ -205,6 +479,17 @@ func TestReconcileGlance_UnsetDeletesChildWithOptIn(t *testing.T) {
 	g.Expect(r.Get(ctx, types.NamespacedName{
 		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
 	}, &esov1.ExternalSecret{})).NotTo(Succeed(), "the DB-credential ExternalSecret must be swept too")
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialSecretName(cp), Namespace: cp.GlanceNamespace(),
+	}, &esgenv1alpha1.VaultDynamicSecret{})).NotTo(Succeed(), "the VaultDynamicSecret generator must be swept too")
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialServiceAccountName, Namespace: cp.GlanceNamespace(),
+	}, &corev1.ServiceAccount{})).NotTo(Succeed(), "the generator's ServiceAccount must be swept too")
+	sweptCert := &unstructured.Unstructured{}
+	sweptCert.SetGroupVersionKind(certificateGVK)
+	g.Expect(r.Get(ctx, types.NamespacedName{
+		Name: glanceDBCredentialClientCertName(cp), Namespace: cp.GlanceNamespace(),
+	}, sweptCert)).NotTo(Succeed(), "the mTLS client Certificate must be swept too")
 }
 
 // TestReconcileGlance_UnsetPreservesForeignChild proves the deletion sweep is
@@ -341,8 +626,8 @@ func TestReconcileGlance_ImageOverrideWins(t *testing.T) {
 
 // TestReconcileGlance_DatabaseManagedProjection verifies the managed-mode DB
 // wiring: the logical schema is always "glance", the secretRef points at the
-// operator-owned DB-credential Secret, and credentialsMode is forced Static
-// (there is no engine role for the glance schema).
+// operator-owned DB-credential Secret, and credentialsMode is Dynamic by default
+// (the managed-shared default now that glance has its own engine role).
 func TestReconcileGlance_DatabaseManagedProjection(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cp := glanceControlPlane()
@@ -358,8 +643,8 @@ func TestReconcileGlance_DatabaseManagedProjection(t *testing.T) {
 		"the logical schema must be glance, not the shared block's keystone")
 	g.Expect(gl.Spec.Database.SecretRef.Name).To(Equal(glanceDBCredentialSecretName(cp)))
 	g.Expect(gl.Spec.Database.SecretRef.Key).To(Equal("password"))
-	g.Expect(gl.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeStatic),
-		"a managed glance database is Static — no engine role can mint its credentials")
+	g.Expect(gl.Spec.Database.CredentialsMode).To(Equal(commonv1.CredentialsModeDynamic),
+		"a managed shared glance database defaults to Dynamic (engine-issued) credentials")
 
 	// DeepCopy: the projected ClusterRef must not alias the ControlPlane spec.
 	g.Expect(gl.Spec.Database.ClusterRef).NotTo(BeIdenticalTo(cp.Spec.Infrastructure.Database.ClusterRef))
@@ -579,12 +864,15 @@ func TestReconcileGlance_DoesNotSetAPIServer(t *testing.T) {
 	g.Expect(gl.Spec.APIServer).To(BeNil())
 }
 
-// TestReconcileGlance_DBCredentialExternalSecretShape verifies the projected
-// DB-credential ExternalSecret reads the per-ControlPlane KV path through the
-// resolved store and materializes the operator-owned Secret.
+// TestReconcileGlance_DBCredentialExternalSecretShape verifies the Static opt-out
+// projects a KV-backed DB-credential ExternalSecret that reads the
+// per-ControlPlane KV path through the resolved store and materializes the
+// operator-owned Secret. The opt-out is set explicitly now that the managed-shared
+// default is Dynamic.
 func TestReconcileGlance_DBCredentialExternalSecretShape(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cp := glanceControlPlane()
+	cp.Spec.Services.Glance.DatabaseCredentialsMode = commonv1.CredentialsModeStatic
 	r := newGlanceTestReconciler(t, cp)
 
 	_, err := r.reconcileGlance(context.Background(), cp)
@@ -597,6 +885,7 @@ func TestReconcileGlance_DBCredentialExternalSecretShape(t *testing.T) {
 
 	g.Expect(es.Spec.Target.Name).To(Equal(glanceDBCredentialSecretName(cp)))
 	g.Expect(es.Spec.SecretStoreRef.Name).To(Equal("openbao-tenant-store"))
+	g.Expect(es.Spec.DataFrom).To(BeEmpty(), "the Static ExternalSecret must not use a generator")
 	g.Expect(es.Spec.Data).To(HaveLen(2))
 	wantKey := glanceDBCredentialRemoteKeyFor(cp)
 	g.Expect(wantKey).To(Equal("openstack/glance/default/cp/db"))

--- a/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
@@ -35,7 +35,8 @@
 #                        ("…-service-account-glance-assign-service-…");
 #                        ServiceAccountsReady=True and status.serviceAccounts[0].ready.
 #   5c. Glance child   — owned Glance CR ("…-glance") with database/cache clusterRefs,
-#                        a Static DB credential, the derived Keystone endpoint, the
+#                        an engine-issued (Dynamic) DB credential drawn from the
+#                        OpenBao database engine, the derived Keystone endpoint, the
 #                        injected service user, and its GlanceBackend ("…-glance-default")
 #                        against the Garage S3 bucket; GlanceReady=True.
 #   5d. Image catalog  — owned K-ORC image Service ("…-image-service") + internal/public
@@ -502,8 +503,40 @@ spec:
             "$(kubectl get glances.glance.openstack.c5c3.io "${GLANCE_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.database.database}')"
           assert_eq "Glance DB secretRef points at the projected DB-credential Secret" "${CP_NAME}-glance-db-credentials" \
             "$(kubectl get glances.glance.openstack.c5c3.io "${GLANCE_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.database.secretRef.name}')"
-          assert_eq "Glance DB credentialsMode forced Static" "Static" \
+          assert_eq "Glance projected with Dynamic credentialsMode" "Dynamic" \
             "$(kubectl get glances.glance.openstack.c5c3.io "${GLANCE_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.database.credentialsMode}')"
+
+          # ── Assert the Glance DB credential is generator-backed (engine-issued) ─
+          # Named after the projected Glance CR: <cp>-glance-db-credentials.
+          # The glance dynamic objects are ensured INSIDE the Keystone-gated
+          # reconcileGlance rather than pre-gate like Keystone's, so these
+          # assertions sit after GlanceReady. That ordering is sound because
+          # reconcileGlance gates the child on this ExternalSecret reporting Ready
+          # AND on the Secret behind it carrying an engine-issued username
+          # (WaitingForGlanceDBCredential) before it projects credentialsMode
+          # Dynamic — so GlanceReady=True already implies an engine-issued
+          # credential has materialised. The username check below re-asserts that
+          # end-to-end against a real ESO+OpenBao, not just the operator's gate.
+          GLANCE_DB_SECRET="${GLANCE_CR}-db-credentials"
+          assert_eq "Glance DB-credential ExternalSecret uses a VaultDynamicSecret generator" "VaultDynamicSecret" \
+            "$(kubectl get externalsecret "${GLANCE_DB_SECRET}" -n "${CP_NS}" \
+              -o "jsonpath={.spec.dataFrom[0].sourceRef.generatorRef.kind}")"
+          assert_eq "Glance DB-credential ExternalSecret carries no static Data refs" "" \
+            "$(kubectl get externalsecret "${GLANCE_DB_SECRET}" -n "${CP_NS}" -o 'jsonpath={.spec.data}')"
+          kubectl get vaultdynamicsecret "${GLANCE_DB_SECRET}" -n "${CP_NS}" >/dev/null
+          # Glance shares the ControlPlane namespace in this suite, so the
+          # per-tenant engine role is glance-<CP_NS>.
+          assert_eq "Glance VaultDynamicSecret reads the glance engine-role creds path" "database/mariadb/creds/glance-${CP_NS}" \
+            "$(kubectl get vaultdynamicsecret "${GLANCE_DB_SECRET}" -n "${CP_NS}" -o 'jsonpath={.spec.path}')"
+          kubectl get serviceaccount glance-db-creds -n "${CP_NS}" >/dev/null
+          # The materialised Secret must carry the engine-issued username (a
+          # transient v-kube-... login), not the static "glance" user.
+          GLANCE_DB_USERNAME="$(kubectl get secret "${GLANCE_DB_SECRET}" -n "${CP_NS}" \
+            -o "jsonpath={.data.username}" | base64 -d)"
+          if [ "${GLANCE_DB_USERNAME}" = "glance" ] || [ -z "${GLANCE_DB_USERNAME}" ]; then
+            echo "ERROR: Glance DB-credential Secret username '${GLANCE_DB_USERNAME}' is not engine-issued"; exit 1
+          fi
+          echo "OK: Glance DB credential is engine-issued (username '${GLANCE_DB_USERNAME}')"
           assert_eq "Glance cache clusterRef wired to infra" "openstack-memcached" \
             "$(kubectl get glances.glance.openstack.c5c3.io "${GLANCE_CR}" -n "${CP_NS}" -o 'jsonpath={.spec.cache.clusterRef.name}')"
           assert_eq "Glance keystoneEndpoint derived from the naming convention" \
@@ -627,6 +660,45 @@ spec:
           echo "OK: an unrelated lease survives another's revoke (AC 4 lease isolation)"
           assert_eq "ControlPlane still Ready after lease revokes" "True" \
             "$(kubectl get controlplane "${CP_NAME}" -n "${CP_NS}" -o "jsonpath={.status.conditions[?(@.type=='Ready')].status}")"
+
+          # ── Link 6c: glance-db / keystone-db SERVICE isolation ─────────────
+          # deploy/openbao/policies/glance-db-dynamic.hcl claims the two role +
+          # policy pairs are told apart by the ServiceAccount NAME the token
+          # carries — glance-db-creds vs keystone-db-creds — and that this holds
+          # even for two services CO-LOCATED in one namespace. This suite runs
+          # exactly that co-located shape (Glance shares ${CP_NS}), so it is the
+          # place to prove it. (The cross-TENANT half of the claim is the
+          # multi-controlplane suite's keystone-db check; this is the
+          # cross-SERVICE half, which nothing exercised before.)
+          GLANCE_ROLE="glance-${CP_NS}"
+          # login <sa> <role> → prints the client token minted from that SA's JWT.
+          db_login() {
+            bao_exec bao write -field=token "auth/kubernetes/management/login" \
+              role="$2" jwt="$(kubectl create token "$1" -n "${CP_NS}" --duration=10m)"
+          }
+          G_TOKEN="$(db_login glance-db-creds glance-db)"
+          if [ -z "${G_TOKEN}" ]; then
+            echo "ERROR: glance-db login returned no token"; exit 1
+          fi
+          # Positive control first, so a broken login cannot make the denies below
+          # pass vacuously.
+          if ! bao_exec env BAO_TOKEN="${G_TOKEN}" \
+            bao read "database/mariadb/creds/${GLANCE_ROLE}" >/dev/null 2>&1; then
+            echo "ERROR: glance token could not read its OWN creds path ${GLANCE_ROLE}"; exit 1
+          fi
+          echo "OK: glance token reads its own creds path (${GLANCE_ROLE})"
+          if bao_exec env BAO_TOKEN="${G_TOKEN}" \
+            bao read "database/mariadb/creds/${ROLE}" >/dev/null 2>&1; then
+            echo "ERROR: glance token READ the keystone creds path ${ROLE} in its own namespace"; exit 1
+          fi
+          echo "OK: glance token denied on the co-located keystone creds path (${ROLE})"
+          # The mirror direction: keystone's token must not reach glance's path.
+          K_TOKEN="$(db_login keystone-db-creds keystone-db)"
+          if bao_exec env BAO_TOKEN="${K_TOKEN}" \
+            bao read "database/mariadb/creds/${GLANCE_ROLE}" >/dev/null 2>&1; then
+            echo "ERROR: keystone token READ the glance creds path ${GLANCE_ROLE} in its own namespace"; exit 1
+          fi
+          echo "OK: keystone token denied on the co-located glance creds path (${GLANCE_ROLE}) — service isolation holds"
           unset BAO_TOKEN
 
           # ── Link 7a: Keystone /v3 returns HTTP 200 ─────────────────────────
@@ -690,6 +762,8 @@ spec:
           kubectl get glances.glance.openstack.c5c3.io,glancebackends.glance.openstack.c5c3.io -n openstack 2>&1 || true
           kubectl describe glance controlplane-keystone-glance -n openstack 2>&1 || true
           kubectl describe externalsecret controlplane-keystone-glance-db-credentials -n openstack 2>&1 || true
+          kubectl describe vaultdynamicsecret controlplane-keystone-glance-db-credentials -n openstack 2>&1 || true
+          kubectl get serviceaccount glance-db-creds -n openstack 2>&1 || true
           echo "=== glance-operator logs (last 200 lines) ==="
           kubectl logs -n glance-system -l app.kubernetes.io/name=glance-operator --tail=200 --all-containers 2>&1 || true
           echo "=== OpenBao logs (last 100 lines) ==="

--- a/tests/e2e/c5c3/invalid-cr/54-keystone-credentials-mode-override-in-external.yaml
+++ b/tests/e2e/c5c3/invalid-cr/54-keystone-credentials-mode-override-in-external.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# services.keystone.databaseCredentialsMode in External mode violates the CEL
+# rule: no managed database is provisioned, so there is no credentials mode to
+# override. A Static value is otherwise valid, so the ONLY violation is the
+# External-mode forbid.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: cp-external-credentials-mode
+spec:
+  openStackRelease: "2025.2"
+  services:
+    keystone:
+      mode: External
+      external:
+        authURL: https://keystone.example.com/v3
+      databaseCredentialsMode: Static
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+      passwordSecretRef:
+        name: external-admin
+        key: password

--- a/tests/e2e/c5c3/invalid-cr/55-keystone-override-dynamic-on-dedicated.yaml
+++ b/tests/e2e/c5c3/invalid-cr/55-keystone-override-dynamic-on-dedicated.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# databaseCredentialsMode Dynamic on the Keystone service is rejected by the
+# webhook when Keystone declares a DEDICATED database: the override retargets the
+# shared database this service does not use, and a dedicated database is
+# Static-only. The CRD Enum admits the value (Static|Dynamic) and no CEL rule
+# spans the dedicated block, so the webhook is the enforcement point.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: cp-override-dynamic-dedicated-ks
+spec:
+  openStackRelease: "2025.2"
+  infrastructure:
+    database:
+      host: db.example.com
+      database: openstack
+      secretRef:
+        name: db-creds
+    cache:
+      backend: dogpile.cache.pymemcache
+      servers:
+      - mc:11211
+  services:
+    keystone:
+      mode: Managed
+      databaseCredentialsMode: Dynamic
+      dedicatedBackingServices:
+        database:
+          clusterRef:
+            name: cp-dedicated-db
+          database: keystone
+          secretRef:
+            name: keystone-db
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+      passwordSecretRef:
+        name: external-admin
+        key: password

--- a/tests/e2e/c5c3/invalid-cr/56-glance-override-dynamic-on-dedicated.yaml
+++ b/tests/e2e/c5c3/invalid-cr/56-glance-override-dynamic-on-dedicated.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# databaseCredentialsMode Dynamic on the Glance service is rejected by the webhook
+# when Glance declares a DEDICATED database, mirroring the Keystone case: the
+# override retargets the shared database this service does not use, and a
+# dedicated database is Static-only. The defaulting webhook injects the glance
+# service account, so the only violation is the credentials-mode override.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: cp-override-dynamic-dedicated-gl
+spec:
+  openStackRelease: "2025.2"
+  infrastructure:
+    database:
+      host: db.example.com
+      database: openstack
+      secretRef:
+        name: db-creds
+    cache:
+      backend: dogpile.cache.pymemcache
+      servers:
+      - mc:11211
+  services:
+    keystone:
+      mode: Managed
+    glance:
+      databaseCredentialsMode: Dynamic
+      backends:
+      - name: primary
+        type: S3
+        isDefault: true
+        s3:
+          endpoint: https://s3.example.com
+          bucket: images
+          credentialsSecretRef:
+            name: glance-s3-creds
+      dedicatedBackingServices:
+        database:
+          clusterRef:
+            name: cp-dedicated-db
+          database: glance
+          secretRef:
+            name: glance-db
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+      passwordSecretRef:
+        name: external-admin
+        key: password

--- a/tests/e2e/c5c3/invalid-cr/57-override-dynamic-on-brownfield.yaml
+++ b/tests/e2e/c5c3/invalid-cr/57-override-dynamic-on-brownfield.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# databaseCredentialsMode Dynamic on a service using the SHARED database is
+# rejected by the webhook when that shared database is brownfield (host set, no
+# clusterRef), mirroring the commonv1 Dynamic-requires-clusterRef contract one
+# level up: the dynamic engine issues per-tenant DB users only against a cluster
+# the operator provisions. The CRD Enum admits the value and the keystone CEL rule
+# forbids the field only in External mode, so the webhook is the enforcement point.
+apiVersion: c5c3.io/v1alpha1
+kind: ControlPlane
+metadata:
+  name: cp-override-dynamic-brownfield
+spec:
+  openStackRelease: "2025.2"
+  infrastructure:
+    database:
+      host: db.example.com
+      database: openstack
+      secretRef:
+        name: db-creds
+    cache:
+      backend: dogpile.cache.pymemcache
+      servers:
+      - mc:11211
+  services:
+    keystone:
+      mode: Managed
+      databaseCredentialsMode: Dynamic
+  korc:
+    adminCredential:
+      cloudCredentialsRef:
+        cloudName: admin
+      passwordSecretRef:
+        name: external-admin
+        key: password

--- a/tests/e2e/c5c3/invalid-cr/_generate.py
+++ b/tests/e2e/c5c3/invalid-cr/_generate.py
@@ -806,6 +806,92 @@ FIXTURES: tuple[Fixture, ...] = (
         infrastructure=MANAGED_INFRA,
         glance=VALID_GLANCE + "      publicEndpoint: https://glance.example.com?utm=1\n",
     ),
+    # --- per-service databaseCredentialsMode override (issue #683, still the
+    #     create-rejection matrix) ---
+    Fixture(
+        filename="54-keystone-credentials-mode-override-in-external.yaml",
+        comment=(
+            "services.keystone.databaseCredentialsMode in External mode violates the CEL\n"
+            "rule: no managed database is provisioned, so there is no credentials mode to\n"
+            "override. A Static value is otherwise valid, so the ONLY violation is the\n"
+            "External-mode forbid."
+        ),
+        name="cp-external-credentials-mode",
+        keystone=VALID_EXTERNAL_KEYSTONE + "      databaseCredentialsMode: Static\n",
+    ),
+    Fixture(
+        filename="55-keystone-override-dynamic-on-dedicated.yaml",
+        comment=(
+            "databaseCredentialsMode Dynamic on the Keystone service is rejected by the\n"
+            "webhook when Keystone declares a DEDICATED database: the override retargets the\n"
+            "shared database this service does not use, and a dedicated database is\n"
+            "Static-only. The CRD Enum admits the value (Static|Dynamic) and no CEL rule\n"
+            "spans the dedicated block, so the webhook is the enforcement point."
+        ),
+        name="cp-override-dynamic-dedicated-ks",
+        keystone=(
+            "      mode: Managed\n"
+            "      databaseCredentialsMode: Dynamic\n"
+            "      dedicatedBackingServices:\n"
+            "        database:\n"
+            "          clusterRef:\n"
+            "            name: cp-dedicated-db\n"
+            "          database: keystone\n"
+            "          secretRef:\n"
+            "            name: keystone-db\n"
+        ),
+        infrastructure=MANAGED_INFRA,
+    ),
+    Fixture(
+        filename="56-glance-override-dynamic-on-dedicated.yaml",
+        comment=(
+            "databaseCredentialsMode Dynamic on the Glance service is rejected by the webhook\n"
+            "when Glance declares a DEDICATED database, mirroring the Keystone case: the\n"
+            "override retargets the shared database this service does not use, and a\n"
+            "dedicated database is Static-only. The defaulting webhook injects the glance\n"
+            "service account, so the only violation is the credentials-mode override."
+        ),
+        name="cp-override-dynamic-dedicated-gl",
+        keystone="      mode: Managed\n",
+        infrastructure=MANAGED_INFRA,
+        glance=(
+            "    glance:\n"
+            "      databaseCredentialsMode: Dynamic\n"
+            "      backends:\n"
+            "      - name: primary\n"
+            "        type: S3\n"
+            "        isDefault: true\n"
+            "        s3:\n"
+            "          endpoint: https://s3.example.com\n"
+            "          bucket: images\n"
+            "          credentialsSecretRef:\n"
+            "            name: glance-s3-creds\n"
+            "      dedicatedBackingServices:\n"
+            "        database:\n"
+            "          clusterRef:\n"
+            "            name: cp-dedicated-db\n"
+            "          database: glance\n"
+            "          secretRef:\n"
+            "            name: glance-db\n"
+        ),
+    ),
+    Fixture(
+        filename="57-override-dynamic-on-brownfield.yaml",
+        comment=(
+            "databaseCredentialsMode Dynamic on a service using the SHARED database is\n"
+            "rejected by the webhook when that shared database is brownfield (host set, no\n"
+            "clusterRef), mirroring the commonv1 Dynamic-requires-clusterRef contract one\n"
+            "level up: the dynamic engine issues per-tenant DB users only against a cluster\n"
+            "the operator provisions. The CRD Enum admits the value and the keystone CEL rule\n"
+            "forbids the field only in External mode, so the webhook is the enforcement point."
+        ),
+        name="cp-override-dynamic-brownfield",
+        keystone=(
+            "      mode: Managed\n"
+            "      databaseCredentialsMode: Dynamic\n"
+        ),
+        infrastructure=MANAGED_INFRA,
+    ),
     # --- transition wave C: shared -> dedicated (Test: c5c3-invalid-cr-shared-to-dedicated) ---
     Fixture(
         filename="40-transition-base-shared.yaml",

--- a/tests/e2e/c5c3/invalid-cr/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/invalid-cr/chainsaw-test.yaml
@@ -465,6 +465,42 @@ spec:
         - check:
             ($error != null): true
             (contains($error, 'must be a bare origin')): true
+    # services.keystone.databaseCredentialsMode in External mode is rejected by the
+    # CEL rule: no managed database is provisioned, so there is no credentials mode
+    # to override. Even a Static value is forbidden (the rule is a plain field forbid).
+    - apply:
+        file: 54-keystone-credentials-mode-override-in-external.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'services.keystone.databaseCredentialsMode is forbidden when services.keystone.mode is External')): true
+    # databaseCredentialsMode Dynamic on the Keystone service with a DEDICATED database
+    # is rejected by the webhook: the override retargets the shared database this
+    # service does not use, and a dedicated database is Static-only. CEL cannot catch it
+    # (the value passes the Enum, and no CEL rule spans the dedicated block).
+    - apply:
+        file: 55-keystone-override-dynamic-on-dedicated.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'Dynamic is not supported as an override on a service with a dedicated database')): true
+    # databaseCredentialsMode Dynamic on the Glance service with a DEDICATED database is
+    # rejected by the webhook, mirroring the keystone case above.
+    - apply:
+        file: 56-glance-override-dynamic-on-dedicated.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'Dynamic is not supported as an override on a service with a dedicated database')): true
+    # databaseCredentialsMode Dynamic on a service using the SHARED database is rejected
+    # by the webhook when that shared database is brownfield (no clusterRef), mirroring
+    # the commonv1 Dynamic-requires-clusterRef contract one level up.
+    - apply:
+        file: 57-override-dynamic-on-brownfield.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'Dynamic requires the shared database to be managed')): true
 ---
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test

--- a/tests/e2e/c5c3/invalid-cr/test_generate.py
+++ b/tests/e2e/c5c3/invalid-cr/test_generate.py
@@ -37,7 +37,7 @@ _CHAINSAW_TEST = _HERE / "chainsaw-test.yaml"
 # Number of fixtures emitted by _generate.py. Bumping this value requires adding
 # the matching Fixture entry AND the matching `file: <name>` line in
 # chainsaw-test.yaml.
-_EXPECTED_FIXTURE_COUNT = 54
+_EXPECTED_FIXTURE_COUNT = 58
 
 
 def _load_generator() -> types.ModuleType:

--- a/tests/unit/deploy/service_namespace_seeding_test.sh
+++ b/tests/unit/deploy/service_namespace_seeding_test.sh
@@ -72,6 +72,71 @@ STUB
   chmod +x "$dir/kubectl"
 }
 
+# make_kubectl_full <dir> <glance_ns> <glance_dedicated_db>
+# A kubectl stub that answers EVERY lookup setup-database-tenant.sh makes so both
+# the keystone AND the glance legs run to completion — the bao writes reach
+# OpenBao via `kubectl exec ... openbao-0`, which the stub swallows. The
+# ControlPlane declares Glance (spec.services.glance non-empty); its service
+# namespace resolves to <glance_ns> (empty defaults to the ControlPlane
+# namespace) and it declares a dedicated glance database only when
+# <glance_dedicated_db> is non-empty. Keystone stays namespace-unassigned, so its
+# role is keyed on the ControlPlane namespace.
+make_kubectl_full() {
+  local dir="$1" glance_ns="$2" glance_dedicated_db="$3"
+  mkdir -p "$dir"
+  cat >"$dir/kubectl" <<STUB
+#!/bin/bash
+# The bao writes reach OpenBao via 'kubectl exec ... openbao-0'; swallow them.
+if [[ "\$1" == "exec" ]]; then
+  exit 0
+fi
+# Existence check: the ControlPlane is there.
+if [[ "\$*" == *"get controlplane"* && "\$*" != *"jsonpath"* ]]; then
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.services.keystone.namespace.name}"* ]]; then
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.services.glance.dedicatedBackingServices.database}"* ]]; then
+  printf '%s' "${glance_dedicated_db}"
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.services.glance.namespace.name}"* ]]; then
+  printf '%s' "${glance_ns}"
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.services.glance}"* ]]; then
+  # A non-empty object marks Glance as declared; its exact shape is irrelevant.
+  printf 'map[namespace:map[name:%s]]' "${glance_ns}"
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.infrastructure.database.clusterRef.name}"* ]]; then
+  printf 'openstack-db'
+  exit 0
+fi
+if [[ "\$*" == *"jsonpath={.spec.infrastructure.database.database}"* ]]; then
+  printf 'keystone'
+  exit 0
+fi
+# MariaDB root-secret resolution (per service), then the root Secret payload.
+if [[ "\$*" == *"get mariadb"* && "\$*" == *"rootPasswordSecretKeyRef.name"* ]]; then
+  printf 'openstack-db-root'
+  exit 0
+fi
+if [[ "\$*" == *"get mariadb"* && "\$*" == *"rootPasswordSecretKeyRef.key"* ]]; then
+  printf 'password'
+  exit 0
+fi
+if [[ "\$*" == *"get secret"* ]]; then
+  # base64("root") — decoded by the script before the (swallowed) bao write.
+  printf 'cm9vdA=='
+  exit 0
+fi
+exit 1
+STUB
+  chmod +x "$dir/kubectl"
+}
+
 # run_db_tenant <stub_dir> <namespace> <controlplane>
 run_db_tenant() {
   local stub_dir="$1" ns="$2" cp="$3"
@@ -132,6 +197,78 @@ test_db_tenant_defaults_to_the_controlplane_namespace() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: the glance engine role follows the Glance service namespace
+# ---------------------------------------------------------------------------
+test_db_tenant_provisions_glance_on_the_glance_namespace() {
+  echo "Test: setup-database-tenant.sh keys the glance engine role on the Glance namespace"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Glance declared, placed in its own "images" namespace, no dedicated database.
+  make_kubectl_full "$tmp" "images" ""
+
+  local output
+  output="$(run_db_tenant "$tmp" "openstack" "cp")"
+
+  assert_contains "the glance engine role is keyed on the Glance service namespace" \
+    "$output" "database/mariadb/roles/glance-images"
+  assert_contains "the glance MariaDB is read from the Glance service namespace" \
+    "$output" "openstack-db.images.svc:3306"
+  assert_contains "keystone is still provisioned on the ControlPlane namespace" \
+    "$output" "database/mariadb/roles/keystone-openstack"
+  assert_not_contains "the glance role must not be keyed on the ControlPlane namespace" \
+    "$output" "roles/glance-openstack"
+}
+
+# ---------------------------------------------------------------------------
+# Test: an unplaced Glance defaults its engine role to the ControlPlane namespace
+# ---------------------------------------------------------------------------
+test_db_tenant_defaults_glance_to_the_controlplane_namespace() {
+  echo "Test: setup-database-tenant.sh defaults the glance role to the ControlPlane namespace"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Glance declared but not placed in a namespace of its own: role follows the CP.
+  make_kubectl_full "$tmp" "" ""
+
+  local output
+  output="$(run_db_tenant "$tmp" "openstack" "cp")"
+
+  assert_contains "an unplaced Glance keeps the ControlPlane-namespace role" \
+    "$output" "database/mariadb/roles/glance-openstack"
+  assert_contains "the glance MariaDB is read from the ControlPlane namespace" \
+    "$output" "openstack-db.openstack.svc:3306"
+}
+
+# ---------------------------------------------------------------------------
+# Test: a dedicated glance database skips the glance engine leg
+# ---------------------------------------------------------------------------
+test_db_tenant_skips_glance_with_a_dedicated_database() {
+  echo "Test: setup-database-tenant.sh skips the glance leg for a dedicated glance database"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Glance declared WITH a dedicated database — Static-only, so no engine role.
+  make_kubectl_full "$tmp" "images" "glance-db"
+
+  local output
+  output="$(run_db_tenant "$tmp" "openstack" "cp")"
+
+  assert_contains "the dedicated-database glance leg is skipped, loudly" \
+    "$output" "skipping the glance database-engine tenant"
+  assert_not_contains "no glance engine role is written for a dedicated database" \
+    "$output" "database/mariadb/roles/glance-"
+  assert_contains "keystone is still provisioned" \
+    "$output" "database/mariadb/roles/keystone-openstack"
+}
+
+# ---------------------------------------------------------------------------
 # Test: the seeder parses the optional Keystone-namespace segment
 # ---------------------------------------------------------------------------
 # write-bootstrap-secrets.sh reaches OpenBao almost immediately, so it is driven
@@ -181,6 +318,9 @@ STUB
 # ---------------------------------------------------------------------------
 test_db_tenant_uses_the_service_namespace
 test_db_tenant_defaults_to_the_controlplane_namespace
+test_db_tenant_provisions_glance_on_the_glance_namespace
+test_db_tenant_defaults_glance_to_the_controlplane_namespace
+test_db_tenant_skips_glance_with_a_dedicated_database
 test_seeder_rejects_a_malformed_identity
 
 echo ""


### PR DESCRIPTION
Closes #683

Managed-mode Glance draws its database credential from a per-ControlPlane static KV path that only the kind/CI bootstrap seeds — a manual day-one step everywhere else, and a password that never rotates. Keystone on the same shared database already defaults to Dynamic: an ESO generator authenticates to OpenBao with a per-ControlPlane ServiceAccount plus mTLS client certificate and mints short-lived MySQL users from the MariaDB secrets engine.

This branch gives Glance its own dynamic path — own engine role, own leases, own generator, independent of Keystone — and makes the credentials mode overridable per service so a migration can be staged rather than all-or-nothing.

## Change set, in commit order

### `a3da611d` feat(openbao): provision a glance-scoped database-engine tenant

The bootstrap layer gains glance-scoped plumbing: a `glance-db-dynamic` templated read policy, a `glance-db` kubernetes/management auth role bound to the `glance-db-creds` ServiceAccount, and — when the ControlPlane declares `spec.services.glance` on the shared managed database — a per-tenant `database/mariadb/config/glance-<ns>` connection and `database/mariadb/roles/glance-<ns>` role.

The connection+role write sequence in `setup-database-tenant.sh` is extracted into a `provision_service_tenant` helper invoked once per service; the keystone-side `bao write` payloads stay byte-identical. A Glance that declares a dedicated database is Static-only and is skipped by the engine leg.

`hack/deploy-infra.sh` now waits on the MariaDB in *every* namespace the tenant script reads a root credential from, not just the ControlPlane's. Each service leg resolves its own service namespace and hard-exits when that namespace's root Secret is missing, so a ControlPlane placing Keystone or Glance in a dedicated namespace could otherwise leave the Keystone leg succeeding and the Glance leg exiting 1 — a partially applied onboarding with the operator already primed to flip Glance to Dynamic. The wait set is resolved from the live CR under the same conditions the script applies (dedicated-database Glance is skipped, since waiting on a shared clusterRef that will never appear would block until timeout).

`tests/unit/deploy/service_namespace_seeding_test.sh` drives both bootstrap scripts with stubs (no cluster, no OpenBao) to pin that per-tenant handles key on the *service* namespace rather than the ControlPlane's.

### `9a705a89` feat(c5c3): add the per-service databaseCredentialsMode override

The keystone and glance service blocks gain an optional `databaseCredentialsMode` overriding the ControlPlane-wide `spec.infrastructure.database.credentialsMode`. A `Dynamic` override is rejected on a service with a dedicated database (Static-only), on a brownfield shared database (Dynamic requires a managed `clusterRef`), and — for keystone — in External mode, via a CEL rule with a webhook mirror. `Static` is always admitted; empty inherits the shared mode.

This commit is API-only: field, CEL rule, validating webhook, regenerated CRDs (both `config/crd/bases/` and the Helm chart copy), webhook unit tests, and the `invalid-cr` e2e rejection fixtures. Controller consumption lands in the next commit.

### `39292be7` feat(c5c3): issue dynamic Glance DB credentials from the engine

Dynamic becomes the default for a managed shared Glance database. `reconcileGlance` provisions the `glance-db-creds` ServiceAccount, the `<glance>-db-openbao-client` mTLS Certificate, a VaultDynamicSecret generator reading `database/mariadb/creds/glance-<ns>` with role `glance-db`, and a generator-backed ExternalSecret — all in the Glance service namespace. The Static opt-out keeps projecting the KV-backed ExternalSecret and tears the dynamic objects down.

The per-service override is consumed for both services: `dbCredentialsDynamicEnabled` lets the keystone override win over the shared mode, `glanceDBCredentialsDynamicEnabled` does the same for glance while keeping a dedicated glance database fail-closed on Static. `applyDBCredentialCertificateSpec` is generalized over name/namespace so both concerns drive their own client cert. `deleteOrphanedGlance` and `sweepExternalNamespaceResidue` sweep the new objects on teardown.

### `761f9c32` test(e2e): assert the dynamic Glance DB credential chain

`full-controlplane-keystone` flips the projected Glance assertion from `Static` to the new `Dynamic` default and asserts the generator chain on the live kind cluster: generator-backed `<cp>-glance-db-credentials` ExternalSecret (VaultDynamicSecret `generatorRef`, no static `Data`), the VaultDynamicSecret reading `database/mariadb/creds/glance-<ns>`, the `glance-db-creds` ServiceAccount, and an engine-issued (non-`glance`) username on the materialised Secret. The failure catch dump is extended with the glance VaultDynamicSecret and ServiceAccount.

New override fixtures cover the rejection matrix: dynamic-on-dedicated for keystone and glance, dynamic-on-brownfield, and keystone-override-in-External.

### `a90ffbe8`, `ac9ba708`, `1b779b63` docs

The operator-facing migration guide (`docs/guides/glance/migrate-glance-db-to-dynamic-credentials.md`) mirrors the Keystone sibling: re-apply the bootstrap on brownfield clusters, onboard the engine role, optionally stage the cutover on the `Static` override, observe the roll via `glance.c5c3.io/db-connection-hash`, retire the leftover static User/Grant and KV secret, roll back by pinning Static and re-seeding.

`ac9ba708` corrects a template carry-over: the guide cited `DBCredentialsReady`, but that condition is set only by the keystone-scoped `reconcileDBCredentials`. Glance's ensure runs inside `reconcileGlance` and surfaces under `GlanceReady` (reason `GlanceDBCredentialError`), so the readiness gates were rescoped accordingly.

`1b779b63` updates the CRD reference (field tables, credential-mode precedence, Enum markers, CEL/webhook rows), the `reconcileGlance` reference, the openbao-bootstrap reference, the quick-start, and a cross-reference in the keystone guide.

## Notes for the reviewer

- **The static glance KV seed is retired, not merely defaulted away.** `write-bootstrap-secrets.sh` no longer writes `kv-v2/openstack/glance/<ns>/<cp>/db`. The issue says the static KV path "keeps working for opt-out and brownfield deployments" — reads still work and Static remains a supported mode, but a ControlPlane that explicitly opts back into Static must now seed that path by hand. This is deliberate (no long-lived DB password at rest by default) and mirrors what #439 did for Keystone; the caveat is called out in the migration guide. Worth a second opinion if it reads as narrower than the issue intended.
- **Glance readiness surfaces under `GlanceReady`, not a glance-scoped `DBCredentialsReady`.** Because the dynamic objects are ensured inside the Keystone-gated `reconcileGlance` rather than pre-gate like Keystone's, the e2e assertions sit after `GlanceReady` and the guide gates on it. Asymmetric with Keystone, and intentional — flagging it so it is reviewed as a design choice rather than skimmed as an inconsistency.
- **`hack/deploy-infra.sh` multi-namespace wait** is not named in the issue; it is fallout from the tenant script gaining a second service leg with an independently resolved namespace.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
