### PR TITLE
docs: add database backup reminder before OpenStack upgrade

### DIFF
--- a/docs/guides/day-2-operations.md
+++ b/docs/guides/day-2-operations.md
@@ -79,17 +79,20 @@ deployment there is no HPA knob — scale by setting
 
 ## Upgrade the OpenStack release
 
-Change `spec.openStackRelease` on the `ControlPlane` CR to a newer release. The
-operator projects the new image tag (`ghcr.io/c5c3/keystone:<release>`) onto the
-`controlplane-keystone` child, which triggers the keystone-operator's
-expand-migrate-contract pipeline. The API stays available throughout — old and
-new schemas coexist while data is migrated.
+Before you start this upgrade, take a database backup so you can recover if the
+upgrade goes bad.
 
 Before you patch, make the target-release images node-local. The devstack
 pre-loads only the `2025.2` Keystone image, and the projected Horizon child
 follows `spec.openStackRelease` too — so pull and `kind load` both the Keystone
 and Horizon images for the target release, or the rollout stalls on an image
 pull:
+
+Change `spec.openStackRelease` on the `ControlPlane` CR to a newer release. The
+operator projects the new image tag (`ghcr.io/c5c3/keystone:<release>`) onto the
+`controlplane-keystone` child, which triggers the keystone-operator's
+expand-migrate-contract pipeline. The API stays available throughout — old and
+new schemas coexist while data is migrated.
 
 ```bash
 docker pull ghcr.io/c5c3/keystone:2026.1


### PR DESCRIPTION
### Summary

This docs change adds an explicit safety reminder to take a database backup before starting the OpenStack release upgrade flow in the day-2 operations guide.

### What changed

Added a clear pre-upgrade backup warning in the Upgrade the OpenStack release section.
Kept the existing upgrade mechanics and image pre-load guidance intact.
Reordered wording so the backup warning appears before procedural upgrade steps.
Why
Upgrades are usually safe, but this makes rollback/recovery expectations explicit and reduces operator risk during day-2 operations.

### Scope

Docs only
1 file changed
No code or behavior changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787559769&installation_model_id=18560&pr_number=744&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F744&signature=4497fa6ef8ef4f47b1f4716a3bba3e8dee907a3d9f3cdd264fbef302f9ec83b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->