### PR TITLE
fix: support Podman workflows and curl-based digest fallback

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -26,6 +26,14 @@ Same toolchain as the [Quick Start](./quick-start.md), plus:
 - Roughly 8 GB RAM, 2 CPU cores, and 10 GB of free disk for a laptop-sized kind cluster
 - `yq` v4.x on `PATH` for the `KIND_HOST_PORT=8443` override path in Step 2
 
+Docker Desktop and Podman are both valid kind providers. When using Podman,
+ensure its machine is already running and select it explicitly before running
+Step 2:
+
+```bash
+export KIND_EXPERIMENTAL_PROVIDER=podman
+```
+
 - The bundled kind `ControlPlane` CR pins its backing services to a single
   instance (`spec.infrastructure.database.replicas: 1`, `cache.replicas: 1`) so
   the fresh-create chain fits a single-node kind cluster.
@@ -45,8 +53,6 @@ Same toolchain as the [Quick Start](./quick-start.md), plus:
 - To mirror the production volume on a bigger box, set
   `CONTROLPLANE_DB_STORAGE=100Gi` for Step 2. Any Kubernetes quantity in
   `Mi`/`Gi`/`Ti` is accepted.
-- Like `database.replicas`, `database.storageSize` is immutable after the CR is
-  created, so change it on a fresh environment (`make teardown-infra` first).
 
 ```bash
 make install-test-deps
@@ -83,7 +89,8 @@ image-digest ConfigMaps consumed by the HelmReleases via `valuesFrom`). After
 a feature merges to `main`, run `make refresh-operator-digests` against the
 running cluster: it re-resolves the digests, updates the ConfigMaps, and
 requests a Flux reconcile so the operators roll to the freshly built images —
-no redeploy needed.
+no redeploy needed. The helper prefers `docker buildx`, but falls back to `curl`
+if Docker is unavailable.
 :::
 
 ## Step 3 — Create the ControlPlane CR

--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -33,7 +33,7 @@ identical to what CI validates.
 
 | Resource | Minimum |
 |----------|---------|
-| RAM | 8 GB available to Docker |
+| RAM | 8 GB available to the container runtime |
 | CPU | 2 cores |
 | Disk | 10 GB free |
 
@@ -41,7 +41,7 @@ identical to what CI validates.
 
 | Tool | Install |
 |------|---------|
-| [Docker](https://docs.docker.com/get-docker/) | platform installer |
+| Container runtime | [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/docs/installation) |
 | [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) | see below |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | see below |
 | [Helm](https://helm.sh/docs/intro/install/) | platform installer |
@@ -71,6 +71,13 @@ still has to be installed separately (kind needs a running daemon).
 ```bash
 git clone https://github.com/c5c3/forge.git
 cd forge
+```
+
+For Podman, ensure the Podman machine is already running and make kind use the
+same provider:
+
+```bash
+export KIND_EXPERIMENTAL_PROVIDER=podman
 ```
 
 The project ships a helper script that downloads and verifies kind and kubectl with pinned
@@ -702,6 +709,14 @@ docker pull ghcr.io/c5c3/keystone:"${RELEASE}"
 kind load docker-image ghcr.io/c5c3/keystone:"${RELEASE}" --name forge
 ```
 
+With Podman, keep `KIND_EXPERIMENTAL_PROVIDER=podman` exported from the
+Prerequisites step:
+
+```bash
+podman pull ghcr.io/c5c3/keystone:"${RELEASE}"
+kind load docker-image ghcr.io/c5c3/keystone:"${RELEASE}" --name forge
+```
+
 ### Option B — Build locally
 
 ```bash
@@ -718,7 +733,7 @@ git clone --depth 1 --branch "${SERVICE_REF}" \
 # Apply constraint overrides
 scripts/apply-constraint-overrides.sh "${RELEASE}"
 
-# Build the image chain
+# Build the image chain (replace `docker` with `podman` when using Podman)
 docker build -t python-base images/python-base/
 docker build -t venv-builder images/venv-builder/
 docker build -t "ghcr.io/c5c3/keystone:${RELEASE}" \

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,7 +18,10 @@ the local-build path, the production HelmRelease, E2E and Tempest, see
 
 ## Prerequisites
 
-- Docker Desktop running
+- A running container runtime:
+  - Docker Desktop, or
+  - Podman with its machine already running.
+
 - `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
 - OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/)) on `PATH` for the authenticated token check in Step 6
 - Pinned `kind`, `kubectl`, `Helm`, `jq` on `PATH`:
