### PR TITLE
docs: clarify Keystone image preparation options

### DIFF
--- a/docs/quick-start-extended.md
+++ b/docs/quick-start-extended.md
@@ -682,10 +682,11 @@ keystone-operator-6d7f9f4d5b-xyz99   1/1     Running   0          30s
 
 ---
 
-## Step 6 — Build and load the Keystone service image
+## Step 6 — Prepare and load the Keystone service image
 
 The `Keystone` CR references a service image that runs the actual OpenStack Keystone API. Either
-pull the pre-built image from GHCR or build it locally.
+pull the pre-built image from GHCR or build it locally. Run **one option only**; both options
+produce the same image reference and load it into the `forge` kind cluster.
 
 Set the release you want to work with. The default is the most recent release; update this variable
 whenever a new release is available:
@@ -694,14 +695,14 @@ whenever a new release is available:
 RELEASE=2025.2   # update to the target release
 ```
 
-### Pull from GHCR
+### Option A — Pull from GHCR (recommended)
 
 ```bash
 docker pull ghcr.io/c5c3/keystone:"${RELEASE}"
 kind load docker-image ghcr.io/c5c3/keystone:"${RELEASE}" --name forge
 ```
 
-### Build locally
+### Option B — Build locally
 
 ```bash
 # Resolve the upstream source ref


### PR DESCRIPTION
clarify that users must choose exactly one path: pull the published image from GHCR or build it locally. Label GHCR as the recommended option, retain the local development workflow, and add inline comments describing both choices.

On-behalf-of: @SAP
Assisted-by: Codex:GPT-5.6-Luna
Signed-off-by: Zaher Abboud zabboud@deloitte.de

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787917972&installation_model_id=18560&pr_number=779&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F779&signature=c33685831b81bf2d0a75a3ee898c2c8c1cfc552187a5012457bb838e7a1bb90d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->