### PR TITLE
chore: add style guide and doc skills

### DIFF
--- a/.claude/skills/check-doc-consistency/SKILL.md
+++ b/.claude/skills/check-doc-consistency/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: check-doc-consistency
+description: >-
+  Audit documentation consistency across forge docs — terminology,
+  naming, release/version references, repeated examples, cross-page
+  claims, and alignment with code or configuration when docs describe
+  implementation details. Use when asked to check for contradictions,
+  after changing shared terminology, or when one doc seems to disagree
+  with another.
+---
+
+# Check documentation consistency
+
+This skill verifies that forge documentation **agrees with itself and
+with the source of truth it describes**. It is the cross-document and
+cross-layer check: the same concept should keep the same name, version,
+shape, and meaning everywhere it appears.
+
+It is repeatable — run it after edits that touch shared terms, repeated
+examples, release references, or any doc section that states facts about
+code, config, or deployment behavior.
+
+## What consistency means here
+
+Consistency is about preventing the docs from contradicting themselves or
+the implementation. This is broader than structure and sharper than
+style.
+
+| Area | What to check | Source of truth |
+|---|---|---|
+| Terminology | same concept uses the same name and capitalization everywhere | the established repo vocabulary |
+| Version and release references | release tags, versions, and defaults agree across pages | `releases/`, `deploy/`, `hack/`, and other live references |
+| Repeated examples | duplicated command snippets and YAML blocks do not drift | the canonical workflow or config |
+| Cross-page claims | overview, guide, and reference pages tell the same story | the underlying code or process |
+| Code-grounded statements | docs that describe behavior match the implementation | the relevant code, config, or generated artifact |
+| Environment/tooling claims | stated CLI/tool version requirements (or the absence of one) match what scripts actually enforce or require | `Makefile`, `hack/`, `scripts/`, CI workflow tool-version pins |
+| Terms defined once, used elsewhere | a term, daemon, or API named on one page is only meaningfully explained on a *different* page, with no link between them | the page the term actually appears on, checked against its own content |
+
+A consistency finding is any place where two docs, or a doc and the code,
+make different claims about the same thing.
+
+## Depth modes
+
+Use depth as a mode, not a separate skill:
+
+- **quick** — compare one page against its nearest sibling or source.
+- **standard** — compare one doc family, such as all pages in a topic.
+- **deep** — compare the broader docs corpus against the current repo
+  state for release, terminology, and implementation drift.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Identify the canonical claim
+
+For each fact in the docs, decide where the truth lives:
+
+- code
+- generated config or schema
+- release metadata
+- another doc page that acts as the reference
+
+If the source is unclear, the doc is already at risk of drift.
+
+### 2. Compare the repeated surfaces
+
+Check the places where the same fact is likely repeated:
+
+- overview pages versus detailed guides
+- user docs versus reference docs
+- examples versus prose descriptions
+- repo docs versus deployment or release files
+
+### 3. Check for contradictions and stale copies
+
+Look for:
+
+- renamed terms that only changed in one place
+- version numbers that no longer match current defaults
+- copied examples that kept old values
+- pages that still describe removed behavior
+- claims about code paths that no longer exist
+- a tool/version requirement stated (or silently assumed) that doesn't
+  match what the scripts the reader is about to run actually need
+- a term or reference a page uses that is only explained on a sibling
+  page — the writer knew the definition existed somewhere, but the
+  reader on this page doesn't have it
+
+### 4. Report
+
+Produce findings as a flat list, most severe first, one line each:
+
+`[SEVERITY] CONS-<n> — <file A>:<line> vs <file B or code path>:<line> —
+<the mismatch> — Fix: <one-line resolution, or "needs research" if the
+correct value isn't established yet>`
+
+Group by severity:
+
+- **HIGH** — a doc contradicts the implementation or a sibling doc on a
+  load-bearing fact such as a version, default, required step, or
+  supported behavior.
+- **MEDIUM** — terminology drift, stale copied examples, a doc that
+  partially matches reality but omits a conflicting detail, or a tool
+  requirement that's wrong rather than merely unstated.
+- **LOW** — minor wording differences, old but harmless examples, or
+  duplicated phrasing that could mislead later edits.
+
+End with a verdict for the doc family or topic.
+
+## Notes
+
+- This skill is read-only; hand findings to [[fix-docs]] to apply them.
+- Pair this with [[check-doc-structure]] for page-level navigation and
+  with [[check-doc-expressions]] for readability and the
+  `STYLE_GUIDE.md` rhetorical-device budget — style drift is out of
+  scope here even when it happens to repeat across pages; that's a
+  consistency-shaped symptom of a style problem, not a truth mismatch.
+- If the disagreement is with code, config, or generated output, cite the
+  code-side source of truth directly rather than treating the doc as the
+  canonical side.
+- If the correct value isn't derivable from anything in the repo (e.g.
+  "why is this the default" has no comment or commit explaining it),
+  report it as **needs research** rather than guessing — that is itself
+  a finding worth surfacing.

