### PR TITLE
chore(skills): fold the glance onboarding lessons into the preparation skills

### DIFF
--- a/.claude/skills/check-service-parity/SKILL.md
+++ b/.claude/skills/check-service-parity/SKILL.md
@@ -40,7 +40,7 @@ threads through five layers:
 | Service operator | `operators/<svc>/` (module, CRD, webhook, helm chart, dashboards) | the keystone operator scaffolding on `internal/common` |
 | CI / e2e / deploy | `.github/workflows/*.yaml`, `hack/ci-resolve-changes.sh` env, `tests/e2e/<svc>/`, `tests/e2e-chaos/`, `deploy/flux-system/` | the enumeration points and canonical suite set keystone populates |
 | ControlPlane integration | `operators/c5c3/api/` `ServicesSpec`, `internal/controller/reconcile_<svc>.go`, c5c3 chart RBAC | the keystone projection (`reconcile_keystone.go`, `KeystoneReady`) |
-| Documentation | `docs/reference/<svc>/`, `docs/guides/enable-<svc>-operator-*.md`, `docs/.vitepress/config.ts` | the keystone reference/guide set |
+| Documentation | `docs/reference/<svc>/`, `docs/guides/<svc>/enable-<svc>-operator-*.md`, `docs/.vitepress/config.ts` | the keystone reference/guide set |
 
 There is no single authoritative gate for parity — that is the point of
 this skill. CI runs exactly the matrices it enumerates, so a service
@@ -95,7 +95,8 @@ inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
   never run and CI stays green.
 - **P6** — e2e coverage: the canonical chainsaw suite set
   (basic-deployment, scale, healthcheck, httproute, network-policy,
-  deletion-cleanup, pod-security-restricted, invalid-cr), the
+  deletion-cleanup, pod-security-restricted, invalid-cr,
+  gateway-quick-start-smoke), the
   latest-release `basic-deployment-<slug>` variant, and at least one
   chaos suite. Keystone's chaos suites predate multi-service naming
   and are unprefixed; later services prefix theirs (`<svc>-*`).
@@ -201,7 +202,11 @@ These recurring shapes are worth grepping for first:
   helm-unittest set are derived live from the keystone tree, so a
   keystone regression surfaces as every other service suddenly
   "leading" the reference. Read multi-service failures with that in
-  mind.
+  mind. The canon has known holes, though — a later service can pioneer
+  a surface keystone lacks (glance: the dual public+internal catalog
+  row, the satellite backend CRD, the backing-store-outage chaos
+  suite). A pioneered surface is a candidate for back-porting or for a
+  recorded deviation, not automatically a finding against the pioneer.
 - `ALLOWED_DEVIATIONS` (top of the audit script) is the single place
   deliberate deviations live, one `<svc>:<check>:<item>` token per
   line. Record the *why* in a comment next to the token.

--- a/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
+++ b/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
@@ -93,7 +93,7 @@ info "reference service: keystone"
 # Canonical per-service chainsaw suite set, derived from the suites every
 # service is expected to carry (the keystone reference has all of them).
 CANONICAL_E2E="basic-deployment scale healthcheck httproute network-policy \
-deletion-cleanup pod-security-restricted invalid-cr"
+deletion-cleanup pod-security-restricted invalid-cr gateway-quick-start-smoke"
 
 # Reference helm-unittest suite set, derived live from the keystone chart.
 REFERENCE_HELM_TESTS="$(find operators/keystone/helm/keystone-operator/tests \

--- a/.claude/skills/prepare-new-guide/SKILL.md
+++ b/.claude/skills/prepare-new-guide/SKILL.md
@@ -51,7 +51,9 @@ container with the devstack's verbatim bring-up command, the section
 structure (`## Steps`, `## Verification`, `## See also`), and the terminal
 `## Tested by` fence; the ControlPlane variant additionally carries the
 operator-owned `::: warning` block and a
-`## Standalone Keystone, without a ControlPlane` stub. Until the
+`## Standalone <Service>, without a ControlPlane` stub — `--service` also
+selects the subject of that prose (projected child `controlplane-<service>`;
+default subject is keystone). Until the
 tested-by suite path resolves to a real `chainsaw-test.yaml`, the
 skeleton fails the docs gate — that is intended, not a scaffold bug.
 
@@ -67,9 +69,10 @@ matching collapsed service group of the `Guides` sidebar section in
 Use only the resource names the declared devstack actually produces — the
 table in `docs/contributing/guide-conventions.md` lists them per devstack.
 Standalone differences go in the terminal
-`## Standalone Keystone, without a ControlPlane` section (modeled on
-`docs/guides/end-to-end-sso.md`); never interleave the two naming worlds
-in the primary walkthrough.
+`## Standalone <Service>, without a ControlPlane` section (keystone model:
+`docs/guides/end-to-end-sso.md`; glance model:
+`docs/guides/glance/glance-s3-multistore.md`); never interleave the two
+naming worlds in the primary walkthrough.
 
 ### 5. Wire the Tested by section
 
