### PR TITLE
fix(operators): keep maintenance pods out of the API Service

### DIFF
--- a/docs/reference/glance/glance-crd.md
+++ b/docs/reference/glance/glance-crd.md
@@ -412,11 +412,12 @@ The CronJob renders as:
 | CronJob field | Value |
 | --- | --- |
 | `metadata.name` | `{name}-db-purge` |
-| `metadata.labels` | `commonLabels` (same as Deployment) |
+| `metadata.labels` | `commonLabels` (name, instance, managed-by) |
 | `spec.schedule` | resolved `dbPurge.schedule` |
 | `spec.suspend` | resolved `dbPurge.suspend` |
 | `spec.concurrencyPolicy` | `Forbid` |
 | `spec.jobTemplate.spec.activeDeadlineSeconds` | `3600` |
+| `spec.jobTemplate.spec.template.metadata.labels` | `commonLabels` + `app.kubernetes.io/component=db-purge`, which keeps the pods out of the API Service |
 | `spec.jobTemplate.spec.template.spec.restartPolicy` | `OnFailure` |
 | Container name | `db-purge` |
 | Container image | `spec.image` reference |

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -270,7 +270,7 @@ The HPA created from this spec has the following shape:
 | HPA Field | Value |
 | --- | --- |
 | `metadata.name` | `{name}` |
-| `metadata.labels` | `commonLabels` (same as Deployment) |
+| `metadata.labels` | `commonLabels` (name, instance, managed-by) |
 | `spec.scaleTargetRef.apiVersion` | `apps/v1` |
 | `spec.scaleTargetRef.kind` | `Deployment` |
 | `spec.scaleTargetRef.name` | `{name}` |
@@ -605,7 +605,8 @@ ever sees the object.
 | CronJob Field | Value |
 | --- | --- |
 | `metadata.name` | `{name}-trust-flush` |
-| `metadata.labels` | `commonLabels` (same as Deployment) |
+| `metadata.labels` | `commonLabels` (name, instance, managed-by) |
+| `spec.jobTemplate.spec.template.metadata.labels` | `commonLabels` + `app.kubernetes.io/component=trust-flush`, which keeps the pods out of the API Service |
 | `spec.schedule` | `trustFlush.schedule` (webhook-defaulted to `"0 * * * *"` when omitted) |
 | `spec.suspend` | `&trustFlush.suspend` (pointer to bool; webhook-defaulted to `false` when omitted) |
 | `spec.jobTemplate.spec.template.spec.restartPolicy` | `OnFailure` |
@@ -806,7 +807,7 @@ The HTTPRoute created from this spec has the following shape
 | --- | --- |
 | `metadata.name` | `{name}` (matches the backend Service, Deployment, HPA, NetworkPolicy naming) |
 | `metadata.namespace` | Keystone CR namespace |
-| `metadata.labels` | `commonLabels` (same as Deployment) |
+| `metadata.labels` | `commonLabels` (name, instance, managed-by) |
 | `metadata.annotations` | Merged from `spec.gateway.annotations` |
 | `spec.parentRefs[0].name` | `spec.gateway.parentRef.name` |
 | `spec.parentRefs[0].namespace` | `spec.gateway.parentRef.namespace` when non-empty; omitted otherwise |

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -237,9 +237,30 @@ RBAC markers on the reconciler generate the required ClusterRole:
 
 The reconciler applies `commonLabels(keystone)` (`app.kubernetes.io/name`,
 `app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`) to every owned
-resource. In addition, the following forge-specific metadata keys carry
-controller-observable semantics and are stable across releases — consumers
-(watch predicates, chainsaw tests, dashboards) may rely on them:
+resource.
+
+Pod templates carry one label on top of that, `app.kubernetes.io/component`,
+naming the workload the pod belongs to:
+
+| Pod template | `app.kubernetes.io/component` |
+| --- | --- |
+| API Deployment | `api` |
+| `{name}-trust-flush` CronJob | `trust-flush` |
+| `{name}-fernet-rotate` CronJob | `fernet-rotation` |
+| `{name}-credential-rotate` CronJob | `credential-rotation` |
+| `{name}-admin-password-rotate` CronJob | `admin-password-rotation` |
+
+The API Service selects on `app.kubernetes.io/component=api` in addition to the
+name and instance labels, so a maintenance pod can never become one of its
+endpoints. The CronJob objects themselves carry plain `commonLabels`; only
+their pod templates get a component. Two selectors stay on name and instance
+alone: the Deployment pod selector (immutable after creation) and the
+NetworkPolicy pod selector (maintenance pods must keep inheriting its egress
+rules).
+
+The following forge-specific metadata keys carry controller-observable
+semantics and are stable across releases — consumers (watch predicates,
+chainsaw tests, dashboards) may rely on them:
 
 | Key | Kind | Applied to | Value | Purpose |
 | --- | --- | --- | --- | --- |
@@ -1619,6 +1640,7 @@ and disaster recovery backup to OpenBao.
 | Field | Value |
 | --- | --- |
 | Name | `{name}-fernet-rotate` |
+| Pod labels | `commonLabels(keystone)` + `app.kubernetes.io/component=fernet-rotation` |
 | Schedule | `spec.fernet.rotationSchedule` |
 | Suspend | `spec.fernet.suspend` (default `false`); set `true` to pause rotation during an incident without deleting the CronJob or changing its schedule |
 | ServiceAccount | `{name}-fernet-rotate` |
@@ -1794,6 +1816,7 @@ with credential migration, and disaster recovery backup to OpenBao.
 | Field | Value |
 | --- | --- |
 | Name | `{name}-credential-rotate` |
+| Pod labels | `commonLabels(keystone)` + `app.kubernetes.io/component=credential-rotation` |
 | Schedule | `spec.credentialKeys.rotationSchedule` |
 | Suspend | `spec.credentialKeys.suspend` (default `false`); set `true` to pause rotation during an incident without deleting the CronJob or changing its schedule |
 | ServiceAccount | `{name}-credential-rotate` |
@@ -2258,7 +2281,7 @@ its readiness probe, which traverses Apache and uWSGI, carries an explicit
 | Field | Value |
 | --- | --- |
 | Name | `{name}` (bare CR name) |
-| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
+| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/component=api` |
 | Port | 5000 TCP |
 
 **Status Endpoint:**
@@ -2798,6 +2821,7 @@ delegations from the Keystone database. Three lifecycle paths:
 | --- | --- |
 | Name | `{name}-trust-flush` |
 | Labels | `commonLabels(keystone)` |
+| Pod labels | `commonLabels(keystone)` + `app.kubernetes.io/component=trust-flush` |
 | Schedule | `spec.trustFlush.schedule` |
 | Suspend | `&spec.trustFlush.suspend` (pointer to CRD bool) |
 | Container name | `trust-flush` |
@@ -2924,6 +2948,7 @@ Two lifecycle paths:
 | --- | --- |
 | Name | `{name}-admin-password-rotate` |
 | Labels | `commonLabels(keystone)` |
+| Pod labels | `commonLabels(keystone)` + `app.kubernetes.io/component=admin-password-rotation` |
 | Schedule | `spec.passwordRotation.schedule` |
 | Suspend | `&spec.passwordRotation.suspend` (pointer to CRD bool) |
 | ServiceAccount | `{name}-admin-password-rotate` |

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -251,11 +251,26 @@ naming the workload the pod belongs to:
 | `{name}-admin-password-rotate` CronJob | `admin-password-rotation` |
 
 The API Service selects on `app.kubernetes.io/component=api` in addition to the
-name and instance labels, so a maintenance pod can never become one of its
-endpoints. The CronJob objects themselves carry plain `commonLabels`; only
-their pod templates get a component. Two selectors stay on name and instance
-alone: the Deployment pod selector (immutable after creation) and the
-NetworkPolicy pod selector (maintenance pods must keep inheriting its egress
+name and instance labels, so a maintenance pod cannot become one of its
+endpoints. It adopts that selector only once the API Deployment runs nothing but
+the labelled pod template, and never gives it up again — see the Service Spec
+section.
+
+The PodDisruptionBudget needs the same exclusion but must not depend on the
+component label: a pod that no budget selects is not protected at all, so keying
+the budget on a label the pods currently serving do not carry would leave them
+without a budget. It therefore stays on name and instance and excludes
+maintenance pods by the *absence* of `batch.kubernetes.io/job-name`, the label
+the Job controller stamps on every pod it creates. Both routes keep a
+maintenance pod from counting towards `currentHealthy` — a Job pod carries no
+readiness probe, so it would be counted as healthy the moment it starts and
+would raise `disruptionsAllowed` — but only this one also covers API pods from a
+template predating the component label.
+
+The CronJob objects themselves carry plain `commonLabels`; only their pod
+templates get a component. Two selectors stay on name and instance alone with no
+further narrowing: the Deployment pod selector (immutable after creation) and
+the NetworkPolicy pod selector (maintenance pods must keep inheriting its egress
 rules).
 
 The following forge-specific metadata keys carry controller-observable
@@ -2222,8 +2237,8 @@ preserving the no-rollout behavior.
 | --- | --- |
 | Name | `{name}` (bare CR name) |
 | Replicas | `spec.deployment.replicas`; left `nil` when `spec.autoscaling` is set, so the HorizontalPodAutoscaler owns the count and the operator does not reset it each reconcile |
-| Labels | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/managed-by=keystone-operator` |
-| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` |
+| Labels | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/managed-by=keystone-operator`, `app.kubernetes.io/component=api` (on the Deployment metadata and on the pod template) |
+| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}` (the component label is left out: a Deployment pod selector is immutable after creation) |
 | Container name | `keystone` |
 | Image | `{spec.image.repository}:{spec.image.tag}` |
 | Port | 5000 (named `keystone`) |
@@ -2281,8 +2296,62 @@ its readiness probe, which traverses Apache and uWSGI, carries an explicit
 | Field | Value |
 | --- | --- |
 | Name | `{name}` (bare CR name) |
-| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/component=api` |
+| Selector | `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`, `app.kubernetes.io/component=api` from the first pass that observes a fully rolled-out Deployment onwards; `app.kubernetes.io/name` and `app.kubernetes.io/instance` alone before that |
 | Port | 5000 TCP |
+
+The selector is narrowed in two phases. The PodDisruptionBudget selector is
+not: it never keys on the component label at all.
+
+`deployment.EnsureDeployment` is a Server-Side Apply: it returns as soon as the
+API server accepts the pod template, long before the rollout finishes. On the
+operator upgrade that first ships `app.kubernetes.io/component=api`, applying
+the narrowed selector in that same reconcile pass would drop every API pod
+still running from the previous build — none of them carries the label — out of
+the EndpointSlices while they are the only pods serving. The Service would have
+no backends until the first re-rolled pod passed its probes, and a rollout that
+never completes (image pull failure, `ResourceQuota` rejection, no schedulable
+node) would never repool them, turning a stuck rollout into an unbounded
+outage.
+
+The reconciler therefore keeps the wide selector until
+`deployment.TemplateConverged` reports that no pod predates the current pod
+template — the deployment controller has observed the latest generation, reports
+at least one pod, and `status.replicas` (pods across all ReplicaSets) equals
+`status.updatedReplicas` (pods of the newest one) — and narrows it on the next
+pass. The Deployment is watched (`Owns`), so that pass is triggered by the status
+update itself.
+
+Readiness is deliberately not part of that gate. An unready pod is not an
+endpoint whichever selector the Service carries, while requiring full readiness
+would strand a Deployment that never reaches it — a third replica pending on
+resource pressure or on an unsatisfiable topology-spread constraint — on the wide
+selector permanently, and with it on the maintenance-pod race the narrowing
+closes. (The stricter `keystoneDeploymentRolledOut`, which does require
+readiness, gates the RollingUpdate → Contracting flip, where old-image pods must
+be gone before their columns are dropped.)
+
+The narrowing is a one-way migration, so the reconciler latches it: when the
+Deployment is not converged it reads the live Service and keeps the narrow
+selector if it is already there (`deployment.APISelectorNarrowed`). Only a pod
+template built by an operator predating `app.kubernetes.io/component=api` can
+miss the narrow selector, and every template this operator builds carries it —
+so after the migration the wide selector protects nothing and only re-admits
+maintenance pods. Without the latch the selector would not migrate once but
+oscillate: `deployment.TemplateConverged` turns false on every later rollout (a
+rotated Dynamic database credential restamps the pod template on each ESO
+refresh), re-admitting maintenance pods for as long as that rollout lasts.
+
+The latch reads the Service through `mgr.GetAPIReader()`, not the informer
+cache. Right after the narrowing write the cache can still hold the wide
+Service; a reconcile triggered in that window by an unrelated event, with the
+Deployment momentarily unconverged, would read the stale copy and apply the wide
+selector again. The read runs at most once per reconcile and only while the
+Deployment is unconverged.
+
+`tests/e2e-operator-upgrade/keystone-helm-upgrade` asserts the migration across
+a real `helm upgrade`: it records the EndpointSlice address count before the
+upgrade and samples it until the selector narrows, failing if the count ever
+drops.
 
 **Status Endpoint:**
 
@@ -2313,8 +2382,34 @@ disruption budget strategy:
 | PDB Field | Value |
 | --- | --- |
 | Name | `{name}` |
-| Labels | Same as Deployment (`commonLabels`) |
-| Selector | Same as Deployment (`selectorLabels`) |
+| Labels | `commonLabels` (the Deployment metadata adds `app.kubernetes.io/component=api` on top; the PDB does not) |
+| Selector | `matchLabels`: `app.kubernetes.io/name=keystone`, `app.kubernetes.io/instance={name}`; `matchExpressions`: `batch.kubernetes.io/job-name DoesNotExist` |
+
+The budget needs the same maintenance-pod exclusion as the Service but reaches it
+the other way round, and it needs no two-phase narrowing.
+
+Excluding maintenance pods matters because the disruption controller counts every
+pod its selector matches towards `currentHealthy`, and a Job pod carries no
+readiness probe, so it is healthy the moment it starts — inflating
+`disruptionsAllowed` and letting a node drain evict the API pods the budget
+exists to protect. Every maintenance workload is a CronJob, so the absence of
+`batch.kubernetes.io/job-name` — the label the Job controller stamps on each pod
+it creates — separates the API pods from them exactly.
+
+Keying on `app.kubernetes.io/component=api` instead would open a worse hole than
+it closes. The eviction API only consults budgets whose selector matches the pod
+being evicted, so a pod that no budget matches has no budget at all: on the
+operator upgrade that first ships the component label, a component-keyed budget
+would match none of the API pods actually serving, and a node drain, an
+autoscaler consolidation, or a node upgrade could take every replica at once. The
+gap would last the whole migration rollout — and, unlike the Service's, it has no
+bound: a rollout that wedges on a bad image tag, a `ResourceQuota` rejection, or
+an unschedulable pod keeps the unlabelled pods alive indefinitely.
+
+Because the Job-name requirement holds for labelled and unlabelled API pods
+alike, the budget can carry its final selector from the first reconcile. Only the
+Service, whose narrow selector genuinely misses the pre-upgrade pods, needs the
+two-phase narrowing.
 
 **Condition Contract:**
 

--- a/docs/reference/testing/keystone-e2e-tests.md
+++ b/docs/reference/testing/keystone-e2e-tests.md
@@ -23,7 +23,7 @@ scaling, key rotation, image upgrades, cross-release upgrades, and deletion clea
 suite is independent and creates its own Keystone CR with a unique name in the `openstack`
 namespace, enabling parallel execution (Chainsaw runs up to 4 suites concurrently).
 
