### PR TITLE
build(images): add the placement service image for both releases

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -49,7 +49,7 @@ concurrency:
 jobs:
   lint-dockerfiles:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       contents: read
     strategy:
@@ -77,7 +77,7 @@ jobs:
   # Single source for lowercase image owner.
   prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       image-owner: ${{ steps.owner.outputs.owner }}
     steps:
@@ -89,7 +89,7 @@ jobs:
   build-base-images:
     needs: [lint-dockerfiles, prepare]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -178,7 +178,7 @@ jobs:
   merge-base-images:
     needs: [build-base-images, prepare]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 23
     permissions:
       contents: read
       packages: write
@@ -228,7 +228,7 @@ jobs:
   verify-base-images:
     needs: [merge-base-images]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: read
@@ -254,7 +254,7 @@ jobs:
   generate-matrix:
     needs: [merge-base-images, verify-base-images]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       contents: read
     outputs:
@@ -276,7 +276,7 @@ jobs:
   build-tempest:
     needs: [lint-dockerfiles, merge-base-images, verify-base-images, generate-matrix, prepare]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -340,7 +340,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [build-tempest, generate-matrix, prepare]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 23
     permissions:
       contents: read
       packages: write
@@ -392,7 +392,7 @@ jobs:
   build-keystone-federation-proxy:
     needs: [lint-dockerfiles, prepare]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -460,7 +460,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [build-keystone-federation-proxy, prepare]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 23
     permissions:
       contents: read
       packages: write
@@ -492,7 +492,7 @@ jobs:
   build-service-images:
     needs: [merge-base-images, verify-base-images, generate-matrix, prepare]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -587,7 +587,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [merge-base-images, build-service-images, generate-matrix, prepare]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -640,7 +640,7 @@ jobs:
   test-service-images:
     needs: [merge-base-images, verify-base-images, generate-matrix]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: read
@@ -705,7 +705,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [merge-service-images, test-service-images, generate-matrix]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -60,6 +60,7 @@ jobs:
           - images/keystone/Dockerfile
           - images/horizon/Dockerfile
           - images/glance/Dockerfile
+          - images/placement/Dockerfile
           - images/tempest/Dockerfile
           - images/keystone-federation-proxy/Dockerfile
           - operators/Dockerfile

--- a/.github/workflows/check-base-image-updates.yaml
+++ b/.github/workflows/check-base-image-updates.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   check-base-image:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
   # all operators are forced active regardless of which files were touched.
   changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     outputs:
       go: ${{ steps.result.outputs.go }}
       docs: ${{ steps.result.outputs.docs }}