@@ -99,8 +102,9 @@ docs gate does not:
   the published operator chart (`oci://ghcr.io/c5c3/charts/`) requires a
   `HelmRelease` mention (Flux-ownership framing).
 - **V4** — a mutating kubectl verb on a projected child CR
-  (`controlplane-keystone` / `controlplane-horizon`) requires a
-  `::: warning` container with revert/projected language.
+  (`controlplane-<svc>` for every onboarded service — the list is
+  discovered from the newest `releases/<version>/source-refs.yaml`)
+  requires a `::: warning` container with revert/projected language.
 
 ### 2. Run the authoritative gate
 
@@ -123,8 +127,13 @@ What the scripts cannot decide:
   names table in `docs/contributing/guide-conventions.md`.
 - Revert warnings sit adjacent to the operations they cover, not in a
   distant section.
+- Readiness signals are scoped to the guide's subject: a service guide
+  watches the service condition on the ControlPlane (`GlanceReady`,
+  `KeystoneReady`, ...) or the child CR's `Ready`, never the
+  ControlPlane-wide `Ready` — the latter couples the guide to every other
+  service's health.
 - Standalone differences live in a terminal
-  `## Standalone Keystone, without a ControlPlane` section with no
+  `## Standalone <Service>, without a ControlPlane` section with no
   interleaved naming worlds.
 - Walkthrough YAML is devstack-named; the imported fixture exhibit is
   isolation-named and labelled as such.

--- a/.claude/skills/prepare-new-guide/scripts/scaffold-guide.sh
+++ b/.claude/skills/prepare-new-guide/scripts/scaffold-guide.sh
@@ -24,6 +24,10 @@
 #   --devstack <name>     quick-start | quick-start-extended | quick-start-controlplane
 #   --service <name>      the guide is service-specific and lives one level deeper
 #                         (docs/guides/<service>/) — deepens the devstack link
+#                         and makes that service the subject of the ControlPlane
+#                         prose (projected child controlplane-<service>, the
+#                         "Standalone <Service>" section); default subject is
+#                         keystone
 #   --title <title>       guide title (default: title-cased slug)
 #   --opt-in WITH_X=true  compose a WITH_* opt-in flag onto the bring-up command
 #                         (repeatable; WITH_CONTROLPLANE is a devstack, not an opt-in)
@@ -121,9 +125,14 @@ if [[ -n "${SUITE}" && ! -f "${REPO_ROOT}/${SUITE}/chainsaw-test.yaml" ]]; then
   echo "note: ${SUITE}/chainsaw-test.yaml does not exist yet — the docs gate fails until it does" >&2
 fi
 if [[ -z "${SUITE}" ]]; then
-  SUITE="tests/e2e/keystone/<TODO-suite>"
+  SUITE="tests/e2e/${SERVICE:-keystone}/<TODO-suite>"
   echo "note: no --suite given — '## Tested by' carries a TODO placeholder the docs gate rejects" >&2
 fi
+
+# Subject service for the skeleton prose: --service when given, else keystone
+# (the reference). The title-cased form is the CR kind (glance -> Glance).
+SUBJECT="${SERVICE:-keystone}"
+SUBJECT_KIND="$(printf '%s' "${SUBJECT}" | awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }')"
 
 # Devstack link depth: service-specific guides live one level deeper
 # (docs/guides/<service>/), so the Getting-Started link climbs twice.
@@ -181,21 +190,21 @@ EOF
 
 case "${DEVSTACK}" in
   quick-start-controlplane)
