### PR TITLE
docs: run fix-docs on quickstart docs

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -9,40 +9,42 @@ SPDX-License-Identifier: Apache-2.0
 
 # Quick Start (ControlPlane): C5C3 + K-ORC on Kind
 
-The shortest path from `git clone` to an authenticated Keystone API call driven
-by a single **c5c3 ControlPlane** CR. Where the [Quick Start](./quick-start.md)
-stops at a hand-applied `Keystone` CR, here one `ControlPlane` CR makes the
-c5c3-operator provision the `MariaDB`, `Memcached`, `Keystone`, `Horizon`, and
-`Glance` children, mint the admin application credential through
-[K-ORC](https://github.com/k-orc/openstack-resource-controller), mirror it to
-OpenBao, and register the identity catalog — all reconciled to an aggregate
-`Ready`.
+This guide takes a single **c5c3 ControlPlane** CR from `git clone` to an authenticated
+Keystone API call. Compared with the [Quick Start](./quick-start.md), the
+c5c3-operator now provisions the `MariaDB`, `Memcached`, `Keystone`, `Horizon`,
+and `Glance` children, mints the admin application credential through
+[K-ORC](https://github.com/k-orc/openstack-resource-controller), mirrors it to
+OpenBao, and registers the identity catalog.
 
 ## Prerequisites
 
-Same toolchain as the [Quick Start](./quick-start.md), plus an internet
-connection (K-ORC is cloned from GitHub at a pinned tag).
+Same toolchain as the [Quick Start](./quick-start.md), plus:
 
-The bundled kind `ControlPlane` CR pins its backing services to a single instance
-(`spec.infrastructure.database.replicas: 1`, `cache.replicas: 1`) so the
-fresh-create chain fits a single-node kind cluster: `database.replicas: 1` yields
-a single-instance, non-Galera MariaDB (the operator derives Galera from
-`replicas > 1`) and `cache.replicas: 1` a single Memcached pod. The CRD default for
-both is `3` — a 3-node Galera cluster plus three Memcached pods, matching the
-production baseline — which OOM-kills a laptop-sized kind. To provision the
-production-shaped topology on a bigger box, set `CONTROLPLANE_DB_REPLICAS=3` and/or
-`CONTROLPLANE_CACHE_REPLICAS=N` for Step 2 (`2` is rejected for the database —
-Galera needs a quorum). `database.replicas` is immutable after the CR is created,
-so change it on a fresh environment (`make teardown-infra` first).
+- The OpenStack CLI (`python-openstackclient`) on `PATH` for the auth check in Step 6
+- A stable internet connection while `make deploy-infra` clones K-ORC from GitHub
+- Roughly 8 GB RAM, 2 CPU cores, and 10 GB of free disk for a laptop-sized kind cluster
 
-The bundled CR also pins the MariaDB volume to a test size
-(`spec.infrastructure.database.storageSize: 512Mi`). The CRD default is `100Gi` —
-the production volume size — which a kind/CI run never fills, so the managed MariaDB
-requests a small volume instead. To mirror the production volume on a bigger box,
-set `CONTROLPLANE_DB_STORAGE=100Gi` for Step 2 (any Kubernetes quantity in
-`Mi`/`Gi`/`Ti` is accepted). Like `database.replicas`, `database.storageSize` is
-immutable after the CR is created — the MariaDB operator refuses to resize a live
-volume — so change it on a fresh environment (`make teardown-infra` first).
+- The bundled kind `ControlPlane` CR pins its backing services to a single
+  instance (`spec.infrastructure.database.replicas: 1`, `cache.replicas: 1`) so
+  the fresh-create chain fits a single-node kind cluster.
+- `database.replicas: 1` yields a single-instance, non-Galera MariaDB and
+  `cache.replicas: 1` a single Memcached pod. The CRD default for both is `3`,
+  which matches the production baseline but OOM-kills a laptop-sized kind.
+- On a bigger box, set `CONTROLPLANE_DB_REPLICAS=3` and/or
+  `CONTROLPLANE_CACHE_REPLICAS=N` for Step 2. `2` is rejected for the database —
+  Galera needs a quorum.
+- `database.replicas` is immutable after the CR is created, so change it on a
+  fresh environment (`make teardown-infra` first).
+
+- The bundled CR also pins the MariaDB volume to a test size
+  (`spec.infrastructure.database.storageSize: 512Mi`).
+- The CRD default is `100Gi`, which a kind/CI run never fills, so the managed
+  MariaDB requests a small volume instead.
+- To mirror the production volume on a bigger box, set
+  `CONTROLPLANE_DB_STORAGE=100Gi` for Step 2. Any Kubernetes quantity in
+  `Mi`/`Gi`/`Ti` is accepted.
+- Like `database.replicas`, `database.storageSize` is immutable after the CR is
+  created, so change it on a fresh environment (`make teardown-infra` first).
 
 ```bash
 make install-test-deps
@@ -70,6 +72,8 @@ itself; you create and apply that in Step 3. In this mode the ControlPlane provi
 maps the Gateway to a non-privileged host port for macOS; on Linux with rootful
 Docker drop the override and use port `443`. Expect **5–10 minutes**.
 
+If a download or image pull fails, run `make teardown-infra` and repeat Step 2.
+
 ::: tip Fresh operator images after a merge
 The operator images are published under the mutable `:latest` tag, so
 deploy-infra pins them to the digest current at deploy time (per-operator
@@ -82,25 +86,21 @@ no redeploy needed.
 
 ## Step 3 — Create the ControlPlane CR
 
-Apply a `ControlPlane` CR — the c5c3-operator reconciles it into the whole stack.
-You only supply `openStackRelease` and the `services.keystone` block: the
-defaulting webhook fills the infrastructure and admin-credential references with
-their well-known names — `openstack-db` (managed MariaDB), `openstack-memcached`
-(managed Memcached), `keystone-db` (DB-credential placeholder — in managed mode
-the operator projects a per-ControlPlane `{name}-keystone-db-credentials`
-Secret and points the Keystone CR at it instead), `keystone-admin` / `password`
-(admin-password placeholder — in managed mode the operator projects a per-ControlPlane
-`{name}-keystone-admin-credentials` Secret and points the Keystone CR at it instead),
-`k-orc-clouds-yaml` with cloud entry `admin`
-(K-ORC clouds.yaml) — which match the Secrets and clusters the infrastructure
-layer (Step 2) seeds. The c5c3-operator seeds the K-ORC bootstrap
-`clouds.yaml` per-CR, deriving the in-cluster Keystone auth URL from the CR's own
-name, so the CR name is no longer pinned by a pre-seeded `clouds.yaml`; to use a
-different name, pass `CONTROLPLANE_NAME=foo` to Step 2 — it renames the bundled CR
-and seeds the matching admin password. The defaulting only fills the
-names/references; the operator still **consumes** the pre-seeded Secret *content*
-(DB credentials, admin password) and materialises the bootstrap `clouds.yaml`
-itself, so it does **not invent** credentials.
+Apply a `ControlPlane` CR. You only supply `openStackRelease` and the
+`services.keystone` block; the defaulting webhook fills the infrastructure and
+admin-credential references with their well-known names:
+
+- `openstack-db` and `openstack-memcached` for the managed infrastructure
+- `keystone-db` and `keystone-admin` / `password` as placeholders that the
+  operator replaces with per-ControlPlane Secrets in managed mode
+- `k-orc-clouds-yaml` with the `admin` cloud entry
+
+The c5c3-operator seeds the K-ORC bootstrap `clouds.yaml` per CR, deriving the
+in-cluster Keystone auth URL from the CR name. To use a different name, pass
+`CONTROLPLANE_NAME=foo` to Step 2; it renames the bundled CR and seeds the
+matching admin password. The defaulting only fills the names and references;
+the operator still consumes the pre-seeded Secret content and materialises the
+bootstrap `clouds.yaml` itself.
 
 ```yaml
 # controlplane.yaml

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -20,9 +20,11 @@ OpenBao, and registers the identity catalog.
 
 Same toolchain as the [Quick Start](./quick-start.md), plus:
 
-- The OpenStack CLI (`python-openstackclient`) on `PATH` for the auth check in Step 6
+- `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
+- The OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/installation/index.html)) on `PATH` for the auth check in Step 6
 - A stable internet connection while `make deploy-infra` clones K-ORC from GitHub
 - Roughly 8 GB RAM, 2 CPU cores, and 10 GB of free disk for a laptop-sized kind cluster
+- `yq` v4.x on `PATH` for the `KIND_HOST_PORT=8443` override path in Step 2
 
 - The bundled kind `ControlPlane` CR pins its backing services to a single
   instance (`spec.infrastructure.database.replicas: 1`, `cache.replicas: 1`) so

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -46,7 +46,25 @@ identical to what CI validates.
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | see below |
 | [Helm](https://helm.sh/docs/intro/install/) | platform installer |
 | [jq](https://jqlang.org/download/) | platform installer |
-| [Flux CLI](https://fluxcd.io/flux/installation/) | **Optional — debugging only.** `make deploy-infra` bootstraps Flux via flux-operator + `FluxInstance` and does not require the CLI. Install it only to run ad-hoc `flux logs` or `flux get` commands against a live cluster. |
+
+**Optional:** [Flux CLI](https://fluxcd.io/flux/installation/) for ad-hoc debugging only. `make deploy-infra` bootstraps Flux via flux-operator + `FluxInstance` and does not require the CLI.
+
+::: tip Nix users
+Instead of `make install-test-deps`, you can run `nix develop` to get every
+tool in the table above — plus `controller-gen`, `gofumpt`, `golangci-lint`,
+`kustomize`, `chainsaw`, and the envtest assets — at the versions CI pins. See
+[Nix Development Environment](./contributing/nix-dev-environment.md). Docker
+still has to be installed separately (kind needs a running daemon).
+:::
+
+---
+
+## Step 1 — Clone the repository
+
+```bash
+git clone https://github.com/c5c3/forge.git
+cd forge
+```
 
 The project ships a helper script that downloads and verifies kind and kubectl with pinned
 SHA256 checksums. The authoritative versions are declared at the top of
@@ -67,23 +85,6 @@ By default, binaries are installed to `~/.local/bin`. Make sure that directory i
 
 ```bash
 export PATH="${HOME}/.local/bin:${PATH}"
-```
-
-::: tip Nix users
-Instead of `make install-test-deps`, you can run `nix develop` to get every
-tool in the table above — plus `controller-gen`, `gofumpt`, `golangci-lint`,
-`kustomize`, `chainsaw`, and the envtest assets — at the versions CI pins. See
-[Nix Development Environment](./contributing/nix-dev-environment.md). Docker
-still has to be installed separately (kind needs a running daemon).
-:::
-
----
-
-## Step 1 — Clone the repository
-
-```bash
-git clone https://github.com/c5c3/forge.git
-cd forge
 ```
 
 ---

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -49,6 +49,13 @@ identical to what CI validates.
 
 **Optional:** [Flux CLI](https://fluxcd.io/flux/installation/) for ad-hoc debugging only. `make deploy-infra` bootstraps Flux via flux-operator + `FluxInstance` and does not require the CLI.
 
+Use Docker Desktop on macOS. On Linux, use rootful Docker or Podman if you
+prefer; the host-port override path documents the privileged-port tradeoffs for
+those runtimes below.
+
+You need `make` for the install and deployment targets below. The `KIND_HOST_PORT`
+override path also needs `yq` v4.x on `PATH`.
+
 ::: tip Nix users
 Instead of `make install-test-deps`, you can run `nix develop` to get every
 tool in the table above — plus `controller-gen`, `gofumpt`, `golangci-lint`,
@@ -193,7 +200,7 @@ c5c3-operator, and the MariaDB root password is expected from a non-kind Flux Ma
 baseline.
 :::
 
-Expected duration: **5–10 minutes** on first run (image pulls dominate).
+Expected duration: **5–10 minutes** on first run.
 
 ::: tip Configurable timeouts
 Override the default timeouts via environment variables if your machine is slow:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,6 +18,7 @@ the production HelmRelease, E2E and Tempest, see
 ## Prerequisites
 
 - Docker Desktop running
+- OpenStack CLI (`python-openstackclient`) on `PATH` for the authenticated token check in Step 6
 - Pinned `kind`, `kubectl`, `Helm`, `jq` on `PATH`:
 
   ```bash
@@ -26,6 +27,7 @@ the production HelmRelease, E2E and Tempest, see
   ```
 
 - `yq` on `PATH` (only required because `KIND_HOST_PORT` is overridden)
+- A stable internet connection for the initial image pulls and package downloads
 
 ## Step 1 — Clone
 
@@ -53,6 +55,9 @@ redoing them, so an interrupted bootstrap can simply be re-executed. Optional
 components can be enabled later by re-running with the flag set — see the
 opt-in tips in the [Extended Quick Start](./quick-start-extended.md). Removing a
 flag does not uninstall that component — that is `make teardown-infra`'s job.
+
+If the first run fails because a download or image pull flakes out, run
+`make teardown-infra` and then repeat Step 2.
 
 ## Step 3 — Keystone operator
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,16 +9,18 @@ SPDX-License-Identifier: Apache-2.0
 
 # Quick Start
 
-The shortest path from `git clone` to an authenticated Keystone API call on
-**macOS** with kind on host port **`8443`** — no `vmnetd` helper, no
-privileged port binding. For UI tours, fallbacks, the local-build path,
-the production HelmRelease, E2E and Tempest, see
+This macOS quick start gets you from `git clone` to an authenticated Keystone
+API call on kind host port **`8443`** — no `vmnetd` helper, no privileged port
+binding. For the Keystone identity service reference, see
+[Keystone Operator](./reference/keystone/index.md). For UI tours, fallbacks,
+the local-build path, the production HelmRelease, E2E and Tempest, see
 [Quick Start (Extended)](./quick-start-extended.md).
 
 ## Prerequisites
 
 - Docker Desktop running
-- OpenStack CLI (`python-openstackclient`) on `PATH` for the authenticated token check in Step 6
+- `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
+- OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/installation/index.html)) on `PATH` for the authenticated token check in Step 6
 - Pinned `kind`, `kubectl`, `Helm`, `jq` on `PATH`:
 
   ```bash
@@ -26,7 +28,7 @@ the production HelmRelease, E2E and Tempest, see
   export PATH="${HOME}/.local/bin:${PATH}"
   ```
 
