### PR TITLE
fix: c5c3-operator crash-loops when a watched ControlPlane CRD is unserved

### DIFF
--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -23,10 +23,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -631,12 +633,52 @@ func storeToControlPlaneMapper(c client.Reader, watchedKind commonv1.SecretStore
 
 // SetupWithManager registers the ControlPlaneReconciler with the controller
 // manager. It Owns every child CR the sub-reconcilers project (MariaDB,
-// Keystone, the K-ORC ApplicationCredential/Service/Endpoint, the Memcached CR,
-// and the ESO ExternalSecret/PushSecret) so an upstream child status transition
-// retriggers reconcile, Watches Secrets so an admin-password rotation wakes the
-// owning ControlPlane via the field indexer, and Watches the OpenBao-backed
-// ClusterSecretStore so an ESO/OpenBao outage reflects in the credential
-// conditions promptly rather than after the next periodic resync (#476).
+// Keystone, Horizon, Glance/GlanceBackend, the eight K-ORC resources, the
+// Memcached CR, the mTLS Certificate, and the ESO ExternalSecret/PushSecret/
+// VaultDynamicSecret) so an upstream child status transition retriggers
+// reconcile, Watches Secrets so an admin-password rotation wakes the owning
+// ControlPlane via the field indexer, and Watches the OpenBao-backed secret
+// stores so an ESO/OpenBao outage reflects in the credential conditions
+// promptly rather than after the next periodic resync (#476).
+//
+// The legs for kinds a sibling operator owns (Keystone, Horizon, Glance,
+// GlanceBackend and KeystoneIdentityBackend) are registered only when a
+// discovery probe reports the CRD served. The eight K-ORC kinds are NOT among
+// them: like MariaDB, Memcached and the ESO kinds, K-ORC is a hard dependency
+// of every reconcile pass, so its watches stay unconditional (see the Owns
+// block below and the HARD CRD DEPENDENCY note in reconcile_korc.go).
+// Registering a watch for an absent CRD dead-locks manager start: its informer
+// never syncs, controller-runtime aborts on the CacheSyncTimeout, and the elected leader
+// crash-loops while still reporting Ready. When any optional CRD is missing, a
+// leader-gated runnable re-probes discovery and returns an error the moment one
+// appears, restarting the process so the now-served watch is registered on the
+// next pass — the only way to add a watch, since controller-runtime cannot
+// mount one on a running manager (see crd_presence.go). The wiring lives in
+// buildControlPlaneController so the production path and the integration test
+// drive identical leg registration.
+func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Shared controller options: MaxConcurrentReconciles lets independent
+	// CRs reconcile in parallel instead of serialising at the
+	// controller-runtime default of 1, and the tuned RateLimiter caps
+	// per-item failure backoff at 30s rather than the default 1000s (see
+	// bootstrap.ControllerOptions).
+	b := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles))
+
+	b, err := r.buildControlPlaneController(mgr, b)
+	if err != nil {
+		return err
+	}
+	return b.Complete(r)
+}
+
+// buildControlPlaneController applies every watch leg to b and returns it ready
+// to Complete. SetupWithManager and the integration test both call it so the
+// production path and the test drive IDENTICAL leg registration. The legs for
+// optional sibling-operator kinds are gated on a discovery probe
+// (probeOptionalWatches); when the probe reports a kind missing its legs are
+// skipped and a leader-gated crdWatchGate is registered to restart the process
+// once the CRD appears (see crd_presence.go).
 //
 // DECISION (Memcached Owns): memcached.c5c3.io ships no Go module (see
 // memcachedGVK in reconcile_infrastructure.go), so the Memcached child is owned
@@ -651,11 +693,37 @@ func storeToControlPlaneMapper(c client.Reader, watchedKind commonv1.SecretStore
 // the goal of reflecting ESO sync/outage transitions in the credential
 // conditions promptly; a relevance predicate could be added later if the
 // reconcile volume becomes a concern.
-func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ControlPlaneReconciler) buildControlPlaneController(mgr ctrl.Manager, b *builder.Builder) (*builder.Builder, error) {
 	// Register the field indexer before Watches so secretToControlPlaneMapper
 	// can rely on it for its MatchingFields lookup.
 	if err := registerControlPlaneSecretNameIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
-		return err
+		return nil, err
+	}
+
+	disco, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("building discovery client for optional CRD probe: %w", err)
+	}
+
+	served, missing, err := probeOptionalWatches(disco, r.Scheme)
+	if err != nil {
+		// A non-NotFound discovery error (API server unreachable, RBAC
+		// forbidden) aborts setup so the pod restarts rather than silently
+		// dropping watches; NotFound is folded into the served map by the probe.
+		return nil, err
+	}
+
+	// isServed reports whether the API server serves obj's kind, reusing the
+	// discovery result the probe already computed. The GVKForObject error branch
+	// is unreachable in practice — the probe resolved these exact types against
+	// the same scheme — so treating a resolution failure as "not served" (skip
+	// the leg) is a safe degraded answer rather than a fatal setup error.
+	isServed := func(obj client.Object) bool {
+		gvk, err := apiutil.GVKForObject(obj, r.Scheme)
+		if err != nil {
+			return false
+		}
+		return served[gvk]
 	}
 
 	memcached := &unstructured.Unstructured{}
@@ -667,23 +735,24 @@ func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	certificate := &unstructured.Unstructured{}
 	certificate.SetGroupVersionKind(certificateGVK)
 
-	return ctrl.NewControllerManagedBy(mgr).
-		// Shared controller options: MaxConcurrentReconciles lets independent
-		// CRs reconcile in parallel instead of serialising at the
-		// controller-runtime default of 1, and the tuned RateLimiter caps
-		// per-item failure backoff at 30s rather than the default 1000s (see
-		// bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+	// Unconditional legs: the ControlPlane itself, the infrastructure children
+	// the c5c3 operator ships or hard-depends on, and the secret-store watches.
+	b = b.
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate). Together with
 		// the no-op status-write skip in updateStatus this closes the
 		// self-wake loop the bare For() previously allowed.
 		For(&c5c3v1alpha1.ControlPlane{}, builder.WithPredicates(watch.CRUpdatePredicate())).
 		Owns(&mariadbv1alpha1.MariaDB{}).
-		Owns(&keystonev1alpha1.Keystone{}).
-		Owns(&horizonv1alpha1.Horizon{}).
-		Owns(&glancev1alpha1.Glance{}).
-		Owns(&glancev1alpha1.GlanceBackend{}).
+		// The eight K-ORC kinds are a HARD dependency of every reconcile pass:
+		// reconcileKORC unconditionally mints the admin ApplicationCredential and
+		// projects the catalog/identity resources (and reconcileServiceAccounts the
+		// RoleAssignments), reading them through the cached client with no spec or
+		// condition gate. A missing K-ORC CRD would surface there as a no-match
+		// hard error, not a slimmable start-up state, so — like MariaDB, Memcached
+		// and the ESO kinds — these Owns legs stay unconditional rather than sitting
+		// behind the discovery guard below. The manager must fail fast at start if
+		// K-ORC is absent.
 		Owns(&orcv1alpha1.ApplicationCredential{}).
 		Owns(&orcv1alpha1.Service{}).
 		Owns(&orcv1alpha1.Endpoint{}).