-    cat <<'EOF'
-Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
-CR named `controlplane` is `Ready` in the `openstack` namespace and its projected
-`controlplane-keystone` Keystone child is running. Every resource name in the
+    cat <<EOF
+Follow that tutorial through to its final **Verify** step, so a \`ControlPlane\`
+CR named \`controlplane\` is \`Ready\` in the \`openstack\` namespace and its projected
+\`controlplane-${SUBJECT}\` ${SUBJECT_KIND} child is running. Every resource name in the
 examples below is one that devstack produces.
 :::
 
-::: warning The Keystone child is operator-owned
-On a ControlPlane deployment the `controlplane-keystone` Keystone CR is
+::: warning The ${SUBJECT_KIND} child is operator-owned
+On a ControlPlane deployment the \`controlplane-${SUBJECT}\` ${SUBJECT_KIND} CR is
 **projected** by the c5c3-operator, so a knob you set directly on the child is
-reverted on the next reconcile. Set operational knobs on the `ControlPlane` CR
-and let the operator project them down. Where the `ControlPlane` CRD does not
+reverted on the next reconcile. Set operational knobs on the \`ControlPlane\` CR
+and let the operator project them down. Where the \`ControlPlane\` CRD does not
 expose a knob, this guide points to the
-[Standalone Keystone](#standalone-keystone-without-a-controlplane) section,
-which drives a Keystone CR you own.
+[Standalone ${SUBJECT_KIND}](#standalone-${SUBJECT}-without-a-controlplane) section,
+which drives a ${SUBJECT_KIND} CR you own.
 :::
 EOF
     ;;
@@ -238,12 +247,12 @@ TODO: how the reader confirms the change took effect.
 EOF
 
 if [[ "${DEVSTACK}" == "quick-start-controlplane" ]]; then
-  cat <<'EOF'
+  cat <<EOF
 
-## Standalone Keystone, without a ControlPlane
+## Standalone ${SUBJECT_KIND}, without a ControlPlane
 
 TODO: where a standalone (non-ControlPlane) installation differs, describe it
-here against a Keystone CR the reader owns — do not interleave the two naming
+here against a ${SUBJECT_KIND} CR the reader owns — do not interleave the two naming
 worlds in the primary walkthrough above.
 EOF
 fi

--- a/.claude/skills/prepare-new-guide/scripts/validate-guide.sh
+++ b/.claude/skills/prepare-new-guide/scripts/validate-guide.sh
@@ -16,7 +16,8 @@
 #       published operator chart (oci://ghcr.io/c5c3/charts/) requires the
 #       guide to frame Flux ownership (a 'HelmRelease' mention)
 #   V4  a mutating kubectl verb on an operator-projected child CR
-#       (kind keystone/horizon, name controlplane-keystone/-horizon)
+#       (kind <svc>, name controlplane-<svc>; the service list is
+#       discovered from the newest releases/<version>/source-refs.yaml)
 #       requires a '::: warning' container with revert/projected language
 #
 # The missing-devstack-block / missing-tested-by half of the conventions is
@@ -69,6 +70,21 @@ FAIL_COUNT=0
 fail() { echo "[FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 pass() { echo "[PASS] $*"; }
 info() { echo "[INFO] $*"; }
+
+# Onboarded services, discovered from the newest releases/<version>/
+# source-refs.yaml (the same discovery the parity audit uses), so V4 covers
+# a newly onboarded service without a hand-kept list here. Falls back to
+# the known set if discovery fails.
+onboarded_services() {
+  local latest
+  latest="$(find "${REPO_ROOT}/releases" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort | tail -1)"
+  if [[ -n "${latest}" && -f "${latest}/source-refs.yaml" ]]; then
+    grep -E '^[a-z0-9_-]+:' "${latest}/source-refs.yaml" | cut -d: -f1 | xargs
+  else
+    echo "keystone horizon glance"
+  fi
+}
+SVC_ALT="$(onboarded_services | tr ' ' '|')"
 
 # Body of the first "::: info Devstack" container (same extractor as the
 # docs gate), including the fence lines.
@@ -143,12 +159,13 @@ check_guide() {
   fi
 
   # V4 — projected-child edits need a revert warning (guide-conventions.md
-  # "Never edit operator-projected children"): a mutating kubectl verb on the
-  # projected keystone/horizon CR requires a '::: warning' container with
+  # "Never edit operator-projected children"): a mutating kubectl verb on a
+  # projected service CR requires a '::: warning' container with
   # projected/revert language. The kind token must sit adjacent to the child
   # name so Secrets/ExternalSecrets named controlplane-keystone-* do not
-  # trigger.
-  local mut_re='kubectl[^`]*[[:space:]](patch|edit|scale|set|annotate|label|delete)[[:space:]](.*[[:space:]])?(keystone|horizon)s?(\.[a-z0-9.]*)?[[:space:]]+(controlplane-keystone|controlplane-horizon)([^a-z0-9-]|$)'
+  # trigger. The service alternation comes from onboarded_services above.
+  local mut_re
+  mut_re='kubectl[^`]*[[:space:]](patch|edit|scale|set|annotate|label|delete)[[:space:]](.*[[:space:]])?('"${SVC_ALT}"')s?(\.[a-z0-9.]*)?[[:space:]]+controlplane-('"${SVC_ALT}"')([^a-z0-9-]|$)'
   hits="$(grep -nE "${mut_re}" "${file}" || true)"
   if [[ -z "${hits}" ]]; then
     pass "V4 ${file}: no mutating kubectl command on a projected child CR"

--- a/.claude/skills/prepare-new-service/SKILL.md
+++ b/.claude/skills/prepare-new-service/SKILL.md
@@ -17,9 +17,14 @@ This skill turns "we want service X next" into a **phased meta issue** whose
 checkboxes are sized to become sub-issues, plus (when needed) a separate
 **generalization pre-work issue**. It analyzes; it does not implement.
 
