### PR TITLE
docs: add curl --resolve fallback for nip.io DNS issues in quick-start-controlplane

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -387,6 +387,59 @@ at `https://keystone.127-0-0-1.nip.io:8443/v3` — the same path as the per-serv
 curl -k https://keystone.127-0-0-1.nip.io:8443/v3
 ```
 
+::: tip If your host cannot resolve `*.nip.io`
+On some local setups that filter or block this specific DNS pattern, the
+following command fails:
+
+```bash
+curl -k https://keystone.127-0-0-1.nip.io:8443/v3
+```
+
+The command returns the following error:
+
+```
+curl: (6) Could not resolve host: keystone.127-0-0-1.nip.io
+```
+
+`nip.io` deliberately resolves hostnames like `keystone.127-0-0-1.nip.io` to
+the loopback address `127.0.0.1`. Some routers ship **DNS rebind
+protection**, a security feature that silently drops any DNS response
+resolving a public hostname to a private or loopback address, which is
+this pattern. When your machine's resolver does this, `nip.io`
+never resolves. Confirm the cause by comparing your
+router against a public resolver:
+
+```bash
+dig +short keystone.127-0-0-1.nip.io @<your-router-ip>   # empty: blocked
+dig +short keystone.127-0-0-1.nip.io @1.1.1.1            # 127.0.0.1: as expected
+```
+
+The most reliable fix is host-local: add loopback
+entries to `/etc/hosts`:
+
+```bash
+sudo sh -c 'cat >> /etc/hosts <<EOF
+127.0.0.1 keystone.127-0-0-1.nip.io
+127.0.0.1 horizon.127-0-0-1.nip.io
+127.0.0.1 glance.127-0-0-1.nip.io
+EOF'
+```
+
+For a one-off `curl` check without touching `/etc/hosts`, use `--resolve` to
+override DNS for a single host/port pair — `curl` still sends the original
+hostname in the request and TLS handshake, but connects directly to
+`127.0.0.1`:
+
+```bash
+curl -k --resolve keystone.127-0-0-1.nip.io:8443:127.0.0.1 \
+  https://keystone.127-0-0-1.nip.io:8443/v3
+```
+
+If you'd rather fix it at the network level, most routers let you exempt
+specific domains from rebind protection, or you can add a public resolver
+(e.g. `1.1.1.1`) ahead of the router in your machine's network settings.
+:::
+
 Then issue a token with the admin password:
 
 ```bash


### PR DESCRIPTION
## What

Documents a fallback for Step 6 (Verify) of the ControlPlane quick start when the local host cannot resolve `*.nip.io` hostnames.

## Why

On some local setups that filter or block this specific DNS pattern, the following command fails:

curl -k https://keystone.127-0-0-1.nip.io:8443/v3

The command returns the following error:

```
curl: (6) Could not resolve host: keystone.127-0-0-1.nip.io
```

This happens even though the ControlPlane and its projected Keystone/Horizon/Glance services are fully `Ready` — it's a local DNS resolution issue, not a cluster problem.

## Change

Adds a `tip` callout right after the first Step 6 `curl` check with:
- `curl --resolve <host>:<port>:127.0.0.1 ...` as a per-request workaround (explains what `--resolve` does).
- An `/etc/hosts` snippet as a persistent fix, since the `openstack` CLI commands later in Step 6 don't support `--resolve`.

## Testing

Verified locally against a live `kind`+Podman ControlPlane deployment:

```bash
curl -k --resolve keystone.127-0-0-1.nip.io:8443:127.0.0.1 \
  https://keystone.127-0-0-1.nip.io:8443/v3
```

returned the expected Keystone version document once the base cluster/ControlPlane were healthy.

Docs-only change, no code paths affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787490717&installation_model_id=18560&pr_number=742&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F742&signature=e1c683a139fde312177d979d301a9b399c6626bc47d8b9f3165a82112f878aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



On-behalf-of: @SAP
Assisted-by: Claude:claude-sonnet-5 
Signed-off-by: zaher-abb-vw zabboud@deloiite.de