### PR TITLE
Refresh the new-operator checklist and close the horizon image-cleanup gap

### DIFF
--- a/.claude/skills/check-service-parity/SKILL.md
+++ b/.claude/skills/check-service-parity/SKILL.md
@@ -89,7 +89,12 @@ inventory. Exit code `1` means at least one `[FAIL]`. Interpret:
   to a registered one.
 - **P5** — CI wiring: the paths-filter block, `ALL_OPERATORS`,
   `FILTER_<svc>`, the unit/integration test matrices, the
-  helm-validate chart loop, and the build/cleanup image matrices.
+  helm-validate chart loop, the build-images coverage, and each of the
+  three cleanup-images matrices on its own (`cleanup-operator-images`,
+  `cleanup-service-images`, and `cleanup-e2e-stale-tags`, the last
+  needing both `<svc>-operator` and `<svc>`), with exact list-item
+  matches so a bare service name cannot satisfy a check by matching
+  its `<svc>-operator` sibling.
   These are the enumeration points `hack/ci-resolve-changes.sh`
   cannot reach on its own — a missing entry means the service's tests
   never run and CI stays green.

--- a/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
+++ b/.claude/skills/check-service-parity/scripts/audit-service-parity.sh
@@ -16,7 +16,8 @@
 #       parity with the keystone reference chart
 #   P4  observability: dashboards/<svc>-operator.json + dashboard_test.go
 #   P5  CI wiring: paths-filter, ALL_OPERATORS, FILTER_<svc>, unit-test
-#       matrices, helm-validate chart loop, build/cleanup image matrices
+#       matrices, helm-validate chart loop, build-images coverage, and each
+#       of the three cleanup-images matrices individually (exact item match)
 #   P6  e2e coverage: canonical chainsaw suite set under tests/e2e/<svc>/
 #       (incl. latest-release variant) plus at least one chaos suite
 #   P7  deploy stack: flux HelmRelease, namespace entry, kustomization entry,
@@ -58,6 +59,19 @@ ALLOWED_DEVIATIONS="
 
 allowed() { # allowed <svc> <check> <item>
   printf '%s\n' "${ALLOWED_DEVIATIONS}" | grep -qx "${1}:${2}:${3}"
+}
+
+# cleanup_matrix <job> — the `package: [...]` line of one cleanup-images.yaml
+# job, so membership is judged per matrix rather than across the whole file.
+cleanup_matrix() {
+  sed -n "/^  ${1}:/,/^  [a-z]/p" .github/workflows/cleanup-images.yaml \
+    | grep -E 'package: \[' || true
+}
+
+# matrix_has <matrix-line> <item> — exact list-item match. grep -w would let
+# a bare service name match its <svc>-operator sibling across the hyphen.
+matrix_has() {
+  grep -Eq "(\[|, )${2}(,|\])" <<<"${1}"
 }
 
 # check <svc> <check-id> <item> <condition-exit-code> <fail-message>
@@ -222,13 +236,25 @@ for svc in ${SERVICES}; do
   check "${svc}" P5 "build-images" "${t}" \
     "build-images.yaml lints/builds images/${svc}/Dockerfile"
 
-  t=0; grep -qw "${svc}-operator" .github/workflows/cleanup-images.yaml || t=1
+  # Each cleanup matrix is checked on its own, with exact list-item matches.
+  # A file-wide (or word-boundary) grep hides two gap classes: a package
+  # present in one matrix but missing from another, and a bare service name
+  # "matching" its <svc>-operator sibling across the hyphen.
+  op_matrix=$(cleanup_matrix cleanup-operator-images)
+  t=0; matrix_has "${op_matrix}" "${svc}-operator" || t=1
   check "${svc}" P5 "cleanup-operator" "${t}" \
-    "cleanup-images.yaml covers the ${svc}-operator package"
+    "cleanup-images.yaml cleanup-operator-images matrix lists ${svc}-operator"
 