-Worked example: Horizon — meta issue #552, generalization pre-work #551.
-Read both before drafting a new one; they are the calibration for scope,
-tone, and checkbox granularity.
+Worked examples: Horizon — meta issue #552, generalization pre-work #551;
+Glance — meta issue #656 with pre-work #653 (Garage S3 test infra), #654
+(c5c3 groundwork: role assignments, generalized catalog, cross-namespace
+credential delivery), #655 (common extractions). Read them before drafting
+a new one; they are the calibration for scope, tone, and checkbox
+granularity. #656 also demonstrates the alternative implementation mode —
+Phases 2–4 as one continuous stacked-PR arc instead of fanned-out
+sub-issues — and a Phase-0 decision record (D1–D10) worth imitating.
 
 ## The five layers
 
@@ -30,9 +35,9 @@ Every service in forge threads through five layers. Keystone
 |---|---|---|
 | 1. Container image | `images/<svc>/Dockerfile`, `releases/*/source-refs.yaml`, `releases/*/extra-packages.yaml`, `tests/container-images/verify_<svc>.sh` | build/test matrix: **yes** (from source-refs keys); hadolint matrix in `build-images.yaml`: **no** |
 | 2. Service operator | `operators/<svc>/` (api, controller, webhook, helm chart on `operators/shared/helm/operator-library`), `go.work`, `Makefile` `OPERATORS` | **no** — module + enumerations by hand |
-| 3. CI / e2e / deploy | `ci.yaml` paths-filter + `ALL_OPERATORS` + matrices, `tests/e2e/<svc>/`, `tests/e2e/<svc>-operator/`, `tests/e2e-chaos/`, `tests/tempest/<svc>-*/`, `deploy/flux-system/releases/<svc>-operator.yaml` | chainsaw suites: **yes** (auto-discovered); ci.yaml wiring: **no** (3-step procedure in `hack/ci-resolve-changes.sh` header) |
-| 4. ControlPlane (c5c3) | `ServicesSpec` in `operators/c5c3/api/v1alpha1/controlplane_types.go`, `reconcile_<svc>.go`, condition/instrumentation maps, RBAC markers + helm `_helpers.tpl`, scheme, webhook | **no** — ~10 enumeration points |
-| 5. Documentation | `docs/reference/<svc>/` (hand-written, `quadrant: operator` frontmatter), VitePress sidebar, guides, `tests/unit/docs/` conventions | **no** — no doc generator exists |
+| 3. CI / e2e / deploy | `ci.yaml` paths-filter + `ALL_OPERATORS` + matrices, `tests/ci/verify_<svc>_ci_pipeline.sh`, `tests/e2e/<svc>/`, `tests/e2e/<svc>-operator/`, `tests/e2e-chaos/<svc>-*/`, `tests/tempest/<svc>-*/`, `deploy/flux-system/releases/<svc>-operator.yaml`, kind devstack wiring (`deploy/kind/base/openstack-gateway.yaml` listener + `deploy/kind/infrastructure/<svc>-nip-io-tls-certificate.yaml`), OpenBao bootstrap legs (`deploy/openbao/bootstrap/`, `deploy/openbao/policies/`) | chainsaw suites: **yes** (auto-discovered); ci.yaml wiring: **no** (3-step procedure in `hack/ci-resolve-changes.sh` header); devstack/OpenBao wiring: **no** |
+| 4. ControlPlane (c5c3) | `ServicesSpec` in `operators/c5c3/api/v1alpha1/controlplane_types.go` (incl. `publicEndpoint` + `databaseCredentialsMode` per-service fields), `reconcile_<svc>.go` (+ `reconcile_<svc>_dbcredentials.go` for DB services), catalog row in `reconcile_catalog.go`, teardown in `reconcile_delete.go`, condition/instrumentation maps, RBAC markers + helm `_helpers.tpl`, scheme, webhook, envtest full chain (`integration_test.go`) + `tests/e2e/c5c3/full-controlplane-keystone/` | **no** — ~10 enumeration points |
+| 5. Documentation | `docs/reference/<svc>/` (hand-written, `quadrant: operator` frontmatter), VitePress sidebar, per-service guides under `docs/guides/<svc>/`, quick-start extension (`docs/quick-start-controlplane.md`), `tests/unit/docs/` conventions | **no** — no doc generator exists |
 
 ## Procedure
 
@@ -43,22 +48,73 @@ applies and which decisions need a Phase-0 spike:
 
 - **Database?** Which migration tool (alembic `db_sync` vs Django
   `migrate` vs none)? No DB ⇒ drop the database/db-sync/upgrade