@@ -39,6 +42,13 @@ cd forge
 ```
 
 ## Step 2 — Cluster + infrastructure stack
+
+When using Podman, ensure its machine is already running and select Podman as
+kind's provider:
+
+```bash
+export KIND_EXPERIMENTAL_PROVIDER=podman
+```
 
 ```bash
 KIND_HOST_PORT=8443 make deploy-infra
@@ -81,6 +91,16 @@ kubectl wait helmrelease/keystone-operator -n keystone-system \
 ```bash
 RELEASE=2025.2
 docker pull ghcr.io/c5c3/keystone:${RELEASE}
+kind load docker-image ghcr.io/c5c3/keystone:${RELEASE} --name forge
+```
+
+With Podman, keep `KIND_EXPERIMENTAL_PROVIDER=podman` exported from the
+Prerequisites step, pull the image into Podman's image store, and load it into
+the same kind provider:
+
+```bash
+RELEASE=2025.2
+podman pull ghcr.io/c5c3/keystone:${RELEASE}
 kind load docker-image ghcr.io/c5c3/keystone:${RELEASE} --name forge
 ```
 

--- a/hack/refresh-operator-image-digests.sh
+++ b/hack/refresh-operator-image-digests.sh
@@ -28,10 +28,10 @@
 # valuesFrom reference is optional). Run it standalone after a feature merge
 # to roll the operators of a running cluster to the freshly built images.
 #
-# Requires docker (with buildx) to resolve digests and kubectl to write the
-# ConfigMaps. Per-image resolve failures are logged and skipped so one
-# unreachable image does not block the others; the exit code is non-zero when
-# any image could not be refreshed.
+# Requires kubectl to write the ConfigMaps and either docker (with buildx) or
+# curl to resolve digests. Per-image resolve failures are logged and skipped
+# so one unreachable image does not block the others; the exit code is non-zero
+# when any image could not be refreshed.
 
 set -euo pipefail
 