@@ -209,7 +209,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -240,7 +240,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -273,7 +273,7 @@ jobs:
   shellcheck:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run shellcheck on hack/*.sh and operator rotation scripts
@@ -286,7 +286,7 @@ jobs:
   feature-ids:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Check the tree is free of internal feature/requirement IDs
@@ -300,7 +300,7 @@ jobs:
   review-markers:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Check no new unresolved reviewer markers were introduced
@@ -315,7 +315,7 @@ jobs:
   test-shell:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install kustomize
@@ -339,7 +339,7 @@ jobs:
   verify-invalid-cr-fixtures:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Verify invalid-CR fixture drift and structure
@@ -354,7 +354,7 @@ jobs:
   chainsaw-lint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: ./.github/actions/setup-test-deps
@@ -367,7 +367,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -402,9 +402,9 @@ jobs:
     # tests tipped it over. envtest is CPU-bound, so the larger runner pulls the
     # wall-clock back down. Even so the keystone controller envtest
     # suite alone runs ~14m and intermittently brushed the 15m job wall (a 15m07s
-    # run was cancelled), so the limit is raised to 20m for headroom.
+    # run was cancelled), so the limit is raised to 30m for headroom.
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -450,7 +450,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -469,7 +469,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -486,7 +486,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -519,7 +519,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -543,7 +543,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.helm == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
@@ -589,7 +589,7 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.e2e-infra == 'true'
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -692,7 +692,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -884,7 +884,7 @@ jobs:
     # largest suite in this matrix and has not been stable on the self-hosted
     # runners since they took over. The other legs stay self-hosted.
     runs-on: ${{ matrix.operator == 'keystone' && 'blacksmith-4vcpu-ubuntu-2404' || 'self-hosted' }}
-    timeout-minutes: 45
+    timeout-minutes: 68
     permissions:
       contents: read
       packages: read
@@ -1035,7 +1035,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 68
     permissions:
       contents: read
       packages: read
@@ -1186,7 +1186,7 @@ jobs:
               tests/e2e-chaos/mariadb-network-partition
               tests/e2e-chaos/glance-garage-outage
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Pod-chaos is blocking; network-chaos stays non-blocking (its kernel-module
     # dependency keeps it flakiness-prone). See the gating note above the job.
     continue-on-error: ${{ matrix.suite == 'network' }}
@@ -1307,7 +1307,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 68
     continue-on-error: false
     permissions:
       contents: read
@@ -1392,7 +1392,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 90
     continue-on-error: false
     permissions:
       contents: read
@@ -1529,7 +1529,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 90
     continue-on-error: false
     permissions:
       contents: read
@@ -1640,7 +1640,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 90
     continue-on-error: false
     permissions:
       contents: read
@@ -1755,7 +1755,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 68
     permissions:
       contents: read
       packages: read
@@ -1890,7 +1890,7 @@ jobs:
       always() &&
       needs.build-e2e-images.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     # Pruning run-scoped tags is best-effort housekeeping — a failure must not
     # fail the PR. A brand-new package (e.g. c5c3-operator before it is first
     # published to main) has only the run-scoped e2e tag, and GHCR refuses to
@@ -1927,7 +1927,7 @@ jobs:
   # Runs only on push events (main branch or v* tags) after E2E passed.
   build-and-push:
     runs-on: ${{ matrix.platform.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 23
     # Publish-only-on-merge: the merged commit's PR was already green, so we do
     # not re-run the E2E suite on push. This job depends only on `changes` (for
     # the operator matrix) and builds the image from its own cache scope,
@@ -2006,7 +2006,7 @@ jobs:
   # and push with final tags (SHA, latest, semver).
   merge-operator-images:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [changes, build-and-push]
     if: github.event_name == 'push' && needs.build-and-push.result == 'success'
     permissions:
@@ -2063,7 +2063,7 @@ jobs:
   # for v* tag pushes.
   helm-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     # Publish-only-on-merge: see build-and-push. The chart is packaged and pushed
     # for every changed operator on push without re-running the E2E suite.
     needs: [changes]
@@ -2096,7 +2096,7 @@ jobs:
   # on v* tag pushes, after images and charts are published.
   github-release:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     needs: [changes, merge-operator-images, helm-push]
     if: |
       startsWith(github.ref, 'refs/tags/v') &&

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -28,6 +28,8 @@ permissions:
 jobs:
   # Cleanup order follows the image dependency chain (leaf → root):
   #   1. Service images  (keystone, tempest)  – depend on venv-builder
+  #      The matrix below must list every images/<service>/Dockerfile that
+  #      build-service-images pushes; verify_release_config.sh gates this.
   #   2. venv-builder                         – depends on python-base
   #   3. python-base                          – base layer
   #   4. Operator images (keystone-operator)  – independent
@@ -39,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone, horizon, glance]
+        package: [keystone, horizon, glance, placement]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -37,7 +37,7 @@ jobs:
   # ── 1. Service images (composite tags) ─────────────────────────────
   cleanup-service-images:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
   # ── 1. Service images (SHA tags) ───────────────────────────────────
   cleanup-service-sha-images:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -81,7 +81,7 @@ jobs:
   cleanup-venv-builder:
     needs: [cleanup-service-images, cleanup-service-sha-images]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -99,7 +99,7 @@ jobs:
   cleanup-python-base:
     needs: [cleanup-venv-builder]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -119,7 +119,7 @@ jobs:
   # independently of the service image chain.
   cleanup-operator-images:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
   # e2e-* tag older than one day across every E2E target package.
   cleanup-e2e-stale-tags:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-container-images.yaml
+++ b/.github/workflows/verify-container-images.yaml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   verify-static-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/docs/reference/ci-cd/build-images-workflow.md
+++ b/docs/reference/ci-cd/build-images-workflow.md
@@ -323,7 +323,7 @@ is assembled by the subsequent `merge-base-images` job.
 | Property | Value |
 | --- | --- |
 | `runs-on` | <code v-pre>${{ matrix.runner }}</code> (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) |
-| `timeout-minutes` | `30` |
+| `timeout-minutes` | `45` |
 | `needs` | `[lint-dockerfiles]` |
 | Matrix | `platform: [linux/amd64, linux/arm64]` × native runner |
 | Push behavior | Pushes by digest to GHCR (even on PRs); tags assigned by `merge-base-images` |
@@ -358,7 +358,7 @@ on the final manifests.
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `15` |
+| `timeout-minutes` | `23` |
 | `needs` | `[build-base-images]` |
 | Permissions | `contents: read`, `packages: write`, `id-token: write`, `attestations: write`, `security-events: write` |
 
@@ -408,7 +408,7 @@ service image builds begin. Runs after `merge-base-images` and blocks
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `10` |
+| `timeout-minutes` | `15` |
 | `needs` | `[merge-base-images]` |
 | Permissions | `contents: read`, `packages: read` |
 
@@ -444,7 +444,7 @@ locally for inline verification instead of being pushed to GHCR.
 | Property | Value |
 | --- | --- |
 | `runs-on` | <code v-pre>${{ matrix.runner }}</code> (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) |
-| `timeout-minutes` | `30` |
+| `timeout-minutes` | `45` |
 | `needs` | `[merge-base-images, verify-base-images, generate-matrix]` |
 | Matrix | `service × release × platform × runner` (from `generate-matrix.build-matrix`; ARM64 excluded on PRs) |
 
@@ -477,7 +477,7 @@ Runs only on push events.
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `30` |
+| `timeout-minutes` | `45` |
 | `needs` | `[merge-base-images, build-service-images, generate-matrix]` |
 | `if` | `github.event_name != 'pull_request'` |
 | Matrix | `service × release` (from `generate-matrix.matrix`) |
@@ -556,7 +556,7 @@ This job runs in parallel with `build-service-images` — both depend on
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `60` |
+| `timeout-minutes` | `90` |
 | `needs` | `[merge-base-images, verify-base-images, generate-matrix]` |
 | Permissions | `contents: read`, `packages: read` |
 | Matrix | `service × release` (from `generate-matrix.matrix`) |
@@ -592,7 +592,7 @@ and steps:
 | Test | Validates |
 | --- | --- |
 | `test_five_jobs_defined` | All five jobs (build-base-images, verify-base-images, build-service-images, test-service-images, verify-service-images) exist |
-| `test_test_service_images_job_structure` | `runs-on: ubuntu-latest`, `timeout-minutes: 60`, `contents: read`, `packages: read`, no `id-token`, `attestations`, or `security-events` |
+| `test_test_service_images_job_structure` | `runs-on: ubuntu-latest`, `timeout-minutes: 90`, `contents: read`, `packages: read`, no `id-token`, `attestations`, or `security-events` |
 | `test_test_service_images_has_matrix` | Matrix includes `service: keystone` and `release: 2025.2`, with `fail-fast: false` |
 | `test_test_service_images_depends_on_base` | `needs` array contains `build-base-images` and `verify-base-images` |
 | `test_test_service_images_uses_venv_builder_output` | Steps reference `needs.build-base-images.outputs.venv-builder-image` |
@@ -638,7 +638,7 @@ On PRs, the equivalent verification runs as an inline step within `build-service
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `10` |
+| `timeout-minutes` | `15` |
 | `needs` | `[merge-service-images, test-service-images, generate-matrix]` |
 | `if` | `github.event_name != 'pull_request'` |
 | Permissions | `contents: read`, `packages: read` |
@@ -1353,7 +1353,7 @@ non-zero, the job fails.
 | Property | Value |
 | --- | --- |
 | `runs-on` | `ubuntu-latest` |
-| `timeout-minutes` | `10` |
+| `timeout-minutes` | `15` |
 
 **Steps:**
 

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -228,7 +228,7 @@ from tracked sources only. If any are found, their paths are printed along with 
 diff (`gofumpt -d`), and the job exits 1. The `-r` flag prevents `xargs` from running
 `gofumpt` when no Go files are piped (GNU coreutils, available on `ubuntu-latest`).
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### shellcheck
 
@@ -240,7 +240,7 @@ The shellcheck binary is pre-installed on `ubuntu-latest` runners.
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `make shellcheck` | Runs `shellcheck --severity=warning` over `hack/*.sh` and the operator rotation scripts (`operators/*/internal/controller/scripts/*.sh`) |
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### feature-ids
 
@@ -254,7 +254,7 @@ docs-only check.
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `make check-feature-ids` | Greps the tracked tree for internal feature/requirement ID patterns and fails on any hit |
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### verify-invalid-cr-fixtures
 
@@ -271,7 +271,7 @@ job runs. Always-on because the check is sub-second and `python3` is preinstalle
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `make verify-invalid-cr-fixtures` | Runs `_generate.py --check` and `test_generate.py` |
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### chainsaw-lint
 
@@ -290,7 +290,7 @@ the `setup-test-deps` composite action, the same one consumed internally by
 | 2 | `./.github/actions/setup-test-deps` | Restores the testdeps cache and runs `make install-test-deps` (puts `chainsaw` on `PATH`) |
 | 3 | `make chainsaw-lint` | Runs `chainsaw lint test -f` and `chainsaw lint configuration -f` over every matching file under `tests/` |
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### test-shell
 
@@ -308,7 +308,7 @@ explicitly so the deploy/ overlay assertions run their full check set
 | 2 | Install kustomize | Downloads the pinned kustomize binary into `/usr/local/bin` |
 | 3 | `make test-shell` | Iterates every `tests/unit/**/*_test.sh` and aggregates exit status |
 
-Timeout: 5 minutes.
+Timeout: 8 minutes.
 
 ### test
 
@@ -376,7 +376,7 @@ The `common` leg runs `make test-integration-common` (producing
 `cover-integration-<operator>.out`). Both targets set `KUBEBUILDER_ASSETS` via
 `$(SETUP_ENVTEST) use <pinned-k8s-version> -p path`.
 
-Timeout: 15 minutes (longer than unit tests to account for envtest startup).
+Timeout: 30 minutes (longer than unit tests to account for envtest startup).
 
 ### test-race
 
@@ -407,7 +407,7 @@ not on the critical path for E2E or publish jobs, so race detector overhead does
 down the primary feedback loop. The corresponding local command is `make test-race`
 (which omits `-count=1` via the default empty `RACE_FLAGS` for developer convenience).
 
-Timeout: 20 minutes (accommodates 2–5x race detector overhead).
+Timeout: 30 minutes (accommodates 2–5x race detector overhead).
 
 ### govulncheck
 
@@ -452,7 +452,7 @@ be updated with the new module name. The verification test
 (`tests/ci/verify_govulncheck_modules.sh`) catches drift between `go.work` and the
 Makefile automatically.
 
-Timeout: 10 minutes.
+Timeout: 15 minutes.
 
 ### verify-codegen
 
@@ -534,7 +534,7 @@ suites; the keystone-operator suites are listed below as representative.
 | `webhook_test.yaml` | `webhook-configuration.yaml` | Mutating/Validating configs when enabled, absent when disabled, cert-manager annotation |
 | `certificate_test.yaml` | `certificate.yaml` | Issuer and Certificate when enabled, absent when disabled, DNS names, issuer reference |
 
-Timeout: 10 minutes.
+Timeout: 15 minutes.
 
 ### e2e-infra
 
@@ -559,7 +559,7 @@ validates health of all operators, CRs, and ExternalSecrets.
 | 10 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
 | 11 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
 
-Timeout: 30 minutes.
+Timeout: 45 minutes.
 
 The two re-run legs (steps 6–9) lock the `make deploy-infra` idempotency
 contract: the unchanged-parameter re-run must converge against the provisioned
@@ -608,7 +608,7 @@ GHCR push/pull because the 355 MB single-blob artifact intermittently timed out 
 the 5-minute `actions/download-artifact` window. Layer-level pull retries plus the
 GHCR CDN dramatically reduce the failure rate.
 
-Timeout: 30 minutes.
+Timeout: 45 minutes.
 
 ### e2e-operator
 
@@ -644,7 +644,7 @@ strategy:
 
 The operator matrix is dynamically constructed by the `changes` job, including only operators
 whose code (or shared code) changed. The `imagePullPolicy: Never` Helm value ensures the
-kind-loaded image is used instead of attempting a registry pull. Timeout: 45 minutes.
+kind-loaded image is used instead of attempting a registry pull. Timeout: 68 minutes.
 
 ### e2e-operator-upgrade
 
@@ -667,7 +667,7 @@ release itself, so it runs in its own single job. The job pulls the run-scoped
 fetches the released baseline via `hack/ci-fetch-released-operator.sh`, installs
 it via `hack/ci-deploy-operator.sh` (with `CHART_DIR` pointing at the pulled
 chart and `IMAGE_TAG=latest`), deploys the infra stack, and runs the suite from
-`tests/e2e-operator-upgrade/`. Blocking (no `continue-on-error`). Timeout: 45
+`tests/e2e-operator-upgrade/`. Blocking (no `continue-on-error`). Timeout: 68
 minutes.
 
 ### e2e-chaos
@@ -719,7 +719,7 @@ per-suite test directories explicitly.
 | Matrix | Dynamic per-operator | Two suites (`pod` / `network`) on different runners |
 | Test config | `tests/e2e/chainsaw-config.yaml` | `tests/e2e-chaos/chainsaw-config.yaml` |
 | Test directory | `tests/e2e/<operator>/` | per-suite `test_dirs` under `tests/e2e-chaos/` |
-| Timeout | 45 minutes | 60 minutes |
+| Timeout | 68 minutes | 90 minutes |
 | Blocking | Yes | `pod` leg blocking; `network` leg non-blocking (`continue-on-error: ${{ matrix.suite == 'network' }}`) |
 | Dependencies | Gate jobs | Gate jobs + `e2e-operator` |
 | Service images | 2025.2 + 2025.2-upgraded + 2026.1 | 2025.2 only |
@@ -811,7 +811,7 @@ at the tag pinned in `deploy/flux-system/sources/k-orc.yaml`.
 The suite runs with `E2E_REQUIRE_CONTROLPLANE_STACK: "true"`, which flips its
 presence guard from a silent SKIP to a hard failure — so a broken operator/CRD
 deployment fails the build instead of going green. Like `e2e-prometheus`, the
-job runs with `continue-on-error: false`, and it uses a 60-minute timeout on the
+job runs with `continue-on-error: false`, and it uses a 90-minute timeout on the
 larger runner because a real MariaDB + Memcached + Keystone + three operators +
 OpenBao + ESO + K-ORC on one node is resource-heavy.
 
@@ -951,7 +951,7 @@ these via `matrix.release`, `matrix.config-dir`, `matrix.cr-name`, and
 | 10 | Upload Tempest results | Uploads `_output/tempest/` as `tempest-<release>-results` artifact (14-day retention) |
 | 11 | `hack/ci-dump-diagnostics.sh` (always) | Dumps diagnostic info with `OPERATOR=keystone` |
 
-Timeout: 45 minutes.
+Timeout: 68 minutes.
 
 ### cleanup-e2e-tags
 
@@ -971,7 +971,7 @@ The nightly `cleanup-e2e-stale-tags` job in `cleanup-images.yaml` is the safety
 net: if a workflow is cancelled before `cleanup-e2e-tags` fires, that job
 deletes any `e2e-*` tag older than one day across the same package set.
 
-Timeout: 10 minutes.
+Timeout: 15 minutes.
 
 ### build-and-push
 
@@ -1097,7 +1097,7 @@ Creates a GitHub Release with auto-generated release notes on v* tag pushes.
 This job runs only after both `merge-operator-images` and `helm-push` complete
 successfully, ensuring the final multi-arch manifest list and charts are published before
 the release is created. Helm chart tarballs
-are attached as release assets for direct download. Timeout: 5 minutes.
+are attached as release assets for direct download. Timeout: 8 minutes.
 
 ## Reusable CI Scripts
 

--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -20,10 +20,12 @@ ubuntu:noble
 │   ├── venv-builder     Build stage: compilers, uv, virtualenv with common packages
 │   │   ├── keystone     Stage 1 (build): install Keystone into virtualenv
 │   │   ├── horizon      Stage 1 (build): install Horizon, pre-build static assets
-│   │   └── glance       Stage 1 (build): install Glance + glance_store[s3]
+│   │   ├── glance       Stage 1 (build): install Glance + glance_store[s3]
+│   │   └── placement    Stage 1 (build): install Placement, write WSGI entry
 │   ├── keystone         Stage 2 (runtime): copy virtualenv, add runtime apt packages
 │   ├── horizon          Stage 2 (runtime): copy virtualenv + static assets
-│   └── glance           Stage 2 (runtime): copy virtualenv, add runtime apt packages
+│   ├── glance           Stage 2 (runtime): copy virtualenv, add runtime apt packages
+│   └── placement        Stage 2 (runtime): copy virtualenv, add runtime apt packages
 ```
 
 The `venv-builder` image is used only as a build stage — it never runs in production.
