### PR TITLE
chore(skills): require recurring maintenance jobs at onboarding

### DIFF
--- a/.claude/skills/check-service-parity/SKILL.md
+++ b/.claude/skills/check-service-parity/SKILL.md
@@ -118,6 +118,15 @@ inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
   `ServicesSpec`, the `reconcile_<svc>.go` projection, the
   `<Svc>Ready` condition mirror, and the RBAC group in the c5c3
   chart helpers.
+- **P10** — recurring maintenance: a database-backed operator projects
+  at least one housekeeping CronJob (`job.EnsureCronJob` — glance's
+  `db purge`, keystone's `trust_flush`). Nothing else in the cluster
+  runs the periodic cleanup a package deployment gets from a cron entry
+  on the controller node, and the omission is invisible: the deployment
+  stays Ready while the soft-deleted backlog grows. Services that model
+  no database are skipped rather than allowlisted. Presence is a smoke
+  signal — whether the CronJobs cover the tasks the service actually
+  needs is step 2 below.
 - The **inventory** lists, per service, the helm-unittest, e2e, and
   chaos suite counts. Cross-reference outliers by hand in step 2.
 
@@ -140,6 +149,16 @@ The script checks presence, not content. Using the inventory, confirm:
 4. That suite *content* tracks the reference where it applies — e.g. a
    new assertion added to keystone's `network-policy` suite usually
    has an analogue in every other service's suite.
+5. That the housekeeping P10 found (or did not find) matches what the
+   service actually needs: compare the projected CronJobs against the
+   `<svc>-manage` subcommands upstream documents for periodic use
+   (`db purge`, `archive_deleted_rows`, `purge_deleted`, cache pruning,
+   expiry sweeps — the table in [[prepare-new-service]] § Recurring
+   maintenance jobs). A service passing P10 with a key task still
+   unscheduled is the same finding as one failing it. Check the shape
+   too: `ConcurrencyPolicy: Forbid`, a per-run row cap,
+   `ActiveDeadlineSeconds`, and a condition that reports the newest
+   terminal run instead of merely confirming the CronJob exists.
 
 ### 3. Run the per-layer authoritative gates
 
@@ -167,7 +186,10 @@ Produce a concise summary grouped by severity:
   service the ControlPlane models.
 - **MEDIUM** — a missing canonical e2e suite, chaos suite, or
   helm-unittest suite without an `ALLOWED_DEVIATIONS` entry; a
-  missing dashboard drift test; a missing deploy-stack entry.
+  missing dashboard drift test; a missing deploy-stack entry; a
+  database-backed service with no housekeeping CronJob (P10), or one
+  whose CronJobs leave a documented periodic task unscheduled — name
+  the task and the growth it leaves unbounded.
 - **LOW** — a missing docs page or nav entry; an inventory outlier
   (suite counts far apart) that turns out to be a recorded deviation.
 
@@ -196,7 +218,15 @@ These recurring shapes are worth grepping for first:
    first; both copies now evolve independently. The onboarding
    pre-work rule in [[prepare-new-service]] exists to prevent exactly
    this.
-5. **Release config added for one release only.** The service key
+5. **Housekeeping deferred to "later".** The service onboards with a
+   database and a deployment but no periodic cleanup, because nothing
+   in the onboarding fails without it. Glance ran that way until
+   `db purge` was retro-fitted, which then cost an API block, an
+   admission bound on `metadata.name` in two operators, and a
+   hash-collapse fallback for the CRs admitted before that bound —
+   [[prepare-new-service]] § Recurring maintenance jobs exists to keep
+   the next service from repeating it.
+6. **Release config added for one release only.** The service key
    landed in the newest `releases/<version>/source-refs.yaml` but not
    the older ones (or vice versa), so the build matrix builds the
    service for half the supported releases.

--- a/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
+++ b/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
@@ -25,6 +25,8 @@
 #   P8  docs: reference set, metrics/networkpolicy guides, vitepress nav
 #   P9  ControlPlane integration: ServicesSpec field, reconcile_<svc>.go,
 #       <Svc>Ready condition, c5c3 chart RBAC rule
+#   P10 recurring maintenance: a database-backed service projects at least
+#       one housekeeping CronJob (job.EnsureCronJob)
 #
 # The keystone reference is audited too — a reference regression is its own
 # [FAIL]. Deliberate thin-profile deviations (a service that legitimately
@@ -358,6 +360,31 @@ for svc in ${SERVICES}; do
   t=0; grep -qi "${svc}\.openstack\.c5c3\.io" "${HELPERS}" || t=1
   check "${svc}" P9 "rbac" "${t}" \
     "c5c3 chart RBAC helper grants the ${svc}.openstack.c5c3.io group"
+done
+
+# ---------------------------------------------------------------------------
+# P10 — recurring maintenance
+# ---------------------------------------------------------------------------
+# Every soft-deleting service needs periodic housekeeping (glance:
+# glance-manage db purge; keystone: keystone-manage trust_flush). Package
+# deployments run it from a cron entry on the controller node; here nothing
+# runs it unless the operator projects a CronJob, and the omission is silent —
+# the deployment stays Ready while the backlog grows. Presence of
+# job.EnsureCronJob is a smoke signal only: whether the projected CronJob
+# covers the tasks the service actually needs is the hand cross-reference in
+# the skill's step 2.
+hdr "P10: recurring maintenance (housekeeping CronJob per database-backed service)"
+for svc in ${SERVICES}; do
+  # Skip services that model no database: they carry no soft-delete backlog,
+  # so their absence is a profile fact, not a deviation worth a token.
+  if ! grep -rq "DatabaseSpec" "operators/${svc}/api/" 2>/dev/null; then
+    info "${svc}: models no database — no housekeeping CronJob expected"
+    continue
+  fi
+
+  t=0; grep -rq "job.EnsureCronJob" "operators/${svc}/internal/controller/" 2>/dev/null || t=1
+  check "${svc}" P10 "maintenance-cronjob" "${t}" \
+    "operator projects at least one recurring-maintenance CronJob (job.EnsureCronJob)"
 done
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/prepare-new-service/SKILL.md
+++ b/.claude/skills/prepare-new-service/SKILL.md
@@ -34,7 +34,7 @@ Every service in forge threads through five layers. Keystone
 | Layer | Canonical locations | Auto-extends? |
 |---|---|---|
 | 1. Container image | `images/<svc>/Dockerfile`, `releases/*/source-refs.yaml`, `releases/*/extra-packages.yaml`, `tests/container-images/verify_<svc>.sh` | build/test matrix: **yes** (from source-refs keys); hadolint matrix in `build-images.yaml`: **no** |
-| 2. Service operator | `operators/<svc>/` (api, controller, webhook, helm chart on `operators/shared/helm/operator-library`), `go.work`, `Makefile` `OPERATORS` | **no** — module + enumerations by hand |
+| 2. Service operator | `operators/<svc>/` (api, controller — including the recurring-maintenance CronJobs of § Recurring maintenance jobs —, webhook, helm chart on `operators/shared/helm/operator-library`), `go.work`, `Makefile` `OPERATORS` | **no** — module + enumerations by hand |
 | 3. CI / e2e / deploy | `ci.yaml` paths-filter + `ALL_OPERATORS` + matrices, `tests/ci/verify_<svc>_ci_pipeline.sh`, `tests/e2e/<svc>/`, `tests/e2e/<svc>-operator/`, `tests/e2e-chaos/<svc>-*/`, `tests/tempest/<svc>-*/`, `deploy/flux-system/releases/<svc>-operator.yaml`, kind devstack wiring (`deploy/kind/base/openstack-gateway.yaml` listener + `deploy/kind/infrastructure/<svc>-nip-io-tls-certificate.yaml`, the `deploy/kind/base/kustomization.yaml` HelmRelease suspend patch **plus its counterparts in `hack/deploy-infra.sh`**: the flux-path un-suspend patch, the `enable_operator_servicemonitor` call, and the `hack/refresh-operator-image-digests.sh` target tuple — a service missing from the un-suspend list stays suspended on the quick-start path, its CRDs never install, and the c5c3-operator's controlplane cache never syncs), OpenBao bootstrap legs (`deploy/openbao/bootstrap/`, `deploy/openbao/policies/`) | chainsaw suites: **yes** (auto-discovered); ci.yaml wiring: **no** (3-step procedure in `hack/ci-resolve-changes.sh` header); devstack/OpenBao wiring: **no** |
 | 4. ControlPlane (c5c3) | `ServicesSpec` in `operators/c5c3/api/v1alpha1/controlplane_types.go` (incl. `publicEndpoint` + `databaseCredentialsMode` per-service fields), `reconcile_<svc>.go` (+ `reconcile_<svc>_dbcredentials.go` for DB services), catalog row in `reconcile_catalog.go`, teardown in `reconcile_delete.go`, condition/instrumentation maps, RBAC markers + helm `_helpers.tpl`, scheme, webhook, envtest full chain (`integration_test.go`) + `tests/e2e/c5c3/full-controlplane-keystone/` | **no** — ~10 enumeration points |
 | 5. Documentation | `docs/reference/<svc>/` (hand-written, `quadrant: operator` frontmatter), VitePress sidebar, per-service guides under `docs/guides/<svc>/`, quick-start extension (`docs/quick-start-controlplane.md`), `tests/unit/docs/` conventions | **no** — no doc generator exists |
@@ -69,6 +69,15 @@ applies and which decisions need a Phase-0 spike:
   migration (glance: `db load_metadefs`) — chain the extra `*-manage` step
   into the db-sync Job with an explicit `--path`, because the config-free
   image does not ship the oslo default locations.
+- **Recurring maintenance?** Which housekeeping does the service expect
+  somebody to run on a schedule — above all the database cleanup every
+  soft-deleting service needs? Enumerate it here, in the profile, and
+  carry it into Phase 2; it is not follow-up work. A package deployment
+  has a cron entry on the controller node doing this, forge has nothing:
+  unless the operator projects a CronJob, no run ever happens, and the
+  growth is silent — no probe, condition, or metric observes a purge that
+  was never scheduled. § Recurring maintenance jobs below is the build
+  sheet and the retro-fit bill.
 - **Message bus?** No shared RabbitMQ spec or backing service exists yet —
   the **first** RabbitMQ consumer must add a `commonv1` messaging type and
   extend `InfrastructureSpec` + `hack/deploy-infra.sh`. That is its own
@@ -179,10 +188,13 @@ Standard phase skeleton (drop/merge phases the profile rules out):
 
 - **Phase 0 — decisions (spike):** session/config/secret-sourcing choices,
   upper-constraints handling, WSGI/launch mode per release, endpoint and
-  catalog-interface wiring, backend-CRD shape if the profile calls for one
-  (record the decisions in the meta as #656 records D1–D10).
+  catalog-interface wiring, backend-CRD shape if the profile calls for one,
+  the recurring-maintenance inventory with its cadence and retention
+  defaults (record the decisions in the meta as #656 records D1–D10).
 - **Phase 1 — container image** (usually independent of pre-work).
-- **Phase 2 — service operator scaffold** (blocked on generalization).
+- **Phase 2 — service operator scaffold** (blocked on generalization) —
+  one checkbox per recurring-maintenance task from the profile; they are
+  part of the scaffold, not a follow-up (§ Recurring maintenance jobs).
 - **Phase 3 — CI, e2e, deploy stack** (alongside Phase 2) — including the
   kind Gateway listener/cert, OpenBao bootstrap legs, and chaos suites.
 - **Phase 4 — ControlPlane integration** (blocked on Phase 2) — including
@@ -218,6 +230,118 @@ sub-issues use them as gates): [[check-crd-drift]], [[check-fixture-drift]],
 [[check-service-parity]] as the closing cross-layer gate once the
 onboarding lands (#656 used it exactly that way).
 
+## Recurring maintenance jobs
+
+Every OpenStack service that soft-deletes rows, caches artefacts, or ages
+out records assumes an operator sweeps up on a schedule. Upstream ships
+the commands and documents the cadence; scheduling them is the deployer's
+job. Package deployments answer that with a cron entry on the controller
+node — forge has no such place, so a maintenance task that the service
+operator does not project simply never runs. That failure is invisible by
+construction: the deployment stays Ready, every probe passes, and the
+only symptom is a table, a cache, or a disk that keeps growing until it
+becomes an incident.
+
+Treat this as part of the initial implementation. Glance is the
+cautionary tale: it onboarded without one, and adding `db purge` later
+(#729) cost an API block, a sub-reconciler, a condition, a metric pair,
+an admission bound on `metadata.name` in **two** operators plus a
+hash-collapse fallback for the CRs admitted before that bound existed,
+and three invalid-CR fixtures — all of which would have been a handful of
+extra lines inside the original scaffolding PRs.
+
+### Find the tasks
+
+For each candidate ask: does upstream document a periodic invocation, and
+what happens over a year without it? Sources, in order of authority: the
+service's admin/operations guide for the pinned release, `<svc>-manage
+--help` run against the built image (authoritative for the subcommand
+names at that exact ref), and the upstream deployment projects
+(openstack-k8s-operators, Yaook, kolla-ansible cron roles) for the
+cadences they picked.
+
+The recurring shapes, with the commands to look for — a starting list to
+verify, not a lookup table:
+
+| Shape | Examples |
+|---|---|
+| Hard-delete soft-deleted rows | `glance-manage db purge` / `db purge_images_table`, `nova-manage db archive_deleted_rows` + `db purge`, `cinder-manage db purge`, `heat-manage purge_deleted`, `barbican-manage db clean` |
+| Expire ephemeral records | `keystone-manage trust_flush` (implemented), token/session expiry sweeps — for Django-session services only when sessions are DB-backed (horizon's signed-cookie default needs none) |
+| Prune caches and staging areas | glance image cache pruner/cleaner, orphaned upload staging directories |
+| Rotate key material | keystone fernet + credential rotation (`internal/common/rotation` — already generalized) |
+| Upstream daemons, not CronJobs | some services ship a long-running housekeeper (octavia) — model it as a Deployment, and say so in the profile rather than leaving the row blank |
+
+A service with no maintenance task is a legitimate answer; record it in
+the meta issue as a decision with its reasoning, so the next audit reads
+it as considered rather than forgotten.
+
+### Build sheet
+
+`reconcile_dbpurge.go` (glance) and `reconcile_trustflush.go` (keystone)
+are the two worked examples; both build on `internal/common/job`. One
+maintenance task touches:
+
+- **API** — an optional `spec.<task>` block (`DBPurgeSpec` in
+  `operators/glance/api/v1alpha1/glance_types.go`) with `schedule`,
+  retention/scope knobs, and `suspend`. Resolve the defaults at reconcile
+  time in an `effective<Task>` helper, not in the defaulting webhook, so
+  an unset field tracks the operator default across upgrades.
+- **Sub-reconciler** — a parallel-group step calling `job.EnsureCronJob`,
+  plus `Owns(&batchv1.CronJob{})` on the builder.
+- **Condition** — `<Task>Ready` in the operator's condition list and in
+  the `subReconcilerConditionTypes` map (else the metric label reads
+  `UNKNOWN`; [[check-condition-coverage]] gates this). Suspension keeps
+  it `True` under its own reason — a pause is a posture, not a failure —
+  but the message must name the backlog that stops draining.
+- **Run visibility** — the CronJob controller prunes its Jobs by history
+  limit, so list the Jobs by the CR's common labels, keep the ones the
+  CronJob controls, and report on the newest that reached a terminal
+  state (`job.TerminalCondition`). Feed
+  `job.RecordJobTerminalState`, which dedupes on the Job UID, into a
+  metric pair (`<svc>_operator_<task>_total` +
+  `_duration_seconds`) and emit a Warning event on failure.
+- **Webhook** — cron grammar via `validation.CronSchedule`
+  (`internal/common/validation`; it accepts `@daily`-style descriptors
+  that a CRD pattern would not), bounds on the retention knobs mirroring
+  the CEL rules, and an update warning when a retention window shrinks,
+  because the shortened window applies retroactively at the next firing.
+- **Safety knobs on the CronJob** — `ConcurrencyPolicy: Forbid` (two
+  purges deleting from the same tables contend: Galera certification
+  failures, InnoDB lock timeouts), a per-invocation row cap
+  (`--max_rows`) keeping each write-set Galera-friendly, and
+  `ActiveDeadlineSeconds` so a wedged run turns into a terminal failure
+  instead of an active Job that holds the condition `True` forever.
+  Document what the cap means for throughput: it is the schedule, not
+  the job, that sets the drain rate.
+- **The same runtime contract as the workload** — config volume, the
+  `database.ConnectionEnvVar` override so the job reads dynamic
+  credentials from the derived Secret rather than the ConfigMap, the
+  db-TLS keypair mount under the same gate the Deployment uses, and pod
+  labels that are a superset of the selector labels so the NetworkPolicy
+  covers the job pods. A job that also talks to the API server needs its
+  own egress rule (keystone's rotation CronJobs do).
+- **Naming** — Kubernetes caps a CronJob name at 52 characters. Bound
+  `metadata.name` in the webhook accordingly (see the gotcha below) and
+  mirror that bound in the c5c3 webhook for the projected child name.
+- **Tests** — unit tests pinning the rendered CronJob and every condition
+  arm, invalid-CR fixtures for each new validation rule
+  (`tests/e2e/glance/invalid-cr/17`–`19` are the template), and a
+  `basic-deployment` assertion that the CronJob exists.
+- **Docs** — the spec block and the projected CronJob shape in
+  `docs/reference/<svc>/<svc>-crd.md`, the step and its condition in
+  `<svc>-reconciler.md`, the events plus an alerting rule in
+  `<svc>-events.md`.
+
+### Sub-issue checkbox
+
+Phase 2 carries one checkbox per maintenance task, named after the
+command it runs, e.g.:
+
+> - [ ] `spec.dbPurge` + `reconcileDBPurge`: project the
+>   `{name}-db-purge` CronJob (`<svc>-manage db purge`), report the
+>   newest terminal run via `DBPurgeReady`, metric pair, invalid-CR
+>   fixtures, CRD/reconciler/events docs
+
 ## Known gotchas (verified 2026-07 post-glance, re-verify at HEAD)
 
 - **upper-constraints pin conflict:** some services (horizon, most
@@ -249,6 +373,18 @@ onboarding lands (#656 used it exactly that way).
   `glance.wsgi.api:application` reads only its default config path and
   needed a hand-shipped shim (`images/glance/glance-wsgi-api`) to load
   the operator's mounted config dirs.
+- **A CronJob shrinks the CR's name budget:** Kubernetes caps a CronJob
+  name at 52 characters (`MaxCronJobNameLength` in
+  `operators/glance/api/v1alpha1/glance_webhook.go`), so
+  `{name}-<suffix>` bounds `metadata.name` itself. Enforce that bound
+  **on create only** — `metadata.name` is immutable, so on update the
+  rule can only fire against objects a pre-bound operator already
+  admitted, including the finalizer-removal update that completes a
+  deletion, wedging them permanently. The controller therefore stays
+  total for over-long names by collapsing them onto a content-stable
+  hash (`dbPurgeCronJobName`). Adding the first CronJob to an existing
+  operator means paying all of this; adding it during onboarding means
+  the bound exists before any CR does.
 - **Paste-deploy divergence between releases:** factory references
   (`API.factory` vs `API_factory`) and oslo.middleware healthcheck
   semantics (filter tolerated in 2025.2, app-only in 2026.1) differ

--- a/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
+++ b/.claude/skills/prepare-new-service/scripts/inventory-touchpoints.sh
@@ -61,6 +61,8 @@ check "operators/${SERVICE}/helm/${SERVICE}-operator chart" \
   test -f "operators/${SERVICE}/helm/${SERVICE}-operator/Chart.yaml"
 check "CRD base under operators/${SERVICE}/config/crd/bases/" \
   bash -c "ls operators/${SERVICE}/config/crd/bases/*.yaml"
+check "recurring-maintenance CronJob sub-reconciler, job.EnsureCronJob (skip only if the profile recorded no maintenance task)" \
+  grep -rq "job.EnsureCronJob" "operators/${SERVICE}/internal/controller/"
 
 header "Layer 3: CI / e2e / deploy"
 check "ci.yaml FILTER_${SERVICE} env" grep -q "FILTER_${SERVICE}" .github/workflows/ci.yaml

--- a/docs/contributing/adding-a-new-operator.md
+++ b/docs/contributing/adding-a-new-operator.md
@@ -84,7 +84,7 @@ bottom when scaffolding `operators/<op>/`:
 
 ## Design decisions the shared scaffolding encodes
 
-Two cross-service decisions were settled when the scaffolding was extracted;
+Three cross-service decisions were settled when the scaffolding was extracted;
 new operators build on them rather than reopening them:
 
 - **Cross-service endpoint discovery is convention-based.** Consumers derive a
@@ -94,6 +94,23 @@ new operators build on them rather than reopening them:
   consumers only; no machine consumer reads it, and no status-based resolve
   helper or cross-CR watch exists. If a new operator needs endpoint shapes the
   convention cannot express, build that helper then — not preemptively.
+- **Periodic maintenance belongs to the operator, from the first release
+  on.** OpenStack services expect somebody to run their housekeeping
+  commands on a schedule — `glance-manage db purge`,
+  `keystone-manage trust_flush`, cache pruning, expiry sweeps. A package
+  deployment answers that with a cron entry on a controller node; a
+  Kubernetes deployment has no such place, so a task the operator does not
+  project as a CronJob never runs at all, silently: the workload stays
+  Ready, every probe passes, and the only symptom is a table or a cache
+  that keeps growing. Model each task in the spec (`spec.dbPurge` on
+  Glance, `spec.trustFlush` on Keystone), project it from a sub-reconciler
+  via `internal/common/job`'s `EnsureCronJob`, and give it a `<Task>Ready`
+  condition that reports the newest terminal run rather than the mere
+  existence of the CronJob. Scaffold this with the operator: the first
+  CronJob added later also has to bound `metadata.name`, since Kubernetes
+  caps a CronJob name at 52 characters and an immutable field can only be
+  bounded on create — leaving the CRs admitted before the bound to a
+  hash-collapse fallback in the controller.
 - **Non-INI configuration rendering gets its own package.**
   `internal/common/config` renders oslo INI only and stays that way. A service
   that renders Python settings (e.g. Horizon's Django `local_settings.py`)


### PR DESCRIPTION
Glance onboarded without any periodic housekeeping. Its database purge landed in #749 — long after the service was in the tree — and retro-fitting it cost an API block, a sub-reconciler, a condition, a metric pair, an admission bound on `metadata.name` in *two* operators plus a hash-collapse fallback for the CRs admitted before that bound existed, and three invalid-CR fixtures. Nothing in the onboarding path had asked for it, and the omission is invisible by construction: the workload stays Ready, every probe passes, and the only symptom is a table that keeps growing.

The underlying gap is structural rather than glance-specific. OpenStack services ship housekeeping commands and document the cadence; running them is the deployer's job. A package deployment answers that with a cron entry on a controller node, forge has no such place — so a maintenance task the service operator does not project as a CronJob simply never runs. This branch moves that question into the onboarding path, where it costs a few lines instead of a follow-up epic.

## `prepare-new-service`

- New profile question **Recurring maintenance?**, next to the other database questions: enumerate the scheduled housekeeping the service expects, and carry it into Phase 2.
- New section **§ Recurring maintenance jobs**, holding what the glance work had to be reverse-engineered from:
  - **Where to find the tasks** — the admin guide for the pinned release, `<svc>-manage --help` against the built image (authoritative for the subcommand names at that ref), and the upstream deployment projects for their cadences.
  - **A shape table** with a starting list to verify: hard-deleting soft-deleted rows (`glance-manage db purge`, `nova-manage db archive_deleted_rows` + `db purge`, `cinder-manage db purge`, `heat-manage purge_deleted`, `barbican-manage db clean`), expiring ephemeral records (`keystone-manage trust_flush`, DB-backed session sweeps), cache and staging pruning, key rotation, and the case where upstream ships a daemon instead of a cron task.
  - **The build sheet** derived from `reconcile_dbpurge.go` and `reconcile_trustflush.go`: optional spec block with reconcile-time defaults, sub-reconciler over `job.EnsureCronJob` plus `Owns`, a `<Task>Ready` condition registered in the instrumentation map, run visibility by label + `job.TerminalCondition` + the UID-deduped metric pair, webhook rules (`validation.CronSchedule`, retention bounds, shrink warning), the `Forbid` / row-cap / `ActiveDeadlineSeconds` safety knobs, the same runtime contract as the workload (dynamic DB credentials, db-TLS mount, NetworkPolicy-covered pod labels), tests, and docs.
  - **A checkbox template** so the task lands as one sub-issue.
- Phase 0 records the maintenance inventory as a decision; Phase 2 carries one checkbox per task, explicitly not a follow-up.
- New gotcha: a CronJob shrinks the CR's own name budget — Kubernetes caps a CronJob name at 52 characters, the bound can only be enforced on create (`metadata.name` is immutable, and an update rule would wedge the finalizer-removal update of pre-bound CRs), hence the hash-collapse fallback in the controller.
- `inventory-touchpoints.sh` reports the layer-2 touch point as `[DONE]`/`[TODO]`.

## `check-service-parity`

The audit counterpart, so this is also caught when nobody invokes the planner:

- **P10** flags a database-backed service whose operator projects no housekeeping CronJob (`job.EnsureCronJob`). Services that model no `DatabaseSpec` are skipped rather than allowlisted — their absence is a profile fact, not a deviation worth a token.
- Step 2 gains the hand cross-reference P10 cannot do: do the projected CronJobs cover the tasks upstream documents for periodic use, and is the shape right (`Forbid`, per-run row cap, `ActiveDeadlineSeconds`, a condition reporting the newest terminal run rather than the CronJob's existence)? A service passing P10 with a key task unscheduled is the same finding as one failing it.
- MEDIUM severity entry and a new drift pattern, *Housekeeping deferred to "later"*.

## `docs/contributing/adding-a-new-operator.md`

The same decision as a third entry under the design decisions the shared scaffolding encodes, for readers who never invoke a skill.

## Verification

- `make check-feature-ids`, `shellcheck --severity=warning` on both skill scripts, and every `tests/unit/docs/*_test.sh`: green.
- `audit-service-parity.sh`: P10 passes for keystone and glance, skips horizon (no database); the overall finding count is unchanged against `main` (5 pre-existing).
- `inventory-touchpoints.sh`: `[DONE]` for glance, `[TODO]` for horizon and a hypothetical nova.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787664908&installation_model_id=18560&pr_number=750&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F750&signature=c86c0fb09837497f5311689bb1bc64653ef56148065e9b210c7e631bc02488df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->