### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Chainsaw E2E).
 Outstanding work is tracked in [GitHub Issues](https://github.com/c5c3/forge/issues) — the issue
 tracker is the single source of truth for planned features (`CC-NNNN` labels), production-hardening
 gaps, and release milestones.
+
+## Security
+
+Found a vulnerability? Please report it privately through GitHub Private Vulnerability
+Reporting rather than opening a public issue. See [SECURITY.md](SECURITY.md) for the
+reporting process, scope, and response expectations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,101 @@
+# Security Policy
+
+CobaltCore (C5C3) is a Kubernetes-native OpenStack distribution for operating
+Hosted Control Planes across a multi-cluster topology (Management, Control
+Plane, Hypervisor, Storage). This repository delivers everything needed to run
+that stack — from infrastructure deployment manifests through the service
+operators to the c5c3-operator orchestration layer — built with Operator SDK
+(Go), controller-runtime, and Kubebuilder.
+
+We take the security of these components seriously and appreciate the effort of
+anyone who reports a potential issue responsibly.
+
+## Supported versions
+
+The project is under active development and has not yet published a tagged
+release. Security fixes are applied to the `main` branch, which is the only
+branch that currently receives them.
+
+| Version               | Supported          |
+| --------------------- | ------------------ |
+| `main` (development)  | :white_check_mark: |
+| Tagged releases       | none yet           |
+
+Once versioned releases are published, this section will list the release lines
+that continue to receive security updates.
+
+## Reporting a vulnerability
+
+Please report vulnerabilities **privately**. Do not open a public issue, pull
+request, or discussion for a suspected security problem.
+
+Use GitHub's Private Vulnerability Reporting:
+
+1. Open the repository's **Security** tab.
+2. Select **Advisories → Report a vulnerability**.
+3. Fill in the report form with as much detail as you can (see below).
+
+Direct link:
+<https://github.com/C5C3/forge/security/advisories/new>
+
+A good report includes:
+
+- the affected component (an operator binary, a controller, CRD validation,
+  generated manifests/RBAC, or a container image) and, if known, the version,
+  commit, or image digest;
+- a description of the impact and the conditions required to trigger it;
+- reproduction steps, a proof of concept, or the relevant manifests/CR;
+- any suggested remediation.
+
+## Scope
+
+**In scope**
+
+- The service operators under `operators/` (Keystone, Glance, Horizon, and any
+  later additions) and the c5c3-operator orchestration layer, including their
+  controllers and reconcilers.
+- CRD schema and validation, including the validating webhooks.
+- Generated manifests and RBAC shipped in the Helm charts and `config/`.
+- Container images built from `images/`.
+- The shared library (`internal/common/`) used by the operators.
+
+**Out of scope**
+
+- Upstream OpenStack services themselves (Keystone, Glance, Horizon, …) — report
+  those to the
+  [OpenStack Vulnerability Management Team](https://security.openstack.org/).
+- Third-party operators and dependencies deployed alongside the stack
+  (for example MariaDB, OpenBao, memcached, cert-manager, External Secrets) —
+  report those to their respective projects.
+- Findings that require privileged cluster access already sufficient to
+  compromise the workload by other means.
+- User misconfiguration that does not stem from an insecure default shipped by
+  this repository.
+
+## Response expectations
+
+- **Acknowledgement:** within 3 business days of the report.
+- **Initial assessment:** within 10 business days, including a severity
+  estimate and whether the report is accepted, needs more information, or is
+  out of scope.
+- **Coordinated disclosure:** we aim to release a fix and publish an advisory
+  within 90 days of triage. We will keep you informed of progress and agree on
+  a disclosure date with you before going public.
+
+Timelines may vary with the complexity of the issue; we will communicate if we
+need longer.
+
+## Coordinated disclosure and safe harbor
+
+Good-faith security research is welcome. We will not pursue or support legal
+action against researchers who:
+
+- make a good-faith effort to avoid privacy violations, data destruction, and
+  service disruption while researching;
+- report a vulnerability promptly and give us reasonable time to remediate
+  before any public disclosure;
+- do not access or modify data beyond what is necessary to demonstrate the
+  issue.
+
+If you would like to be credited in the advisory, let us know in your report;
+otherwise reports are handled confidentially.


### PR DESCRIPTION
## Summary

Add a top-level `SECURITY.md` so external researchers and downstream users have
a discoverable, private path for reporting vulnerabilities. GitHub surfaces the
file in the Security tab and links to it from advisories, and it satisfies the
OpenSSF Scorecard *Security-Policy* check.

The policy is service-agnostic, so it stays correct as more operators are
onboarded. It documents:

- **Supported versions** — fixes land on the `main` branch; no tagged release
  exists yet.
- **Reporting channel** — GitHub Private Vulnerability Reporting only, with a
  direct advisory link and a note not to open public issues.
- **Scope** — in scope: the operators under `operators/` (Keystone, Glance,
  Horizon, and later additions), the c5c3-operator orchestration layer, CRD
  validation and webhooks, generated manifests/RBAC, container images from
  `images/`, and `internal/common/`; out of scope: upstream OpenStack (routed
  to the OpenStack VMT), third-party operators, and user misconfiguration.
- **Response expectations** — 3-business-day acknowledgement, 10-business-day
  triage, 90-day coordinated disclosure.
- **Coordinated disclosure and safe harbor** — good-faith research welcome,
  optional credit.

A short Security section in `README.md` points to the policy. The opening
paragraph mirrors the README overview.

Closes #335

## Remaining acceptance criterion

Enabling *Settings → Code security → Private vulnerability reporting* is a
repository-settings action outside this PR and is left as a manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)