### PR TITLE
docs: improve onboarding documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,36 +4,50 @@ title: Overview
 
 # CobaltCore Forge
 
-CobaltCore (C5C3) is a Kubernetes-native OpenStack distribution for operating
-Hosted Control Planes across a multi-cluster topology — Management, Control
-Plane, Hypervisor, and Storage. This repository delivers everything needed for
-a self-contained Keystone deployment stack: from the declarative infrastructure
-manifests, through the service operators, to the c5c3-operator orchestration
-layer — built with the Operator SDK (Go), controller-runtime, and Kubebuilder.
+CobaltCore Forge helps teams run OpenStack control planes on Kubernetes.
 
-The implementation follows a Keystone-first strategy. The Keystone operator is
-the reference implementation that establishes the patterns — CRD layout,
-sub-reconciler chain, webhooks, finalizers, instrumentation — replicated by
-every subsequent service operator. Horizon and Glance are already onboarded on
-the same scaffolding, and the c5c3-operator ties the services together into a
-single ControlPlane resource.
+This repository includes deployment manifests, Kubernetes operators, and tested
+workflows for running the stack locally and in CI.
+
+You can complete the main quick start and make an authenticated Keystone API
+call on a local kind cluster.
+
+## Who this is for
+
+- Platform engineers and site reliability engineers (SREs) managing
+  Kubernetes-based control planes.
+- OpenStack operators.
+- Developers contributing to Kubernetes operators.
 
 ## Start here
 
-- **[Quick Start](./quick-start.md)** — from `git clone` to an authenticated
-  Keystone API call on a local kind cluster.
-- **[Quick Start (Extended)](./quick-start-extended.md)** — UI tours, the
-  local-build path, the production HelmRelease, E2E, and Tempest.
-- **[Quick Start (ControlPlane)](./quick-start-controlplane.md)** — bring up a
-  full ControlPlane through the c5c3-operator.
+If you open only one page first, open **[Quick Start](./quick-start.md)**.
 
-## What's inside
+- **[Quick Start](./quick-start.md)** — Path from clone to an
+  authenticated Keystone API call on a local kind cluster.
+- **[Quick Start (ControlPlane)](./quick-start-controlplane.md)** — bring up a
+  full ControlPlane through the c5c3-operator after the main quick start.
+- **[Quick Start (Extended)](./quick-start-extended.md)** *(optional)* — UI
+  tours, local-build path, production HelmRelease, E2E, and Tempest.
+
+## Architecture at a glance
+
+CobaltCore (C5C3) operates hosted control planes across a multi-cluster
+topology: Management, Control Plane, Hypervisor, and Storage.
+
+The architecture follows a Keystone-first strategy. CobaltCore delivers a
+self-contained deployment stack, from declarative infrastructure
+manifests through service operators to c5c3-operator orchestration, built with
+Operator SDK (Go), controller-runtime, and Kubebuilder.
 
 - **Operators.** Service operators following a shared sub-reconciler pattern,
   with [Keystone](./reference/keystone/) as the reference implementation and the
   [c5c3-operator](./reference/c5c3/controlplane-crd.md) as the ControlPlane
   orchestration layer. [Horizon](./reference/horizon/) and
   [Glance](./reference/glance/) are onboarded on the same conventions.
+- **Operator pattern details.** The Keystone reference pattern includes CRD
+  layout, sub-reconciler chain, webhooks, finalizers, and instrumentation,
+  replicated by subsequent service operators.
 - **Shared library.** Common types, conditions, config rendering, and
   Kubernetes helpers in `internal/common/`, plus the Helm chart, operator
   packaging, and rotation scripts. See the


### PR DESCRIPTION
### Overview
This PR updates the docs landing page to make first contact clearer for humans while preserving the original technical depth.

Closes #745.

### What Changed
Reworked the opening of [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use plain language.

Added a new Who this is for section in [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with explicit target audience.

Improved onboarding flow in Start here in [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Made the primary one-click path explicit.
- Marked Quick Start (Extended) as optional.

Renamed What’s inside to Architecture at a glance in [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and moved architecture-heavy content below Start here.

Preserved the dense technical context under Architecture at a glance in [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Multi-cluster topology naming
- Keystone-first strategy
- Self-contained Keystone stack framing
- Implementation stack (Operator SDK, controller-runtime, Kubebuilder)
- Keystone pattern internals (CRD layout, sub-reconciler chain, webhooks, finalizers, instrumentation)

### Why
The goal is to make the landing page immediately actionable for new readers while keeping architecture details accessible for technical audiences.

### Scope
Docs-only change.
No code, API, CRD, or behavior changes.

### Validation
Manual review of [index.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for:
- readability on first screen
- clear start path
- optional path labeling
- retention of prior technical claims in Architecture at a glance

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787567340&installation_model_id=18560&pr_number=746&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F746&signature=198dc7c56e83c463bf74fe3d017ff835d0b13e4cb0f73e3a59cff20bc230229a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->