--- a/.claude/skills/check-doc-expressions/SKILL.md
+++ b/.claude/skills/check-doc-expressions/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: check-doc-expressions
+description: >-
+  Audit documentation prose quality for forge docs — sentence clarity,
+  active voice, terminology, ambiguity, tone, jargon control, adherence
+  to STYLE_GUIDE.md's rhetorical-device budget, and the readability of
+  command examples and code-adjacent explanations. Use when asked to
+  improve writing quality, after drafting or editing prose, or when a
+  page reads correctly but not clearly.
+---
+
+# Check documentation expressions
+
+This skill verifies that forge documentation **reads cleanly and says
+exactly what it means**. It focuses on prose quality rather than page
+shape: sentences should be direct, terminology should be consistent,
+examples should be readable, and important claims should not be buried
+in vague language.
+
+It is repeatable — run it any time text changes materially, especially in
+user-facing guides, tutorials, reference prose, or release notes.
+
+## What expressions means here
+
+Expression quality is the writing layer that sits on top of structure.
+The content can be technically correct and still be hard to use if the
+prose is muddy or inconsistent.
+
+| Area | What to check | Source of truth |
+|---|---|---|
+| Sentence clarity | short, direct sentences; one idea per sentence; no dangling references | the intended reader outcome |
+| Voice and tone | active voice, concrete verbs, minimal hedging; no marketing or aspirational phrasing ("the shortest path to…", "seamlessly") in operational docs | `STYLE_GUIDE.md` and the doc family style used elsewhere in the repo |
+| Rhetorical-device budget | em-dash, italic emphasis, antithesis ("not X, but Y"), aphoristic one-liner closers, and `:::` callouts stay within the per-1,000-word limits; filler vocabulary and meta-signposting are cut | `STYLE_GUIDE.md`'s budget table and Do/Don't list |
+| Terminology | one term per concept, no accidental synonyms | the repo glossary and established usage |
+| Command examples | commands are complete, ordered, and copyable | the real workflow the docs describe |
+| Explanatory text | definitions appear before specialized terms are used | the implementation or process being documented |
+| Unexplained references | named tools, daemons, helper processes, or APIs (e.g. a background service invoked indirectly, an internal API) are explained or linked on first use **on the page they appear on** — a definition living only in a different page does not count | the reader landing on this specific page, not the whole corpus |
+| Prerequisite accuracy | stated tool/version requirements match what the workflow actually needs (minimum versions, why a tool is required, what it's required *for*) | the scripts/Makefile/CI steps the doc walks the reader through |
+| Operational realism | the page covers what to do when a step fails, times out, or needs a retry — not only the happy path; environment assumptions (network, resources) that can make a step fail are stated as prerequisites | known failure reports and support history for that workflow |
+| Depth parity | every step/section of one walkthrough gets a comparable level of explanation — no step is a bare command while its siblings get paragraphs of context | the other steps on the same page |
+| Readability | long paragraphs, repetition, and filler are removed | the page's purpose and audience |
+
+A writing finding is any place where the prose forces the reader to infer
+meaning that the document should have stated directly.
+
+## Depth modes
+
+Use the same skill at multiple depths rather than splitting it into more
+skills:
+
+- **quick** — one page, line-level wording cleanup.
+- **standard** — one document set, such as a guide and its reference
+  neighbors.
+- **deep** — repo-wide terminology and phrase consistency.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Identify the audience
+
+Decide whether the page is for a new contributor, an operator, a release
+owner, or a reader looking up a fact. The same sentence can be clear for
+one audience and opaque for another.
+
+### 2. Read for meaning, not grammar alone
+
+Check whether each paragraph does the following:
+
+- states the point up front
+- uses the same term for the same concept
+- avoids unexplained acronyms, jargon, or named tools/daemons/APIs that
+  this page never defines (checking the page itself, not whether some
+  other page defines it)
+- makes examples match the surrounding text
+- keeps warnings and exceptions easy to spot
+- gives each step of a multi-step walkthrough comparable depth — flag a
+  step that is a bare command next to siblings with full explanations
+
+### 3. Check the style-guide budget
+
+`STYLE_GUIDE.md` sets checkable limits per ~1,000 words: at most 2
+em-dashes, 4 italic spans, 1 antithesis ("not X, but Y" / "rather
+than"), 1 aphoristic one-liner close, and 1–2 `:::` callout boxes.
+Count each device against the page and flag:
+
+- More em-dashes or italic spans than the budget allows.
+- A second "not X, but Y" construction on the same page.
+- A quality self-label ("robust", "clean", "battle-tested", "seamless")
+  with nothing concrete backing it — the fix replaces the label with
+  the fact it was standing in for (a linked test, a condition name, a
+  command), it doesn't just delete the sentence.
+- A paragraph that closes on a slogan *and* a `:::` box repeating it.
+- Filler vocabulary past its retirement point (`load-bearing`,
+  `by construction`, `structural rather than aspirational`,
+  `first-class`, `precisely`, `exactly`, `deliberately`) — `precisely`
+  and `exactly` are cut outright rather than replaced.
+- A sentence with three or more subordinate clauses that can't be read
+  aloud in one breath — the fix splits it at a colon or semicolon.
+- A sentence that only previews the next one ("The section below
+  covers…") — the fix deletes it; the heading already orients the
+  reader.
+
+This is a mechanical count, separate from the meaning-level read in
+step 2 — do both passes.
+
+### 4. Inspect code-adjacent text
+
+For commands, YAML, shell snippets, and API examples:
+
+- ensure the example is complete enough to run or adapt
+- check that flags, paths, and release names are not stale
+- verify the prose around the example explains what changes and why
+- for any stated tool/version prerequisite, check it against what the
+  workflow actually requires (e.g. a command uses a flag or operator
+  that only exists from some minimum version) — a requirement that is
+  present but wrong is worse than one that is simply missing
+- check whether the page tells the reader what to do if the step fails,
+  times out, or needs a retry, and whether failure-prone environment
+  assumptions (network access, resource limits) are stated up front as
+  prerequisites rather than discovered by trial and error
+
+### 5. Report
+
+Produce findings as a flat list, most severe first, one line each:
+
+`[SEVERITY] EXPR-<n> — <file>:<line> — <problem, quoting the offending
+text> — Fix: <one-line suggested rewording, or "needs judgment" if the
+right wording depends on a decision the audit can't make>`
+
+Group by severity:
+
+- **HIGH** — text says the opposite of what the intended behavior is;
+  an example is misleading enough to cause a bad operation; a stated
+  prerequisite is wrong (not just unclear) and follows it fails.
+- **MEDIUM** — ambiguous wording, unexplained jargon/reference, repeated
+  terms for one concept, missing failure/retry guidance, or prose that
+  obscures the actual workflow; a style-guide budget blown so far past
+  the limit (e.g. the machine-written claim → contrast → em-dash → tidy
+  one-liner pattern repeating every paragraph) that it degrades
+  readability rather than just drifting from house style.
+- **LOW** — awkward phrasing, overly long sentences, depth-parity
+  drift, or a step 3 style-guide budget item over its per-1,000-word
+  limit without otherwise changing the meaning.
+
+End with a short verdict for the page or doc set.
+
+## Notes
+
+- This skill is read-only; do not rewrite the page until the wording
+  issue has been localized. Hand findings to [[fix-docs]] to apply them.
+  Step 3 findings map to STYLE_GUIDE.md's own Do/Don't pairs, so
+  fix-docs can usually treat them as mechanical.
+- Pair this with [[check-doc-structure]] so the page is both readable
+  and well organized, and with [[check-doc-consistency]] so the prose
+  matches the rest of the docs corpus.
+- If the issue is a factual mismatch rather than wording, hand it off to
+  [[check-doc-consistency]].

--- a/.claude/skills/check-doc-structure/SKILL.md
+++ b/.claude/skills/check-doc-structure/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: check-doc-structure
+description: >-
+  Audit documentation structure and navigation for forge docs — required
+  frontmatter, heading hierarchy, section order, index/nav coverage,
+  link and anchor integrity, orphan pages, and duplicate or misplaced
+  topics. Use when asked to check doc structure, after adding or moving
+  a doc page, or when a page becomes hard to discover from the docs nav.
+---
+
+# Check documentation structure
+
+This skill verifies that forge documentation is **structurally sound and
+navigable**: pages have the expected frontmatter, headings appear in the
+right order, links resolve, anchors exist, and docs show up where readers
+expect them in the site nav and index pages.
+
+It is repeatable — run it any time a page is added, renamed, moved, or
+split, and especially before publishing a docs-heavy change.
+
+## What structure means here
+
+Structure is the page-level and site-level scaffolding that makes docs
+usable. The exact expectations depend on the doc family, but the same
+classes of drift appear everywhere:
+
+| Layer | What to check | Source of truth |
+|---|---|---|
+| Page metadata | frontmatter fields, title, sidebar order, quadrant/category markers | the doc family conventions in `docs/` and `architecture/` |
+| Heading hierarchy | H1/H2/H3 order, required section names, no skipped levels | the current page template for that doc type |
+| Navigation | VitePress sidebar, index pages, cross-links from sibling docs | `docs/.vitepress/` and the relevant section index |
+| Links and anchors | relative links, fragment anchors, code-block references | the linked page and its actual heading text |
+| Coverage | orphan pages, duplicate topics, stale renamed paths | the directory tree under `docs/` and `architecture/` |
+| Tutorial-family naming | when several pages walk through the same workflow at different depth/audience (e.g. a base quick start plus deeper variants), names signal the relationship and scope instead of ambiguous modifiers like "extended"; cross-references point at the specific source section instead of restating it | the full set of sibling walkthrough pages, read together, not each in isolation |
+
+A structural finding is any page that cannot be discovered, rendered,
+or read in the expected order because its scaffolding drifted.
+
+## Depth modes
+
+This skill should be usable at different depths without becoming a new
+skill for each one:
+
+- **quick** — one page plus its direct links and parent index.
+- **standard** — one doc family, such as a guide or reference section.
+- **deep** — repository-wide navigation and path consistency across all
+  doc roots.
+
+Use the same criteria at each depth; only the scope changes.
+
+## Procedure
+
+Work through these steps in order and report findings at the end.
+
+### 1. Identify the doc family
+
+Decide whether the target is a guide, reference page, architecture
+chapter, README, or generated artifact. The required sections and nav
+expectations come from that family, not from a single universal template.
+
+### 2. Check the page skeleton
+
+Verify the page has the expected metadata and outline:
+
+- frontmatter exists and is valid
+- title matches the page purpose
+- required headings appear in the expected order
+- no empty or duplicated sections remain after edits
+- code blocks and admonitions are not breaking the flow
+
+### 3. Check discoverability
+
+Confirm the page is reachable from the places readers actually use:
+
+- sidebar or nav config
+- section index pages
+- sibling cross-links
+- any landing page that lists the topic
+
+### 4. Check links and anchors
+
+Resolve every local link and fragment anchor that the page introduces or
+updates. If a link target moved, update the source and the destination
+path together.
+
+### 5. Check tutorial/guide families as a set
+
+When two or more pages cover the same workflow at different depth or for
+a different audience (a quick start plus a deeper variant, a base guide
+plus a role-specific one), read them together, not just individually:
+
+- do the names tell a reader which one to open first, and what the
+  others add — a bare modifier like "extended" doesn't say what it
+  extends or why
+- does the deeper page belong in this section at all, or does its real
+  audience (e.g. developers) mean it should live and be named elsewhere
+- when one page mentions a topic the sibling covers in depth, does it
+  link to the sibling's specific section instead of re-explaining or
+  silently assuming the reader already read it
+
+### 6. Report
+
+Produce findings as a flat list, most severe first, one line each:
+
+`[SEVERITY] STRUCT-<n> — <source page>:<line> [+ nav/index page] —
+<problem> — Fix: <one-line resolution, or "needs judgment" if it
+involves a rename/move/reorg a human should confirm>`
+
+Group by severity:
+
+- **HIGH** — a page cannot be found through the documented nav; a link
+  target is missing; the page skeleton is broken enough that the doc
+  family no longer renders as intended.
+- **MEDIUM** — a required section is missing or out of order; an index or
+  sidebar entry is stale; a renamed page still has old inbound links; a
+  tutorial family's naming or scope actively misleads about what each
+  page covers.
+- **LOW** — a cosmetic heading-level mismatch, duplicate wording, or a
+  stale anchor that still resolves after redirects.
+
+End with a per-doc-family verdict.
+
+## Notes
+
+- This skill is read-only; hand findings to [[fix-docs]] to apply them.
+  Renames and reorganizations from step 5 are judgment calls — flag them
+  for confirmation rather than treating them as mechanical fixes.
+- Pair this with [[check-doc-expressions]] for prose quality and with
+  [[check-doc-consistency]] for cross-document truth alignment.
+- `STYLE_GUIDE.md`'s "Keep" list (frontmatter, tables/diagrams/code
+  blocks, cross-links) overlaps this skill's scope — if a prose-style
+  pass under [[check-doc-expressions]] or [[fix-docs]] touched one of
+  those, re-run this skill on the page.
+- If a generated doc or a site template is involved, verify the generator
+  or template separately before patching the rendered page.

--- a/.claude/skills/fix-docs/SKILL.md
+++ b/.claude/skills/fix-docs/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: fix-docs
+description: >-
+  Apply fixes for findings produced by check-doc-consistency,
+  check-doc-expressions, and check-doc-structure — or run those audits
+  first if no findings are supplied. Classifies each finding as
+  mechanical (safe to apply directly), a judgment call (propose the
+  change, confirm before applying), or needs-research (establish the
+  correct fact before writing anything), then edits the docs and
+  re-verifies with the originating audit. Use when asked to fix
+  documentation issues, action a docs audit report, or clean up findings
+  from check-doc-consistency/expressions/structure.
+---
+
+# Fix documentation findings
+
+This skill turns a docs audit into an actual edit. The three check-doc-*
+skills are deliberately read-only — this is the paired skill that closes
+the loop by applying their findings, or a subset of them, to the repo.
+
+## Input
+
+Either:
+
+- a findings list already produced by check-doc-consistency,
+  check-doc-expressions, or check-doc-structure (the `[SEVERITY]
+  <PREFIX>-<n> — <location> — <problem> — Fix: <hint>` format those
+  skills emit), or
+- nothing — in which case, run **all** check-doc-* skills, at
+  a depth matching the requested scope, to generate findings. Default to
+  all even when the request names only "the style guide" or
+  "STYLE_GUIDE.md" — that file covers one narrow slice of
+  check-doc-expressions. Run a subset instead of all three only when the
+  user explicitly names a single check-doc-* skill or scopes the request
+  to one of their concerns (e.g. "just check terminology consistency").
+
+If given a specific severity or file scope ("just the HIGH ones", "only
+the quick-start pages"), filter to that before classifying — this narrows
+which findings to act on, not which check-doc-* skills produce them.
+
+## Procedure
+
+### 1. Classify every finding
+
+- **Mechanical** — a stale value, dead link, wrong field/flag name,
+  duplicate section, or unexplained-reference gap where the correct
+  text is directly derivable from code, config, or a sibling doc. The
+  finding's `Fix:` hint already states the resolution, or it's a single
+  unambiguous edit. A `STYLE_GUIDE.md` budget finding from
+  [[check-doc-expressions]] step 3 is also mechanical: excess em-dashes
+  or italics get cut per the guide's Do example, a second antithesis on
+  a page becomes a plain statement, a repeated aphorism/callout keeps
+  one copy, a bare quality label ("robust", "clean") is replaced with
+  the concrete fact it stood in for, retired filler vocabulary is
+  reworded or (for `precisely`/`exactly`) deleted outright, and a
+  meta-signposting sentence is deleted. Splitting a long sentence at
+  its colon or semicolon is mechanical only if the split doesn't change
+  what the sentence claims — otherwise treat it as a judgment call.
+- **Judgment call** — page renames or moves, tone/marketing-language
+  rewrites, tutorial-family reorganization, condensing a paragraph,
+  anything the audits tagged "needs judgment." The right answer depends
+  on a decision, not a lookup.
+- **Needs research** — the finding's `Fix:` hint says "needs research,"
+  or the correct value isn't yet established (e.g. a version pin's
+  justification, a minimum tool version nobody wrote down). Investigate
+  first — grep `hack/`, `Makefile`, CI workflows, commit history, or the
+  relevant script — until the fact is pinned down, then treat it as
+  mechanical.
+
+### 2. Confirm before applying judgment calls
+
+Present the proposed change (old vs. new wording, or the rename/move
+plan including every inbound link and nav entry that would need to
+update) and get explicit confirmation before editing. Renames ripple
+through sidebar config and cross-links repo-wide — treat them as a
+reversible-but-noisy action worth a quick check-in, not a silent edit.
+
+### 3. Apply
+
+- Apply mechanical fixes and confirmed judgment calls with direct edits.
+- When a page is renamed or moved, update in the same change: every
+  inbound link, the VitePress sidebar/nav config, and any section index
+  that lists it. A rename that doesn't update its own inbound links just
+  trades one structural finding for another.
+- When condensing or rewording prose, preserve any warnings, exceptions,
+  or version-specific caveats the original sentence carried — cutting
+  marketing fluff should not also cut the caveat sitting next to it.
+- When applying a `STYLE_GUIDE.md` fix, leave frontmatter, tables,
+  diagrams, code blocks, and cross-links untouched — the guide's "Keep"
+  list protects them from style sanding even when the surrounding prose
+  is being cut down.
+
+### 4. Re-verify
+
+Re-run the check-doc-* skill(s) that produced the fixed findings, scoped
+to just the touched pages ("quick" depth), to confirm the fix didn't:
+
+- introduce a new dead link or anchor (structure)
+- leave a sibling page's copy of the same fact now out of sync
+  (consistency)
+- swap one wording problem for another (expressions)
+
+For any touched page, also run `STYLE_GUIDE.md`'s own pre-commit check
+(em-dash/italic counts back under budget, no second antithesis, no
+unbacked quality label, no sentence too long to read in one breath, no
+leftover meta-signposting) — this is the same check as
+[[check-doc-expressions]] step 3, so a quick-depth re-run of that skill
+covers it.
+
+### 5. Report
+
+List what was fixed, what was skipped and why (deferred pending user
+decision, or still needs research), grouped the same way the input
+findings were grouped. Reference the original finding ID
+(`CONS-3`, `EXPR-1`, `STRUCT-2`, …) next to its outcome.
+
+## Notes
+
+- Unlike its three siblings, this skill writes to the repo — treat file
+  renames/moves as the one action class that always needs confirmation,
+  even under an otherwise-autonomous invocation.
+- Don't invent a fix for a needs-research finding — establish the fact
+  first, and if it truly isn't derivable from the repo, say so instead
+  of guessing at a plausible-sounding value.
+- Pair with [[check-doc-consistency]], [[check-doc-expressions]], and
+  [[check-doc-structure]], which generate the findings this skill
+  consumes.
+- For any prose rewrite, `STYLE_GUIDE.md` is the contract: its Do/Don't
+  pairs are the default rewrite pattern for a given device, and its
+  "Keep" list is the boundary this skill must not cross.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,91 @@
+# Writing style
+
+A guide for writing docs (`docs/`) so they read as if a person wrote them:
+varied, plain where it can be, with no filler.
+
+**Scope.** This file governs rhetorical style: em-dash/italics/
+antithesis/callout/aphorism budgets, filler vocabulary, and quality
+self-labels. It is not a completeness check.
+
+## The one principle
+
+Docs start to read machine-written when every sentence does the same rhetorical
+work: claim → contrast → em-dash aside → tidy one-liner. The fix is **restraint
+and variation**, not more polish. Dial the machinery down.
+
+- **Vary.** Mix short sentences with long. Let some paragraphs end plainly, with no mic-drop.
+- **Show, don't announce.** Don't tell the reader something is "simple," "robust," or
+  "battle-tested". A code reference, a linked test suite, or a status condition name
+  demonstrates it instead.
+- **Cut the scaffolding.** A sentence that only tells the reader what the next one will do is filler.
+
+## Budget (per ~1,000 words)
+
+Checkable limits:
+
+| Device | Limit |
+|---|---|
+| Em-dash (—) | ≤ 2 |
+| Italic emphasis (`*word*`) | ≤ 4 |
+| Antithesis ("not X, but Y" / "rather than") | ≤ 1 per page |
+| `:::` callout boxes | ≤ 1–2 per page |
+| Aphoristic one-liner close | ≤ 1 per page |
+
+## Do / Don't
+
+### 1. Antithesis — keep one, drop the rest
+The "not X, but Y" chiasmus makes a point land once per page. Reused every paragraph, it's a tell.
+
+- **Don't:** "The webhook doesn't just validate the CR — it doesn't let bad state through, it stops it at the door, not after it lands. And the operator doesn't just reconcile once — it keeps going, forever chasing drift."
+- **Do:** "The webhook rejects an invalid CR before it's persisted, not after. The operator then reconciles continuously, correcting drift as it appears."
+
+### 2. Em-dash — reserve it for the real pivot
+- **Don't:** two or three em-dashes carrying one sentence's structure.
+- **Do:** replace most of them with a period, comma, colon, or parentheses. At most one em-dash per paragraph, saved for the actual turn.
+
+### 3. Italics — only terms and true contrasts
+- **Don't:** "The *reconciler* watches the *CR* and drives it toward the *desired* state."
+- **Do:** italicize a term once, on first definition (a *sub-reconciler* owns one condition type) and leave it upright everywhere after. When in doubt, leave it upright.
+
+### 4. Aphorisms and callouts — ration them
+- **Don't:** end every paragraph on a slogan ("Idempotency is the whole point.") or restate the same point again in a `:::` box.
+- **Do:** one memorable line per page, earned, tied to something concrete. Let other paragraphs stop when the point is made. Keep `:::` boxes for one genuine takeaway per page; fold the rest into prose.
+
+### 5. Don't announce quality — demonstrate it
+- **Don't:** "this is the robust way to do it," "a clean, correct implementation," "this is not just a workaround."
+- **Do:** let the specifics carry it — a linked test suite, a condition name, an exact command. Delete the self-assessment; state the fact it was standing in for.
+
+### 6. Tricolons — break the symmetry
+Three parallel items in a row, again and again, reads mechanical.
+- **Do:** sometimes use two, sometimes four; sometimes split into separate sentences. Variation over symmetry.
+
+### 7. Cut the meta-signposting
+- **Don't:** "The previous section explained the CRD fields; this one shows how they're used." "The above gives the detail, this is the same thing at a glance."
+- **Do:** delete it. The page's opening paragraph and its heading already orient the reader.
+
+### 8. Retire the filler vocabulary
+Recurring abstractions that turn from style into template by their sixth use:
+`load-bearing`, `by construction`, `structural rather than aspirational`, `first-class`,
+`precisely`, `exactly`, `deliberately`. Use concrete wording instead, and delete
+`precisely`/`exactly` outright — they rarely strengthen anything.
+
+### 9. Sentences you can read in one breath
+- **Don't:** 3–5 subordinate clauses and asides packed into one sentence (overview paragraphs and bullet lists are the worst offenders).
+- **Do:** split at the colon or semicolon. If you run out of breath reading it aloud, break it.
+
+## Keep — don't sand these off
+
+- **Frontmatter** (`title`, `quadrant`) and the page's structure.
+- **Tables, diagrams, and code blocks.** Structure is fine unless you are explicitly tasked to restructure the docs.
+- **Cross-links between pages.** They do real orienting work; don't replace them with prose recaps.
+
+## Pre-commit check
+
+Before committing edited docs, scan for:
+
+1. More than ~2 em-dashes or ~4 italic spans per 1,000 words? Cut.
+2. A second "not X, but Y" on the same page? Rewrite it as a plain statement.
+3. A quality self-label ("robust," "clean," "battle-tested") with nothing concrete backing it? Replace or delete.
+4. A paragraph that ends on a slogan *and* a `:::` box that repeats it? Keep one.
+5. A sentence you can't read aloud in one breath? Split it.
+6. A sentence that only previews the next one? Delete it.

--- a/docs/contributing/claude-skills.md
+++ b/docs/contributing/claude-skills.md
@@ -16,12 +16,14 @@ Most skills are focused **audits** that compare one surface of the
 codebase against its source of truth — the operator CRDs, the
 sub-reconciler chains, the validation rules, the release wiring, the
 FluxCD infrastructure stack, the Renovate configuration, the e2e
-fixture corpus, the SPDX/REUSE coverage, the Go workspace — and report
-drift before it reaches a release. The suite also carries three
-**planners** (`prepare-new-service`, `prepare-new-release`,
-`prepare-new-guide`) that turn an onboarding or authoring task into a
-phased checklist, and a **runbook** (`debug-e2e-failure`) for diagnosing
-failing chainsaw e2e jobs.
+fixture corpus, the SPDX/REUSE coverage, the Go workspace, and the
+documentation itself — and report drift before it reaches a release.
+The suite also carries three **planners** (`prepare-new-service`,
+`prepare-new-release`, `prepare-new-guide`) that turn an onboarding or
+authoring task into a phased checklist, a **doc-fix driver**
+(`fix-docs`) that turns audit findings into actual edits, and a
+**runbook** (`debug-e2e-failure`) for diagnosing failing chainsaw e2e
+jobs.
 
 The skills complement the CI gates configured in
 [`.github/workflows/`](https://github.com/c5c3/forge/tree/main/.github/workflows)
@@ -115,6 +117,9 @@ a companion Bash script (the deterministic part).
 | Skill | Audits | Use when |
 |---|---|---|
 | [`check-doc-drift`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-drift/SKILL.md) | The forge documentation against the implementation — the `docs/reference/` pages vs the operator code, and the guides and quick-starts vs the `deploy/` infrastructure stack. | After adding or removing a sub-reconciler, status condition, operator binary, or infrastructure component, before tagging a release. |
+| [`check-doc-consistency`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-consistency/SKILL.md) | Documentation consistency across forge docs — terminology, naming, release/version references, repeated examples, cross-page claims, and alignment with code or configuration when docs describe implementation details. | When asked to check for contradictions; after changing shared terminology; when one doc seems to disagree with another. |
+| [`check-doc-expressions`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-expressions/SKILL.md) | Documentation prose quality — sentence clarity, active voice, terminology, ambiguity, tone, jargon control, adherence to `STYLE_GUIDE.md`'s rhetorical-device budget, and the readability of command examples and code-adjacent explanations. | When asked to improve writing quality; after drafting or editing prose; when a page reads correctly but not clearly. |
+| [`check-doc-structure`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-doc-structure/SKILL.md) | Documentation structure and navigation — required frontmatter, heading hierarchy, section order, index/nav coverage, link and anchor integrity, orphan pages, and duplicate or misplaced topics. | When asked to check doc structure; after adding or moving a doc page; when a page becomes hard to discover from the docs nav. |
 | [`check-spdx-reuse`](https://github.com/c5c3/forge/blob/main/.claude/skills/check-spdx-reuse/SKILL.md) | SPDX / REUSE compliance across the source tree — every `*.go`, `*.sh`, hand-authored YAML, and CI workflow file should carry matching `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers; every licence referenced has a corresponding text under `LICENSES/`. Defers to `reuse lint` as the authoritative gate. | After adding a new source file; before tagging a release where SAP supply-chain audits require clean REUSE output. |
 
 ### Planners and runbooks
@@ -125,6 +130,7 @@ a companion Bash script (the deterministic part).
 | [`prepare-new-release`](https://github.com/c5c3/forge/blob/main/.claude/skills/prepare-new-release/SKILL.md) | Plans the addition of a new OpenStack release — inventories the touch points auto-discovery does not cover (release config files, the Tempest config directory, per-release e2e variants, constraint overrides) and walks the decision points: moving the default release, extending the upgrade-path tests, retiring an old release. | When asked to add a new OpenStack release, bump the release matrix, or remove an old release. |
 | [`prepare-new-guide`](https://github.com/c5c3/forge/blob/main/.claude/skills/prepare-new-guide/SKILL.md) | Scaffolds a new how-to guide skeleton under `docs/guides/` for a chosen devstack anchor and validates draft guides against the guide conventions — placeholder names no tutorial produces, devstack↔flag consistency, raw-helm instructions against Flux-owned releases, projected-child edits without a revert warning. Defers to `tests/unit/docs/guide_devstack_and_tested_by_test.sh` as the authoritative gate. | When writing a new guide under `docs/guides/`; when checking a draft guide for convention violations. |
 | [`debug-e2e-failure`](https://github.com/c5c3/forge/blob/main/.claude/skills/debug-e2e-failure/SKILL.md) | Diagnoses a failing chainsaw e2e job — resolves the failed run, pulls the failed-step logs and JUnit/diagnostic evidence, maps the failure back to the suite directory under `tests/`, classifies it against the known flake patterns, and reproduces it locally against a kind cluster. | When any CI e2e job fails (`e2e-operator`, `e2e-chaos`, `e2e-controlplane`, …); when reproducing an e2e failure locally. |
+| [`fix-docs`](https://github.com/c5c3/forge/blob/main/.claude/skills/fix-docs/SKILL.md) | Applies fixes for findings produced by `check-doc-consistency`, `check-doc-expressions`, and `check-doc-structure` — or runs those audits first if no findings are supplied. Classifies each finding as mechanical (safe to apply directly), a judgment call (propose first, confirm before applying), or needs-research (establish the correct fact before writing anything), then edits the docs and re-verifies with the originating audit. | When asked to fix documentation issues; when actioning a docs audit report; when cleaning up findings from `check-doc-consistency`, `check-doc-expressions`, or `check-doc-structure`. |
 
 ## What a skill is, structurally
 


### PR DESCRIPTION
Added a STYLE_GUIDE.md that defines the rhetorical-device budget and vocabulary rules for forge docs.  Added docs skills that operationalize document checking.
- check-doc-consistency audits facts, terms, and version references across pages and against the implementation
- check-doc-expressions audits clarity, active voice, and adherence to the style-guide
- check-doc-structure audits frontmatter, hierarchy, navigation, and link integrity
- fix-docs applies findings from all three checks, classifying each as auto-apply, confirm-first, or needs-research before modifying files

On-behalf-of: @SAP
Assisted-by: Claude:claude-sonnet-5