-  t=0; grep -E 'package: \[' .github/workflows/cleanup-images.yaml | grep -qw "${svc}" || t=1
+  svc_matrix=$(cleanup_matrix cleanup-service-images)
+  t=0; matrix_has "${svc_matrix}" "${svc}" || t=1
   check "${svc}" P5 "cleanup-service" "${t}" \
-    "cleanup-images.yaml covers the ${svc} service-image package"
+    "cleanup-images.yaml cleanup-service-images matrix lists ${svc}"
+
+  stale_matrix=$(cleanup_matrix cleanup-e2e-stale-tags)
+  t=0; matrix_has "${stale_matrix}" "${svc}-operator" \
+    && matrix_has "${stale_matrix}" "${svc}" || t=1
+  check "${svc}" P5 "cleanup-e2e-stale" "${t}" \
+    "cleanup-images.yaml cleanup-e2e-stale-tags matrix lists ${svc}-operator and ${svc}"
 done
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone-operator, c5c3-operator, glance-operator]
+        package: [keystone-operator, c5c3-operator, horizon-operator, glance-operator]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone-operator, c5c3-operator, keystone, glance-operator, glance, tempest]
+        package: [keystone-operator, c5c3-operator, keystone, horizon-operator, horizon, glance-operator, glance, tempest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/docs/contributing/adding-a-new-operator.md
+++ b/docs/contributing/adding-a-new-operator.md
@@ -18,17 +18,20 @@ build/CI/config seams that are still enumerated per operator.
 ## Shared packages to consume
 
 Build the operator on the shared scaffolding rather than hand-rolling copies.
-The keystone operator is the reference consumer for every package listed.
+The keystone operator is the reference consumer for most packages listed (for
+`pysettings` it is the horizon operator).
 
 | Package | Provides |
 | --- | --- |
 | `internal/common/types` | Shared CRD spec types (`DatabaseSpec`, `CacheSpec`, `GatewaySpec`, `ImageSpec`, `DeploymentSpec`, `AutoscalingSpec`, `NetworkPolicySpec`, `LoggingSpec`, ...) with their CEL rules and `Default()` methods |
 | `internal/common/naming` | Label keys and `CommonLabels`/`SelectorLabels`, the workload naming convention (and the cross-service endpoint contract, see below); the sub-resource name is the bare CR name, so each operator keeps its own one-line helper |
 | `internal/common/reconcile` | Table-driven pipeline (`Step`/`RunPipeline`), parallel groups (`ParallelStep`/`RunParallelGroup`), non-short-circuiting sequential groups (`RunSequentialGroup`), `ShortestRequeue`, `SetAggregateReady`, the no-op-skipping `UpdateStatus`, `EnsureFinalizer`, the shared requeue constants (`RequeueDeploymentPolling`/`RequeueSecretPolling`), the `Skeleton[T,S]` controller-skeleton glue (Ready aggregation, status write, `MarkFailed`, parallel-group), and `ProjectChild`/`DeleteOrphanedChild` for orchestrating operators that project child CRs |
+| `internal/common/conditions` | `SetCondition` (a `LastTransitionTime`-preserving upsert), `GetCondition`, `IsReady`, `AllTrue` |
 | `internal/common/watch` | `CRUpdatePredicate` for the `For(...)` watch, `SecretToOwnersMapper` + `RegisterSecretNameIndex`, `StoreRefFanOut` (enqueues only the CRs whose effective `spec.secretStoreRef` matches a changed cluster-scoped `ClusterSecretStore` or namespaced `SecretStore`), `ClusterRefMapper` (database-cluster reference to owning CRs) |
 | `internal/common/bootstrap` | `Run`/`ManagerConfig` manager bootstrap, `NewScheme` scheme assembly (client-go baseline first, then the per-operator extras), `ControllerOptions` (concurrency + tuned rate limiter), `DetectOperatorNamespace` |
 | `internal/common/instrumentation` | Sub-reconciler duration/error metrics; declare a `NewSubReconcilerInstrumenter("<op>_operator", conditionTypes)` in the operator and pass its bound `Instrument` method to the reconcile pipeline, then register it from a `RegisterMetrics()` wired into `main.go` (registration returns an error instead of panicking) |
 | `internal/common/deployment` | SSA ensure primitives, `BuildWorkload`/`BuildService` (shared pod-template and Service assembly), `RestrictedSecurityContext`, PDB/HPA builders, `ReconcileHPA` flow, replica normalization, pod-knob default helpers |
+| `internal/common/apply` | The SSA apply primitives under every ensure helper: `EnsureObject` (owner-referenced) and `EnsureUnownedObject` |
 | `internal/common/networkpolicy` | `Ensure`/`Delete`, the auto-derived egress rules (`DNSEgressRule`/`DatabaseEgressRule`/`CacheEgressRule`/`CacheEgressPorts`), `IngressPeers`, and the three-path `Reconcile` flow with the fail-closed empty-ingress guard |
 | `internal/common/gateway` | `IsGVKAvailable` CRD probe, HTTPRoute builder/acceptance/ensure/delete over the shared `GatewaySpec`, and the three-path `ReconcileHTTPRoute` flow |
 | `internal/common/secrets` | ESO primitives, `OpenBaoClusterStoreName`, per-CR store-ref resolution (`EffectiveStoreRef`, `IsStoreRefReady`, `ESOSecretStoreRef`, `PushSecretStoreRefs`), the `GateSyncedSecret` ladder, the `GateStoreReady` store-ref gate and `GateCredential`/`GateCredentials` condition-reporting loop |
@@ -36,10 +39,15 @@ The keystone operator is the reference consumer for every package listed.
 | `internal/common/webhook` | `NoopDeleteValidator` (the never-invoked `ValidateDelete` embed for webhooks that guard create and update only) |
 | `internal/common/database`, `internal/common/cache` | MariaDB CR apply, `BuildDatabase`/`BuildUser`/`BuildGrant` provisioning builders, host/port/username resolution, pymysql DSN + TLS params + rollout digest, memcache server resolution; plus the reconcile flows layered on top: `ReconcileProvision` (cluster gate + Database/User/Grant ensure + Dynamic-credentials skip), `ReconcileSyncJobs` (db-sync + schema-check via the parameterized `JobSetParams` table, `InstalledRelease` tracking), `ReconcileConnectionSecret` + `ConnectionEnvVar`/`ConnectionSecretName` (derived `<name>-db-connection` Secret + DSN digest), and `FinalizeResources`/`HasLiveResources` finalizer cleanup |
 | `internal/common/rotation` | Split-compute-write credential rotation: `EnsureStagingSecret`, `CommitStaged`/`CommitSpec`, `EnsureRBAC`, `CompletedAt`/`ObserveAge`, `BuildCronJob`/`CronJobParams` |
+| `internal/common/tls` | `EnsureCertificate` for cert-manager Certificate objects |
 | `internal/common/release` | OpenStack release parsing and upgrade/downgrade classification |
 | `internal/common/healthcheck` | `HTTPDoer` seam, probe-error classifier, TTL probe cache, the shared timing constants, and the `ReconcileProbe` flow |
 | `internal/common/job` | `RunJob`/`RunJobWithRerunKey`/`EnsureCronJob`/`DeleteCronJob`, the `BuildMigrationJob` skeleton, and the at-most-once `RecordJobTerminalState` recorder |
-| `internal/common/config` | oslo INI rendering + immutable-ConfigMap lifecycle (see the design decisions below for non-INI services) |
+| `internal/common/config` | oslo INI rendering + immutable-ConfigMap lifecycle, the extraConfig overlay (`MergeDefaults`) with owned-key health tracking, and the option-catalog machinery (`ParseOptionCatalog`, `MustParseEmbeddedCatalogs`); see the design decisions below for non-INI services |
+| `internal/common/keystoneauth` | `[keystone_authtoken]` section rendering without the password (`Section`) plus the `OS_KEYSTONE_AUTHTOKEN__PASSWORD` env-var injection (`PasswordEnvVar`) |
+| `internal/common/policy` | oslo policy handling: `LoadPolicyFromConfigMap`, `RenderPolicyYAML`, `MergePolicies`, `ValidatePolicyRules` |
+| `internal/common/plugins` | Paste-pipeline and middleware/plugin config rendering for services with a paste-deploy stack |
+| `internal/common/pysettings` | Python-settings rendering for non-INI services (Django `local_settings.py`); see the design decisions below |
 | `internal/common/testutil/envtest` | envtest bootstrap, `BuildScheme`, `CommonExternalSchemes`, `CommonFakeCRDDirs`, `StartManagedEnvTest`, `SetupEnvTestWithCRDs` (webhook-less), `SetupUnstartedManager` |
 
 ## Residual touch list
@@ -47,14 +55,14 @@ The keystone operator is the reference consumer for every package listed.
 Everything below is still enumerated per operator. Work through it top to
 bottom when scaffolding `operators/<op>/`:
 
-- **`go.work`** — add `./operators/<op>`; keep the Go directive, toolchain, and
-  the controller-runtime/k8s.io dependency versions in lockstep with the other
+- **`go.work`** — add `./operators/<op>`; keep the Go directive and the
+  controller-runtime/k8s.io dependency versions in lockstep with the other
   modules (see [Dependency Management](./dependency-management.md)).
 - **`operators/Dockerfile`** — the parameterized Dockerfile builds every
   operator via `--build-arg OPERATOR=<op>`; add the new module's
   `go.mod`/`go.sum` and source `COPY` lines (two lines total).
-- **`Makefile`** — extend `OPERATORS ?= keystone c5c3`; every build/test/
-  generate/lint target iterates it, provided the chart lives at
+- **`Makefile`** — append the operator to the `OPERATORS ?=` list; every
+  build/test/generate/lint target iterates it, provided the chart lives at
   `operators/<op>/helm/<op>-operator/`.
 - **Helm chart** — scaffold `operators/<op>/helm/<op>-operator/` consuming the
   `operator-library` chart: every shared manifest (deployment, certificate,
@@ -62,9 +70,20 @@ bottom when scaffolding `operators/<op>/`:
   webhook-configuration) is a one-line `include`; per-operator content is
   `Chart.yaml`, `values.yaml`, the `<op>-operator.rbacRules` helper, and the
   helm-unittest suite.
+- **`.gitignore`** — add `operators/<op>/helm/<op>-operator/charts/` (bare
+  pattern, no leading slash) so the `operator-library` tarball vendored by
+  `make helm-deps` stays untracked.
 - **`hack/gen-helm-values-schema.py`** — charts are discovered from the
   directory layout; add the new chart's `WEBHOOK_ENABLED_DESCRIPTIONS` entry
   (the generator fails loudly without it), then run `make gen-helm-schema`.
+- **Option catalog** (oslo-INI services only) — map the service to its
+  upstream oslo-config-generator config in `hack/gen-option-catalog.sh`, add
+  it to the service loops of the `gen-option-catalogs` and
+  `verify-option-catalogs` Makefile targets, and commit the generated
+  per-release catalogs under `operators/<op>/api/v1alpha1/catalogs/` with a
+  `go:embed` accessor. The validating webhook checks `spec.extraConfig`
+  against these catalogs; both targets need docker and the published service
+  images.
 - **`.github/workflows/ci.yaml`** — the biggest surface: add the operator to
   the paths-filter groups, `ALL_OPERATORS` and the `FILTER_<op>` env var, the
   unit/integration test matrices, the helm-validate chart loops, and the
@@ -73,15 +92,32 @@ bottom when scaffolding `operators/<op>/`:
   image (the shared `operators/Dockerfile` is already wired); only new service
   images under `images/` need matrix entries.
 - **`.github/workflows/cleanup-images.yaml`** — add `<op>-operator` to the
-  `cleanup-operator-images` and `cleanup-e2e-stale-tags` matrices.
+  `cleanup-operator-images` matrix, and both `<op>-operator` and `<op>` to
+  the `cleanup-e2e-stale-tags` matrix. Only the `cleanup-service-images`
+  matrix is guarded by a test
+  (`tests/container-images/verify_release_config.sh`); the other two are
+  checked by the service-parity audit alone.
 - **`.codecov.yml`** — add the per-operator `unit-<op>`/`integration-<op>`
   flag blocks; the components section auto-scales via `operators/*` globs.
+- **Dashboards** — ship `operators/<op>/dashboards/<op>-operator.json` with a
+  `dashboard_test.go` asserting the JSON parses and every metric a panel
+  references is registered by the operator. Only the keystone dashboard is
+  staged into the kind Prometheus stack; no deploy wiring is needed.
 - **Tests** — `operators/<op>/internal/testutil/` wraps
   `internal/common/testutil/envtest` with the op-local CRD/webhook paths and
   scheme list; E2E suites live under `tests/e2e/<op>/` (one directory per
-  feature, mirroring `tests/e2e/keystone/`).
+  feature, mirroring `tests/e2e/keystone/`), plus at least one chaos suite
+  under `tests/e2e-chaos/`.
+- **Deploy stack** — a flux HelmRelease under `deploy/flux-system/releases/`
+  with the matching kind-overlay suspend patch, plus the literal lists in
+  `hack/deploy-infra.sh` (the un-suspend step and the ServiceMonitor toggle)
+  and the target tuple in `hack/refresh-operator-image-digests.sh`. An
+  operator missing from the un-suspend list wedges the ControlPlane cache
+  sync.
 - **Docs** — a CRD reference and reconciler reference under