@@ -697,14 +766,6 @@ func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&esov1.ExternalSecret{}).
 		Owns(&esov1alpha1.PushSecret{}).
 		Owns(&esgenv1alpha1.VaultDynamicSecret{}).
-		// KeystoneIdentityBackend CRs are authored by the operator, not projected
-		// by the ControlPlane, so they carry no owner reference an Owns() could
-		// match. Watch them by keystoneRef so attaching (or detaching, or the
-		// backend reaching Ready) re-projects the Horizon websso choices and the
-		// Keystone trusted_dashboard without waiting for a periodic resync.
-		Watches(&keystonev1alpha1.KeystoneIdentityBackend{}, handler.EnqueueRequestsFromMapFunc(
-			r.identityBackendToControlPlaneMapper,
-		)).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
 			secretToControlPlaneMapper(mgr.GetClient()),
 		)).
@@ -729,17 +790,57 @@ func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// keep flowing through Owns() alone and neither leg double-enqueues the
 		// other's objects. The Namespace leg installs a cluster-wide Namespace
 		// informer, so the predicate is what keeps that informer from waking the
-		// mapper on every namespace event in the cluster.
-		Watches(&keystonev1alpha1.Keystone{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
-		Watches(&horizonv1alpha1.Horizon{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
-		Watches(&glancev1alpha1.Glance{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
-		Watches(&glancev1alpha1.GlanceBackend{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
+		// mapper on every namespace event in the cluster. (The Keystone, Horizon,
+		// Glance and GlanceBackend cross-namespace legs belong to this group too but
+		// are registered under the discovery guard below, co-located with their Owns.)
 		Watches(&mariadbv1alpha1.MariaDB{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
 		Watches(memcached, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
 		Watches(&esov1.ExternalSecret{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
 		// The namespace itself: a Managed one being deleted out from under a live
 		// ControlPlane must re-drive NamespacesReady rather than wait for the next
 		// periodic resync.
-		Watches(&corev1.Namespace{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate())).
-		Complete(r)
+		Watches(&corev1.Namespace{}, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate()))
+
+	// Guarded legs: kinds owned by a sibling operator whose CRD may be absent.
+	// For each service-operator kind both its Owns leg and its cross-namespace
+	// Watches leg (see the cross-namespace block above) are co-located under one
+	// guard because both informers target the same CRD and both would block
+	// manager start when it is not served.
+	for _, obj := range []client.Object{
+		&keystonev1alpha1.Keystone{},
+		&horizonv1alpha1.Horizon{},
+		&glancev1alpha1.Glance{},
+		&glancev1alpha1.GlanceBackend{},
+	} {
+		if isServed(obj) {
+			b = b.Owns(obj).
+				Watches(obj, crossNamespaceChildHandler(), builder.WithPredicates(crossNamespaceChildPredicate()))
+		}
+	}
+	// KeystoneIdentityBackend CRs are authored by the operator, not projected
+	// by the ControlPlane, so they carry no owner reference an Owns() could
+	// match. Watch them by keystoneRef so attaching (or detaching, or the
+	// backend reaching Ready) re-projects the Horizon websso choices and the
+	// Keystone trusted_dashboard without waiting for a periodic resync.
+	if isServed(&keystonev1alpha1.KeystoneIdentityBackend{}) {
+		b = b.Watches(&keystonev1alpha1.KeystoneIdentityBackend{}, handler.EnqueueRequestsFromMapFunc(
+			r.identityBackendToControlPlaneMapper,
+		))
+	}
+
+	if len(missing) > 0 {
+		msgs := make([]string, 0, len(missing))
+		for _, gvk := range missing {
+			msgs = append(msgs, gvk.String())
+		}
+		ctrl.Log.WithName("setup").Info(
+			"skipping watches for optional CRDs not served by the API server; a leader-gated re-check will restart the operator when one appears",
+			"missingKinds", msgs,
+		)
+		if err := mgr.Add(&crdWatchGate{disco: disco, missing: missing, interval: crdRecheckInterval}); err != nil {
+			return nil, fmt.Errorf("registering crdWatchGate for missing optional CRDs: %w", err)
+		}
+	}
+
+	return b, nil
 }

--- a/operators/c5c3/internal/controller/crd_presence.go
+++ b/operators/c5c3/internal/controller/crd_presence.go
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	glancev1alpha1 "github.com/c5c3/forge/operators/glance/api/v1alpha1"
+	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
+	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// The ControlPlane reconciler watches kinds owned by sibling service operators —
+// Keystone, Horizon and Glance. controller-runtime installs a shared informer for
+// each watched kind and blocks manager start until every informer has synced; on a
+// cluster missing one of those CRDs the informer never syncs, the manager fails start
+// after CacheSyncTimeout, and the leader crash-loops. The helpers here let
+// SetupWithManager register the fragile watches only when their CRD is actually
+// served, so a slimmed-down install (Keystone-only, no Glance) starts clean. The
+// infrastructure hard dependencies — MariaDB, Memcached, the ESO kinds and the eight
+// K-ORC kinds — are deliberately NOT guarded: every reconcile pass reads them
+// unconditionally, so their absence must fail fast rather than defer to a wedged
+// reconcile (see optionalWatchObjects).
+//
+// Presence is decided by a discovery probe against the live API server rather than by
+// checking the runtime scheme: the scheme is compiled in and always advertises every
+// type the binary knows about, so it says nothing about whether the cluster has the
+// CRD installed. Discovery is the only source of truth for what the API server will
+// actually serve a watch for.
+//
+// A CRD installed after start cannot be picked up in place — controller-runtime cannot
+// add a watch to a running manager — so the recovery mechanism is a process restart:
+// crdWatchGate detects the newly served CRD and returns an error that tears down
+// mgr.Start, letting the Deployment restart the leader with the watch now registered.
+
+// serverResourcesLister is the narrow slice of the discovery API the presence probe
+// needs. It is defined here, at the consumer, so the probe depends on one method
+// rather than the whole discovery.DiscoveryInterface: *discovery.DiscoveryClient
+// satisfies it in production and a lightweight stub satisfies it in unit tests.
+type serverResourcesLister interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+// optionalWatchObjects returns one instance of every kind whose CRD is owned by a
+// sibling service operator and may therefore be absent when the c5c3 operator
+// starts. These are exactly the watch legs SetupWithManager must guard behind a
+// discovery probe; the mandatory kinds the c5c3 operator ships itself (ControlPlane)
+// and the infrastructure kinds it hard-depends on — MariaDB, Memcached, the ESO
+// kinds and the eight K-ORC kinds — are intentionally not listed. K-ORC in
+// particular is read unconditionally by every reconcile pass (reconcileKORC,
+// reconcileServiceAccounts), so a missing K-ORC CRD is a fail-fast startup error,
+// not a slimmable state that a guarded watch could paper over.
+func optionalWatchObjects() []client.Object {
+	return []client.Object{
+		&keystonev1alpha1.Keystone{},
+		&horizonv1alpha1.Horizon{},
+		&glancev1alpha1.Glance{},
+		&glancev1alpha1.GlanceBackend{},
+		&keystonev1alpha1.KeystoneIdentityBackend{},
+	}
+}
+
+// servedKindsForGroupVersion asks discovery which Kinds the API server serves under a
+// single GroupVersion and returns them as a set. Querying once per GroupVersion — not
+// once per Kind — is why callers group their GVKs first: the keystone and glance
+// groups each carry two optional kinds, so a per-Kind probe would issue two identical
+// GETs against /apis/keystone.openstack.c5c3.io/v1alpha1 where one suffices.
+//
+// A missing GroupVersion surfaces from discovery as a NotFound error; that is the
+// expected "CRD not installed" signal, so it collapses to an empty set with a nil
+// error rather than a hard error. Any other discovery error (RBAC forbidden, API
+// server unreachable) is a genuine failure the caller must see, so it is wrapped and
+// returned; the wrap string is mandated verbatim by the acceptance criteria. A kind a
+// caller asks about but the returned set omits — for example the keystone group present
+// but the KeystoneIdentityBackend CRD not installed — is simply absent from the set.
+func servedKindsForGroupVersion(disco serverResourcesLister, gv schema.GroupVersion) (map[string]bool, error) {
+	list, err := disco.ServerResourcesForGroupVersion(gv.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("listing server resources for %s: %w", gv, err)
+	}
+	kinds := make(map[string]bool, len(list.APIResources))
+	for _, res := range list.APIResources {
+		kinds[res.Kind] = true
+	}
+	return kinds, nil
+}
+
+// groupByGroupVersion buckets GVKs by their GroupVersion, preserving first-seen order,
+// so every caller probes each GroupVersion against discovery exactly once and then
+// tests all of that group's kinds against the single returned resource list.
+func groupByGroupVersion(gvks []schema.GroupVersionKind) ([]schema.GroupVersion, map[schema.GroupVersion][]schema.GroupVersionKind) {
+	order := make([]schema.GroupVersion, 0, len(gvks))
+	byGV := make(map[schema.GroupVersion][]schema.GroupVersionKind, len(gvks))
+	for _, gvk := range gvks {
+		gv := gvk.GroupVersion()
+		if _, seen := byGV[gv]; !seen {
+			order = append(order, gv)
+		}
+		byGV[gv] = append(byGV[gv], gvk)
+	}
+	return order, byGV
+}
+
+// discoveryProbeAttempts is how many times the startup probe queries one GroupVersion
+// before giving up on a transient (non-NotFound) discovery error; discoveryProbeBackoff
+// is the pause between tries. They are vars, not consts, only so tests can zero the
+// backoff and exercise the retry path without real sleeps.
+var (
+	discoveryProbeAttempts = 3
+	discoveryProbeBackoff  = 500 * time.Millisecond
+)
+
+// servedKindsWithRetry wraps servedKindsForGroupVersion in a bounded retry so a single
+// transient discovery blip during operator (re)start — an apiserver rollout, an etcd
+// defrag/compaction pause, a momentarily overloaded API server returning 5xx — does not
+// abort SetupWithManager and crash-loop the pod. Before this probe existed, GVK→GVR
+// resolution happened lazily during informer sync, which controller-runtime already
+// retries within CacheSyncTimeout; the retry here restores that tolerance for the now
+// eager probe. A NotFound never reaches the retry (servedKindsForGroupVersion folds it
+// to an empty set), so only genuine transient failures are retried and a persistent one
+// still surfaces after the last attempt, aborting setup rather than starting with
+// watches silently dropped.
+func servedKindsWithRetry(disco serverResourcesLister, gv schema.GroupVersion) (map[string]bool, error) {
+	for attempt := 1; ; attempt++ {
+		kinds, err := servedKindsForGroupVersion(disco, gv)
+		if err == nil || attempt >= discoveryProbeAttempts {
+			return kinds, err
+		}
+		time.Sleep(discoveryProbeBackoff)
+	}
+}
+
+// probeOptionalWatches resolves every optional watch object to its GroupVersionKind
+// and probes discovery for it, querying each distinct GroupVersion exactly once. It
+// returns a served map with an entry for all optional kinds (true when the CRD is
+// installed, false when it is not) so callers can gate each watch leg individually,
+// and a missing slice listing the unserved kinds so the crdWatchGate knows which GVKs
+// to keep polling for. A discovery error other than NotFound aborts the whole probe
+// after a bounded retry (servedKindsWithRetry): at start-up a persistently unreachable
+// API server is fatal, not a signal to silently drop watches.
+func probeOptionalWatches(disco serverResourcesLister, scheme *runtime.Scheme) (map[schema.GroupVersionKind]bool, []schema.GroupVersionKind, error) {
+	objs := optionalWatchObjects()
+	gvks := make([]schema.GroupVersionKind, 0, len(objs))
+	for _, obj := range objs {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving GVK for optional watch object %T: %w", obj, err)
+		}
+		gvks = append(gvks, gvk)
+	}
+
+	order, byGV := groupByGroupVersion(gvks)
+	served := make(map[schema.GroupVersionKind]bool, len(gvks))
+	var missing []schema.GroupVersionKind
+	for _, gv := range order {
+		kinds, err := servedKindsWithRetry(disco, gv)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, gvk := range byGV[gv] {
+			ok := kinds[gvk.Kind]
+			served[gvk] = ok
+			if !ok {
+				missing = append(missing, gvk)
+			}
+		}
+	}
+	return served, missing, nil
+}
+
+// crdWatchGate is a manager.Runnable that watches for an optional CRD to appear after
+// the operator has started without it. controller-runtime cannot add a watch to a
+// running manager, so once a missing CRD is installed the only way to register its
+// watch is to restart the process: Start returns an error, mgr.Start unwinds, main
+// exits non-zero, and the Deployment restarts the leader — which re-runs
+// SetupWithManager with the CRD now served. The re-check interval is a field so
+// production can pass a steady constant and unit tests can inject a short one.
+type crdWatchGate struct {
+	disco    serverResourcesLister
+	missing  []schema.GroupVersionKind
+	interval time.Duration
+}
+
+// Start blocks until one of the missing CRDs becomes available, the context is
+// cancelled, or forever if none ever appears. When there is nothing to wait for it
+// returns immediately. A CRD becoming served returns a non-nil error whose message is
+// mandated verbatim by the acceptance criteria; that error is the intended trigger for
+// the process restart, not a fault. Context cancellation — lost leadership or manager
+// shutdown — returns nil, because standing down is not an error. A transient discovery
+// failure on a single tick is logged at V(1) and skipped: a blip in API-server
+// reachability must never be mistaken for "the CRD appeared" and must never abort the
+// gate, so the loop simply retries on the next tick.
+func (g *crdWatchGate) Start(ctx context.Context) error {
+	if len(g.missing) == 0 {
+		return nil
+	}
+	// Group once up front so each tick queries every distinct GroupVersion exactly
+	// once instead of re-fetching it per kind — the keystone and glance groups each
+	// carry two optional kinds.
+	order, byGV := groupByGroupVersion(g.missing)
+	ticker := time.NewTicker(g.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			for _, gv := range order {
+				kinds, err := servedKindsForGroupVersion(g.disco, gv)
+				if err != nil {
+					log.FromContext(ctx).V(1).Info(
+						"discovery probe for optional CRD failed; will retry",
+						"groupVersion", gv, "err", err.Error(),
+					)
+					continue
+				}
+				for _, gvk := range byGV[gv] {
+					if kinds[gvk.Kind] {
+						return fmt.Errorf("optional CRD %s became available after startup; restarting to register its watch", gvk)
+					}
+				}
+			}
+		}
+	}
+}
+
+// NeedLeaderElection ties the gate to leadership: only the elected leader owns the
+// watches, so only it should restart itself to pick up a new one. A non-leader replica
+// would restart pointlessly without ever having registered the watch.
+func (g *crdWatchGate) NeedLeaderElection() bool {
+	return true
+}
+
+var (
+	_ manager.Runnable               = (*crdWatchGate)(nil)
+	_ manager.LeaderElectionRunnable = (*crdWatchGate)(nil)
+)

--- a/operators/c5c3/internal/controller/crd_presence_test.go
+++ b/operators/c5c3/internal/controller/crd_presence_test.go
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the optional-CRD presence probe and the restart gate:
+// servedKindsForGroupVersion against discovery, probeOptionalWatches classification,
+// and crdWatchGate lifecycle.
+package controller
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	glancev1alpha1 "github.com/c5c3/forge/operators/glance/api/v1alpha1"
+	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
+	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
+	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/v2/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// The GroupVersions referenced by the presence-probe tests. keystone, horizon and
+// glance are the sibling-operator groups SetupWithManager probes for; orc is the
+// hard-dependency group TestOptionalWatchObjects_ExcludesKORC asserts never appears in
+// the optional set. Verified against the api packages' GroupVersion / GroupName before
+// hardcoding here.
+var (
+	keystoneGV = schema.GroupVersion{Group: "keystone.openstack.c5c3.io", Version: "v1alpha1"}
+	horizonGV  = schema.GroupVersion{Group: "horizon.openstack.c5c3.io", Version: "v1alpha1"}
+	glanceGV   = schema.GroupVersion{Group: "glance.openstack.c5c3.io", Version: "v1alpha1"}
+	orcGV      = schema.GroupVersion{Group: "openstack.k-orc.cloud", Version: "v1alpha1"}
+)
+
+// optionalWatchTestScheme registers the sibling-operator API groups the presence probe
+// resolves GVKs against (keystone, horizon, glance) plus K-ORC, which
+// TestOptionalWatchObjects_ExcludesKORC needs registered to prove no K-ORC kind is
+// listed as an optional watch. controllerTestScheme registers only c5c3 + client-go,
+// so it cannot resolve Keystone/Horizon/Glance/K-ORC kinds; this helper adds them.
+func optionalWatchTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	adders := []struct {
+		name string
+		add  func(*runtime.Scheme) error
+	}{
+		{"keystone", keystonev1alpha1.AddToScheme},
+		{"horizon", horizonv1alpha1.AddToScheme},
+		{"glance", glancev1alpha1.AddToScheme},
+		{"orc", orcv1alpha1.AddToScheme},
+	}
+	for _, a := range adders {
+		if err := a.add(s); err != nil {
+			t.Fatalf("adding %s scheme: %v", a.name, err)
+		}
+	}
+	return s
+}
+
+// fakeServerResources is a mutex-guarded serverResourcesLister stub. It is safe to
+// mutate from a test goroutine while a crdWatchGate.Start goroutine reads it, so the
+// gate tests stay clean under go test -race. GroupVersions absent from byGV return the
+// real client-side NotFound StatusError shape via apierrors.NewNotFound, matching how
+// discovery reports an uninstalled CRD.
+type fakeServerResources struct {
+	mu   sync.Mutex
+	byGV map[string]*metav1.APIResourceList
+	// err, when set together with a non-zero errCalls, is returned instead of a
+	// resource list. errCalls < 0 means "return err on every call"; errCalls > 0
+	// returns err for that many calls and then decrements toward zero, after which
+	// the stub serves normally again — this models a transient discovery outage.
+	err      error
+	errCalls int
+	// callCount records every ServerResourcesForGroupVersion invocation so tests can
+	// assert the probe fetches each GroupVersion once rather than once per kind.
+	callCount int
+}
+
+func newFakeServerResources() *fakeServerResources {
+	return &fakeServerResources{byGV: map[string]*metav1.APIResourceList{}}
+}
+
+func (f *fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callCount++
+	if f.err != nil && f.errCalls != 0 {
+		if f.errCalls > 0 {
+			f.errCalls--
+		}
+		return nil, f.err
+	}
+	if list, ok := f.byGV[groupVersion]; ok {
+		return list, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, groupVersion)
+}
+
+// serve records that the given GroupVersion lists the given Kinds, so subsequent
+// lookups for it succeed. Callable mid-test to simulate a CRD being installed.
+func (f *fakeServerResources) serve(gv schema.GroupVersion, kinds ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := gv.String()
+	list := f.byGV[key]
+	if list == nil {
+		list = &metav1.APIResourceList{GroupVersion: key}
+		f.byGV[key] = list
+	}
+	for _, k := range kinds {
+		list.APIResources = append(list.APIResources, metav1.APIResource{Kind: k})
+	}
+}
+
+// setError makes every subsequent call return err (a non-NotFound discovery failure).
+func (f *fakeServerResources) setError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+	f.errCalls = -1
+}
+
+// setErrorForCalls makes the next n calls return err, then serve normally.
+func (f *fakeServerResources) setErrorForCalls(err error, n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+	f.errCalls = n
+}
+
+// calls returns how many times ServerResourcesForGroupVersion has been invoked.
+func (f *fakeServerResources) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+// zeroProbeBackoff removes the startup-probe retry sleep for the duration of a test so
+// the retry path runs instantly, restoring the production value afterwards.
+func zeroProbeBackoff(t *testing.T) {
+	t.Helper()
+	prev := discoveryProbeBackoff
+	discoveryProbeBackoff = 0
+	t.Cleanup(func() { discoveryProbeBackoff = prev })
+}
+
+// --- servedKindsForGroupVersion ---
+
+func TestServedKindsForGroupVersion_ServedKind(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	disco := newFakeServerResources()
+	disco.serve(keystoneGV, "Keystone")
+
+	kinds, err := servedKindsForGroupVersion(disco, keystoneGV)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(kinds).To(HaveKeyWithValue("Keystone", true), "a listed Kind must be in the served set")
+}
+
+func TestServedKindsForGroupVersion_AbsentGroupVersion(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// The real fake discovery client with no Resources returns the genuine
+	// client-side NotFound StatusError, proving apierrors.IsNotFound matches it.
+	disco := &discoveryfake.FakeDiscovery{Fake: &clienttesting.Fake{}}
+
+	kinds, err := servedKindsForGroupVersion(disco, keystoneGV)
+	g.Expect(err).NotTo(HaveOccurred(), "an absent GroupVersion is not-found, not an error")
+	g.Expect(kinds).To(BeEmpty())
+}
+
+func TestServedKindsForGroupVersion_GroupPresentKindAbsent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// The keystone group is served but only lists Keystone, not the separately
+	// installed KeystoneIdentityBackend CRD.
+	disco := newFakeServerResources()
+	disco.serve(keystoneGV, "Keystone")
+
+	kinds, err := servedKindsForGroupVersion(disco, keystoneGV)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(kinds).NotTo(HaveKey("KeystoneIdentityBackend"), "an unlisted Kind must be absent from the served set")
+}
+
+func TestServedKindsForGroupVersion_UpstreamError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	sentinel := errors.New("discovery boom")
+	disco := newFakeServerResources()
+	disco.setError(sentinel)
+
+	kinds, err := servedKindsForGroupVersion(disco, keystoneGV)
+	g.Expect(kinds).To(BeNil())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(errors.Is(err, sentinel)).To(BeTrue(), "the upstream error must be wrapped with %%w")
+	g.Expect(err.Error()).To(ContainSubstring("listing server resources for keystone.openstack.c5c3.io/v1alpha1: "))
+}
+
+// --- probeOptionalWatches ---
+
+// serveAllOptionalKinds populates the stub with every optional kind across the three
+// sibling-operator GroupVersions, matching optionalWatchObjects.
+func serveAllOptionalKinds(f *fakeServerResources) {
+	f.serve(keystoneGV, "Keystone", "KeystoneIdentityBackend")
+	f.serve(horizonGV, "Horizon")
+	f.serve(glanceGV, "Glance", "GlanceBackend")
+}
+
+func TestProbeOptionalWatches_AllServed(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	disco := newFakeServerResources()
+	serveAllOptionalKinds(disco)
+
+	served, missing, err := probeOptionalWatches(disco, optionalWatchTestScheme(t))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(missing).To(BeEmpty(), "no CRD is missing when every group is served")
+	g.Expect(served).To(HaveLen(5), "all 5 optional kinds must be recorded")
+	for gvk, ok := range served {
+		g.Expect(ok).To(BeTrue(), "expected %s to be served", gvk)
+	}
+}
+
+func TestProbeOptionalWatches_SubsetServed(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// keystone group served but without KeystoneIdentityBackend; horizon and glance
+	// groups entirely absent.
+	disco := newFakeServerResources()
+	disco.serve(keystoneGV, "Keystone")
+
+	served, missing, err := probeOptionalWatches(disco, optionalWatchTestScheme(t))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(missing).To(ConsistOf(
+		horizonGV.WithKind("Horizon"),
+		glanceGV.WithKind("Glance"),
+		glanceGV.WithKind("GlanceBackend"),
+		keystoneGV.WithKind("KeystoneIdentityBackend"),
+	), "exactly the uninstalled kinds must be reported missing")
+
+	g.Expect(served).To(HaveLen(5))
+	// The one served kind is marked true.
+	g.Expect(served[keystoneGV.WithKind("Keystone")]).To(BeTrue())
+	// The four missing kinds are marked false.
+	g.Expect(served[horizonGV.WithKind("Horizon")]).To(BeFalse())
+	g.Expect(served[glanceGV.WithKind("Glance")]).To(BeFalse())
+	g.Expect(served[glanceGV.WithKind("GlanceBackend")]).To(BeFalse())
+	g.Expect(served[keystoneGV.WithKind("KeystoneIdentityBackend")]).To(BeFalse())
+}
+
+func TestProbeOptionalWatches_DiscoveryError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	zeroProbeBackoff(t)
+
+	// Every call fails: a persistent (not merely transient) discovery outage must
+	// still abort the probe once the bounded retry is exhausted, so the pod restarts
+	// rather than starting with watches silently dropped.
+	sentinel := errors.New("api server unreachable")
+	disco := newFakeServerResources()
+	disco.setError(sentinel)
+
+	served, missing, err := probeOptionalWatches(disco, optionalWatchTestScheme(t))
+	g.Expect(served).To(BeNil())
+	g.Expect(missing).To(BeNil())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(errors.Is(err, sentinel)).To(BeTrue(), "a non-NotFound discovery error must abort the probe")
+}
+
+func TestProbeOptionalWatches_TransientErrorRetries(t *testing.T) {
+	g := NewGomegaWithT(t)
+	zeroProbeBackoff(t)
+
+	// A single transient (non-NotFound) discovery blip on the first GroupVersion
+	// query — realistic during an apiserver rollout or etcd compaction — must be
+	// absorbed by the bounded retry rather than aborting setup and crash-looping the
+	// pod. After the blip clears every kind classifies as served.
+	disco := newFakeServerResources()
+	serveAllOptionalKinds(disco)
+	disco.setErrorForCalls(errors.New("transient discovery blip"), 1)
+
+	served, missing, err := probeOptionalWatches(disco, optionalWatchTestScheme(t))
+	g.Expect(err).NotTo(HaveOccurred(), "a single transient blip must not abort the startup probe")
+	g.Expect(missing).To(BeEmpty())
+	g.Expect(served).To(HaveLen(5))
+	for gvk, ok := range served {
+		g.Expect(ok).To(BeTrue(), "expected %s to be served after the blip cleared", gvk)
+	}
+}
+
+func TestProbeOptionalWatches_FetchesEachGroupVersionOnce(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// The 5 optional kinds span only three GroupVersions, so the probe must query
+	// discovery three times, not once per kind.
+	disco := newFakeServerResources()
+	serveAllOptionalKinds(disco)
+
+	_, _, err := probeOptionalWatches(disco, optionalWatchTestScheme(t))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(disco.calls()).To(Equal(3),
+		"each of the three GroupVersions must be queried exactly once, not per kind")
+}
+
+// --- optionalWatchObjects ---
+
+// TestOptionalWatchObjects_ExcludesKORC guards the invariant that the eight K-ORC
+// kinds are hard dependencies Owned unconditionally by buildControlPlaneController, not
+// slimmable watches guarded behind the discovery probe. Listing any K-ORC kind here
+// would let the manager start on a cluster whose K-ORC CRDs are unserved, only for the
+// very next reconcile pass to hard-error with a no-match when reconcileKORC reads the
+// admin ApplicationCredential (or reconcileServiceAccounts applies a RoleAssignment) —
+// wedging the ControlPlane instead of failing fast at startup. The probe never reports
+// K-ORC missing, so nothing else in the suite catches a regression here.
+func TestOptionalWatchObjects_ExcludesKORC(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme := optionalWatchTestScheme(t)
+	for _, obj := range optionalWatchObjects() {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(gvk.Group).NotTo(Equal(orcGV.Group),
+			"K-ORC kind %s must not be an optional watch: it is a hard dependency read unconditionally on every reconcile pass", gvk)
+	}
+}
+
+// --- crdWatchGate ---
+
+func TestCRDWatchGate_NeedLeaderElection(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	gate := &crdWatchGate{}
+	g.Expect(gate.NeedLeaderElection()).To(BeTrue(),
+		"only the elected leader should restart itself for a new watch")
+}
+
+func TestCRDWatchGate_StartEmptyMissing(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// No missing CRDs: Start must return immediately even called synchronously. The
+	// non-zero interval guards the test from hanging if the early return regressed.
+	gate := &crdWatchGate{
+		disco:    newFakeServerResources(),
+		interval: time.Second,
+	}
+	g.Expect(gate.Start(context.Background())).To(Succeed(),
+		"an empty missing set must return nil without waiting")
+}
+
+func TestCRDWatchGate_StartContextCancelled(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// The CRD never appears; cancelling the context must stop the gate with nil,
+	// because losing leadership or shutting down is not an error.
+	disco := newFakeServerResources()
+	gate := &crdWatchGate{
+		disco:    disco,
+		missing:  []schema.GroupVersionKind{keystoneGV.WithKind("Keystone")},
+		interval: 10 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- gate.Start(ctx) }()
+	cancel()
+
+	g.Eventually(errCh, time.Second, 10*time.Millisecond).Should(Receive(BeNil()),
+		"a cancelled context must return nil")
+}
+
+func TestCRDWatchGate_StartReturnsWhenCRDAppears(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	disco := newFakeServerResources()
+	gvk := keystoneGV.WithKind("Keystone")
+	gate := &crdWatchGate{
+		disco:    disco,
+		missing:  []schema.GroupVersionKind{gvk},
+		interval: 10 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- gate.Start(ctx) }()
+
+	// Let a few ticks observe the CRD still absent, then install it mid-run.
+	time.Sleep(40 * time.Millisecond)
+	disco.serve(keystoneGV, "Keystone")
+
+	var got error
+	g.Eventually(errCh, time.Second, 10*time.Millisecond).Should(Receive(&got))
+	g.Expect(got).To(HaveOccurred())
+	g.Expect(got.Error()).To(ContainSubstring(gvk.String()))
+	g.Expect(got.Error()).To(ContainSubstring("became available after startup; restarting to register its watch"))
+}
+
+func TestCRDWatchGate_TransientErrorContinues(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// The first few discovery calls fail with a non-NotFound error; the gate must
+	// log and retry rather than return early or return nil. Once the stub serves the
+	// kind, the gate returns the became-available error, proving the transient
+	// failure did not abort it.
+	disco := newFakeServerResources()
+	gvk := keystoneGV.WithKind("Keystone")
+	disco.setErrorForCalls(errors.New("transient discovery blip"), 3)
+	disco.serve(keystoneGV, "Keystone")
+
+	gate := &crdWatchGate{
+		disco:    disco,
+		missing:  []schema.GroupVersionKind{gvk},
+		interval: 10 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- gate.Start(ctx) }()
+
+	var got error
+	g.Eventually(errCh, time.Second, 10*time.Millisecond).Should(Receive(&got))
+	g.Expect(got).To(HaveOccurred())
+	g.Expect(got.Error()).To(ContainSubstring("became available after startup; restarting to register its watch"))
+}

--- a/operators/c5c3/internal/controller/requeue_intervals.go
+++ b/operators/c5c3/internal/controller/requeue_intervals.go
@@ -114,4 +114,15 @@ const (
 	// window mirrors remintStallTimeout: generous enough that a slow-but-
 	// progressing revoke is not cut short.
 	orcTeardownStallTimeout = 5 * time.Minute
+
+	// crdRecheckInterval is the cadence at which the crdWatchGate re-probes
+	// discovery for the optional sibling-operator CRDs that were missing when
+	// the operator started. When one of them appears the gate returns an error
+	// so mgr.Start unwinds and the Deployment restarts the process into a clean
+	// discovery pass; a restart is the only recovery path because
+	// controller-runtime cannot add a watch to a running manager. The cadence is
+	// deliberately unhurried: installing a sibling operator is a rare,
+	// human-driven event, so one extra wait of up to this interval is invisible
+	// next to the operator's own restart time.
+	crdRecheckInterval = 30 * time.Second
 )

--- a/operators/c5c3/internal/controller/setupwithmanager_integration_test.go
+++ b/operators/c5c3/internal/controller/setupwithmanager_integration_test.go
@@ -20,14 +20,21 @@
 // rejects a second controller named "controlplane" registered without
 // controller.Options{SkipNameValidation}. The inline harness
 // (setupControlPlaneEnvTest) sets SkipNameValidation precisely so it does not
-// contend with this test.
+// contend with this test. TestBuildControlPlaneController_StartsWithoutServiceCRDs
+// below likewise does not contend: it wires the controller through
+// buildControlPlaneController on a builder configured with
+// controller.Options{SkipNameValidation: ptr.To(true)} — the same escape the
+// inline harness uses — instead of calling SetupWithManager.
 package controller
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	c5c3v1alpha1 "github.com/c5c3/forge/operators/c5c3/api/v1alpha1"
 	"github.com/c5c3/forge/operators/c5c3/internal/testutil"
@@ -82,4 +89,72 @@ func TestSetupWithManager_BothControllersStart(t *testing.T) {
 
 	g.Expect(registered).To(BeTrue(),
 		"both SetupWithManager calls must have completed without error")
+}
+
+// TestBuildControlPlaneController_StartsWithoutServiceCRDs is the exact scenario
+// that crash-looped before #648: the c5c3-operator installed BEFORE its sibling
+// operators, so the Keystone/Horizon/Glance/GlanceBackend/KeystoneIdentityBackend
+// CRDs are unserved when the ControlPlane controller starts. Before the fix the
+// controller registered watches for those absent kinds, their informers never
+// synced, controller-runtime aborted on the CacheSyncTimeout, and the leader
+// crash-looped. With the discovery guard in buildControlPlaneController the
+// manager starts with the optional legs skipped and the CR still reconciles.
+// K-ORC stays served via the common fake CRDs (BaselineCRDDirectoryPaths) because
+// its kinds are Owned unconditionally as hard dependencies — the manager would fail
+// to start without them. The discovery guard covers only the sibling service-operator
+// legs, which this baseline leaves unserved.
+func TestBuildControlPlaneController_StartsWithoutServiceCRDs(t *testing.T) {
+	testutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	// The setup helper only returns once mgr.Start succeeded and every registered
+	// informer synced. A regression that re-registered a watch for one of the
+	// unserved Keystone/Horizon/Glance/GlanceBackend/KeystoneIdentityBackend kinds
+	// would leave that informer stuck, fail mgr.Start on the CacheSyncTimeout, and
+	// the shared harness (internal/common/testutil/envtest/manager.go) would surface
+	// the error via t.Errorf — so the crash-loop regression fails this test either
+	// way. The controller is wired through buildControlPlaneController (the same
+	// builder the production SetupWithManager drives) on a builder carrying
+	// controller.Options{SkipNameValidation: ptr.To(true)}, so it does not contend
+	// with TestSetupWithManager_BothControllersStart for the global controller name.
+	c, ctx, _ := testutil.SetupC5c3EnvTestWithControllerAndCRDs(
+		t,
+		testutil.BaselineCRDDirectoryPaths(),
+		c5c3v1alpha1.AddToScheme,
+		func(mgr ctrl.Manager) error {
+			// mgr.GetAPIReader() mirrors main.go: admission lookups read the API
+			// server directly, never a stale cache.
+			return (&c5c3v1alpha1.ControlPlaneWebhook{Client: mgr.GetAPIReader()}).SetupWebhookWithManager(mgr)
+		},
+		func(mgr ctrl.Manager) error {
+			r := &ControlPlaneReconciler{
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("controlplane-controller"),
+			}
+			b, err := r.buildControlPlaneController(mgr, ctrl.NewControllerManagedBy(mgr).
+				WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}))
+			if err != nil {
+				return err
+			}
+			return b.Complete(r)
+		},
+	)
+
+	// Positive reconcile signal: create a minimal ControlPlane and wait for the
+	// controller to install controlPlaneORCFinalizer. Reconcile adds that finalizer
+	// (controlplane_controller.go, before the sub-reconciler pipeline runs), so its
+	// appearance proves the controller both started and reconciles despite the
+	// service CRDs being absent.
+	cp := integrationMinimalControlPlane("baseline-cp", "default")
+	g.Expect(c.Create(ctx, cp)).To(Succeed())
+
+	g.Eventually(func() ([]string, error) {
+		var got c5c3v1alpha1.ControlPlane
+		if err := c.Get(ctx, client.ObjectKeyFromObject(cp), &got); err != nil {
+			return nil, err
+		}
+		return got.Finalizers, nil
+	}, itEventuallyTimeout, itPollInterval).Should(ContainElement(controlPlaneORCFinalizer),
+		"Reconcile must install the ORC-teardown finalizer even with the service CRDs unserved")
 }

--- a/operators/c5c3/internal/testutil/envtest_setup.go
+++ b/operators/c5c3/internal/testutil/envtest_setup.go
@@ -60,10 +60,35 @@ func SetupC5c3EnvTestWithController(
 ) (client.Client, context.Context, context.CancelFunc) {
 	t.Helper()
 
+	return SetupC5c3EnvTestWithControllerAndCRDs(
+		t,
+		crdDirectoryPaths(),
+		addToScheme,
+		registerWebhooks,
+		registerController,
+	)
+}
+
+// SetupC5c3EnvTestWithControllerAndCRDs is the caller-supplied-dirs variant of
+// SetupC5c3EnvTestWithController: it is identical except the CRD directories
+// envtest loads come from crdDirs rather than the full built-in set.
+// SetupC5c3EnvTestWithController delegates here with crdDirectoryPaths() (the
+// full CRD set). Integration tests pass BaselineCRDDirectoryPaths() to model a
+// cluster missing the sibling service-operator CRDs (Keystone, Horizon, Glance),
+// proving the ControlPlane controller starts when those kinds are unserved.
+func SetupC5c3EnvTestWithControllerAndCRDs(
+	t testing.TB,
+	crdDirs []string,
+	addToScheme func(*k8sruntime.Scheme) error,
+	registerWebhooks func(ctrl.Manager) error,
+	registerController func(ctrl.Manager) error,
+) (client.Client, context.Context, context.CancelFunc) {
+	t.Helper()
+
 	return commonenvtest.StartManagedEnvTest(t, commonenvtest.ManagedEnvTestConfig{
 		Name:               "c5c3",
 		Scheme:             buildControllerScheme(addToScheme),
-		CRDDirectoryPaths:  crdDirectoryPaths(),
+		CRDDirectoryPaths:  crdDirs,
 		WebhookDir:         c5c3WebhookDir(),
 		RegisterWebhooks:   registerWebhooks,
 		RegisterController: registerController,
@@ -73,20 +98,42 @@ func SetupC5c3EnvTestWithController(
 // crdDirectoryPaths returns the absolute CRD directories envtest loads for a
 // ControlPlane integration test, resolved relative to this
 // source file via runtime.Caller(0):
-//   - c5c3 CRDs (controlplanes, credentialrotations, secretaggregates).
-//   - the Keystone CRD (the reconciler Owns a Keystone child).
-//   - every shared fake CRD dir under internal/common/testutil/fake_crds/*
+//   - the sibling service-operator CRDs (Keystone, Horizon, Glance — and with
+//     them GlanceBackend and KeystoneIdentityBackend) the reconciler Owns as
+//     children.
+//   - BaselineCRDDirectoryPaths(): the c5c3 CRDs plus every shared fake CRD dir
 //     (mariadb-operator, memcached-operator, external-secrets, cert-manager,
 //     k-orc, ...) so the external operator kinds the reconciler create-or-updates
 //     resolve in the apiserver RESTMapper.
 func crdDirectoryPaths() []string {
 	base := callerDir()
-	c5c3CRDDir := filepath.Join(base, "..", "..", "config", "crd", "bases")
 	keystoneCRDDir := filepath.Join(base, "..", "..", "..", "keystone", "config", "crd", "bases")
 	horizonCRDDir := filepath.Join(base, "..", "..", "..", "horizon", "config", "crd", "bases")
 	glanceCRDDir := filepath.Join(base, "..", "..", "..", "glance", "config", "crd", "bases")
 
-	dirs := []string{c5c3CRDDir, keystoneCRDDir, horizonCRDDir, glanceCRDDir}
+	dirs := []string{keystoneCRDDir, horizonCRDDir, glanceCRDDir}
+	return append(dirs, BaselineCRDDirectoryPaths()...)
+}
+
+// BaselineCRDDirectoryPaths returns the absolute CRD directories for an envtest
+// environment carrying only the c5c3 CRDs and the shared fake CRDs for the hard
+// infrastructure baseline (MariaDB, Memcached, external-secrets, cert-manager,
+// K-ORC), resolved relative to this source file via runtime.Caller(0):
+//   - c5c3 CRDs (controlplanes, credentialrotations, secretaggregates).
+//   - every shared fake CRD dir under internal/common/testutil/fake_crds/*.
+//
+// The sibling service-operator CRDs (Keystone, Horizon, Glance — and with them
+// GlanceBackend and KeystoneIdentityBackend) are DELIBERATELY absent, so tests
+// can prove the ControlPlane controller starts when those kinds are unserved.
+// K-ORC IS served — its fake CRDs are part of the common fake dirs — because the
+// K-ORC kinds are Owned unconditionally as hard dependencies (see optionalWatchObjects
+// in crd_presence.go): the manager would fail to start without them. Tests therefore
+// exercise the intended partial state — the guarded sibling service-operator legs are
+// skipped while every unconditional infrastructure leg, K-ORC included, stays wired.
+func BaselineCRDDirectoryPaths() []string {
+	c5c3CRDDir := filepath.Join(callerDir(), "..", "..", "config", "crd", "bases")
+
+	dirs := []string{c5c3CRDDir}
 	return append(dirs, commonenvtest.CommonFakeCRDDirs()...)
 }
 


### PR DESCRIPTION
## Summary

The c5c3-operator can be installed before its sibling service operators, so the
`Keystone`, `Horizon`, `Glance`, `GlanceBackend`, and `KeystoneIdentityBackend`
CRDs may be unserved when the elected leader starts. In that state the
`ControlPlaneReconciler` registered watches for the absent kinds unconditionally,
their informers never synced, controller-runtime aborted `mgr.Start` on the
two-minute `CacheSyncTimeout`, and the leader crash-looped — all while the pod
kept reporting `Ready`. This made a slimmed-down, install-before-siblings
deployment unusable through an invisible install-order dependency.

The fix registers each optional sibling-operator watch only when a discovery
probe reports its CRD served, and installs a leader-gated runnable that restarts
the process once a missing CRD appears (the only way to add a watch, since
controller-runtime cannot mount one on a running manager).

Closes #648

## Change set (commit order)

1. **`fix: add CRD-presence probe and restart gate helpers`** (`9e69bbe3`) —
   New `crd_presence.go`, touching no existing file. `gvkServed` decides
   presence via a discovery probe against the live API server rather than the
   compiled-in runtime scheme (which always advertises every known type),
   treating a `NotFound` GroupVersion as "CRD absent" and surfacing any other
   discovery error. `probeOptionalWatches` classifies the optional kinds into a
   `served` map and a `missing` slice. `crdWatchGate` is a leader-only
   `manager.Runnable` that polls discovery for the missing CRDs and returns an
   error once one appears — tearing down `mgr.Start` so the Deployment restarts
   the leader with the watch now registered; transient discovery failures are
   logged at `V(1)` and retried, never returned.

2. **`fix: register optional ControlPlane watches only for served CRDs`**
   (`303dccfa`) — Splits `SetupWithManager` into a thin entry point plus a new
   `buildControlPlaneController` that both the production path and the
   integration test drive, so leg registration is identical. Optional kinds
   (`Keystone`, `Horizon`, `Glance`, `GlanceBackend`, `KeystoneIdentityBackend`)
   register their `Owns` and cross-namespace `Watches` legs only when the CRD is
   served. The eight K-ORC kinds are deliberately **not** probed: like MariaDB,
   Memcached, and the ESO kinds, K-ORC is a hard dependency every reconcile pass
   reads unconditionally, so its legs stay unconditional and a missing K-ORC CRD
   is a fail-fast startup error. When anything is missing, one info-level
   startup log names the skipped kinds and the leader-gated `crdWatchGate`
   (30s re-probe cadence) is registered. Adds `crdRecheckInterval` to
   `requeue_intervals.go`.

3. **`test: add baseline-CRD envtest variant to the c5c3 testutil`**
   (`fbcc20ba`) — Adds `BaselineCRDDirectoryPaths` (c5c3 CRDs plus the shared
   fake infrastructure CRDs — MariaDB, Memcached, external-secrets, cert-manager,
   K-ORC — but deliberately omitting the sibling service-operator CRDs) and
   `SetupC5c3EnvTestWithControllerAndCRDs`, a caller-supplied-dirs setup variant.
   The existing `SetupC5c3EnvTestWithController` now delegates to it with the
   full CRD set, and `crdDirectoryPaths` composes the three service CRD dirs onto
   `BaselineCRDDirectoryPaths` instead of duplicating the fake-CRD path math.

4. **`test: prove the ControlPlane controller starts without service CRDs`**
   (`109bcec0`) — Integration test reproducing the baseline-only cluster via
   `BaselineCRDDirectoryPaths` (K-ORC stays served so the guarded K-ORC legs
   still register). It wires the controller through `buildControlPlaneController`
   on a builder carrying `controller.Options{SkipNameValidation: ptr.To(true)}`,
   the same escape the inline harness uses, so it does not contend with the one
   test that calls the real `SetupWithManager`. It asserts the manager starts
   (the shared harness fails the test if `mgr.Start` errors on a stuck informer)
   and that a minimal `ControlPlane` still reconciles: the ORC-teardown
   finalizer appears, which `Reconcile` installs before the sub-reconciler
   pipeline runs.

## Notes for the reviewer

- The recovery path is a **process restart**, not an in-place watch mount:
  controller-runtime cannot add a watch to a running manager, so `crdWatchGate`
  intentionally unwinds `mgr.Start` when a missing CRD appears. This is by
  design, not a leak.
- The K-ORC kinds are excluded from the guard on purpose (hard dependency,
  fail-fast). This is the one deviation a reviewer might expect the issue to
  cover but the fix does not — it is documented inline and in the commit body.
- No divergence from the issue: the change scopes exactly to the served-CRD
  watch guard plus its test coverage; no code outside the c5c3 controller and
  testutil is touched.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 494b8a9 with Claude:claude-opus-4-8_
