### PR TITLE
fix(deploy): make repeated deploy-infra runs idempotent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -589,7 +589,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.e2e-infra == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -607,9 +607,47 @@ jobs:
         run: |
           mkdir -p _output/reports
           chainsaw test --config tests/e2e/chainsaw-config.yaml tests/e2e/infrastructure/
-      # Use shared diagnostic dump script.
+      # Locks the same-parameter re-run convergence (#650).  Runs make
+      # deploy-infra directly (not the composite action, and deliberately
+      # WITHOUT SKIP_KIND_CREATE) so the script's own existing-cluster
+      # detection path -- the developer flow from the bug report -- is
+      # exercised.  CLUSTER_NAME is passed explicitly from KIND_CLUSTER rather
+      # than relying on the script's default happening to match it: without it,
+      # editing KIND_CLUSTER above would make the script find no cluster of that
+      # name, `kind create cluster` a fresh one, and deploy into that instead --
+      # a silently-green second fresh deploy that tests zero convergence.
+      - name: Re-run deploy-infra with unchanged parameters
+        run: make deploy-infra
+        env:
+          CLUSTER_NAME: ${{ env.KIND_CLUSTER }}
+      # Verifies a healthy stack is left unchanged after the same-parameter
+      # re-run -- including the two `no-*` absence suites still passing.  A
+      # distinct report name keeps the first run's JUnit XML intact.
+      - name: Re-run Chainsaw E2E tests after unchanged re-run
+        run: |
+          chainsaw test --config tests/e2e/chainsaw-config.yaml --report-name chainsaw-report-rerun tests/e2e/infrastructure/
+      # Additive opt-in leg (#650) -- the script's own Phase-3 wait gates the
+      # newly enabled metrics-server HelmRelease on Ready, so exit 0 proves
+      # the additive install landed without disturbing the base stack.
+      - name: Re-run deploy-infra with WITH_METRICS_SERVER=true
+        run: make deploy-infra
+        env:
+          CLUSTER_NAME: ${{ env.KIND_CLUSTER }}
+          WITH_METRICS_SERVER: "true"
+      # The full suite is NOT re-run here because
+      # `no-metrics-server-when-disabled` asserts the absence of
+      # metrics-server, which the additive leg just (correctly) installed --
+      # the scoped set proves the base stack is untouched and Prometheus is
+      # still absent.
+      - name: Run scoped Chainsaw E2E tests after additive re-run
+        run: |
+          chainsaw test --config tests/e2e/chainsaw-config.yaml --report-name chainsaw-report-additive tests/e2e/infrastructure/infra-stack-health tests/e2e/infrastructure/garage-health tests/e2e/infrastructure/flux-web-health tests/e2e/infrastructure/no-prometheus-when-disabled
+      # Use shared diagnostic dump script.  `always()` (matching every other
+      # e2e job) also covers the timeout-cancellation path -- `failure()`
+      # alone is skipped when timeout-minutes expires, discarding the cluster
+      # state exactly when a hung re-run leg makes it hardest to debug.
       - name: Dump diagnostic info
-        if: failure()
+        if: always()
         run: hack/ci-dump-diagnostics.sh
       - name: Upload JUnit report
         if: always()

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -273,6 +273,24 @@ before running the chaos E2E suites — see
 list and `make e2e-chaos` workflow.
 :::
 
+::: tip Re-running deploy-infra
+`make deploy-infra` is idempotent: a re-run with the same parameters converges
+and leaves a healthy stack unchanged, and each `WITH_*` opt-in below can be
+enabled later by re-running against the existing cluster — only the newly
+enabled components are installed.
+
+Two caveats apply. `WITH_REGISTRY_CACHE=true` only becomes fully active on a
+cluster **created** with it — on a pre-existing cluster the deploy prints a
+warning that the mirrors stay inert until the cluster is recreated with the
+flag. And flipping `WITH_CONTROLPLANE=true` on an already-provisioned standalone
+stack is a **mode change** — the ControlPlane provisions its own
+MariaDB/Memcached — not an additive opt-in; use a fresh cluster
+(`make teardown-infra` first).
+
+Removing a previously enabled flag does not uninstall that component; cleanup is
+`make teardown-infra`'s job.
+:::
+
 ::: tip Enabling Prometheus & Grafana
 The kube-prometheus-stack is **not installed by default** in the kind Quick Start. The default
 `make deploy-infra` flow leaves the `monitoring` namespace absent so first-run
@@ -314,13 +332,12 @@ scales.
 :::
 
 ::: tip Enabling the local registry pull-through cache
-Every `make deploy-infra` run creates a fresh kind cluster, and every
-third-party image (from `docker.io`, `ghcr.io`, `registry.k8s.io`, `quay.io`,
-and the per-project vanity registries `oci.external-secrets.io` and
-`docker-registry3.mariadb.com`) is then pulled from its upstream registry inside
-the node's containerd. If you recreate the cluster many times a day, the same
-images are fetched over the wire again and again — slow, and exposed to Docker
-Hub rate limits and transient upstream flakes. `kind load docker-image` only
+Every **fresh** kind cluster pulls every third-party image (from `docker.io`,
+`ghcr.io`, `registry.k8s.io`, `quay.io`, and the per-project vanity registries
+`oci.external-secrets.io` and `docker-registry3.mariadb.com`) from its upstream
+registry inside the node's containerd. If you recreate the cluster many times a
+day, the same images are fetched over the wire again and again — slow, and
+exposed to Docker Hub rate limits and transient upstream flakes. `kind load docker-image` only
 helps for the handful of images you build yourself; it does nothing for the
 dozen-plus third-party images the infra stack pulls.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,6 +47,13 @@ MariaDB operator + `openstack-db`, External Secrets, Memcached operator +
 `openstack-memcached`, Envoy Gateway and the shared `openstack-gw`. Expect
 **5–10 minutes** on first run (image pulls dominate).
 