-  sub-reconcilers entirely.
+  sub-reconcilers entirely. A DB service also inherits the **dynamic
+  credential chain**: the shared `credentialsMode` on `DatabaseSpec`, a
+  per-service `databaseCredentialsMode` override on its c5c3 service spec,
+  a `provision_service_tenant` leg in
+  `deploy/openbao/bootstrap/setup-database-tenant.sh`, a `<svc>-db` auth
+  role + `<svc>-db-dynamic` policy, the generator-backed ExternalSecret
+  glue (`reconcile_<svc>_dbcredentials.go` on the shared builders in
+  `reconcile_dbcredentials.go`), and a
+  `migrate-<svc>-db-to-dynamic-credentials` guide (keystone and glance are
+  the two worked examples).
+- **db-sync side-loads?** Some services need seed data beyond the schema
+  migration (glance: `db load_metadefs`) — chain the extra `*-manage` step
+  into the db-sync Job with an explicit `--path`, because the config-free
+  image does not ship the oslo default locations.
 - **Message bus?** No shared RabbitMQ spec or backing service exists yet —
   the **first** RabbitMQ consumer must add a `commonv1` messaging type and
   extend `InfrastructureSpec` + `hack/deploy-infra.sh`. That is its own
   pre-work issue.
-- **Service-catalog endpoints?** If yes, mirror the c5c3 catalog
-  reconciler pattern (K-ORC `Service` + `Endpoint`).
+- **Extra backing store?** (object store, message queue, cache beyond
+  memcached) — a new backing service is its own pre-work issue (#653:
+  Garage S3 for glance is the template — operator + declarative
+  buckets/keys in `deploy/flux-system/infrastructure/`, OpenBao-seeded
+  credentials materialized via ESO, kind ExternalSecrets), and it earns a
+  **backing-store-outage chaos suite** (`glance-garage-outage`: writes
+  fail closed, `/healthcheck` and `Ready` stay up).
+- **Consumes another service's API?** A service user
+  (`[keystone_authtoken]`-style) needs credential sourcing, c5c3 role
+  assignments, and cross-namespace credential delivery — glance was the
+  first consumer; #654/#655 are the templates.
+- **Pluggable backends?** If users attach a variable number of backends
+  (image stores, identity domains), model them as a **satellite CRD**
+  mirroring `KeystoneIdentityBackend`/`GlanceBackend`: inverted
+  attachment via `<svc>Ref`, dedicated per-backend controller + an
+  aggregating sub-reconciler on the parent, curated `backends[]`
+  projection from c5c3 with prefix-guarded pruning, plus the three suites
+  the pattern demands (multi-instance, default/aggregation-switch with
+  last-good retention, `invalid-<child>-cr`).
+- **Service-catalog endpoints?** If yes, add a row to the generalized
+  `managedCatalogRows` table in `reconcile_catalog.go` (K-ORC `Service` +
+  `Endpoint`). Register **public + internal from birth** (the glance D6
+  posture) — adding an interface later is a catalog migration. Extend the
+  c5c3 teardown (`reconcile_delete.go`) for the new catalog CRs.
 - **Config format?** oslo INI is covered by `internal/common/config`;
   anything else (Django settings, JSON) needs a renderer decision first.
+- **Behavior breaks between the supported releases?** Check upstream
+  release notes for launch-mode/WSGI/paste divergence between the pinned
+  releases (glance 2025.2 eventlet vs 2026.1 uWSGI forced a
+  release-switched command in the deployment builder). If yes, the
+  per-release `basic-deployment-<slug>` e2e variant and the tempest legs
+  must genuinely differ, and unit tests must pin the rendered config for
+  **both** releases.
 - **Stateful key material?** (fernet-like) — keystone's rotation machinery
   is deliberately NOT extracted; a second consumer changes that calculus.
 - **Depends on other services?** Determines the gating condition in the
   c5c3 sub-reconciler chain (e.g. Horizon gates on `KeystoneReady`).
 - **Tempest plugin maintained upstream?** If not (e.g. horizon), plan
   HTTP-level chainsaw assertions instead and say so explicitly.
-- **Ingress?** `commonv1.GatewaySpec` / HTTPRoute.
+- **Ingress?** `commonv1.GatewaySpec` / HTTPRoute via
+  `internal/common/gateway` — plus the full public surface that hangs off
+  it: an `https-<svc>` listener + hostname on the shared kind Gateway
+  (`deploy/kind/base/openstack-gateway.yaml`) with a
+  `<svc>-nip-io-tls-certificate.yaml` Certificate, a `publicEndpoint`
+  catalog override on the c5c3 service spec (webhook-validated; it may be
+  projected into no child, making the webhook the only gate), a
+  `gateway-quick-start-smoke` e2e suite driving real host→listener→pod
+  traffic, and the quick-start walkthrough doing its user-facing calls
+  through the gateway.
 
 ### 2. Run the deterministic inventory
 