@@ -280,6 +282,63 @@ runs its suite under stestr (the default path, as for keystone).
 **Image contract check:** `tests/container-images/verify_glance.sh` is the hard
 gate — it verifies the CLIs, importability, the uWSGI entry script, the S3 store
 driver's boto3 resolution, non-root execution, and the absence of build tools.
+
+### placement
+
+**Location:** `images/placement/Dockerfile`
+
+The Placement service image uses the same two-stage build as Keystone. Its one
+service-specific twist is the WSGI entry script: upstream ships no usable one
+for either release. 2025.2 declares `placement-api` as a PBR `wsgi_scripts`
+entry in `setup.cfg`, which uv's `--prefix` install mode does not generate;
+2026.1 moved packaging to `pyproject.toml` and declares no WSGI script at all.
+The entry is therefore written by hand in the build stage under the upstream
+name, for both releases, with no release conditional.
+
+**Stage 1 (`build`)** — extends `venv-builder`:
+
+- Declares `ARG PIP_EXTRAS` and `ARG PIP_PACKAGES` (both empty for placement
+  today; the wiring mirrors the other service images so `extra-packages.yaml`
+  stays the single edit point)
+- Mounts `upper-constraints.txt` and the Placement source tree via named build
+  contexts (`--build-context placement=...` /
+  `--build-context upper-constraints=...`)
+- Installs Placement into the virtualenv using `uv pip install --constraint`.
+  The `--prefix` install generates the `placement-manage` and `placement-status`
+  console scripts (it only skips PBR `wsgi_scripts`)
+- Writes `/var/lib/openstack/bin/placement-api` — a two-line entry that calls
+  `placement.wsgi.init_application()` — and marks it executable
+
+**Stage 2 (runtime)** — extends `python-base`:
+
+- Declares `ARG EXTRA_APT_PACKAGES`, which carries `libpython3.12t64`: the
+  venv-builder-compiled uwsgi binary links `libpython3.12.so.1.0`, which
+  python-base does not ship (the same rationale as glance and horizon).
+  Placement is otherwise pure Python at runtime
+- Copies `/var/lib/openstack` from the build stage using `COPY --from=build --link`
+- Sets `USER openstack` for non-root execution
+
+The image stays config-free: placement locates its configuration via the
+`OS_PLACEMENT_CONFIG_DIR` environment variable set by the operator.
+
+**Runtime packages:**
+
+| Package | Purpose |
+| --- | --- |
+| `libpython3.12t64` | Shared `libpython3.12.so.1.0` for the venv-builder-compiled uwsgi |
+
+**Final image properties:**
+
+- Runs as `openstack` user (UID 42424, GID 42424)
+- Contains no build tools (`gcc`, `python3-dev`, `build-essential`, `uv` are absent)
+- Virtualenv at `/var/lib/openstack` with all Placement dependencies
+- `placement-manage` and `placement-status` CLIs available via `PATH`
+- The uWSGI entry script at `/var/lib/openstack/bin/placement-api`
+
+**Image contract check:** `tests/container-images/verify_placement.sh` is the
+hard gate — it verifies the CLIs, importability, the uWSGI entry script
+(present, executable, parsable, and its import target resolvable), that uwsgi
+runs, non-root execution, and the absence of build tools.
 
 ## Named Build Contexts
 
@@ -568,4 +627,5 @@ the user via `USER openstack` without needing its own user creation step.
 
 The `# DEVIATION` comment appears in `images/python-base/Dockerfile` (where the
 user is created) and in every service Dockerfile that uses it instead of a
-per-service user (`images/keystone/Dockerfile`, `images/horizon/Dockerfile`).
+per-service user (`images/keystone/Dockerfile`, `images/horizon/Dockerfile`,
+`images/glance/Dockerfile`, `images/placement/Dockerfile`).

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -301,7 +301,7 @@ of the `changes` job matches. It depends only on `changes` — not on the `lint`
 
 | Setting | Value |
 | --- | --- |
-| `timeout-minutes` | 30 |
+| `timeout-minutes` | 45 |
 | `permissions` | `contents: read` (inherited from workflow-level) |
 | `concurrency` | Cancel-in-progress on PRs (inherited from workflow-level) |
 | Action pinning | All `uses:` references are SHA-pinned with version comments |

--- a/docs/reference/testing/chaos-e2e-tests.md
+++ b/docs/reference/testing/chaos-e2e-tests.md
@@ -166,7 +166,7 @@ fails the build. The `network` leg stays **non-blocking**, because its
 flakiness; its failures are visible but do not
 block merges. The `run-chaos` PR label runs both legs on demand for pre-validation.
 
-**Timeout:** 45 minutes to accommodate serial test execution and longer recovery
+**Timeout:** 90 minutes to accommodate serial test execution and longer recovery
 assertion windows.
 
 ## Test Suite Inventory

--- a/docs/reference/testing/tempest-test-infrastructure.md
+++ b/docs/reference/testing/tempest-test-infrastructure.md
@@ -114,13 +114,14 @@ in three ways: (1) it installs from PyPI instead of mounting a git source tree,
 - Declares `ARG TEMPEST_VERSION` and `ARG KEYSTONE_TEMPEST_PLUGIN_VERSION` for
   build-time version injection (resolved from `test-refs.yaml` by CI)
 - Mounts `upper-constraints.txt` from the release directory via named build context
-- Installs six packages into the shared virtualenv via `uv pip install --constraint`:
+- Installs seven packages into the shared virtualenv via `uv pip install --constraint`:
 
 | Package | Purpose |
 | --- | --- |
 | `tempest` | OpenStack Tempest testing framework |
 | `keystone-tempest-plugin` | Keystone-specific Tempest test plugins |
 | `python-openstackclient` | `openstack` CLI, used by the full-chain ControlPlane E2E verify Job (`token issue` / `catalog list`); version pinned by `upper-constraints.txt` |
+| `osc-placement` | `openstack` CLI placement plugin, used by the full-chain ControlPlane E2E placement round-trip (`resource class list`); version pinned by `upper-constraints.txt` |
 | `python-subunit` | Subunit test result streaming protocol |
 | `junitxml` | Subunit-to-JUnit XML conversion (`subunit2junitxml`) |
 | `defusedxml` | Hardened XML parsing for the result-processing tooling |

