### PR TITLE
docs: add curl --resolve fallback for nip.io DNS issues in controlpla…

### DIFF
--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -387,6 +387,32 @@ at `https://keystone.127-0-0-1.nip.io:8443/v3` — the same path as the per-serv
 curl -k https://keystone.127-0-0-1.nip.io:8443/v3
 ```
 
+::: tip If your host cannot resolve `*.nip.io`
+Some local resolvers (observed on macOS) fail to resolve `nip.io` hostnames,
+which surfaces as `curl: (6) Could not resolve host`. Force the hostname to
+resolve to the loopback address for a single request with `curl`'s
+`--resolve`:
+
+```bash
+curl -k --resolve keystone.127-0-0-1.nip.io:8443:127.0.0.1 \
+  https://keystone.127-0-0-1.nip.io:8443/v3
+```
+
+`--resolve <host>:<port>:<ip>` overrides DNS for that host/port pair only —
+`curl` still sends the original hostname in the request and TLS handshake, but
+connects directly to `127.0.0.1`. For a fix that also covers the `openstack`
+CLI commands below (which do not support `--resolve`), add loopback entries to
+`/etc/hosts` instead:
+
+```bash
+sudo sh -c 'cat >> /etc/hosts <<EOF
+127.0.0.1 keystone.127-0-0-1.nip.io
+127.0.0.1 horizon.127-0-0-1.nip.io
+127.0.0.1 glance.127-0-0-1.nip.io
+EOF'
+```
+:::
+
 Then issue a token with the admin password:
 
 ```bash


### PR DESCRIPTION
…ne quick start

Some local resolvers (observed on macOS) fail to resolve *.nip.io hostnames, causing 'curl: (6) Could not resolve host' during Step 6 verification. Document curl's --resolve flag as a per-request workaround, and an /etc/hosts entry as a persistent fix covering the openstack CLI commands as well.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787490810&installation_model_id=18560&pr_number=743&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F743&signature=07f9ba47f150bc7a5fae640b7fc09c1e56f1d4da32fde9d61716ac21859c4ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->