-  `docs/reference/<op>/`, wired into `docs/.vitepress/config.ts`.
+  `docs/reference/<op>/`, wired into `docs/.vitepress/config.ts`, plus a
+  naming-convention test in `tests/unit/docs/` (discovered by glob, so
+  nothing fails while it is missing).
 
 ## Design decisions the shared scaffolding encodes
 
@@ -116,6 +152,5 @@ new operators build on them rather than reopening them:
   `internal/common/config` renders oslo INI only and stays that way. A service
   that renders Python settings (e.g. Horizon's Django `local_settings.py`)
   gets a separate shared renderer package rather than bolting Python emission
-  onto the INI renderer. `internal/common/pysettings` now exists — implemented
-  with its first consumer, the horizon-operator, which is also the checklist's
-  first full second-operator walk-through.
+  onto the INI renderer. `internal/common/pysettings` now exists, implemented
+  with its first consumer, the horizon-operator.


### PR DESCRIPTION
Closes #788.

The new-operator contributing checklist drifted behind the repository, and the drift produced a real gap: horizon is missing from two of the three cleanup matrices in `cleanup-images.yaml`, so its old CI tags accumulate on GHCR without bound. Three commits, in order:

1. **ci: add horizon to the cleanup-images matrices** — adds `horizon-operator` to the `cleanup-operator-images` matrix and `horizon-operator` plus `horizon` to the `cleanup-e2e-stale-tags` matrix. Only the `cleanup-service-images` matrix is test-guarded (`verify_release_config.sh`, still 95/0 after the change), which is why this went unnoticed.
2. **chore(skills): check each cleanup matrix individually in the parity audit** — the P5 cleanup checks matched file-wide, so a package present in one matrix but absent from another passed, and `grep -w horizon` matched `horizon-operator` across the hyphen. The audit now extracts each job's `package:` line and matches exact list items, with a new third check for the stale-tags matrix. Run against the unfixed matrices it reports the horizon rows as `[FAIL]`; after commit 1 they pass.
3. **docs(contributing): refresh the adding-a-new-operator checklist** — full re-audit of `docs/contributing/adding-a-new-operator.md`: enumeration-free `OPERATORS` step, the phantom toolchain pin removed, new steps for `.gitignore`, dashboards, the option catalog, and the deploy stack, a sharpened cleanup step, seven missing rows in the shared-packages table, and the stale horizon walk-through framing dropped.

The audit's `placement` rows still report `[FAIL]` by design; that wiring is #770's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXVpPJ1LVeqqg2zVPpAya5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788018452&installation_model_id=18560&pr_number=789&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F789&signature=6c6fa83c54d88082a5a4c1ac984c4b4cf33f8aa1e5ef8046e5cae3645121871d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->