--- a/hack/ci-run-unit-tests.sh
+++ b/hack/ci-run-unit-tests.sh
@@ -81,7 +81,27 @@ docker run --rm --network host \
   bash -c '
     set -e
     source /var/lib/openstack/bin/activate
-    printf "Metadata-Version: 2.1\nName: %s\nVersion: %s\n" "$SERVICE_NAME" "$SERVICE_VERSION" > PKG-INFO
+    # pbr only trusts PKG-INFO when its Name matches the package name in
+    # setup.cfg / pyproject.toml, and that name can differ from the CI
+    # service name (placement ships as openstack-placement). Derive it
+    # from the source tree, falling back to SERVICE_NAME.
+    PKG_NAME="$(python3 <<"PYEOF"
+import configparser, os
+name = None
+cp = configparser.ConfigParser()
+try:
+    if cp.read("setup.cfg") and cp.has_option("metadata", "name"):
+        name = cp.get("metadata", "name")
+except configparser.Error:
+    pass
+if not name and os.path.exists("pyproject.toml"):
+    import tomllib
+    with open("pyproject.toml", "rb") as f:
+        name = tomllib.load(f).get("project", {}).get("name")
+print(name or os.environ["SERVICE_NAME"])
+PYEOF
+)"
+    printf "Metadata-Version: 2.1\nName: %s\nVersion: %s\n" "$PKG_NAME" "$SERVICE_VERSION" > PKG-INFO
     # Old sdist-only pins (e.g. the 2025.2 XStatic set) have legacy setup.py
     # scripts importing pkg_resources, which setuptools 81 removed from uv
     # isolated build envs; pin the build backend to the last bundling release.

--- a/images/placement/Dockerfile
+++ b/images/placement/Dockerfile
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------- Stage 1: build ----------
+# hadolint ignore=DL3006
+FROM venv-builder AS build
+
+# Comma-separated Python extras (unused by placement today; kept for parity
+# with the extra-packages.yaml wiring shared by all service images).
+# Passed by CI from releases/<release>/extra-packages.yaml.
+ARG PIP_EXTRAS=""
+# Space-separated additional pip packages to install alongside the service.
+# Empty for placement today; kept for parity with the other service images.
+# Passed by CI from releases/<release>/extra-packages.yaml.
+ARG PIP_PACKAGES=""
+
+# Install Placement and extras into the shared virtualenv.
+# Named build contexts supply the source tree and constraints file:
+#   --build-context placement=<path-to-placement-source>
+#   --build-context upper-constraints=<path-to-release-dir>
+#
+# 'set -f' disables pathname expansion for the install step: PIP_PACKAGES stays
+# unquoted so multiple space-separated packages word-split, but a PEP 508
+# extras suffix (e.g. some_lib[s3]) is also a glob bracket expression that the
+# shell would rewrite if a matching file existed in the build CWD.
+RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \
+    --mount=type=bind,from=placement,target=/tmp/placement,readwrite \
+    PKG="/tmp/placement" && \
+    if [ -n "$PIP_EXTRAS" ]; then PKG="${PKG}[${PIP_EXTRAS}]"; fi && \
+    set -f && \
+    uv pip install --prefix /var/lib/openstack \
+        --constraint /tmp/upper-constraints.txt \
+        "$PKG" $PIP_PACKAGES
+
+# Generate the WSGI entry-point script that uWSGI loads at runtime.
+# 2025.2 declares placement-api as a PBR wsgi_scripts entry in setup.cfg, which
+# uv's --prefix install mode does not generate; 2026.1 moved packaging to
+# pyproject.toml and declares no WSGI script at all. The entry therefore ships
+# by hand for both releases under the upstream name, with no release
+# conditional. The placement-operator, once it lands, must launch uWSGI with
+# `--wsgi-file /var/lib/openstack/bin/placement-api`; the two paths have to
+# stay in lockstep from that point on.
+# The image itself stays config-free: placement locates its configuration via
+# the OS_PLACEMENT_CONFIG_DIR environment variable set by the operator.
+RUN printf '#!/var/lib/openstack/bin/python\n\
+from placement.wsgi import init_application\n\
+application = init_application()\n' \
+    > /var/lib/openstack/bin/placement-api && \
+    chmod +x /var/lib/openstack/bin/placement-api
+
+# ---------- Stage 2: runtime ----------
+# hadolint ignore=DL3006
+FROM python-base
+
+# DEVIATION from the original build-pipeline design:
+# Uses the generic 'openstack' user (UID/GID 42424) from python-base instead
+# of a per-service user. See python-base/Dockerfile for rationale.
+
+# Space-separated runtime system packages.
+# Passed by CI from releases/<release>/extra-packages.yaml.
+ARG EXTRA_APT_PACKAGES=""
+
+COPY --from=build --link /var/lib/openstack /var/lib/openstack
+
+# Runtime system packages required by Placement. Placement is otherwise pure
+# Python at runtime, but the venv-builder-compiled uwsgi binary links
+# libpython3.12.so.1.0, which python-base does not ship — CI passes
+# libpython3.12t64 from releases/<release>/extra-packages.yaml (the same
+# rationale as glance and horizon). The guard keeps local builds without
+# --build-arg EXTRA_APT_PACKAGES a clean no-op.
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    if [ -n "${EXTRA_APT_PACKAGES}" ]; then \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends ${EXTRA_APT_PACKAGES} && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Static OCI Image Spec annotations for local builds (runtime stage only).
+# CI-generated labels from docker/metadata-action supplement these at push time.
+LABEL org.opencontainers.image.title="placement" \
+      org.opencontainers.image.description="OpenStack placement service" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="SAP SE"
+
+USER openstack

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -19,12 +19,15 @@ ARG KEYSTONE_TEMPEST_PLUGIN_VERSION=0.19.0
 # python-openstackclient provides the `openstack` CLI used by the
 # full-controlplane-keystone E2E verify Job (token issue / catalog list);
 # its version is pinned by upper-constraints like the other unversioned deps.
+# osc-placement is the placement plugin for that CLI, used by the
+# full-ControlPlane E2E placement round-trip (resource class list).
 RUN --mount=type=bind,from=upper-constraints,source=upper-constraints.txt,target=/tmp/upper-constraints.txt \
     uv pip install --prefix /var/lib/openstack \
         --constraint /tmp/upper-constraints.txt \
         tempest==${TEMPEST_VERSION} \
         keystone-tempest-plugin==${KEYSTONE_TEMPEST_PLUGIN_VERSION} \
         python-openstackclient \
+        osc-placement \
         python-subunit \
         junitxml \
         defusedxml

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -3670,16 +3670,25 @@ func TestIntegration_DedicatedBackingServices_TransitionRejected(t *testing.T) {
 	shared := integrationManagedControlPlane("cp", ns.Name)
 	g.Expect(c.Create(ctx, shared)).To(Succeed(), "create shared-backing-services ControlPlane")
 
-	// shared -> dedicated is rejected.
-	live := &c5c3v1alpha1.ControlPlane{}
-	g.Expect(c.Get(ctx, types.NamespacedName{Name: "cp", Namespace: ns.Name}, live)).To(Succeed())
-	live.Spec.Services.Keystone.DedicatedBackingServices = &c5c3v1alpha1.KeystoneDedicatedBackingServicesSpec{
-		Cache: &commonv1.CacheSpec{
-			ClusterRef: &corev1.LocalObjectReference{Name: "cp-keystone-cache"},
-			Backend:    commonv1.DefaultCacheBackend,
-		},
-	}
-	err := c.Update(ctx, live)
+	// shared -> dedicated is rejected. Get-mutate-update under RetryOnConflict:
+	// the live controller writes to the freshly created CR concurrently (the
+	// c5c3.io/orc-teardown finalizer, then status), and a stale resourceVersion
+	// returns 409 Conflict before admission ever evaluates the transition. The
+	// webhook denial is deterministic once the update reaches it, so only the
+	// Conflict is retried.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		live := &c5c3v1alpha1.ControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: "cp", Namespace: ns.Name}, live); err != nil {
+			return err
+		}
+		live.Spec.Services.Keystone.DedicatedBackingServices = &c5c3v1alpha1.KeystoneDedicatedBackingServicesSpec{
+			Cache: &commonv1.CacheSpec{
+				ClusterRef: &corev1.LocalObjectReference{Name: "cp-keystone-cache"},
+				Backend:    commonv1.DefaultCacheBackend,
+			},
+		}
+		return c.Update(ctx, live)
+	})
 	g.Expect(err).To(HaveOccurred(), "moving a live service onto dedicated backing services must be rejected")
 	g.Expect(err.Error()).To(ContainSubstring("switching a service between shared and dedicated backing services"))
 
