### PR TITLE
docs: document both operators in the Helm values reference

### DIFF
--- a/docs/reference/backend/helm-values-schema.md
+++ b/docs/reference/backend/helm-values-schema.md
@@ -6,14 +6,28 @@ quadrant: backend
 # Helm Values Schema
 
 Reference documentation for the `values.schema.json` JSON Schema that validates
-Helm chart values for the keystone-operator chart. Helm enforces this schema automatically
-during `helm install`, `helm upgrade`, `helm lint`, and `helm template`.
+the Helm chart values of every forge operator — **keystone-operator** and
+**c5c3-operator**, plus the glance-operator and horizon-operator siblings. Helm
+enforces this schema automatically during `helm install`, `helm upgrade`,
+`helm lint`, and `helm template`.
+
+All charts share one schema source, so the value tables below apply to every
+operator unchanged. The few keys that exist on only some charts are called out
+in the [per-operator applicability matrix](#per-operator-applicability). Chart
+values themselves — the keystone-operator and c5c3-operator defaults, resource
+recommendations, and ready-to-use override snippets — are in
+[Values by operator](#values-by-operator) at the end.
 
 ## File Location
 
-```text
-operators/keystone/helm/keystone-operator/values.schema.json
-```
+Each chart ships its own generated copy of the schema:
+
+| Chart | Schema path |
+| --- | --- |
+| keystone-operator | `operators/keystone/helm/keystone-operator/values.schema.json` |
+| c5c3-operator | `operators/c5c3/helm/c5c3-operator/values.schema.json` |
+| glance-operator | `operators/glance/helm/glance-operator/values.schema.json` |
+| horizon-operator | `operators/horizon/helm/horizon-operator/values.schema.json` |
 
 ::: warning Generated file
 This schema is generated from the shared source in
@@ -35,8 +49,29 @@ ensuring typos and unsupported keys are caught at deploy time rather than silent
 | Property | Value |
 | --- | --- |
 | JSON Schema Draft | `draft-07` |
-| Chart version | `0.5.0` |
 | `additionalProperties` | `false` at all object levels |
+
+Each chart carries its own version in its `Chart.yaml`; the schema is not tied
+to a chart version, so it is not repeated here.
+
+## Per-Operator Applicability
+
+Every chart exposes the same core value keys. Three keys are conditional on what
+a chart actually ships, so they are present only where they apply:
+
+| Key | keystone-operator | c5c3-operator | glance-operator | horizon-operator |
+| --- | :---: | :---: | :---: | :---: |
+| `image`, `replicas`, `resources`, `rbac`, `leaderElection`, `webhook`, `metrics`, `logging`, `monitoring`, `serviceAccount`, `controller`, `nameOverride`, `fullnameOverride` | Yes | Yes | Yes | Yes |
+| `networkPolicy` | Yes | — | Yes | Yes |
+| `federation` | Yes | — | — | — |
+
+- `networkPolicy` is emitted for every chart that ships a
+  `templates/networkpolicy.yaml` (all service operators); the c5c3-operator does
+  not, so the key is rejected there.
+- `federation` is keystone-only — only the keystone-operator registers the
+  SSRF-guarded federation-metadata client flag.
+- `controller.maxConcurrentReconciles` is accepted by every chart, but only the
+  controllers that opt in consume it (see [controller](#controller)).
 
 ## Validated Properties
 
@@ -96,6 +131,21 @@ for the privilege-escalation path this closes. The default stays `false` because
 | --- | --- | --- | --- |
 | `leaderElection.enabled` | `boolean` | — | `true` |
 
+### controller
+
+| Field | Type | Constraint | Default |
+| --- | --- | --- | --- |
+| `controller.maxConcurrentReconciles` | `integer` | minimum: `1` | unset |
+
+The maximum number of CRs that may reconcile concurrently
+(controller-runtime `MaxConcurrentReconciles`), rendered as
+`--max-concurrent-reconciles`. Left unset in the c5c3-operator chart; the
+keystone-operator chart defaults it to `2` (the upstream default of `1`
+serialises reconciles across CRs, so one slow or flapping CR delays every
+other). Raise to 5–10 for fleets with many CRs. The key is accepted by every
+chart, but only controllers that opt in consume it — the c5c3-operator accepts
+the flag without acting on it yet.
+
 ### webhook
 
 | Field | Type | Constraint | Default |
@@ -120,7 +170,10 @@ See [How to enable the Keystone operator metrics endpoint](../../guides/keystone
 ### networkPolicy
 
 The `networkPolicy` block (default-off operator pod hardening with fail-closed
-render guards) is validated by the schema as well; its fields are documented in
+render guards) is validated by the schema on every chart that ships a
+`templates/networkpolicy.yaml` — keystone-operator, glance-operator, and
+horizon-operator. The c5c3-operator does not ship the template, so the key is
+rejected there. Its fields are documented in
 [Keystone Operator NetworkPolicy](../keystone/keystone-operator-networkpolicy.md).
 
 ### federation
@@ -129,9 +182,10 @@ render guards) is validated by the schema as well; its fields are documented in
 | --- | --- | --- | --- |
 | `federation.metadataAllowCidrs` | `array` | each item matches the shared `cidr` pattern definition | `[]` |
 
-The `federation` block is keystone-only — like `networkPolicy`, it is layered
-onto the keystone-operator schema alone (the sibling operators do not register
-the flag). Each `metadataAllowCidrs` entry is validated against the same shared
+The `federation` block is keystone-only — it is layered onto the
+keystone-operator schema alone (unlike `networkPolicy`, which every service
+operator registers; the sibling operators do not register the federation flag).
+Each `metadataAllowCidrs` entry is validated against the same shared
 `cidr` pattern definition the `networkPolicy` block reuses. The rendered
 `--federation-metadata-allow-cidrs` flag and its runtime semantics are covered in
 the [keystone-operator packaging reference](./keystone-operator-packaging.md#federation).
@@ -231,3 +285,113 @@ Schema validation is tested with helm-unittest in
 | Exponent-only quantities | `cpu: "1e3"` |
 | Conditional constraint | `rbac.namespaceScoped=true` with `webhook.enabled=false` |
 | Logging overrides | `development: true`, `level: debug`, `encoder: console` |
+
+## Values by Operator
+
+The schema above is shared; the shipped **defaults** differ only where a chart
+does not carry a key. The table below is the practical values summary for the
+two operators this reference centres on. The glance-operator and horizon-operator
+follow the keystone-operator defaults — including `controller.maxConcurrentReconciles: 2`
+— and differ only by their own `image.repository`, their `webhook.enabled`
+description, and by carrying no `federation` key (see the
+[applicability matrix](#per-operator-applicability)).
+
+| Key | keystone-operator | c5c3-operator |
+| --- | --- | --- |
+| `image.repository` | `ghcr.io/c5c3/keystone-operator` | `ghcr.io/c5c3/c5c3-operator` |
+| `image.tag` | `""` (falls back to `.Chart.AppVersion`) | `""` (falls back to `.Chart.AppVersion`) |
+| `image.pullPolicy` | `IfNotPresent` | `IfNotPresent` |
+| `replicas` | `2` | `2` |
+| `resources.requests` | `cpu: 10m`, `memory: 64Mi` | `cpu: 10m`, `memory: 64Mi` |
+| `resources.limits` | `cpu: 500m`, `memory: 128Mi` | `cpu: 500m`, `memory: 128Mi` |
+| `rbac.namespaceScoped` | `false` | `false` |
+| `leaderElection.enabled` | `true` | `true` |
+| `controller.maxConcurrentReconciles` | `2` | unset (accepted, not consumed) |
+| `webhook.enabled` | `true` | `true` |
+| `metrics.port` | `8080` | `8080` |
+| `monitoring.serviceMonitor.enabled` | `false` | `false` |
+| `networkPolicy.enabled` | `false` | key not present |
+| `federation.metadataAllowCidrs` | `[]` | key not present |
+
+`replicas: 2` runs an active/standby pair: leader election keeps exactly one
+replica reconciling, and the standby takes over on pod loss. The two operators
+never reconcile the same CRs, so they are sized independently.
+
+### Resource Recommendations
+
+The shipped defaults (`requests: 10m/64Mi`, `limits: 500m/128Mi`) are tuned for a
+laptop-sized kind cluster and a handful of CRs. They are a floor, not a
+production target: the requests are deliberately tiny so a dev cluster schedules
+the pod anywhere, and the 128Mi memory limit is close to the working set once an
+operator reconciles many CRs concurrently.
+
+| Profile | requests | limits | Notes |
+| --- | --- | --- | --- |
+| kind / dev (default) | `cpu: 10m`, `memory: 64Mi` | `cpu: 500m`, `memory: 128Mi` | Ships as-is; fits a single-node kind. |
+| Production baseline | `cpu: 100m`, `memory: 128Mi` | `cpu: "1"`, `memory: 256Mi` | Reserve real headroom; raise the memory limit so a reconcile burst does not OOM-kill the pod. |
+| Large fleet | `cpu: 250m`, `memory: 256Mi` | `cpu: "2"`, `memory: 512Mi` | Pair with a higher `controller.maxConcurrentReconciles` (5–10) so the extra CPU is usable. |
+
+Treat these as starting points and confirm against your own load — the
+[reconcile-performance benchmark](../testing/reconcile-performance-benchmark.md)
+measures per-reconcile cost, and a `VerticalPodAutoscaler` in recommendation
+mode is a reliable way to right-size the requests before pinning them.
+
+### Example Overrides
+
+Both charts install with `helm install <release> <chart> -f overrides.yaml`. Only
+the keys you change need to appear; everything else keeps its default.
+
+**keystone-operator — production hardening.** Raise the resources, publish a
+`ServiceMonitor`, widen concurrency, allow federation-metadata fetches against
+the in-cluster identity provider, and turn on the operator NetworkPolicy:
+
+```yaml
+# keystone-overrides.yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: "1"
+    memory: 256Mi
+controller:
+  maxConcurrentReconciles: 5
+monitoring:
+  serviceMonitor:
+    enabled: true          # requires the prometheus-operator CRDs in-cluster
+federation:
+  metadataAllowCidrs:
+    - 10.96.0.0/12         # cluster Service CIDR — reach a trusted in-cluster IdP
+networkPolicy:
+  enabled: true
+  kubeApiServer:
+    # cluster-specific — discover with: kubectl get endpoints kubernetes -o json
+    cidrs: ["10.96.0.1/32"]
+    ports: [6443]
+```
+
+**c5c3-operator — single-namespace, hardened.** The ControlPlane operator has no
+`federation` or `networkPolicy` key; namespace-scoped RBAC is the main hardening
+knob (it requires `webhook.enabled: false`):
+
+```yaml
+# c5c3-overrides.yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: "1"
+    memory: 256Mi
+rbac:
+  namespaceScoped: true    # bounds the operator to its release namespace
+webhook:
+  enabled: false           # required by namespaceScoped: true
+monitoring:
+  serviceMonitor:
+    enabled: true
+```
+
+See the [Multi-Tenant Deployment guide](../../guides/multi-tenant-deployment.md#security-trade-off-the-cluster-wide-rbac-default)
+for the privilege-escalation path `rbac.namespaceScoped: true` closes and the
+[capabilities that still need cluster scope](../../guides/multi-tenant-deployment.md#when-cluster-wide-rbac-is-still-required).


### PR DESCRIPTION
## Summary

The Helm values reference (`docs/reference/backend/helm-values-schema.md`)
described only the keystone-operator chart, so a reader deploying the
c5c3-operator had to infer that the same generated schema applied. This
presents both operators explicitly and fixes two drift points the
single-operator framing had let go stale.

This is the last open item of #371 — the runnable deployment guide and the
CRD API reference that issue also asked for already landed; the issue body is
updated to record what remained.

## Changes

- **Cover every operator chart.** Reframe the intro and the file-location
  table, and add a per-operator applicability matrix for the top-level value
  keys (which keys ship on which chart).
- **Document `controller.maxConcurrentReconciles`**, which previously had no
  section at all.
- **Fix stale scope.** `networkPolicy` ships on every chart with a
  `networkpolicy.yaml` template (keystone, glance, horizon), not keystone
  alone; `federation` stays keystone-only. Drop the hard-coded, now-stale
  chart version from the overview.
- **Add a Values-by-operator section** with the keystone-operator and
  c5c3-operator defaults, kind/dev vs production resource recommendations,
  and ready-to-use override snippets for both charts.

## Verification

- `make check-feature-ids` passes (no internal identifiers introduced).
- Facts cross-checked against each chart's `values.yaml` and
  `hack/gen-helm-values-schema.py`.

Closes #371
