### PR TITLE
ci: move the E2E and integration jobs to the self-hosted runners

### DIFF
--- a/.claude/skills/debug-e2e-failure/SKILL.md
+++ b/.claude/skills/debug-e2e-failure/SKILL.md
@@ -138,7 +138,7 @@ Family-specific constraints:
 | Cleanup timeout exceeded in deletion suites under `parallel: 4` | MariaDB operator serializes Database/User/Grant deletions past the old 60s window | `cleanup: 3m` in `tests/e2e/chainsaw-config.yaml` |
 | Image pull / manifest inspect flakes against ghcr.io | registry eventual consistency, transient 5xx | `4b3cfbde`, `1f43aee7`, `f67318cd` — bounded retries; `b5efce28` — GHCR transport replaced artifact download |
 | OpenBao pod 0/1 Running forever after a chaos kill | single-replica Shamir sealing — new pod starts sealed, no auto-unseal in kind | `tests/e2e-chaos/unseal-openbao.sh` |
-| NetworkChaos suites fail only on Blacksmith runners | Firecracker microVM kernel lacks `ip_set`/`xt_set`/`sch_netem` | chaos matrix `network` leg pinned to `ubuntu-24.04`, `continue-on-error` |
+| NetworkChaos suites fail with missing `ip_set`/`xt_set`/`sch_netem` | runner kernel ships without the modules | `hack/deploy-infra.sh` installs `linux-modules-extra-$(uname -r)` and retries; chaos matrix `network` leg stays `continue-on-error` |
 | Individual tempest test fails intermittently in one release row | upstream test races under concurrency | `ca194368` — failed tests rerun once serially, rewritten as flakes in JUnit |
 
 ## Notes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -403,7 +403,7 @@ jobs:
     # wall-clock back down. Even so the keystone controller envtest
     # suite alone runs ~14m and intermittently brushed the 15m job wall (a 15m07s
     # run was cancelled), so the limit is raised to 20m for headroom.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -588,7 +588,7 @@ jobs:
   e2e-infra:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.e2e-infra == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -691,7 +691,7 @@ jobs:
       github.event.pull_request.head.repo.fork != true &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 30
     permissions:
       contents: read
@@ -880,7 +880,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 45
     permissions:
       contents: read
@@ -1031,7 +1031,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 45
     permissions:
       contents: read
@@ -1124,9 +1124,9 @@ jobs:
   # Gating is split by matrix leg (see continue-on-error below): the pod-chaos
   # leg is blocking — an operator-restart/PDB/rotation regression fails the
   # build — while the network-chaos leg stays non-blocking because its
-  # ip_set/xt_set/sch_netem dependency is resolvable only on the GitHub-hosted
-  # runner and remains prone to environment flakiness. On-demand pre-validation
-  # of either leg is available via the run-chaos PR label.
+  # ip_set/xt_set/sch_netem dependency makes it prone to environment flakiness.
+  # On-demand pre-validation of either leg is available via the run-chaos PR
+  # label.
   e2e-chaos:
     needs: [changes, lint, shellcheck, test, test-integration, verify-codegen, chainsaw-lint, build-e2e-images, e2e-operator]
     # always(): allow the job to run when upstream Go jobs are skipped
@@ -1139,11 +1139,9 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    # Split into two matrix entries to work around the Blacksmith
-    # Firecracker microVM kernel, which ships without ip_set/xt_set/sch_netem
-    # modules and has no matching linux-modules-extra package. PodChaos runs
-    # on Blacksmith for speed; NetworkChaos runs on a GitHub-hosted ubuntu
-    # runner where linux-modules-extra-$(uname -r) is resolvable.
+    # Both legs run on the self-hosted runners. The split into two matrix
+    # entries is kept so PodChaos and NetworkChaos stay independently gated
+    # (see continue-on-error below) and so the two suites run in parallel.
     #
     # test_dirs lists the per-suite test directories explicitly. chainsaw
     # v0.2.14 accepts --{include,exclude}-test-regex flags but does not apply
@@ -1160,7 +1158,7 @@ jobs:
           # runners set WITH_CHAOS_MESH=true via setup-e2e-infra (env block
           # below), so the test's runtime presence guard never SKIPs here.
           - suite: pod
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: self-hosted
             test_dirs: >-
               tests/e2e/infrastructure/chaos-mesh-health
               tests/e2e-chaos/api-pod-kill-pdb
