### PR TITLE
fix: align Flux Web pin with operator v0.56.0

### DIFF
--- a/deploy/kind/base/flux-web.yaml
+++ b/deploy/kind/base/flux-web.yaml
@@ -46,7 +46,7 @@
 #
 # Version pin: `spec.inputs[0].version` is a SemVer range locked to the
 # minor track of `FLUX_OPERATOR_VERSION` in hack/deploy-infra.sh (today
-# v0.55.0 → 0.55.x). Bump both together when upgrading the operator.
+# v0.56.0 → 0.56.x). Bump both together when upgrading the operator.
 #
 ---
 apiVersion: fluxcd.controlplane.io/v1
@@ -63,7 +63,7 @@ spec:
   # This keeps the kind-only addon self-contained — no extra
   # ResourceSetInputProvider CR to maintain.
   inputs:
-    - version: "0.55.x"
+    - version: "0.56.x"
   resources:
     - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository

--- a/tests/unit/deploy/kind_base_flux_web_test.sh
+++ b/tests/unit/deploy/kind_base_flux_web_test.sh
@@ -133,7 +133,7 @@ test_kustomize_build_emits_resourceset() {
 # --- Test 3: chart version pin is a SemVer range locked to the minor
 #             track shipped by hack/deploy-infra.sh ---
 test_chart_version_pin_is_semver_range() {
-  echo "Test: ResourceSet spec.inputs[0].version is 0.55.x and matches FLUX_OPERATOR_VERSION minor track"
+  echo "Test: ResourceSet spec.inputs[0].version is 0.56.x and matches FLUX_OPERATOR_VERSION minor track"
 
   if [[ ! -f "$FLUX_WEB_FILE" ]]; then
     echo "  FAIL: $FLUX_WEB_FILE does not exist"
@@ -147,12 +147,12 @@ test_chart_version_pin_is_semver_range() {
   else
     local version
     version="$(yq -r '.spec.inputs[0].version' "$FLUX_WEB_FILE" 2>/dev/null | head -n1)"
-    assert_eq "spec.inputs[0].version pins the 0.55.x SemVer range" "0.55.x" "$version"
+    assert_eq "spec.inputs[0].version pins the 0.56.x SemVer range" "0.56.x" "$version"
   fi
 
-  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.55.0\"" \
+  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.56.0\"" \
     "$DEPLOY_INFRA_SH" \
-    'FLUX_OPERATOR_VERSION="v0.55.0"'
+    'FLUX_OPERATOR_VERSION="v0.56.0"'
 }
 
 # --- Test 4: kind kustomization lists flux-web.yaml after headlamp.yaml ---


### PR DESCRIPTION
Update the kind-only Flux Web chart range and documentation from 0.55.x to 0.56.x, and align the shell-test expectation with FLUX_OPERATOR_VERSION=v0.56.0. This keeps the operator version, ResourceSet chart pin, and CI assertion synchronized.

On-behalf-of: @SAP
Assisted-by: Codex:GPT-5.6-Luna
Signed-off-by: Zaher Abboud zabboud@deloitte.de

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787922124&installation_model_id=18560&pr_number=780&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F780&signature=c5b6eb56f96337441a74daf37344d78575f01ff37587286830a683f20b22f7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->