@@ -60,21 +60,32 @@ log() {
 # preflight — Verify the required tools exist before touching anything.
 # ---------------------------------------------------------------------------
 preflight() {
-  local tool
-  for tool in docker kubectl; do
-    if ! command -v "${tool}" >/dev/null 2>&1; then
-      log "ERROR: required tool not found: ${tool}"
-      exit 1
-    fi
-  done
-  if ! docker buildx version >/dev/null 2>&1; then
-    log "ERROR: docker buildx is required to resolve image digests (docker buildx version failed)."
+  if ! command -v kubectl >/dev/null 2>&1; then
+    log "ERROR: required tool not found: kubectl"
+    exit 1
+  fi
+  if ! have_docker_buildx && ! have_curl; then
+    log "ERROR: need either docker with buildx or curl to resolve image digests."
     exit 1
   fi
 }
 
 # ---------------------------------------------------------------------------
-# resolve_image_digest — Resolve the manifest digest behind an image ref.
+# have_docker_buildx — Return success when docker buildx is available.
+# ---------------------------------------------------------------------------
+have_docker_buildx() {
+  command -v docker >/dev/null 2>&1 && docker buildx version >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# have_curl — Return success when curl is available.
+# ---------------------------------------------------------------------------
+have_curl() {
+  command -v curl >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# resolve_image_digest_via_docker — Resolve the manifest digest behind an image ref.
 #
 # $1: image reference (e.g. ghcr.io/c5c3/keystone-operator:latest)
 #
@@ -82,7 +93,7 @@ preflight() {
 # registry is unreachable or the resolved digest is empty. Same idiom as
 # hack/ci-resolve-ubuntu-digest.sh.
 # ---------------------------------------------------------------------------
-resolve_image_digest() {
+resolve_image_digest_via_docker() {
   local image="$1"
   local digest
   if ! digest=$(docker buildx imagetools inspect "${image}" \
@@ -93,6 +104,112 @@ resolve_image_digest() {
     return 1
   fi
   echo "${digest}"
+}
+
+# ---------------------------------------------------------------------------
+# resolve_image_digest_via_curl — Resolve the manifest digest behind an image
+# ref using curl against the registry HTTP API.
+#
+# This fallback avoids requiring docker on the host. It supports public and
+# bearer-token protected registries (including ghcr.io) by honoring the
+# standard WWW-Authenticate challenge.
+# ---------------------------------------------------------------------------
+resolve_image_digest_via_curl() {
+  local image="$1"
+  local registry repo reference digest tmp_headers http_code
+
+  # Parse the image reference (simplified; handles most cases)
+  if [[ "$image" == *"@"* ]]; then
+    # Already has digest
+    echo "${image#*@}"
+    return 0
+  fi
+
+  # Extract registry, repo, and tag
+  if [[ "$image" == *"/"* ]]; then
+    registry="${image%%/*}"
+    repo="${image#*/}"
+  else
+    registry="registry-1.docker.io"
+    repo="library/$image"
+  fi
+
+  if [[ "$repo" == *":"* ]]; then
+    reference="${repo##*:}"
+    repo="${repo%:*}"
+  else
+    reference="latest"
+  fi
+
+  tmp_headers="$(mktemp)"
+  trap 'rm -f "$tmp_headers"' RETURN
+
+  # Try without auth first
+  http_code=$(curl -s -w '%{http_code}' -o /dev/null \
+    -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+    -D "$tmp_headers" \
+    "https://${registry}/v2/${repo}/manifests/${reference}")
+
+  if [[ "$http_code" == "200" ]]; then
+    grep -i "Docker-Content-Digest:" "$tmp_headers" | sed 's/.*: //' | tr -d '\r'
+    return 0
+  fi
+
+  # If 401, try with bearer token
+  if [[ "$http_code" == "401" ]]; then
+    local auth_header service scope realm token
+    auth_header=$(grep -i "WWW-Authenticate:" "$tmp_headers" | head -1 | sed 's/.*: //')
+
+    if [[ "$auth_header" == *"Bearer"* ]]; then
+      realm=$(echo "$auth_header" | grep -o 'realm="[^"]*"' | cut -d'"' -f2)
+      service=$(echo "$auth_header" | grep -o 'service="[^"]*"' | cut -d'"' -f2)
+      scope="repository:${repo}:pull"
+
+      if [[ -n "$realm" ]]; then
+        local token_url="${realm}?service=${service}&scope=${scope}"
+        token=$(curl -s "$token_url" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+
+        if [[ -n "$token" ]]; then
+          # Retry with bearer token
+          curl -s \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+            -D "$tmp_headers" \
+            "https://${registry}/v2/${repo}/manifests/${reference}" > /dev/null
+
+          grep -i "Docker-Content-Digest:" "$tmp_headers" | sed 's/.*: //' | tr -d '\r'
+          return 0
+        fi
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# resolve_image_digest — Resolve the manifest digest behind an image ref.
+#
+# Prefer docker buildx when available, otherwise use curl against the registry
+# HTTP API. If docker exists but fails for a given image, the curl fallback
+# is still attempted.
+# ---------------------------------------------------------------------------
+resolve_image_digest() {
+  local image="$1"
+  local digest
+  if have_docker_buildx; then
+    if digest=$(resolve_image_digest_via_docker "${image}"); then
+      echo "${digest}"
+      return 0
+    fi
+  fi
+  if have_curl; then
+    if digest=$(resolve_image_digest_via_curl "${image}"); then
+      echo "${digest}"
+      return 0
+    fi
+  fi
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hack/refresh_operator_image_digests_test.sh
+++ b/tests/unit/hack/refresh_operator_image_digests_test.sh
@@ -12,8 +12,13 @@
 # best-effort.
 #
 # Strategy: source the script in a subshell (the BASH_SOURCE guard keeps main
-# from running) with recording docker/kubectl stubs prepended to PATH — the
-# same harness as the sibling deploy_infra_*_test.sh files.
+# from running) with recording docker/kubectl/curl stubs prepended to PATH —
+# the same harness as the sibling deploy_infra_*_test.sh files. The curl stub
+# is required: without it, resolve_image_digest_via_curl's fallback issues a
+# REAL network request to the registry, which succeeds for real published
+# images (e.g. ghcr.io/c5c3/keystone-operator) and silently masks the
+# "resolution genuinely fails" scenarios these tests exercise via
+# DOCKER_FAIL_FOR.
 #
 # Usage: bash tests/unit/hack/refresh_operator_image_digests_test.sh
 
@@ -42,9 +47,16 @@ PLACEMENT_DIGEST="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 # ---------------------------------------------------------------------------
 
 # make_stubs <dir>
-# Recording docker/kubectl stubs.
+# Recording docker/kubectl/curl stubs.
 #   docker buildx imagetools inspect <ref> → prints the JSON-quoted per-image
 #     digest ("sha256:…"), or exits 1 when <ref> equals $DOCKER_FAIL_FOR.
+#   curl ... <registry>/v2/<repo>/manifests/<ref> → the resolve_image_digest_via_curl
+#     fallback's registry call: writes a Docker-Content-Digest response header
+#     and prints HTTP 200 for a known image, or a bodyless 404 when the image
+#     matches $DOCKER_FAIL_FOR (same variable as the docker stub, so a single
+#     env assignment fails digest resolution through BOTH code paths — the
+#     "genuinely unresolvable" scenario these tests exercise). No bearer-token
+#     challenge is simulated: the stub always answers the first request.
 #   kubectl get configmap <name> …         → prints the stored values payload
 #     for that ConfigMap when KUBECTL_CM_EXISTS=true, else nothing.
 #   kubectl apply -f -                     → records argv and captures stdin
@@ -59,6 +71,9 @@ make_stubs() {
 #!/bin/bash
 echo "docker $*" >> "$DOCKER_LOG"
 if [ "${1:-}" = "buildx" ] && [ "${2:-}" = "version" ]; then
+  if [ "${DOCKER_BUILDX_FAIL:-false}" = "true" ]; then
+    exit 1
+  fi
   exit 0
 fi
 if [ "${1:-}" = "buildx" ] && [ "${2:-}" = "imagetools" ] && [ "${3:-}" = "inspect" ]; then
@@ -76,6 +91,61 @@ if [ "${1:-}" = "buildx" ] && [ "${2:-}" = "imagetools" ] && [ "${3:-}" = "inspe
   esac
   exit 0
 fi
+exit 0
+STUB
+
+  cat >"$dir/curl" <<'STUB'
+#!/bin/bash
+echo "curl $*" >> "${CURL_LOG:-/dev/null}"
+
+headers_file=""
+url=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-D" ]; then
+    headers_file="$arg"
+  fi
+  case "$arg" in
+    http*://*) url="$arg" ;;
+  esac
+  prev="$arg"
+done
+
+if [ -z "$url" ]; then
+  # Bearer-token endpoint call: unreached by these tests since the manifest
+  # response below never challenges with a 401. Fail closed if it ever is.
+  exit 1
+fi
+
+# https://<registry>/v2/<repo>/manifests/<reference> → <repo>
+repo="$(printf '%s' "$url" | sed -E 's#https?://[^/]+/v2/(.*)/manifests/.*#\1#')"
+
+fail_repo=""
+if [ -n "${DOCKER_FAIL_FOR:-}" ]; then
+  # Strip the leading registry and trailing :tag from DOCKER_FAIL_FOR so it
+  # compares against the <repo> the URL was parsed down to above.
+  fail_repo="$(printf '%s' "${DOCKER_FAIL_FOR}" | sed -E 's#^[^/]+/##; s#:.*##')"
+fi
+
+if [ -n "$fail_repo" ] && [ "$repo" = "$fail_repo" ]; then
+  [ -n "$headers_file" ] && : > "$headers_file"
+  printf '404'
+  exit 0
+fi
+
+digest=""
+case "$repo" in
+  *keystone-operator*) digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;
+  *c5c3-operator*)     digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *horizon-operator*)  digest="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ;;
+  *glance-operator*)   digest="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" ;;
+  *placement-operator*) digest="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" ;;
+esac
+
+if [ -n "$headers_file" ]; then
+  printf 'HTTP/1.1 200 OK\r\nDocker-Content-Digest: %s\r\n\r\n' "$digest" > "$headers_file"
+fi
+printf '200'
 exit 0
 STUB
 
@@ -107,7 +177,7 @@ fi
 exit 0
 STUB
 
-  chmod +x "$dir/docker" "$dir/kubectl"
+  chmod +x "$dir/docker" "$dir/curl" "$dir/kubectl"
 }
 
 # run_refresh <tmp dir> [env assignments...]
@@ -122,9 +192,10 @@ run_refresh() {
     done
     export PATH="$tmp/bin:$PATH"
     export DOCKER_LOG="$tmp/docker.log"
+    export CURL_LOG="$tmp/curl.log"
     export KUBECTL_APPLY_LOG="$tmp/apply.log"
     export KUBECTL_ANNOTATE_LOG="$tmp/annotate.log"
-    touch "$DOCKER_LOG" "$KUBECTL_APPLY_LOG" "$KUBECTL_ANNOTATE_LOG"
+    touch "$DOCKER_LOG" "$CURL_LOG" "$KUBECTL_APPLY_LOG" "$KUBECTL_ANNOTATE_LOG"
     # shellcheck source=/dev/null
     source "$REFRESH_SH"
     refresh_operator_image_digests
@@ -152,10 +223,13 @@ test_resolve_image_digest_success() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 2: resolve_image_digest fails when the registry is unreachable
+# Test 2: resolve_image_digest fails when both docker and its curl fallback
+# cannot resolve the image (the curl stub also fails for $DOCKER_FAIL_FOR —
+# see make_stubs — so this exercises the "genuinely unresolvable" case rather
+# than "docker fails, curl fallback quietly succeeds").
 # ---------------------------------------------------------------------------
 test_resolve_image_digest_failure() {
-  echo "Test: resolve_image_digest returns non-zero on inspect failure"
+  echo "Test: resolve_image_digest returns non-zero when docker and curl both fail"
   local tmp
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' RETURN
@@ -163,7 +237,7 @@ test_resolve_image_digest_failure() {
 
   local out rc=0
   out=$(
-    export PATH="$tmp/bin:$PATH" DOCKER_LOG="$tmp/docker.log"
+    export PATH="$tmp/bin:$PATH" DOCKER_LOG="$tmp/docker.log" CURL_LOG="$tmp/curl.log"
     export DOCKER_FAIL_FOR="ghcr.io/c5c3/keystone-operator:latest"
     # shellcheck source=/dev/null
     source "$REFRESH_SH"
@@ -200,7 +274,28 @@ test_render_digest_configmap_yaml() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: the loop applies all five ConfigMaps and requests reconciles
+# Test 4: the fallback resolves digests via curl without Docker buildx
+# ---------------------------------------------------------------------------
+test_resolve_image_digest_fallback_to_curl() {
+  echo "Test: resolve_image_digest falls back to curl when docker buildx is unavailable"
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  make_stubs "$tmp/bin"
+
+  local digest
+  digest=$(
+    export PATH="$tmp/bin:$PATH" DOCKER_LOG="$tmp/docker.log" CURL_LOG="$tmp/curl.log" DOCKER_BUILDX_FAIL=true
+    # shellcheck source=/dev/null
+    source "$REFRESH_SH"
+    resolve_image_digest "ghcr.io/c5c3/keystone-operator:latest"
+  )
+  assert_eq "fallback digest resolved without Docker" "$KEYSTONE_DIGEST" "$digest"
+  assert_contains "curl fallback was used" "$(cat "$tmp/curl.log")" "v2/c5c3/keystone-operator/manifests/latest"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: the loop applies all five ConfigMaps and requests reconciles
 # ---------------------------------------------------------------------------
 test_refresh_applies_and_annotates_all_operators() {
   echo "Test: refresh applies 5 ConfigMaps and annotates 5 HelmReleases"
@@ -246,7 +341,7 @@ test_refresh_applies_and_annotates_all_operators() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 5: unchanged digests re-apply the ConfigMaps but skip the reconcile
+# Test 6: unchanged digests re-apply the ConfigMaps but skip the reconcile
 # ---------------------------------------------------------------------------
 test_refresh_skips_annotate_when_digest_unchanged() {
   echo "Test: unchanged digest skips the reconcile request"
@@ -264,7 +359,7 @@ test_refresh_skips_annotate_when_digest_unchanged() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 6: one unresolvable image does not block the others
+# Test 7: one unresolvable image does not block the others
 # ---------------------------------------------------------------------------
 test_refresh_continues_on_resolve_failure() {
   echo "Test: a per-image resolve failure warns, continues, and fails the exit code"
@@ -289,7 +384,7 @@ test_refresh_continues_on_resolve_failure() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 7: deploy-infra.sh calls the refresh only on the flux ControlPlane path
+# Test 8: deploy-infra.sh calls the refresh only on the flux ControlPlane path
 # ---------------------------------------------------------------------------
 test_deploy_infra_gates_refresh_call() {
   echo "Test: deploy-infra.sh gates the refresh call inside the flux branch, best-effort"
@@ -316,6 +411,7 @@ test_deploy_infra_gates_refresh_call() {
 test_resolve_image_digest_success
 test_resolve_image_digest_failure
 test_render_digest_configmap_yaml
+test_resolve_image_digest_fallback_to_curl
 test_refresh_applies_and_annotates_all_operators
 test_refresh_skips_annotate_when_digest_unchanged
 test_refresh_continues_on_resolve_failure


### PR DESCRIPTION
`hack/refresh-operator-image-digests.sh` refused to run on any host without Docker: `preflight()` required `docker` plus a working `docker buildx` before doing any work, even though the only step that actually needs Docker is resolving the digest behind a tag. That blocked `make refresh-operator-digests` — and `hack/deploy-infra.sh` on the `WITH_CONTROLPLANE=true CONTROLPLANE_OPERATORS=flux` path, which calls it internally — for Podman, Lima, Rancher Desktop, and kubectl-only setups.

Closes #695

## What the reviewer walks through

**`hack/refresh-operator-image-digests.sh` — two digest backends instead of one**

`preflight()` now hard-requires only `kubectl`, and fails when *neither* `docker buildx` nor `curl` is present (`have_docker_buildx` / `have_curl`). `resolve_image_digest()` becomes a dispatcher: it tries `resolve_image_digest_via_docker` (the previous `docker buildx imagetools inspect` implementation, moved verbatim) and falls back to `resolve_image_digest_via_curl` — so a host that *has* Docker but cannot reach one particular image still gets the second attempt.

`resolve_image_digest_via_curl` speaks the Registry V2 API directly: it splits the ref into registry / repo / reference (a ref that already carries `@sha256:…` short-circuits, a bare name defaults to `registry-1.docker.io` + `library/`), requests `GET /v2/<repo>/manifests/<reference>` with the OCI and Docker manifest `Accept` types, and reads `Docker-Content-Digest` off a 200. On a 401 it parses the `WWW-Authenticate: Bearer` challenge, fetches a token from `realm` with `scope=repository:<repo>:pull`, and repeats the request — the ghcr.io path.

The per-image contract is unchanged: a resolve failure warns, skips that image, lets the others through, and still makes the overall exit code non-zero.

**`tests/unit/hack/refresh_operator_image_digests_test.sh` — a `curl` stub, and a fallback test**

The stub harness gains a recording `curl` alongside `docker` and `kubectl`. It is not optional: without it the new fallback fires a *real* network request at ghcr.io, which succeeds for the real published operator images and silently masks the failure scenarios these tests exercise. The stub keys on the same `DOCKER_FAIL_FOR` variable as the docker stub, so one env assignment fails *both* backends and Test 2 keeps testing "genuinely unresolvable" rather than "docker failed, curl quietly rescued it". No bearer challenge is simulated — the stub answers the first request, and fails closed if the token path is ever reached.

New Test 4 sets `DOCKER_BUILDX_FAIL=true`, asserts the digest still resolves, and asserts the curl log contains the `v2/c5c3/keystone-operator/manifests/latest` request. The later tests are renumbered.

**`docs/quick-start.md`, `docs/quick-start-extended.md`, `docs/quick-start-controlplane.md` — Podman as a kind provider**

Prerequisites now name a container runtime (Docker Desktop *or* Podman) rather than Docker Desktop, and the RAM row reads "available to the container runtime". `export KIND_EXPERIMENTAL_PROVIDER=podman` is set once before cluster creation and stays exported for the image-load step, the pull step gains a `podman pull` variant against the same provider, and the local build chain notes the `docker` → `podman` substitution. The refresh-digests note in the ControlPlane quick start records the new preference order (`docker buildx`, else `curl`).

## Test

```console
$ bash tests/unit/hack/refresh_operator_image_digests_test.sh
Results: 54 passed, 0 failed, 0 skipped
```

Hermetic — `docker`, `curl`, and `kubectl` are all stubbed, no network and no cluster.