@@ -1176,7 +1174,7 @@ jobs:
               tests/e2e-chaos/operator-pod-kill
               tests/e2e-chaos/glance-operator-pod-kill
           - suite: network
-            runner: ubuntu-24.04
+            runner: self-hosted
             test_dirs: >-
               tests/e2e/infrastructure/chaos-mesh-health
               tests/e2e-chaos/mariadb-network-latency
@@ -1185,8 +1183,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     # Pod-chaos is blocking; network-chaos stays non-blocking (its kernel-module
-    # dependency is only resolvable on the GitHub-hosted runner and remains
-    # flakiness-prone). See the gating note above the job.
+    # dependency keeps it flakiness-prone). See the gating note above the job.
     continue-on-error: ${{ matrix.suite == 'network' }}
     permissions:
       contents: read
@@ -1287,7 +1284,7 @@ jobs:
   # presence in openstack, Prometheus target health for keystone-operator,
   # Grafana dashboard presence).
   #
-  # Single matrix entry on the Blacksmith runner — the
+  # Single matrix entry on the self-hosted runner — the
   # kube-prometheus stack is deterministic, so unlike e2e-chaos this job runs
   # `continue-on-error: false`.  Inherits the e2e-chaos `needs:` chain so the
   # same upstream Go gate applies and an operator code change re-runs the
@@ -1304,7 +1301,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 45
     continue-on-error: false
     permissions:
@@ -1389,7 +1386,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 60
     continue-on-error: false
     permissions:
@@ -1526,7 +1523,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 60
     continue-on-error: false
     permissions:
@@ -1637,7 +1634,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 60
     continue-on-error: false
     permissions:
@@ -1752,7 +1749,7 @@ jobs:
       needs.build-e2e-images.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: self-hosted
     timeout-minutes: 45
     permissions:
       contents: read

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -150,9 +150,8 @@ The E2E jobs (`e2e-infra`, `e2e-operator`, `e2e-operator-upgrade`, `e2e-chaos`,
 `e2e-prometheus`, `e2e-controlplane`, `e2e-external-keystone`, `tempest`) share
 infrastructure setup via
 the `setup-e2e-infra` composite action and diagnostic teardown via
-`hack/ci-dump-diagnostics.sh`. They run on `blacksmith-4vcpu-ubuntu-2404` runners
-(as does `test-integration`), except the `e2e-chaos` network suite, which uses a
-GitHub-hosted `ubuntu-24.04` runner for its kernel-module requirements.
+`hack/ci-dump-diagnostics.sh`. They run on the `self-hosted` runners, as does
+`test-integration`.
 
 ## Jobs
 
@@ -686,16 +685,15 @@ tests run after the happy-path operator E2E suite has passed. Gating is set per
 matrix leg via `continue-on-error: ${{ matrix.suite == 'network' }}`: the `pod`
 leg is **blocking** — an operator-restart, PDB, or rotation regression fails the
 build — while the `network` leg stays **non-blocking**, because its
-`ip_set`/`sch_netem` kernel-module dependency is resolvable only on the
-GitHub-hosted runner and remains prone to environment flakiness. On-demand
-pre-validation of either leg is available via the `run-chaos` PR label.
+`ip_set`/`sch_netem` kernel-module dependency keeps it prone to environment
+flakiness. On-demand pre-validation of either leg is available via the
+`run-chaos` PR label.
 
-The job runs as a two-entry matrix split by chaos type: the `pod` suite (PodChaos
-tests) runs on `blacksmith-4vcpu-ubuntu-2404` for speed, while the `network` suite
-(NetworkChaos tests) runs on a GitHub-hosted `ubuntu-24.04` runner, where the
-`linux-modules-extra` kernel modules required by `ip_set`/`sch_netem` are resolvable
-(the Blacksmith Firecracker microVM kernel ships without them). Each matrix entry
-lists its per-suite test directories explicitly.
+The job runs as a two-entry matrix split by chaos type: the `pod` suite
+(PodChaos tests) and the `network` suite (NetworkChaos tests). Both legs run on
+the `self-hosted` runners; the split keeps the two suites independently gated and
+lets them run in parallel. Each matrix entry lists its per-suite test directories
+explicitly.
 
 | Step | Action | Details |
 | --- | --- | --- |