-`tests/e2e/keystone/` currently holds **47 suites** and is the canonical
+`tests/e2e/keystone/` currently holds **50 suites** and is the canonical
 inventory — the [Test Suite Inventory](#test-suite-inventory) below lists all of
 them, and the [Test Suite Details](#test-suite-details) sections walk through a
 representative subset step by step.
@@ -123,6 +123,7 @@ Deployment rollout, bootstrap Job).
 | invalid-cr | multiple (rejected) | Every CEL XValidation and webhook rejection path pinned to a deterministic admission failure |
 | key-repository-mode | `keystone-keymode` | Fernet/credential key volumes are not world-readable (no `key_repository is world readable` startup warning) |
 | logging | `keystone-logging` | `spec.logging` propagation to oslo.log: defaults, level/format overrides, per-logger levels |
+| maintenance-endpoint-isolation | `keystone-endpoint-isolation` | Maintenance pods never become API Service backends: the non-terminating EndpointSlice address count for the API Service stays at exactly the live replica count — never above, never empty — across a sampling window that observes a live trust-flush pod holding a pod IP |
 | metrics | — (operator-level) | keystone-operator chart renders and removes the ServiceMonitor; metrics endpoint scrapeable |
 | namespace-scoped-rbac | `keystone-ns-scoped` | Operator deployed with `rbac.namespaceScoped=true` + `webhook.enabled=false` still reconciles to Ready |
 | network-policy | `keystone-netpol` | Per-CR NetworkPolicy create/update/delete driven by `spec.networkPolicy` ingress sources |
@@ -968,6 +969,9 @@ tests/e2e/keystone/
 │   ├── 01-patch-debug-true.yaml        Patch enabling debug
 │   ├── 02-patch-format-json.yaml       Patch switching to JSON format
 │   └── 03-patch-invalid-perloggerlevel.yaml Invalid per-logger level (rejected)
+├── maintenance-endpoint-isolation/
+│   ├── chainsaw-test.yaml              API Service endpoints during a trust-flush run
+│   └── 00-keystone-cr.yaml             Keystone CR with an every-minute trust flush
 ├── metrics/
 │   └── chainsaw-test.yaml              Operator ServiceMonitor render/remove
 ├── middleware-config/

--- a/docs/reference/testing/operator-upgrade-e2e-tests.md
+++ b/docs/reference/testing/operator-upgrade-e2e-tests.md
@@ -58,17 +58,26 @@ cluster. `hack/ci-deploy-operator.sh` installs the pulled chart via its optional
 | # | Action | Details |
 | --- | --- | --- |
 | 1 | Deploy CR on released operator | Applies the CR and asserts `Ready=True` (AllReady) and `status.installedRelease == "2025.2"` under the released operator |
-| 2 | Capture baseline | Reads the `keystone-op-upgrade-bootstrap` Job UID and stashes it in a ConfigMap (the bootstrap Job persists — `TTLSecondsAfterFinished` is unset — so its UID is a stable "no re-bootstrap" anchor) |
+| 2 | Capture baseline | Reads the `keystone-op-upgrade-bootstrap` Job UID and the API Service backend count and stashes both in a ConfigMap (the bootstrap Job persists — `TTLSecondsAfterFinished` is unset — so its UID is a stable "no re-bootstrap" anchor) |
 | 3 | helm upgrade | Applies the locally built CRDs, `helm dependency build`s the in-repo chart, `helm upgrade`s the release to the `:dev` image, and waits for the rollout |
 | 4 | Assert operator rolled | Verifies the `manager` container runs the `:dev` image and `updatedReplicas == replicas` — proving the rollout actually happened, not just that the spec was patched |
-| 5 | Poke reconcile | Annotates the CR to force one full reconcile by the new operator (`AnnotationChangedPredicate` admits it; generation is unchanged) |
-| 6 | Assert after upgrade | Asserts `Ready=True` (AllReady), `status.observedGeneration == metadata.generation`, `status.installedRelease` still `2025.2`, the bootstrap Job UID is unchanged, and exactly one bootstrap Job exists |
+| 5 | Assert endpoints survive upgrade | Samples the API Service EndpointSlices until the new operator has narrowed the Service selector to `app.kubernetes.io/component=api`, failing if the non-terminating backend count ever drops below the step-2 baseline, or if the narrowing never lands |
+| 6 | Poke reconcile | Annotates the CR to force one full reconcile by the new operator (`AnnotationChangedPredicate` admits it; generation is unchanged) |
+| 7 | Assert after upgrade | Asserts `Ready=True` (AllReady), `status.observedGeneration == metadata.generation`, `status.installedRelease` still `2025.2`, the bootstrap Job UID is unchanged, and exactly one bootstrap Job exists |
 
 `status.installedRelease` tracks the Keystone service image tag (`2025.2`), not
 the operator version, so "unchanged" means it stays `2025.2` across the operator
 upgrade. Bootstrap is gated on the admin-password digest (not the image), so the
 operator upgrade must not re-run it — asserted via the unchanged bootstrap Job
 UID and the exactly-one-bootstrap-Job count.
+
+Step 5 covers a failure mode the CR-level assertions cannot see: `Ready=True`
+and `observedGeneration` are both derived from Deployment status, so they stay
+green even if the API Service is left with no backends at all. The new operator
+narrows the Service selector to `app.kubernetes.io/component=api`, a label the
+pods running under the released operator do not carry, so the narrowing must
+wait for the Deployment to roll onto the labelled template — see the
+[Keystone Reconciler reference](../keystone/keystone-reconciler.md).
 
 ## Running locally
 

--- a/internal/common/deployment/deployment.go
+++ b/internal/common/deployment/deployment.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/c5c3/forge/internal/common/apply"
+	"github.com/c5c3/forge/internal/common/naming"
 )
 
 // EnsureDeployment creates a Deployment if it does not exist or applies its
@@ -103,6 +104,56 @@ func EnsureService(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 	}
 
 	return apply.EnsureObject(ctx, c, scheme, owner, svc, apply.FieldManager)
+}
+
+// TemplateConverged reports whether every pod of the Deployment belongs to its
+// current pod template: the deployment controller has observed the latest
+// generation and reported at least one pod, and Status.Replicas (pods across all
+// ReplicaSets) equals Status.UpdatedReplicas (pods of the newest one only), so no
+// old-template pod survives. A status that reports no pod at all is not
+// convergence, it is a Deployment the controller has not acted on yet.
+//
+// It is the precondition for narrowing the API Service selector to the API
+// component. Readiness is deliberately not part of it — an unready pod is not an
+// endpoint regardless of which selector the Service carries, while demanding it
+// would strand an install that never reaches full readiness (a replica pending
+// on resource pressure or an unsatisfiable topology-spread constraint) on the
+// wide selector forever, and with it on the maintenance-pod race the narrowing
+// closes. Callers that need full convergence *including* readiness — the
+// RollingUpdate → Contracting flip, which drops columns old-image pods still
+// read — keep their own stricter check.
+func TemplateConverged(deploy *appsv1.Deployment) bool {
+	return deploy.Status.ObservedGeneration >= deploy.Generation &&
+		deploy.Status.Replicas > 0 &&
+		deploy.Status.UpdatedReplicas == deploy.Status.Replicas
+}
+
+// APISelectorNarrowed reports whether the named Service already selects by
+// naming.ComponentAPI. Callers latch the two-phase narrowing of the API Service
+// selector on it: the narrowing is a one-way migration off pod templates that
+// predate the component label, so once a Service carries the narrow selector it
+// must never widen again. Every template the operator builds carries the label,
+// so no later rollout can produce a pod the narrow selector misses — while
+// widening would re-admit maintenance pods as endpoints for the duration of
+// every later rollout.
+//
+// c must be an uncached reader (mgr.GetAPIReader()). Reading through the
+// informer cache would decide the latch from state that can still predate the
+// narrowing write: a reconcile triggered in that window by an unrelated event
+// would see a wide Service, and if the Deployment happened to be unconverged
+// just then it would apply the wide selector again — reopening the race for as
+// long as the Deployment takes to converge.
+//
+// A Service that does not exist yet counts as not narrowed.
+func APISelectorNarrowed(ctx context.Context, c client.Reader, namespace, name string) (bool, error) {
+	svc := &corev1.Service{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting Service %s/%s: %w", namespace, name, err)
+	}
+	return svc.Spec.Selector[naming.LabelKeyComponent] == naming.ComponentAPI, nil
 }
 
 // EnsurePDB creates a PodDisruptionBudget if it does not exist or applies its

--- a/internal/common/deployment/deployment_test.go
+++ b/internal/common/deployment/deployment_test.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/naming"
 )
 
 func newScheme() *runtime.Scheme {
@@ -473,6 +475,113 @@ func TestEnsureService_decodesServerResponseIntoObject(t *testing.T) {
 	// the server-assigned ClusterIP and a resourceVersion.
 	g.Expect(desired.Spec.ClusterIP).To(Equal("10.0.0.42"))
 	g.Expect(desired.ResourceVersion).NotTo(BeEmpty())
+}
+
+// TestTemplateConverged covers the gate the operators narrow the API Service
+// selector on. Convergence means "no pod predates the current template", which
+// is deliberately independent of health: a Deployment that never reaches full
+// readiness still runs nothing but the labelled template, and gating on
+// readiness would leave it on the wide selector forever — the latch cannot
+// rescue it, because it can only hold a narrowing that already happened.
+func TestTemplateConverged(t *testing.T) {
+	cases := []struct {
+		name   string
+		deploy appsv1.Deployment
+		want   bool
+	}{
+		{
+			name: "generation not observed yet",
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 4},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 3, Replicas: 3, UpdatedReplicas: 3},
+			},
+			want: false,
+		},
+		{
+			name: "old-template pods still counted",
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 4},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 4, Replicas: 4, UpdatedReplicas: 1},
+			},
+			want: false,
+		},
+		{
+			name: "no pod reported yet",
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+			},
+			want: false,
+		},
+		{
+			name: "converged and ready",
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 4},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 4, Replicas: 3, UpdatedReplicas: 3, ReadyReplicas: 3},
+			},
+			want: true,
+		},
+		{
+			// A third replica pending on resource pressure or on an
+			// unsatisfiable topology-spread constraint: permanently degraded,
+			// but every live pod runs the current template.
+			name: "converged but never fully ready",
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 4},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 4, Replicas: 3, UpdatedReplicas: 3, ReadyReplicas: 2},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(TemplateConverged(&tc.deploy)).To(Equal(tc.want))
+		})
+	}
+}
+
+// TestAPISelectorNarrowed covers the latch the operators use to keep the
+// two-phase narrowing one-way: only a Service that already selects by the API
+// component reports true, and a Service that does not exist yet is not an error.
+func TestAPISelectorNarrowed(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing *corev1.Service
+		want     bool
+	}{
+		{name: "no Service yet", existing: nil, want: false},
+		{name: "wide selector", existing: func() *corev1.Service {
+			svc := testService()
+			svc.Spec.Selector = naming.SelectorLabels("keystone", "test")
+			return svc
+		}(), want: false},
+		{name: "narrowed selector", existing: func() *corev1.Service {
+			svc := testService()
+			svc.Spec.Selector = naming.APISelectorLabels("keystone", "test")
+			return svc
+		}(), want: true},
+		{name: "some other component", existing: func() *corev1.Service {
+			svc := testService()
+			svc.Spec.Selector = naming.ComponentLabels("keystone", "test", "trust-flush")
+			return svc
+		}(), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cb := fake.NewClientBuilder().WithScheme(newScheme())
+			if tc.existing != nil {
+				cb = cb.WithObjects(tc.existing)
+			}
+
+			got, err := APISelectorNarrowed(context.Background(), cb.Build(), "default", "test-svc")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tc.want))
+		})
+	}
 }
 
 func TestEnsureService_updatesPreservingNodePorts(t *testing.T) {

--- a/internal/common/naming/naming.go
+++ b/internal/common/naming/naming.go
@@ -4,6 +4,8 @@
 
 package naming
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 // Selector label keys used by the workload pod selectors, webhook TSC
 // validation, and CommonLabels. Exported so webhooks and controllers across
 // operators reference the same constants — prevents silent drift.
@@ -11,7 +13,19 @@ const (
 	LabelKeyName      = "app.kubernetes.io/name"
 	LabelKeyInstance  = "app.kubernetes.io/instance"
 	LabelKeyManagedBy = "app.kubernetes.io/managed-by"
+	LabelKeyComponent = "app.kubernetes.io/component"
 )
+
+// LabelKeyJobName is the label the Job controller stamps on every pod it
+// creates. ExcludeJobPods keys the API PodDisruptionBudget selector on its
+// absence.
+const LabelKeyJobName = "batch.kubernetes.io/job-name"
+
+// ComponentAPI is the component value carried by the API pods, the ones the
+// API Service is allowed to route to. Maintenance workloads (trust flush, key
+// and password rotation, database purge) carry their own component value so
+// they never become endpoints of that Service.
+const ComponentAPI = "api"
 
 // CommonLabels returns the standard Kubernetes labels applied to all
 // resources owned by a service CR instance. The managed-by value is derived
@@ -33,4 +47,53 @@ func SelectorLabels(appName, instanceName string) map[string]string {
 		LabelKeyName:     appName,
 		LabelKeyInstance: instanceName,
 	}
+}
+
+// APISelectorLabels returns the selector of the API Service. It narrows
+// SelectorLabels by the API component so that pods of other components cannot
+// become endpoints of the Service. Deployment.spec.selector must keep using
+// SelectorLabels: Deployment selectors are immutable after creation, so adding
+// a key there would wedge every existing workload.
+//
+// The Service must not apply this selector while pods from a template without
+// the component label are still running: a Service that matches none of the
+// pods currently serving is an outage. See the two-phase narrowing in each
+// operator's reconcileDeployment. The API PodDisruptionBudget does not use this
+// selector at all — see ExcludeJobPods.
+func APISelectorLabels(appName, instanceName string) map[string]string {
+	labels := SelectorLabels(appName, instanceName)
+	labels[LabelKeyComponent] = ComponentAPI
+	return labels
+}
+
+// ExcludeJobPods returns the label-selector requirement that keeps every
+// Job-created pod out of a selector. Together with SelectorLabels it is the
+// selector of the API PodDisruptionBudget, deliberately not APISelectorLabels:
+// every maintenance workload is a Job, so the absence of the Job name label
+// separates the API pods from them without depending on the component label —
+// which pods built by an operator predating it do not carry.
+//
+// A budget must not miss the pods it protects. The eviction API only consults
+// budgets whose selector matches the pod being evicted, so a pod outside every
+// selector has no budget at all: a node drain, an autoscaler consolidation, or
+// a node upgrade may take all replicas at once. Keying on the component label
+// would open exactly that gap for the whole one-time migration off the
+// unlabelled template, and indefinitely whenever that rollout wedges.
+func ExcludeJobPods() []metav1.LabelSelectorRequirement {
+	return []metav1.LabelSelectorRequirement{{
+		Key:      LabelKeyJobName,
+		Operator: metav1.LabelSelectorOpDoesNotExist,
+	}}
+}
+
+// ComponentLabels returns the pod-template labels for a workload of the given
+// component. The result is always a strict superset of SelectorLabels, so the
+// Deployment pod selector and the NetworkPolicy pod selector keep matching
+// every component flavor — maintenance pods must stay covered by the egress
+// rules. The API Service and PDB selectors deliberately do not: they use
+// APISelectorLabels.
+func ComponentLabels(appName, instanceName, component string) map[string]string {
+	labels := CommonLabels(appName, instanceName)
+	labels[LabelKeyComponent] = component
+	return labels
 }

--- a/internal/common/naming/naming_test.go
+++ b/internal/common/naming/naming_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestCommonLabels(t *testing.T) {
@@ -36,4 +38,88 @@ func TestSelectorLabels_SubsetOfCommonLabels(t *testing.T) {
 		g.Expect(common).To(gomega.HaveKeyWithValue(k, v))
 	}
 	g.Expect(len(selector)).To(gomega.BeNumerically("<", len(common)))
+}
+
+func TestAPISelectorLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	labels := APISelectorLabels("keystone", "my-instance")
+
+	g.Expect(labels).To(gomega.Equal(map[string]string{
+		"app.kubernetes.io/name":      "keystone",
+		"app.kubernetes.io/instance":  "my-instance",
+		"app.kubernetes.io/component": "api",
+	}))
+}
+
+func TestComponentLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	labels := ComponentLabels("keystone", "my-instance", "trust-flush")
+
+	g.Expect(labels).To(gomega.Equal(map[string]string{
+		"app.kubernetes.io/name":       "keystone",
+		"app.kubernetes.io/instance":   "my-instance",
+		"app.kubernetes.io/managed-by": "keystone-operator",
+		"app.kubernetes.io/component":  "trust-flush",
+	}))
+}
+
+// The API Service selector must be satisfied by the API pod template,
+// otherwise the Service loses every endpoint on the next rollout.
+func TestAPISelectorLabels_SubsetOfAPIComponentLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pod := ComponentLabels("keystone", "my-instance", ComponentAPI)
+	selector := APISelectorLabels("keystone", "my-instance")
+
+	g.Expect(selector).NotTo(gomega.BeEmpty())
+	for k, v := range selector {
+		g.Expect(pod).To(gomega.HaveKeyWithValue(k, v))
+	}
+	g.Expect(len(selector)).To(gomega.BeNumerically("<", len(pod)))
+}
+
+// SelectorLabels must stay a subset of the labels of every component, not
+// just of the API one: the immutable Deployment selector and the NetworkPolicy
+// pod selectors match maintenance pods through it, and so does the API Service
+// selector until the component label has rolled out everywhere.
+func TestSelectorLabels_SubsetOfComponentLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pod := ComponentLabels("keystone", "my-instance", "trust-flush")
+	selector := SelectorLabels("keystone", "my-instance")
+
+	g.Expect(selector).NotTo(gomega.BeEmpty())
+	for k, v := range selector {
+		g.Expect(pod).To(gomega.HaveKeyWithValue(k, v))
+	}
+	g.Expect(len(selector)).To(gomega.BeNumerically("<", len(pod)))
+}
+
+// The API PodDisruptionBudget selector — SelectorLabels plus ExcludeJobPods —
+// must cover every API pod, including one from a template that predates the
+// component label, and no Job-created maintenance pod. Keying it on the
+// component instead would leave the pods that are actually serving during the
+// migration outside every budget, and the eviction API only consults budgets
+// that match the pod being evicted.
+func TestExcludeJobPods_CoversAPIPodsButNoJobPod(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels:      SelectorLabels("keystone", "my-instance"),
+		MatchExpressions: ExcludeJobPods(),
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Expect(selector.Matches(labels.Set(ComponentLabels("keystone", "my-instance", ComponentAPI)))).To(gomega.BeTrue())
+	g.Expect(selector.Matches(labels.Set(CommonLabels("keystone", "my-instance")))).To(gomega.BeTrue(),
+		"an API pod predating the component label must stay covered")
+
+	jobPod := ComponentLabels("keystone", "my-instance", "trust-flush")
+	jobPod[LabelKeyJobName] = "my-instance-trust-flush-29000000"
+	g.Expect(selector.Matches(labels.Set(jobPod))).To(gomega.BeFalse())
+
+	// Another instance is out of scope regardless of the Job label.
+	g.Expect(selector.Matches(labels.Set(ComponentLabels("keystone", "other", ComponentAPI)))).To(gomega.BeFalse())
 }