@@ -3690,10 +3699,15 @@ func TestIntegration_DedicatedBackingServices_TransitionRejected(t *testing.T) {
 	dedicated := integrationDedicatedControlPlane("cp", ns2.Name)
 	g.Expect(c.Create(ctx, dedicated)).To(Succeed(), "create dedicated-backing-services ControlPlane")
 
-	live2 := &c5c3v1alpha1.ControlPlane{}
-	g.Expect(c.Get(ctx, types.NamespacedName{Name: "cp", Namespace: ns2.Name}, live2)).To(Succeed())
-	live2.Spec.Services.Keystone.DedicatedBackingServices = nil
-	err = c.Update(ctx, live2)
+	// Same RetryOnConflict rationale as the shared -> dedicated leg above.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		live2 := &c5c3v1alpha1.ControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: "cp", Namespace: ns2.Name}, live2); err != nil {
+			return err
+		}
+		live2.Spec.Services.Keystone.DedicatedBackingServices = nil
+		return c.Update(ctx, live2)
+	})
 	g.Expect(err).To(HaveOccurred(), "moving a live service back onto the shared instances must be rejected")
 	g.Expect(err.Error()).To(ContainSubstring("switching a service between shared and dedicated backing services"))
 }

--- a/releases/2025.2/extra-packages.yaml
+++ b/releases/2025.2/extra-packages.yaml
@@ -49,3 +49,11 @@ glance:
     # The image_conversion image-import plugin shells out to `qemu-img info`
     # and `qemu-img convert` on the staged image.
     - qemu-utils
+placement:
+  pip_extras: []
+  pip_packages: []
+  apt_packages:
+    # uWSGI is compiled in venv-builder against the shared libpython; placement
+    # is otherwise pure Python at runtime. Without this, uwsgi fails to load
+    # (python-base ships no libpython3.12.so.1.0).
+    - libpython3.12t64

--- a/releases/2025.2/source-refs.yaml
+++ b/releases/2025.2/source-refs.yaml
@@ -8,3 +8,4 @@
 keystone: "28.0.0"
 horizon: "25.5.1"
 glance: "31.1.0"
+placement: "14.0.0"

--- a/releases/2026.1/extra-packages.yaml
+++ b/releases/2026.1/extra-packages.yaml
@@ -49,3 +49,11 @@ glance:
     # The image_conversion image-import plugin shells out to `qemu-img info`
     # and `qemu-img convert` on the staged image.
     - qemu-utils
+placement:
+  pip_extras: []
+  pip_packages: []
+  apt_packages:
+    # uWSGI is compiled in venv-builder against the shared libpython; placement
+    # is otherwise pure Python at runtime. Without this, uwsgi fails to load
+    # (python-base ships no libpython3.12.so.1.0).
+    - libpython3.12t64

--- a/releases/2026.1/source-refs.yaml
+++ b/releases/2026.1/source-refs.yaml
@@ -8,3 +8,4 @@
 keystone: "29.0.0"
 horizon: "25.7.0"
 glance: "32.0.0"
+placement: "15.0.0"