+`make deploy-infra` is safe to re-run: a run with the same parameters detects
+the existing cluster and the steps already completed and converges without
+redoing them, so an interrupted bootstrap can simply be re-executed. Optional
+components can be enabled later by re-running with the flag set — see the
+opt-in tips in the [Extended Quick Start](./quick-start-extended.md). Removing a
+flag does not uninstall that component — that is `make teardown-infra`'s job.
+
 ## Step 3 — Keystone operator
 
 ```bash

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -550,10 +550,19 @@ validates health of all operators, CRs, and ExternalSecrets.
 | 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
 | 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
 | 5 | `chainsaw test` | Runs E2E tests from `tests/e2e/infrastructure/` |
-| 6 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
-| 7 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
+| 6 | `make deploy-infra` (re-run) | Unchanged-parameter re-run (no `SKIP_KIND_CREATE`) — exercises the script's existing-cluster detection |
+| 7 | `chainsaw test --report-name chainsaw-report-rerun` | Re-runs the full infrastructure suite to prove the healthy stack is left unchanged |
+| 8 | `make deploy-infra` with `WITH_METRICS_SERVER=true` | Additive re-run — the script's Phase-3 wait gates the new metrics-server HelmRelease on Ready |
+| 9 | `chainsaw test --report-name chainsaw-report-additive` | Scoped run over infra-stack-health, garage-health, flux-web-health, and no-prometheus-when-disabled; the metrics-server absence suite is deliberately excluded |
+| 10 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
+| 11 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
 
-Timeout: 20 minutes.
+Timeout: 30 minutes.
+
+The two re-run legs (steps 6–9) lock the `make deploy-infra` idempotency
+contract: the unchanged-parameter re-run must converge against the provisioned
+cluster, and the additive `WITH_METRICS_SERVER=true` re-run must install only
+the newly enabled component while leaving the base stack untouched.
 
 ### build-e2e-images
 

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -104,6 +104,11 @@ Step 2 ── Install flux-operator + apply FluxInstance
      │         kubectl apply --server-side -f <upstream standard-install.yaml>
      │         Required by the keystone-operator HTTPRoute watch; version
      │         pinned via GATEWAY_API_VERSION, default matches go.mod.
+     │         Skipped when all five standard-channel CRDs already exist
+     │         (gatewayclasses, gateways, grpcroutes, httproutes,
+     │         referencegrants): on a provisioned cluster the envoy-gateway
+     │         chart (helm-controller) may field-manage them, so re-asserting
+     │         would SSA-conflict. The skip never upgrades present CRDs.
      │
      ├── Install Envoy Gateway + Gateway/openstack-gw (kind-only)
      │         Installed as part of the deploy/kind/base/ overlay applied
@@ -153,6 +158,34 @@ types (Namespaces, HelmRepository, HelmRelease). The infrastructure kustomizatio
 contains CRD-dependent resources (ClusterIssuer, MariaDB CR, Memcached CR) that require
 operator CRDs to be installed first. Applying them in two phases prevents
 `kubectl apply` failures on fresh clusters where CRDs do not yet exist.
+
+### Idempotent Re-runs
+
+Re-running `make deploy-infra` against an existing cluster converges rather than
+failing — each step detects the work it already completed and skips it:
+
+- **Step 1** skips cluster creation when the kind cluster already exists.
+- The **containerd nofile cap** skips the write, the containerd restart, and the
+  node-Ready wait only when the node's drop-in *and* the limit the running
+  containerd reports both already match. Checking the drop-in alone would
+  permanently skip a node whose write landed but whose restart failed, leaving
+  containerd uncapped behind a clean-looking deploy.
+- **Gateway API CRDs** are skipped when all five standard-channel CRDs are
+  present (see the sequence above).
+- The **kustomize overlays** and **TLS prerequisites** re-apply convergently
+  (`kubectl apply` / upserts).
+- **OpenBao init, unseal, and bootstrap** detect completed work: initialized
+  and unsealed checks, enable-if-missing for engines/auth/policies, and
+  write-if-missing for the bootstrap secrets.
+- Additional `WITH_*` opt-ins on a re-run install only the newly enabled
+  components; the already-deployed ones are left untouched.
+- Removing a previously enabled flag does **not** uninstall that component —
+  cleanup is `make teardown-infra`'s job.
+- `WITH_REGISTRY_CACHE` needs a cluster created with the flag; enabling it on a
+  pre-existing cluster leaves the mirrors inert and prints a warning.
+- `WITH_CONTROLPLANE` on a provisioned standalone stack is a mode change (the
+  ControlPlane owns MariaDB/Memcached), not supported as a re-run — start from a
+  fresh cluster.
 
 ## Kustomize Overlay Structure
 
@@ -242,14 +275,18 @@ of the `changes` job matches. It depends only on `changes` — not on the `lint`
 5. Install test dependencies (`make install-test-deps`, adds `~/.local/bin` to `PATH`)
 6. Deploy infrastructure stack (`make deploy-infra` with `SKIP_KIND_CREATE=true`)
 7. Run Chainsaw E2E tests against `tests/e2e/infrastructure/`
-8. Dump diagnostic info on failure (`kubectl get`, `flux logs` for troubleshooting)
-9. Upload JUnit report as workflow artifact (SHA-pinned `actions/upload-artifact`, `if: always()`)
+8. Re-run `make deploy-infra` with unchanged parameters (no `SKIP_KIND_CREATE`, exercises the script's existing-cluster detection)
+9. Re-run the full infrastructure suite (report `chainsaw-report-rerun`) to prove the healthy stack is left unchanged
+10. Re-run `make deploy-infra` with `WITH_METRICS_SERVER=true` (additive leg — the script's Phase-3 wait gates the new metrics-server HelmRelease on Ready)
+11. Run a scoped Chainsaw suite (report `chainsaw-report-additive`) over infra-stack-health, garage-health, flux-web-health, and no-prometheus-when-disabled, skipping the metrics-server absence suite it would now rightly fail
+12. Dump diagnostic info on failure (`kubectl get`, `flux logs` for troubleshooting)
+13. Upload JUnit report as workflow artifact (SHA-pinned `actions/upload-artifact`, `if: always()`)
 
 **Configuration:**
 
 | Setting | Value |
 | --- | --- |
-| `timeout-minutes` | 20 |
+| `timeout-minutes` | 30 |
 | `permissions` | `contents: read` (inherited from workflow-level) |
 | `concurrency` | Cancel-in-progress on PRs (inherited from workflow-level) |
 | Action pinning | All `uses:` references are SHA-pinned with version comments |

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -229,6 +229,10 @@ CONTROLPLANE_DB_STORAGE="${CONTROLPLANE_DB_STORAGE:-512Mi}"
 # Gateway API CRD release installed before the keystone-operator HelmRelease so
 # the operator's HTTPRoute watch has a registered kind at startup.
 # Keep aligned with sigs.k8s.io/gateway-api in operators/keystone/go.mod.
+# When bumping this, re-check the gwapi_crds presence list in
+# install_gateway_api_crds(): it enumerates the standard-channel CRD names of
+# this bundle, and a release that adds a CRD needs the new name added there —
+# otherwise the presence check passes on the old set and skips the install.
 GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.1.0}"
 GATEWAY_API_CRDS_URL="${GATEWAY_API_CRDS_URL:-https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml}"
 
@@ -638,6 +642,130 @@ wait_for_crds() {
 
     sleep 5
   done
+}
+
+# ---------------------------------------------------------------------------
+# install_gateway_api_crds — Register the Gateway API CRDs before Flux owns them.
+#
+# Purpose: the Gateway API CRDs must be registered before the keystone-operator
+# Pod starts, so its HTTPRoute watch finds the gateway.networking.k8s.io/v1 kind
+# at startup. Without them the operator logs 'no matches for kind HTTPRoute' and
+# never becomes Ready.
+#
+# Skip rationale: on a re-run against an already-provisioned cluster the CRDs
+# already exist and may since be field-managed by another owner — the
+# envoy-gateway chart via Flux's helm-controller. Re-asserting them with
+# `kubectl apply --server-side` then fails with a field-manager conflict, and
+# could downgrade a newer live bundle back to this script's pinned version.
+# Presence of all five standard-channel CRDs already fulfills this step's
+# purpose, so the install is skipped. Upgrading the CRDs is the chart's (or a
+# teardown/redeploy's) job, never this script's — a live bundle that differs
+# from GATEWAY_API_VERSION is therefore reported as a warning, not reconciled.
+#
+# Presence is probed per CRD, so an INCOMPLETE live set (some names present,
+# some missing) is distinguishable from a bare cluster instead of silently
+# taking the install path. It still attempts the install — a live bundle whose
+# present CRDs are content-identical co-owns cleanly — but names the split set
+# up front so the conflict, if it comes, is already diagnosed.
+#
+# --force-conflicts is deliberately NOT used: surfacing (or avoiding) the SSA
+# conflict is correct; forcibly stealing field ownership from helm-controller is
+# not. A conflict is therefore terminal and NOT retried — only transient
+# failures (bundle fetch, API server hiccup) consume the retry budget.
+# ---------------------------------------------------------------------------
+install_gateway_api_crds() {
+  # Standard-channel CRD names shipped by the GATEWAY_API_VERSION bundle. This
+  # list is hand-maintained against that pin (see its definition above) — a
+  # release that adds a standard-channel CRD needs its name added here, or the
+  # presence check below passes on the stale set and skips the install.
+  local gwapi_crds=(
+    gatewayclasses.gateway.networking.k8s.io
+    gateways.gateway.networking.k8s.io
+    grpcroutes.gateway.networking.k8s.io
+    httproutes.gateway.networking.k8s.io
+    referencegrants.gateway.networking.k8s.io
+  )
+
+  # Probe each name separately. `kubectl get crd a b c` exits non-zero as soon
+  # as ONE name is NotFound, which would make a partially-present set (a live
+  # bundle whose standard channel differs from this pin by one CRD) look exactly
+  # like a bare cluster and send the run down the install path — where the
+  # co-owned CRDs then fail on a field-manager conflict.
+  local gwapi_present=()
+  local gwapi_missing=()
+  local crd
+  for crd in "${gwapi_crds[@]}"; do
+    if kubectl get crd "${crd}" &>/dev/null; then
+      gwapi_present+=("${crd}")
+    else
+      gwapi_missing+=("${crd}")
+    fi
+  done
+
+  if (( ${#gwapi_missing[@]} == 0 )); then
+    local live_bundle_version
+    live_bundle_version="$(kubectl get crd httproutes.gateway.networking.k8s.io \
+      -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}' \
+      2>/dev/null || true)"
+    log "Gateway API CRDs already present (live bundle ${live_bundle_version:-unknown}); skipping install — another owner (e.g. the envoy-gateway chart via helm-controller) may manage them now."
+    if [[ -z "${live_bundle_version}" ]]; then
+      log "  WARNING: the live CRDs carry no bundle-version annotation, so the installed"
+      log "           Gateway API version cannot be verified against the requested"
+      log "           ${GATEWAY_API_VERSION} — an arbitrarily divergent bundle is accepted here."
+      log "           Recreate the cluster (\`make teardown-infra\`) to install ${GATEWAY_API_VERSION}."
+    elif [[ "${live_bundle_version}" != "${GATEWAY_API_VERSION}" ]]; then
+      log "  WARNING: the live bundle does not match the requested ${GATEWAY_API_VERSION}."
+      log "           This step never upgrades present CRDs, so the cluster keeps"
+      log "           ${live_bundle_version}. Recreate the cluster (\`make teardown-infra\`)"
+      log "           to install ${GATEWAY_API_VERSION}."
+    fi
+    return 0
+  fi
+
+  # server-side apply avoids the 'metadata.annotations: Too long' error that
+  # client-side apply hits on the upstream CRD bundle.
+  log "=== Installing Gateway API CRDs (${GATEWAY_API_VERSION}) ==="
+  if (( ${#gwapi_present[@]} > 0 )); then
+    log "  WARNING: the cluster carries an INCOMPLETE Gateway API CRD set."
+    log "           present: ${gwapi_present[*]}"
+    log "           missing: ${gwapi_missing[*]}"
+    log "           The present CRDs are likely field-managed by another owner (the"
+    log "           envoy-gateway chart via helm-controller), so the bundle apply below"
+    log "           may fail on a field-manager conflict — see the ERROR path there."
+  fi
+  local gwapi_attempts=3
+  local gwapi_attempt=0
+  local gwapi_delay=5
+  local gwapi_output
+  while (( gwapi_attempt < gwapi_attempts )); do
+    gwapi_attempt=$((gwapi_attempt + 1))
+    if gwapi_output="$(kubectl apply --server-side -f "${GATEWAY_API_CRDS_URL}" 2>&1)"; then
+      printf '%s\n' "${gwapi_output}"
+      break
+    fi
+    printf '%s\n' "${gwapi_output}"
+    # A field-manager conflict is deterministic — another owner holds the
+    # fields and --force-conflicts is deliberately not used (see the docblock),
+    # so re-applying the identical bundle cannot succeed. Fail fast with the
+    # real diagnosis instead of burning the backoff on a misleading
+    # 'after N attempts' message. Everything else (bundle fetch, API server
+    # hiccup) is transient and keeps its retries.
+    if [[ "${gwapi_output}" == *"conflict"* ]]; then
+      log "ERROR: Gateway API CRD apply hit a field-manager conflict — another owner"
+      log "       (e.g. the envoy-gateway chart via helm-controller) already manages"
+      log "       part of this bundle. Not retried: the conflict is deterministic."
+      log "       Recreate the cluster (\`make teardown-infra && make deploy-infra\`) to"
+      log "       install ${GATEWAY_API_VERSION} cleanly."
+      exit 1
+    fi
+    if (( gwapi_attempt >= gwapi_attempts )); then
+      log "ERROR: Failed to install Gateway API CRDs after ${gwapi_attempts} attempts from ${GATEWAY_API_CRDS_URL}"
+      exit 1
+    fi
+    log "  Gateway API CRD apply failed (attempt ${gwapi_attempt}/${gwapi_attempts}); retrying in ${gwapi_delay}s..."
+    sleep "${gwapi_delay}"
+  done
+  log "Gateway API CRDs installed."
 }
 
 # ---------------------------------------------------------------------------
@@ -1524,29 +1652,7 @@ main() {
   wait_for_fluxinstance "${HELMRELEASE_TIMEOUT}"
   log "flux-operator installed and FluxInstance/flux is Ready."
 
-  # Gateway API CRDs. Installed before the base kustomize overlay so
-  # the keystone-operator Pod (deployed via HelmRelease in Step 3/4) finds the
-  # gateway.networking.k8s.io/v1 HTTPRoute kind at startup. Without this, the
-  # operator logs 'no matches for kind HTTPRoute' and never becomes Ready.
-  # server-side apply avoids the 'metadata.annotations: Too long' error that
-  # client-side apply hits on the upstream CRD bundle.
-  log "=== Installing Gateway API CRDs (${GATEWAY_API_VERSION}) ==="
-  local gwapi_attempts=3
-  local gwapi_attempt=0
-  local gwapi_delay=5
-  while (( gwapi_attempt < gwapi_attempts )); do
-    gwapi_attempt=$((gwapi_attempt + 1))
-    if kubectl apply --server-side -f "${GATEWAY_API_CRDS_URL}"; then
-      break
-    fi
-    if (( gwapi_attempt >= gwapi_attempts )); then
-      log "ERROR: Failed to install Gateway API CRDs after ${gwapi_attempts} attempts from ${GATEWAY_API_CRDS_URL}"
-      exit 1
-    fi
-    log "  Gateway API CRD apply failed (attempt ${gwapi_attempt}/${gwapi_attempts}); retrying in ${gwapi_delay}s..."
-    sleep "${gwapi_delay}"
-  done
-  log "Gateway API CRDs installed."
+  install_gateway_api_crds
 
   # Step 3: Apply base kustomize overlay (namespaces, HelmRepos, HelmReleases)
   #

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -36,6 +36,22 @@
 #   EnvoyProxy CR that GatewayClass/envoy's parametersRef targets has been
 #   applied via the infrastructure overlay), dumping describe +
 #   envoy-gateway-system pod logs on timeout.
+#
+# Idempotent re-runs:
+#   Re-running with the SAME parameters converges without errors and leaves a
+#   healthy stack unchanged — steps either detect completed work and skip it
+#   (cluster create, nofile cap, Gateway API CRDs, OpenBao init/bootstrap) or
+#   apply their changes convergently (kubectl apply / upserts).
+#   Re-running with ADDITIONAL opt-in flags (e.g. WITH_METRICS_SERVER=true,
+#   WITH_PROMETHEUS=true) installs only the newly enabled components and leaves
+#   the already-deployed ones untouched. Two flags are NOT additive:
+#   WITH_REGISTRY_CACHE only takes effect on a cluster CREATED with it (the
+#   mirror files stay inert otherwise — wire_node_registry_mirror warns), and
+#   WITH_CONTROLPLANE on a provisioned standalone stack is a mode change (the
+#   ControlPlane provisions its own MariaDB/Memcached), not an opt-in — start
+#   from a fresh cluster for both.
+#   Removing a previously enabled flag does NOT uninstall that run's components —
+#   cleanup is hack/teardown-infra.sh's job.
 
 set -euo pipefail
 
@@ -1332,8 +1348,11 @@ render_controlplane_replicas() {
 # NODE_NOFILE_LIMIT and restart containerd. This must run BEFORE any workload is
 # scheduled: a containerd restart does not change the limit of already-running
 # containers, so only pods created afterwards inherit the sane value (the target
-# is the fresh-deploy path). Idempotent — re-writing the same drop-in and
-# restarting again is a no-op — and best-effort per node: a node that cannot be
+# is the fresh-deploy path). Convergent — a node is skipped without a containerd
+# restart only when its drop-in AND the limit the running containerd reports are
+# both already at NODE_NOFILE_LIMIT, so a healthy same-parameter re-run is
+# read-only here while a node whose drop-in was written but whose restart failed
+# is retried instead of masked — and best-effort per node: a node that cannot be
 # patched logs a warning but does not abort the deploy.
 #
 # No-op when NODE_NOFILE_LIMIT is empty (opt out on a runtime that already ships
@@ -1354,8 +1373,24 @@ cap_node_nofile() {
 
   log "Capping containerd RLIMIT_NOFILE to ${NODE_NOFILE_LIMIT} on kind node(s): ${nodes//$'\n'/ }"
 
+  local restarted=false
   local node
   for node in ${nodes}; do
+    # Skip only when BOTH the drop-in on disk AND the limit the running
+    # containerd reports are already at the cap. Checking the file alone would
+    # permanently mask a prior run whose write succeeded but whose `systemctl
+    # restart containerd` failed: the drop-in is on disk, so every later run
+    # skips the node while containerd keeps the inherited ~1e9 limit — exactly
+    # the #546 OOM-crashloop this function exists to prevent, and unrecoverable
+    # by re-running.
+    if docker exec "${node}" sh -c '
+      grep -qx "LimitNOFILE='"${NODE_NOFILE_LIMIT}"'" \
+        /etc/systemd/system/containerd.service.d/nofile.conf 2>/dev/null &&
+      [ "$(systemctl show containerd -p LimitNOFILE --value 2>/dev/null)" = "'"${NODE_NOFILE_LIMIT}"'" ]
+    ' 2>/dev/null; then
+      log "  ${node}: containerd RLIMIT_NOFILE already capped to ${NODE_NOFILE_LIMIT} — skipping restart."
+      continue
+    fi
     if docker exec "${node}" sh -c '
       set -e
       mkdir -p /etc/systemd/system/containerd.service.d