--- a/operators/glance/internal/controller/glance_controller.go
+++ b/operators/glance/internal/controller/glance_controller.go
@@ -196,6 +196,15 @@ type GlanceReconciler struct {
 	// health check uses http.DefaultClient; tests inject a stub transport.
 	HTTPClient HTTPDoer
 
+	// apiReader is set during SetupWithManager from mgr.GetAPIReader(): a direct,
+	// uncached reader. reconcileDeployment latches the two-phase narrowing of the
+	// API Service selector on the live Service, and the informer cache can still
+	// hold the pre-narrowing state right after the narrowing write — a latch
+	// decided from it could widen the selector back. Nil in unit tests that
+	// construct the reconciler without a manager; those fall back to the
+	// (read-your-writes) fake client.
+	apiReader client.Reader
+
 	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
 	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1 HTTPRoute
 	// CRD is installed. When false, the controller skips the HTTPRoute watch
@@ -532,6 +541,7 @@ func (r *GlanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Owns(HTTPRoute) unconditionally would fail at Start with "no matches for
 	// kind HTTPRoute" when the CRD is missing, blocking every Glance CR.
 	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = mgr.GetAPIReader()
 	setupLog := ctrl.Log.WithName("glance-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")

--- a/operators/glance/internal/controller/reconcile_dbpurge.go
+++ b/operators/glance/internal/controller/reconcile_dbpurge.go
@@ -298,9 +298,11 @@ func dbPurgeCronJob(glance *glancev1alpha1.Glance, configMapName string) *batchv
 						// selectorLabels — and the auto-derived DB and DNS egress is all
 						// glance-manage needs, so no purge-specific rule is required
 						// (keystone hit the opposite case: its rotation CronJobs also talk
-						// to the apiserver, see reconcile_networkpolicy.go).
+						// to the apiserver, see reconcile_networkpolicy.go). The component
+						// value differs from the one the API pods carry, which is what keeps
+						// the purge pods out of the API Service selector.
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: commonLabels(glance),
+							Labels: componentLabels(glance, "db-purge"),
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: corev1.RestartPolicyOnFailure,

--- a/operators/glance/internal/controller/reconcile_dbpurge_test.go
+++ b/operators/glance/internal/controller/reconcile_dbpurge_test.go
@@ -14,6 +14,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
@@ -25,6 +26,7 @@ import (
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
 	"github.com/c5c3/forge/internal/common/job"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	glancev1alpha1 "github.com/c5c3/forge/operators/glance/api/v1alpha1"
 	"github.com/c5c3/forge/operators/glance/internal/metrics"
@@ -177,13 +179,15 @@ func TestReconcileDBPurge_CreatesCronJobWithDefaults(t *testing.T) {
 	g.Expect(cronJob.OwnerReferences).To(HaveLen(1))
 	g.Expect(cronJob.OwnerReferences[0].Name).To(Equal("test-glance"))
 
-	// The spawned Jobs must be listable by label, so the labels sit on the
-	// CronJob, the JobTemplate, and the pod template alike.
+	// The spawned Jobs must be listable by label, so the common labels sit on the
+	// CronJob and the JobTemplate alike. The pod template adds the component on
+	// top, which is what keeps the purge pods out of the API Service.
 	g.Expect(cronJob.Labels).To(Equal(commonLabels(glance)))
 	g.Expect(cronJob.Spec.JobTemplate.Labels).To(Equal(commonLabels(glance)),
 		"the JobTemplate must carry the labels reconcileDBPurge lists runs by")
 	podTemplate := cronJob.Spec.JobTemplate.Spec.Template
-	g.Expect(podTemplate.Labels).To(Equal(commonLabels(glance)))
+	g.Expect(podTemplate.Labels).To(Equal(componentLabels(glance, "db-purge")))
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, "db-purge"))
 	g.Expect(podTemplate.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
 	g.Expect(podTemplate.Spec.PriorityClassName).To(BeEmpty(),
 		"glance's own migration Jobs set no priority class either")
@@ -216,6 +220,28 @@ func TestReconcileDBPurge_CreatesCronJobWithDefaults(t *testing.T) {
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 	g.Expect(cond.Reason).To(Equal(conditionReasonDBPurgeScheduled))
 	g.Expect(cond.Message).To(ContainSubstring("30 days"))
+}
+
+// TestDBPurgePodsNotSelectedByAPIService locks the invariant the API Service
+// depends on: only the API pods satisfy its selector. The purge pod template
+// once carried the full selector, and because the Service targets a numeric
+// port and job pods have no readiness probe, every scheduled run turned a pod
+// with nothing listening on 9292 into a ready endpoint.
+func TestDBPurgePodsNotSelectedByAPIService(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+
+	selector := labels.SelectorFromSet(buildGlanceService(glance, true).Spec.Selector)
+
+	// The API pods must keep matching, or the Service would have no backends.
+	apiPodLabels := buildGlanceDeployment(glance, testArtifacts(), "", "").Spec.Template.Labels
+	g.Expect(selector.Matches(labels.Set(apiPodLabels))).To(BeTrue(),
+		"the API pod template must satisfy the API Service selector")
+
+	purgePodLabels := dbPurgeCronJob(glance, dbPurgeConfigMapName).Spec.JobTemplate.Spec.Template.Labels
+	g.Expect(purgePodLabels).To(HaveKeyWithValue(naming.LabelKeyComponent, "db-purge"))
+	g.Expect(selector.Matches(labels.Set(purgePodLabels))).To(BeFalse(),
+		"db-purge pods must never become endpoints of the API Service")
 }
 
 func TestReconcileDBPurge_HonorsSpecKnobs(t *testing.T) {

--- a/operators/glance/internal/controller/reconcile_deployment.go
+++ b/operators/glance/internal/controller/reconcile_deployment.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -126,6 +127,15 @@ func selectorLabels(glance *glancev1alpha1.Glance) map[string]string {
 	return naming.SelectorLabels(glanceAppName, glance.Name)
 }
 
+// componentLabels returns the pod-template labels for a workload of the given
+// component. It is commonLabels plus app.kubernetes.io/component, so the result
+// stays a superset of selectorLabels and keeps matching the Deployment pod
+// selector and the NetworkPolicy pod selector. It delegates to the shared
+// naming package to stay in sync across operators.
+func componentLabels(glance *glancev1alpha1.Glance, component string) map[string]string {
+	return naming.ComponentLabels(glanceAppName, glance.Name, component)
+}
+
 // reconcileDeployment ensures the Glance API Deployment, Service, and PDB exist
 // with the correct spec. It sets the DeploymentReady condition and stamps the
 // status endpoint when the Deployment becomes available.
@@ -163,7 +173,36 @@ func (r *GlanceReconciler) reconcileDeployment(ctx context.Context, glance *glan
 		return ctrl.Result{}, fmt.Errorf("ensuring Deployment: %w", err)
 	}
 
-	svc := buildGlanceService(glance)
+	// Narrow the Service selector to the API component only once every live pod
+	// carries that label. EnsureDeployment is a Server-Side Apply: it returns as
+	// soon as the API server accepts the pod template, long before the rollout
+	// finishes. Applying the narrowed selector in the same pass would drop every
+	// pod still running from before the upgrade out of the EndpointSlices while
+	// it is still the only thing serving — and a rollout that never completes
+	// would never repool them.
+	//
+	// Once narrowed, stay narrowed. The migration is one-way: only a template
+	// built by an operator predating the component label produces pods the
+	// narrow selector misses. Re-widening on a later rollout would re-admit
+	// db-purge pods as endpoints for exactly as long as it lasts, reopening the
+	// race this narrowing closes. The latch reads the live Service through the
+	// uncached APIReader, so it cannot be decided from a cache that still
+	// predates the narrowing write (see deployment.APISelectorNarrowed);
+	// r.apiReader is nil only in unit tests, whose fake client is
+	// read-your-writes anyway.
+	narrowSelector := deployment.TemplateConverged(deploy)
+	if !narrowSelector {
+		reader := client.Reader(r.Client)
+		if r.apiReader != nil {
+			reader = r.apiReader
+		}
+		narrowSelector, err = deployment.APISelectorNarrowed(ctx, reader, glance.Namespace, subResourceName(glance))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	svc := buildGlanceService(glance, narrowSelector)
 	if err := deployment.EnsureService(ctx, r.Client, r.Scheme, glance, svc); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring Service: %w", err)
 	}
@@ -300,7 +339,7 @@ func effectiveStagingSizeLimit(glance *glancev1alpha1.Glance) *resource.Quantity
 // one built before the cache existed.
 func buildGlanceDeployment(glance *glancev1alpha1.Glance, art configArtifacts, dsnDigest, authtokenDigest string) *appsv1.Deployment {
 	selector := selectorLabels(glance)
-	labels := commonLabels(glance)
+	labels := componentLabels(glance, naming.ComponentAPI)
 
 	// Both scratch emptyDirs carry the same resolved bound, each with its own
 	// Quantity so the two volumes never share a pointer. Both stay nil when the
@@ -763,11 +802,38 @@ func glanceDBTLSVolumeAndMount(glance *glancev1alpha1.Glance) (corev1.Volume, co
 // buildPodDisruptionBudget constructs the desired PDB for the Glance API
 // deployment, delegating to the shared builder (minAvailable=1 for multi-replica,
 // maxUnavailable=1 for single-replica to avoid drain deadlock).
+//
+// The selector keeps the stable name and instance labels and excludes the
+// db-purge pods by the absence of the Job name label (naming.ExcludeJobPods)
+// rather than by the API component. Both keep db-purge pods from inflating
+// currentHealthy — the disruption controller counts every matching pod, and Job
+// pods carry no readiness probe, so they are Ready from their first moment,
+// which raises disruptionsAllowed and lets a drain evict the API pods the budget
+// exists to protect. Only this one also covers the API pods of a template
+// predating the component label: a pod no budget selects is not protected at
+// all, and the Service's two-phase narrowing has no counterpart here that would
+// bound that gap.
 func buildPodDisruptionBudget(glance *glancev1alpha1.Glance) *policyv1.PodDisruptionBudget {
-	return deployment.BuildPDB(glance.Namespace, subResourceName(glance), commonLabels(glance), selectorLabels(glance), &glance.Spec.Deployment)
+	pdb := deployment.BuildPDB(glance.Namespace, subResourceName(glance), commonLabels(glance), selectorLabels(glance), &glance.Spec.Deployment)
+	pdb.Spec.Selector.MatchExpressions = naming.ExcludeJobPods()
+	return pdb
 }
 
-// buildGlanceService builds the Glance API Service on the API port.
-func buildGlanceService(glance *glancev1alpha1.Glance) *corev1.Service {
-	return deployment.BuildService(glance.Namespace, subResourceName(glance), commonLabels(glance), selectorLabels(glance), glanceAPIPort, glanceAPIPort)
+// buildGlanceService builds the Glance API Service on the API port. With
+// narrowSelector the selector narrows to the API component, so only the API
+// pods can become endpoints (see apiSelector for when that is safe).
+func buildGlanceService(glance *glancev1alpha1.Glance, narrowSelector bool) *corev1.Service {
+	return deployment.BuildService(glance.Namespace, subResourceName(glance), commonLabels(glance), apiSelector(glance, narrowSelector), glanceAPIPort, glanceAPIPort)
+}
+
+// apiSelector returns the selector of the API Service. It narrows to
+// app.kubernetes.io/component=api only when narrowSelector is set, which the
+// caller derives from deployment.TemplateConverged and then latches: until every
+// live pod runs the labelled template, the wide selector is the only one that
+// still matches them.
+func apiSelector(glance *glancev1alpha1.Glance, narrowSelector bool) map[string]string {
+	if narrowSelector {
+		return naming.APISelectorLabels(glanceAppName, glance.Name)
+	}
+	return selectorLabels(glance)
 }

--- a/operators/glance/internal/controller/reconcile_deployment_pin_test.go
+++ b/operators/glance/internal/controller/reconcile_deployment_pin_test.go
@@ -23,6 +23,7 @@ import (
 
 const pinGlanceDeploymentDefaultGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -42,6 +43,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -165,6 +167,7 @@ status: {}
 
 const pinGlanceDeploymentEventletGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -184,6 +187,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -291,6 +295,7 @@ status: {}
 
 const pinGlanceDeploymentImageCacheGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -310,6 +315,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -500,6 +506,7 @@ status: {}
 
 const pinGlanceDeploymentDBTLSGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -519,6 +526,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -661,6 +669,7 @@ status: {}
 
 const pinGlanceDeploymentAutoscalingGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -682,6 +691,7 @@ spec:
         glance.c5c3.io/authtoken-hash: auth456
         glance.c5c3.io/db-connection-hash: dsn123
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -805,6 +815,7 @@ status: {}
 
 const pinGlanceDeploymentUnboundedStagingGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/managed-by: glance-operator
     app.kubernetes.io/name: glance
@@ -824,6 +835,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-glance
         app.kubernetes.io/managed-by: glance-operator
         app.kubernetes.io/name: glance
@@ -956,6 +968,7 @@ spec:
     protocol: TCP
     targetPort: 9292
   selector:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-glance
     app.kubernetes.io/name: glance
 status:
@@ -1064,7 +1077,7 @@ func TestPinGlanceService(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		g := NewWithT(t)
 
-		got, err := yaml.Marshal(buildGlanceService(testGlance()))
+		got, err := yaml.Marshal(buildGlanceService(testGlance(), true))
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(string(got)).To(Equal(pinGlanceServiceGolden),
 			"the rendered Glance Service must stay byte-identical")

--- a/operators/glance/internal/controller/reconcile_deployment_test.go
+++ b/operators/glance/internal/controller/reconcile_deployment_test.go
@@ -6,15 +6,18 @@ package controller
 
 import (
 	"context"
+	"maps"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -23,6 +26,7 @@ import (
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
 	"github.com/c5c3/forge/internal/common/keystoneauth"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	glancev1alpha1 "github.com/c5c3/forge/operators/glance/api/v1alpha1"
@@ -696,9 +700,170 @@ func TestReconcileDeployment_ServiceAndPDBEnsured(t *testing.T) {
 	var svc corev1.Service
 	g.Expect(r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-glance"}, &svc)).To(Succeed())
 	g.Expect(svc.Spec.Ports[0].Port).To(Equal(glanceAPIPort))
+	// The component key is absent while the freshly created Deployment has not
+	// rolled out — see TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout.
+	g.Expect(svc.Spec.Selector).To(Equal(map[string]string{
+		"app.kubernetes.io/name":     "glance",
+		"app.kubernetes.io/instance": "test-glance",
+	}))
 
 	var deploy appsv1.Deployment
 	g.Expect(r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-glance"}, &deploy)).To(Succeed())
+	g.Expect(deploy.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+	// The Deployment selector is immutable, so the component key must stay out
+	// of it: adding one would force a delete/recreate of every live Deployment.
+	g.Expect(deploy.Spec.Selector.MatchLabels).NotTo(HaveKey(naming.LabelKeyComponent))
+}
+
+// TestReconcileDeployment_PDBSelectorCoversAPIPodsOnly verifies the budget
+// covers every API pod and no db-purge pod. The exclusion must not be keyed on
+// app.kubernetes.io/component=api: that label arrives with this operator build,
+// so on the operator upgrade a component-keyed budget matches none of the API
+// pods actually serving — and the eviction API only consults budgets matching
+// the pod being evicted, so those pods would have no budget at all until the
+// migration rollout lands, and forever if it wedges.
+func TestReconcileDeployment_PDBSelectorCoversAPIPodsOnly(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	glance := deployGlance("2026.1")
+	r := newGlanceTestReconciler(glance)
+	art := testArtifacts()
+
+	_, err := r.reconcileDeployment(context.Background(), glance, art, "", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var pdb policyv1.PodDisruptionBudget
+	g.Expect(r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-glance"}, &pdb)).To(Succeed())
+
+	g.Expect(pdbSelects(g, &pdb, buildGlanceDeployment(glance, art, "", "").Spec.Template.Labels)).To(BeTrue(),
+		"the budget must cover the API pods")
+	g.Expect(pdbSelects(g, &pdb, commonLabels(glance))).To(BeTrue(),
+		"the budget must cover API pods from a template predating the component label")
+
+	// A db-purge pod carries the CronJob pod-template labels plus the Job
+	// controller's own job-name label, and no readiness probe — so a budget that
+	// matched it would count it as healthy from its first moment and raise
+	// disruptionsAllowed for the API pods.
+	purgePod := maps.Clone(dbPurgeCronJob(glance, "glance-config").Spec.JobTemplate.Spec.Template.Labels)
+	purgePod[naming.LabelKeyJobName] = "test-glance-db-purge-29000000"
+	g.Expect(pdbSelects(g, &pdb, purgePod)).To(BeFalse(),
+		"a Job-created db-purge pod must never count towards the budget")
+}
+
+// pdbSelects reports whether the budget's selector — MatchLabels and
+// MatchExpressions together — matches a pod carrying podLabels.
+func pdbSelects(g *WithT, pdb *policyv1.PodDisruptionBudget, podLabels map[string]string) bool {
+	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+	g.Expect(err).NotTo(HaveOccurred())
+	return selector.Matches(labels.Set(podLabels))
+}
+
+// TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout pins the two-phase
+// narrowing of the API Service selector. EnsureDeployment is a Server-Side
+// Apply that returns as soon as the API server accepts the pod template, so
+// narrowing to app.kubernetes.io/component=api in the same pass would drop
+// every pod still running from the pre-upgrade template out of the
+// EndpointSlices — the Service would have no backends at all until the first
+// re-rolled pod passed its probes, and a rollout that wedges would never
+// repool them. The PDB selector, by contrast, covers the API pods in every
+// phase — labelled or not, see buildPodDisruptionBudget.
+func TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout(t *testing.T) {
+	// surgingDeployment is the state the narrowing must survive: the first
+	// new-template pod is Ready — so EnsureDeployment already reports ready —
+	// while the old-template pods, the ones without the component label, are
+	// still counted and still serving.
+	surgingDeployment := func(glance *glancev1alpha1.Glance, art configArtifacts) *appsv1.Deployment {
+		deploy := readyGlanceDeployment(glance, art)
+		deploy.Status.UpdatedReplicas = 1
+		deploy.Status.Replicas = *deploy.Spec.Replicas + 1
+		return deploy
+	}
+
+	cases := []struct {
+		name     string
+		deploy   func(*glancev1alpha1.Glance, configArtifacts) *appsv1.Deployment
+		narrowed bool
+	}{
+		{name: "rollout in flight", deploy: surgingDeployment, narrowed: false},
+		{name: "fully rolled out", deploy: readyGlanceDeployment, narrowed: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			glance := deployGlance("2026.1")
+			art := testArtifacts()
+			r := newGlanceTestReconciler(glance, tc.deploy(glance, art))
+
+			_, err := r.reconcileDeployment(context.Background(), glance, art, "", "")
+			g.Expect(err).NotTo(HaveOccurred())
+
+			key := types.NamespacedName{Namespace: "default", Name: "test-glance"}
+			var svc corev1.Service
+			g.Expect(r.Get(context.Background(), key, &svc)).To(Succeed())
+			var pdb policyv1.PodDisruptionBudget
+			g.Expect(r.Get(context.Background(), key, &pdb)).To(Succeed())
+
+			if tc.narrowed {
+				g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+			} else {
+				g.Expect(svc.Spec.Selector).NotTo(HaveKey(naming.LabelKeyComponent),
+					"pods from the pre-upgrade template must stay in the EndpointSlices until the rollout completes")
+			}
+			// Either way the API pods must satisfy the Service selector, or it
+			// has no backends at all.
+			apiPodLabels := buildGlanceDeployment(glance, art, "", "").Spec.Template.Labels
+			g.Expect(labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(apiPodLabels))).To(BeTrue())
+			// The budget covers the API pods in BOTH phases, the pre-upgrade
+			// ones included. Anything else leaves the pods that are actually
+			// serving outside every budget for the whole migration — and
+			// forever if the rollout wedges — because the eviction API only
+			// consults budgets matching the pod being evicted.
+			g.Expect(pdbSelects(g, &pdb, apiPodLabels)).To(BeTrue(),
+				"the budget must cover the API pods")
+			g.Expect(pdbSelects(g, &pdb, commonLabels(glance))).To(BeTrue(),
+				"the budget must cover API pods from a template predating the component label")
+		})
+	}
+}
+
+// TestReconcileDeployment_NarrowedServiceSelectorNeverWidens pins the latch on
+// the two-phase narrowing. deployment.TemplateConverged turns false on every
+// later rollout, so deriving the selector from it on every pass would not
+// migrate the Service once but oscillate it, re-admitting db-purge pods as
+// endpoints for the whole window.
+func TestReconcileDeployment_NarrowedServiceSelectorNeverWidens(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	glance := deployGlance("2026.1")
+	art := testArtifacts()
+	r := newGlanceTestReconciler(glance, readyGlanceDeployment(glance, art))
+	key := types.NamespacedName{Namespace: "default", Name: "test-glance"}
+
+	// Pass 1: the Deployment is fully converged, so the migration completes and
+	// the Service selector narrows.
+	_, err := r.reconcileDeployment(ctx, glance, art, "", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	var svc corev1.Service
+	g.Expect(r.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+
+	// Pass 2: the Deployment drops back below full convergence. The Deployment
+	// is watched without a generation predicate, so this status transition
+	// drives a reconcile of its own.
+	var deploy appsv1.Deployment
+	g.Expect(r.Get(ctx, key, &deploy)).To(Succeed())
+	deploy.Status.UpdatedReplicas = 0
+	deploy.Status.ReadyReplicas = 0
+	g.Expect(r.Status().Update(ctx, &deploy)).To(Succeed())
+
+	_, err = r.reconcileDeployment(ctx, glance, art, "", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(r.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI),
+		"an already narrowed Service selector must never widen again — every pod template this operator builds carries the component label")
 }
 
 func TestReconcileDeployment_ReadyStampsEndpoint(t *testing.T) {

--- a/operators/glance/internal/controller/reconcile_networkpolicy_test.go
+++ b/operators/glance/internal/controller/reconcile_networkpolicy_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -88,6 +89,34 @@ func TestBuildGlanceNetworkPolicy_IngressAndEgressRules(t *testing.T) {
 	g.Expect(np.Spec.Egress[1].Ports[0].Port.IntValue()).To(Equal(3306))
 	g.Expect(np.Spec.Egress[2].Ports[0].Port.IntValue()).To(Equal(11211))
 	g.Expect(np.Spec.Egress[3].Ports[0].Port.IntValue()).To(Equal(443))
+}
+
+// The pod selector matches on name and instance only, so both the API pods and
+// the purge pods keep inheriting the auto-derived egress rules even though
+// their component labels differ. Without the DB and DNS egress, glance-manage
+// cannot reach the database and every scheduled purge fails.
+func TestBuildGlanceNetworkPolicy_PodSelectorCoversPurgePods(t *testing.T) {
+	glance := testGlance()
+	glance.Spec.NetworkPolicy = glanceNetworkPolicySpec()
+
+	selector := labels.SelectorFromSet(buildGlanceNetworkPolicy(glance, "", nil).Spec.PodSelector.MatchLabels)
+
+	cases := []struct {
+		name      string
+		podLabels map[string]string
+	}{
+		{"api", buildGlanceDeployment(glance, testArtifacts(), "", "").Spec.Template.Labels},
+		{"db-purge", dbPurgeCronJob(glance, dbPurgeConfigMapName).Spec.JobTemplate.Spec.Template.Labels},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			g.Expect(selector.Matches(labels.Set(tc.podLabels))).To(BeTrue(),
+				"%s pods must stay selected by the NetworkPolicy", tc.name)
+		})
+	}
 }
 
 func TestBuildGlanceNetworkPolicy_OmitsCacheAndS3WhenAbsent(t *testing.T) {

--- a/operators/horizon/internal/controller/horizon_controller.go
+++ b/operators/horizon/internal/controller/horizon_controller.go
@@ -103,6 +103,15 @@ type HorizonReconciler struct {
 	// added.
 	OperatorNamespace string
 
+	// apiReader is set during SetupWithManager from mgr.GetAPIReader(): a
+	// direct, uncached reader. reconcileDeployment latches the two-phase
+	// narrowing of the dashboard Service selector on the live Service, and the
+	// informer cache can still hold the pre-narrowing state right after the
+	// narrowing write — a latch decided from it could widen the selector back.
+	// Nil in unit tests that construct the reconciler without a manager; those
+	// fall back to the (read-your-writes) fake client.
+	apiReader client.Reader
+
 	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
 	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1
 	// HTTPRoute CRD is installed. When false, the controller skips the
@@ -332,6 +341,7 @@ func (r *HorizonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// fail at Start with "no matches for kind HTTPRoute" when the CRD is
 	// missing, preventing every Horizon CR from being reconciled.
 	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = mgr.GetAPIReader()
 	setupLog := ctrl.Log.WithName("horizon-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")

--- a/operators/horizon/internal/controller/reconcile_deployment.go
+++ b/operators/horizon/internal/controller/reconcile_deployment.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -79,7 +80,35 @@ func (r *HorizonReconciler) reconcileDeployment(ctx context.Context, horizon *ho
 		return ctrl.Result{}, fmt.Errorf("ensuring Deployment: %w", err)
 	}
 
-	svc := buildHorizonService(horizon)
+	// Narrow the Service selector to the API component only once every live pod
+	// carries that label. EnsureDeployment is a Server-Side Apply: it returns as
+	// soon as the API server accepts the pod template, long before the rollout
+	// finishes. Applying the narrowed selector in the same pass would drop every
+	// pod still running from before the upgrade out of the EndpointSlices while
+	// it is still the only thing serving — and a rollout that never completes
+	// would never repool them.
+	//
+	// Once narrowed, stay narrowed. The migration is one-way: only a template
+	// built by an operator predating the component label produces pods the
+	// narrow selector misses. Re-widening on a later rollout would put the
+	// Service selector back on a wider set than the dashboard pods for exactly
+	// as long as it lasts. The latch reads the live Service through the uncached
+	// APIReader, so it cannot be decided from a cache that still predates the
+	// narrowing write (see deployment.APISelectorNarrowed); r.apiReader is nil
+	// only in unit tests, whose fake client is read-your-writes anyway.
+	narrowSelector := deployment.TemplateConverged(deploy)
+	if !narrowSelector {
+		reader := client.Reader(r.Client)
+		if r.apiReader != nil {
+			reader = r.apiReader
+		}
+		narrowSelector, err = deployment.APISelectorNarrowed(ctx, reader, horizon.Namespace, subResourceName(horizon))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	svc := buildHorizonService(horizon, narrowSelector)
 	if err := deployment.EnsureService(ctx, r.Client, r.Scheme, horizon, svc); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring Service: %w", err)
 	}
@@ -122,7 +151,7 @@ func (r *HorizonReconciler) reconcileDeployment(ctx context.Context, horizon *ho
 // never enters the ConfigMap.
 func buildHorizonDeployment(horizon *horizonv1alpha1.Horizon, configMapName, secretKeyHash string) *appsv1.Deployment {
 	selector := selectorLabels(horizon)
-	labels := commonLabels(horizon)
+	labels := naming.ComponentLabels(horizonv1alpha1.AppName, horizon.Name, naming.ComponentAPI)
 	// Roll the Deployment when the SECRET_KEY rotates: the key is consumed
 	// via HORIZON_SECRET_KEY, so a changed value only takes effect on Pod
 	// restart.
@@ -244,10 +273,36 @@ func uwsgiCommand() []string {
 // deployment, delegating to the shared builder (minAvailable=1 for
 // multi-replica, maxUnavailable=1 for single-replica to avoid drain
 // deadlock).
+//
+// The selector keeps the stable name and instance labels and excludes
+// Job-created pods (naming.ExcludeJobPods) rather than narrowing to the API
+// component. Horizon runs no maintenance Job today, so the requirement is a
+// no-op here and only keeps the budget shaped like the other operators' — but
+// unlike the component key it also covers the dashboard pods of a template
+// predating that label: a pod no budget selects is not protected at all, and the
+// Service's two-phase narrowing has no counterpart here that would bound that
+// gap.
 func buildPodDisruptionBudget(horizon *horizonv1alpha1.Horizon) *policyv1.PodDisruptionBudget {
-	return deployment.BuildPDB(horizon.Namespace, subResourceName(horizon), commonLabels(horizon), selectorLabels(horizon), &horizon.Spec.Deployment)
+	pdb := deployment.BuildPDB(horizon.Namespace, subResourceName(horizon), commonLabels(horizon), selectorLabels(horizon), &horizon.Spec.Deployment)
+	pdb.Spec.Selector.MatchExpressions = naming.ExcludeJobPods()
+	return pdb
 }
 
-func buildHorizonService(horizon *horizonv1alpha1.Horizon) *corev1.Service {
-	return deployment.BuildService(horizon.Namespace, subResourceName(horizon), commonLabels(horizon), selectorLabels(horizon), horizonAPIPort, horizonAPIPort)
+// buildHorizonService builds the dashboard Service on the dashboard port. With
+// narrowSelector the selector narrows to the API component, so only the
+// dashboard pods can become endpoints (see apiSelector for when that is safe).
+func buildHorizonService(horizon *horizonv1alpha1.Horizon, narrowSelector bool) *corev1.Service {
+	return deployment.BuildService(horizon.Namespace, subResourceName(horizon), commonLabels(horizon), apiSelector(horizon, narrowSelector), horizonAPIPort, horizonAPIPort)
+}
+
+// apiSelector returns the selector of the dashboard Service. It narrows to
+// app.kubernetes.io/component=api only when narrowSelector is set, which the
+// caller derives from deployment.TemplateConverged and then latches: until every
+// live pod runs the labelled template, the wide selector is the only one that
+// still matches them.
+func apiSelector(horizon *horizonv1alpha1.Horizon, narrowSelector bool) map[string]string {
+	if narrowSelector {
+		return naming.APISelectorLabels(horizonv1alpha1.AppName, horizon.Name)
+	}
+	return selectorLabels(horizon)
 }

--- a/operators/horizon/internal/controller/reconcile_deployment_pin_test.go
+++ b/operators/horizon/internal/controller/reconcile_deployment_pin_test.go
@@ -22,6 +22,7 @@ import (
 
 const pinHorizonDeploymentDefaultGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-horizon
     app.kubernetes.io/managed-by: horizon-operator
     app.kubernetes.io/name: horizon
@@ -43,6 +44,7 @@ spec:
       annotations:
         horizon.c5c3.io/secret-key-hash: sk-hash-123
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-horizon
         app.kubernetes.io/managed-by: horizon-operator
         app.kubernetes.io/name: horizon
@@ -153,6 +155,7 @@ status: {}
 
 const pinHorizonDeploymentAutoscalingGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-horizon
     app.kubernetes.io/managed-by: horizon-operator
     app.kubernetes.io/name: horizon
@@ -171,6 +174,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-horizon
         app.kubernetes.io/managed-by: horizon-operator
         app.kubernetes.io/name: horizon
@@ -292,6 +296,7 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-horizon
     app.kubernetes.io/name: horizon
 status:
@@ -346,7 +351,7 @@ func TestPinHorizonService(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		g := NewWithT(t)
 
-		got, err := yaml.Marshal(buildHorizonService(testHorizon()))
+		got, err := yaml.Marshal(buildHorizonService(testHorizon(), true))
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(string(got)).To(Equal(pinHorizonServiceGolden),
 			"the rendered Horizon Service must stay byte-identical")

--- a/operators/horizon/internal/controller/reconcile_deployment_test.go
+++ b/operators/horizon/internal/controller/reconcile_deployment_test.go
@@ -11,10 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 )
 
@@ -106,6 +109,13 @@ func TestBuildHorizonDeployment_Shape(t *testing.T) {
 
 	// Rotated SECRET_KEY rolls the pods via the hash annotation.
 	g.Expect(deploy.Spec.Template.Annotations).To(HaveKeyWithValue(secretKeyHashAnnotation, "digest123"))
+
+	// The dashboard pods carry the component the Service selects on.
+	g.Expect(deploy.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+	// The Deployment selector is immutable, so the component key must stay out
+	// of it: adding one would force a delete/recreate of every live Deployment.
+	g.Expect(deploy.Spec.Selector.MatchLabels).NotTo(HaveKey(naming.LabelKeyComponent))
 }
 
 func TestBuildHorizonDeployment_NoHashAnnotationWhenDigestEmpty(t *testing.T) {
@@ -175,14 +185,155 @@ func TestReconcileDeployment_ReadySetsEndpoint(t *testing.T) {
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 }
 
+// TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout pins the two-phase
+// narrowing of the dashboard Service selector. EnsureDeployment is a
+// Server-Side Apply that returns as soon as the API server accepts the pod
+// template, so narrowing to app.kubernetes.io/component=api in the same pass
+// would drop every pod still running from the pre-upgrade template out of the
+// EndpointSlices — the Service would have no backends at all until the first
+// re-rolled pod passed its probes, and a rollout that wedges would never
+// repool them. The PDB selector, by contrast, covers the dashboard pods in
+// every phase — labelled or not, see buildPodDisruptionBudget.
+func TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout(t *testing.T) {
+	cases := []struct {
+		name string
+		// updatedReplicas is what the deployment controller reports; a value
+		// below the replica count means old-template pods are still counted
+		// and still serving.
+		updatedReplicas int32
+		totalReplicas   int32
+		narrowed        bool
+	}{
+		{name: "rollout in flight", updatedReplicas: 1, totalReplicas: 4, narrowed: false},
+		{name: "fully rolled out", updatedReplicas: 3, totalReplicas: 3, narrowed: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			h := testHorizon()
+			r := newTestReconciler(testScheme(), h)
+			ctx := context.Background()
+
+			// First pass creates the Deployment; then stamp the rollout state.
+			_, err := r.reconcileDeployment(ctx, h, "cm-name", "")
+			g.Expect(err).NotTo(HaveOccurred())
+
+			key := types.NamespacedName{Namespace: "default", Name: "test-horizon"}
+			var deploy appsv1.Deployment
+			g.Expect(r.Get(ctx, key, &deploy)).To(Succeed())
+			deploy.Status.ReadyReplicas = 3
+			deploy.Status.UpdatedReplicas = tc.updatedReplicas
+			deploy.Status.Replicas = tc.totalReplicas
+			deploy.Status.Conditions = []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			}}
+			g.Expect(r.Status().Update(ctx, &deploy)).To(Succeed())
+
+			_, err = r.reconcileDeployment(ctx, h, "cm-name", "")
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var svc corev1.Service
+			g.Expect(r.Get(ctx, key, &svc)).To(Succeed())
+			var pdb policyv1.PodDisruptionBudget
+			g.Expect(r.Get(ctx, key, &pdb)).To(Succeed())
+
+			if tc.narrowed {
+				g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+			} else {
+				g.Expect(svc.Spec.Selector).NotTo(HaveKey(naming.LabelKeyComponent),
+					"pods from the pre-upgrade template must stay in the EndpointSlices until the rollout completes")
+			}
+			// Either way the dashboard pods must satisfy the Service selector,
+			// or it has no backends at all.
+			podLabels := buildHorizonDeployment(h, "cm-name", "").Spec.Template.Labels
+			g.Expect(labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(podLabels))).To(BeTrue())
+			// The budget covers the dashboard pods in BOTH phases, the
+			// pre-upgrade ones included. Anything else leaves the pods that are
+			// actually serving outside every budget for the whole migration —
+			// and forever if the rollout wedges — because the eviction API only
+			// consults budgets matching the pod being evicted.
+			pdbSelector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pdbSelector.Matches(labels.Set(podLabels))).To(BeTrue(),
+				"the budget must cover the dashboard pods")
+			g.Expect(pdbSelector.Matches(labels.Set(commonLabels(h)))).To(BeTrue(),
+				"the budget must cover dashboard pods from a template predating the component label")
+		})
+	}
+}
+
+// TestReconcileDeployment_NarrowedServiceSelectorNeverWidens pins the latch on
+// the two-phase narrowing. deployment.TemplateConverged turns false on every
+// later rollout, so deriving the selector from it on every pass would not
+// migrate the Service once but oscillate it.
+func TestReconcileDeployment_NarrowedServiceSelectorNeverWidens(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	h := testHorizon()
+	r := newTestReconciler(testScheme(), h)
+	key := types.NamespacedName{Namespace: "default", Name: "test-horizon"}
+
+	// Pass 1 creates the Deployment; stamping full convergence and reconciling
+	// again completes the migration and narrows the Service selector.
+	_, err := r.reconcileDeployment(ctx, h, "cm-name", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	var deploy appsv1.Deployment
+	g.Expect(r.Get(ctx, key, &deploy)).To(Succeed())
+	deploy.Status.ReadyReplicas = 3
+	deploy.Status.UpdatedReplicas = 3
+	deploy.Status.Replicas = 3
+	deploy.Status.Conditions = []appsv1.DeploymentCondition{{
+		Type:   appsv1.DeploymentAvailable,
+		Status: corev1.ConditionTrue,
+	}}
+	g.Expect(r.Status().Update(ctx, &deploy)).To(Succeed())
+
+	_, err = r.reconcileDeployment(ctx, h, "cm-name", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	var svc corev1.Service
+	g.Expect(r.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+
+	// A later rollout drops the Deployment back below full convergence. The
+	// Deployment is watched without a generation predicate, so this status
+	// transition drives a reconcile of its own.
+	g.Expect(r.Get(ctx, key, &deploy)).To(Succeed())
+	deploy.Status.UpdatedReplicas = 1
+	deploy.Status.Replicas = 4
+	g.Expect(r.Status().Update(ctx, &deploy)).To(Succeed())
+
+	_, err = r.reconcileDeployment(ctx, h, "cm-name", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(r.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI),
+		"an already narrowed Service selector must never widen again — every pod template this operator builds carries the component label")
+}
+
 func TestBuildHorizonService_Port8080(t *testing.T) {
 	g := NewGomegaWithT(t)
 	h := testHorizon()
 
-	svc := buildHorizonService(h)
+	svc := buildHorizonService(h, true)
 
 	g.Expect(svc.Name).To(Equal("test-horizon"))
 	g.Expect(svc.Spec.Ports).To(HaveLen(1))
 	g.Expect(svc.Spec.Ports[0].Port).To(Equal(int32(8080)))
-	g.Expect(svc.Spec.Selector).To(Equal(selectorLabels(h)))
+	// The Service routes to a numeric targetPort, which admits any pod of this
+	// instance regardless of the ports it declares, and a pod without a
+	// readiness probe counts as Ready as soon as it starts. The component key
+	// is what keeps a workload other than the dashboard from becoming an
+	// endpoint with nothing listening on 8080.
+	g.Expect(svc.Spec.Selector).To(Equal(map[string]string{
+		"app.kubernetes.io/name":      "horizon",
+		"app.kubernetes.io/instance":  "test-horizon",
+		"app.kubernetes.io/component": "api",
+	}))
+
+	// The dashboard pods must keep satisfying the selector, or the Service
+	// would have no backends at all.
+	podLabels := buildHorizonDeployment(h, "cm", "").Spec.Template.Labels
+	g.Expect(labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(podLabels))).To(BeTrue(),
+		"the dashboard pod template must satisfy the Service selector")
 }

--- a/operators/horizon/internal/controller/reconcile_networkpolicy_test.go
+++ b/operators/horizon/internal/controller/reconcile_networkpolicy_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -83,6 +84,22 @@ func TestBuildHorizonNetworkPolicy_Rules(t *testing.T) {
 	g.Expect(np.Spec.Egress[0].Ports[0].Port.IntValue()).To(Equal(53))
 	g.Expect(np.Spec.Egress[1].Ports[0].Port.IntValue()).To(Equal(5000))
 	g.Expect(np.Spec.Egress[2].Ports[0].Port.IntValue()).To(Equal(11211))
+}
+
+// The pod selector matches on name and instance only, so the dashboard pods
+// stay selected even though their labels carry a component on top, and any
+// workload added under another component inherits the same auto-derived
+// egress. Losing the DNS and keystone egress would depool every pod.
+func TestBuildHorizonNetworkPolicy_PodSelectorCoversAPIPods(t *testing.T) {
+	g := NewGomegaWithT(t)
+	h := testHorizon()
+	h.Spec.NetworkPolicy = networkPolicySpec()
+
+	selector := labels.SelectorFromSet(buildHorizonNetworkPolicy(h, "horizon-system").Spec.PodSelector.MatchLabels)
+
+	apiPodLabels := buildHorizonDeployment(h, "cm", "").Spec.Template.Labels
+	g.Expect(selector.Matches(labels.Set(apiPodLabels))).To(BeTrue(),
+		"the dashboard pod template must stay selected by the NetworkPolicy")
 }
 
 func TestBuildHorizonNetworkPolicy_GatewayPeerAppended(t *testing.T) {

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -239,6 +239,15 @@ type KeystoneReconciler struct {
 	// the user nonetheless sets spec.gateway.
 	gatewayAPIAvailable bool
 
+	// apiReader is set during SetupWithManager from mgr.GetAPIReader(): a
+	// direct, uncached reader. reconcileDeployment latches the two-phase
+	// narrowing of the API Service selector on the live Service, and the
+	// informer cache can still hold the pre-narrowing state right after the
+	// narrowing write — a latch decided from it could widen the selector back.
+	// Nil in unit tests that construct the reconciler without a manager; those
+	// fall back to the (read-your-writes) fake client.
+	apiReader client.Reader
+
 	// certManagerAvailable is set during SetupWithManager from the cluster's
 	// RESTMapper and indicates whether the cert-manager.io/v1 Certificate CRD
 	// is installed. When false, the controller skips the Certificate watch and
@@ -817,6 +826,7 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when the CRD is missing, preventing every Keystone CR from being
 	// reconciled — including those that do not use spec.gateway.
 	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = mgr.GetAPIReader()
 	setupLog := ctrl.Log.WithName("keystone-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")

--- a/operators/keystone/internal/controller/reconcile_credential_test.go
+++ b/operators/keystone/internal/controller/reconcile_credential_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -663,14 +664,19 @@ func TestReconcileCredentialKeys_CronJobSpec(t *testing.T) {
 		Name:      "test-keystone-credential-rotate",
 	}, &cronJob)).To(Succeed())
 
-	// Verify labels on CronJob ObjectMeta and pod template.
+	// Verify labels on CronJob ObjectMeta and pod template. The CronJob object
+	// is not a pod, so its metadata stays on the plain common labels; the pod
+	// template adds the component that keeps rotation pods out of the API
+	// Service.
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(cronJob.Labels).NotTo(HaveKey(naming.LabelKeyComponent))
 	podTemplate := cronJob.Spec.JobTemplate.Spec.Template
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, "credential-rotation"))
 
 	podSpec := podTemplate.Spec
 

--- a/operators/keystone/internal/controller/reconcile_deployment.go
+++ b/operators/keystone/internal/controller/reconcile_deployment.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -106,7 +107,36 @@ func (r *KeystoneReconciler) reconcileDeployment(ctx context.Context, keystone *
 		return ctrl.Result{}, fmt.Errorf("ensuring Deployment: %w", err)
 	}
 
-	svc := buildKeystoneService(keystone, fed != nil)
+	// Narrow the Service selector to the API component only once every live pod
+	// carries that label. EnsureDeployment is a Server-Side Apply: it returns as
+	// soon as the API server accepts the pod template, long before the rollout
+	// finishes. Applying the narrowed selector in the same pass would drop every
+	// pod still running from before the upgrade out of the EndpointSlices while
+	// it is still the only thing serving — and a rollout that never completes
+	// would never repool them.
+	//
+	// Once narrowed, stay narrowed. The migration is one-way: only a template
+	// built by an operator predating the component label produces pods the
+	// narrow selector misses. Re-widening on a later rollout would re-admit
+	// maintenance pods as endpoints for exactly as long as it lasts, reopening
+	// the race this narrowing closes. The latch reads the live Service through
+	// the uncached APIReader, so it cannot be decided from a cache that still
+	// predates the narrowing write (see deployment.APISelectorNarrowed);
+	// r.apiReader is nil only in unit tests, whose fake client is
+	// read-your-writes anyway.
+	narrowSelector := deployment.TemplateConverged(deploy)
+	if !narrowSelector {
+		reader := client.Reader(r.Client)
+		if r.apiReader != nil {
+			reader = r.apiReader
+		}
+		narrowSelector, err = deployment.APISelectorNarrowed(ctx, reader, keystone.Namespace, subResourceName(keystone))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	svc := buildKeystoneService(keystone, fed != nil, narrowSelector)
 	if err := deployment.EnsureService(ctx, r.Client, r.Scheme, keystone, svc); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring Service: %w", err)
 	}
@@ -216,6 +246,15 @@ func selectorLabels(keystone *keystonev1alpha1.Keystone) map[string]string {
 	return naming.SelectorLabels(keystonev1alpha1.AppName, keystone.Name)
 }
 
+// componentLabels returns the pod-template labels for a workload of the given
+// component. It is commonLabels plus app.kubernetes.io/component, so the result
+// stays a superset of selectorLabels and keeps matching the Deployment pod
+// selector and the NetworkPolicy pod selector. It delegates to the shared
+// naming package to stay in sync across operators.
+func componentLabels(keystone *keystonev1alpha1.Keystone, component string) map[string]string {
+	return naming.ComponentLabels(keystonev1alpha1.AppName, keystone.Name, component)
+}
+
 // dbConnectionHashAnnotation is the pod-template annotation key stamped with the
 // SHA-256 of the DSN in Dynamic credentials mode so a rotated engine-issued
 // credential rolls the Deployment (the DSN is env-var-consumed, not volume-
@@ -239,7 +278,7 @@ func buildKeystoneDeployment(keystone *keystonev1alpha1.Keystone, configMapName,
 	deploy := deployment.BuildWorkload(deployment.WorkloadParams{
 		Namespace:      keystone.Namespace,
 		Name:           subResourceName(keystone),
-		Labels:         commonLabels(keystone),
+		Labels:         componentLabels(keystone, naming.ComponentAPI),
 		SelectorLabels: selectorLabels(keystone),
 		PodAnnotations: podAnnotations,
 		Deployment:     &keystone.Spec.Deployment,
@@ -547,8 +586,33 @@ func buildFederationVolumes(fed *federationProjection) []corev1.Volume {
 // disruptions. When it is 1, maxUnavailable=1 is used instead to avoid drain
 // deadlock (a PDB with minAvailable=1 on a single-replica deployment would block
 // all evictions).
+//
+// The selector keeps the stable name and instance labels and excludes the
+// maintenance pods by the absence of the Job name label (naming.ExcludeJobPods)
+// rather than by the API component. Both keep maintenance pods from inflating
+// currentHealthy — the disruption controller counts every matching pod, and Job
+// pods carry no readiness probe, so they are Ready from their first moment,
+// which raises disruptionsAllowed and lets a drain evict the API pods the budget
+// exists to protect. Only this one also covers the API pods of a template
+// predating the component label: a pod no budget selects is not protected at
+// all, and the Service's two-phase narrowing has no counterpart here that would
+// bound that gap.
 func buildPodDisruptionBudget(keystone *keystonev1alpha1.Keystone) *policyv1.PodDisruptionBudget {
-	return deployment.BuildPDB(keystone.Namespace, subResourceName(keystone), commonLabels(keystone), selectorLabels(keystone), &keystone.Spec.Deployment)
+	pdb := deployment.BuildPDB(keystone.Namespace, subResourceName(keystone), commonLabels(keystone), selectorLabels(keystone), &keystone.Spec.Deployment)
+	pdb.Spec.Selector.MatchExpressions = naming.ExcludeJobPods()
+	return pdb
+}
+
+// apiSelector returns the selector of the API Service. It narrows to
+// app.kubernetes.io/component=api only when narrowSelector is set, which the
+// caller derives from deployment.TemplateConverged and then latches: until every
+// live pod runs the labelled template, the wide selector is the only one that
+// still matches them.
+func apiSelector(keystone *keystonev1alpha1.Keystone, narrowSelector bool) map[string]string {
+	if narrowSelector {
+		return naming.APISelectorLabels(keystonev1alpha1.AppName, keystone.Name)
+	}
+	return selectorLabels(keystone)
 }
 
 // uwsgiCommand constructs the uWSGI container command from the given spec.
@@ -641,11 +705,13 @@ func priorityClassName(keystone *keystonev1alpha1.Keystone) string {
 // stays 5000 in every configuration — internalAPIURL, the status endpoint,
 // the HTTPRoute backend, and the health check all key on it — but with
 // federation active the targetPort switches to the sidecar so every request
-// traverses the header-stripping proxy.
-func buildKeystoneService(keystone *keystonev1alpha1.Keystone, federationActive bool) *corev1.Service {
+// traverses the header-stripping proxy. With narrowSelector the selector
+// narrows to the API component, so only the API pods can become endpoints
+// (see apiSelector for when that is safe).
+func buildKeystoneService(keystone *keystonev1alpha1.Keystone, federationActive, narrowSelector bool) *corev1.Service {
 	targetPort := int32(5000)
 	if federationActive {
 		targetPort = federationProxyPort
 	}
-	return deployment.BuildService(keystone.Namespace, subResourceName(keystone), commonLabels(keystone), selectorLabels(keystone), 5000, targetPort)
+	return deployment.BuildService(keystone.Namespace, subResourceName(keystone), commonLabels(keystone), apiSelector(keystone, narrowSelector), 5000, targetPort)
 }

--- a/operators/keystone/internal/controller/reconcile_deployment_pin_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_pin_test.go
@@ -24,6 +24,7 @@ import (
 
 const pinKeystoneDeploymentDefaultGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/managed-by: keystone-operator
     app.kubernetes.io/name: keystone
@@ -43,6 +44,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-keystone
         app.kubernetes.io/managed-by: keystone-operator
         app.kubernetes.io/name: keystone
@@ -166,6 +168,7 @@ status: {}
 
 const pinKeystoneDeploymentDynamicCredentialsGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/managed-by: keystone-operator
     app.kubernetes.io/name: keystone
@@ -187,6 +190,7 @@ spec:
       annotations:
         keystone.c5c3.io/db-connection-hash: 0123abc
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-keystone
         app.kubernetes.io/managed-by: keystone-operator
         app.kubernetes.io/name: keystone
@@ -310,6 +314,7 @@ status: {}
 
 const pinKeystoneDeploymentDBTLSDomainsGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/managed-by: keystone-operator
     app.kubernetes.io/name: keystone
@@ -329,6 +334,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-keystone
         app.kubernetes.io/managed-by: keystone-operator
         app.kubernetes.io/name: keystone
@@ -478,6 +484,7 @@ status: {}
 
 const pinKeystoneDeploymentFederationGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/managed-by: keystone-operator
     app.kubernetes.io/name: keystone
@@ -497,6 +504,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-keystone
         app.kubernetes.io/managed-by: keystone-operator
         app.kubernetes.io/name: keystone
@@ -713,6 +721,7 @@ status: {}
 
 const pinKeystoneDeploymentAutoscalingGolden = `metadata:
   labels:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/managed-by: keystone-operator
     app.kubernetes.io/name: keystone
@@ -731,6 +740,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: api
         app.kubernetes.io/instance: test-keystone
         app.kubernetes.io/managed-by: keystone-operator
         app.kubernetes.io/name: keystone
@@ -865,6 +875,7 @@ spec:
     protocol: TCP
     targetPort: 5000
   selector:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/name: keystone
 status:
@@ -884,6 +895,7 @@ spec:
     protocol: TCP
     targetPort: 5050
   selector:
+    app.kubernetes.io/component: api
     app.kubernetes.io/instance: test-keystone
     app.kubernetes.io/name: keystone
 status:
@@ -1009,7 +1021,7 @@ func TestPinKeystoneService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			got, err := yaml.Marshal(buildKeystoneService(testKeystone(), tc.federationActive))
+			got, err := yaml.Marshal(buildKeystoneService(testKeystone(), tc.federationActive, true))
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(string(got)).To(Equal(tc.golden),
 				"the rendered Keystone Service must stay byte-identical")

--- a/operators/keystone/internal/controller/reconcile_deployment_test.go
+++ b/operators/keystone/internal/controller/reconcile_deployment_test.go
@@ -7,17 +7,20 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,6 +34,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -215,7 +219,11 @@ func TestReconcileDeployment_DeploymentSpec(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := deployTestScheme()
 	ks := deployTestKeystone()
-	r := newDeployTestReconciler(s, ks)
+	// Seed a fully rolled-out Deployment so the Service assertions below see
+	// the converged selector; it is narrowed to the API component only once
+	// every live pod carries the label (see
+	// TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout).
+	r := newDeployTestReconciler(s, ks, readyDeployment(ks, "keystone-config-abc123"))
 
 	_, err := r.reconcileDeployment(context.Background(), ks, "keystone-config-abc123", "", "", nil)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -340,10 +348,15 @@ func TestReconcileDeployment_DeploymentSpec(t *testing.T) {
 	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(deploy.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(deploy.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
 	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
 	g.Expect(deploy.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(deploy.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	// The Deployment selector is immutable, so the component key must stay out
+	// of it: adding one would force a delete/recreate of every live Deployment.
+	g.Expect(deploy.Spec.Selector.MatchLabels).NotTo(HaveKey(naming.LabelKeyComponent))
 
 	// Verify Service spec.
 	var svc corev1.Service
@@ -359,6 +372,7 @@ func TestReconcileDeployment_DeploymentSpec(t *testing.T) {
 	g.Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
 	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
 }
 
 // TestBuildKeystoneDeployment_NilReplicasWhenAutoscaling verifies that the
@@ -599,15 +613,243 @@ func TestReconcileDeployment_ServiceCreatedAlongsideDeployment(t *testing.T) {
 		Name: "test-keystone", Namespace: "default",
 	}, &svc)).To(Succeed())
 
-	// Verify the Service targets the Deployment's pods.
+	// Verify the Service targets the Deployment's pods. The component key is
+	// absent while the freshly created Deployment has not rolled out — see
+	// TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout.
 	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(svc.Spec.Selector).NotTo(HaveKey(naming.LabelKeyComponent))
 	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(deploy.Spec.Template.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
 
 	// Both should have owner references.
 	g.Expect(deploy.OwnerReferences).To(HaveLen(1))
 	g.Expect(svc.OwnerReferences).To(HaveLen(1))
+}
+
+// TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout pins the two-phase
+// narrowing of the API Service selector — and the fact that it only ever runs
+// once. EnsureDeployment is a Server-Side Apply that returns as soon as the API
+// server accepts the pod template, so narrowing to
+// app.kubernetes.io/component=api in the same pass would drop every pod still
+// running from the pre-upgrade template out of the EndpointSlices — the Service
+// would have no backends at all until the first re-rolled pod passed its
+// probes, and a rollout that wedges would never repool them.
+//
+// Once the live Service carries the narrow selector the migration is over and
+// widening it again is pure regression: every template this operator builds
+// carries the component label, so a later rollout would re-admit maintenance
+// pods as endpoints for as long as it lasts. The PDB selector, by contrast,
+// covers the API pods in every phase — labelled or not, see
+// buildPodDisruptionBudget.
+func TestReconcileDeployment_SelectorsNarrowOnlyAfterRollout(t *testing.T) {
+	// surgingDeployment is the state the narrowing must survive: the first
+	// new-template pod is Ready — so EnsureDeployment already reports ready —
+	// while the old-template pods, the ones without the component label, are
+	// still counted and still serving.
+	surgingDeployment := func(ks *keystonev1alpha1.Keystone) *appsv1.Deployment {
+		deploy := readyDeployment(ks, "keystone-config-abc123")
+		deploy.Status.UpdatedReplicas = 1
+		deploy.Status.Replicas = *deploy.Spec.Replicas + 1
+		return deploy
+	}
+
+	cases := []struct {
+		name     string
+		deploy   func(*keystonev1alpha1.Keystone) *appsv1.Deployment
+		narrowed bool
+	}{
+		{name: "rollout in flight", deploy: surgingDeployment, narrowed: false},
+		{name: "fully rolled out", deploy: func(ks *keystonev1alpha1.Keystone) *appsv1.Deployment {
+			return readyDeployment(ks, "keystone-config-abc123")
+		}, narrowed: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			s := deployTestScheme()
+			ks := deployTestKeystone()
+			r := newDeployTestReconciler(s, ks, tc.deploy(ks))
+
+			_, err := r.reconcileDeployment(context.Background(), ks, "keystone-config-abc123", "", "", nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			key := types.NamespacedName{Name: "test-keystone", Namespace: "default"}
+			var svc corev1.Service
+			g.Expect(r.Client.Get(context.Background(), key, &svc)).To(Succeed())
+			var pdb policyv1.PodDisruptionBudget
+			g.Expect(r.Client.Get(context.Background(), key, &pdb)).To(Succeed())
+
+			if tc.narrowed {
+				g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+			} else {
+				g.Expect(svc.Spec.Selector).NotTo(HaveKey(naming.LabelKeyComponent),
+					"pods from the pre-upgrade template must stay in the EndpointSlices until the rollout completes")
+			}
+			// Either way the API pods must satisfy the Service selector, or it
+			// has no backends at all.
+			apiPodLabels := buildKeystoneDeployment(ks, "keystone-config-abc123", "", "", nil).Spec.Template.Labels
+			g.Expect(labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(apiPodLabels))).To(BeTrue())
+			// The budget covers the API pods in BOTH phases, the pre-upgrade
+			// ones included. Anything else leaves the pods that are actually
+			// serving outside every budget for the whole migration — and
+			// forever if the rollout wedges — because the eviction API only
+			// consults budgets matching the pod being evicted.
+			g.Expect(pdbSelects(g, &pdb, apiPodLabels)).To(BeTrue(),
+				"the budget must cover the API pods")
+			g.Expect(pdbSelects(g, &pdb, legacyAPIPodLabels(ks))).To(BeTrue(),
+				"the budget must cover API pods from a template predating the component label")
+		})
+	}
+}
+
+// TestReconcileDeployment_NarrowedServiceSelectorNeverWidens pins the latch on
+// the two-phase narrowing. deployment.TemplateConverged turns false on every
+// later rollout — a rotated Dynamic DB credential restamps the pod template on
+// each ESO refresh. Deriving the selector from it on every pass would therefore
+// not migrate the Service once but oscillate it, re-admitting maintenance pods
+// as endpoints for the whole window: exactly the race the narrowing closes,
+// during the rolling update where it matters most.
+func TestReconcileDeployment_NarrowedServiceSelectorNeverWidens(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+	r := newDeployTestReconciler(s, ks, readyDeployment(ks, "keystone-config-abc123"))
+	key := types.NamespacedName{Name: "test-keystone", Namespace: "default"}
+
+	// Pass 1: the Deployment is fully converged, so the migration completes and
+	// the Service selector narrows.
+	_, err := r.reconcileDeployment(ctx, ks, "keystone-config-abc123", "", "", nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	var svc corev1.Service
+	g.Expect(r.Client.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI))
+
+	// Pass 2: the Deployment drops back below full convergence. The Deployment
+	// is watched without a generation predicate, so this status transition
+	// drives a reconcile of its own.
+	var deploy appsv1.Deployment
+	g.Expect(r.Client.Get(ctx, key, &deploy)).To(Succeed())
+	deploy.Status.UpdatedReplicas = 0
+	deploy.Status.ReadyReplicas = 0
+	g.Expect(r.Client.Status().Update(ctx, &deploy)).To(Succeed())
+
+	_, err = r.reconcileDeployment(ctx, ks, "keystone-config-abc123", "", "", nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(r.Client.Get(ctx, key, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI),
+		"an already narrowed Service selector must never widen again — every pod template this operator builds carries the component label")
+}
+
+// TestReconcileDeployment_SelectorNarrowsWithoutFullReadiness pins that the
+// narrowing gate is template convergence, not health. An install that never
+// reaches full readiness — a third replica pending on resource pressure or on an
+// unsatisfiable topology-spread constraint — still runs nothing but the labelled
+// template, so it must narrow. Gating on readiness instead would leave such a
+// deployment on the wide selector permanently, and the latch cannot help: it can
+// only hold a narrowing that already happened. The hourly trust-flush pod would
+// keep joining the EndpointSlices on every run, which is the bug the component
+// label exists to fix.
+func TestReconcileDeployment_SelectorNarrowsWithoutFullReadiness(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+
+	deploy := readyDeployment(ks, "keystone-config-abc123")
+	// Every pod runs the current template, but one replica never becomes Ready.
+	deploy.Status.ReadyReplicas = *deploy.Spec.Replicas - 1
+	deploy.Status.Conditions = nil
+	r := newDeployTestReconciler(s, ks, deploy)
+
+	_, err := r.reconcileDeployment(ctx, ks, "keystone-config-abc123", "", "", nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var svc corev1.Service
+	g.Expect(r.Client.Get(ctx, types.NamespacedName{Name: "test-keystone", Namespace: "default"}, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI),
+		"a Deployment that runs only the current template must narrow even while it is degraded")
+}
+
+// TestReconcileDeployment_NarrowingLatchReadsUncached pins that the latch reads
+// the live Service through the uncached APIReader, not the informer cache. Right
+// after the narrowing write the cache can still hold the wide Service; a
+// reconcile triggered in that window by an unrelated event, with the Deployment
+// momentarily unconverged, would read the stale copy and apply the wide selector
+// again — reopening the maintenance-pod race until the Deployment converges.
+//
+// The two readers are separate fake clients: the writable one stands in for the
+// stale cache (it has no Service at all) and apiReader for the API server (it
+// carries the narrowed Service).
+func TestReconcileDeployment_NarrowingLatchReadsUncached(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+	s := deployTestScheme()
+	ks := deployTestKeystone()
+
+	// Unconverged, so the latch is what decides.
+	deploy := readyDeployment(ks, "keystone-config-abc123")
+	deploy.Status.UpdatedReplicas = 1
+	deploy.Status.Replicas = *deploy.Spec.Replicas + 1
+	r := newDeployTestReconciler(s, ks, deploy)
+	r.apiReader = fake.NewClientBuilder().WithScheme(s).
+		WithObjects(buildKeystoneService(ks, false, true)).Build()
+
+	_, err := r.reconcileDeployment(ctx, ks, "keystone-config-abc123", "", "", nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var svc corev1.Service
+	g.Expect(r.Client.Get(ctx, types.NamespacedName{Name: "test-keystone", Namespace: "default"}, &svc)).To(Succeed())
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(naming.LabelKeyComponent, naming.ComponentAPI),
+		"the latch must read the API server, or a stale cache re-widens an already narrowed selector")
+}
+
+// TestMaintenancePodsNotSelectedByAPIService locks the invariant the API
+// Service depends on: only the API pods satisfy its selector. The maintenance
+// CronJob pod templates once carried the full selector, and because the Service
+// targets a numeric port and job pods have no readiness probe, every scheduled
+// run turned a pod with nothing listening into a ready endpoint.
+func TestMaintenancePodsNotSelectedByAPIService(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := deployTestKeystone()
+	ks.Spec.TrustFlush = &keystonev1alpha1.TrustFlushSpec{
+		Schedule: keystonev1alpha1.DefaultTrustFlushSchedule,
+	}
+	ks.Spec.PasswordRotation = &keystonev1alpha1.PasswordRotationSpec{
+		Enabled:  true,
+		Schedule: "0 0 1 * *",
+	}
+
+	selector := labels.SelectorFromSet(buildKeystoneService(ks, false, true).Spec.Selector)
+
+	// The API pods must keep matching, or the Service would have no backends.
+	apiPodLabels := buildKeystoneDeployment(ks, "keystone-config-abc123", "", "", nil).Spec.Template.Labels
+	g.Expect(selector.Matches(labels.Set(apiPodLabels))).To(BeTrue(),
+		"the API pod template must satisfy the API Service selector")
+
+	cases := []struct {
+		component string
+		cronJob   *batchv1.CronJob
+	}{
+		{"trust-flush", trustFlushCronJob(ks, "keystone-config-abc123", "")},
+		{"fernet-rotation", fernetRotationCronJob(ks, "keystone-config-abc123", "fernet-scripts-cm", "")},
+		{"credential-rotation", credentialRotationCronJob(ks, "keystone-config-abc123", "credential-scripts-cm", "")},
+		{"admin-password-rotation", adminPasswordRotationCronJob(ks, "admin-password-scripts-cm")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.component, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			podLabels := tc.cronJob.Spec.JobTemplate.Spec.Template.Labels
+			g.Expect(podLabels).To(HaveKeyWithValue(naming.LabelKeyComponent, tc.component))
+			g.Expect(selector.Matches(labels.Set(podLabels))).To(BeFalse(),
+				"%s pods must never become endpoints of the API Service", tc.component)
+		})
+	}
 }
 
 // TestBuildKeystoneDeployment_StablePodTemplate verifies that two calls to
@@ -858,10 +1100,25 @@ func TestReconcileDeployment_PDBUpdatedOnReplicaChange(t *testing.T) {
 	g.Expect(pdb.Spec.MinAvailable).To(BeNil())
 }
 
-func TestReconcileDeployment_PDBSelectorMatchesDeployment(t *testing.T) {
+// TestReconcileDeployment_PDBSelectorMatchesDeploymentPods verifies the budget
+// covers every API pod and no maintenance pod. It deliberately does not equal
+// the Deployment's own selector: that one is immutable and therefore stays on
+// name and instance, while the budget additionally excludes Job-created pods so
+// they cannot inflate currentHealthy.
+//
+// The exclusion must not be keyed on app.kubernetes.io/component=api. That label
+// arrives with this operator build, so on the operator upgrade a component-keyed
+// budget matches none of the API pods actually serving — and the eviction API
+// only consults budgets matching the pod being evicted, so those pods would have
+// no budget at all until the migration rollout lands, and forever if it wedges.
+// A node drain could then take every replica at once.
+func TestReconcileDeployment_PDBSelectorMatchesDeploymentPods(t *testing.T) {
 	g := NewGomegaWithT(t)
 	s := deployTestScheme()
 	ks := deployTestKeystone()
+	ks.Spec.TrustFlush = &keystonev1alpha1.TrustFlushSpec{
+		Schedule: keystonev1alpha1.DefaultTrustFlushSchedule,
+	}
 	r := newDeployTestReconciler(s, ks)
 
 	_, err := r.reconcileDeployment(context.Background(), ks, "keystone-config-abc123", "", "", nil)
@@ -877,7 +1134,34 @@ func TestReconcileDeployment_PDBSelectorMatchesDeployment(t *testing.T) {
 		Name: "test-keystone", Namespace: "default",
 	}, &pdb)).To(Succeed())
 
-	g.Expect(pdb.Spec.Selector.MatchLabels).To(Equal(deploy.Spec.Selector.MatchLabels))
+	g.Expect(pdbSelects(g, &pdb, deploy.Spec.Template.Labels)).To(BeTrue(),
+		"the budget must cover the API pods")
+	g.Expect(pdbSelects(g, &pdb, legacyAPIPodLabels(ks))).To(BeTrue(),
+		"the budget must cover API pods from a template predating the component label")
+
+	// A maintenance pod carries the CronJob pod-template labels plus the Job
+	// controller's own job-name label, and no readiness probe — so a budget that
+	// matched it would count it as healthy from its first moment and raise
+	// disruptionsAllowed for the API pods.
+	trustFlushPod := maps.Clone(trustFlushCronJob(ks, "keystone-config-abc123", "").Spec.JobTemplate.Spec.Template.Labels)
+	trustFlushPod[naming.LabelKeyJobName] = "test-keystone-trust-flush-29000000"
+	g.Expect(pdbSelects(g, &pdb, trustFlushPod)).To(BeFalse(),
+		"a Job-created maintenance pod must never count towards the budget")
+}
+
+// pdbSelects reports whether the budget's selector — MatchLabels and
+// MatchExpressions together — matches a pod carrying podLabels.
+func pdbSelects(g *WithT, pdb *policyv1.PodDisruptionBudget, podLabels map[string]string) bool {
+	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+	g.Expect(err).NotTo(HaveOccurred())
+	return selector.Matches(labels.Set(podLabels))
+}
+
+// legacyAPIPodLabels returns the pod-template labels an API pod created by an
+// operator build predating app.kubernetes.io/component carries. Those pods are
+// the ones still serving while the migration rollout runs.
+func legacyAPIPodLabels(ks *keystonev1alpha1.Keystone) map[string]string {
+	return commonLabels(ks)
 }
 
 func TestBuildPodDisruptionBudget_BoundaryReplicas2(t *testing.T) {
@@ -1962,7 +2246,7 @@ func TestBuildKeystoneService_NameMatchesCR(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ks := deployTestKeystone()
 
-	svc := buildKeystoneService(ks, false)
+	svc := buildKeystoneService(ks, false, true)
 
 	g.Expect(svc.Name).To(Equal(ks.Name),
 		"Service Name must equal the CR name")
@@ -2362,11 +2646,11 @@ func TestBuildKeystoneService_FederationTargetPortSwitch(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ks := deployTestKeystone()
 
-	plain := buildKeystoneService(ks, false)
+	plain := buildKeystoneService(ks, false, true)
 	g.Expect(plain.Spec.Ports[0].Port).To(Equal(int32(5000)))
 	g.Expect(plain.Spec.Ports[0].TargetPort.IntValue()).To(Equal(5000))
 
-	federated := buildKeystoneService(ks, true)
+	federated := buildKeystoneService(ks, true, true)
 	g.Expect(federated.Spec.Ports[0].Port).To(Equal(int32(5000)), "the Service port is the stable API contract")
 	g.Expect(federated.Spec.Ports[0].TargetPort.IntValue()).To(Equal(int(federationProxyPort)))
 }

--- a/operators/keystone/internal/controller/reconcile_fernet_test.go
+++ b/operators/keystone/internal/controller/reconcile_fernet_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
+	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -658,14 +659,19 @@ func TestReconcileFernetKeys_CronJobSpec(t *testing.T) {
 		Name:      "test-keystone-fernet-rotate",
 	}, &cronJob)).To(Succeed())
 
-	// Verify labels on CronJob ObjectMeta and pod template.
+	// Verify labels on CronJob ObjectMeta and pod template. The CronJob object
+	// is not a pod, so its metadata stays on the plain common labels; the pod
+	// template adds the component that keeps rotation pods out of the API
+	// Service.
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(cronJob.Labels).NotTo(HaveKey(naming.LabelKeyComponent))
 	podTemplate := cronJob.Spec.JobTemplate.Spec.Template
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(podTemplate.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(podTemplate.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, "fernet-rotation"))
 
 	podSpec := podTemplate.Spec
 

--- a/operators/keystone/internal/controller/reconcile_networkpolicy.go
+++ b/operators/keystone/internal/controller/reconcile_networkpolicy.go
@@ -157,7 +157,7 @@ func buildAutoEgressRules(keystone *keystonev1alpha1.Keystone) []networkingv1.Ne
 	rules := []networkingv1.NetworkPolicyEgressRule{networkpolicy.DNSEgressRule()}
 
 	// kube-apiserver egress: always required (TCP 443+6443). The
-	// fernet/credential/admin-password rotation CronJob pods carry commonLabels
+	// fernet/credential/admin-password rotation CronJob pods carry componentLabels
 	// — a superset of the Deployment selectorLabels — so they are selected by
 	// this NetworkPolicy's podSelector and share its egress rules. Those scripts
 	// PATCH the rotated keys back to a Kubernetes Secret via

--- a/operators/keystone/internal/controller/reconcile_networkpolicy_test.go
+++ b/operators/keystone/internal/controller/reconcile_networkpolicy_test.go
@@ -15,6 +15,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -126,6 +127,50 @@ func TestBuildKeystoneNetworkPolicy_PodSelector(t *testing.T) {
 	g.Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(np.Spec.PodSelector.MatchLabels).To(HaveLen(2))
+}
+
+// TestBuildKeystoneNetworkPolicy_PodSelectorCoversMaintenancePods locks the
+// egress guarantee the rotation scripts depend on: the pod selector matches on
+// name and instance only, so every maintenance pod keeps inheriting the
+// auto-derived egress rules even though its component label differs from the
+// API pods'. Without the apiserver rule those scripts cannot PATCH their
+// rotated keys back and every scheduled run fails.
+func TestBuildKeystoneNetworkPolicy_PodSelectorCoversMaintenancePods(t *testing.T) {
+	ks := npTestKeystone()
+	ks.Spec.NetworkPolicy = &keystonev1alpha1.NetworkPolicySpec{
+		Ingress: []keystonev1alpha1.NetworkPolicyIngressSource{
+			{NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openstack"}}},
+		},
+	}
+	ks.Spec.TrustFlush = &keystonev1alpha1.TrustFlushSpec{
+		Schedule: keystonev1alpha1.DefaultTrustFlushSchedule,
+	}
+	ks.Spec.PasswordRotation = &keystonev1alpha1.PasswordRotationSpec{
+		Enabled:  true,
+		Schedule: "0 0 1 * *",
+	}
+
+	selector := labels.SelectorFromSet(buildKeystoneNetworkPolicy(ks, "", nil).Spec.PodSelector.MatchLabels)
+
+	cases := []struct {
+		name      string
+		podLabels map[string]string
+	}{
+		{"api", buildKeystoneDeployment(ks, "keystone-config-abc123", "", "", nil).Spec.Template.Labels},
+		{"trust-flush", trustFlushCronJob(ks, "keystone-config-abc123", "").Spec.JobTemplate.Spec.Template.Labels},
+		{"fernet-rotation", fernetRotationCronJob(ks, "keystone-config-abc123", "fernet-scripts-cm", "").Spec.JobTemplate.Spec.Template.Labels},
+		{"credential-rotation", credentialRotationCronJob(ks, "keystone-config-abc123", "credential-scripts-cm", "").Spec.JobTemplate.Spec.Template.Labels},
+		{"admin-password-rotation", adminPasswordRotationCronJob(ks, "admin-password-scripts-cm").Spec.JobTemplate.Spec.Template.Labels},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			g.Expect(selector.Matches(labels.Set(tc.podLabels))).To(BeTrue(),
+				"%s pods must stay selected by the NetworkPolicy", tc.name)
+		})
+	}
 }
 
 func TestBuildKeystoneNetworkPolicy_PolicyTypes(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -364,7 +364,7 @@ func adminPasswordRotationCronJob(keystone *keystonev1alpha1.Keystone, scriptCon
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: commonLabels(keystone),
+							Labels: componentLabels(keystone, "admin-password-rotation"),
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: adminPasswordRotateSAName(keystone),

--- a/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/c5c3/forge/internal/common/naming"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -259,6 +260,29 @@ func TestAdminPasswordRotationCronJob_Shape(t *testing.T) {
 	g.Expect(scriptsVol.ConfigMap).NotTo(BeNil())
 	g.Expect(scriptsVol.ConfigMap.Name).To(Equal("test-keystone-admin-password-rotate-script-abc123"))
 	g.Expect(*scriptsVol.ConfigMap.DefaultMode).To(Equal(int32(0o555)))
+}
+
+func TestAdminPasswordRotationCronJob_Labels(t *testing.T) {
+	g := NewWithT(t)
+	ks := pwRotationTestKeystone()
+
+	cj := adminPasswordRotationCronJob(ks, "test-keystone-admin-password-rotate-script-abc123")
+
+	// The CronJob object is not a pod, so its metadata stays on the plain common
+	// labels.
+	g.Expect(cj.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(cj.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(cj.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(cj.Labels).NotTo(HaveKey(naming.LabelKeyComponent))
+
+	// The pod template keeps the common labels — the NetworkPolicy pod selector
+	// matches on a subset of them — and adds the component that keeps rotation
+	// pods out of the API Service.
+	podLabels := cj.Spec.JobTemplate.Spec.Template.Labels
+	g.Expect(podLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
+	g.Expect(podLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(podLabels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(podLabels).To(HaveKeyWithValue(naming.LabelKeyComponent, "admin-password-rotation"))
 }
 
 func TestAdminPasswordRotationCronJob_Suspend(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_trustflush.go
+++ b/operators/keystone/internal/controller/reconcile_trustflush.go
@@ -120,7 +120,7 @@ func trustFlushCronJob(keystone *keystonev1alpha1.Keystone, configMapName, domai
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: commonLabels(keystone),
+							Labels: componentLabels(keystone, "trust-flush"),
 						},
 						Spec: corev1.PodSpec{
 							PriorityClassName: priorityClassName(keystone),

--- a/operators/keystone/internal/controller/reconcile_trustflush_test.go
+++ b/operators/keystone/internal/controller/reconcile_trustflush_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/c5c3/forge/internal/common/naming"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -418,10 +419,16 @@ func TestTrustFlushCronJob_Labels(t *testing.T) {
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 	g.Expect(cronJob.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	// The CronJob object itself is not a pod, so its metadata stays on the plain
+	// common labels.
+	g.Expect(cronJob.Labels).NotTo(HaveKey(naming.LabelKeyComponent))
 
-	// Pod template labels should match.
+	// Pod template labels keep the common labels and add the component that
+	// keeps trust-flush pods out of the API Service.
 	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "keystone"))
 	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "keystone-operator"))
+	g.Expect(cronJob.Spec.JobTemplate.Spec.Template.Labels).To(HaveKeyWithValue(naming.LabelKeyComponent, "trust-flush"))
 }
 
 func TestTrustFlushCronJob_Image(t *testing.T) {

--- a/operators/keystone/internal/controller/rotation_cronjob.go
+++ b/operators/keystone/internal/controller/rotation_cronjob.go
@@ -201,7 +201,7 @@ func keyRotationCronJob(keystone *keystonev1alpha1.Keystone, configMapName, scri
 		Namespace: keystone.Namespace,
 		Labels:    commonLabels(keystone),
 		Schedule:  p.schedule,
-		PodLabels: commonLabels(keystone),
+		PodLabels: componentLabels(keystone, p.keyKind+"-rotation"),
 		PodSpec:   podSpec,
 	})
 }

--- a/tests/e2e-operator-upgrade/keystone-helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-operator-upgrade/keystone-helm-upgrade/chainsaw-test.yaml
@@ -16,7 +16,12 @@
 #     Keystone service image tag, not the operator version),
 #   - the bootstrap Job is NOT re-run (its UID is unchanged and exactly one
 #     bootstrap Job exists), guarding the cross-version re-bootstrap failure
-#     mode (bootstrap is gated on the admin-password digest, not the image).
+#     mode (bootstrap is gated on the admin-password digest, not the image),
+#   - the API Service never loses its backends while the new operator narrows
+#     the Service selector to app.kubernetes.io/component=api. Ready=True and
+#     observedGeneration are derived from Deployment status and stay green
+#     through a total endpoint outage, so the EndpointSlices are sampled
+#     directly.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -67,8 +72,24 @@ spec:
             exit 1
           fi
           echo "Baseline bootstrap Job UID: ${BOOT_UID}"
+          # Stash the API Service backend count too: Step 5 asserts it never
+          # drops while the new operator narrows the Service selector. The
+          # pipeline is guarded so a failed kubectl or jq leaves ENDPOINTS
+          # empty and reaches the diagnostic below instead of aborting the
+          # script under set -e with no message.
+          ENDPOINTS=$(kubectl get endpointslices -n openstack \
+            -l kubernetes.io/service-name=keystone-op-upgrade -o json 2>/dev/null \
+            | jq '[.items[].endpoints[]?
+                   | select((.conditions.terminating // false) == false)
+                   | .addresses[]?] | length' 2>/dev/null || true)
+          if [ -z "${ENDPOINTS}" ] || [ "${ENDPOINTS}" -lt 1 ]; then
+            echo "FAIL: API Service has no backends before the upgrade (${ENDPOINTS:-0})"
+            exit 1
+          fi
+          echo "Baseline API Service backend count: ${ENDPOINTS}"
           kubectl create configmap keystone-op-upgrade-baseline -n openstack \
             --from-literal=bootstrap-uid="${BOOT_UID}" \
+            --from-literal=endpoints="${ENDPOINTS}" \
             --dry-run=client -o yaml | kubectl apply -f -
   # ── Step 3: helm upgrade to the locally built chart + CRDs ─────────────
   # Chainsaw runs scripts with the test directory as CWD, so ../../.. is the
@@ -129,15 +150,94 @@ spec:
             exit 1
           fi
           echo "OK: rollout complete (updatedReplicas=${UPD} == replicas=${REP})"
-  # ── Step 5: Force one full reconcile by the NEW operator ───────────────
+  # ── Step 5: Assert the API Service keeps its backends across the upgrade ─
+  # The new operator narrows the API Service selector to
+  # app.kubernetes.io/component=api, a label the pods running under the
+  # released operator do not carry. Applying that narrowing before the
+  # Deployment has rolled onto the labelled template would empty the
+  # EndpointSlices while those pods are the only ones serving — and a rollout
+  # that wedges would never repool them. Ready=True, installedRelease, and
+  # observedGeneration are all derived from Deployment status and stay green
+  # through that outage, so sample the EndpointSlices directly, from the moment
+  # the new operator takes over until the narrowing actually lands. Runs before
+  # the Step-6 replica patch so the baseline count still describes the CR.
+  - name: assert-endpoints-survive-upgrade
+    try:
+    - script:
+        shell: bash
+        # 5m: the migration rollout has to create a new API pod and get it
+        # through the keystone startup probe before the selector may narrow.
+        timeout: 300s
+        content: |
+          set -euo pipefail
+          SERVICE=keystone-op-upgrade
+          BASE=$(kubectl get configmap keystone-op-upgrade-baseline -n openstack \
+            -o jsonpath='{.data.endpoints}')
+          if [ -z "${BASE}" ]; then
+            echo "FAIL: no baseline backend count stashed by the capture-baseline step"
+            exit 1
+          fi
+          echo "baseline backend count: ${BASE}"
+          deadline=$(( $(date +%s) + 240 ))
+          narrowed=false
+          while :; do
+            # Terminating addresses are excluded: the surge pod replacement
+            # briefly publishes the old and the new address at once, and the
+            # old one is what leaves. A transient API-server error yields an
+            # empty COUNT; that sample counts as no observation, and the next
+            # tick retries — this loop samples the API server for up to 240s
+            # while the operator Deployment rolls, so a hiccup here must not be
+            # reported as an upgrade regression.
+            COUNT=$(kubectl get endpointslices -n openstack \
+              -l kubernetes.io/service-name="${SERVICE}" -o json 2>/dev/null \
+              | jq '[.items[].endpoints[]?
+                     | select((.conditions.terminating // false) == false)
+                     | .addresses[]?] | length' 2>/dev/null || true)
+            if [ -n "${COUNT}" ] && [ "${COUNT}" -lt "${BASE}" ]; then
+              echo "FAIL: API Service backends dropped to ${COUNT} (baseline ${BASE}) during the operator upgrade"
+              echo "The selector was narrowed before the live API pods carried app.kubernetes.io/component=api."
+              kubectl get svc "${SERVICE}" -n openstack -o yaml 2>&1 || true
+              kubectl get endpointslices -n openstack \
+                -l kubernetes.io/service-name="${SERVICE}" -o yaml 2>&1 || true
+              kubectl get pods -n openstack \
+                -l app.kubernetes.io/instance="${SERVICE}" -o wide 2>&1 || true
+              exit 1
+            fi
+            SEL=$(kubectl get svc "${SERVICE}" -n openstack -o json 2>/dev/null \
+              | jq -r '.spec.selector["app.kubernetes.io/component"] // ""' 2>/dev/null || true)
+            if [ "${SEL}" = "api" ]; then
+              narrowed=true
+              echo "OK: selector narrowed to component=api and backends never fell below ${BASE}"
+              break
+            fi
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              break
+            fi
+            sleep 2
+          done
+          if [ "${narrowed}" = false ]; then
+            echo "FAIL: the new operator never narrowed the API Service selector to app.kubernetes.io/component=api"
+            echo "Without the narrowing the sampling above proves nothing — maintenance pods can still become backends."
+            kubectl get svc "${SERVICE}" -n openstack -o yaml 2>&1 || true
+            kubectl get deploy "${SERVICE}" -n openstack -o yaml 2>&1 || true
+            exit 1
+          fi
+    catch:
+    - script:
+        content: |
+          kubectl get endpointslices -n openstack \
+            -l kubernetes.io/service-name=keystone-op-upgrade -o yaml 2>&1 || true
+          kubectl get pods -n openstack -o wide 2>&1 || true
+          kubectl logs -n keystone-system -l app.kubernetes.io/name=keystone-operator --all-containers --tail=100 2>&1 || true
+  # ── Step 6: Force one full reconcile by the NEW operator ───────────────
   # Patch a real spec field (spec.deployment.replicas 1 → 2) so
   # metadata.generation advances. An annotation poke would NOT bump generation
   # (with the /status subresource the apiserver increments generation only on
-  # .spec changes), which is exactly what would make the Step-6
+  # .spec changes), which is exactly what would make the Step-7
   # observedGeneration check tautological: observedGeneration == generation was
   # already true from the released operator's last status write and would stay
   # true whether or not the NEW operator ever reconciled. Bumping generation is
-  # what lets Step 6 prove the NEW operator drove a post-upgrade reconcile to
+  # what lets Step 7 prove the NEW operator drove a post-upgrade reconcile to
   # completion. Same field and pattern as tests/e2e/keystone/semantic-invariants.
   - name: poke-reconcile
     try:
@@ -175,7 +275,7 @@ spec:
             echo "FAIL: spec patch did not advance metadata.generation (${GEN_BEFORE} -> ${GEN_AFTER})"
             exit 1
           fi
-  # ── Step 6: Assert Ready persists and no re-bootstrap happened ─────────
+  # ── Step 7: Assert Ready persists and no re-bootstrap happened ─────────
   - name: assert-after-upgrade
     try:
     - assert:
@@ -198,7 +298,7 @@ spec:
         timeout: 3m
         content: |
           set -euo pipefail
-          # Poll until status.observedGeneration catches up to the (Step-5
+          # Poll until status.observedGeneration catches up to the (Step-6
           # bumped) metadata.generation — this is what proves the NEW operator
           # drove a post-upgrade reconcile to completion. The declarative
           # Ready=True assert above cannot prove it on its own: Ready was already

--- a/tests/e2e/keystone/maintenance-endpoint-isolation/00-keystone-cr.yaml
+++ b/tests/e2e/keystone/maintenance-endpoint-isolation/00-keystone-cr.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Keystone CR fixture for the maintenance endpoint-isolation E2E test.
+# Managed mode with a trust flush that fires every minute, so the sampling
+# window of the test spans at least one CronJob run.
+apiVersion: keystone.openstack.c5c3.io/v1alpha1
+kind: Keystone
+metadata:
+  name: keystone-endpoint-isolation
+  namespace: openstack
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: openbao-tenant-store
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/keystone
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: keystone_endpoint_isolation
+    secretRef:
+      name: keystone-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+    backend: dogpile.cache.pymemcache
+  fernet:
+    rotationSchedule: "0 0 * * 0"
+    maxActiveKeys: 3
+  trustFlush:
+    schedule: "* * * * *"
+    suspend: false
+  bootstrap:
+    adminUser: admin
+    adminPasswordSecretRef:
+      name: keystone-admin
+    region: RegionOne

--- a/tests/e2e/keystone/maintenance-endpoint-isolation/chainsaw-test.yaml
+++ b/tests/e2e/keystone/maintenance-endpoint-isolation/chainsaw-test.yaml
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for maintenance-pod isolation from the API Service.
+# Verifies:
+#   - The EndpointSlices of the API Service never list more addresses than the
+#     replica count while a maintenance CronJob runs, i.e. a trust-flush pod
+#     never becomes a backend of the API Service
+#   - The API Service is never left without backends: the full replica count is
+#     observed at least once, so an empty selector cannot pass the upper bound
+#   - The sampling window really overlaps a trust flush, proven by a live
+#     trust-flush pod holding a pod IP — the exact state that used to land in
+#     the EndpointSlices
+#
+# The CR schedules the trust flush every minute so the check is deterministic.
+# The same regression was previously only reachable by coincidence: the
+# rolling-update-zero-downtime suite caught it whenever its 60 s load window
+# happened to overlap the top of an hour, which is roughly 2 % of runs.
+#
+# This suite is keystone-only on purpose. The label mechanism lives in the
+# shared naming package and is unit-tested per operator (glance db-purge,
+# horizon dashboard); one cluster-level suite is enough to prove the
+# EndpointSlice behaviour the unit tests cannot observe.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: keystone-maintenance-endpoint-isolation
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply Keystone CR with an every-minute trust flush ───────────
+  - try:
+    - apply:
+        file: 00-keystone-cr.yaml
+  # ── Step 2: Wait for Ready=True ────────────────────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: keystone.openstack.c5c3.io/v1alpha1
+          kind: Keystone
+          metadata:
+            name: keystone-endpoint-isolation
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== All pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Failed Job logs ==="
+          for job in $(kubectl get jobs -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $job ---"
+            kubectl logs -n $NAMESPACE "$job" --all-containers --tail=100 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Sample the API Service endpoints across a trust-flush run ───
+  # The CR is never patched after Step 1: any spec change would roll the
+  # Deployment and put a second API pod into the EndpointSlices, which the
+  # address count below would report as a failure.
+  - try:
+    - script:
+        timeout: 180s
+        content: |
+          set -eu
+
+          SERVICE=keystone-endpoint-isolation
+          CRONJOB=keystone-endpoint-isolation-trust-flush
+
+          # Read the bound off the live Deployment rather than restating the
+          # fixture: a copy here would silently stop matching the CR.
+          REPLICAS=$(kubectl get deploy "$SERVICE" -n "$NAMESPACE" \
+            -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+          [ -n "$REPLICAS" ] || { echo "FAIL: could not read spec.replicas of Deployment $SERVICE"; exit 1; }
+
+          # 90 s over an every-minute schedule covers at least one CronJob
+          # firing; the SAW_FLUSH_POD flag below turns that from an expectation
+          # into an observation.
+          WINDOW=90
+          DEADLINE=$(( $(date +%s) + WINDOW ))
+          SAW_FLUSH_POD=false
+          SAW_FULL=false
+
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            # Every non-terminating address of every slice counts, not just the
+            # ready ones: a maintenance pod that satisfies the Service selector
+            # is published as an address as soon as it is scheduled, and a Job
+            # pod carries no readiness probe, so it is Ready from its first
+            # moment. Counting only ready addresses would hide exactly the
+            # state this suite is about. Terminating addresses are excluded so
+            # an ordinary API-pod replacement — which briefly puts the old and
+            # the new address in the slice — is not misreported as a
+            # maintenance-pod leak. A transient API-server error yields an
+            # empty COUNT; that sample counts as no observation and the next
+            # tick retries.
+            COUNT=$(kubectl get endpointslices -n "$NAMESPACE" \
+              -l kubernetes.io/service-name="$SERVICE" -o json 2>/dev/null \
+              | jq '[.items[].endpoints[]?
+                     | select((.conditions.terminating // false) == false)
+                     | .addresses[]?] | length' 2>/dev/null || true)
+            [ -n "$COUNT" ] || COUNT=0
+
+            if [ "$COUNT" -gt "$REPLICAS" ]; then
+              echo "FAIL: API Service $SERVICE has $COUNT endpoint addresses, expected at most $REPLICAS"
+              echo "=== EndpointSlices ==="
+              kubectl get endpointslices -n "$NAMESPACE" \
+                -l kubernetes.io/service-name="$SERVICE" -o yaml 2>&1 || true
+              echo "=== Pods ==="
+              kubectl get pods -n "$NAMESPACE" \
+                -l app.kubernetes.io/instance="$SERVICE" -o wide 2>&1 || true
+              exit 1
+            fi
+
+            # The upper bound alone is satisfied by an empty Service, which is
+            # the opposite failure: a selector that matches no API pod at all.
+            if [ "$COUNT" -eq "$REPLICAS" ]; then
+              SAW_FULL=true
+            fi
+
+            # A trust-flush pod holding a pod IP is exactly the state that used
+            # to land in the EndpointSlices, so it is what the sampling above
+            # has to overlap. Completed pods are excluded: they keep their IP
+            # in status but the endpoints controller ignores them, so a
+            # leftover from an earlier run would prove nothing.
+            if [ "$SAW_FLUSH_POD" = false ]; then
+              LIVE=$(kubectl get pods -n "$NAMESPACE" \
+                -l app.kubernetes.io/instance="$SERVICE",app.kubernetes.io/component=trust-flush \
+                -o json 2>/dev/null \
+                | jq '[.items[]
+                       | select(.status.phase == "Running" or .status.phase == "Pending")
+                       | select((.status.podIP // "") != "")] | length' 2>/dev/null || true)
+              if [ "${LIVE:-0}" -gt 0 ]; then
+                SAW_FLUSH_POD=true
+                echo "Observed $LIVE live trust-flush pod(s) holding a pod IP"
+              fi
+            fi
+
+            sleep 1
+          done
+
+          if [ "$SAW_FULL" = false ]; then
+            echo "FAIL: API Service $SERVICE never had its full $REPLICAS endpoint address(es) during the ${WINDOW}s window"
+            echo "The selector matches no API pod, so the upper bound above proves nothing."
+            echo "=== Service ==="
+            kubectl get svc "$SERVICE" -n "$NAMESPACE" -o yaml 2>&1 || true
+            echo "=== EndpointSlices ==="
+            kubectl get endpointslices -n "$NAMESPACE" \
+              -l kubernetes.io/service-name="$SERVICE" -o yaml 2>&1 || true
+            exit 1
+          fi
+
+          if [ "$SAW_FLUSH_POD" = false ]; then
+            echo "FAIL: no live trust-flush pod observed during the ${WINDOW}s sampling window"
+            echo "The window did not overlap a trust-flush run, so the endpoint count above proves nothing."
+            echo "=== CronJob ==="
+            kubectl get cronjob "$CRONJOB" -n "$NAMESPACE" -o wide 2>&1 || true
+            echo "=== Jobs ==="
+            kubectl get jobs -n "$NAMESPACE" -o wide 2>&1 || true
+            echo "=== trust-flush pods ==="
+            kubectl get pods -n "$NAMESPACE" \
+              -l app.kubernetes.io/component=trust-flush -o wide 2>&1 || true
+            exit 1
+          fi
+
+          echo "PASS: API Service $SERVICE kept exactly its $REPLICAS backend(s) across at least one live trust-flush pod"
+    catch:
+    - script:
+        content: |
+          echo "=== EndpointSlices ==="
+          kubectl get endpointslices -n $NAMESPACE \
+            -l kubernetes.io/service-name=keystone-endpoint-isolation -o yaml 2>&1 || true
+          echo "=== Pods ==="
+          kubectl get pods -n $NAMESPACE \
+            -l app.kubernetes.io/instance=keystone-endpoint-isolation -o wide 2>&1 || true
+          echo "=== CronJob describe ==="
+          kubectl describe cronjob keystone-endpoint-isolation-trust-flush -n $NAMESPACE 2>&1 | tail -40 || true
+          echo "=== Jobs ==="
+          kubectl get jobs -n $NAMESPACE -o wide 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true


### PR DESCRIPTION
Closes #778

Maintenance CronJob pods carried `commonLabels` — a strict superset of the two labels the API Service selected on — so every scheduled run published a pod with nothing listening on the API port as a Service endpoint. The Service uses a numeric `targetPort`, so the EndpointSlice controller admits a pod without a matching container port, and a Job pod carries no readiness probe, so it is Ready from its first moment. A share of in-cluster API traffic was answered with `ECONNREFUSED` for the pod's whole runtime — hourly by default, from the keystone trust flush.

The fix distinguishes API pods with `app.kubernetes.io/component=api` and narrows the API Service selector to it.

## Commits in order

**`df2ad1e9` feat(common): add component label helpers to the naming package**

`naming` gains `LabelKeyComponent`, `ComponentAPI`, `APISelectorLabels` (selector labels plus the API component), `ComponentLabels` (a strict superset of `SelectorLabels`, so the Deployment and NetworkPolicy pod selectors keep matching every component), and `ExcludeJobPods` (a `batch.kubernetes.io/job-name DoesNotExist` requirement). `internal/common/deployment` gains two helpers the two-phase narrowing is built on: `TemplateConverged` (observed generation current, at least one pod, `UpdatedReplicas == Replicas`) and `APISelectorNarrowed` (reads the live Service to latch the migration; requires an uncached reader).

**`8dbaf1ac` fix(keystone): keep maintenance pods out of the API Service**

API Deployment labels and the API Service selector gain `component=api`; the trust-flush, fernet-rotation, credential-rotation and admin-password-rotation pod templates each get their own component value, so none can satisfy the Service selector again. The Deployment pod selector (immutable after creation) and the NetworkPolicy `podSelector` (which the maintenance pods must keep matching to inherit the kube-apiserver egress rule from #461) stay on name and instance.

**`cbae0135` fix(glance): keep db-purge pods out of the API Service** — the same shape, with `component=db-purge` on the purge pod template; the NetworkPolicy selector stays wide so `glance-manage` keeps its auto-derived database and DNS egress.

**`f3626012` fix(horizon): select the API Service by component label** — convention alignment. Horizon projects no CronJobs today, so nothing is landing in its Service wrongly; it shares `deployment.BuildService`, and taking the fixed shape now keeps any later maintenance pod out from day one. Adds the `horizonDeploymentRolledOut` predicate mirroring its keystone and glance counterparts.

**`90d268a5` test(e2e): pin API endpoint isolation across a trust-flush run**

New keystone suite `maintenance-endpoint-isolation`: a CR whose trust flush fires every minute, with the API Service EndpointSlices sampled once a second for 90 s. It fails as soon as the slices list more non-terminating addresses than the live Deployment's `spec.replicas`. All addresses count, not only ready ones (a Job pod has no readiness probe); terminating addresses are excluded so an ordinary API-pod replacement is not misreported. Because an upper bound alone is also satisfied by a Service with no backends, the suite additionally requires the full replica count to be observed at least once, and requires a live trust-flush pod holding a pod IP to be observed while sampling — a completed pod keeps its IP but is ignored by the endpoints controller, so a leftover from an earlier run would prove nothing. `tests/e2e-operator-upgrade/keystone-helm-upgrade` additionally samples the EndpointSlices across a real helm upgrade and fails if the backend count ever drops or if the narrowing never lands.

**`ac742437` docs(keystone): document component labels and the two-phase narrowing** — Deployment/Service/PDB spec tables, the rationale for the two-phase narrowing, and the new suite in the e2e inventory. The stated keystone suite count moves to 50; the previous 47 had already drifted by two before this suite existed.

## Divergences from the issue

Two, both deliberate, both taking an option the issue named:

1. **No endpoint gap on upgrade.** The issue accepted a window with no backends ("roughly 20–40 s for keystone") and asked for a release note, while noting an implementer could instead gate the narrow selector on the rollout having converged. This branch takes that second path. `EnsureDeployment` is a Server-Side Apply that returns as soon as the API server accepts the pod template, so narrowing in the same pass would drop every still-running pre-upgrade pod out of the EndpointSlices while those are the only ones serving — and a wedged rollout would never repool them. The reconciler keeps the wide selector until `TemplateConverged`, narrows on the next pass (triggered by the Deployment watch), and latches the result via `APISelectorNarrowed` so no later rollout — or a single restarted pod — can widen it again. Consequence: no upgrade note is needed, but `reconcileDeployment` carries a migration branch, and the controllers need `mgr.GetAPIReader()` (reading the latch through the informer cache could decide it from pre-narrowing state).

2. **The PodDisruptionBudget selector is fixed here, not deferred.** The issue put it out of scope pending its own migration questions. Those questions resolve differently than the Service's, which is why it landed: keying the budget on `component=api` would leave the pre-upgrade pods matched by *no* budget at all — and unlike the Service's, that gap has no bound, since a rollout wedged on a bad image or a quota rejection keeps unlabelled pods alive indefinitely. The budget therefore keeps name and instance and excludes maintenance pods by the *absence* of `batch.kubernetes.io/job-name` instead, which holds for labelled and unlabelled API pods alike and needs no staging.

The other item the issue deferred, the default topology spread constraints, is untouched.

## Reviewer note

The PDB paragraph in the three `fix(...)` commit bodies is stale: it describes narrowing the budget by the component label and argues "a budget that matches no pod is inert, so the narrow form is safe from the very first pass". The shipped code and the docs commit reject exactly that reasoning and use `ExcludeJobPods` instead, for the reason given above. The code is consistent within every commit — only that paragraph of the commit prose describes a superseded approach.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) bb6d479 with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788001223&installation_model_id=18560&pr_number=785&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F785&signature=51d4b8b37ba56445c0a0a90a38a3a66e90b1b657eccfecebe86bfebef350fc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->