--- a/tests/ci/verify_chaos_ci_pipeline.sh
+++ b/tests/ci/verify_chaos_ci_pipeline.sh
@@ -335,12 +335,12 @@ test_e2e_chaos_if_condition() {
 }
 
 test_e2e_chaos_timeout() {
-  echo "Test: e2e-chaos job timeout is 60 minutes"
+  echo "Test: e2e-chaos job timeout is 90 minutes"
 
   assert_contains \
-    "e2e-chaos timeout-minutes is 60" \
+    "e2e-chaos timeout-minutes is 90" \
     "$E2E_CHAOS_JOB_SECTION" \
-    "timeout-minutes: 60"
+    "timeout-minutes: 90"
 }
 
 test_e2e_chaos_continue_on_error() {

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -714,7 +714,7 @@ test_test_service_images_job_structure() {
 
   local timeout
   timeout=$(yq_raw '.jobs["test-service-images"]["timeout-minutes"]' "$WORKFLOW" || echo "null")
-  assert_eq "test-service-images has timeout-minutes: 60" "60" "$timeout"
+  assert_eq "test-service-images has timeout-minutes: 90" "90" "$timeout"
 
   local contents_perms
   contents_perms=$(yq_raw '.jobs["test-service-images"]["permissions"]["contents"]' "$WORKFLOW" || echo "null")

--- a/tests/container-images/verify_build_images_workflow.sh
+++ b/tests/container-images/verify_build_images_workflow.sh
@@ -853,6 +853,22 @@ test_test_service_images_run_tests_stestr() {
   assert_file_contains "ci-run-unit-tests.sh runs stestr run" "$HACK_RUN_UNIT_TESTS" "stestr run"
 }
 
+# --- test-service-images derives the PBR package name for PKG-INFO ---
+test_test_service_images_pkg_info_name() {
+  echo "Test: test-service-images derives the PBR package name for PKG-INFO"
+
+  # pbr ignores PKG-INFO when its Name does not match setup.cfg /
+  # pyproject.toml (placement ships as openstack-placement), so the
+  # runner must derive the name from the source tree instead of
+  # hard-coding SERVICE_NAME.
+  assert_file_contains "ci-run-unit-tests.sh reads the package name from setup.cfg metadata" \
+    "$HACK_RUN_UNIT_TESTS" 'cp.get("metadata", "name")'
+  assert_file_contains "ci-run-unit-tests.sh falls back to the pyproject.toml project name" \
+    "$HACK_RUN_UNIT_TESTS" 'tomllib.load(f).get("project", {}).get("name")'
+  assert_file_contains "ci-run-unit-tests.sh writes the derived name into PKG-INFO" \
+    "$HACK_RUN_UNIT_TESTS" '"$PKG_NAME" "$SERVICE_VERSION"'
+}
+
 # --- test-service-images uses exclude-list from test-excludes ---
 test_test_service_images_exclude_list() {
   echo "Test: test-service-images uses exclude-list from test-excludes"
@@ -1828,6 +1844,8 @@ echo ""
 test_test_service_images_run_tests_volumes
 echo ""
 test_test_service_images_run_tests_stestr
+echo ""
+test_test_service_images_pkg_info_name
 echo ""
 test_test_service_images_exclude_list
 echo ""

--- a/tests/container-images/verify_deviation_comments.sh
+++ b/tests/container-images/verify_deviation_comments.sh
@@ -14,8 +14,21 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PASS=0
 FAIL=0
 
+# Service images that inherit the generic user instead of creating their own.
+# python-base is checked separately: it is where the user is created.
+SERVICES="keystone horizon glance placement"
+
 # shellcheck source=tests/lib/assertions.sh
 source "$SCRIPT_DIR/../lib/assertions.sh"
+
+# Print the DEVIATION comment block: the '# DEVIATION' line plus the comment
+# lines that follow it, stopping at the first non-comment line. Scoping the
+# rationale assertion to this block matters — 'openstack' also appears in
+# /var/lib/openstack paths and USER openstack, so grepping the whole
+# Dockerfile would pass no matter what the comment says.
+deviation_block() {
+  awk '/^# DEVIATION/{f=1} f&&!/^#/{exit} f' "$1"
+}
 
 # --- Test 1: python-base has DEVIATION comment ---
 test_python_base_deviation_comment() {
@@ -24,49 +37,30 @@ test_python_base_deviation_comment() {
   local dockerfile="$PROJECT_ROOT/images/python-base/Dockerfile"
 
   assert_file_contains "python-base/Dockerfile contains DEVIATION comment" "$dockerfile" "# DEVIATION"
-  assert_file_contains "DEVIATION comment references generic openstack user" "$dockerfile" "openstack"
+  assert_contains "DEVIATION comment references generic openstack user" \
+    "$(deviation_block "$dockerfile")" "openstack"
 }
 
-# --- Test 2: keystone has DEVIATION comment ---
-test_keystone_deviation_comment() {
-  echo "Test: keystone Dockerfile has DEVIATION comment"
+# --- Test 2: every service image has a DEVIATION comment ---
+test_service_deviation_comment() {
+  local service="$1"
+  echo "Test: $service Dockerfile has DEVIATION comment"
 
-  local dockerfile="$PROJECT_ROOT/images/keystone/Dockerfile"
+  local dockerfile="$PROJECT_ROOT/images/${service}/Dockerfile"
 
-  assert_file_contains "keystone/Dockerfile contains DEVIATION comment" "$dockerfile" "# DEVIATION"
-  assert_file_contains "DEVIATION comment references generic user vs per-service" "$dockerfile" "openstack"
-}
-
-# --- Test 3: horizon has DEVIATION comment ---
-test_horizon_deviation_comment() {
-  echo "Test: horizon Dockerfile has DEVIATION comment"
-
-  local dockerfile="$PROJECT_ROOT/images/horizon/Dockerfile"
-
-  assert_file_contains "horizon/Dockerfile contains DEVIATION comment" "$dockerfile" "# DEVIATION"
-  assert_file_contains "DEVIATION comment references generic user vs per-service" "$dockerfile" "openstack"
-}
-
-# --- Test 4: glance has DEVIATION comment ---
-test_glance_deviation_comment() {
-  echo "Test: glance Dockerfile has DEVIATION comment"
-
-  local dockerfile="$PROJECT_ROOT/images/glance/Dockerfile"
-
-  assert_file_contains "glance/Dockerfile contains DEVIATION comment" "$dockerfile" "# DEVIATION"
-  assert_file_contains "DEVIATION comment references generic user vs per-service" "$dockerfile" "openstack"
+  assert_file_contains "$service/Dockerfile contains DEVIATION comment" "$dockerfile" "# DEVIATION"
+  assert_contains "DEVIATION comment references generic user vs per-service" \
+    "$(deviation_block "$dockerfile")" "openstack"
 }
 
 # --- Run all tests ---
 echo "=== DEVIATION comment verification tests ==="
 echo ""
 test_python_base_deviation_comment
-echo ""
-test_keystone_deviation_comment
-echo ""
-test_horizon_deviation_comment
-echo ""
-test_glance_deviation_comment
+for service in $SERVICES; do
+  echo ""
+  test_service_deviation_comment "$service"
+done
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/container-images/verify_placement.sh
+++ b/tests/container-images/verify_placement.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify placement container image meets requirements
+# Usage: bash tests/container-images/verify_placement.sh [image_name]
+# Default image: c5c3/placement:14.0.0
+# Requires: Docker daemon running
+
+set -euo pipefail
+
+IMAGE="${1:-c5c3/placement:14.0.0}"
+
+PASS=0
+FAIL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib/assertions.sh
+source "$SCRIPT_DIR/../lib/assertions.sh"
+
+# --- Test 1: placement-manage --version outputs version and exits 0 ---
+test_placement_manage_version() {
+  echo "Test: placement-manage --version succeeds"
+  local version exit_code=0
+  version=$(docker run --rm "$IMAGE" placement-manage --version 2>&1) || exit_code=$?
+
+  assert_eq "placement-manage --version exits 0" "0" "$exit_code"
+  assert_not_empty "version output is non-empty" "$version"
+}
+
+# --- Test 2: placement-status console script runs ---
+test_placement_status_help() {
+  echo "Test: placement-status --help succeeds"
+  # Plain --help needs no config and no database, so it proves the console
+  # script uv generated is runnable.
+  local help_output exit_code=0
+  help_output=$(docker run --rm "$IMAGE" placement-status --help 2>&1) || exit_code=$?
+
+  assert_eq "placement-status --help exits 0" "0" "$exit_code"
+  assert_not_empty "help output is non-empty" "$help_output"
+}
+
+# --- Test 3: placement is importable ---
+test_placement_importable() {
+  echo "Test: placement imports cleanly"
+  local exit_code=0
+  docker run --rm "$IMAGE" \
+    /var/lib/openstack/bin/python -c "import placement" > /dev/null 2>&1 || exit_code=$?
+
+  assert_eq "import placement exits 0" "0" "$exit_code"
+}
+
+# --- Test 4: the uWSGI entry script is present, executable, and loadable ---
+test_wsgi_entry_present() {
+  echo "Test: placement-api entry is present, executable, and loadable"
+  # The placement-operator will launch uWSGI with
+  # `--wsgi-file /var/lib/openstack/bin/placement-api`. Executing the entry
+  # needs operator-mounted runtime config, so assert what the launch needs
+  # without running it: the file exists, is executable, and is valid Python
+  # (ast.parse writes no bytecode, unlike py_compile, which would fail as the
+  # openstack user).
+  local exit_code=0
+  docker run --rm "$IMAGE" \
+    sh -c 'test -x /var/lib/openstack/bin/placement-api' \
+    > /dev/null 2>&1 || exit_code=$?
+  assert_eq "placement-api exists and is executable" "0" "$exit_code"
+
+  local parse_exit=0
+  docker run --rm "$IMAGE" \
+    /var/lib/openstack/bin/python -c \
+    'import ast; ast.parse(open("/var/lib/openstack/bin/placement-api").read())' \
+    > /dev/null 2>&1 || parse_exit=$?
+  assert_eq "placement-api parses as Python" "0" "$parse_exit"
+
+  # ast.parse only proves the entry is grammatical. The entry is hand-written
+  # because upstream ships no WSGI script for either release, so its import
+  # target is an assumption against two independently-moving trees — resolve
+  # it here. Test 3 imports the package, not this submodule and symbol.
+  # Execute the entry's own import statements rather than a re-typed copy: a
+  # typo in the Dockerfile's printf parses fine and would only surface when
+  # uWSGI loads the file at pod start. The remaining statement calls
+  # init_application(), which needs the operator-mounted config, so it stays
+  # out. The assert turns an entry that lost its imports into a failure
+  # instead of an empty, trivially-passing exec.
+  # The exec alone proves only whatever the entry imports today, so the
+  # trailing explicit import stays as the independent oracle: an entry
+  # rewritten as `from placement import wsgi` execs cleanly even after
+  # init_application is renamed away, and uWSGI is what calls that symbol via
+  # --wsgi-file. Stderr is captured rather than discarded — file missing, no
+  # imports, module gone and symbol gone otherwise collapse into a bare exit
+  # code that has to be reproduced by hand to tell apart.
+  local import_exit=0 import_err=""
+  import_err=$(docker run --rm "$IMAGE" \
+    /var/lib/openstack/bin/python -c \
+    'import ast
+src = open("/var/lib/openstack/bin/placement-api").read()
+nodes = [n for n in ast.parse(src).body if isinstance(n, (ast.Import, ast.ImportFrom))]
+assert nodes, "placement-api declares no imports"
+exec(compile(ast.Module(body=nodes, type_ignores=[]), "placement-api", "exec"))
+from placement.wsgi import init_application' \
+    2>&1 > /dev/null) || import_exit=$?
+  [ "$import_exit" -eq 0 ] || echo "    $import_err"
+  assert_eq "placement-api imports and init_application resolve" "0" "$import_exit"
+}
+
+# --- Test 5: runs as openstack user ---
+test_runs_as_openstack_user() {
+  echo "Test: container runs as openstack user"
+  local whoami_output exit_code=0
+  whoami_output=$(docker run --rm "$IMAGE" whoami 2>&1) || exit_code=$?
+
+  assert_eq "whoami exits 0" "0" "$exit_code"
+  assert_eq "whoami outputs openstack" "openstack" "$whoami_output"
+}
+
+# --- Test 6: no build tools in final image ---
+test_no_build_tools_in_final_image() {
+  echo "Test: no build tools in final image"
+
+  # gcc should not be present
+  local gcc_exit=0
+  docker run --rm "$IMAGE" which gcc > /dev/null 2>&1 || gcc_exit=$?
+  assert_nonzero_exit "gcc not found" "$gcc_exit"
+
+  # python3-dev should not be installed
+  local pydev_exit=0
+  docker run --rm "$IMAGE" dpkg -s python3-dev > /dev/null 2>&1 || pydev_exit=$?
+  assert_nonzero_exit "python3-dev not installed" "$pydev_exit"
+
+  # uv should not be present in the final image
+  local uv_exit=0
+  docker run --rm "$IMAGE" which uv > /dev/null 2>&1 || uv_exit=$?
+  assert_nonzero_exit "uv not found" "$uv_exit"
+}
+
+# --- Test 7: uwsgi is runnable (serves placement-api at runtime) ---
+test_uwsgi_runnable() {
+  echo "Test: uwsgi --version succeeds"
+  # Transitively proves the libpython3.12t64 apt wiring: the venv-builder
+  # uwsgi binary links libpython3.12.so.1.0, which python-base does not ship.
+  local version exit_code=0
+  version=$(docker run --rm "$IMAGE" /var/lib/openstack/bin/uwsgi --version 2>&1) || exit_code=$?
+
+  assert_eq "uwsgi --version exits 0" "0" "$exit_code"
+  assert_not_empty "uwsgi version output is non-empty" "$version"
+}
+
+# --- Run all tests ---
+echo "=== placement container verification tests ==="
+echo "Image: $IMAGE"
+echo ""
+test_placement_manage_version
+echo ""
+test_placement_status_help
+echo ""
+test_placement_importable
+echo ""
+test_wsgi_entry_present
+echo ""
+test_runs_as_openstack_user
+echo ""
+test_no_build_tools_in_final_image
+echo ""
+test_uwsgi_runnable
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/container-images/verify_release_config.sh
+++ b/tests/container-images/verify_release_config.sh
@@ -17,7 +17,7 @@ FAIL=0
 
 # Services that every release must register in source-refs.yaml and
 # extra-packages.yaml, each with a matching images/<service>/Dockerfile.
-SERVICES="keystone horizon glance"
+SERVICES="keystone horizon glance placement"
 
 # shellcheck source=tests/lib/assertions.sh
 source "$SCRIPT_DIR/../lib/assertions.sh"
@@ -60,6 +60,23 @@ test_source_refs_valid_yaml_with_services() {
         FAIL=$((FAIL + 1))
       fi
     done
+
+    # $SERVICES is what tests 2-4 iterate, and the build matrix derives from
+    # these keys instead. Assert the converse direction too: a service
+    # registered here but absent from the list would build and ship while its
+    # extra-packages entries go unvalidated and its Dockerfile never gets
+    # checked for hardcoded apt packages. Fail loudly rather than skip four
+    # tests silently.
+    local unlisted
+    unlisted=$(yq 'keys | .[]' "$source_refs" | tr -d '"' \
+      | grep -vxF -f <(tr ' ' '\n' <<< "$SERVICES") || true)
+    if [ -z "$unlisted" ]; then
+      echo "  PASS: [$release_name] every service in $rel_path is covered by the SERVICES list"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: [$release_name] services in $rel_path missing from the SERVICES list: $(echo "$unlisted" | tr '\n' ' ')"
+      FAIL=$((FAIL + 1))
+    fi
   done
 
   if [ "$found_any" = false ]; then
@@ -450,6 +467,53 @@ test_option_catalogs_present_and_parse() {
   fi
 }
 
+# --- Test 9: nightly GHCR cleanup covers every service image ---
+test_cleanup_matrix_covers_services() {
+  echo "Test: cleanup-images.yaml service matrix covers every service"
+
+  local workflow="$PROJECT_ROOT/.github/workflows/cleanup-images.yaml"
+
+  if [ ! -f "$workflow" ]; then
+    echo "  FAIL: .github/workflows/cleanup-images.yaml not found"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # build-service-images derives its matrix from source-refs.yaml, so a newly
+  # registered service starts pushing composite tags and untagged per-platform
+  # digests to GHCR immediately. The cleanup matrix is hand-maintained, so an
+  # unlisted service accumulates both forever. Compare against the same YAML
+  # keys the build matrix reads, not the hand-maintained $SERVICES list, or a
+  # service onboarded without touching this file slips through unnoticed.
+  # Both sides go through the same quote strip as every other yq read here —
+  # normalizing only one side would report every service missing at once.
+  local matrix
+  matrix=$(yq '.jobs.cleanup-service-images.strategy.matrix.package[]' "$workflow" | tr -d '"')
+
+  local registered
+  registered=$(for source_refs in "$PROJECT_ROOT"/releases/*/source-refs.yaml; do
+    [ -f "$source_refs" ] || continue
+    yq 'keys | .[]' "$source_refs" | tr -d '"'
+  done | sort -u)
+
+  if [ -z "$registered" ]; then
+    echo "  FAIL: no services registered in releases/*/source-refs.yaml"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local service
+  while IFS= read -r service; do
+    if grep -qxF "$service" <<< "$matrix"; then
+      echo "  PASS: [$service] listed in the cleanup-service-images matrix"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: [$service] missing from the cleanup-service-images matrix"
+      FAIL=$((FAIL + 1))
+    fi
+  done <<< "$registered"
+}
+
 # --- Run all tests ---
 echo "=== Release config verification tests ==="
 echo ""
@@ -468,6 +532,8 @@ echo ""
 test_test_excludes_files_match_services
 echo ""
 test_option_catalogs_present_and_parse
+echo ""
+test_cleanup_matrix_covers_services
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/container-images/verify_tempest.sh
+++ b/tests/container-images/verify_tempest.sh
@@ -90,6 +90,23 @@ test_no_build_tools_in_final_image() {
   assert_nonzero_exit "uv not found" "$uv_exit"
 }
 
+# --- Test 7: osc-placement registers its openstack CLI commands ---
+test_osc_placement_cli_registered() {
+  echo "Test: osc-placement registers its openstack CLI commands"
+  # osc-placement is installed for the `openstack resource class list`
+  # round-trip, which needs its openstack.cli.extension entry points to
+  # resolve — importing the module would only prove the wheel is on sys.path.
+  # --help builds the command without contacting a cloud, so no credentials
+  # are needed. cliff prints "Unknown command" and can still exit 0 for an
+  # unregistered command, so assert on the rendered usage line too.
+  local help_output exit_code=0
+  help_output=$(docker run --rm "$IMAGE" openstack resource class list --help 2>&1) || exit_code=$?
+
+  assert_eq "openstack resource class list --help exits 0" "0" "$exit_code"
+  assert_contains "resource class list is a registered command" "$help_output" \
+    "usage: openstack resource class list"
+}
+
 # --- Run all tests ---
 echo "=== tempest container verification tests ==="
 echo "Image: $IMAGE"
@@ -105,6 +122,8 @@ echo ""
 test_runs_as_openstack_user
 echo ""
 test_no_build_tools_in_final_image
+echo ""
+test_osc_placement_cli_registered
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/e2e-chaos/glance-garage-outage/chainsaw-test.yaml
+++ b/tests/e2e-chaos/glance-garage-outage/chainsaw-test.yaml
@@ -67,9 +67,21 @@ spec:
         timeout: 5m
         content: |
           set -eu
-          OUT="$(kubectl run glance-garage-baseline-probe -n $NAMESPACE \
-            --image=ghcr.io/c5c3/glance:2025.2 --rm -i --restart=Never \
-            --pod-running-timeout=3m --command -- python3 -c '
+          # Every probe in this suite reads its verdict from the pod log, not
+          # from an attached stream. `kubectl run -i` carries only what the
+          # container writes after the attach is established, so a probe that
+          # reaches its sentinel first leaves the captured output holding
+          # nothing but the deletion notice — the sentinel grep then fails on a
+          # run where the assertion itself held. The kubelet writes the
+          # container log to disk as it is produced, so reading it after
+          # termination cannot race. That costs --rm: the pod has to outlive
+          # the run to stay readable, and the trap removes it.
+          POD=glance-garage-baseline-probe
+          cleanup() { kubectl delete pod "$POD" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          kubectl run "$POD" -n "$NAMESPACE" \
+            --image=ghcr.io/c5c3/glance:2025.2 --restart=Never \
+            --command -- python3 -c '
           import json, sys, time, urllib.request, urllib.error
 
           BASE = "http://glance-chaos-garage.openstack.svc:9292"
@@ -110,8 +122,23 @@ spec:
               fail("image status is %r, want active" % final.get("status"))
           print("image active with stores %r" % final.get("stores"))
           print("WRITE-OK")
-          ')"
+          '
+          # Poll for a terminal phase instead of waiting for Succeeded alone: a
+          # probe that fails its assertion ends in Failed, and waiting only for
+          # Succeeded would burn the step timeout and then throw away the log
+          # that says why. The sentinel below, not the phase, is the verdict.
+          phase=""
+          for _ in $(seq 1 100); do
+            phase="$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+            case "${phase}" in Succeeded|Failed) break ;; esac
+            sleep 2
+          done
+          # || true so a log read that fails is echoed and grepped like any
+          # other output rather than aborting the step under set -e with the
+          # diagnosis unprinted.
+          OUT="$(kubectl logs -n "$NAMESPACE" "$POD" 2>&1 || true)"
           echo "${OUT}"
+          echo "pod phase: ${phase:-<none>}"
           echo "${OUT}" | grep -q 'WRITE-OK'
           echo "OK: baseline image PUT landed and went active"
     catch:
@@ -153,9 +180,13 @@ spec:
         timeout: 5m
         content: |
           set -eu
-          OUT="$(kubectl run glance-garage-failclosed-probe -n $NAMESPACE \
-            --image=ghcr.io/c5c3/glance:2025.2 --rm -i --restart=Never \
-            --pod-running-timeout=3m --command -- python3 -c '
+          # Log-based verdict, not an attached stream — see step 2 for why.
+          POD=glance-garage-failclosed-probe
+          cleanup() { kubectl delete pod "$POD" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          kubectl run "$POD" -n "$NAMESPACE" \
+            --image=ghcr.io/c5c3/glance:2025.2 --restart=Never \
+            --command -- python3 -c '
           import json, sys, time, urllib.request, urllib.error
 
           BASE = "http://glance-chaos-garage.openstack.svc:9292"
@@ -210,8 +241,16 @@ spec:
           except (urllib.error.URLError, ConnectionError, OSError) as e:
               print("PUT -> %r during partition (fail-closed OK)" % e)
           print("FAILCLOSED-OK")
-          ')"
+          '
+          phase=""
+          for _ in $(seq 1 100); do
+            phase="$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+            case "${phase}" in Succeeded|Failed) break ;; esac
+            sleep 2
+          done
+          OUT="$(kubectl logs -n "$NAMESPACE" "$POD" 2>&1 || true)"
           echo "${OUT}"
+          echo "pod phase: ${phase:-<none>}"
           echo "${OUT}" | grep -q 'FAILCLOSED-OK'
           echo "OK: image write failed closed while API stayed up"
     - assert:
@@ -259,15 +298,7 @@ spec:
         timeout: 3m
         content: |
           set -eu
-          # The verdict is read from the pod log, not from an attached stream.
-          # `kubectl run -i` carries only what the container writes after the
-          # attach is established, and this probe issues a single GET and exits
-          # in well under a second — fast enough to finish first, which leaves
-          # the captured output holding nothing but the deletion notice and
-          # fails the sentinel grep on a run where the assertion itself held.
-          # The kubelet writes the container log to disk as it is produced, so
-          # reading it after termination cannot race. That costs --rm: the pod
-          # has to outlive the run to stay readable, and the trap removes it.
+          # Log-based verdict, not an attached stream — see step 2 for why.
           POD=glance-garage-failclosed-verify
           cleanup() { kubectl delete pod "$POD" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true; }
           trap cleanup EXIT
@@ -316,19 +347,12 @@ spec:
                   fail("fail-closed image went active after recovery -- glance persisted a write the client was never confirmed on")
           print("STAYED-FAILED-OK")
           '
-          # Poll for a terminal phase instead of waiting for Succeeded alone: a
-          # probe that fails its assertion ends in Failed, and waiting only for
-          # Succeeded would burn the step timeout and then throw away the log
-          # that says why. The sentinel below, not the phase, is the verdict.
           phase=""
           for _ in $(seq 1 60); do
             phase="$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
             case "${phase}" in Succeeded|Failed) break ;; esac
             sleep 2
           done
-          # || true so a log read that fails is echoed and grepped like any
-          # other output rather than aborting the step under set -e with the
-          # diagnosis unprinted — the failure mode this step just had.
           OUT="$(kubectl logs -n "$NAMESPACE" "$POD" 2>&1 || true)"
           echo "${OUT}"
           echo "pod phase: ${phase:-<none>}"
@@ -346,9 +370,13 @@ spec:
         timeout: 5m
         content: |
           set -eu
-          OUT="$(kubectl run glance-garage-recovery-probe -n $NAMESPACE \
-            --image=ghcr.io/c5c3/glance:2025.2 --rm -i --restart=Never \
-            --pod-running-timeout=3m --command -- python3 -c '
+          # Log-based verdict, not an attached stream — see step 2 for why.
+          POD=glance-garage-recovery-probe
+          cleanup() { kubectl delete pod "$POD" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          kubectl run "$POD" -n "$NAMESPACE" \
+            --image=ghcr.io/c5c3/glance:2025.2 --restart=Never \
+            --command -- python3 -c '
           import json, sys, time, urllib.request, urllib.error
 
           BASE = "http://glance-chaos-garage.openstack.svc:9292"
@@ -389,8 +417,16 @@ spec:
               fail("image status is %r, want active" % final.get("status"))
           print("image active with stores %r" % final.get("stores"))
           print("WRITE-OK")
-          ')"
+          '
+          phase=""
+          for _ in $(seq 1 100); do
+            phase="$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+            case "${phase}" in Succeeded|Failed) break ;; esac
+            sleep 2
+          done
+          OUT="$(kubectl logs -n "$NAMESPACE" "$POD" 2>&1 || true)"
           echo "${OUT}"
+          echo "pod phase: ${phase:-<none>}"
           echo "${OUT}" | grep -q 'WRITE-OK'
           echo "OK: image PUT succeeds again after the partition was lifted"
     catch:


### PR DESCRIPTION
Ships the placement service container image for both supported OpenStack
releases (2025.2 and 2026.1), wired through the existing build, test, verify
and Renovate machinery, plus the tempest-image half of the D7 CLI round-trip.

Closes #768

## Change set, in commit order

**`48174331` build(images): add the placement service image**

Adds `images/placement/Dockerfile` on the keystone two-stage template: the
build stage installs the placement source tree from the named build context
into the shared virtualenv under the release's `upper-constraints.txt`
(honouring `PIP_EXTRAS` / `PIP_PACKAGES`), and the runtime stage copies that
prefix onto `python-base`, keeps runtime apt packages behind the
`EXTRA_APT_PACKAGES` guard, and runs as the generic `openstack` user with the
`# DEVIATION` comment and static OCI labels.

The WSGI entry ships by hand for both releases: 2025.2 declares
`placement-api` as a PBR `wsgi_scripts` entry in `setup.cfg`, which uv's
`--prefix` install mode does not generate, and 2026.1 moved packaging to
`pyproject.toml` and declares no WSGI script at all. A `printf`-generated
script under the upstream name covers both without a release conditional and
fixes the path contract the placement-operator will reference as
`--wsgi-file /var/lib/openstack/bin/placement-api`.

The hand-maintained `lint-dockerfiles` matrix in `build-images.yaml` gains
the new Dockerfile.

**`e5f1b3f3` build(releases): register placement for both supported releases**

Adds `placement: "14.0.0"` (2025.2) and `placement: "15.0.0"` (2026.1) to
`source-refs.yaml`. Since that file is the single source of truth for the
per-release matrices, the two keys enroll placement in the build,
upstream-unit-test, merge and verify jobs with no further wiring.

The `extra-packages.yaml` block keeps both pip lists empty and installs
`libpython3.12t64` as the only runtime apt package — the venv-builder-compiled
uwsgi binary links `libpython3.12.so.1.0`, which `python-base` does not ship.
The existing Renovate custom manager for `source-refs.yaml` already matches
the new pins, so `renovate.json` is unchanged.

Enrolling placement also surfaced a latent assumption in
`hack/ci-run-unit-tests.sh`: the PKG-INFO it seeds for pbr hard-coded the CI
service name, but pbr only trusts PKG-INFO when its `Name` matches the
package name in `setup.cfg` / `pyproject.toml` — and placement is the first
onboarded service whose package name (`openstack-placement`) differs, so
both test-service-images jobs failed at `uv pip install`. The runner now
derives the name from the source tree, falling back to `SERVICE_NAME`, and
`verify_build_images_workflow.sh` pins the mechanism.

**`1f018d64` test(images): add verify_placement and cover placement in static checks**

Adds `tests/container-images/verify_placement.sh`, the PR-mode hard gate CI
dispatches by convention. Seven checks: `placement-manage --version` and
`placement-status --help` run (proving uv generated the console scripts),
`import placement` succeeds, the WSGI entry exists / is executable / parses
via `ast.parse` (which writes no bytecode, unlike `py_compile`, and would fail
as the `openstack` user), the container runs as `openstack`, `gcc` /
`python3-dev` / `uv` are absent, and `uwsgi` runs — transitively proving the
`libpython3.12t64` wiring.

The hand-maintained lists in `verify_release_config.sh` and
`verify_deviation_comments.sh` now name placement. Test 8's separate
option-catalog list deliberately stays at keystone and glance: the per-release
catalog is a placement-operator artifact that does not exist yet.

**`6707a841` build(images): bundle osc-placement in the tempest image**

Adds `osc-placement` to the tempest image's `uv pip install` list, unversioned
because the release's `upper-constraints.txt` pins it (4.7.0 on 2025.2, 4.8.0
on 2026.1), so the full-ControlPlane e2e can run its placement round-trip with
the same `openstack` client it already uses for the Keystone token and catalog
checks. `verify_tempest.sh` gains the matching check so a dropped install line
fails the image verify instead of the first e2e run.

**`31e0bbec` chore(deps): finish the flux-operator v0.56.0 bump**

Not placement scope — a repair inherited from main. Renovate automerged
`FLUX_OPERATOR_VERSION` v0.55.0 → v0.56.0 in `hack/deploy-infra.sh`
(`4f1427d2`, this branch's merge-base) but left behind the flux-web chart
range in `deploy/kind/base/flux-web.yaml` and the version stubs in
`kind_base_flux_web_test.sh`; main's path-filtered run never executed that
tripwire, so every branch that runs test-shell inherits the red check. This
commit aligns the chart pin to `0.56.x` (chart 0.56.0 is published) and the
stubs to v0.56.0.

## Divergences from the issue

Five places where the diff does more than, or differs from, the issue text —
each deliberate:

- **`cleanup-images.yaml` is touched, though the issue lists it as a Non-Goal
  for #770.** Registering placement in `source-refs.yaml` makes
  `build-service-images` push composite tags and untagged per-platform digests
  to GHCR immediately, so leaving the hand-maintained cleanup matrix behind
  would accumulate both forever between now and #770. The matrix gains
  `placement`, and a new test 9 in `verify_release_config.sh` gates it against
  the `source-refs.yaml` keys the build matrix actually reads (not the
  hand-maintained `SERVICES` list), so the next service onboarding cannot slip
  through.
- **`verify_tempest.sh` asserts more than the requested `import osc_placement`.**
  The check runs `openstack resource class list --help` and asserts on the
  rendered usage line, which proves the `openstack.cli.extension` entry points
  resolve — an import only proves the wheel is on `sys.path`, and cliff can
  exit 0 while printing "Unknown command".
- **`verify_deviation_comments.sh` is refactored rather than extended with a
  fourth copy.** The four near-identical per-service functions collapse into
  one loop over a `SERVICES` list, and the rationale assertion is now scoped to
  the `# DEVIATION` comment block via an awk helper. The previous whole-file
  `grep` for `openstack` passed regardless of what the comment said, since
  `/var/lib/openstack` and `USER openstack` appear in every service Dockerfile.
- **`hack/ci-run-unit-tests.sh` is touched, though the issue never names it.**
  The pbr PKG-INFO name mismatch described under `e5f1b3f3` cannot be fixed
  from the placement files themselves — the unit-test runner writes the
  PKG-INFO. The reach is minimal and behavior-neutral for keystone, glance,
  and horizon, whose package names equal their service names.
- **Docs are updated, though the issue assigns documentation to #772.** Only
  the two existing CI/CD reference pages that enumerate the image inventory:
  `container-images.md` (image tree, a placement section, the DEVIATION list)
  and `tempest-test-infrastructure.md` (the package table, six → seven). #772
  still owns the placement reference pages themselves.

`verify_release_config.sh` test 1 also gained a converse check — a service
registered in `source-refs.yaml` but missing from the `SERVICES` list now
fails loudly instead of silently skipping four tests.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) bb6d479 with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787872778&installation_model_id=18560&pr_number=773&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F773&signature=26da066b609cb3119a23367d00050f3faaadd6ca8edbec77e4015ccb0c968822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