@@ -78,8 +134,10 @@ The repo evolves — do not trust this skill's tables blindly. Spot-check
 that the enumeration points named above still exist at HEAD (grep for
 `ALL_OPERATORS`, `subConditionTypes`, `OPERATORS ?=`, `ServicesSpec`), and
 skim the per-layer "Adding a New Service" docs, which are authoritative
-for layer 1 and 3 details:
+for layer 1, 2, and 3 details:
 
+- `docs/contributing/adding-a-new-operator.md` (layer 2 — the documented
+  onboarding path over `internal/common`)
 - `docs/reference/ci-cd/build-images-workflow.md` § Adding a New Service
 - `docs/reference/ci-cd/container-images.md` (release config files)
 - `docs/reference/testing/tempest-test-infrastructure.md` § Adding a New Service
@@ -99,8 +157,9 @@ a second (or third) time?** Classify keystone internals into:
 If category 2 is non-empty, file (or update) a **separate refactor issue**
 listing the candidates with file:line references, S/M/L effort, and a
 must-before / opportunistic split — then mark the meta **blocked on it**.
-#551 is the template; check first whether it (or a successor) is still
-open and simply needs extending. Also check open API-shape issues
+#551 is the template (#655 is the second round: DB orchestration +
+`keystone_authtoken` renderer for glance); check first whether it (or a
+successor) is still open and simply needs extending. Also check open API-shape issues
 (e.g. #471) — a new CRD must be born with the target shape, not the
 legacy one.
 
@@ -112,12 +171,17 @@ Out of scope, italic footer with date + `main` SHA + relations.
 Standard phase skeleton (drop/merge phases the profile rules out):
 
 - **Phase 0 — decisions (spike):** session/config/secret-sourcing choices,
-  upper-constraints handling, WSGI server, endpoint wiring.
+  upper-constraints handling, WSGI/launch mode per release, endpoint and
+  catalog-interface wiring, backend-CRD shape if the profile calls for one
+  (record the decisions in the meta as #656 records D1–D10).
 - **Phase 1 — container image** (usually independent of pre-work).
 - **Phase 2 — service operator scaffold** (blocked on generalization).
-- **Phase 3 — CI, e2e, deploy stack** (alongside Phase 2).
-- **Phase 4 — ControlPlane integration** (blocked on Phase 2).
-- **Phase 5 — documentation** (continuous, gates each phase).
+- **Phase 3 — CI, e2e, deploy stack** (alongside Phase 2) — including the
+  kind Gateway listener/cert, OpenBao bootstrap legs, and chaos suites.
+- **Phase 4 — ControlPlane integration** (blocked on Phase 2) — including
+  catalog row, credential glue, teardown, envtest + full-ControlPlane e2e.
+- **Phase 5 — documentation** (continuous, gates each phase) — reference
+  set, per-service guides, and the quick-start extension.
 
 Rules that keep it splittable:
 
@@ -141,30 +205,48 @@ Before publishing, sanity-check the claims that rot fastest:
 
 Related skills for the implementation phase (mention them in the meta so
 sub-issues use them as gates): [[check-crd-drift]], [[check-fixture-drift]],
-[[check-condition-coverage]], [[check-doc-drift]], [[check-renovate-coverage]],
-[[check-go-workspace-deps]], [[check-spdx-reuse]].
+[[check-condition-coverage]], [[check-validation-parity]],
+[[check-doc-drift]], [[check-renovate-coverage]],
+[[check-go-workspace-deps]], [[check-spdx-reuse]], and
+[[check-service-parity]] as the closing cross-layer gate once the
+onboarding lands (#656 used it exactly that way).
 
-## Known gotchas (verified 2026-07, re-verify at HEAD)
+## Known gotchas (verified 2026-07 post-glance, re-verify at HEAD)
 
 - **upper-constraints pin conflict:** some services (horizon, most
   clients' dashboards/libraries) are already pinned in
   `releases/*/upper-constraints.txt`. Installing from source with
   `--constraint` then requires the source ref to match the pin exactly,
   or a `-<svc>` line in `overrides/<release>/constraints.txt`
-  (`scripts/apply-constraint-overrides.sh`). Keystone never hit this.
+  (`scripts/apply-constraint-overrides.sh`). Check the service's
+  **libraries** too, not just the service: glance itself is unpinned, but
+  `glance_store`/`boto3` are — the driver extra must resolve against the
+  existing pins.
 - **hadolint matrix is static** in `build-images.yaml` — new Dockerfiles
   must be added by hand even though the build matrix auto-discovers.
-- **`tests/container-images/verify_release_config.sh` and
-  `verify_deviation_comments.sh` are keystone-hardcoded** — extend or
-  generalize them, or the new service's release config goes unvalidated.
-- **Operator Dockerfiles are coupled to `go.work`:** each copies every
-  module's go.mod, so adding a module edits all existing operator
-  Dockerfiles (until a parameterized `ARG OPERATOR` Dockerfile lands).
-- **Tempest matrix naming** (`hack/ci-generate-tempest-matrix.sh`) and the
-  chaos CI job's image list are keystone-specific today.
+- **Hand-maintained per-service lists in the verify/matrix scripts:**
+  `tests/container-images/verify_release_config.sh` (`SERVICES=` list),
+  `verify_deviation_comments.sh` (per-service functions),
+  `hack/ci-generate-tempest-matrix.sh` (`for service in …` loop), and the
+  chaos CI job's image-load lists in `ci.yaml` are all generalized now but
+  still enumerate services by hand — extend each one, or the new
+  service's coverage silently never runs.
+- **The parameterized `operators/Dockerfile` (`ARG OPERATOR`) is still
+  coupled to `go.work`:** it COPYs every module's go.mod and source, so a
+  new module still edits that one Dockerfile's COPY lines (no more
+  per-operator Dockerfiles, though).
 - **WSGI entry points:** `uv pip install --prefix` skips PBR
   `wsgi_scripts` generation — service Dockerfiles hand-write their WSGI
-  launcher (see `images/keystone/Dockerfile`).
+  launcher (see `images/keystone/Dockerfile`). Also verify the stock WSGI
+  module actually honors `--config-dir`/`--pyargv`: glance's
+  `glance.wsgi.api:application` reads only its default config path and
+  needed a hand-shipped shim (`images/glance/glance-wsgi-api`) to load
+  the operator's mounted config dirs.
+- **Paste-deploy divergence between releases:** factory references
+  (`API.factory` vs `API_factory`) and oslo.middleware healthcheck
+  semantics (filter tolerated in 2025.2, app-only in 2026.1) differ
+  between the pinned releases — pin the rendered paste config in unit
+  tests and run the e2e/tempest legs against both releases.
 
 ## Notes
 

--- a/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
+++ b/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
@@ -66,8 +66,11 @@ header "Layer 3: CI / e2e / deploy"
 check "ci.yaml FILTER_${SERVICE} env" grep -q "FILTER_${SERVICE}" .github/workflows/ci.yaml
 check "ci.yaml ALL_OPERATORS includes '${SERVICE}'" \
   bash -c "grep -E 'ALL_OPERATORS' .github/workflows/ci.yaml | grep -qw '${SERVICE}'"
-check "tests/ci/verify_${SERVICE}_ci_pipeline.sh" test -f "tests/ci/verify_${SERVICE}_ci_pipeline.sh"
+check "tests/ci/verify_${SERVICE}_ci_pipeline.sh (keystone predates this pattern)" \
+  test -f "tests/ci/verify_${SERVICE}_ci_pipeline.sh"
 check "tests/e2e/${SERVICE}/ chainsaw suites" bash -c "ls tests/e2e/${SERVICE}/*/chainsaw-test.yaml"
+check "tests/e2e/${SERVICE}/gateway-quick-start-smoke suite" \
+  test -f "tests/e2e/${SERVICE}/gateway-quick-start-smoke/chainsaw-test.yaml"
 check "tests/e2e/${SERVICE}-operator/ chart-level suites (optional)" \
   bash -c "ls tests/e2e/${SERVICE}-operator/*/chainsaw-test.yaml"
 check "tests/e2e-chaos scenarios exercising a ${SERVICE} CR" \
@@ -76,6 +79,14 @@ check "tests/tempest/${SERVICE}-*/ config (skip if no tempest plugin)" \
   bash -c "ls -d tests/tempest/${SERVICE}-*/"
 check "deploy/flux-system/releases/${SERVICE}-operator.yaml" \
   test -f "deploy/flux-system/releases/${SERVICE}-operator.yaml"
+check "kind Gateway listener hostname ${SERVICE}.127-0-0-1.nip.io" \
+  grep -q "${SERVICE}\.127-0-0-1\.nip\.io" deploy/kind/base/openstack-gateway.yaml
+check "deploy/kind/infrastructure/${SERVICE}-nip-io-tls-certificate.yaml" \
+  test -f "deploy/kind/infrastructure/${SERVICE}-nip-io-tls-certificate.yaml"
+check "OpenBao DB-engine tenant leg for ${SERVICE} (skip if no database)" \
+  grep -q "${SERVICE}" deploy/openbao/bootstrap/setup-database-tenant.sh
+check "deploy/openbao/policies/${SERVICE}-db-dynamic.hcl (skip if no database)" \
+  test -f "deploy/openbao/policies/${SERVICE}-db-dynamic.hcl"
 
 header "Layer 4: ControlPlane (c5c3) integration"
 check "ServicesSpec has Service…Spec for '${SERVICE}'" \
@@ -84,11 +95,25 @@ check "operators/c5c3/internal/controller/reconcile_${SERVICE}.go" \
   test -f "operators/c5c3/internal/controller/reconcile_${SERVICE}.go"
 check "c5c3 helm _helpers.tpl rbacRules mention '${SERVICE}'" \
   grep -q "${SERVICE}" operators/c5c3/helm/c5c3-operator/templates/_helpers.tpl
+check "controlplane_controller.go mirrors a ${SERVICE}Ready condition" \
+  grep -qi "${SERVICE}Ready" operators/c5c3/internal/controller/controlplane_controller.go
+check "catalog row in reconcile_catalog.go (skip if no catalog endpoints)" \
+  grep -qi "${SERVICE}" operators/c5c3/internal/controller/reconcile_catalog.go
+check "reconcile_${SERVICE}_dbcredentials.go (skip if no database; keystone's glue lives in reconcile_dbcredentials.go)" \
+  test -f "operators/c5c3/internal/controller/reconcile_${SERVICE}_dbcredentials.go"
+check "envtest full chain covers '${SERVICE}' (integration_test.go)" \
+  grep -qi "${SERVICE}" operators/c5c3/internal/controller/integration_test.go
+check "full-ControlPlane e2e suite drives '${SERVICE}'" \
+  grep -qi "${SERVICE}" tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
 
 header "Layer 5: documentation"
 check "docs/reference/${SERVICE}/ pages" bash -c "ls docs/reference/${SERVICE}/*.md"
 check "VitePress sidebar references reference/${SERVICE}/" \
   grep -q "reference/${SERVICE}/" docs/.vitepress/config.ts
+check "per-service guides under docs/guides/${SERVICE}/" \
+  bash -c "ls docs/guides/${SERVICE}/*.md"
+check "quick start integrates '${SERVICE}' (docs/quick-start-controlplane.md)" \
+  grep -qi "${SERVICE}" docs/quick-start-controlplane.md
 
 header "Gotcha warnings"
 for uc in releases/*/upper-constraints.txt; do


### PR DESCRIPTION
## Summary

The Glance onboarding (#656) exercised surfaces the preparation skills did not know about yet — the Gateway API integration in the quick start and the dynamic DB credential chain landed as follow-ups outside the meta's original plan, and several skill gotchas were resolved along the way. This PR folds those lessons back into the skills.

### prepare-new-service
- Adds Glance (#656 with pre-work #653/#654/#655) as the second worked example, including the stacked-PR implementation mode and the D1–D10 decision record.
- Extends the service profile with the surfaces added after the fact: the dynamic DB credential chain (per-service `databaseCredentialsMode` override, OpenBao database-engine tenant leg, role/policy pair, generator-backed ExternalSecret glue, migration guide), db-sync side-loads, extra backing stores with a backing-store-outage chaos suite, service-user consumption of another service's API, satellite backend CRDs, per-release behavior breaks, and the full gateway surface (shared kind listener + certificate, `publicEndpoint` catalog override, `gateway-quick-start-smoke` suite, quick-start integration).
- Refreshes the gotchas the glance effort resolved (per-service verify scripts, tempest matrix, chaos image lists, the parameterized `operators/Dockerfile`) and adds the WSGI config-dir shim and paste-divergence lessons.
- `inventory-touchpoints.sh` covers the new touch points — glance now inventories 37/37 done; horizon shows only its legitimate skips.

### prepare-new-guide
- The scaffold hardcoded Keystone as the subject service; it is now parameterized on `--service` (projected child `controlplane-<svc>`, operator-owned warning block, the `Standalone <Service>` section).
- The V4 projected-child check was pinned to keystone/horizon and blind for glance guides; the service list is now discovered from the newest `releases/<version>/source-refs.yaml`.
- Adds the service-scoped readiness-signal rule (`GlanceReady`, not the ControlPlane-wide `Ready`) to the prose checklist.

### check-service-parity
- Moves the guide paths to the per-service subdirectory layout, adds `gateway-quick-start-smoke` to the canonical e2e suite set (all three services carry it — no new findings), and notes that a later service can legitimately pioneer a surface the keystone canon lacks.

## Verification

- `inventory-touchpoints.sh` run for keystone, horizon, and glance — glance all-done, deviations labeled.
- `scaffold-guide.sh` output checked for `--service glance` and the keystone default.
- `validate-guide.sh` green over every existing guide; a synthetic glance projected-child mutation is correctly flagged by V4.
- `audit-service-parity.sh` — the new canonical suite rows pass for all three services; the five reported findings (missing `releases/*/test-excludes/{horizon,glance}.txt`, `cleanup-images.yaml` horizon-operator coverage) pre-date this change.
- shellcheck clean on the edited scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UoejXndpNpJoYpw2UANtp