--- a/tests/e2e-chaos/README.md
+++ b/tests/e2e-chaos/README.md
@@ -31,11 +31,12 @@ as in `tests/e2e/README.md`. Chaos-specific rules:
   matrix leg (chainsaw v0.2.14's include/exclude-regex flags are
   no-ops). A new suite **must** be added to the `pod` or `network` leg
   there, or it never runs in CI.
-- **Runner split:** PodChaos suites (e.g. `glance-operator-pod-kill`) run
-  on Blacksmith runners; the NetworkChaos suites
-  (`mariadb-network-latency`, `-partition`, `glance-garage-outage`) need
-  the `sch_netem`/`ip_set` kernel modules that only GitHub-hosted
-  `ubuntu-24.04` runners provide, and that leg is `continue-on-error`.
+- **Runner split:** both legs run on the `self-hosted` runners. The
+  NetworkChaos suites (`mariadb-network-latency`, `-partition`,
+  `glance-garage-outage`) need the `sch_netem`/`ip_set` kernel modules,
+  which `hack/deploy-infra.sh` loads (installing
+  `linux-modules-extra-$(uname -r)` on demand); that leg stays
+  `continue-on-error`.
 - **Recovery assertions are UID-gated** where the contract is "a new pod
   recovered" (compare the pod UID before/after the kill), and
   restart-count-gated where the contract is "survived without restart".


### PR DESCRIPTION
## What

Replaces `blacksmith-4vcpu-ubuntu-2404` with `self-hosted` across `ci.yaml`. Blacksmith is no longer used anywhere in the repo.

Jobs moved: `test-integration`, `e2e-infra`, `build-e2e-images`, `e2e-operator`, `e2e-operator-upgrade`, `e2e-chaos` (both matrix legs), `e2e-prometheus`, `e2e-controlplane`, `e2e-controlplane-sso`, `e2e-external-keystone`, `tempest`.

Untouched: the `ubuntu-latest` jobs (lint, unit tests, release) and the `ubuntu-24.04-arm` leg of `build-and-push`.

No `useblacksmith/*` action was in use, so this is a label change plus comment and documentation updates — no step logic changed.

## The e2e-chaos network leg

Both matrix legs now run on `self-hosted`. The `network` leg had been pinned to a GitHub-hosted `ubuntu-24.04` runner because the Blacksmith Firecracker microVM kernel shipped without `ip_set`/`xt_set`/`sch_netem` and had no matching `linux-modules-extra` package. `hack/deploy-infra.sh` loads those modules itself and installs `linux-modules-extra-$(uname -r)` on demand, so the self-hosted runners cover the dependency without a workflow-side change.

The two-entry split stays — it now keeps the suites independently gated and running in parallel. The `network` leg keeps `continue-on-error: true`, since the kernel-module dependency still makes it flakiness-prone.

## Docs

`docs/reference/ci-cd/ci-workflow.md`, `tests/e2e-chaos/README.md` and the `debug-e2e-failure` skill's flake table drop their Blacksmith and GitHub-hosted-runner references.

## Verification

- `git grep -i "blacksmith\|firecracker"` returns nothing.
- `ci.yaml` parses; 31 jobs.
- `actionlint` reports only pre-existing shellcheck findings in `run:` blocks this PR does not touch.

CI has not run against the new runners yet — this PR is the first exercise of them.

## Review notes

Three things worth a look before merging:

1. **No size constraint.** `runs-on: self-hosted` matches any registered runner in the repo or org; the 4-vCPU guarantee the Blacksmith label carried is gone. If the fleet is heterogeneous, an additional size label (`[self-hosted, <size>]`) would restore it.
2. **`sudo`/apt on the runners.** The `network` chaos leg needs `hack/deploy-infra.sh` to install `linux-modules-extra-$(uname -r)`. If the runners lack that, the leg fails — non-blocking, but permanently red.
3. **Public repo + self-hosted runners.** The E2E jobs trigger on `pull_request`, so fork PRs would execute untrusted code on our infrastructure. Worth confirming that "Require approval for all external contributors" is enabled and the runners are ephemeral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787898595&installation_model_id=18560&pr_number=775&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F775&signature=b0cb719d3cf6b8df1df1b62add03b1940b3713cf307b9f071703248fe606e1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->