### PR TITLE
docs: fix links from quickstart

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -21,7 +21,7 @@ OpenBao, and registers the identity catalog.
 Same toolchain as the [Quick Start](./quick-start.md), plus:
 
 - `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
-- The OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/installation/index.html)) on `PATH` for the auth check in Step 6
+- The OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/)) on `PATH` for the auth check in Step 6
 - A stable internet connection while `make deploy-infra` clones K-ORC from GitHub
 - Roughly 8 GB RAM, 2 CPU cores, and 10 GB of free disk for a laptop-sized kind cluster
 - `yq` v4.x on `PATH` for the `KIND_HOST_PORT=8443` override path in Step 2
@@ -333,7 +333,7 @@ Skip this step only when:
   bundled ControlPlane automatically, or
 - the ControlPlane opts out of Dynamic credentials with
   `spec.infrastructure.database.credentialsMode: Static` (see
-  [Migrate Keystone DB to Dynamic Credentials](/guides/keystone/migrate-keystone-db-to-dynamic-credentials)).
+  [Migrate Keystone DB to Dynamic Credentials](./guides/keystone/migrate-keystone-db-to-dynamic-credentials.md)).
 
 ::: warning If you skip it
 The reconcile chain stalls before any Keystone or Horizon child is created: the
@@ -352,7 +352,7 @@ enforces isolation from other tenants), run
 `openbao-tenant-store` SecretStore to be `Ready`, then set
 `spec.secretStoreRef: {kind: SecretStore, name: openbao-tenant-store}` on the
 ControlPlane. See the
-[multi-tenant deployment guide](/guides/multi-tenant-deployment#per-controlplane-secret-stores-and-openbao-identities).
+[multi-tenant deployment guide](./guides/multi-tenant-deployment.md#per-controlplane-secret-stores-and-openbao-identities).
 :::
 
 ## Step 5 — Watch the chain reconcile

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,7 +20,7 @@ the local-build path, the production HelmRelease, E2E and Tempest, see
 
 - Docker Desktop running
 - `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
-- OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/installation/index.html)) on `PATH` for the authenticated token check in Step 6
+- OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/)) on `PATH` for the authenticated token check in Step 6
 - Pinned `kind`, `kubectl`, `Helm`, `jq` on `PATH`:
 
   ```bash


### PR DESCRIPTION
update broken reference links

On-behalf-of: @SAP
Assisted-by: Copilot:claude-haiku-4.5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787470483&installation_model_id=18560&pr_number=738&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F738&signature=e8f930dcc8339e7422fc8496c0476341fc7ad8e21e0501e3d06fa8517ea6a803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->