-- `yq` on `PATH` (only required because `KIND_HOST_PORT` is overridden)
+- `yq` v4.x on `PATH` (only required because `KIND_HOST_PORT` is overridden)
 - A stable internet connection for the initial image pulls and package downloads
 
 ## Step 1 — Clone
@@ -47,7 +49,7 @@ then installs Flux, cert-manager, the Gateway API CRDs,
 prometheus-operator-crds, OpenBao (initialised, unsealed and bootstrapped),
 MariaDB operator + `openstack-db`, External Secrets, Memcached operator +
 `openstack-memcached`, Envoy Gateway and the shared `openstack-gw`. Expect
-**5–10 minutes** on first run (image pulls dominate).
+**5–10 minutes** on first run.
 
 `make deploy-infra` is safe to re-run: a run with the same parameters detects
 the existing cluster and the steps already completed and converges without
@@ -71,6 +73,10 @@ kubectl wait helmrelease/keystone-operator -n keystone-system \
 ## Step 4 — Keystone service image
 
 > Note: the keystone-operator controller runs in `keystone-system`; the Keystone workload it manages runs in `openstack` (controller-vs-workload split).
+
+> The `2025.2` image tag below matches the OpenStack release pinned in this
+> repository under `releases/2025.2/`; if you are following a different release
+> branch, substitute the matching tag there.
 
 ```bash
 RELEASE=2025.2


### PR DESCRIPTION
Updated quickstart docs to close the gaps around prerequisites, references, and failure handling

Refined quickstart wording. Clarified macOS versus Linux/Podman guidance, documented keystone release information.
