### PR TITLE
docs: land on an in-docs overview instead of a hero page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -13,11 +13,17 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'Quick Start', link: '/quick-start' },
+      { text: 'Guides', link: '/guides/observability' },
+      { text: 'Reference', link: '/reference/keystone/' },
+      { text: 'Future', link: '/future/' },
+      { text: 'Contributing', link: '/contributing/adding-a-new-operator' },
     ],
     sidebar: [
       {
         text: 'Getting Started',
         items: [
+          { text: 'Overview', link: '/' },
           { text: 'Quick Start', link: '/quick-start' },
           { text: 'Quick Start (Extended)', link: '/quick-start-extended' },
           { text: 'Quick Start (ControlPlane)', link: '/quick-start-controlplane' },
@@ -182,6 +188,13 @@ export default defineConfig({
     ],
     socialLinks: [
       { icon: 'github', link: 'https://github.com/c5c3/forge' },
+      {
+        icon: {
+          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M18 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"/></svg>',
+        },
+        link: 'https://deepwiki.com/C5C3/forge',
+        ariaLabel: 'DeepWiki',
+      },
     ],
   },
 })

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,64 @@
 ---
-layout: home
-hero:
-  name: CobaltCore Forge
-  text: Kubernetes-native OpenStack
-  tagline: Operator-driven OpenStack distribution for Hosted Control Planes
-  actions:
-    - theme: brand
-      text: Quick Start
-      link: /quick-start
-    - theme: alt
-      text: Reference Docs
-      link: /reference/keystone/keystone-crd
-features:
-  - title: Operators
-    details: Service operators following a shared sub-reconciler pattern, with Keystone as the reference implementation and c5c3-operator as the ControlPlane orchestration layer.
-  - title: Backend & Shared Library
-    details: Common types, conditions, config rendering, and Kubernetes helpers in internal/common/, plus Helm chart, operator packaging, and rotation scripts.
-  - title: Infrastructure Stack
-    details: Declarative FluxCD HelmReleases for OpenBao HA, External Secrets Operator, MariaDB, and Memcached.
-  - title: CI/CD & Container Images
-    details: GitHub Actions workflows for CI and image builds, plus multi-stage builds for OpenStack service images, Tempest, python-base, and the venv-builder.
-  - title: Test Suites
-    details: Unit, envtest integration, Chainsaw E2E, Tempest, and Chaos Mesh coverage across the stack.
-  - title: Day 2 Operations
-    details: Guides for observability, key rotation, multi-tenant deployment, and advanced configuration.
-  - title: Maintenance & Dependencies
-    details: <a href="/forge/contributing/dependency-management">Dependency Management</a> — Go version upgrades, library updates, and the Renovate workflow.
+title: Overview
 ---
+
+# CobaltCore Forge
+
+CobaltCore (C5C3) is a Kubernetes-native OpenStack distribution for operating
+Hosted Control Planes across a multi-cluster topology — Management, Control
+Plane, Hypervisor, and Storage. This repository delivers everything needed for
+a self-contained Keystone deployment stack: from the declarative infrastructure
+manifests, through the service operators, to the c5c3-operator orchestration
+layer — built with the Operator SDK (Go), controller-runtime, and Kubebuilder.
+
+The implementation follows a Keystone-first strategy. The Keystone operator is
+the reference implementation that establishes the patterns — CRD layout,
+sub-reconciler chain, webhooks, finalizers, instrumentation — replicated by
+every subsequent service operator. Horizon and Glance are already onboarded on
+the same scaffolding, and the c5c3-operator ties the services together into a
+single ControlPlane resource.
+
+## Start here
+
+- **[Quick Start](./quick-start.md)** — from `git clone` to an authenticated
+  Keystone API call on a local kind cluster.
+- **[Quick Start (Extended)](./quick-start-extended.md)** — UI tours, the
+  local-build path, the production HelmRelease, E2E, and Tempest.
+- **[Quick Start (ControlPlane)](./quick-start-controlplane.md)** — bring up a
+  full ControlPlane through the c5c3-operator.
+
+## What's inside
+
+- **Operators.** Service operators following a shared sub-reconciler pattern,
+  with [Keystone](./reference/keystone/) as the reference implementation and the
+  [c5c3-operator](./reference/c5c3/controlplane-crd.md) as the ControlPlane
+  orchestration layer. [Horizon](./reference/horizon/) and
+  [Glance](./reference/glance/) are onboarded on the same conventions.
+- **Shared library.** Common types, conditions, config rendering, and
+  Kubernetes helpers in `internal/common/`, plus the Helm chart, operator
+  packaging, and rotation scripts. See the
+  [Backend reference](./reference/backend/helm-values-schema.md).
+- **Infrastructure stack.** Declarative FluxCD HelmReleases for OpenBao HA,
+  External Secrets Operator, MariaDB, Memcached, and the Envoy Gateway. See
+  [Infrastructure Manifests](./reference/infrastructure/infrastructure-manifests.md).
+- **CI/CD & container images.** GitHub Actions for CI and image builds, plus
+  multi-stage builds for the OpenStack service images, Tempest, and the
+  python-base / venv-builder layers. See the
+  [CI Workflow](./reference/ci-cd/ci-workflow.md).
+- **Test suites.** Unit, envtest integration, Chainsaw E2E, Tempest, and Chaos
+  Mesh coverage across the stack — see the
+  [Testing reference](./reference/testing/keystone-e2e-tests.md).
+
+## Go deeper
+
+- **[Guides](./guides/observability.md)** — day-2 operations, key rotation,
+  multi-tenant deployment, identity backends, and advanced configuration.
+- **[Reference](./reference/keystone/)** — CRDs, reconciler architecture,
+  controller events, metrics, and the infrastructure and CI/CD internals.
+- **[Future](./future/)** — idea sketches for where the operators could go next.
+- **[Contributing](./contributing/adding-a-new-operator.md)** — onboard a new
+  operator or release, follow the guide conventions, and set up the development
+  environment.
+
+For an AI-assisted tour of the codebase, browse the repository on
+[DeepWiki](https://deepwiki.com/C5C3/forge).


### PR DESCRIPTION
## Summary

Visiting the site root (`https://c5c3.github.io/forge`) now opens an
**Overview inside the docs** — with the sidebar visible — instead of a
dedicated `layout: home` hero landing page.

## Changes

- **Remove the hero landing page.** `docs/index.md` is now a regular
  documentation page titled "CobaltCore Forge" that renders at `/` with
  the docs layout and sidebar.
- **Add an explicit Overview.** A new "Overview" entry is the first item
  under *Getting Started* in the sidebar, linking to `/`. The page routes
  readers onward via three blocks: *Start here* (Quick Starts),
  *What's inside* (each area linked to its reference), and *Go deeper*
  (Guides, Reference, Future, Contributing).
- **Expand the top navigation bar.** Beyond "Home", the top bar now
  carries Quick Start, Guides, Reference, Future, and Contributing.
- **Link DeepWiki.** Added [DeepWiki](https://deepwiki.com/C5C3/forge)
  as a social link next to the GitHub icon.

## Verification

- `npm run docs:build` completes cleanly (the pre-existing `promql`
  syntax-highlighting warnings are unrelated).
- VitePress fails hard on broken internal links, so a passing build
  confirms every new link on the Overview resolves.
- The built `index.html` no longer emits the `VPHome` hero component and
  renders `<h1>CobaltCore Forge` within a `VPDoc` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)