@@ -1365,14 +1400,19 @@ cap_node_nofile() {
       systemctl restart containerd
     ' >/dev/null 2>&1; then
       log "  ${node}: containerd RLIMIT_NOFILE set to ${NODE_NOFILE_LIMIT}."
+      restarted=true
     else
       log "  WARNING: failed to cap RLIMIT_NOFILE on ${node} — uWSGI workloads (Keystone) may OOM-crashloop."
     fi
   done
 
-  # containerd was just restarted; give the node a moment to re-register with the
-  # API server before Step 2 starts issuing kubectl apply against it.
-  wait_for_node_ready "${POD_TIMEOUT}"
+  # containerd was just restarted on at least one node; give the node(s) a moment
+  # to re-register with the API server before Step 2 starts issuing kubectl apply
+  # against them. Skipped when no containerd was restarted (every node's drop-in
+  # already matched), so a healthy same-parameter re-run stays read-only here.
+  if [[ "${restarted}" == "true" ]]; then
+    wait_for_node_ready "${POD_TIMEOUT}"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1504,6 +1544,14 @@ start_registry_cache() {
 #
 # Best-effort per node/host: a docker-exec failure warns but does not abort the
 # deploy. No-op unless WITH_REGISTRY_CACHE=true.
+#
+# containerd only honours these files when it was started with the certs.d
+# config_path, which render_kind_config injects only on a fresh `kind create
+# cluster` under WITH_REGISTRY_CACHE=true. When the probe finds a node whose
+# containerd config lacks that setting (the cluster was created without the
+# flag), we warn that the mirror files are inert and name the recreate remedy —
+# but still write them, so they become active if the cluster is later recreated
+# with the flag.
 # ---------------------------------------------------------------------------
 wire_node_registry_mirror() {
   if [[ "${WITH_REGISTRY_CACHE}" != "true" ]]; then
@@ -1521,6 +1569,14 @@ wire_node_registry_mirror() {
 
   local node entry host url suffix container
   for node in ${nodes}; do
+    if ! docker exec "${node}" grep -q '/etc/containerd/certs.d' /etc/containerd/config.toml 2>/dev/null; then
+      log "  WARNING: ${node}: containerd config lacks the 'config_path = /etc/containerd/certs.d'"
+      log "           registry setting — cluster '${CLUSTER_NAME}' was created WITHOUT"
+      log "           WITH_REGISTRY_CACHE=true. The hosts.toml mirror files written below will"
+      log "           be IGNORED and image pulls fall back to the origin registries. To activate"
+      log "           the cache, recreate the cluster with WITH_REGISTRY_CACHE=true (e.g."
+      log "           \`make teardown-infra && WITH_REGISTRY_CACHE=true make deploy-infra\`)."
+    fi
     for entry in "${REGISTRY_CACHE_UPSTREAMS[@]}"; do
       IFS='|' read -r host url suffix <<<"${entry}"
       container="registry-cache-${suffix}"

--- a/tests/unit/hack/deploy_infra_gateway_crds_test.sh
+++ b/tests/unit/hack/deploy_infra_gateway_crds_test.sh
@@ -1,0 +1,414 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify hack/deploy-infra.sh `install_gateway_api_crds` skips the
+# `kubectl apply --server-side` when all five standard-channel Gateway API
+# CRDs already exist (so a re-run against a provisioned cluster no longer hits
+# an SSA field-manager conflict with helm-controller), still runs the 3-attempt
+# retry install on a bare cluster, tells an INCOMPLETE live CRD set apart from a
+# bare one, and fails fast on a field-manager conflict instead of retrying it.
+#
+# Follows the stub-kubectl + source-and-invoke pattern established by
+# deploy_infra_gateway_wait_test.sh.
+#
+# Usage: bash tests/unit/hack/deploy_infra_gateway_crds_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEPLOY_INFRA_SH="$PROJECT_ROOT/hack/deploy-infra.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# The five standard-channel CRD names the function probes. A bare cluster
+# reports every one missing — that, not "any one missing", is the fresh-install
+# state.
+GWAPI_ALL_CRDS="gatewayclasses.gateway.networking.k8s.io \
+gateways.gateway.networking.k8s.io \
+grpcroutes.gateway.networking.k8s.io \
+httproutes.gateway.networking.k8s.io \
+referencegrants.gateway.networking.k8s.io"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# install_kubectl_stub <dir>
+# Writes a stub `kubectl` into <dir> that fakes the API responses
+# `install_gateway_api_crds` uses. The stub's behaviour is baked in from the
+# caller-set variables:
+#   - APPLY_LOG             — every `apply` argv is appended here, one per line.
+#   - MISSING_CRDS          — space-separated CRD names that report NotFound
+#                             (empty → every CRD reports present).
+#   - LIVE_BUNDLE_VERSION   — printed for the jsonpath bundle-version query.
+#   - APPLY_FAIL            — when "1", `apply` still logs but exits non-zero.
+#   - APPLY_OUTPUT          — what a failing `apply` writes to stderr, so a
+#                             field-manager conflict can be told apart from a
+#                             transient error.
+# Everything else exits 0 silently.
+install_kubectl_stub() {
+  local dir="$1"
+  mkdir -p "$dir"
+  local apply_log="${APPLY_LOG}"
+  local missing_crds="${MISSING_CRDS:-}"
+  local live_bundle_version="${LIVE_BUNDLE_VERSION:-}"
+  local apply_fail="${APPLY_FAIL:-0}"
+  local apply_output="${APPLY_OUTPUT:-error: the server could not find the requested resource}"
+
+  cat >"$dir/kubectl" <<STUB
+#!/bin/bash
+# Stub kubectl for tests/unit/hack/deploy_infra_gateway_crds_test.sh.
+if [[ "\$1" == "apply" ]]; then
+  printf '%s\n' "\$*" >>"${apply_log}"
+  if [[ "${apply_fail}" == "1" ]]; then
+    printf '%s\n' "${apply_output}" >&2
+    exit 1
+  fi
+  exit 0
+fi
+if [[ "\$1" == "get" && "\$2" == "crd" ]]; then
+  # The bundle-version query carries a jsonpath arg; answer it with the
+  # stubbed live version instead of a presence check.
+  for arg in "\$@"; do
+    if [[ "\$arg" == jsonpath=* ]]; then
+      printf '%s' "${live_bundle_version}"
+      exit 0
+    fi
+  done
+  # Presence check — one CRD name per invocation.
+  for arg in "\$@"; do
+    for missing in ${missing_crds}; do
+      if [[ "\$arg" == "\$missing" ]]; then
+        exit 1
+      fi
+    done
+  done
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+
+  # No-op sleep so the retry test does not actually wait out the backoff.
+  printf '#!/bin/bash\nexit 0\n' >"$dir/sleep"
+  chmod +x "$dir/sleep"
+}
+
+# Source the script and call the function under test in a subshell with PATH
+# pointing at the stub. Echoes combined stdout/stderr; returns the exit status.
+# The function calls `exit 1` on the failure path, so the subshell keeps the
+# test process alive.
+run_install() {
+  local stub_dir="$1"
+  (
+    # Prepend the stub dir so our fake kubectl takes precedence, but keep the
+    # rest of the PATH so real coreutils remain available.
+    PATH="$stub_dir:$PATH"
+    export PATH
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    install_gateway_api_crds
+  ) 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: all five CRDs present → skip the apply, log the live bundle version
+# ---------------------------------------------------------------------------
+test_all_present_skips_apply() {
+  echo "Test: install_gateway_api_crds skips the apply when all five CRDs exist"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS=""
+  LIVE_BUNDLE_VERSION="v1.5.1"
+  APPLY_FAIL=0
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+
+  assert_eq "install_gateway_api_crds exits 0 when all CRDs present" "0" "$exit_code"
+
+  local apply_count
+  apply_count="$(wc -l <"$APPLY_LOG" | tr -d ' ')"
+  assert_eq "no kubectl apply is issued on the skip path" "0" "$apply_count"
+
+  assert_contains "skip log line announces the CRDs are already present" "$output" \
+    "Gateway API CRDs already present"
+  assert_contains "skip log line reports the live bundle version" "$output" \
+    "v1.5.1"
+  assert_contains "skip log line notes another owner may manage the CRDs" "$output" \
+    "helm-controller"
+  # The stubbed live bundle (v1.5.1) differs from the GATEWAY_API_VERSION pin,
+  # so the skip must not silently claim the requested bundle is installed.
+  assert_contains "bundle drift against GATEWAY_API_VERSION is warned about" "$output" \
+    "WARNING: the live bundle does not match the requested v1.1.0"
+  assert_contains "drift warning names the recreate remedy" "$output" \
+    "teardown-infra"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1b: all five CRDs present AND the live bundle matches the pin →
+# skip without the drift warning
+# ---------------------------------------------------------------------------
+test_matching_bundle_skips_without_warning() {
+  echo "Test: install_gateway_api_crds skips quietly when the live bundle matches"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS=""
+  LIVE_BUNDLE_VERSION="v9.9.9"
+  APPLY_FAIL=0
+  export GATEWAY_API_VERSION="v9.9.9"
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+  unset GATEWAY_API_VERSION
+
+  assert_eq "install_gateway_api_crds exits 0 when the bundle matches" "0" "$exit_code"
+  assert_contains "skip log line still announces the CRDs are already present" "$output" \
+    "Gateway API CRDs already present"
+  assert_not_contains "no drift warning when live bundle == GATEWAY_API_VERSION" "$output" \
+    "WARNING: the live bundle does not match"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1c: all five present but no bundle-version annotation → the skip must
+# say the live version could not be verified, not accept it silently
+# ---------------------------------------------------------------------------
+test_unknown_bundle_version_warns() {
+  echo "Test: install_gateway_api_crds warns when the live bundle version is unknown"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS=""
+  LIVE_BUNDLE_VERSION=""   # e.g. a chart that templates the CRDs itself
+  APPLY_FAIL=0
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+
+  assert_eq "install_gateway_api_crds still exits 0" "0" "$exit_code"
+  assert_contains "skip log line reports the version as unknown" "$output" \
+    "live bundle unknown"
+  assert_contains "an unverifiable live bundle is warned about, not accepted silently" "$output" \
+    "cannot be verified"
+  assert_contains "the warning names the recreate remedy" "$output" \
+    "teardown-infra"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: bare cluster (every CRD missing) → install exactly once
+# ---------------------------------------------------------------------------
+test_missing_crd_runs_apply_once() {
+  echo "Test: install_gateway_api_crds applies once on a bare cluster"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS="$GWAPI_ALL_CRDS"   # bare cluster: nothing present yet
+  LIVE_BUNDLE_VERSION=""
+  APPLY_FAIL=0
+  export GATEWAY_API_CRDS_URL="https://example.test/gwapi/standard-install.yaml"
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+  unset GATEWAY_API_CRDS_URL
+
+  assert_eq "install_gateway_api_crds exits 0 on a successful install" "0" "$exit_code"
+
+  local apply_count
+  apply_count="$(wc -l <"$APPLY_LOG" | tr -d ' ')"
+  assert_eq "exactly one kubectl apply is issued on the install path" "1" "$apply_count"
+
+  assert_file_contains "apply uses server-side" \
+    "$APPLY_LOG" "server-side"
+  assert_file_contains "apply targets the GATEWAY_API_CRDS_URL bundle" \
+    "$APPLY_LOG" "https://example.test/gwapi/standard-install.yaml"
+  assert_contains "success log line surfaced" "$output" \
+    "Gateway API CRDs installed."
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: persistent apply failure → 3 attempts, non-zero exit, ERROR log
+# ---------------------------------------------------------------------------
+test_persistent_failure_retries_three_times() {
+  echo "Test: install_gateway_api_crds retries three times then fails"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS="$GWAPI_ALL_CRDS"   # bare cluster: nothing present yet
+  LIVE_BUNDLE_VERSION=""
+  APPLY_FAIL=1
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+
+  assert_nonzero_exit "install_gateway_api_crds exits non-zero after exhausting retries" \
+    "$exit_code"
+
+  local apply_count
+  apply_count="$(wc -l <"$APPLY_LOG" | tr -d ' ')"
+  assert_eq "kubectl apply is retried exactly three times" "3" "$apply_count"
+
+  assert_contains "ERROR log line reports the exhausted retries" "$output" \
+    "ERROR: Failed to install Gateway API CRDs after 3 attempts"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3b: an INCOMPLETE live CRD set is named before the apply
+#
+# `kubectl get crd a b c` exits non-zero as soon as one name is NotFound, so a
+# single presence call cannot tell "four of five present, co-owned by
+# helm-controller" apart from a bare cluster. The partial set must be probed per
+# CRD and reported, so the conflict that follows is already diagnosed instead of
+# surfacing as a misleading retry-exhaustion message.
+# ---------------------------------------------------------------------------
+test_partial_crd_set_is_reported() {
+  echo "Test: install_gateway_api_crds names an incomplete live CRD set"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  # A live bundle predating grpcroutes' promotion to the standard channel: the
+  # other four exist and are field-managed by someone else.
+  MISSING_CRDS="grpcroutes.gateway.networking.k8s.io"
+  LIVE_BUNDLE_VERSION=""
+  APPLY_FAIL=0
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+
+  assert_eq "a partial set still attempts the install" "0" "$exit_code"
+  assert_contains "the incomplete set is called out" "$output" \
+    "INCOMPLETE Gateway API CRD set"
+  assert_contains "the missing CRD is named" "$output" \
+    "missing: grpcroutes.gateway.networking.k8s.io"
+  assert_contains "the already-present CRDs are named" "$output" \
+    "present: gatewayclasses.gateway.networking.k8s.io"
+  assert_not_contains "a partial set is NOT mistaken for a completed install" "$output" \
+    "Gateway API CRDs already present"
+
+  local apply_count
+  apply_count="$(wc -l <"$APPLY_LOG" | tr -d ' ')"
+  assert_eq "the bundle apply is still attempted once" "1" "$apply_count"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3c: a field-manager conflict fails fast — it is deterministic, so the
+# retry budget must not be spent re-applying the identical bundle
+# ---------------------------------------------------------------------------
+test_conflict_fails_fast_without_retry() {
+  echo "Test: install_gateway_api_crds fails fast on a field-manager conflict"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  APPLY_LOG="$tmp/apply.log"
+  : >"$APPLY_LOG"
+  MISSING_CRDS="grpcroutes.gateway.networking.k8s.io"
+  LIVE_BUNDLE_VERSION=""
+  APPLY_FAIL=1
+  APPLY_OUTPUT='error: Apply failed with 4 conflicts: conflicts with "helm-controller"'
+
+  install_kubectl_stub "$tmp"
+
+  local output exit_code
+  output="$(run_install "$tmp")"
+  exit_code=$?
+  APPLY_OUTPUT=""
+
+  assert_nonzero_exit "install_gateway_api_crds exits non-zero on a conflict" "$exit_code"
+
+  local apply_count
+  apply_count="$(wc -l <"$APPLY_LOG" | tr -d ' ')"
+  assert_eq "a conflict is applied exactly once, not retried" "1" "$apply_count"
+
+  assert_contains "the ERROR names the conflict as the cause" "$output" \
+    "field-manager conflict"
+  assert_contains "the ERROR says it is deliberately not retried" "$output" \
+    "Not retried"
+  assert_not_contains "the misleading retry-exhaustion message is not used" "$output" \
+    "after 3 attempts"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: static wiring — main() invokes install_gateway_api_crds
+# Static-text check so this test stays independent of the stub plumbing above,
+# mirroring test_main_calls_gateway_wait_after_phase_3 in the sibling file.
+# ---------------------------------------------------------------------------
+test_main_calls_install_gateway_api_crds() {
+  echo "Test: main() invokes install_gateway_api_crds"
+
+  # Anchor on end-of-line so the bare call site matches but the
+  # `install_gateway_api_crds()` definition and the docblock do not.
+  assert_file_contains "install_gateway_api_crds is invoked by main()" \
+    "$DEPLOY_INFRA_SH" "install_gateway_api_crds$"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_all_present_skips_apply
+test_matching_bundle_skips_without_warning
+test_unknown_bundle_version_warns
+test_missing_crd_runs_apply_once
+test_persistent_failure_retries_three_times
+test_partial_crd_set_is_reported
+test_conflict_fails_fast_without_retry
+test_main_calls_install_gateway_api_crds
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/hack/deploy_infra_nofile_test.sh
+++ b/tests/unit/hack/deploy_infra_nofile_test.sh
@@ -51,6 +51,28 @@ STUB
   cat >"$dir/docker" <<'STUB'
 #!/bin/bash
 echo "docker $*" >> "$DOCKER_LOG"
+# Convergence probe of the containerd nofile cap — the read-only `docker exec`
+# that inspects the node (the write path is told apart by its `printf`). This
+# models node state, so each leg is answered only if the probe actually asks
+# for it; a probe that drops a leg gets the weaker answer a real node gives:
+#   grep "LimitNOFILE=<n>" ... nofile.conf   → matched against $NOFILE_CURRENT
+#   systemctl show containerd -p LimitNOFILE → matched against $NOFILE_EFFECTIVE
+# Unset ⇒ absent/uncapped ⇒ that leg misses ⇒ the write path runs.
+argv="$*"
+if [ "${1:-}" = "exec" ] && [[ "$argv" == *nofile.conf* && "$argv" != *printf* ]]; then
+  # Read the requested value back out of the probe rather than duplicating the
+  # script's NODE_NOFILE_LIMIT default here.
+  limit="${argv#*LimitNOFILE=}"
+  limit="${limit%%[\" ]*}"
+  case "${NOFILE_CURRENT:-}" in
+    *"LimitNOFILE=${limit}"*) ;;
+    *) exit 1 ;;
+  esac
+  if [[ "$argv" == *"systemctl show containerd"* && "${NOFILE_EFFECTIVE:-}" != "${limit}" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
 exit "${DOCKER_EXIT:-0}"
 STUB
 
@@ -67,7 +89,10 @@ STUB
 # run_cap <stub_dir>
 # Sources deploy-infra.sh in a subshell with <stub_dir> prepended to PATH and
 # invokes cap_node_nofile. The caller controls behaviour via the exported env:
-# KIND_NODES, DOCKER_LOG, DOCKER_EXIT, and NODE_NOFILE_LIMIT (set/unset).
+# KIND_NODES, DOCKER_LOG, DOCKER_EXIT, NODE_NOFILE_LIMIT (set/unset),
+# NOFILE_CURRENT (the drop-in the probe's `grep` leg matches against; unset ⇒
+# the file is absent) and NOFILE_EFFECTIVE (what the probe's `systemctl show`
+# leg reports for the running containerd; unset ⇒ uncapped).
 # Echoes combined stdout/stderr.
 run_cap() {
   local stub_dir="$1"
@@ -96,6 +121,8 @@ test_default_limit_applied() {
   export DOCKER_EXIT=0
   : >"$DOCKER_LOG"
   unset NODE_NOFILE_LIMIT   # exercise the built-in 1048576 default
+  unset NOFILE_CURRENT      # no existing drop-in  → probe misses → write path
+  unset NOFILE_EFFECTIVE    # containerd still uncapped
 
   local output
   output="$(run_cap "$tmp/bin")"
@@ -126,6 +153,8 @@ test_override_limit() {
   export DOCKER_EXIT=0
   : >"$DOCKER_LOG"
   export NODE_NOFILE_LIMIT=524288
+  unset NOFILE_CURRENT      # no existing drop-in  → probe misses → write path
+  unset NOFILE_EFFECTIVE    # containerd still uncapped
 
   run_cap "$tmp/bin" >/dev/null
 
@@ -199,6 +228,8 @@ test_multi_node() {
   export DOCKER_EXIT=0
   : >"$DOCKER_LOG"
   unset NODE_NOFILE_LIMIT
+  unset NOFILE_CURRENT      # no existing drop-in  → probe misses → write path
+  unset NOFILE_EFFECTIVE    # containerd still uncapped
 
   run_cap "$tmp/bin" >/dev/null
 
@@ -224,6 +255,8 @@ test_docker_failure_is_best_effort() {
   export DOCKER_EXIT=1          # docker exec fails
   : >"$DOCKER_LOG"
   unset NODE_NOFILE_LIMIT
+  unset NOFILE_CURRENT      # probe misses → write path (which then fails)
+  unset NOFILE_EFFECTIVE
 
   local output exit_code
   output="$(run_cap "$tmp/bin")"
@@ -231,6 +264,86 @@ test_docker_failure_is_best_effort() {
 
   assert_eq "cap_node_nofile returns 0 despite the failure" "0" "$exit_code"
   assert_contains "log warns about the failed node" "$output" "failed to cap RLIMIT_NOFILE on forge-control-plane"
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: a node already capped in BOTH legs is skipped — no restart, no wait
+# ---------------------------------------------------------------------------
+test_matching_dropin_skips_restart() {
+  echo "Test: cap_node_nofile skips the restart when drop-in and containerd both match"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT   # exercise the built-in 1048576 default
+  # The node reports the exact drop-in the function would write AND a running
+  # containerd already at that limit, so both the restart and the node-Ready
+  # wait are skipped.
+  export NOFILE_CURRENT=$'[Service]\nLimitNOFILE=1048576'
+  export NOFILE_EFFECTIVE=1048576
+
+  local output
+  output="$(run_cap "$tmp/bin")"
+
+  local docker_log
+  docker_log="$(cat "$DOCKER_LOG")"
+
+  assert_contains "the drop-in leg of the probe is issued" "$docker_log" \
+    'grep -qx "LimitNOFILE=1048576" '
+  assert_contains "the effective-limit leg of the probe is issued" "$docker_log" \
+    "systemctl show containerd -p LimitNOFILE --value"
+  assert_not_contains "containerd is NOT restarted on a match" "$docker_log" "systemctl restart containerd"
+  assert_contains "log reports the skip" "$output" "already capped"
+  assert_not_contains "the node-Ready wait is skipped too" "$output" "for all nodes to be Ready"
+
+  unset NOFILE_CURRENT
+  unset NOFILE_EFFECTIVE
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: drop-in present but containerd NOT capped → the node is still patched
+#
+# Regression guard for the write-succeeded/restart-failed state: a prior run
+# wrote the drop-in and then failed `systemctl restart containerd`, so the file
+# is on disk while containerd keeps the inherited ~1e9 limit. A file-only
+# convergence check would skip the node forever and report a clean deploy while
+# Keystone OOM-crashloops (#546); the effective-limit leg must force the retry.
+# ---------------------------------------------------------------------------
+test_stale_dropin_without_restart_is_retried() {
+  echo "Test: cap_node_nofile re-patches a node whose drop-in exists but containerd is uncapped"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_recording_stubs "$tmp/bin"
+
+  export KIND_NODES="forge-control-plane"
+  export DOCKER_LOG="$tmp/docker.log"
+  export DOCKER_EXIT=0
+  : >"$DOCKER_LOG"
+  unset NODE_NOFILE_LIMIT   # exercise the built-in 1048576 default
+  export NOFILE_CURRENT=$'[Service]\nLimitNOFILE=1048576'   # file written...
+  export NOFILE_EFFECTIVE=1073741816                        # ...restart never took
+
+  local output
+  output="$(run_cap "$tmp/bin")"
+
+  local docker_log
+  docker_log="$(cat "$DOCKER_LOG")"
+
+  assert_not_contains "the node is NOT reported as already capped" "$output" "already capped"
+  assert_contains "the drop-in is rewritten" "$docker_log" "LimitNOFILE=1048576"
+  assert_contains "containerd IS restarted" "$docker_log" "systemctl restart containerd"
+  assert_contains "log confirms the applied limit" "$output" "containerd RLIMIT_NOFILE set to 1048576"
+
+  unset NOFILE_CURRENT
+  unset NOFILE_EFFECTIVE
 }
 
 # ---------------------------------------------------------------------------
@@ -242,6 +355,8 @@ test_empty_limit_skips
 test_no_nodes_warns
 test_multi_node
 test_docker_failure_is_best_effort
+test_matching_dropin_skips_restart
+test_stale_dropin_without_restart_is_retried
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/unit/hack/deploy_infra_registry_cache_test.sh
+++ b/tests/unit/hack/deploy_infra_registry_cache_test.sh
@@ -62,6 +62,8 @@ resolve_flag() {
 #   network inspect → $DOCKER_NETWORK_EXISTS (default 0 = exists)
 #   volume inspect  → 1 (absent, so `volume create` runs)
 #   inspect -f …    → prints $DOCKER_RUNNING (default false = recreate)
+#   exec … grep … config.toml → $NODE_CONFIG_PATH_EXISTS (default 0 = present,
+#     so the config_path probe stays quiet unless a test opts into the warning)
 #   everything else → 0
 # kind prints $KIND_NODES for `kind get nodes`.
 make_docker_stub() {
@@ -80,6 +82,14 @@ case "${1:-}" in
     exit 0 ;;
   inspect)
     printf '%s' "${DOCKER_RUNNING:-false}"; exit 0 ;;
+  exec)
+    # The config_path probe: `docker exec <node> grep -q … config.toml`.
+    for arg in "$@"; do
+      if [ "$arg" = "/etc/containerd/config.toml" ]; then
+        exit "${NODE_CONFIG_PATH_EXISTS:-0}"
+      fi
+    done
+    exit 0 ;;
   *)
     exit 0 ;;
 esac
@@ -304,10 +314,11 @@ test_wire_node_registry_mirror() {
   local log
   log="$(cat "$tmp/docker.log")"
 
-  # 2 nodes × 6 upstreams = 12 docker exec calls.
+  # One config_path probe per node + one write exec per node per upstream:
+  # 2 probes + 2 nodes × 6 upstreams = 14 docker exec calls.
   local execs
   execs="$(grep -c 'docker exec' "$tmp/docker.log" || true)"
-  assert_eq "one docker exec per node per upstream (2×6=12)" "12" "$execs"
+  assert_eq "one probe per node + one exec per node per upstream (2+12=14)" "14" "$execs"
 
   # Each exec passes the host/server/mirror as env so the node shell writes the
   # right hosts.toml. Spot-check docker.io, quay, and a vanity front.
@@ -330,7 +341,67 @@ test_wire_node_registry_mirror() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 8: main() gates both calls behind WITH_REGISTRY_CACHE
+# Test 8: wire_node_registry_mirror warns when containerd lacks the config_path
+# ---------------------------------------------------------------------------
+test_wire_warns_without_config_path() {
+  echo "Test: wire_node_registry_mirror warns (but still writes) when config_path is absent"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_docker_stub "$tmp/bin"
+
+  local output
+  output="$(
+    PATH="$tmp/bin:$PATH"; export PATH
+    export DOCKER_LOG="$tmp/docker.log"; : >"$DOCKER_LOG"
+    export KIND_NODES="forge-control-plane"
+    export NODE_CONFIG_PATH_EXISTS=1        # cluster created WITHOUT the flag
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    WITH_REGISTRY_CACHE=true wire_node_registry_mirror 2>&1
+  )"
+
+  assert_contains "the warning names the missing config_path setting" "$output" "config_path"
+  assert_contains "the warning names the recreate remedy" "$output" "recreate"
+
+  # Warn-only: the hosts.toml mirror files are still written.
+  local log
+  log="$(cat "$tmp/docker.log")"
+  assert_contains "hosts.toml writes still run despite the warning" "$log" "HOSTS_HOST=docker.io"
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: no warning when containerd already carries the config_path setting
+# ---------------------------------------------------------------------------
+test_wire_no_warning_with_config_path() {
+  echo "Test: wire_node_registry_mirror stays quiet when config_path is present"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_docker_stub "$tmp/bin"
+
+  local output
+  output="$(
+    PATH="$tmp/bin:$PATH"; export PATH
+    export DOCKER_LOG="$tmp/docker.log"; : >"$DOCKER_LOG"
+    export KIND_NODES="forge-control-plane"
+    export NODE_CONFIG_PATH_EXISTS=0        # cluster created WITH the flag
+    # shellcheck source=/dev/null
+    source "$DEPLOY_INFRA_SH"
+    WITH_REGISTRY_CACHE=true wire_node_registry_mirror 2>&1
+  )"
+
+  assert_not_contains "no config_path warning when the setting is present" "$output" "config_path"
+
+  local log
+  log="$(cat "$tmp/docker.log")"
+  assert_contains "hosts.toml writes still run" "$log" "HOSTS_HOST=docker.io"
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: main() gates both calls behind WITH_REGISTRY_CACHE
 # ---------------------------------------------------------------------------
 test_main_gates_calls() {
   echo "Test: main() gates start_registry_cache + wire_node_registry_mirror behind the flag"
@@ -357,6 +428,8 @@ test_start_registry_cache
 test_start_registry_cache_idempotent
 test_start_registry_cache_noop_when_off
 test_wire_node_registry_mirror
+test_wire_warns_without_config_path
+test_wire_no_warning_with_config_path
 test_main_gates_calls
 
 echo ""


### PR DESCRIPTION
Closes #650

`make deploy-infra` is now safe to re-run against an already-provisioned kind cluster. A same-parameter re-run converges without errors and leaves a healthy stack unchanged; a re-run with additional opt-in flags installs only the newly enabled components.

## Change set, in commit order

### `efd38004` fix(deploy): skip Gateway API CRD install when CRDs already exist

The concrete failure from the issue. Once the envoy-gateway chart's helm-controller owns the Gateway API CRD fields, re-running `kubectl apply --server-side` on the same bundle dies on a field-manager conflict.

The inline block in `main()` moves into a documented `install_gateway_api_crds()` function in `hack/deploy-infra.sh` that:

- probes the five standard-channel CRD names **individually** — `kubectl get crd a b c` exits non-zero on the first `NotFound`, which would make a partially-present set look identical to a bare cluster and send the run down the install path;
- skips the apply when all five are present, logging the live `gateway.networking.k8s.io/bundle-version`. A live bundle differing from `GATEWAY_API_VERSION` is a **warning**, not a reconcile — upgrading CRDs is the chart's (or a teardown/redeploy's) job, and re-asserting the pin could downgrade a newer live bundle;
- warns up front when the live set is *incomplete*, then still attempts the install (content-identical CRDs co-own cleanly) so the conflict, if it comes, is already diagnosed;
- treats a field-manager conflict as **terminal, not retried** — it is deterministic, so burning the 3-attempt backoff would only replace the real diagnosis with a misleading "after N attempts" message. Transient failures (bundle fetch, API-server hiccup) keep their retries.

`--force-conflicts` is deliberately **not** used: avoiding or surfacing the conflict is correct, forcibly stealing field ownership from helm-controller is not.

The CRD name list is hand-maintained against the `GATEWAY_API_VERSION` pin; a comment at that pin points reviewers (and Renovate bumps) at the list, since a release adding a standard-channel CRD would otherwise make the presence check pass on the stale set.

New `tests/unit/hack/deploy_infra_gateway_crds_test.sh` (414 lines) covers the fresh-install, full-skip, partial-set, version-mismatch, missing-annotation, conflict-fail-fast and transient-retry paths.

### `bbb8f031` fix(deploy): converge node-level steps on deploy-infra re-runs

The issue scopes the promise to the whole bootstrap sequence, not just the CRDs. Two node-level steps were audited:

- **`cap_node_nofile()`** — previously rewrote the drop-in and restarted containerd on every run. It now skips a node only when **both** the drop-in on disk **and** the limit the running containerd reports match `NODE_NOFILE_LIMIT`. Checking the file alone would permanently mask a prior run whose write succeeded but whose `systemctl restart containerd` failed — the node keeps the inherited ~1e9 limit, every later run skips it, and the Keystone OOM-crashloop this function exists to prevent becomes unrecoverable by re-running. The trailing `wait_for_node_ready` is now gated on at least one node actually having been restarted, so a healthy re-run is read-only here.
- **`wire_node_registry_mirror()`** — `WITH_REGISTRY_CACHE=true` only takes effect on a cluster *created* with it, because the certs.d `config_path` is injected at `kind create cluster` time. Setting the flag on an existing cluster used to write inert `hosts.toml` files in silence. It now probes the node's containerd config and warns that the mirrors will be ignored, naming the recreate remedy — while still writing the files, so they activate if the cluster is later recreated with the flag.

The script header gains an explicit "Idempotent re-runs" contract block.

### `db0273c4` test(e2e): re-run deploy-infra in e2e-infra to lock idempotency

`.github/workflows/ci.yaml` — after the existing suite, the `e2e-infra` job now:

1. re-runs `make deploy-infra` with unchanged parameters and re-asserts the **full** infrastructure suite (including both `no-*` absence suites);
2. re-runs with `WITH_METRICS_SERVER=true` and asserts a **scoped** suite — the full suite would rightly fail `no-metrics-server-when-disabled`, which the additive leg just correctly installed.

The re-run legs call `make deploy-infra` directly rather than the composite action, and deliberately **without** `SKIP_KIND_CREATE`, so the script's own existing-cluster detection — the developer flow from the bug report — is what gets exercised. `CLUSTER_NAME` is passed explicitly from `KIND_CLUSTER` instead of relying on the script default happening to match: without it, editing `KIND_CLUSTER` would make the script find no cluster, create a fresh one, and deploy into that — a silently-green second fresh deploy testing zero convergence.

Two side effects worth a reviewer's eye: `timeout-minutes` goes 20 → 30 for the two extra deploy legs, and the diagnostic dump moves from `if: failure()` to `if: always()` (matching every other e2e job) so a timeout-cancelled run — exactly when a hung re-run leg is hardest to debug — does not discard cluster state.

### `0139dbba` docs: document the idempotent deploy-infra re-run contract

Quick starts state the safe-re-run and later-opt-in flow, and the registry-cache tip no longer claims every run creates a fresh cluster. `docs/reference/infrastructure/e2e-deployment.md` documents the per-step converge-or-skip behavior including the Gateway API CRD skip semantics; `docs/reference/ci-cd/ci-workflow.md` covers the new `e2e-infra` legs and the 30-minute timeout.

## Divergence from the issue

The issue promises that a re-run "with additional opt-in parameters ... installs the newly enabled components". The implementation carves out **two flags that are not additive**, and documents them rather than making them work:

- `WITH_REGISTRY_CACHE` — needs the certs.d `config_path` baked in at cluster-create time (warned about, remedy named);
- `WITH_CONTROLPLANE` — on a provisioned standalone stack this is a *mode change*, not an opt-in, since the ControlPlane provisions its own MariaDB/Memcached.

Both require starting from a fresh cluster. Making either genuinely additive would mean recreating the cluster or migrating datastores, which is beyond an idempotency fix. The e2e additive leg therefore uses `WITH_METRICS_SERVER`, which is genuinely additive.

Also as the issue allows: removing a previously enabled flag does **not** uninstall that run's components — cleanup stays `hack/teardown-infra.sh`'s job.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
