### PR TITLE
feat(placement): wire placement through CI, e2e, and the deploy stack

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -54,6 +54,10 @@ flag_management:
       paths:
         - operators/glance/
       carryforward: true
+    - name: unit-placement
+      paths:
+        - operators/placement/
+      carryforward: true
     - name: integration-common
       paths:
         - internal/common/
@@ -73,6 +77,10 @@ flag_management:
     - name: integration-glance
       paths:
         - operators/glance/
+      carryforward: true
+    - name: integration-placement
+      paths:
+        - operators/placement/
       carryforward: true
 
 # Component-level thresholds: each component is tracked independently on the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,10 @@ jobs:
               - 'operators/glance/**'
               - 'operators/Dockerfile'
               - 'images/glance/**'
+            placement:
+              - 'operators/placement/**'
+              - 'operators/Dockerfile'
+              - 'images/placement/**'
             docs:
               - 'docs/**'
               - 'package.json'
@@ -114,6 +118,7 @@ jobs:
               - 'operators/c5c3/helm/**'
               - 'operators/horizon/helm/**'
               - 'operators/glance/helm/**'
+              - 'operators/placement/helm/**'
               - 'operators/shared/helm/**'
               - 'hack/gen-helm-values-schema.py'
               - 'Makefile'
@@ -183,11 +188,12 @@ jobs:
       - name: Resolve effective changes
         id: result
         env:
-          ALL_OPERATORS: keystone c5c3 horizon glance
+          ALL_OPERATORS: keystone c5c3 horizon glance placement
           FILTER_keystone: ${{ steps.filter.outputs.keystone }}
           FILTER_c5c3: ${{ steps.filter.outputs.c5c3 }}
           FILTER_horizon: ${{ steps.filter.outputs.horizon }}
           FILTER_glance: ${{ steps.filter.outputs.glance }}
+          FILTER_placement: ${{ steps.filter.outputs.placement }}
           FILTER_docs: ${{ steps.filter.outputs.docs }}
           FILTER_helm: ${{ steps.filter.outputs.helm }}
           FILTER_e2e_infra: ${{ steps.filter.outputs.e2e_infra }}
@@ -371,7 +377,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [common, keystone, c5c3, horizon, glance]
+        target: [common, keystone, c5c3, horizon, glance, placement]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -408,7 +414,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [common, keystone, c5c3, horizon, glance]
+        target: [common, keystone, c5c3, horizon, glance, placement]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -556,13 +562,13 @@ jobs:
         run: make helm-deps
       - name: Helm lint
         run: |
-          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator; do
+          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator operators/placement/helm/placement-operator; do
             echo "--- lint $chart ---"
             helm lint "$chart"
           done
       - name: Helm template
         run: |
-          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator; do
+          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator operators/placement/helm/placement-operator; do
             echo "=== $chart ==="
             echo "--- Scenario 1: default values ---"
             helm template test "$chart"
@@ -577,7 +583,7 @@ jobs:
           done
       - name: Helm unittest
         run: |
-          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator; do
+          for chart in operators/keystone/helm/keystone-operator operators/c5c3/helm/c5c3-operator operators/horizon/helm/horizon-operator operators/glance/helm/glance-operator operators/placement/helm/placement-operator; do
             echo "--- unittest $chart ---"
             helm unittest "$chart"
           done
@@ -711,13 +717,32 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Tempest and the e2e-chaos suites always exercise both keystone and
-      # glance, so both must be built regardless of which operator triggered
-      # the pipeline.  Union the changed-operator list with fixed "keystone"
-      # and "glance" entries so the dependency is explicit.
+      # glance, and the e2e-chaos pod leg always exercises placement, so all
+      # three must be built regardless of which operator triggered the
+      # pipeline.  Union the changed-operator list with fixed "keystone",
+      # "glance" and "placement" entries so the dependency is explicit.
+      #
+      # placement is unioned in unconditionally rather than behind a copy of
+      # the e2e-chaos `if:`. That condition lives hundreds of lines away and
+      # nothing keeps a duplicate in sync, so a third trigger added there
+      # would leave the pod leg pulling a placement tag this job never
+      # pushed — a blocking failure an hour into the run. Such a gate would
+      # also save very little: a non-empty operator matrix already implies
+      # e2e-chaos runs (every path that fills the matrix sets go=true or
+      # forces the full E2E suite), so it would skip the build only on the
+      # PRs that reach this job through the e2e-prometheus or
+      # e2e-controlplane paths alone.
       - name: Resolve build operators
         run: |
-          ops=$(echo '${{ needs.changes.outputs.e2e-operators }}' | jq -r '.operator[]')
-          for base in keystone glance; do
+          # ci-resolve-changes.sh emits {"operator":["__none__"]} when no
+          # operator changed, so fromJson() stays valid in the matrix jobs that
+          # gate on has-e2e-operators. This job is the one consumer that reads
+          # the matrix ungated (it also runs for e2e-chaos/-prometheus/
+          # -controlplane), so the sentinel must be dropped here — otherwise
+          # `make docker-build OPERATOR=__none__` fails the build on exactly
+          # the PRs the comment above describes.
+          ops=$(echo '${{ needs.changes.outputs.e2e-operators }}' | jq -r '.operator[] | select(. != "__none__")')
+          for base in keystone glance placement; do
             if ! printf '%s\n' $ops | grep -qx "$base"; then
               ops=$(printf '%s\n%s' "$ops" "$base")
             fi
@@ -972,6 +997,7 @@ jobs:
           kubectl apply -f operators/keystone/helm/keystone-operator/crds/
           kubectl apply -f operators/horizon/helm/horizon-operator/crds/
           kubectl apply -f operators/glance/helm/glance-operator/crds/
+          kubectl apply -f operators/placement/helm/placement-operator/crds/
           hack/ci-deploy-korc.sh
       # Use shared operator deployment script. NAMESPACE mirrors what
       # hack/ci-dump-diagnostics.sh derives (${OPERATOR}-system) so the
@@ -1178,6 +1204,7 @@ jobs:
               tests/e2e-chaos/operator-pod-crash
               tests/e2e-chaos/operator-pod-kill
               tests/e2e-chaos/glance-operator-pod-kill
+              tests/e2e-chaos/placement-operator-pod-kill
           - suite: network
             runner: self-hosted
             test_dirs: >-
@@ -1212,6 +1239,11 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/horizon:2025.2
             ${{ env.IMAGE_PREFIX }}/glance-operator:dev
             ${{ env.IMAGE_PREFIX }}/glance:2025.2
+            # placement is exercised by the pod leg alone (see the pod-leg-only
+            # load and deploy steps below); the action skips the blank lines the
+            # network leg renders here.
+            ${{ matrix.suite == 'pod' && format('{0}/placement-operator:dev', env.IMAGE_PREFIX) || '' }}
+            ${{ matrix.suite == 'pod' && format('{0}/placement:2025.2', env.IMAGE_PREFIX) || '' }}
       - name: Load images into kind
         run: |
           kind load docker-image ${{ env.IMAGE_PREFIX }}/keystone-operator:dev --name ${{ env.KIND_CLUSTER }}
@@ -1221,6 +1253,16 @@ jobs:
           kind load docker-image ${{ env.IMAGE_PREFIX }}/horizon:2025.2 --name ${{ env.KIND_CLUSTER }}
           kind load docker-image ${{ env.IMAGE_PREFIX }}/glance-operator:dev --name ${{ env.KIND_CLUSTER }}
           kind load docker-image ${{ env.IMAGE_PREFIX }}/glance:2025.2 --name ${{ env.KIND_CLUSTER }}
+      # placement-operator-pod-kill is the only suite that touches placement and
+      # it runs on the pod leg; none of the network leg's four suites reference
+      # it. Keep the load off that leg — `kind load docker-image` is a docker
+      # save piped into the node's containerd and the placement service image is
+      # the expensive half of the pair.
+      - name: Load placement images into kind
+        if: matrix.suite == 'pod'
+        run: |
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/placement-operator:dev --name ${{ env.KIND_CLUSTER }}
+          kind load docker-image ${{ env.IMAGE_PREFIX }}/placement:2025.2 --name ${{ env.KIND_CLUSTER }}
       # Use composite action for shared Flux CLI + test deps + deploy-infra sequence.
       # Opt in to Chaos Mesh - required for the chaos suites; covers both matrix entries.
       - name: Setup E2E infrastructure
@@ -1261,6 +1303,19 @@ jobs:
           OPERATOR: glance
           IMAGE_REPO: ${{ env.IMAGE_PREFIX }}/glance-operator
           NAMESPACE: glance-system
+      # The placement chaos suite needs the placement-operator too. Like horizon
+      # and glance it must land in its own placement-system namespace, not the
+      # script's keystone-system default: that is where the Flux/deploy-infra
+      # path installs it and where the suite's pod selector and PodChaos look.
+      # Pod leg only — the suite that needs it runs there, so the network leg
+      # would `helm install --wait` an operator that reconciles nothing.
+      - name: Deploy placement operator
+        if: matrix.suite == 'pod'
+        run: hack/ci-deploy-operator.sh
+        env:
+          OPERATOR: placement
+          IMAGE_REPO: ${{ env.IMAGE_PREFIX }}/placement-operator
+          NAMESPACE: placement-system
       - name: Run chaos E2E tests
         run: |
           mkdir -p _output/reports
@@ -1904,7 +1959,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone-operator, keystone, c5c3-operator, horizon-operator, horizon, glance-operator, glance, tempest]
+        package: [keystone-operator, keystone, c5c3-operator, horizon-operator, horizon, glance-operator, glance, placement-operator, placement, tempest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # GH-312: do NOT pass delete-untagged here. This job runs in

--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone-operator, c5c3-operator, horizon-operator, glance-operator]
+        package: [keystone-operator, c5c3-operator, horizon-operator, glance-operator, placement-operator]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [keystone-operator, c5c3-operator, keystone, horizon-operator, horizon, glance-operator, glance, tempest]
+        package: [keystone-operator, c5c3-operator, keystone, horizon-operator, horizon, glance-operator, glance, placement-operator, placement, tempest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ verify-invalid-cr-fixtures:
 	@python3 tests/e2e/c5c3/invalid-cr/_generate.py --check
 	@python3 tests/e2e/glance/invalid-cr/_generate.py --check
 	@python3 tests/e2e/glance/invalid-glancebackend-cr/_generate.py --check
+	@python3 tests/e2e/placement/invalid-cr/_generate.py --check
 	@echo "Running invalid-CR fixture unit tests..."
 	@python3 tests/e2e/keystone/invalid-cr/test_generate.py
 	@python3 tests/e2e/keystone/invalid-identitybackend-cr/test_generate.py
@@ -388,6 +389,7 @@ verify-invalid-cr-fixtures:
 	@python3 tests/e2e/c5c3/invalid-cr/test_generate.py
 	@python3 tests/e2e/glance/invalid-cr/test_generate.py
 	@python3 tests/e2e/glance/invalid-glancebackend-cr/test_generate.py
+	@python3 tests/e2e/placement/invalid-cr/test_generate.py
 
 .PHONY: gen-option-catalogs
 # gen-option-catalogs regenerates the per-release option catalogs the

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ chainsaw-lint:
 test-shell:
 	@echo "Running shell unit tests..."
 	@status=0; \
-	for t in tests/unit/hack/*_test.sh tests/unit/deploy/*_test.sh tests/unit/renovate/*_test.sh tests/unit/docs/*_test.sh; do \
+	for t in tests/unit/hack/*_test.sh tests/unit/deploy/*_test.sh tests/unit/renovate/*_test.sh tests/unit/docs/*_test.sh tests/unit/ci/*_test.sh; do \
 		[ -f "$$t" ] || continue; \
 		echo "=== $$t ==="; \
 		bash "$$t" || status=1; \

--- a/deploy/flux-system/kustomization.yaml
+++ b/deploy/flux-system/kustomization.yaml
@@ -50,6 +50,7 @@ resources:
   - releases/keystone-operator.yaml
   - releases/horizon-operator.yaml
   - releases/glance-operator.yaml
+  - releases/placement-operator.yaml
   - releases/k-orc.yaml
   - releases/c5c3-operator.yaml
   # Garage object store operator (S3 backend for the CI/e2e stack).

--- a/deploy/flux-system/namespaces.yaml
+++ b/deploy/flux-system/namespaces.yaml
@@ -73,6 +73,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: placement-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: c5c3-system
 ---
 apiVersion: v1

--- a/deploy/flux-system/releases/placement-operator.yaml
+++ b/deploy/flux-system/releases/placement-operator.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The placement-operator controller runs in its own dedicated placement-system
+# Namespace; the Placement CR and the operator-managed payload (Deployment,
+# Secrets, HTTPRoute, NetworkPolicy) live in the openstack tenant Namespace.
+# dependsOn: keystone-operator is ordered so the resource-tracking service's
+# identity backend exists before Placement is projected; mariadb-operator is
+# required because Placement has a database and memcached-operator because it
+# caches Keystone tokens. That is the same dependency set as glance-operator.
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: placement-operator
+  namespace: placement-system
+spec:
+  interval: 30m
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: mariadb-operator
+      namespace: mariadb-system
+    - name: memcached-operator
+      namespace: memcached-system
+    - name: external-secrets
+      namespace: external-secrets
+    - name: keystone-operator
+      namespace: keystone-system
+  chart:
+    spec:
+      chart: placement-operator
+      # Floor 0.1.0: the first published chart, whose values schema already
+      # accepts image.digest. Older charts do not exist — this operator is
+      # first published to GHCR when this release lands on main.
+      version: ">=0.1.0 <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: c5c3-charts
+        namespace: flux-system
+  values:
+    replicas: 2
+    leaderElection:
+      enabled: true
+    image:
+      # Use latest until a versioned release (v* git tag) publishes a semver image tag.
+      # The chart default (appVersion) only works once 0.1.0 has been released.
+      tag: latest
+  # image.digest is injected from a ConfigMap that
+  # hack/refresh-operator-image-digests.sh (re)applies at deploy time on the
+  # WITH_CONTROLPLANE flux path, pinning the mutable :latest tag to the digest
+  # current at deploy. optional: true — when the ConfigMap is absent (default
+  # Quick Start and CI paths) the release renders exactly as before. Flux
+  # merges valuesFrom first, then spec.values on top per-key (deep merge), so
+  # image.tag stays from spec.values and image.digest comes only from here.
+  valuesFrom:
+    - kind: ConfigMap
+      name: placement-operator-image-digest
+      valuesKey: values.yaml
+      optional: true
+  install:
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3

--- a/deploy/kind/base/kustomization.yaml
+++ b/deploy/kind/base/kustomization.yaml
@@ -147,6 +147,25 @@ patches:
       spec:
         suspend: true
 
+  # placement-operator: suspend Flux management in kind for the same reason as
+  # keystone-operator above — the e2e CI job installs it manually with a
+  # locally built dev image, and the published chart and the dev image cannot
+  # share the same release name without one overwriting the other.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: placement-operator
+      namespace: placement-system
+    patch: |
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: placement-operator
+        namespace: placement-system
+      spec:
+        suspend: true
+
   # The Chaos Mesh kind-tuning patch (containerd runtime, dashboard disabled,
   # reduced resource requests) lives in the opt-in deploy/kind/chaos-mesh/
   # overlay. It cannot stay here because Chaos Mesh is no longer in the base

--- a/deploy/kind/base/openstack-gateway.yaml
+++ b/deploy/kind/base/openstack-gateway.yaml
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Gateway API wiring for the kind Quick Start — `GatewayClass/envoy`
-# plus a five-listener HTTPS Gateway on port 443
+# plus a six-listener HTTPS Gateway on port 443
 # (`keystone.127-0-0-1.nip.io`, `horizon.127-0-0-1.nip.io`,
-# `glance.127-0-0-1.nip.io`, `dizzy.127-0-0-1.nip.io`, and
-# `glance-upload.127-0-0-1.nip.io`, routed by SNI) terminating TLS with
-# self-signed certificates issued by the existing `selfsigned-cluster-issuer`
-# ClusterIssuer (the same issuer OpenBao uses; see
+# `glance.127-0-0-1.nip.io`, `dizzy.127-0-0-1.nip.io`,
+# `glance-upload.127-0-0-1.nip.io`, and `placement.127-0-0-1.nip.io`,
+# routed by SNI) terminating TLS with self-signed certificates issued by
+# the existing `selfsigned-cluster-issuer` ClusterIssuer (the same issuer
+# OpenBao uses; see
 # `deploy/flux-system/infrastructure/cluster-issuer.yaml`).
 #
 # The Gateway lives in the `openstack` namespace alongside the Keystone
@@ -163,6 +164,34 @@ spec:
         certificateRefs:
           - kind: Secret
             name: glance-upload-nip-io-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+    # Sixth HTTPS listener for the Placement API. It shares port 443 with
+    # the listeners above, routed by SNI on its distinct `hostname` and
+    # terminating with its own certificate
+    # (deploy/kind/infrastructure/placement-nip-io-tls-certificate.yaml).
+    # Another listener on the same port leaves the NodePort pin intact:
+    # `envoy-nodeport.yaml` keys its StrategicMerge patch by `port: 443`,
+    # which selects the single ServicePort Envoy generates for all
+    # listeners.
+    #
+    # The HTTPRoute the placement-operator projects from the Placement
+    # CR's `spec.gateway` carries the hostname
+    # `placement.127-0-0-1.nip.io`, so it attaches to THIS listener
+    # (matching hostname) and not the ones above. Its first consumer is
+    # tests/e2e/placement/gateway-quick-start-smoke. Like the listeners
+    # above it is unconditional: with no HTTPRoute projected onto this
+    # hostname, requests for this SNI get 404.
+    - name: https-placement
+      protocol: HTTPS
+      port: 443
+      hostname: placement.127-0-0-1.nip.io
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: placement-nip-io-tls
       allowedRoutes:
         namespaces:
           from: Same

--- a/deploy/kind/infrastructure/kustomization.yaml
+++ b/deploy/kind/infrastructure/kustomization.yaml
@@ -29,6 +29,9 @@ resources:
   # TLS for the fifth Gateway listener (`https-glance-upload`) the Glance
   # large-upload e2e suite streams through (deploy/kind/base/openstack-gateway.yaml).
   - glance-upload-nip-io-tls-certificate.yaml
+  # TLS for the sixth Gateway listener (`https-placement`) the Placement API
+  # is exposed through (deploy/kind/base/openstack-gateway.yaml).
+  - placement-nip-io-tls-certificate.yaml
   # kind-only: standalone Keystone CRs (Quick Start, keystone e2e/tempest/
   # chaos suites) reference the Secret "keystone-db"; ControlPlane-based
   # deployments use the operator-projected per-ControlPlane ExternalSecret

--- a/deploy/kind/infrastructure/kustomization.yaml
+++ b/deploy/kind/infrastructure/kustomization.yaml
@@ -49,6 +49,12 @@ resources:
   # names (keystone-admin/keystone-db/mariadb-root-password), so it survives that
   # filter on the ControlPlane path.
   - glance-db-externalsecret.yaml
+  # kind-only: standalone Placement CRs (the placement e2e suites) reference the
+  # Secret "placement-db" through the Placement CR's database.secretRef,
+  # mirroring the glance-db shim above. It is NOT one of the WITH_CONTROLPLANE
+  # shim-drop names (keystone-admin/keystone-db/mariadb-root-password), so it
+  # survives that filter on the ControlPlane path.
+  - placement-db-externalsecret.yaml
   - keystone-admin-externalsecret.yaml
   - mariadb-root-password-externalsecret.yaml
   # horizon-secret-key is the Django SECRET_KEY shim for standalone Horizon

--- a/deploy/kind/infrastructure/placement-db-externalsecret.yaml
+++ b/deploy/kind/infrastructure/placement-db-externalsecret.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# kind-only ExternalSecret for Placement database credentials.
+#
+# Standalone Placement CRs (the placement e2e suites) reference a Secret named
+# "placement-db" in the openstack namespace through the Placement CR's
+# database.secretRef. In ControlPlane-based deployments this standalone shim is
+# NOT used — per-service DB credentials are operator-projected there — which is
+# why the production stack (deploy/eso/, included by deploy/flux-system/) ships
+# no placement-db ExternalSecret.
+#
+# This kind overlay keeps the standalone flows working: it pulls username and
+# password from the dedicated standalone OpenBao path
+# (openstack/placement/openstack/standalone/db, seeded by
+# write-bootstrap-secrets.sh) and materialises them as the Secret
+# "placement-db".
+#
+# It authenticates through the per-tenant openbao-tenant-store — the enforced
+# default since #606, the same store the glance-db shim uses — rather than the
+# shared cluster store. On the standalone path hack/deploy-infra.sh provisions
+# that store via setup-eso-tenant.sh openstack; the store's eso-tenant identity
+# scopes reads to openstack/placement/openstack/*, which is why the remote key
+# carries the openstack namespace segment.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: placement-db
+  namespace: openstack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao-tenant-store
+    kind: SecretStore
+  target:
+    name: placement-db
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: openstack/placement/openstack/standalone/db
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: openstack/placement/openstack/standalone/db
+        property: password

--- a/deploy/kind/infrastructure/placement-nip-io-tls-certificate.yaml
+++ b/deploy/kind/infrastructure/placement-nip-io-tls-certificate.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# TLS material for the sixth Gateway listener (`https-placement`)
+# defined in deploy/kind/base/openstack-gateway.yaml. cert-manager
+# issues a self-signed certificate for `placement.127-0-0-1.nip.io` and
+# writes it to the `placement-nip-io-tls` Secret in the `openstack`
+# namespace, where the Gateway's `https-placement` listener
+# `certificateRefs` picks it up. Kept as a sibling of
+# `glance-nip-io-tls-certificate.yaml` and the other per-listener
+# certificates (one Certificate per listener hostname) rather than a
+# shared SAN certificate so each listener terminates with its own key
+# material.
+#
+# Lives in the infrastructure overlay (Phase 2 of hack/deploy-infra.sh)
+# rather than the base overlay because the `cert-manager.io/v1`
+# Certificate CRD is installed by the `cert-manager` HelmRelease in
+# Phase 1; applying this resource before Phase 4 ("wait HelmReleases
+# Ready") would fail with `no matches for kind "Certificate"`.
+# The same reasoning applies to the `selfsigned-cluster-issuer`
+# ClusterIssuer it references (deploy/flux-system/infrastructure/
+# cluster-issuer.yaml), also a Phase-2 resource.
+#
+# Self-signed is correct for a kind quick-start cluster (single-user
+# localhost-only), matching the sibling keystone/horizon/glance/dizzy
+# certificates.
+#
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: placement-nip-io-tls
+  namespace: openstack
+spec:
+  secretName: placement-nip-io-tls
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - placement.127-0-0-1.nip.io

--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -158,6 +158,51 @@ main() {
     token_max_ttl=72h
   log "glance-db role written."
 
+  # placement-db role on the management cluster's Kubernetes auth mount — the
+  # Placement analogue of the glance-db role above, and equally
+  # keystone-independent. The c5c3 operator's per-ControlPlane
+  # VaultDynamicSecret generator authenticates with the "placement-db-creds"
+  # ServiceAccount to read short-lived DB credentials at
+  # database/mariadb/creds/placement-<namespace>.
+  # bound_service_account_namespaces="*" lets any ControlPlane namespace
+  # authenticate; the fixed SA name is what tells this role apart from
+  # keystone-db and glance-db (a placement-db-creds token can never read their
+  # creds paths), and the cross-tenant boundary is enforced by the
+  # placement-db-dynamic policy, which templates the readable creds path to the
+  # caller's OWN service_account_namespace (an exact match).
+  #
+  # Token TTLs are pinned to DB_CREDS_MAX_TTL (72h, setup-database-tenant.sh) for
+  # the same reason spelled out on the keystone-db role above: OpenBao revokes a
+  # dynamic-secret lease together with the token that minted it, so the token must
+  # outlive the lease or the issued DB credential dies early under a running
+  # Placement.
+  #
+  # The role is written unconditionally but stays dormant until the ControlPlane
+  # spec carries a placement service: no placement-db-creds ServiceAccount is
+  # projected before then, so nothing authenticates against it. Pre-creating it
+  # (as the per-cluster ESO roles above are pre-created) gets the auth half of
+  # that onboarding out of the way.
+  #
+  # The ENGINE half is still open: setup-database-tenant.sh writes the
+  # database/mariadb connection+role pair per service and has a keystone and a
+  # glance branch but no placement one, so database/mariadb/creds/placement-<ns>
+  # — the exact path placement-db-dynamic grants — does not resolve yet.
+  # Kubernetes auth would succeed and the ACL would permit the read, but OpenBao
+  # answers 404 and the Placement CR parks on WaitingForDBCredentials. That
+  # branch cannot be written before the ControlPlane CRD grows
+  # spec.services.placement (the field it gates on) and the c5c3 operator grows
+  # the credential generator whose role-name derivation it must mirror; it
+  # belongs in that same change, so onboarding placement dynamic credentials
+  # needs a second bootstrap pass after it.
+  log "Writing placement-db role on kubernetes/management..."
+  bao_exec bao write "auth/kubernetes/management/role/placement-db" \
+    bound_service_account_names=placement-db-creds \
+    bound_service_account_namespaces="*" \
+    token_policies=placement-db-dynamic \
+    token_ttl=72h \
+    token_max_ttl=72h
+  log "placement-db role written."
+
   # eso-tenant role on the management cluster's Kubernetes auth mount. This is
   # the per-ControlPlane ESO identity a namespaced SecretStore authenticates
   # with (created per tenant by setup-eso-tenant.sh with the "eso-tenant-auth"

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -304,6 +304,21 @@ main() {
     "username=glance" \
     "password=${GENERATED_PASSWORD}"
 
+  # Standalone (non-ControlPlane) Placement demos read a static KV DB credential
+  # too, mirroring the Glance standalone seed above. It is read by the kind-only
+  # placement-db ExternalSecret
+  # (deploy/kind/infrastructure/placement-db-externalsecret.yaml) and materialised
+  # as the Secret the placement e2e suites' Placement CR selects via
+  # database.secretRef. No PushSecret targets it, so no mark_eso_managed is needed.
+  #
+  # The path mirrors the Keystone standalone shape with the placement service
+  # segment (openstack/placement/{namespace}/standalone/db); like glance-db, the
+  # placement-db ExternalSecret reaches it through the per-tenant
+  # openbao-tenant-store.
+  write_secret_if_missing "kv-v2/openstack/placement/openstack/standalone/db" \
+    "username=placement" \
+    "password=${GENERATED_PASSWORD}"
+
   log "=== Done ==="
 }
 

--- a/deploy/openbao/policies/eso-tenant.hcl
+++ b/deploy/openbao/policies/eso-tenant.hcl
@@ -46,6 +46,7 @@
 # --- read: the tenant's own Keystone and bootstrap subtrees ---
 # Covers the keystone-db ExternalSecret (openstack/keystone/{ns}/db), the
 # glance-db ExternalSecret (openstack/glance/{ns}/standalone/db), the
+# placement-db ExternalSecret (openstack/placement/{ns}/standalone/db), the
 # keystone-admin ExternalSecret (bootstrap/{ns}/{name}/admin), and the read-back
 # leg of every PushSecret below.
 path "kv-v2/data/openstack/keystone/{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}/*" {
@@ -53,6 +54,10 @@ path "kv-v2/data/openstack/keystone/{{identity.entity.aliases.KUBERNETES_MANAGEM
 }
 
 path "kv-v2/data/openstack/glance/{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}/*" {
+  capabilities = ["read"]
+}
+
+path "kv-v2/data/openstack/placement/{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}/*" {
   capabilities = ["read"]
 }
 

--- a/deploy/openbao/policies/placement-db-dynamic.hcl
+++ b/deploy/openbao/policies/placement-db-dynamic.hcl
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# placement-db-dynamic policy — grants read on the per-tenant dynamic MariaDB
+# database-engine credentials path for the Placement service DB user. Bound to
+# the "placement-db" role on the kubernetes/management auth mount (see
+# setup-auth.sh), which the c5c3 operator's per-ControlPlane VaultDynamicSecret
+# generator uses to issue short-lived Placement service-DB users at
+# database/mariadb/creds/placement-<namespace>.
+#
+# TENANT ISOLATION: the read path is scoped by OpenBao ACL identity templating to
+# the caller's OWN service-account namespace — {{...service_account_namespace}}
+# resolves, at request time, to the namespace of the placement-db-creds SA token
+# that authenticated. Per-tenant roles are named placement-<namespace> (one
+# ControlPlane per namespace, so the namespace is a unique, collision-free tenant
+# key), so this is an EXACT match with no wildcard: a token minted in namespace A
+# can read only database/mariadb/creds/placement-A and cannot read another
+# tenant's placement-B path. The placement-db role deliberately keeps
+# bound_service_account_namespaces="*" (any ControlPlane namespace may
+# authenticate); it is this templated policy — not the role binding — that
+# enforces the cross-tenant boundary (the client cert only gates transport).
+#
+# SERVICE ISOLATION: this policy and its placement-db role are entirely separate
+# from the keystone-db pair. Both roles bind bound_service_account_namespaces="*"
+# and are told apart by the ServiceAccount NAME the token carries —
+# placement-db-creds here versus keystone-db-creds for keystone-db-dynamic — so
+# a Placement credential generator can never read a Keystone creds path (or vice
+# versa), even for two services co-located in one namespace.
+#
+# The KUBERNETES_MANAGEMENT_ACCESSOR placeholder is substituted with the live
+# kubernetes/management auth-mount accessor at apply time by setup-policies.sh —
+# the accessor is generated when the mount is enabled (setup-auth.sh, run first)
+# and is not known until runtime.
+#
+# READ-ONLY by design: a dynamic secrets engine has no long-lived static
+# password to push back, so there is no write/push grant here.
+path "database/mariadb/creds/placement-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}" {
+  capabilities = ["read"]
+}

--- a/hack/ci-resolve-changes.sh
+++ b/hack/ci-resolve-changes.sh
@@ -21,6 +21,7 @@
 #   FILTER_c5c3               — paths-filter output for c5c3 paths
 #   FILTER_horizon            — paths-filter output for horizon paths
 #   FILTER_glance             — paths-filter output for glance paths
+#   FILTER_placement          — paths-filter output for placement paths
 #   FILTER_docs               — paths-filter output for docs paths
 #   FILTER_helm               — paths-filter output for helm paths
 #   FILTER_e2e_infra          — paths-filter output for e2e-infra paths

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -1990,19 +1990,22 @@ main() {
   if [[ "${WITH_CONTROLPLANE}" == "true" && "${CONTROLPLANE_OPERATORS}" == "flux" ]]; then
     # Deploy the full ControlPlane stack via Flux from the published c5c3-operator
     # chart and the K-ORC GitRepository/Kustomization. The kind base overlay
-    # suspends the keystone-, horizon-, and glance-operator HelmReleases for the
-    # local-build E2E path; un-suspend all three here so the c5c3-operator
-    # HelmRelease's dependsOn is satisfied and the projected service CRs can
-    # reconcile. Without the glance-operator the Glance CRDs never install and
-    # the c5c3-operator's controlplane cache never syncs, so the ControlPlane CR
-    # stays status-less. c5c3-operator, k-orc, and the c5c3-charts / k-orc
-    # sources are left un-suspended (the base applied them active).
-    log "WITH_CONTROLPLANE=true: deploying the c5c3 ControlPlane stack (keystone-operator, horizon-operator, glance-operator, k-orc, c5c3-operator)."
+    # suspends the keystone-, horizon-, glance- and placement-operator
+    # HelmReleases for the local-build E2E path; un-suspend all four here so the
+    # c5c3-operator HelmRelease's dependsOn is satisfied and the projected
+    # service CRs can reconcile. Without the glance-operator the Glance CRDs
+    # never install and the c5c3-operator's controlplane cache never syncs, so
+    # the ControlPlane CR stays status-less. c5c3-operator, k-orc, and the
+    # c5c3-charts / k-orc sources are left un-suspended (the base applied them
+    # active).
+    log "WITH_CONTROLPLANE=true: deploying the c5c3 ControlPlane stack (keystone-operator, horizon-operator, glance-operator, placement-operator, k-orc, c5c3-operator)."
     kubectl patch helmrelease keystone-operator -n keystone-system \
       --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
     kubectl patch helmrelease horizon-operator -n horizon-system \
       --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
     kubectl patch helmrelease glance-operator -n glance-system \
+      --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
+    kubectl patch helmrelease placement-operator -n placement-system \
       --type merge -p '{"spec":{"suspend":false}}' 2>/dev/null || true
     # Pin the GHCR :latest operator images to their current digest so a
     # feature merged since the last deploy actually rolls out (the tag is
@@ -2139,6 +2142,7 @@ main() {
     enable_operator_servicemonitor keystone-operator keystone-system "${HELMRELEASE_TIMEOUT}"
     enable_operator_servicemonitor horizon-operator horizon-system "${HELMRELEASE_TIMEOUT}"
     enable_operator_servicemonitor glance-operator glance-system "${HELMRELEASE_TIMEOUT}"
+    enable_operator_servicemonitor placement-operator placement-system "${HELMRELEASE_TIMEOUT}"
   fi
 
   # Step 5: Apply infrastructure kustomize overlay (CRD-dependent resources)

--- a/hack/refresh-operator-image-digests.sh
+++ b/hack/refresh-operator-image-digests.sh
@@ -7,8 +7,8 @@
 # to their current digest.
 #
 # The Flux HelmReleases for the self-built operators (keystone-operator,
-# c5c3-operator, horizon-operator, glance-operator) reference the mutable
-# :latest image tag.
+# c5c3-operator, horizon-operator, glance-operator, placement-operator)
+# reference the mutable :latest image tag.
 # A moved tag alone never rolls a running Deployment: the kubelet does not
 # re-pull an image that is already present on the node, and the HelmRelease
 # does not upgrade when neither chart version nor values change. This script
@@ -45,6 +45,7 @@ OPERATOR_DIGEST_TARGETS=(
   "c5c3-operator|c5c3-system|ghcr.io/c5c3/c5c3-operator:latest"
   "horizon-operator|horizon-system|ghcr.io/c5c3/horizon-operator:latest"
   "glance-operator|glance-system|ghcr.io/c5c3/glance-operator:latest"
+  "placement-operator|placement-system|ghcr.io/c5c3/placement-operator:latest"
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/verify_glance_ci_pipeline.sh
+++ b/tests/ci/verify_glance_ci_pipeline.sh
@@ -106,7 +106,7 @@ test_glance_test_matrices() {
   echo "Test: unit and integration test matrices include glance"
 
   local matrix_count
-  matrix_count=$(grep -c "target: \[common, keystone, c5c3, horizon, glance\]" "$CI_YAML")
+  matrix_count=$(grep -c "target: \[common, keystone, c5c3, horizon, glance, placement\]" "$CI_YAML")
 
   assert_eq \
     "both test and test-integration matrices list glance" \

--- a/tests/ci/verify_horizon_ci_pipeline.sh
+++ b/tests/ci/verify_horizon_ci_pipeline.sh
@@ -106,7 +106,7 @@ test_horizon_test_matrices() {
   echo "Test: unit and integration test matrices include horizon"
 
   local matrix_count
-  matrix_count=$(grep -c "target: \[common, keystone, c5c3, horizon, glance\]" "$CI_YAML")
+  matrix_count=$(grep -c "target: \[common, keystone, c5c3, horizon, glance, placement\]" "$CI_YAML")
 
   assert_eq \
     "both test and test-integration matrices list horizon" \

--- a/tests/ci/verify_placement_ci_pipeline.sh
+++ b/tests/ci/verify_placement_ci_pipeline.sh
@@ -1,0 +1,485 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify placement operator CI pipeline wiring meets requirements.
+# Validates: placement paths-filter block, the helm filter entry,
+# FILTER_placement env, ALL_OPERATORS membership, test/helm-validate/cleanup
+# matrices, the e2e-chaos pod-kill leg and its pod-leg-only image load/deploy,
+# the placement entry in the build-e2e-images operator union, and
+# that ci-resolve-changes.sh emits placement in the e2e-operators matrix once
+# placement is a known operator.
+# Placement ships no tempest plugin, so the tempest job carries no placement
+# leg to assert.
+# Usage: bash tests/ci/verify_placement_ci_pipeline.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$SCRIPT_DIR/../lib/assertions.sh"
+
+CI_YAML="$PROJECT_ROOT/.github/workflows/ci.yaml"
+CLEANUP_YAML="$PROJECT_ROOT/.github/workflows/cleanup-images.yaml"
+RESOLVE_SCRIPT="$PROJECT_ROOT/hack/ci-resolve-changes.sh"
+
+echo "=== placement operator CI pipeline verification ==="
+echo ""
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+# Extract a YAML job section from a workflow file by job name.
+extract_yaml_job_section() {
+  local file="$1" job_name="$2"
+  sed -n "/^  ${job_name}:/,/^  [a-zA-Z]/p" "$file"
+}
+
+# Extract a single paths-filter block from ci.yaml by filter name. Filter keys
+# sit at 12-space indent and their path entries deeper, so the next 12-space key
+# ends the block. Scoping matters for shared entries such as
+# operators/Dockerfile, which every operator filter lists.
+extract_paths_filter_block() {
+  local file="$1" filter_name="$2"
+  sed -n "/^            ${filter_name}:/,/^            [a-z]/p" "$file"
+}
+
+# Extract a single step from a job section by step name. Steps sit at 6-space
+# indent, so the next 6-space "- name:" ends the block. Needed to assert on a
+# step's own `if:` — a job-wide grep cannot tell which step carries a gate.
+extract_yaml_step() {
+  local section="$1" step_name="$2"
+  echo "$section" | sed -n "/^      - name: ${step_name}\$/,/^      - name: /p"
+}
+
+# Run ci-resolve-changes.sh with the supplied env and echo the GITHUB_OUTPUT
+# contents. ALL_OPERATORS deliberately mirrors the ci.yaml value ("keystone
+# c5c3 horizon glance placement") so the behavioural assertions exercise the
+# real resolution codepath. Args are passed as KEY=VALUE pairs through the
+# caller's env block.
+run_resolve() {
+  local out
+  out=$(mktemp)
+  GITHUB_OUTPUT="$out" bash "$RESOLVE_SCRIPT" >/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+# Extract the value of a single GITHUB_OUTPUT key from resolve output.
+output_value() {
+  local resolved="$1" key="$2"
+  echo "$resolved" | grep "^${key}=" | head -1 | cut -d= -f2-
+}
+
+# ── ci.yaml paths-filter / env wiring tests ─────────────────────────────────
+
+test_placement_filter_block() {
+  echo "Test: ci.yaml has a placement paths-filter block"
+
+  assert_file_contains \
+    "ci.yaml declares a placement filter" \
+    "$CI_YAML" \
+    "^            placement:"
+
+  local filter_block
+  filter_block=$(extract_paths_filter_block "$CI_YAML" "placement")
+
+  assert_contains \
+    "placement filter includes operators/placement/**" \
+    "$filter_block" \
+    "operators/placement/**"
+
+  assert_contains \
+    "placement filter includes operators/Dockerfile" \
+    "$filter_block" \
+    "operators/Dockerfile"
+
+  assert_contains \
+    "placement filter includes images/placement/**" \
+    "$filter_block" \
+    "images/placement/**"
+}
+
+test_placement_helm_filter() {
+  echo "Test: the helm paths-filter covers the placement operator chart"
+
+  local helm_block
+  helm_block=$(extract_paths_filter_block "$CI_YAML" "helm")
+
+  assert_contains \
+    "helm filter includes operators/placement/helm/**" \
+    "$helm_block" \
+    "operators/placement/helm/**"
+}
+
+test_placement_all_operators() {
+  echo "Test: ci.yaml ALL_OPERATORS includes placement"
+
+  local all_operators_line
+  all_operators_line=$(grep "ALL_OPERATORS:" "$CI_YAML" | head -1)
+
+  assert_contains \
+    "ALL_OPERATORS lists keystone" \
+    "$all_operators_line" \
+    "keystone"
+
+  assert_contains \
+    "ALL_OPERATORS lists placement" \
+    "$all_operators_line" \
+    "placement"
+}
+
+test_placement_filter_env_var() {
+  echo "Test: ci.yaml passes FILTER_placement env var to the resolve step"
+
+  assert_file_contains \
+    "FILTER_placement env var is wired from steps.filter.outputs.placement" \
+    "$CI_YAML" \
+    'FILTER_placement: ${{ steps.filter.outputs.placement }}'
+}
+
+test_placement_test_matrices() {
+  echo "Test: unit and integration test matrices include placement"
+
+  local matrix_count
+  matrix_count=$(grep -c "target: \[common, keystone, c5c3, horizon, glance, placement\]" "$CI_YAML")
+
+  assert_eq \
+    "both test and test-integration matrices list placement" \
+    "2" \
+    "$matrix_count"
+}
+
+test_placement_helm_validate_loops() {
+  echo "Test: helm-validate loops include the placement-operator chart"
+
+  local loop_count
+  loop_count=$(grep -c "operators/placement/helm/placement-operator" "$CI_YAML")
+
+  if [ "$loop_count" -ge 3 ]; then
+    echo "  PASS: helm-validate references the placement-operator chart in $loop_count loops"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: expected >=3 helm-validate references to the placement-operator chart, found $loop_count"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_cleanup_matrices_include_placement() {
+  echo "Test: cleanup matrices include placement-operator and placement"
+
+  local cleanup_section
+  cleanup_section=$(extract_yaml_job_section "$CI_YAML" "cleanup-e2e-tags")
+
+  assert_contains \
+    "cleanup-e2e-tags package matrix lists placement-operator" \
+    "$cleanup_section" \
+    "placement-operator"
+
+  assert_contains \
+    "cleanup-e2e-tags package matrix lists the placement service image" \
+    "$cleanup_section" \
+    "placement-operator, placement,"
+
+  local operator_images_section stale_tags_section
+  operator_images_section=$(extract_yaml_job_section "$CLEANUP_YAML" "cleanup-operator-images")
+  stale_tags_section=$(extract_yaml_job_section "$CLEANUP_YAML" "cleanup-e2e-stale-tags")
+
+  assert_contains \
+    "cleanup-operator-images matrix lists placement-operator" \
+    "$operator_images_section" \
+    "placement-operator"
+
+  assert_contains \
+    "cleanup-e2e-stale-tags matrix lists placement-operator and the placement service image" \
+    "$stale_tags_section" \
+    "placement-operator, placement,"
+}
+
+# ── e2e-chaos wiring ────────────────────────────────────────────────────────
+
+test_placement_chaos_wiring() {
+  echo "Test: e2e-chaos deploys the placement operator and runs the pod-kill suite"
+
+  # Scope every needle to the e2e-chaos job: the image name also occurs in the
+  # build and load jobs, so a whole-file grep would still pass with the
+  # e2e-chaos image-load and deploy steps deleted — leaving
+  # placement-operator-pod-kill to run against a cluster with no
+  # placement-operator and an empty pod selector.
+  local chaos_section
+  chaos_section=$(extract_yaml_job_section "$CI_YAML" "e2e-chaos")
+
+  assert_contains \
+    "pod-leg test_dirs include the placement operator-kill suite" \
+    "$chaos_section" \
+    "tests/e2e-chaos/placement-operator-pod-kill"
+
+  # Loading placement onto the pod leg takes two steps with two different
+  # renderings, so each needs its own needle. The GHCR pull step interpolates
+  # through format() to stay blank on the network leg, and therefore contains
+  # no `IMAGE_PREFIX }}/placement...` literal at all — a single chaos_section
+  # substring check silently covers only the kind-load step.
+  local pull_step
+  pull_step=$(extract_yaml_step "$chaos_section" "Load E2E images")
+
+  assert_contains \
+    "the GHCR pull step lists the placement-operator image on the pod leg" \
+    "$pull_step" \
+    "format('{0}/placement-operator:dev', env.IMAGE_PREFIX)"
+
+  assert_contains \
+    "the GHCR pull step lists the placement service image on the pod leg" \
+    "$pull_step" \
+    "format('{0}/placement:2025.2', env.IMAGE_PREFIX)"
+
+  local kind_load_step
+  kind_load_step=$(extract_yaml_step "$chaos_section" "Load placement images into kind")
+
+  assert_contains \
+    "the kind-load step loads the placement-operator image" \
+    "$kind_load_step" \
+    "IMAGE_PREFIX }}/placement-operator:dev"
+
+  assert_contains \
+    "the kind-load step loads the placement service image" \
+    "$kind_load_step" \
+    "IMAGE_PREFIX }}/placement:2025.2"
+
+  assert_contains \
+    "e2e-chaos deploys the placement operator into placement-system" \
+    "$chaos_section" \
+    "NAMESPACE: placement-system"
+
+  # placement-operator-pod-kill is the only suite touching placement and it is
+  # on the pod leg; the network leg (mariadb-network-latency,
+  # mariadb-network-partition, glance-garage-outage, chaos-mesh-health) never
+  # references it. Ungated, that leg kind-loads and helm-installs placement on
+  # every run for zero coverage.
+  assert_contains \
+    "the placement kind-load step is gated on the pod leg" \
+    "$kind_load_step" \
+    "if: matrix.suite == 'pod'"
+
+  assert_contains \
+    "the placement operator deploy step is gated on the pod leg" \
+    "$(extract_yaml_step "$chaos_section" "Deploy placement operator")" \
+    "if: matrix.suite == 'pod'"
+}
+
+# ── build-e2e-images wiring ─────────────────────────────────────────────────
+
+test_placement_build_is_unconditional() {
+  echo "Test: build-e2e-images always builds placement"
+
+  local build_section resolve_step
+  build_section=$(extract_yaml_job_section "$CI_YAML" "build-e2e-images")
+  resolve_step=$(extract_yaml_step "$build_section" "Resolve build operators")
+
+  # The e2e-chaos pod leg consumes placement-operator:dev and placement:2025.2
+  # unconditionally, so placement joins keystone and glance in the fixed union.
+  assert_contains \
+    "the unconditional build union lists keystone, glance and placement" \
+    "$resolve_step" \
+    "for base in keystone glance placement; do"
+
+  # Gating the union on a hand-copied duplicate of the e2e-chaos `if:` is the
+  # failure this asserts against: the two conditions drift, build-e2e-images
+  # stops pushing the placement tags, and the blocking pod leg fails on
+  # `manifest unknown` an hour into the run. A non-empty operator matrix
+  # already implies e2e-chaos runs, so the gate saved almost nothing anyway.
+  assert_not_contains \
+    "the build union does not re-derive the e2e-chaos trigger condition" \
+    "$resolve_step" \
+    "needs.changes.outputs.e2e-chaos"
+
+  assert_not_contains \
+    "the build union does not re-derive the run-chaos label condition" \
+    "$resolve_step" \
+    "run-chaos"
+}
+
+# ── ci-resolve-changes.sh documentation ─────────────────────────────────────
+
+test_resolve_script_documents_filter() {
+  echo "Test: ci-resolve-changes.sh documents FILTER_placement"
+
+  assert_file_contains \
+    "resolve script documents FILTER_placement" \
+    "$RESOLVE_SCRIPT" \
+    "FILTER_placement"
+}
+
+# ── ci-resolve-changes.sh behavioural tests ─────────────────────────────────
+
+test_resolve_emits_placement_on_operator_change() {
+  echo "Test: ci-resolve-changes.sh emits placement in e2e-operators on a placement-only change"
+
+  local resolved operators has
+  resolved=$(
+    ALL_OPERATORS="keystone c5c3 horizon glance placement" \
+    GITHUB_REF="refs/heads/main" \
+    FILTER_keystone="false" \
+    FILTER_c5c3="false" \
+    FILTER_horizon="false" \
+    FILTER_glance="false" \
+    FILTER_placement="true" \
+    FILTER_docs="false" \
+    FILTER_helm="false" \
+    FILTER_e2e_infra="false" \
+    FILTER_e2e_chaos="false" \
+    FILTER_go_common="false" \
+    run_resolve
+  )
+
+  operators=$(output_value "$resolved" "e2e-operators")
+  has=$(output_value "$resolved" "has-e2e-operators")
+
+  assert_contains \
+    "placement-only change emits placement in the e2e-operators matrix" \
+    "$operators" \
+    '"placement"' # JSON array entry
+
+  assert_not_contains \
+    "placement-only change does not pull in keystone" \
+    "$operators" \
+    '"keystone"'
+
+  assert_eq \
+    "placement-only change sets has-e2e-operators=true" \
+    "true" \
+    "$has"
+}
+
+test_resolve_excludes_placement_on_keystone_only_change() {
+  echo "Test: ci-resolve-changes.sh excludes placement on a keystone-only change"
+
+  local resolved operators
+  resolved=$(
+    ALL_OPERATORS="keystone c5c3 horizon glance placement" \
+    GITHUB_REF="refs/heads/main" \
+    FILTER_keystone="true" \
+    FILTER_c5c3="false" \
+    FILTER_horizon="false" \
+    FILTER_glance="false" \
+    FILTER_placement="false" \
+    FILTER_docs="false" \
+    FILTER_helm="false" \
+    FILTER_e2e_infra="false" \
+    FILTER_e2e_chaos="false" \
+    FILTER_go_common="false" \
+    run_resolve
+  )
+
+  operators=$(output_value "$resolved" "e2e-operators")
+
+  assert_contains \
+    "keystone-only change includes keystone" \
+    "$operators" \
+    '"keystone"'
+
+  assert_not_contains \
+    "keystone-only change excludes placement" \
+    "$operators" \
+    '"placement"'
+}
+
+test_resolve_emits_all_on_go_common_change() {
+  echo "Test: ci-resolve-changes.sh emits all five operators on a go_common change"
+
+  local resolved operators op
+  resolved=$(
+    ALL_OPERATORS="keystone c5c3 horizon glance placement" \
+    GITHUB_REF="refs/heads/main" \
+    FILTER_keystone="false" \
+    FILTER_c5c3="false" \
+    FILTER_horizon="false" \
+    FILTER_glance="false" \
+    FILTER_placement="false" \
+    FILTER_docs="false" \
+    FILTER_helm="false" \
+    FILTER_e2e_infra="false" \
+    FILTER_e2e_chaos="false" \
+    FILTER_go_common="true" \
+    run_resolve
+  )
+
+  operators=$(output_value "$resolved" "e2e-operators")
+
+  for op in keystone c5c3 horizon glance placement; do
+    assert_contains \
+      "go_common change includes $op" \
+      "$operators" \
+      "\"$op\""
+  done
+}
+
+test_resolve_emits_all_on_tag_push() {
+  echo "Test: ci-resolve-changes.sh emits all five operators on a tag push"
+
+  local resolved operators op
+  resolved=$(
+    ALL_OPERATORS="keystone c5c3 horizon glance placement" \
+    GITHUB_REF="refs/tags/v1.0.0" \
+    FILTER_keystone="false" \
+    FILTER_c5c3="false" \
+    FILTER_horizon="false" \
+    FILTER_glance="false" \
+    FILTER_placement="false" \
+    FILTER_docs="false" \
+    FILTER_helm="false" \
+    FILTER_e2e_infra="false" \
+    FILTER_e2e_chaos="false" \
+    FILTER_go_common="false" \
+    run_resolve
+  )
+
+  operators=$(output_value "$resolved" "e2e-operators")
+
+  for op in keystone c5c3 horizon glance placement; do
+    assert_contains \
+      "tag push forces $op into the e2e-operators matrix" \
+      "$operators" \
+      "\"$op\""
+  done
+}
+
+# ── Run all tests ────────────────────────────────────────────────────────────
+test_placement_filter_block
+echo ""
+test_placement_helm_filter
+echo ""
+test_placement_all_operators
+echo ""
+test_placement_filter_env_var
+echo ""
+test_placement_test_matrices
+echo ""
+test_placement_helm_validate_loops
+echo ""
+test_cleanup_matrices_include_placement
+echo ""
+test_placement_chaos_wiring
+echo ""
+test_placement_build_is_unconditional
+echo ""
+test_resolve_script_documents_filter
+echo ""
+test_resolve_emits_placement_on_operator_change
+echo ""
+test_resolve_excludes_placement_on_keystone_only_change
+echo ""
+test_resolve_emits_all_on_go_common_change
+echo ""
+test_resolve_emits_all_on_tag_push
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/e2e-chaos/placement-operator-pod-kill/00-placement-cr.yaml
+++ b/tests/e2e-chaos/placement-operator-pod-kill/00-placement-cr.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the chaos test. Unique name (placement-chaos-op) and
+# database (placement_chaos_op) to avoid conflicts with other test suites.
+# Managed database via clusterRef to openstack-db, cache via clusterRef to
+# openstack-memcached. Placement owns no store backend, so the CR is the only
+# fixture the suite applies.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-chaos-op
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_chaos_op
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e-chaos/placement-operator-pod-kill/01-podchaos.yaml
+++ b/tests/e2e-chaos/placement-operator-pod-kill/01-podchaos.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# PodChaos CR to kill a placement-operator pod in placement-system.
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: kill-placement-operator
+  namespace: placement-system
+spec:
+  action: pod-kill
+  mode: one
+  selector:
+    namespaces:
+    - placement-system
+    labelSelectors:
+      app.kubernetes.io/name: placement-operator
+  gracePeriod: 0

--- a/tests/e2e-chaos/placement-operator-pod-kill/02-patch-scale.yaml
+++ b/tests/e2e-chaos/placement-operator-pod-kill/02-patch-scale.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch applied AFTER the operator pod kill: proves the recovered operator
+# still reconciles spec changes end-to-end.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-chaos-op
+  namespace: openstack
+spec:
+  deployment:
+    replicas: 2

--- a/tests/e2e-chaos/placement-operator-pod-kill/chainsaw-test.yaml
+++ b/tests/e2e-chaos/placement-operator-pod-kill/chainsaw-test.yaml
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw chaos E2E test for placement-operator pod kill.
+# Verifies the deployed Placement workload is undisturbed by the operator outage
+# (operational-independence contract): its API pods are never restarted while
+# the operator is killed and recovers, asserted by comparing the placement-api
+# pod UIDs across the kill. And that the operator resumes reconciliation after
+# the kill: a spec change patched afterwards is rolled out.
+# Identity-based verification: snapshot ALL pre-chaos pod UIDs, then
+# wait for at least one to disappear. Snapshotting only .items[0] is racy —
+# the operator runs 2 replicas and PodChaos mode: one picks its victim at
+# random, so the recorded pod survives the kill in ~half the runs and the
+# old-pod-gone poll fails spuriously. Mirrors glance-operator-pod-kill.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-operator-pod-kill
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply Placement CR and wait for baseline Ready ─────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-chaos-op
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: ../diagnostics.sh baseline placement-chaos-op --cr-kind=placement --dep-label=app.kubernetes.io/name=placement-operator --dep-ns=placement-system
+  # ── Step 2: Inject chaos and verify one operator pod was replaced ──────
+  # Snapshot, apply and poll live in one script so the pre-chaos UID
+  # snapshot and the wait share state. mode: one kills exactly one of the
+  # two replicas, so "at least one pre-chaos UID gone" proves the kill took
+  # effect regardless of which pod chaos-mesh picked. Phase 3 then compares
+  # the workload UIDs snapshotted here against the post-recovery set.
+  - try:
+    - script:
+        # Timeout budget: Phase 1 (60×2s=120s) + Phase 2 (60×2s=120s) = 240s
+        # worst case; Phase 3 is two kubectl reads with no polling. 270s gives
+        # 30s margin.
+        timeout: 270s
+        content: |
+          # NOTE: set -euo pipefail is intentionally omitted. The polling
+          # loops use ${VAR:-0} defensive defaults that would fail under
+          # set -e when kubectl returns empty output, and loop exit
+          # conditions are checked explicitly rather than via exit codes.
+
+          # Read desired replica count from the Deployment so the test stays
+          # valid if the operator replica count changes.
+          DESIRED=$(kubectl get deployment placement-operator -n placement-system -o jsonpath='{.spec.replicas}')
+          if [ -z "$DESIRED" ] || [ "$DESIRED" -lt 1 ]; then
+            echo "ERROR: could not determine desired replica count from placement-operator Deployment"
+            exit 1
+          fi
+          echo "Desired replicas: ${DESIRED}"
+
+          # Snapshot pre-chaos pod UIDs. mode: one must replace at least one
+          # of these; checking that at least one disappears is race-free.
+          OLD_UIDS=$(kubectl get pods -n placement-system -l app.kubernetes.io/name=placement-operator -o jsonpath='{.items[*].metadata.uid}')
+          if [ -z "$OLD_UIDS" ]; then
+            echo "ERROR: no operator pods found before chaos injection"
+            exit 1
+          fi
+          echo "Pre-chaos operator pod UIDs: ${OLD_UIDS}"
+
+          # Snapshot the managed workload's pod UIDs too. The operator is a
+          # control-plane component: killing it must not disturb the running
+          # placement-api pods. Phase 3 re-reads these and fails if any UID
+          # changed, which is the operational-independence contract.
+          WORKLOAD_UIDS=$(kubectl get pods -n openstack -l app.kubernetes.io/instance=placement-chaos-op -o jsonpath='{.items[*].metadata.uid}')
+          if [ -z "$WORKLOAD_UIDS" ]; then
+            echo "ERROR: no placement-api pods found before chaos injection"
+            exit 1
+          fi
+          echo "Pre-chaos placement-api pod UIDs: ${WORKLOAD_UIDS}"
+
+          # Inject chaos (kill one operator pod).
+          kubectl apply -f 01-podchaos.yaml
+
+          # Phase 1: wait until at least one pre-chaos UID is gone, proving
+          # mode: one replaced a pod. 60 iterations × 2s = 120s max.
+          # Empty CURRENT_UIDS (transient kubectl failure) would spuriously
+          # match "no UIDs present" — skip those iterations instead.
+          # REPLACED is seeded here, not only inside the loop body: every
+          # iteration can hit the empty-CURRENT_UIDS `continue` above, and an
+          # unset REPLACED would make the guard below an "integer expression
+          # expected" error that the `if` reads as false, silently falling
+          # through to Phase 2 instead of failing.
+          REPLACED=0
+          for i in $(seq 1 60); do
+            CURRENT_UIDS=$(kubectl get pods -n placement-system -l app.kubernetes.io/name=placement-operator -o jsonpath='{.items[*].metadata.uid}')
+            if [ -z "$CURRENT_UIDS" ]; then
+              sleep 2
+              continue
+            fi
+            REPLACED=0
+            for uid in $OLD_UIDS; do
+              case " $CURRENT_UIDS " in
+                *" $uid "*) ;;
+                *) REPLACED=1; break ;;
+              esac
+            done
+            if [ "$REPLACED" -eq 1 ]; then
+              echo "At least one pre-chaos operator pod replaced"
+              break
+            fi
+            sleep 2
+          done
+          if [ "$REPLACED" -ne 1 ]; then
+            echo "ERROR: no pre-chaos operator pod was replaced by chaos injection"
+            echo "  pre-chaos UIDs: ${OLD_UIDS}"
+            echo "  current UIDs:   ${CURRENT_UIDS}"
+            exit 1
+          fi
+
+          # Phase 2: wait until readyReplicas returns to DESIRED (operator
+          # recovered and reconciliation resumed). 60×2s = 120s max.
+          RECOVERED=0
+          for i in $(seq 1 60); do
+            READY=$(kubectl get deployment placement-operator -n placement-system -o jsonpath='{.status.readyReplicas}')
+            if [ "${READY:-0}" -eq "${DESIRED}" ]; then
+              echo "Operator recovered: readyReplicas=${DESIRED}"
+              RECOVERED=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$RECOVERED" -ne 1 ]; then
+            echo "ERROR: operator did not recover — readyReplicas=${READY:-0}, desired=${DESIRED}"
+            exit 1
+          fi
+
+          # Phase 3: operational independence. The workload must have been
+          # untouched by the operator outage — same pods, never restarted.
+          # Any UID that changed means the placement-api pods were disrupted by
+          # an operator kill, which the contract forbids.
+          NOW_WORKLOAD_UIDS=$(kubectl get pods -n openstack -l app.kubernetes.io/instance=placement-chaos-op -o jsonpath='{.items[*].metadata.uid}')
+          if [ -z "$NOW_WORKLOAD_UIDS" ]; then
+            echo "ERROR: no placement-api pods present after the operator kill"
+            exit 1
+          fi
+          for uid in $WORKLOAD_UIDS; do
+            case " $NOW_WORKLOAD_UIDS " in
+              *" $uid "*) ;;
+              *)
+                echo "ERROR: placement-api pod ${uid} was replaced during the operator outage"
+                echo "  pre-chaos workload UIDs: ${WORKLOAD_UIDS}"
+                echo "  current workload UIDs:   ${NOW_WORKLOAD_UIDS}"
+                exit 1
+                ;;
+            esac
+          done
+          echo "Workload undisturbed: placement-api pod UIDs unchanged across the kill"
+          exit 0
+    catch:
+    - script:
+        content: ../diagnostics.sh chaos placement-chaos-op --cr-kind=placement --dep-label=app.kubernetes.io/name=placement-operator --dep-ns=placement-system
+  # ── Step 3: Delete PodChaos ────────────────────────────────────────────
+  - try:
+    - delete:
+        ref:
+          apiVersion: chaos-mesh.org/v1alpha1
+          kind: PodChaos
+          name: kill-placement-operator
+          namespace: placement-system
+  # ── Step 4: Prove the recovered operator reconciles a spec change ──────
+  - try:
+    - patch:
+        file: 02-patch-scale.yaml
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-chaos-op
+            namespace: openstack
+          spec:
+            replicas: 2
+          status:
+            availableReplicas: 2
+            updatedReplicas: 2
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-chaos-op
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: ../diagnostics.sh chaos placement-chaos-op --cr-kind=placement --dep-label=app.kubernetes.io/name=placement-operator --dep-ns=placement-system

--- a/tests/e2e/placement-operator/metrics/chainsaw-test.yaml
+++ b/tests/e2e/placement-operator/metrics/chainsaw-test.yaml
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the placement-operator metrics ServiceMonitor.
+# Verifies that the placement-operator chart renders (and later removes) a
+# monitoring.coreos.com/v1 ServiceMonitor pointing at the operator's
+# /metrics endpoint when monitoring.serviceMonitor.enabled is toggled.
+#
+# This mirrors tests/e2e/glance-operator/metrics/chainsaw-test.yaml so the
+# metrics flow is asserted on a real cluster rather than only by the chart's
+# helm-unittest.
+#
+# DEPLOYMENT NOTE — why this test installs its own Helm release:
+# The placement-operator HelmRelease at placement-system/placement-operator is
+# intentionally suspended in the kind CI overlay (see
+# deploy/kind/base/kustomization.yaml). The operator that actually runs in the
+# cluster is installed by hack/ci-deploy-operator.sh, which `helm install`s the
+# chart with a locally built dev image. Patching the suspended HelmRelease
+# therefore has no observable effect. Mirroring the pattern in
+# tests/e2e/glance-operator/metrics, this test installs a dedicated release
+# ("placement-operator-metrics") whose lifecycle directly produces and tears
+# down the ServiceMonitor under assertion.
+#
+# DECISION: Prometheus target-Up polling is intentionally NOT implemented here.
+# The end-to-end scrape path (a live Prometheus that discovers the
+# ServiceMonitor and marks the target Up) is exercised by the WITH_PROMETHEUS
+# kind bring-up, not by this suite: the e2e cluster only installs
+# prometheus-operator-crds (see
+# deploy/flux-system/releases/prometheus-operator-crds.yaml) and does NOT run a
+# Prometheus instance, so there is no /api/v1/targets endpoint to poll. The
+# structural ServiceMonitor assertion below (CRD shape, labels, selector,
+# endpoints port/path/interval) is what this cluster can honestly verify.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-operator-metrics
+spec:
+  namespace: placement-system
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Install placement-operator chart with monitoring enabled ─────
+  # webhook.enabled=false avoids the cluster-scoped MutatingWebhookConfiguration
+  # registered by the primary placement-operator deployed by
+  # hack/ci-deploy-operator.sh (same rationale as the keystone metrics twin).
+  - try:
+    - script:
+        timeout: 120s
+        content: |
+          helm install placement-operator-metrics \
+            ${GITHUB_WORKSPACE:-.}/operators/placement/helm/placement-operator/ \
+            --namespace placement-system --create-namespace \
+            --set image.repository=ghcr.io/c5c3/placement-operator \
+            --set image.tag=dev \
+            --set image.pullPolicy=Never \
+            --set replicas=1 \
+            --set webhook.enabled=false \
+            --set monitoring.serviceMonitor.enabled=true \
+            --set monitoring.serviceMonitor.interval=30s \
+            --wait --timeout 90s
+    catch:
+    - script:
+        content: |
+          echo "=== Helm status ==="
+          helm status placement-operator-metrics -n placement-system 2>&1 || true
+          echo "=== Pod status ==="
+          kubectl get pods -n placement-system -l app.kubernetes.io/instance=placement-operator-metrics -o wide 2>&1 || true
+          echo "=== Operator pod logs ==="
+          for pod in $(kubectl get pods -n placement-system -l app.kubernetes.io/instance=placement-operator-metrics -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n placement-system "$pod" --all-containers --tail=120 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n placement-system --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 2: Assert the ServiceMonitor exists with the expected spec ──────
+  # Mirrors operators/shared/helm/operator-library/templates/_servicemonitor.tpl.
+  # With release name "placement-operator-metrics" the helper
+  # "operator-library.fullname" resolves to "placement-operator-metrics" (the
+  # chart name "placement-operator" is a substring of the release name; see
+  # operators/shared/helm/operator-library/templates/_helpers.tpl).
+  - try:
+    - assert:
+        resource:
+          apiVersion: monitoring.coreos.com/v1
+          kind: ServiceMonitor
+          metadata:
+            name: placement-operator-metrics
+            namespace: placement-system
+            labels:
+              app.kubernetes.io/name: placement-operator
+              app.kubernetes.io/instance: placement-operator-metrics
+              app.kubernetes.io/managed-by: Helm
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: placement-operator
+                app.kubernetes.io/instance: placement-operator-metrics
+            endpoints:
+            - port: metrics
+              path: /metrics
+              interval: 30s
+    catch:
+    - script:
+        content: |
+          echo "=== ServiceMonitor list ==="
+          kubectl get servicemonitor -n placement-system -o wide 2>&1 || true
+          echo "=== ServiceMonitor yaml ==="
+          kubectl get servicemonitor placement-operator-metrics -n placement-system -o yaml 2>&1 || true
+          echo "=== Helm values ==="
+          helm get values placement-operator-metrics -n placement-system 2>&1 || true
+  # ── Step 3: Uninstall the test release (cleanup) ─────────────────────────
+  - try:
+    - script:
+        timeout: 120s
+        content: |
+          helm uninstall placement-operator-metrics -n placement-system --wait --timeout 60s 2>&1 || true
+  # ── Step 4: Assert the ServiceMonitor is removed ─────────────────────────
+  - try:
+    - script:
+        content: |
+          # Verify the ServiceMonitor is gone after helm uninstall
+          for i in $(seq 1 12); do
+            if ! kubectl get servicemonitor placement-operator-metrics -n placement-system >/dev/null 2>&1; then
+              echo "PASS: ServiceMonitor correctly removed"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "FAIL: ServiceMonitor still present after helm uninstall"
+          kubectl get servicemonitor placement-operator-metrics -n placement-system -o yaml 2>&1 || true
+          exit 1

--- a/tests/e2e/placement/basic-deployment-2026-1/00-placement-cr.yaml
+++ b/tests/e2e/placement/basic-deployment-2026-1/00-placement-cr.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the basic-deployment E2E test (2026.1 release).
+# Managed mode: database via clusterRef to openstack-db (schema
+# placement_basic_2026), cache via clusterRef to openstack-memcached. The
+# database credentials come from the ESO-synced placement-db Secret and the
+# service-user password from the pre-seeded keystone-admin Secret (both
+# deploy/kind/infrastructure). Apart from the release, the image tag, and the
+# names, this is the 2025.2 fixture: placement has shipped the same WSGI
+# application across both releases, so the operator renders the same launch
+# command and the same placement.conf for either one.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-basic-2026
+  namespace: openstack
+spec:
+  openStackRelease: "2026.1"
+  deployment:
+    replicas: 3
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2026.1"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_basic_2026
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/basic-deployment-2026-1/chainsaw-test.yaml
+++ b/tests/e2e/placement/basic-deployment-2026-1/chainsaw-test.yaml
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for happy-path Placement deployment (2026.1 release).
+# The per-release twin of the 2025.2 basic-deployment suite. Placement has only
+# ever shipped a WSGI application, so there is no launch mode to select per
+# release: this suite asserts the SAME uWSGI command and the same
+# [placement_database] config shape against the 2026.1 image, and a difference
+# between the two legs is the failure it exists to catch.
+#   - All 7 sub-conditions progress to True with expected reasons
+#   - Aggregate Ready=True with reason AllReady
+#   - The API Deployment launches uWSGI against the image-shipped WSGI entry
+#     (--wsgi-file /var/lib/openstack/bin/placement-api) and points placement at
+#     the mounted config through OS_PLACEMENT_CONFIG_DIR
+#   - The database URL and the service-user password arrive as env vars, and
+#     both content-digest annotations are stamped on the pod template
+#   - Owned resources exist (Deployment, Service on 8778, PDB, config ConfigMap)
+#   - The rendered placement.conf keeps its database options in
+#     [placement_database] and renders no [database] section
+#   - The Placement API answers the unauthenticated version document with 200,
+#     and rejects an unauthenticated /resource_providers request with exactly 401
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-basic-deployment-2026-1
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR ──────────────────────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert all sub-conditions and Ready ────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-basic-2026
+            namespace: openstack
+          status:
+            (conditions[?type == 'SecretsReady']):
+            - status: "True"
+              reason: SecretsAvailable
+            (conditions[?type == 'DatabaseReady']):
+            - status: "True"
+              reason: DatabaseSynced
+            (conditions[?type == 'DeploymentReady']):
+            - status: "True"
+              reason: DeploymentReady
+            (conditions[?type == 'PlacementAPIReady']):
+            - status: "True"
+              reason: APIHealthy
+            (conditions[?type == 'HPAReady']):
+            - status: "True"
+              reason: HPANotRequired
+            (conditions[?type == 'NetworkPolicyReady']):
+            - status: "True"
+              reason: NetworkPolicyNotRequired
+            (conditions[?type == 'HTTPRouteReady']):
+            - status: "True"
+              reason: HTTPRouteNotRequired
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-basic-2026 -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic-2026 -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Assert the Deployment, its uWSGI launch command, Service ────
+  # ── and PDB ─────────────────────────────────────────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-basic-2026
+            namespace: openstack
+          spec:
+            template:
+              spec:
+                containers:
+                - name: placement-api
+                  image: ghcr.io/c5c3/placement:2026.1
+                  command:
+                  - uwsgi
+                  - "--http"
+                  - ":8778"
+                  - "--http-keepalive"
+                  - "--log-master"
+                  - "--log-format"
+                  - "%(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status))"
+                  - "--wsgi-file"
+                  - "/var/lib/openstack/bin/placement-api"
+                  - "--master"
+                  - "--lazy-apps"
+                  - "--need-app"
+                  - "--processes"
+                  - "2"
+                  - "--threads"
+                  - "1"
+                (length(containers) == `1`): true
+                (containers[0].env[?name == 'OS_PLACEMENT_CONFIG_DIR'].value | [0]): /etc/placement
+                (containers[0].env[?name == 'OS_PLACEMENT_DATABASE__CONNECTION'].valueFrom.secretKeyRef.name | [0]): placement-basic-2026-db-connection
+                (containers[0].env[?name == 'OS_PLACEMENT_DATABASE__CONNECTION'].valueFrom.secretKeyRef.key | [0]): connection
+                (containers[0].env[?name == 'OS_KEYSTONE_AUTHTOKEN__PASSWORD'].valueFrom.secretKeyRef.name | [0]): keystone-admin
+                (containers[0].env[?name == 'OS_KEYSTONE_AUTHTOKEN__PASSWORD'].valueFrom.secretKeyRef.key | [0]): password
+          status:
+            (availableReplicas > `0`): true
+    - script:
+        content: |
+          set -eu
+          for key in db-connection-hash authtoken-hash; do
+            VALUE=$(kubectl get deploy placement-basic-2026 -n openstack \
+              -o "jsonpath={.spec.template.metadata.annotations['placement\.c5c3\.io/${key}']}")
+            if [ -z "$VALUE" ]; then
+              echo "ERROR: pod template carries no placement.c5c3.io/${key} annotation"
+              exit 1
+            fi
+            echo "OK: placement.c5c3.io/${key} = $VALUE"
+          done
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: placement-basic-2026
+            namespace: openstack
+          spec:
+            ports:
+            - port: 8778
+    - assert:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-basic-2026
+            namespace: openstack
+            labels:
+              app.kubernetes.io/name: placement
+              app.kubernetes.io/instance: placement-basic-2026
+              app.kubernetes.io/managed-by: placement-operator
+          spec:
+            minAvailable: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: placement
+                app.kubernetes.io/instance: placement-basic-2026
+              matchExpressions:
+              - key: batch.kubernetes.io/job-name
+                operator: DoesNotExist
+  # ── Step 4: Assert the rendered config ConfigMap ────────────────────────
+  # The 2025.2 leg asserts the same two greps. Keeping them here is what turns
+  # the golden-file claim (both releases render byte-identical placement.conf)
+  # into an end-to-end one against the 2026.1 image.
+  - try:
+    - script:
+        content: |
+          kubectl get cm -n openstack -o name | grep placement-basic-2026-config-
+    - script:
+        content: |
+          set -eu
+          CM=$(kubectl get deploy placement-basic-2026 -n openstack \
+            -o 'jsonpath={.spec.template.spec.volumes[?(@.name=="config")].configMap.name}')
+          test -n "$CM"
+          kubectl get cm "$CM" -n openstack -o 'jsonpath={.data.placement\.conf}' \
+            > /tmp/placement-basic-2026.conf
+          grep -q '^\[placement_database\]$' /tmp/placement-basic-2026.conf
+          if grep -q '^\[database\]$' /tmp/placement-basic-2026.conf; then
+            echo "ERROR: placement.conf carries a [database] section"
+            exit 1
+          fi
+          echo "OK: $CM keeps the database options in [placement_database]"
+  # ── Step 5: Assert the Placement API answers over HTTP ──────────────────
+  # HTTP-level API coverage. "/" is the version document, which placement serves
+  # without a token and without touching the database, so a 200 there proves the
+  # WSGI app is serving requests. The probe retries connection-level failures
+  # inside the pod: kube-proxy's endpoint programming can trail the CR's Ready
+  # flip by a second or two, so a single-shot request races it (seen in CI).
+  # HTTP errors still fail hard.
+  - try:
+    - script:
+        timeout: 90s
+        content: |
+          kubectl run curl-test-placement-basic-2026 -n $NAMESPACE --image=ghcr.io/c5c3/placement:2026.1 --rm -i --restart=Never \
+            --command -- python3 -c "
+          import time, urllib.error, urllib.request
+          last = None
+          for _ in range(15):
+              try:
+                  r = urllib.request.urlopen('http://placement-basic-2026.openstack.svc.cluster.local:8778/')
+                  body = r.read().decode()
+                  assert r.status == 200, r.status
+                  assert 'versions' in body, body
+                  print('version document OK, status %d: %s' % (r.status, body))
+                  break
+              except urllib.error.HTTPError as exc:
+                  raise SystemExit('GET / -> HTTP %d' % exc.code)
+              except (urllib.error.URLError, ConnectionError, OSError) as exc:
+                  last = exc
+                  print('version document retry: %s' % exc)
+                  time.sleep(2)
+          else:
+              raise SystemExit('version document never answered after retries: %r' % last)
+          "
+    # /resource_providers sits behind keystonemiddleware, so an unauthenticated
+    # GET must come back 401. A 200 would mean [api] auth_strategy never reached
+    # the config; a 503 would mean the middleware cannot reach Keystone at all.
+    - script:
+        timeout: 90s
+        content: |
+          kubectl run authz-test-placement-basic-2026 -n $NAMESPACE --image=ghcr.io/c5c3/placement:2026.1 --rm -i --restart=Never \
+            --command -- python3 -c "
+          import time, urllib.error, urllib.request
+          last = None
+          for _ in range(15):
+              try:
+                  r = urllib.request.urlopen('http://placement-basic-2026.openstack.svc.cluster.local:8778/resource_providers')
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 401:
+                      print('unauthenticated GET /resource_providers -> HTTP 401')
+                      break
+                  raise SystemExit('unauthenticated GET /resource_providers -> HTTP %d, want 401' % exc.code)
+              except (urllib.error.URLError, ConnectionError, OSError) as exc:
+                  last = exc
+                  print('resource_providers retry: %s' % exc)
+                  time.sleep(2)
+              else:
+                  raise SystemExit('unauthenticated GET /resource_providers -> HTTP %d, want 401' % r.status)
+          else:
+              raise SystemExit('resource_providers never answered after retries: %r' % last)
+          "
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-basic-2026 -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic-2026 -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Service and Endpoints ==="
+          kubectl get svc,endpoints -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic-2026 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/basic-deployment/00-placement-cr.yaml
+++ b/tests/e2e/placement/basic-deployment/00-placement-cr.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the basic-deployment E2E test (2025.2 release).
+# Managed mode: database via clusterRef to openstack-db (schema
+# placement_basic), cache via clusterRef to openstack-memcached. The database
+# credentials come from the ESO-synced placement-db Secret and the service-user
+# password from the pre-seeded keystone-admin Secret (both
+# deploy/kind/infrastructure). Placement owns no store backend, so the CR is the
+# only fixture the suite applies.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-basic
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 3
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_basic
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/basic-deployment/chainsaw-test.yaml
+++ b/tests/e2e/placement/basic-deployment/chainsaw-test.yaml
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for happy-path Placement deployment (2025.2 release).
+# Validates the full reconciliation cycle:
+#   - All 7 sub-conditions progress to True with expected reasons
+#   - Aggregate Ready=True with reason AllReady
+#   - The API Deployment launches uWSGI against the image-shipped WSGI entry
+#     (--wsgi-file /var/lib/openstack/bin/placement-api) and points placement at
+#     the mounted config through OS_PLACEMENT_CONFIG_DIR
+#   - The database URL and the service-user password arrive as env vars, and
+#     both content-digest annotations are stamped on the pod template so a
+#     rotated credential rolls the pods
+#   - Owned resources exist (Deployment, Service on 8778, PDB, config ConfigMap)
+#   - The rendered placement.conf keeps its database options in
+#     [placement_database] and renders no [database] section
+#   - The Placement API answers the unauthenticated version document with 200,
+#     and rejects an unauthenticated /resource_providers request with exactly
+#     401 — the token-validation path is wired, not disabled
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-basic-deployment
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR ──────────────────────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert all sub-conditions and Ready ────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-basic
+            namespace: openstack
+          status:
+            (conditions[?type == 'SecretsReady']):
+            - status: "True"
+              reason: SecretsAvailable
+            (conditions[?type == 'DatabaseReady']):
+            - status: "True"
+              reason: DatabaseSynced
+            (conditions[?type == 'DeploymentReady']):
+            - status: "True"
+              reason: DeploymentReady
+            (conditions[?type == 'PlacementAPIReady']):
+            - status: "True"
+              reason: APIHealthy
+            (conditions[?type == 'HPAReady']):
+            - status: "True"
+              reason: HPANotRequired
+            (conditions[?type == 'NetworkPolicyReady']):
+            - status: "True"
+              reason: NetworkPolicyNotRequired
+            (conditions[?type == 'HTTPRouteReady']):
+            - status: "True"
+              reason: HTTPRouteNotRequired
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-basic -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Assert the Deployment, its uWSGI launch command, Service ────
+  # ── and PDB ─────────────────────────────────────────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-basic
+            namespace: openstack
+          spec:
+            template:
+              spec:
+                containers:
+                - name: placement-api
+                  command:
+                  - uwsgi
+                  - "--http"
+                  - ":8778"
+                  - "--http-keepalive"
+                  - "--log-master"
+                  - "--log-format"
+                  - "%(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status))"
+                  - "--wsgi-file"
+                  - "/var/lib/openstack/bin/placement-api"
+                  - "--master"
+                  - "--lazy-apps"
+                  - "--need-app"
+                  - "--processes"
+                  - "2"
+                  - "--threads"
+                  - "1"
+                # Placement runs one process per pod: no store backend, no
+                # maintenance sidecar, no cache warmer. A second container here
+                # would mean something injected itself into every Placement
+                # deployment in the fleet.
+                (length(containers) == `1`): true
+                # The WSGI entry resolves its config as
+                # $OS_PLACEMENT_CONFIG_DIR/placement.conf, so this env var is
+                # the only thing pointing placement at the mounted ConfigMap —
+                # there is no --config-file and no --pyargv on the command line
+                # asserted above.
+                (containers[0].env[?name == 'OS_PLACEMENT_CONFIG_DIR'].value | [0]): /etc/placement
+                # The DSN and the service-user password travel as oslo.config
+                # env overrides sourced from Secrets, so no credential material
+                # enters the rendered ConfigMap.
+                (containers[0].env[?name == 'OS_PLACEMENT_DATABASE__CONNECTION'].valueFrom.secretKeyRef.name | [0]): placement-basic-db-connection
+                (containers[0].env[?name == 'OS_PLACEMENT_DATABASE__CONNECTION'].valueFrom.secretKeyRef.key | [0]): connection
+                (containers[0].env[?name == 'OS_KEYSTONE_AUTHTOKEN__PASSWORD'].valueFrom.secretKeyRef.name | [0]): keystone-admin
+                (containers[0].env[?name == 'OS_KEYSTONE_AUTHTOKEN__PASSWORD'].valueFrom.secretKeyRef.key | [0]): password
+          status:
+            (availableReplicas > `0`): true
+    # Both credentials are env-var-consumed, so a rotation only reaches the
+    # workers on a Pod restart. The digest annotations are what turns a rotated
+    # DSN or service-user password into a rollout; a missing annotation means a
+    # rotation would leave the pods running the old credential until something
+    # else happened to roll them.
+    - script:
+        content: |
+          set -eu
+          for key in db-connection-hash authtoken-hash; do
+            VALUE=$(kubectl get deploy placement-basic -n openstack \
+              -o "jsonpath={.spec.template.metadata.annotations['placement\.c5c3\.io/${key}']}")
+            if [ -z "$VALUE" ]; then
+              echo "ERROR: pod template carries no placement.c5c3.io/${key} annotation"
+              exit 1
+            fi
+            echo "OK: placement.c5c3.io/${key} = $VALUE"
+          done
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: placement-basic
+            namespace: openstack
+          spec:
+            ports:
+            - port: 8778
+    - assert:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-basic
+            namespace: openstack
+            labels:
+              app.kubernetes.io/name: placement
+              app.kubernetes.io/instance: placement-basic
+              app.kubernetes.io/managed-by: placement-operator
+          spec:
+            minAvailable: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: placement
+                app.kubernetes.io/instance: placement-basic
+              # db-sync pods carry no readiness probe, so they count as healthy
+              # from their first moment. Without this exclusion they inflate
+              # currentHealthy and let a drain evict the API pods the budget
+              # protects.
+              matchExpressions:
+              - key: batch.kubernetes.io/job-name
+                operator: DoesNotExist
+  # ── Step 4: Assert the rendered config ConfigMap ────────────────────────
+  # Placement is the one service in the fleet that reads its database options
+  # from [placement_database]. A [database] section would be inert: placement
+  # would fall back to its own default DSN and fail to reach the schema the
+  # db-sync Job migrated. The ConfigMap is resolved through the Deployment's
+  # config volume so the assertion follows the content hash instead of guessing
+  # the current name.
+  - try:
+    - script:
+        content: |
+          kubectl get cm -n openstack -o name | grep placement-basic-config-
+    - script:
+        content: |
+          set -eu
+          CM=$(kubectl get deploy placement-basic -n openstack \
+            -o 'jsonpath={.spec.template.spec.volumes[?(@.name=="config")].configMap.name}')
+          test -n "$CM"
+          kubectl get cm "$CM" -n openstack -o 'jsonpath={.data.placement\.conf}' \
+            > /tmp/placement-basic.conf
+          grep -q '^\[placement_database\]$' /tmp/placement-basic.conf
+          if grep -q '^\[database\]$' /tmp/placement-basic.conf; then
+            echo "ERROR: placement.conf carries a [database] section"
+            exit 1
+          fi
+          echo "OK: $CM keeps the database options in [placement_database]"
+  # ── Step 5: Assert the Placement API answers over HTTP ──────────────────
+  # HTTP-level API coverage. "/" is the version document, which placement serves
+  # without a token and without touching the database, so a 200 there proves the
+  # WSGI app is serving requests. The probe retries connection-level failures
+  # inside the pod: kube-proxy's endpoint programming can trail the CR's Ready
+  # flip by a second or two, so a single-shot request races it (seen in CI).
+  # HTTP errors still fail hard.
+  - try:
+    - script:
+        timeout: 90s
+        content: |
+          kubectl run curl-test-placement-basic -n $NAMESPACE --image=ghcr.io/c5c3/placement:2025.2 --rm -i --restart=Never \
+            --command -- python3 -c "
+          import time, urllib.error, urllib.request
+          last = None
+          for _ in range(15):
+              try:
+                  r = urllib.request.urlopen('http://placement-basic.openstack.svc.cluster.local:8778/')
+                  body = r.read().decode()
+                  assert r.status == 200, r.status
+                  assert 'versions' in body, body
+                  print('version document OK, status %d: %s' % (r.status, body))
+                  break
+              except urllib.error.HTTPError as exc:
+                  raise SystemExit('GET / -> HTTP %d' % exc.code)
+              except (urllib.error.URLError, ConnectionError, OSError) as exc:
+                  last = exc
+                  print('version document retry: %s' % exc)
+                  time.sleep(2)
+          else:
+              raise SystemExit('version document never answered after retries: %r' % last)
+          "
+    # The version document alone cannot tell a keystone-protected API from an
+    # open one: placement serves it unauthenticated either way. /resource_providers
+    # is behind keystonemiddleware, so an unauthenticated GET must come back 401.
+    # A 200 would mean [api] auth_strategy never reached the config and every
+    # inventory in the deployment is world-writable; a 503 would mean the
+    # middleware cannot reach Keystone at all. Both fail here, and only
+    # connection-level errors are retried.
+    - script:
+        timeout: 90s
+        content: |
+          kubectl run authz-test-placement-basic -n $NAMESPACE --image=ghcr.io/c5c3/placement:2025.2 --rm -i --restart=Never \
+            --command -- python3 -c "
+          import time, urllib.error, urllib.request
+          last = None
+          for _ in range(15):
+              try:
+                  r = urllib.request.urlopen('http://placement-basic.openstack.svc.cluster.local:8778/resource_providers')
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 401:
+                      print('unauthenticated GET /resource_providers -> HTTP 401')
+                      break
+                  raise SystemExit('unauthenticated GET /resource_providers -> HTTP %d, want 401' % exc.code)
+              except (urllib.error.URLError, ConnectionError, OSError) as exc:
+                  last = exc
+                  print('resource_providers retry: %s' % exc)
+                  time.sleep(2)
+              else:
+                  raise SystemExit('unauthenticated GET /resource_providers -> HTTP %d, want 401' % r.status)
+          else:
+              raise SystemExit('resource_providers never answered after retries: %r' % last)
+          "
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-basic -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Service and Endpoints ==="
+          kubectl get svc,endpoints -n $NAMESPACE -l app.kubernetes.io/instance=placement-basic 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/deletion-cleanup/00-placement-cr.yaml
+++ b/tests/e2e/placement/deletion-cleanup/00-placement-cr.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the deletion-cleanup E2E test.
+# Managed mode: same pattern as basic-deployment, unique name placement-deletion
+# (schema placement_deletion). Deleting the CR exercises the finalizer-driven
+# MariaDB CR sweep and the garbage collection of every owned child. A single
+# replica keeps the teardown short.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-deletion
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_deletion
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/deletion-cleanup/chainsaw-test.yaml
+++ b/tests/e2e/placement/deletion-cleanup/chainsaw-test.yaml
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the finalizer-driven cleanup on Placement CR deletion.
+#
+# Deploys a Placement CR, waits for Ready=True, then:
+#   - asserts the cleanup finalizer and every owned child (Deployment, Service,
+#     PDB, the content-hashed config ConfigMap, the derived db-connection
+#     Secret, and the db-sync Job);
+#   - deletes the CR and asserts all of them are gone within a bounded deletion
+#     window, together with the MariaDB Database/User/Grant CRs the operator
+#     created in managed mode.
+#
+# Placement owns no store backend and renders no CronJob, so the CR is the only
+# fixture and the sweep has no periodic workload to reap.
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-deletion-cleanup
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR ──────────────────────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Wait for Ready=True and assert the cleanup finalizer ────────
+  # The finalizer is added on first reconcile so deletion can trigger the
+  # MariaDB CR cleanup before the Placement CR leaves etcd.
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+            # Nil-safe: on the first poll after apply the controller may not
+            # have added the finalizer yet (`finalizers` is nil). The `|| `[]``
+            # fallback lets the assert retry rather than raising a non-retryable
+            # JMESPath type error.
+            (contains(finalizers || `[]`, 'placement.openstack.c5c3.io/finalizer')): true
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-deletion -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Assert the owned children exist before the deletion ─────────
+  # Asserting them here is what gives step 5 its meaning: an absence assertion
+  # on a resource that never existed passes for the wrong reason.
+  - try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - assert:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: placement-deletion-db-connection
+            namespace: openstack
+    - assert:
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: placement-deletion-db-sync
+            namespace: openstack
+    - script:
+        content: |
+          set -eu
+          kubectl get cm -n openstack -o name | grep placement-deletion-config-
+  # ── Step 4: Delete the Placement CR ─────────────────────────────────────
+  # Bounded timeout (<= 2m) to keep deletion responsive; fails the test if the
+  # finalizer blocks removal for longer than this.
+  - try:
+    - delete:
+        timeout: 2m
+        ref:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          name: placement-deletion
+          namespace: openstack
+  # ── Step 5: Assert owned resources and MariaDB CRs are deleted ──────────
+  - try:
+    - error:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: placement-deletion-db-connection
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: placement-deletion-db-sync
+            namespace: openstack
+    # MariaDB CRs created by reconcileDatabase in managed mode (clusterRef).
+    # Owner references are set on these CRs, but the cleanup finalizer also
+    # issues an explicit Delete so the schema teardown is triggered before the
+    # owner-ref chain disappears.
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Database
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: User
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Grant
+          metadata:
+            name: placement-deletion
+            namespace: openstack
+  # ── Step 6: Assert the content-hashed ConfigMaps are gone ──────────────
+  # These carry a content-hash suffix so they cannot use a static error
+  # assertion. A script step with an inverted grep verifies none with the
+  # expected prefix remains after garbage collection.
+  - try:
+    - script:
+        content: |
+          set -eu
+          if kubectl get cm -n openstack -o name | grep -q placement-deletion-config-; then
+            echo "ERROR: ConfigMap matching placement-deletion-config-* still exists"
+            exit 1
+          fi
+          echo "OK: no placement-deletion config ConfigMap remains"
+    catch:
+    - script:
+        content: |
+          echo "=== remaining placement-deletion objects ==="
+          kubectl get all,cm,secret,job -n $NAMESPACE 2>&1 | grep placement-deletion || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/gateway-quick-start-smoke/00-namespace.yaml
+++ b/tests/e2e/placement/gateway-quick-start-smoke/00-namespace.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Namespace fixture for the Placement Gateway quick-start smoke test.
+#
+# The `openstack` namespace is already created by the kind overlay
+# (`deploy/kind/base/`) because it holds the Gateway/Certificate objects wired
+# in `openstack-gateway.yaml` and the managed backing services the Placement API
+# depends on (`openstack-db`, `openstack-memcached`). We still apply it here
+# defensively so the suite is self-contained — chainsaw's `apply` is idempotent
+# on an existing Namespace, which makes the test tolerate being invoked against
+# a bare cluster as well.
+#
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack

--- a/tests/e2e/placement/gateway-quick-start-smoke/01-smoke-placement-cr.yaml
+++ b/tests/e2e/placement/gateway-quick-start-smoke/01-smoke-placement-cr.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal Placement CR fixture for the Gateway quick-start smoke test — the
+# resource-tracking counterpart to tests/e2e/keystone/gateway-quick-start-smoke,
+# tests/e2e/horizon/gateway-quick-start-smoke and
+# tests/e2e/glance/gateway-quick-start-smoke.
+#
+# This smoke test exercises the end-to-end TLS + Gateway data-plane path:
+# `curl -k https://placement.127-0-0-1.nip.io/` must return HTTP 200 carrying the
+# Placement version document. That requires a Placement CR whose spec.gateway
+# produces an HTTPRoute attaching to the kind overlay's `openstack-gw` Gateway.
+# The hostname MUST match the listener on `openstack-gw` that terminates TLS for
+# `placement.127-0-0-1.nip.io` AND the dnsName of that listener's Certificate, so
+# the listener's TLS Secret matches the SNI the client presents.
+#
+# Name-collision avoidance: chainsaw-config.yaml sets `execution.parallel: 4`,
+# so this fixture uses a unique CR name (`placement-smoke`) to avoid clashing
+# with the sibling placement suites that share the `openstack` namespace and the
+# backing services (`openstack-db`, `openstack-memcached`) and on HTTPRoute
+# object names inside the `openstack` namespace. No other placement suite
+# attaches to the nip.io Gateway hostname, so a root-path route does not
+# conflict.
+#
+# The version document at `/` is served above the auth pipeline, so it answers
+# 200 without a live Keystone and without a database round-trip;
+# keystoneEndpoint therefore points at the cluster-local convention URL and the
+# smoke needs no running Keystone — exactly like the placement basic-deployment
+# fixture.
+#
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-smoke
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_smoke
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password
+  gateway:
+    parentRef:
+      name: openstack-gw
+    hostname: placement.127-0-0-1.nip.io
+    path: /

--- a/tests/e2e/placement/gateway-quick-start-smoke/chainsaw-test.yaml
+++ b/tests/e2e/placement/gateway-quick-start-smoke/chainsaw-test.yaml
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E smoke test for the Placement Gateway quick-start path — the
+# resource-tracking counterpart to tests/e2e/keystone/gateway-quick-start-smoke,
+# tests/e2e/horizon/gateway-quick-start-smoke and
+# tests/e2e/glance/gateway-quick-start-smoke. Exercises end-to-end:
+#   `curl -k https://placement.127-0-0-1.nip.io/` returns HTTP 200 with the
+#   Placement version document (a JSON body carrying a "versions" key).
+#
+# The full chain under test:
+#   kind host :443 → kindnode :31443 (NodePort) → Envoy Gateway proxy
+#   → the HTTPS listener on `openstack/openstack-gw` that terminates
+#   `placement.127-0-0-1.nip.io` → HTTPRoute managed by the Placement Operator
+#   → Service → placement-api pod.
+#
+# Suite location: lives under `tests/e2e/placement/` (not
+# `tests/e2e/infrastructure/`) so the operator-installed `e2e-operator` matrix
+# job runs it — that job is the only place where the Placement CRD is registered
+# and the operator can reconcile the smoke Placement CR into an HTTPRoute. The
+# `e2e-infra` job brings up no placement-operator at all, so a smoke suite under
+# `tests/e2e/infrastructure/` could never apply a Placement CR.
+#
+# ── DECISION: curl from the chainsaw host (Option B) ─────────────────
+# curl runs directly from the chainsaw script step on the CI host, NOT from an
+# ephemeral in-cluster pod: the nip.io → 127.0.0.1 mapping is an external DNS
+# concern, `hack/kind-config.yaml` already bridges host 127.0.0.1:443 to the
+# proxy NodePort 31443, and the point of a quick-start smoke is to prove "the
+# external URL the docs tell the user to open WORKS". Mirrors the sibling
+# keystone, horizon and glance gateway-quick-start-smoke suites.
+#
+# ── DECISION: probe "/", accept HTTP 200 only ────────────────────────
+# Placement serves no oslo healthcheck app, so there is no `/healthcheck` path
+# to probe and no plain-text `OK` body to match: the analogue is the version
+# document at "/", which placement renders without a token and without a
+# database round-trip, exactly like the keystone smoke's JSON `version` check.
+# Accepting only 200 (not 200-or-404/302) proves the HTTPRoute is attached AND
+# the placement-api backend is serving — a 404 would only prove the data-plane
+# is reachable. The self-contained fixture (01-smoke-placement-cr.yaml) makes
+# the 200 independent of sibling-suite ordering under `parallel: 4`.
+#
+# ── Scope gating — runtime presence checks ──────────────────────────
+# The script probes for `GatewayClass/envoy`, `Gateway/openstack-gw`, and the
+# `placements.placement.openstack.c5c3.io` CRD. If any is absent it exits 0 with
+# a SKIP line, so production overlays (no Envoy Gateway, operator suspended)
+# default-skip the test off any non-kind cluster with no `--selector` needed.
+#
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-gateway-quick-start-smoke
+spec:
+  # The db-sync Job plus the API warm-up make the envelope 8m. The inner
+  # `kubectl wait` bounds (5m each) stay under this outer cap so their failure
+  # mode surfaces as a targeted `condition X not reached` diagnostic rather than
+  # chainsaw's generic script-timeout kill. The two waits are sequential phases
+  # of one reconcile chain (the Gateway must be Programmed before the HTTPRoute
+  # can attach and Placement's aggregate Ready — which includes HTTPRouteReady —
+  # can flip True), so both complete well inside 8m on a warm cluster.
+  timeouts:
+    assert: 8m
+    exec: 8m
+  steps:
+  # ── Step 1: Apply namespace ───────────────────────────────────────
+  # The Placement CR (01-smoke-placement-cr.yaml) is NOT applied here — its CRD
+  # is registered by the placement-operator, which is suspended in some
+  # overlays. Applying it unconditionally would abort chainsaw with `no matches
+  # for kind "Placement"` on those clusters, so the apply lives in the Step 2
+  # script body behind a CRD presence guard to keep this test default-safe.
+  - try:
+    - apply:
+        file: 00-namespace.yaml
+  # ── Step 2: Smoke-check Placement API reachability ────────────────
+  - try:
+    - script:
+        timeout: 8m
+        # Chainsaw defaults to `sh`, which rejects `set -o pipefail`; all other
+        # infra/keystone e2e scripts pin bash for the same reason.
+        shell: bash
+        content: |
+          set -euo pipefail
+
+          # ── Presence guard ──────────────────────────────
+          # The kind overlay alone applies
+          # `deploy/kind/base/openstack-gateway.yaml`, which materialises
+          # GatewayClass/envoy and Gateway/openstack-gw. Their absence
+          # unambiguously signals a non-kind cluster — exit 0 with a SKIP line.
+          if ! kubectl get gatewayclass envoy >/dev/null 2>&1; then
+            echo "SKIP: GatewayClass/envoy not present (non-kind overlay)."
+            exit 0
+          fi
+          if ! kubectl get gateway openstack-gw -n openstack >/dev/null 2>&1; then
+            echo "SKIP: Gateway/openstack-gw not present in openstack namespace"
+            echo "      (non-kind overlay)."
+            exit 0
+          fi
+          # Placement CRD gate — the `e2e-operator` matrix job installs the
+          # operator so the CRD is present and this guard passes; on infra-only
+          # or production clusters where the operator is suspended/absent, the
+          # guard exits 0 and the suite skips cleanly.
+          if ! kubectl get crd placements.placement.openstack.c5c3.io >/dev/null 2>&1; then
+            echo "SKIP: Placement CRD not present (operator not deployed)."
+            exit 0
+          fi
+          echo "OK: Gateway + Placement CRD present — running smoke checks"
+
+          # Apply the minimal Placement CR now that the CRD presence guard has
+          # passed. Chainsaw runs scripts with the test directory as CWD, so the
+          # relative path resolves.
+          kubectl apply -f 01-smoke-placement-cr.yaml
+
+          # ── Pre-flight: Gateway Programmed ────────────────────────
+          # Envoy Gateway sets `Programmed=True` once the listeners have usable
+          # TLS Secrets and the xDS data-plane is ready. Without this wait an
+          # early curl races kind startup (cert issuance + Envoy roll-out).
+          kubectl wait --for=condition=Programmed \
+            gateway/openstack-gw -n openstack --timeout=5m
+          echo "OK: Gateway/openstack-gw is Programmed"
+
+          # ── Pre-flight: Placement Ready=True ──────────────────────
+          # Placement's aggregate Ready condition includes the HTTPRouteReady
+          # sub-condition (only True after Envoy publishes Accepted=True on the
+          # route's parent) AND the deployment/health sub-conditions (pods
+          # serving the version document). Waiting on Ready gates the curl on
+          # BOTH the route being attached AND the backend being up — the same
+          # strong single gate the horizon and glance smokes use. --timeout=5m
+          # stays inside the outer 8m script cap.
+          kubectl wait --for=condition=Ready \
+            placement/placement-smoke -n openstack --timeout=5m
+          echo "OK: Placement/placement-smoke Ready=True"
+
+          # ── HTTP 200 from the CI host ────────────────────
+          # `-k` accepts the self-signed cert issued by
+          # selfsigned-cluster-issuer (expected for a kind cluster). Retry
+          # loop: Envoy's xDS push and the placement-api pod's warm-up can race
+          # the Ready signal by a few seconds — up to 15 attempts, 2s apart — so
+          # a brief 503 from the proxy doesn't fail the whole run.
+          URL="https://placement.127-0-0-1.nip.io/"
+          HTTP_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+            HTTP_CODE="$(curl -sk -o /tmp/body -w '%{http_code}' "$URL" || true)"
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "OK: got HTTP 200 on attempt $attempt"
+              break
+            fi
+            echo "attempt $attempt: HTTP $HTTP_CODE (retrying in 2s)"
+            sleep 2
+          done
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: $URL returned HTTP $HTTP_CODE (expected 200)"
+            echo "--- response body (first 2KB) ---"
+            head -c 2048 /tmp/body 2>/dev/null || true
+            echo
+            exit 1
+          fi
+
+          # Non-empty body assertion: a 200 with an empty body would mean the
+          # HTTPRoute is attached but the placement-api backend returned
+          # nothing.
+          if [ ! -s /tmp/body ]; then
+            echo "ERROR: $URL returned HTTP 200 with empty body"
+            exit 1
+          fi
+
+          # Version-document assertion: placement answers "/" with a JSON
+          # document whose top-level key is "versions". Matching the quoted key
+          # (not a bare `versions`) keeps an arbitrary error page from passing.
+          # This is the placement analogue of the keystone smoke's JSON
+          # `"version"` check, the glance smoke's oslo healthcheck `OK` marker
+          # and the horizon smoke's `csrfmiddlewaretoken` marker: it proves the
+          # Gateway served the placement-api response rather than a bare proxy
+          # 200.
+          if grep -q '"versions"' /tmp/body; then
+            echo "OK: response body is the Placement version document"
+          else
+            echo "ERROR: response body is not the Placement version document"
+            echo "--- response body (first 2KB) ---"
+            head -c 2048 /tmp/body 2>/dev/null || true
+            echo
+            exit 1
+          fi
+
+          echo "OK: placement-api answered 200 on https://placement.127-0-0-1.nip.io/"
+    catch:
+    # On failure, dump post-mortem state to help CI triage. Each resource is
+    # individually scoped so a missing one doesn't short-circuit the dump.
+    - describe:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: Gateway
+        name: openstack-gw
+        namespace: openstack
+    - describe:
+        apiVersion: placement.openstack.c5c3.io/v1alpha1
+        kind: Placement
+        name: placement-smoke
+        namespace: openstack
+    - script:
+        # The HTTPRoute and the Certificate may not exist on an early failure
+        # (the Placement CR hasn't reconciled yet), so `|| true` so the dump
+        # always runs to completion. The operator-managed HTTPRoute is listed
+        # generically rather than by a guessed name.
+        shell: bash
+        content: |
+          echo "=== HTTPRoutes in openstack ==="
+          kubectl get httproute -n openstack -o wide 2>&1 || true
+          echo
+          echo "=== Certificates in openstack ==="
+          kubectl get certificate -n openstack -o wide 2>&1 || true
+          echo
+          echo "=== Placement pods ==="
+          kubectl get pods -n openstack -l app.kubernetes.io/instance=placement-smoke -o wide 2>&1 || true
+          echo
+          echo "=== placement-operator logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          echo
+          echo "=== events (last 30) ==="
+          kubectl get events -n openstack --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    - podLogs:
+        namespace: envoy-gateway-system
+        selector: app.kubernetes.io/name=gateway-helm
+        tail: 200
+    finally:
+    # The CR is applied with `kubectl` from inside the Step 2 script (it sits
+    # behind the CRD presence guard), so chainsaw's own `cleanup` never sees it
+    # and its namespace teardown does not apply — the suite shares the
+    # long-lived `openstack` namespace with every other placement suite. Without
+    # this block each run would permanently leak the placement-api Deployment,
+    # the HTTPRoute holding `placement.127-0-0-1.nip.io` on the shared Gateway,
+    # and the MariaDB Database/User/Grant CRs plus the `placement_smoke` schema
+    # the operator provisions. Best-effort: a SKIP run created nothing, and a
+    # cleanup failure must not mask the assertion result.
+    - script:
+        shell: bash
+        content: |
+          kubectl delete placement placement-smoke -n openstack \
+            --ignore-not-found --timeout=2m 2>&1 || true

--- a/tests/e2e/placement/healthcheck/00-placement-cr.yaml
+++ b/tests/e2e/placement/healthcheck/00-placement-cr.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the healthcheck E2E test (2025.2 release).
+# Managed mode: database via clusterRef to openstack-db (schema
+# placement_healthcheck), cache via clusterRef to openstack-memcached. A single
+# replica is enough to exercise the operator's HTTP probe of the Placement API.
+# The CR carries no spec.gateway, so status.endpoint must report the
+# cluster-local Service URL.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-healthcheck
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_healthcheck
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/healthcheck/chainsaw-test.yaml
+++ b/tests/e2e/placement/healthcheck/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the HealthCheck sub-reconciler.
+# Verifies the operator's HTTP probe of the Placement API version document
+# drives PlacementAPIReady and status.endpoint:
+#   - PlacementAPIReady=True with reason APIHealthy once the Deployment serves
+#   - status.endpoint carries the cluster-local URL (no gateway configured)
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-healthcheck
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR ──────────────────────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert PlacementAPIReady and the endpoint ──────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-healthcheck
+            namespace: openstack
+          status:
+            endpoint: http://placement-healthcheck.openstack.svc.cluster.local:8778/
+            (conditions[?type == 'DeploymentReady']):
+            - status: "True"
+            (conditions[?type == 'PlacementAPIReady']):
+            - status: "True"
+              reason: APIHealthy
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-healthcheck -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-healthcheck -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/httproute/00-httproute-crd.yaml
+++ b/tests/e2e/placement/httproute/00-httproute-crd.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal HTTPRoute CRD for the E2E test cluster.
+#
+# The E2E kind cluster does not install a Gateway controller, so the upstream
+# sigs.k8s.io/gateway-api CRDs are not present by default. This minimal CRD
+# lets the operator create an HTTPRoute and lets the test simulate an
+# "Accepted" parent status without pulling in the 6000-line upstream schema.
+# The spec and status sub-trees use x-kubernetes-preserve-unknown-fields so
+# the reconciler's full ParentRef/Hostnames/Rules structure round-trips.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httproutes.gateway.networking.k8s.io
+  annotations:
+    # Required because gateway.networking.k8s.io is a Kubernetes-protected API
+    # group. Points to the upstream approval PR for the real CRD.
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    plural: httproutes
+    singular: httproute
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/tests/e2e/placement/httproute/01-placement-cr.yaml
+++ b/tests/e2e/placement/httproute/01-placement-cr.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR with spec.gateway for the HTTPRoute lifecycle test.
+# Managed mode (clusterRef openstack-db, schema placement_httproute), same shape
+# as the basic-deployment fixture. Placement owns no store backend, so the CR is
+# the only fixture the suite applies: it reaches a running Deployment on its own
+# and the operator runs the parallel group that owns the HTTPRoute.
+#
+# The parentRef is deliberately non-existent so no real Gateway controller ever
+# writes its own RouteParentStatus slot and races the status merge-patch in the
+# acceptance-simulation step.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-httproute
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_httproute
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password
+  gateway:
+    parentRef:
+      name: not-a-real-gateway
+    hostname: placement.e2e.example.com

--- a/tests/e2e/placement/httproute/02-patch-remove-gateway.yaml
+++ b/tests/e2e/placement/httproute/02-patch-remove-gateway.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch: unset spec.gateway so the operator deletes the HTTPRoute.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-httproute
+  namespace: openstack
+spec:
+  gateway: null

--- a/tests/e2e/placement/httproute/chainsaw-test.yaml
+++ b/tests/e2e/placement/httproute/chainsaw-test.yaml
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the optional HTTPRoute sub-reconciler.
+# Verifies the full lifecycle of spec.gateway driven by the Placement CR:
+#   - Apply a Placement CR with spec.gateway and assert the HTTPRoute is created
+#     with the expected ParentRef/Hostname/BackendRef (Placement API port 8778)
+#     and that status.endpoint flips to the public gateway URL.
+#   - Before any Gateway controller reports Accepted, HTTPRouteReady is
+#     False with reason HTTPRouteNotAccepted.
+#   - Simulate a Gateway controller accepting the route by patching the
+#     parent status, then assert HTTPRouteReady flips True/HTTPRouteAccepted.
+#   - Unset spec.gateway and assert the HTTPRoute is deleted and
+#     HTTPRouteReady is True with reason HTTPRouteNotRequired.
+#
+# SCOPE: this suite covers the operator's HTTPRoute contract only — it patches
+# the Accepted condition itself rather than running a Gateway controller, so
+# nothing here proves traffic actually reaches the Placement API. The
+# real-Gateway leg lives in the sibling
+# tests/e2e/placement/gateway-quick-start-smoke/ suite, which drives kind host
+# :443 → NodePort → Envoy Gateway → HTTPRoute → Service → pod, mirroring the
+# keystone, horizon and glance gateway-quick-start-smoke suites.
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-httproute
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Install HTTPRoute CRD ──────────────────────────────────────
+  # The E2E cluster may not install a Gateway controller; apply the minimal
+  # CRD so the operator can create HTTPRoute objects and the test can patch
+  # their status.
+  - try:
+    - apply:
+        file: 00-httproute-crd.yaml
+  # ── Step 2: Apply the Placement CR with spec.gateway ───────────────────
+  - try:
+    - apply:
+        file: 01-placement-cr.yaml
+  # ── Step 3: Assert HTTPRoute created with the expected spec ────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: placement-httproute
+            namespace: openstack
+            labels:
+              app.kubernetes.io/name: placement
+              app.kubernetes.io/instance: placement-httproute
+              app.kubernetes.io/managed-by: placement-operator
+          spec:
+            parentRefs:
+            - name: not-a-real-gateway
+            hostnames:
+            - placement.e2e.example.com
+            rules:
+            - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+              backendRefs:
+              - name: placement-httproute
+                port: 8778
+              # Unlike the glance route, this rule carries no `timeouts`
+              # stanza: placement answers short JSON requests and streams
+              # nothing, so the operator leaves the request cap to the gateway
+              # implementation's default (buildPlacementHTTPRoute passes no
+              # RequestTimeout). The stub CRD above preserves unknown fields, so
+              # a timeout the operator started rendering would round-trip and
+              # show up as a diff against this assertion.
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-httproute -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== HTTPRoute ==="
+          kubectl get httproute -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 4: Assert gateway-aware status.endpoint ───────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-httproute
+            namespace: openstack
+          status:
+            endpoint: https://placement.e2e.example.com/
+            (conditions[?type == 'HTTPRouteReady']):
+            - status: "False"
+              reason: HTTPRouteNotAccepted
+  # ── Step 5: Simulate Gateway controller accepting the HTTPRoute ────────
+  - try:
+    - script:
+        content: |
+          kubectl patch httproute placement-httproute -n $NAMESPACE \
+            --subresource=status --type=merge -p '{
+              "status": {
+                "parents": [{
+                  "parentRef": {"name": "not-a-real-gateway"},
+                  "controllerName": "e2e.example.com/fake-gateway-controller",
+                  "conditions": [{
+                    "type": "Accepted",
+                    "status": "True",
+                    "reason": "Accepted",
+                    "message": "Simulated Accepted condition for E2E test",
+                    "lastTransitionTime": "2026-07-05T00:00:00Z",
+                    "observedGeneration": 1
+                  }]
+                }]
+              }
+            }'
+  # ── Step 6: Assert HTTPRouteReady=True/HTTPRouteAccepted ───────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-httproute
+            namespace: openstack
+          status:
+            (conditions[?type == 'HTTPRouteReady']):
+            - status: "True"
+              reason: HTTPRouteAccepted
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-httproute -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== HTTPRoute ==="
+          kubectl get httproute -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 7: Unset spec.gateway ─────────────────────────────────────────
+  - try:
+    - patch:
+        file: 02-patch-remove-gateway.yaml
+  # ── Step 8: Assert HTTPRoute deleted and NotRequired ───────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-httproute
+            namespace: openstack
+          status:
+            (conditions[?type == 'HTTPRouteReady']):
+            - status: "True"
+              reason: HTTPRouteNotRequired
+    - script:
+        content: |
+          # Verify HTTPRoute no longer exists.
+          if kubectl get httproute placement-httproute -n $NAMESPACE 2>/dev/null; then
+            echo "FAIL: HTTPRoute should have been deleted"
+            exit 1
+          fi
+          echo "PASS: HTTPRoute correctly deleted"

--- a/tests/e2e/placement/invalid-cr/00-openstackrelease-missing.yaml
+++ b/tests/e2e/placement/invalid-cr/00-openstackrelease-missing.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.openStackRelease omitted. What answers is the CRD pattern, not the
+# required-properties list: the defaulting webhook marshals the whole typed
+# object back into its admission patch, and PlacementSpec.OpenStackRelease
+# carries no omitempty tag, so the patch materializes the field as an empty
+# string. By the time the schema is checked the property is present and the
+# empty value fails the pattern. The fixture still earns its place: it pins
+# that no layer invents a release for a CR that names none.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-release-missing
+spec:
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/01-openstackrelease-pattern.yaml
+++ b/tests/e2e/placement/invalid-cr/01-openstackrelease-pattern.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.openStackRelease with a non-cadence minor violates the CRD pattern
+# (^\d{4}\.[12]$), a schema-level rejection the API server answers before
+# the validating webhook runs. 2025.9 is deliberately well-formed apart
+# from the minor: it pins the [12] class rather than the digit count.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-release-pattern
+spec:
+  openStackRelease: "2025.9"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/02-replicas-below-minimum.yaml
+++ b/tests/e2e/placement/invalid-cr/02-replicas-below-minimum.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.deployment.replicas below the CRD Minimum=1 marker. The value is -1
+# rather than 0 because DeploymentSpec.Default() normalizes a zero to
+# DefaultReplicas in the mutating webhook, which runs before schema
+# validation — a CR asking for 0 replicas is admitted and scaled to 3. Only
+# a negative count survives defaulting and reaches the Minimum marker. The
+# keystone corpus makes the same choice for the same reason.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-replicas
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: -1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/03-image-both-tag-digest.yaml
+++ b/tests/e2e/placement/invalid-cr/03-image-both-tag-digest.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.image with both tag and digest violates the ImageSpec XOR CEL rule
+# (has(self.tag) != has(self.digest)); the webhook mirrors it with the same
+# message.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-image-both
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+    digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/04-image-neither-tag-nor-digest.yaml
+++ b/tests/e2e/placement/invalid-cr/04-image-neither-tag-nor-digest.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.image with neither tag nor digest violates the same ImageSpec XOR CEL
+# rule from the other side: a repository alone names no reproducible image,
+# and the reconciler would render a bare repository reference that resolves
+# to :latest. Both fields are omitted rather than set to an empty string,
+# which the tag/digest patterns would reject first.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-image-neither
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/05-database-clusterref-and-host.yaml
+++ b/tests/e2e/placement/invalid-cr/05-database-clusterref-and-host.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.database with both clusterRef and host violates the shared
+# DatabaseSpec XOR CEL rule; the webhook mirrors it via DatabaseXOR.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-database-both
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+    host: mariadb.example.com
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/06-database-neither-clusterref-nor-host.yaml
+++ b/tests/e2e/placement/invalid-cr/06-database-neither-clusterref-nor-host.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.database with neither clusterRef nor host violates the same
+# DatabaseSpec XOR CEL rule from the other side: the operator has no way to
+# resolve a connection URL, so [placement_database] connection would name no
+# server at all.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-database-neither
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/07-database-dynamic-without-clusterref.yaml
+++ b/tests/e2e/placement/invalid-cr/07-database-dynamic-without-clusterref.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.database.credentialsMode Dynamic without clusterRef violates the
+# second DatabaseSpec CEL rule; the webhook mirrors it via
+# DynamicCredentialsRequireClusterRef. Dynamic credentials are minted
+# against a MariaDB CR the operator manages, so there is nothing to mint
+# against in brownfield (host) mode. The host field keeps the XOR rule
+# satisfied so this fixture reaches the credentialsMode rule.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-database-dynamic
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    host: mariadb.example.com
+    credentialsMode: Dynamic
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/08-cache-clusterref-and-servers.yaml
+++ b/tests/e2e/placement/invalid-cr/08-cache-clusterref-and-servers.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.cache with both clusterRef and servers violates the shared CacheSpec
+# XOR CEL rule; the webhook mirrors it via CacheXOR.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-cache-both
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+    servers:
+    - memcached-0:11211
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/09-cache-neither-clusterref-nor-servers.yaml
+++ b/tests/e2e/placement/invalid-cr/09-cache-neither-clusterref-nor-servers.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.cache with neither clusterRef nor servers violates the same CacheSpec
+# XOR CEL rule from the other side. backend is spelled out because the CRD
+# requires it and the defaulting webhook would otherwise be the only thing
+# filling it, which would obscure what this fixture omits on purpose.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-cache-neither
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    backend: dogpile.cache.pymemcache
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/10-cache-server-control-char.yaml
+++ b/tests/e2e/placement/invalid-cr/10-cache-server-control-char.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A spec.cache.servers entry carrying a newline violates the items pattern
+# (^[^\n\r]*$) on CacheSpec.Servers. The list renders verbatim into
+# [keystone_authtoken] memcached_servers, so a newline would inject a whole
+# config section past the (section, key)-keyed extraConfig gates, which
+# inspect map structure and never look inside a value. The webhook repeats
+# the check via CacheNoControlChars for objects that bypass the schema.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-cache-control-char
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    servers:
+    - "memcached-0:11211\n[api]\nauth_strategy = noauth2"
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/11-secretstoreref-empty-name.yaml
+++ b/tests/e2e/placement/invalid-cr/11-secretstoreref-empty-name.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.secretStoreRef.name empty violates the MinLength=1 marker on the
+# shared SecretStoreRefSpec. An unnamed store would leave every
+# ExternalSecret and PushSecret the operator renders pointing at nothing.
+# The webhook repeats it via validation.SecretStoreRef.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-secretstoreref
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  secretStoreRef:
+    kind: SecretStore
+    name: ""

--- a/tests/e2e/placement/invalid-cr/12-keystone-endpoint-bad-scheme.yaml
+++ b/tests/e2e/placement/invalid-cr/12-keystone-endpoint-bad-scheme.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.keystoneEndpoint with a non-http(s) scheme violates the CRD pattern
+# (^https?://); the webhook's validateEndpointURL mirrors it. The value is
+# rendered as [keystone_authtoken] auth_url, which keystonemiddleware can
+# only reach over http or https.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-endpoint-scheme
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: ftp://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/13-keystone-public-endpoint-not-a-url.yaml
+++ b/tests/e2e/placement/invalid-cr/13-keystone-public-endpoint-not-a-url.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.keystonePublicEndpoint with a non-numeric port is rejected by the
+# validating webhook alone. The value clears the CRD pattern, which
+# constrains the scheme only; url.Parse is what refuses the port, so
+# validateEndpointURL is the sole gate. Left admitted, the string would
+# reach clients as the [keystone_authtoken] www_authenticate_uri a 401
+# points them at.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-public-endpoint
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  keystonePublicEndpoint: http://keystone.example.com:not-a-port/v3

--- a/tests/e2e/placement/invalid-cr/14-serviceuser-username-control-char.yaml
+++ b/tests/e2e/placement/invalid-cr/14-serviceuser-username-control-char.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.serviceUser.username carrying a newline is rejected by the validating
+# webhook alone: the field has no schema marker, and it renders verbatim
+# into [keystone_authtoken] username. A newline therefore injects the
+# [api] auth_strategy line the extraConfig ownership gate exists to refuse.
+# The username is set explicitly because the defaulting webhook fills it
+# only when empty.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-username-control-char
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: "placement\n[api]\nauth_strategy = noauth2"
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/15-logging-level-invalid.yaml
+++ b/tests/e2e/placement/invalid-cr/15-logging-level-invalid.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.logging.level outside the CRD enum (DEBUG, INFO, WARNING, ERROR,
+# CRITICAL). TRACE is a level oslo.log does not define, so the schema enum
+# answers first and the webhook's NotSupported twin never runs.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-logging-level
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  logging:
+    level: TRACE

--- a/tests/e2e/placement/invalid-cr/16-logging-per-logger-level-invalid.yaml
+++ b/tests/e2e/placement/invalid-cr/16-logging-per-logger-level-invalid.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A spec.logging.perLoggerLevels value outside the accepted set. A CRD enum
+# on additionalProperties is not expressible, so the constraint is written
+# as an `in [...]` CEL rule on the map; the webhook repeats it per entry.
+# The name is a real oslo.log logger so the fixture violates the value rule
+# and nothing else.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-per-logger-level
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  logging:
+    perLoggerLevels:
+      sqlalchemy.engine: TRACE

--- a/tests/e2e/placement/invalid-cr/17-termination-grace-below-minimum.yaml
+++ b/tests/e2e/placement/invalid-cr/17-termination-grace-below-minimum.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.deployment.terminationGracePeriodSeconds below the CRD Minimum=10
+# marker. preStopSleepSeconds is pinned to 0 so the drain-window CEL rule on
+# DeploymentSpec stays satisfied (0 < 9) and the Minimum marker is the only
+# rule this fixture breaks; left unset it would resolve to 5 and break that
+# rule too.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-grace-period
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    terminationGracePeriodSeconds: 9
+    preStopSleepSeconds: 0
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/18-prestop-not-below-grace.yaml
+++ b/tests/e2e/placement/invalid-cr/18-prestop-not-below-grace.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.deployment.preStopSleepSeconds equal to terminationGracePeriodSeconds
+# violates the drain-window CEL rule on DeploymentSpec: the pod would spend
+# its entire grace period asleep in the preStop hook and be SIGKILLed with
+# requests still in flight. The webhook repeats the rule with the two
+# resolved numbers in its message.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-prestop
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    terminationGracePeriodSeconds: 30
+    preStopSleepSeconds: 30
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/19-harakiri-not-below-drain-window.yaml
+++ b/tests/e2e/placement/invalid-cr/19-harakiri-not-below-drain-window.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.apiServer.uwsgi.harakiri equal to the drain window
+# (terminationGracePeriodSeconds - preStopSleepSeconds = 25) is rejected by
+# the validating webhook alone. The rule correlates a uWSGI field with two
+# spec.deployment fields, which no marker can express. A harakiri that does
+# not fit inside the window lets uWSGI kill a request after SIGKILL has
+# already taken the pod. The grace and preStop values are spelled out so the
+# arithmetic in the error message does not depend on the webhook's defaults.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-harakiri
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    terminationGracePeriodSeconds: 30
+    preStopSleepSeconds: 5
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  apiServer:
+    uwsgi:
+      harakiri: 25

--- a/tests/e2e/placement/invalid-cr/20-uwsgi-keepalive-timeout-without-keepalive.yaml
+++ b/tests/e2e/placement/invalid-cr/20-uwsgi-keepalive-timeout-without-keepalive.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.apiServer.uwsgi.httpKeepAliveTimeout set while httpKeepAlive is false
+# violates the UWSGISpec CEL rule: the timeout flag is only emitted under
+# --http-keepalive. httpKeepAlive is set EXPLICITLY to false because the
+# defaulting webhook restores true when the pointer is nil, which would
+# satisfy the rule and make this CR admissible.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-uwsgi-keepalive
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  apiServer:
+    uwsgi:
+      httpKeepAlive: false
+      httpKeepAliveTimeout: 30

--- a/tests/e2e/placement/invalid-cr/21-strategy-recreate-with-rollingupdate.yaml
+++ b/tests/e2e/placement/invalid-cr/21-strategy-recreate-with-rollingupdate.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.deployment.strategy of type Recreate carrying a rollingUpdate block
+# is rejected by the validating webhook alone. DeploymentStrategy is an
+# embedded upstream type with no CEL rule of its own here, so admission is
+# the only gate before the Deployment controller refuses the child object
+# and the CR stalls with a rendered workload it cannot apply.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-strategy
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    strategy:
+      type: Recreate
+      rollingUpdate:
+        maxUnavailable: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/22-autoscaling-min-above-max.yaml
+++ b/tests/e2e/placement/invalid-cr/22-autoscaling-min-above-max.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.autoscaling.minReplicas above maxReplicas violates the shared
+# AutoscalingSpec CEL rule; the webhook mirrors it. The rule is declared on
+# the type, so the API server reports it at the parent path spec.autoscaling
+# rather than at the minReplicas field.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-autoscaling-range
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  autoscaling:
+    minReplicas: 5
+    maxReplicas: 2
+    targetCPUUtilization: 80

--- a/tests/e2e/placement/invalid-cr/23-autoscaling-cpu-utilization-above-max.yaml
+++ b/tests/e2e/placement/invalid-cr/23-autoscaling-cpu-utilization-above-max.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.autoscaling.targetCPUUtilization above the CRD Maximum=100 marker.
+# The field is a utilization percentage of the container's CPU request, so
+# 150 asks the HPA to hold pods at a level the request cannot express. The
+# replica bounds are kept consistent so the marker is the only rule broken.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-autoscaling-cpu
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilization: 150

--- a/tests/e2e/placement/invalid-cr/24-networkpolicy-empty-ingress.yaml
+++ b/tests/e2e/placement/invalid-cr/24-networkpolicy-empty-ingress.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.networkPolicy with an empty ingress list violates the CEL rule on
+# NetworkPolicySpec; the webhook mirrors it. A NetworkPolicy with no ingress
+# source denies all inbound traffic, so the API would be unreachable while
+# every readiness probe still passed. The rule is declared on the type, so
+# the API server reports it at spec.networkPolicy, not at .ingress.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-networkpolicy
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  networkPolicy:
+    ingress: []

--- a/tests/e2e/placement/invalid-cr/25-gateway-empty-hostname.yaml
+++ b/tests/e2e/placement/invalid-cr/25-gateway-empty-hostname.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.gateway.hostname empty violates the MinLength=1 marker on the shared
+# GatewaySpec. An HTTPRoute without a hostname would attach to the Gateway
+# and match every request reaching its listener. The webhook repeats the
+# check as field.Required.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-gateway
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  gateway:
+    parentRef:
+      name: openstack-gw
+    hostname: ""

--- a/tests/e2e/placement/invalid-cr/26-extraconfig-empty-section.yaml
+++ b/tests/e2e/placement/invalid-cr/26-extraconfig-empty-section.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig with an empty section name is rejected by the validating
+# webhook — extraConfig is a preserve-unknown-fields map, so CEL cannot
+# constrain its keys and the webhook is the sole gate. A nameless section
+# would render as a bare [] line in placement.conf.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-section
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    "":
+      foo: bar

--- a/tests/e2e/placement/invalid-cr/27-extraconfig-empty-key.yaml
+++ b/tests/e2e/placement/invalid-cr/27-extraconfig-empty-key.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig with an empty option key is rejected by the validating
+# webhook — a bare `= value` line must never reach the rendered
+# placement.conf.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-key
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    placement:
+      "": bar

--- a/tests/e2e/placement/invalid-cr/28-extraconfig-value-control-char.yaml
+++ b/tests/e2e/placement/invalid-cr/28-extraconfig-value-control-char.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig carrying a newline in an option VALUE is rejected by the
+# validating webhook. The rendered INI writes `key = value` verbatim, so the
+# newline would inject a whole [api] auth_strategy line past the ownership
+# and catalog gates — they key on (section, key) names and never look inside
+# a value. The section and key here are both catalog-known and unowned,
+# which is exactly the shape that would otherwise be admitted.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-value-control-char
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    placement:
+      randomize_allocation_candidates: "true\n[api]\nauth_strategy = noauth2"

--- a/tests/e2e/placement/invalid-cr/29-extraconfig-unknown-option.yaml
+++ b/tests/e2e/placement/invalid-cr/29-extraconfig-unknown-option.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig setting an unknown option in the known [placement]
+# section is rejected by the validating webhook: the singular spelling is
+# absent from the placement 2025.2 option catalog, so a typo'd key can never
+# silently reach the rendered placement.conf. The value is quoted because
+# extraConfig is a map of string to string: a bare YAML boolean would draw a
+# schema type error and never reach the catalog check.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-unknown-option
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    placement:
+      randomize_allocation_candidate: "true"

--- a/tests/e2e/placement/invalid-cr/30-extraconfig-unknown-section.yaml
+++ b/tests/e2e/placement/invalid-cr/30-extraconfig-unknown-section.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig declaring an unknown section 'placemnt' (a typo for
+# [placement]) is rejected by the validating webhook: the section is absent
+# from the placement 2025.2 option catalog, so a typo'd section name can
+# never silently reach the rendered placement.conf.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-unknown-section
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    placemnt:
+      randomize_allocation_candidates: "true"

--- a/tests/e2e/placement/invalid-cr/31-extraconfig-owned-auth-strategy.yaml
+++ b/tests/e2e/placement/invalid-cr/31-extraconfig-owned-auth-strategy.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig setting [api] auth_strategy is rejected by the validating
+# webhook. extraConfig has the last word in the merge, so honoring noauth2
+# would put the API on the no-auth middleware: every request
+# unauthenticated, project and role taken from the x-auth-token header, and
+# reachable from outside the cluster whenever spec.gateway is set. The
+# damage lands the moment the pods load the rendered file, which is why the
+# registry marks the key Rejected rather than Reported.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-auth-strategy
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    api:
+      auth_strategy: noauth2

--- a/tests/e2e/placement/invalid-cr/32-extraconfig-owned-password.yaml
+++ b/tests/e2e/placement/invalid-cr/32-extraconfig-owned-password.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# spec.extraConfig setting [keystone_authtoken] password is rejected by the
+# validating webhook. The operator owns it via spec.serviceUser.secretRef
+# and the middleware reads it from the OS_KEYSTONE_AUTHTOKEN__PASSWORD env
+# override, so a file value is inert at runtime but would leak the service
+# password into the namespace-readable ConfigMap — the second of the
+# registry's Rejected entries. Reaching that error at all is the per-key
+# registry exemption at work: password is in no catalog, so an unexempted
+# key would draw the unknown-option verdict instead.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-extraconfig-password
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password
+  extraConfig:
+    keystone_authtoken:
+      password: s3cr3t

--- a/tests/e2e/placement/invalid-cr/33-resources-request-above-limit.yaml
+++ b/tests/e2e/placement/invalid-cr/33-resources-request-above-limit.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A spec.deployment.resources memory request above its limit is rejected by
+# the validating webhook alone: ResourceRequirements is an embedded upstream
+# type carrying no cross-field marker, so admission is the only gate before
+# the kubelet refuses to admit the pod. Both maps are non-empty, so the
+# defaulting webhook leaves the block untouched.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-resources
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    resources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 1Gi
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/34-topologyspread-selector-mismatch.yaml
+++ b/tests/e2e/placement/invalid-cr/34-topologyspread-selector-mismatch.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A spec.deployment.topologySpreadConstraints selector that does not equal
+# the Deployment's own selector labels (app.kubernetes.io/name=placement,
+# app.kubernetes.io/instance=<CR name>) is rejected by the validating
+# webhook via validation.TopologySpreadSelector. The constraint correlates
+# with labels the operator derives from metadata.name, so no marker can
+# express it. A selector matching nothing spreads no pods while reporting
+# no error at all.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-invalid-topologyspread
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: placement
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: placement-service-password

--- a/tests/e2e/placement/invalid-cr/_generate.py
+++ b/tests/e2e/placement/invalid-cr/_generate.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Generator for the placement invalid-CR Chainsaw fixtures.
+
+Single source of truth for the minimal valid Placement CR scaffold used by every
+``invalid-cr`` rejection test, mirroring
+``tests/e2e/glance/invalid-cr/_generate.py``. Each fixture mutates exactly one
+aspect of the canonical scaffold so the surrounding CR passes validation for
+every rule OTHER than the one under test, which makes the admission error
+attributable to that single field.
+
+Most of these rejections are answered by the CRD schema, not by the validating
+webhook: the API server validates the object against the structural schema and
+its CEL rules before it calls any validating webhook, so wherever both layers
+carry the same rule the schema message is the one the user sees. Each fixture
+comment names the layer that answers it, and the matching Chainsaw step asserts
+that layer's message.
+
+There is no long-name fixture here. Glance needs one because its db-purge
+CronJob leaves only 52 characters for the CR name; placement renders no CronJob,
+so its webhook enforces no metadata.name bound at all (see the ValidateCreate
+doc comment in operators/placement/api/v1alpha1/placement_webhook.go).
+
+The fixtures deliberately carry NO metadata.namespace: Chainsaw runs each Test
+in its own ephemeral namespace, so the create-rejection fixtures never depend on
+the shared ``openstack`` namespace existing.
+
+Usage:
+
+    # Regenerate all fixtures from this single source of truth.
+    python3 _generate.py
+
+    # CI-friendly drift check: exit non-zero if any on-disk fixture diverges
+    # from the regenerated content (or an orphan fixture file exists).
+    python3 _generate.py --check
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Matches every two-digit-prefixed fixture in this directory. Used by the
+# orphan-detection sweep in main() so a fixture removed from FIXTURES but
+# left on disk is reported as drift (both directions are guarded).
+_FIXTURE_FILENAME_PATTERN = re.compile(r"^[0-9]{2}-.+\.yaml$")
+
+LICENSE_HEADER = """\
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+
+# Canonical valid Placement CR scaffold. Any future required field on
+# PlacementSpec must be added below AND verified against every fixture.
+# Placeholders: {name} CR name, {release} the whole openStackRelease line
+# (empty for the fixture that omits the field, hence its position right at the
+# start of the template line that carries `deployment:`), {deployment} the
+# spec.deployment block body, {image} image block body, {database} database
+# block body, {cache} cache block body, {endpoint} keystoneEndpoint value,
+# {service_user} serviceUser block body, {extra} trailing spec additions.
+SCAFFOLD = """\
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: {name}
+spec:
+{release}  deployment:
+{deployment}
+  image:
+{image}
+  database:
+{database}
+  cache:
+{cache}
+  keystoneEndpoint: {endpoint}
+  serviceUser:
+{service_user}
+{extra}"""
+
+VALID_RELEASE = "2025.2"
+
+VALID_DEPLOYMENT = "    replicas: 1"
+
+VALID_IMAGE = """\
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2\""""
+
+VALID_DATABASE = """\
+    clusterRef:
+      name: openstack-db
+    database: placement
+    secretRef:
+      name: placement-db"""
+
+VALID_CACHE = """\
+    clusterRef:
+      name: openstack-memcached"""
+
+VALID_ENDPOINT = "http://keystone.openstack.svc.cluster.local:5000/v3"
+
+VALID_SERVICE_USER = """\
+    secretRef:
+      name: placement-service-password"""
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """One generated rejection fixture."""
+
+    filename: str
+    comment: str
+    name: str
+    # None omits the openStackRelease line entirely (the required-field fixture).
+    release: str | None = VALID_RELEASE
+    deployment: str = VALID_DEPLOYMENT
+    image: str = VALID_IMAGE
+    database: str = VALID_DATABASE
+    cache: str = VALID_CACHE
+    endpoint: str = VALID_ENDPOINT
+    service_user: str = VALID_SERVICE_USER
+    extra: str = ""
+
+    def render(self) -> str:
+        release = "" if self.release is None else f'  openStackRelease: "{self.release}"\n'
+        body = SCAFFOLD.format(
+            name=self.name,
+            release=release,
+            deployment=self.deployment,
+            image=self.image,
+            database=self.database,
+            cache=self.cache,
+            endpoint=self.endpoint,
+            service_user=self.service_user,
+            extra=self.extra,
+        )
+        comment_lines = "".join(f"# {line}\n" for line in self.comment.splitlines())
+        return LICENSE_HEADER + comment_lines + body
+
+
+FIXTURES: tuple[Fixture, ...] = (
+    Fixture(
+        filename="00-openstackrelease-missing.yaml",
+        comment=(
+            "spec.openStackRelease omitted. What answers is the CRD pattern, not the\n"
+            "required-properties list: the defaulting webhook marshals the whole typed\n"
+            "object back into its admission patch, and PlacementSpec.OpenStackRelease\n"
+            "carries no omitempty tag, so the patch materializes the field as an empty\n"
+            "string. By the time the schema is checked the property is present and the\n"
+            "empty value fails the pattern. The fixture still earns its place: it pins\n"
+            "that no layer invents a release for a CR that names none."
+        ),
+        name="placement-invalid-release-missing",
+        release=None,
+    ),
+    Fixture(
+        filename="01-openstackrelease-pattern.yaml",
+        comment=(
+            "spec.openStackRelease with a non-cadence minor violates the CRD pattern\n"
+            "(^\\d{4}\\.[12]$), a schema-level rejection the API server answers before\n"
+            "the validating webhook runs. 2025.9 is deliberately well-formed apart\n"
+            "from the minor: it pins the [12] class rather than the digit count."
+        ),
+        name="placement-invalid-release-pattern",
+        release="2025.9",
+    ),
+    Fixture(
+        filename="02-replicas-below-minimum.yaml",
+        comment=(
+            "spec.deployment.replicas below the CRD Minimum=1 marker. The value is -1\n"
+            "rather than 0 because DeploymentSpec.Default() normalizes a zero to\n"
+            "DefaultReplicas in the mutating webhook, which runs before schema\n"
+            "validation — a CR asking for 0 replicas is admitted and scaled to 3. Only\n"
+            "a negative count survives defaulting and reaches the Minimum marker. The\n"
+            "keystone corpus makes the same choice for the same reason."
+        ),
+        name="placement-invalid-replicas",
+        deployment="    replicas: -1",
+    ),
+    Fixture(
+        filename="03-image-both-tag-digest.yaml",
+        comment=(
+            "spec.image with both tag and digest violates the ImageSpec XOR CEL rule\n"
+            "(has(self.tag) != has(self.digest)); the webhook mirrors it with the same\n"
+            "message."
+        ),
+        name="placement-invalid-image-both",
+        image=(
+            "    repository: ghcr.io/c5c3/placement\n"
+            '    tag: "2025.2"\n'
+            "    digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ),
+    ),
+    Fixture(
+        filename="04-image-neither-tag-nor-digest.yaml",
+        comment=(
+            "spec.image with neither tag nor digest violates the same ImageSpec XOR CEL\n"
+            "rule from the other side: a repository alone names no reproducible image,\n"
+            "and the reconciler would render a bare repository reference that resolves\n"
+            "to :latest. Both fields are omitted rather than set to an empty string,\n"
+            "which the tag/digest patterns would reject first."
+        ),
+        name="placement-invalid-image-neither",
+        image="    repository: ghcr.io/c5c3/placement",
+    ),
+    Fixture(
+        filename="05-database-clusterref-and-host.yaml",
+        comment=(
+            "spec.database with both clusterRef and host violates the shared\n"
+            "DatabaseSpec XOR CEL rule; the webhook mirrors it via DatabaseXOR."
+        ),
+        name="placement-invalid-database-both",
+        database=(
+            "    clusterRef:\n"
+            "      name: openstack-db\n"
+            "    database: placement\n"
+            "    secretRef:\n"
+            "      name: placement-db\n"
+            "    host: mariadb.example.com"
+        ),
+    ),
+    Fixture(
+        filename="06-database-neither-clusterref-nor-host.yaml",
+        comment=(
+            "spec.database with neither clusterRef nor host violates the same\n"
+            "DatabaseSpec XOR CEL rule from the other side: the operator has no way to\n"
+            "resolve a connection URL, so [placement_database] connection would name no\n"
+            "server at all."
+        ),
+        name="placement-invalid-database-neither",
+        database=(
+            "    database: placement\n"
+            "    secretRef:\n"
+            "      name: placement-db"
+        ),
+    ),
+    Fixture(
+        filename="07-database-dynamic-without-clusterref.yaml",
+        comment=(
+            "spec.database.credentialsMode Dynamic without clusterRef violates the\n"
+            "second DatabaseSpec CEL rule; the webhook mirrors it via\n"
+            "DynamicCredentialsRequireClusterRef. Dynamic credentials are minted\n"
+            "against a MariaDB CR the operator manages, so there is nothing to mint\n"
+            "against in brownfield (host) mode. The host field keeps the XOR rule\n"
+            "satisfied so this fixture reaches the credentialsMode rule."
+        ),
+        name="placement-invalid-database-dynamic",
+        database=(
+            "    host: mariadb.example.com\n"
+            "    credentialsMode: Dynamic\n"
+            "    database: placement\n"
+            "    secretRef:\n"
+            "      name: placement-db"
+        ),
+    ),
+    Fixture(
+        filename="08-cache-clusterref-and-servers.yaml",
+        comment=(
+            "spec.cache with both clusterRef and servers violates the shared CacheSpec\n"
+            "XOR CEL rule; the webhook mirrors it via CacheXOR."
+        ),
+        name="placement-invalid-cache-both",
+        cache=(
+            "    clusterRef:\n"
+            "      name: openstack-memcached\n"
+            "    servers:\n"
+            "    - memcached-0:11211"
+        ),
+    ),
+    Fixture(
+        filename="09-cache-neither-clusterref-nor-servers.yaml",
+        comment=(
+            "spec.cache with neither clusterRef nor servers violates the same CacheSpec\n"
+            "XOR CEL rule from the other side. backend is spelled out because the CRD\n"
+            "requires it and the defaulting webhook would otherwise be the only thing\n"
+            "filling it, which would obscure what this fixture omits on purpose."
+        ),
+        name="placement-invalid-cache-neither",
+        cache="    backend: dogpile.cache.pymemcache",
+    ),
+    Fixture(
+        filename="10-cache-server-control-char.yaml",
+        comment=(
+            "A spec.cache.servers entry carrying a newline violates the items pattern\n"
+            "(^[^\\n\\r]*$) on CacheSpec.Servers. The list renders verbatim into\n"
+            "[keystone_authtoken] memcached_servers, so a newline would inject a whole\n"
+            "config section past the (section, key)-keyed extraConfig gates, which\n"
+            "inspect map structure and never look inside a value. The webhook repeats\n"
+            "the check via CacheNoControlChars for objects that bypass the schema."
+        ),
+        name="placement-invalid-cache-control-char",
+        cache=(
+            "    servers:\n"
+            '    - "memcached-0:11211\\n[api]\\nauth_strategy = noauth2"'
+        ),
+    ),
+    Fixture(
+        filename="11-secretstoreref-empty-name.yaml",
+        comment=(
+            "spec.secretStoreRef.name empty violates the MinLength=1 marker on the\n"
+            "shared SecretStoreRefSpec. An unnamed store would leave every\n"
+            "ExternalSecret and PushSecret the operator renders pointing at nothing.\n"
+            "The webhook repeats it via validation.SecretStoreRef."
+        ),
+        name="placement-invalid-secretstoreref",
+        extra=(
+            "  secretStoreRef:\n"
+            "    kind: SecretStore\n"
+            '    name: ""\n'
+        ),
+    ),
+    Fixture(
+        filename="12-keystone-endpoint-bad-scheme.yaml",
+        comment=(
+            "spec.keystoneEndpoint with a non-http(s) scheme violates the CRD pattern\n"
+            "(^https?://); the webhook's validateEndpointURL mirrors it. The value is\n"
+            "rendered as [keystone_authtoken] auth_url, which keystonemiddleware can\n"
+            "only reach over http or https."
+        ),
+        name="placement-invalid-endpoint-scheme",
+        endpoint="ftp://keystone.openstack.svc.cluster.local:5000/v3",
+    ),
+    Fixture(
+        filename="13-keystone-public-endpoint-not-a-url.yaml",
+        comment=(
+            "spec.keystonePublicEndpoint with a non-numeric port is rejected by the\n"
+            "validating webhook alone. The value clears the CRD pattern, which\n"
+            "constrains the scheme only; url.Parse is what refuses the port, so\n"
+            "validateEndpointURL is the sole gate. Left admitted, the string would\n"
+            "reach clients as the [keystone_authtoken] www_authenticate_uri a 401\n"
+            "points them at."
+        ),
+        name="placement-invalid-public-endpoint",
+        extra="  keystonePublicEndpoint: http://keystone.example.com:not-a-port/v3\n",
+    ),
+    Fixture(
+        filename="14-serviceuser-username-control-char.yaml",
+        comment=(
+            "spec.serviceUser.username carrying a newline is rejected by the validating\n"
+            "webhook alone: the field has no schema marker, and it renders verbatim\n"
+            "into [keystone_authtoken] username. A newline therefore injects the\n"
+            "[api] auth_strategy line the extraConfig ownership gate exists to refuse.\n"
+            "The username is set explicitly because the defaulting webhook fills it\n"
+            "only when empty."
+        ),
+        name="placement-invalid-username-control-char",
+        service_user=(
+            '    username: "placement\\n[api]\\nauth_strategy = noauth2"\n'
+            "    secretRef:\n"
+            "      name: placement-service-password"
+        ),
+    ),
+    Fixture(
+        filename="15-logging-level-invalid.yaml",
+        comment=(
+            "spec.logging.level outside the CRD enum (DEBUG, INFO, WARNING, ERROR,\n"
+            "CRITICAL). TRACE is a level oslo.log does not define, so the schema enum\n"
+            "answers first and the webhook's NotSupported twin never runs."
+        ),
+        name="placement-invalid-logging-level",
+        extra=(
+            "  logging:\n"
+            "    level: TRACE\n"
+        ),
+    ),
+    Fixture(
+        filename="16-logging-per-logger-level-invalid.yaml",
+        comment=(
+            "A spec.logging.perLoggerLevels value outside the accepted set. A CRD enum\n"
+            "on additionalProperties is not expressible, so the constraint is written\n"
+            "as an `in [...]` CEL rule on the map; the webhook repeats it per entry.\n"
+            "The name is a real oslo.log logger so the fixture violates the value rule\n"
+            "and nothing else."
+        ),
+        name="placement-invalid-per-logger-level",
+        extra=(
+            "  logging:\n"
+            "    perLoggerLevels:\n"
+            "      sqlalchemy.engine: TRACE\n"
+        ),
+    ),
+    Fixture(
+        filename="17-termination-grace-below-minimum.yaml",
+        comment=(
+            "spec.deployment.terminationGracePeriodSeconds below the CRD Minimum=10\n"
+            "marker. preStopSleepSeconds is pinned to 0 so the drain-window CEL rule on\n"
+            "DeploymentSpec stays satisfied (0 < 9) and the Minimum marker is the only\n"
+            "rule this fixture breaks; left unset it would resolve to 5 and break that\n"
+            "rule too."
+        ),
+        name="placement-invalid-grace-period",
+        deployment=(
+            "    replicas: 1\n"
+            "    terminationGracePeriodSeconds: 9\n"
+            "    preStopSleepSeconds: 0"
+        ),
+    ),
+    Fixture(
+        filename="18-prestop-not-below-grace.yaml",
+        comment=(
+            "spec.deployment.preStopSleepSeconds equal to terminationGracePeriodSeconds\n"
+            "violates the drain-window CEL rule on DeploymentSpec: the pod would spend\n"
+            "its entire grace period asleep in the preStop hook and be SIGKILLed with\n"
+            "requests still in flight. The webhook repeats the rule with the two\n"
+            "resolved numbers in its message."
+        ),
+        name="placement-invalid-prestop",
+        deployment=(
+            "    replicas: 1\n"
+            "    terminationGracePeriodSeconds: 30\n"
+            "    preStopSleepSeconds: 30"
+        ),
+    ),
+    Fixture(
+        filename="19-harakiri-not-below-drain-window.yaml",
+        comment=(
+            "spec.apiServer.uwsgi.harakiri equal to the drain window\n"
+            "(terminationGracePeriodSeconds - preStopSleepSeconds = 25) is rejected by\n"
+            "the validating webhook alone. The rule correlates a uWSGI field with two\n"
+            "spec.deployment fields, which no marker can express. A harakiri that does\n"
+            "not fit inside the window lets uWSGI kill a request after SIGKILL has\n"
+            "already taken the pod. The grace and preStop values are spelled out so the\n"
+            "arithmetic in the error message does not depend on the webhook's defaults."
+        ),
+        name="placement-invalid-harakiri",
+        deployment=(
+            "    replicas: 1\n"
+            "    terminationGracePeriodSeconds: 30\n"
+            "    preStopSleepSeconds: 5"
+        ),
+        extra=(
+            "  apiServer:\n"
+            "    uwsgi:\n"
+            "      harakiri: 25\n"
+        ),
+    ),
+    Fixture(
+        filename="20-uwsgi-keepalive-timeout-without-keepalive.yaml",
+        comment=(
+            "spec.apiServer.uwsgi.httpKeepAliveTimeout set while httpKeepAlive is false\n"
+            "violates the UWSGISpec CEL rule: the timeout flag is only emitted under\n"
+            "--http-keepalive. httpKeepAlive is set EXPLICITLY to false because the\n"
+            "defaulting webhook restores true when the pointer is nil, which would\n"
+            "satisfy the rule and make this CR admissible."
+        ),
+        name="placement-invalid-uwsgi-keepalive",
+        extra=(
+            "  apiServer:\n"
+            "    uwsgi:\n"
+            "      httpKeepAlive: false\n"
+            "      httpKeepAliveTimeout: 30\n"
+        ),
+    ),
+    Fixture(
+        filename="21-strategy-recreate-with-rollingupdate.yaml",
+        comment=(
+            "spec.deployment.strategy of type Recreate carrying a rollingUpdate block\n"
+            "is rejected by the validating webhook alone. DeploymentStrategy is an\n"
+            "embedded upstream type with no CEL rule of its own here, so admission is\n"
+            "the only gate before the Deployment controller refuses the child object\n"
+            "and the CR stalls with a rendered workload it cannot apply."
+        ),
+        name="placement-invalid-strategy",
+        deployment=(
+            "    replicas: 1\n"
+            "    strategy:\n"
+            "      type: Recreate\n"
+            "      rollingUpdate:\n"
+            "        maxUnavailable: 1"
+        ),
+    ),
+    Fixture(
+        filename="22-autoscaling-min-above-max.yaml",
+        comment=(
+            "spec.autoscaling.minReplicas above maxReplicas violates the shared\n"
+            "AutoscalingSpec CEL rule; the webhook mirrors it. The rule is declared on\n"
+            "the type, so the API server reports it at the parent path spec.autoscaling\n"
+            "rather than at the minReplicas field."
+        ),
+        name="placement-invalid-autoscaling-range",
+        extra=(
+            "  autoscaling:\n"
+            "    minReplicas: 5\n"
+            "    maxReplicas: 2\n"
+            "    targetCPUUtilization: 80\n"
+        ),
+    ),
+    Fixture(
+        filename="23-autoscaling-cpu-utilization-above-max.yaml",
+        comment=(
+            "spec.autoscaling.targetCPUUtilization above the CRD Maximum=100 marker.\n"
+            "The field is a utilization percentage of the container's CPU request, so\n"
+            "150 asks the HPA to hold pods at a level the request cannot express. The\n"
+            "replica bounds are kept consistent so the marker is the only rule broken."
+        ),
+        name="placement-invalid-autoscaling-cpu",
+        extra=(
+            "  autoscaling:\n"
+            "    minReplicas: 1\n"
+            "    maxReplicas: 3\n"
+            "    targetCPUUtilization: 150\n"
+        ),
+    ),
+    Fixture(
+        filename="24-networkpolicy-empty-ingress.yaml",
+        comment=(
+            "spec.networkPolicy with an empty ingress list violates the CEL rule on\n"
+            "NetworkPolicySpec; the webhook mirrors it. A NetworkPolicy with no ingress\n"
+            "source denies all inbound traffic, so the API would be unreachable while\n"
+            "every readiness probe still passed. The rule is declared on the type, so\n"
+            "the API server reports it at spec.networkPolicy, not at .ingress."
+        ),
+        name="placement-invalid-networkpolicy",
+        extra=(
+            "  networkPolicy:\n"
+            "    ingress: []\n"
+        ),
+    ),
+    Fixture(
+        filename="25-gateway-empty-hostname.yaml",
+        comment=(
+            "spec.gateway.hostname empty violates the MinLength=1 marker on the shared\n"
+            "GatewaySpec. An HTTPRoute without a hostname would attach to the Gateway\n"
+            "and match every request reaching its listener. The webhook repeats the\n"
+            "check as field.Required."
+        ),
+        name="placement-invalid-gateway",
+        extra=(
+            "  gateway:\n"
+            "    parentRef:\n"
+            "      name: openstack-gw\n"
+            '    hostname: ""\n'
+        ),
+    ),
+    Fixture(
+        filename="26-extraconfig-empty-section.yaml",
+        comment=(
+            "spec.extraConfig with an empty section name is rejected by the validating\n"
+            "webhook — extraConfig is a preserve-unknown-fields map, so CEL cannot\n"
+            "constrain its keys and the webhook is the sole gate. A nameless section\n"
+            "would render as a bare [] line in placement.conf."
+        ),
+        name="placement-invalid-extraconfig-section",
+        extra=(
+            "  extraConfig:\n"
+            '    "":\n'
+            "      foo: bar\n"
+        ),
+    ),
+    Fixture(
+        filename="27-extraconfig-empty-key.yaml",
+        comment=(
+            "spec.extraConfig with an empty option key is rejected by the validating\n"
+            "webhook — a bare `= value` line must never reach the rendered\n"
+            "placement.conf."
+        ),
+        name="placement-invalid-extraconfig-key",
+        extra=(
+            "  extraConfig:\n"
+            "    placement:\n"
+            '      "": bar\n'
+        ),
+    ),
+    Fixture(
+        filename="28-extraconfig-value-control-char.yaml",
+        comment=(
+            "spec.extraConfig carrying a newline in an option VALUE is rejected by the\n"
+            "validating webhook. The rendered INI writes `key = value` verbatim, so the\n"
+            "newline would inject a whole [api] auth_strategy line past the ownership\n"
+            "and catalog gates — they key on (section, key) names and never look inside\n"
+            "a value. The section and key here are both catalog-known and unowned,\n"
+            "which is exactly the shape that would otherwise be admitted."
+        ),
+        name="placement-invalid-extraconfig-value-control-char",
+        extra=(
+            "  extraConfig:\n"
+            "    placement:\n"
+            '      randomize_allocation_candidates: "true\\n[api]\\nauth_strategy = noauth2"\n'
+        ),
+    ),
+    Fixture(
+        filename="29-extraconfig-unknown-option.yaml",
+        comment=(
+            "spec.extraConfig setting an unknown option in the known [placement]\n"
+            "section is rejected by the validating webhook: the singular spelling is\n"
+            "absent from the placement 2025.2 option catalog, so a typo'd key can never\n"
+            "silently reach the rendered placement.conf. The value is quoted because\n"
+            "extraConfig is a map of string to string: a bare YAML boolean would draw a\n"
+            "schema type error and never reach the catalog check."
+        ),
+        name="placement-invalid-extraconfig-unknown-option",
+        extra=(
+            "  extraConfig:\n"
+            "    placement:\n"
+            '      randomize_allocation_candidate: "true"\n'
+        ),
+    ),
+    Fixture(
+        filename="30-extraconfig-unknown-section.yaml",
+        comment=(
+            "spec.extraConfig declaring an unknown section 'placemnt' (a typo for\n"
+            "[placement]) is rejected by the validating webhook: the section is absent\n"
+            "from the placement 2025.2 option catalog, so a typo'd section name can\n"
+            "never silently reach the rendered placement.conf."
+        ),
+        name="placement-invalid-extraconfig-unknown-section",
+        extra=(
+            "  extraConfig:\n"
+            "    placemnt:\n"
+            '      randomize_allocation_candidates: "true"\n'
+        ),
+    ),
+    Fixture(
+        filename="31-extraconfig-owned-auth-strategy.yaml",
+        comment=(
+            "spec.extraConfig setting [api] auth_strategy is rejected by the validating\n"
+            "webhook. extraConfig has the last word in the merge, so honoring noauth2\n"
+            "would put the API on the no-auth middleware: every request\n"
+            "unauthenticated, project and role taken from the x-auth-token header, and\n"
+            "reachable from outside the cluster whenever spec.gateway is set. The\n"
+            "damage lands the moment the pods load the rendered file, which is why the\n"
+            "registry marks the key Rejected rather than Reported."
+        ),
+        name="placement-invalid-extraconfig-auth-strategy",
+        extra=(
+            "  extraConfig:\n"
+            "    api:\n"
+            "      auth_strategy: noauth2\n"
+        ),
+    ),
+    Fixture(
+        filename="32-extraconfig-owned-password.yaml",
+        comment=(
+            "spec.extraConfig setting [keystone_authtoken] password is rejected by the\n"
+            "validating webhook. The operator owns it via spec.serviceUser.secretRef\n"
+            "and the middleware reads it from the OS_KEYSTONE_AUTHTOKEN__PASSWORD env\n"
+            "override, so a file value is inert at runtime but would leak the service\n"
+            "password into the namespace-readable ConfigMap — the second of the\n"
+            "registry's Rejected entries. Reaching that error at all is the per-key\n"
+            "registry exemption at work: password is in no catalog, so an unexempted\n"
+            "key would draw the unknown-option verdict instead."
+        ),
+        name="placement-invalid-extraconfig-password",
+        extra=(
+            "  extraConfig:\n"
+            "    keystone_authtoken:\n"
+            "      password: s3cr3t\n"
+        ),
+    ),
+    Fixture(
+        filename="33-resources-request-above-limit.yaml",
+        comment=(
+            "A spec.deployment.resources memory request above its limit is rejected by\n"
+            "the validating webhook alone: ResourceRequirements is an embedded upstream\n"
+            "type carrying no cross-field marker, so admission is the only gate before\n"
+            "the kubelet refuses to admit the pod. Both maps are non-empty, so the\n"
+            "defaulting webhook leaves the block untouched."
+        ),
+        name="placement-invalid-resources",
+        deployment=(
+            "    replicas: 1\n"
+            "    resources:\n"
+            "      requests:\n"
+            "        memory: 2Gi\n"
+            "      limits:\n"
+            "        memory: 1Gi"
+        ),
+    ),
+    Fixture(
+        filename="34-topologyspread-selector-mismatch.yaml",
+        comment=(
+            "A spec.deployment.topologySpreadConstraints selector that does not equal\n"
+            "the Deployment's own selector labels (app.kubernetes.io/name=placement,\n"
+            "app.kubernetes.io/instance=<CR name>) is rejected by the validating\n"
+            "webhook via validation.TopologySpreadSelector. The constraint correlates\n"
+            "with labels the operator derives from metadata.name, so no marker can\n"
+            "express it. A selector matching nothing spreads no pods while reporting\n"
+            "no error at all."
+        ),
+        name="placement-invalid-topologyspread",
+        deployment=(
+            "    replicas: 1\n"
+            "    topologySpreadConstraints:\n"
+            "    - maxSkew: 1\n"
+            "      topologyKey: kubernetes.io/hostname\n"
+            "      whenUnsatisfiable: DoNotSchedule\n"
+            "      labelSelector:\n"
+            "        matchLabels:\n"
+            "          app: placement"
+        ),
+    ),
+)
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    here = Path(__file__).resolve().parent
+    drift = False
+
+    for fixture in FIXTURES:
+        target = here / fixture.filename
+        content = fixture.render()
+        if check:
+            on_disk = target.read_text(encoding="utf-8") if target.exists() else None
+            if on_disk != content:
+                print(f"DRIFT: {fixture.filename}")
+                drift = True
+        else:
+            target.write_text(content, encoding="utf-8")
+            print(f"wrote {fixture.filename}")
+
+    # Orphan sweep (both directions): a fixture file on disk that is not
+    # declared in FIXTURES is drift too.
+    declared = {fixture.filename for fixture in FIXTURES}
+    for path in sorted(here.iterdir()):
+        if not _FIXTURE_FILENAME_PATTERN.match(path.name):
+            continue
+        if path.name in declared:
+            continue
+        if check:
+            print(f"DRIFT: orphan fixture {path.name} not declared in FIXTURES")
+            drift = True
+        else:
+            path.unlink()
+            print(f"removed orphan {path.name}")
+
+    if check and drift:
+        print("run `python3 tests/e2e/placement/invalid-cr/_generate.py` to regenerate")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/placement/invalid-cr/chainsaw-test.yaml
+++ b/tests/e2e/placement/invalid-cr/chainsaw-test.yaml
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E tests for Placement CRD webhook + CEL validation rejection.
+# Pins the implemented CEL XValidation, kubebuilder-marker, and
+# webhook.validate() rejection paths in operators/placement/api/v1alpha1/ to a
+# deterministic admission failure. Each step applies an otherwise-valid
+# Placement CR with a single aspect violating the rule under test, captures the
+# admission $error, and asserts the field path plus message substring.
+#
+# The API server validates against the structural schema and its CEL rules
+# before it calls the validating webhook, so a rule carried by both layers is
+# answered by the schema and the assertions below quote the schema message. The
+# webhook message is asserted only where the rule has no schema counterpart.
+#
+# There is no long-name fixture: placement renders no CronJob, so its webhook
+# enforces no metadata.name bound (see the ValidateCreate doc comment in
+# operators/placement/api/v1alpha1/placement_webhook.go).
+#
+# All fixtures are generated from the single canonical scaffold in
+# `_generate.py` (mirroring tests/e2e/glance/invalid-cr/). After editing the
+# scaffold or any per-fixture override, regenerate via:
+#   python3 tests/e2e/placement/invalid-cr/_generate.py
+# CI runs `make verify-invalid-cr-fixtures`, which invokes
+# `_generate.py --check` (drift mode, both directions incl. orphans) and
+# `test_generate.py` (FIXTURES count + chainsaw-test.yaml cross-reference)
+# so any hand-edit to a generated fixture fails the build before the
+# cluster-bound e2e-operator job runs.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-invalid-cr
+spec:
+  steps:
+  # spec.openStackRelease omitted must be rejected. The defaulting webhook
+  # materializes the field as an empty string (no omitempty on the Go field), so
+  # the CRD pattern answers rather than the required-properties list.
+  - try:
+    - apply:
+        file: 00-openstackrelease-missing.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'openStackRelease')): true
+            (contains($error, 'should match')): true
+  # spec.openStackRelease with a non-cadence minor must be rejected by the CRD
+  # pattern.
+  - try:
+    - apply:
+        file: 01-openstackrelease-pattern.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'openStackRelease')): true
+            (contains($error, 'should match')): true
+  # spec.deployment.replicas below the Minimum=1 marker must be rejected. The
+  # value is -1, not 0: the defaulting webhook normalizes a zero before schema
+  # validation sees it.
+  - try:
+    - apply:
+        file: 02-replicas-below-minimum.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'replicas')): true
+            (contains($error, 'should be greater than or equal to 1')): true
+  # spec.image with both tag and digest must be rejected.
+  - try:
+    - apply:
+        file: 03-image-both-tag-digest.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'image')): true
+            (contains($error, 'exactly one of image.tag or image.digest')): true
+  # spec.image with neither tag nor digest must be rejected by the same rule.
+  - try:
+    - apply:
+        file: 04-image-neither-tag-nor-digest.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'image')): true
+            (contains($error, 'exactly one of image.tag or image.digest')): true
+  # spec.database with both clusterRef and host must be rejected.
+  - try:
+    - apply:
+        file: 05-database-clusterref-and-host.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database')): true
+            (contains($error, 'exactly one of clusterRef or host')): true
+  # spec.database with neither clusterRef nor host must be rejected by the same
+  # rule.
+  - try:
+    - apply:
+        file: 06-database-neither-clusterref-nor-host.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database')): true
+            (contains($error, 'exactly one of clusterRef or host')): true
+  # spec.database.credentialsMode Dynamic without clusterRef must be rejected:
+  # dynamic credentials are minted against a MariaDB CR the operator manages.
+  - try:
+    - apply:
+        file: 07-database-dynamic-without-clusterref.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'database')): true
+            (contains($error, 'credentialsMode Dynamic requires clusterRef')): true
+  # spec.cache with both clusterRef and servers must be rejected.
+  - try:
+    - apply:
+        file: 08-cache-clusterref-and-servers.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'cache')): true
+            (contains($error, 'exactly one of clusterRef or servers')): true
+  # spec.cache with neither clusterRef nor servers must be rejected by the same
+  # rule.
+  - try:
+    - apply:
+        file: 09-cache-neither-clusterref-nor-servers.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'cache')): true
+            (contains($error, 'exactly one of clusterRef or servers')): true
+  # A newline in a spec.cache.servers entry must be rejected by the items
+  # pattern on CacheSpec.Servers: the list renders verbatim into
+  # [keystone_authtoken] memcached_servers.
+  - try:
+    - apply:
+        file: 10-cache-server-control-char.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'cache.servers[0]')): true
+            (contains($error, 'should match')): true
+  # spec.secretStoreRef.name empty must be rejected by the MinLength=1 marker on
+  # the shared SecretStoreRefSpec.
+  - try:
+    - apply:
+        file: 11-secretstoreref-empty-name.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'secretStoreRef.name')): true
+            (contains($error, 'should be at least 1 chars long')): true
+  # spec.keystoneEndpoint with a non-http(s) scheme must be rejected by the CRD
+  # pattern.
+  - try:
+    - apply:
+        file: 12-keystone-endpoint-bad-scheme.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'keystoneEndpoint')): true
+            (contains($error, 'should match')): true
+  # spec.keystonePublicEndpoint with a non-numeric port must be rejected by the
+  # validating webhook: the value clears the CRD pattern, which constrains the
+  # scheme only, so url.Parse in validateEndpointURL is the sole gate.
+  - try:
+    - apply:
+        file: 13-keystone-public-endpoint-not-a-url.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'keystonePublicEndpoint')): true
+            (contains($error, 'must be a valid URL')): true
+  # A newline in spec.serviceUser.username must be rejected by the validating
+  # webhook: the field has no schema marker and renders verbatim into
+  # [keystone_authtoken] username.
+  - try:
+    - apply:
+        file: 14-serviceuser-username-control-char.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'serviceUser.username')): true
+            (contains($error, 'must not contain a newline or carriage return')): true
+  # spec.logging.level outside the CRD enum must be rejected.
+  - try:
+    - apply:
+        file: 15-logging-level-invalid.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'logging.level')): true
+            (contains($error, 'Unsupported value')): true
+  # A spec.logging.perLoggerLevels value outside the accepted set must be
+  # rejected by the CEL rule on the map (a CRD enum on additionalProperties is
+  # not expressible); the webhook repeats it per entry.
+  - try:
+    - apply:
+        file: 16-logging-per-logger-level-invalid.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'perLoggerLevels')): true
+            (contains($error, 'level must be one of DEBUG, INFO, WARNING, ERROR, CRITICAL')): true
+  # spec.deployment.terminationGracePeriodSeconds below the Minimum=10 marker
+  # must be rejected.
+  - try:
+    - apply:
+        file: 17-termination-grace-below-minimum.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'terminationGracePeriodSeconds')): true
+            (contains($error, 'should be greater than or equal to 10')): true
+  # spec.deployment.preStopSleepSeconds not below terminationGracePeriodSeconds
+  # must be rejected by the drain-window CEL rule on DeploymentSpec. The rule is
+  # declared on the type, so the API server reports it at spec.deployment.
+  - try:
+    - apply:
+        file: 18-prestop-not-below-grace.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'preStopSleepSeconds')): true
+            (contains($error, 'must be strictly less than terminationGracePeriodSeconds')): true
+  # spec.apiServer.uwsgi.harakiri not below the drain window must be rejected by
+  # the validating webhook: the rule correlates a uWSGI field with two
+  # spec.deployment fields, which no marker can express.
+  - try:
+    - apply:
+        file: 19-harakiri-not-below-drain-window.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'uwsgi.harakiri')): true
+            (contains($error, 'must be strictly less than terminationGracePeriodSeconds - preStopSleepSeconds')): true
+  # spec.apiServer.uwsgi.httpKeepAliveTimeout set with httpKeepAlive false must
+  # be rejected (CEL rule on UWSGISpec).
+  - try:
+    - apply:
+        file: 20-uwsgi-keepalive-timeout-without-keepalive.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'httpKeepAliveTimeout may only be set when httpKeepAlive is true')): true
+  # A Recreate strategy carrying a rollingUpdate block must be rejected by the
+  # validating webhook: DeploymentStrategy is an embedded upstream type with no
+  # CEL rule here, so admission is the only gate before the Deployment
+  # controller refuses the child object.
+  - try:
+    - apply:
+        file: 21-strategy-recreate-with-rollingupdate.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'strategy.rollingUpdate')): true
+            (contains($error, 'rollingUpdate must not be set when strategy.type is Recreate')): true
+  # spec.autoscaling.minReplicas above maxReplicas must be rejected. The CEL
+  # rule is declared on AutoscalingSpec, so the API server reports it at the
+  # parent path spec.autoscaling, NOT at spec.autoscaling.minReplicas.
+  - try:
+    - apply:
+        file: 22-autoscaling-min-above-max.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'autoscaling')): true
+            (contains($error, 'minReplicas must not exceed maxReplicas')): true
+  # spec.autoscaling.targetCPUUtilization above the Maximum=100 marker must be
+  # rejected.
+  - try:
+    - apply:
+        file: 23-autoscaling-cpu-utilization-above-max.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'targetCPUUtilization')): true
+            (contains($error, 'should be less than or equal to 100')): true
+  # spec.networkPolicy with an empty ingress list must be rejected by the CEL
+  # rule on NetworkPolicySpec. The rule is declared on the type, so the API
+  # server reports it at spec.networkPolicy, not at spec.networkPolicy.ingress.
+  - try:
+    - apply:
+        file: 24-networkpolicy-empty-ingress.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'networkPolicy')): true
+            (contains($error, 'at least one ingress source must be specified')): true
+  # spec.gateway.hostname empty must be rejected by the MinLength=1 marker on
+  # the shared GatewaySpec.
+  - try:
+    - apply:
+        file: 25-gateway-empty-hostname.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'gateway.hostname')): true
+            (contains($error, 'should be at least 1 chars long')): true
+  # spec.extraConfig with an empty section name must be rejected by the webhook.
+  - try:
+    - apply:
+        file: 26-extraconfig-empty-section.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'extraConfig section name must not be empty')): true
+  # spec.extraConfig with an empty option key must be rejected by the webhook.
+  - try:
+    - apply:
+        file: 27-extraconfig-empty-key.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'extraConfig key must not be empty')): true
+  # A newline in a spec.extraConfig option VALUE must be rejected: the rendered
+  # INI writes `key = value` verbatim, so it would inject a whole section past
+  # the ownership and catalog gates, which key on names and never inspect
+  # values.
+  - try:
+    - apply:
+        file: 28-extraconfig-value-control-char.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'extraConfig key and value must not contain a newline or carriage return')): true
+  # spec.extraConfig setting an unknown option (typo'd key) in a known section
+  # must be rejected: it is absent from the placement 2025.2 option catalog.
+  - try:
+    - apply:
+        file: 29-extraconfig-unknown-option.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'no such option in the placement 2025.2 option catalog')): true
+  # spec.extraConfig declaring an unknown section (typo'd section name) must be
+  # rejected: it is absent from the placement 2025.2 option catalog.
+  - try:
+    - apply:
+        file: 30-extraconfig-unknown-section.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'no such section in the placement 2025.2 option catalog')): true
+  # spec.extraConfig setting [api] auth_strategy must be rejected by the
+  # webhook: extraConfig has the last word in the merge, so noauth2 would put
+  # the API on the no-auth middleware the moment the pods load the file.
+  - try:
+    - apply:
+        file: 31-extraconfig-owned-auth-strategy.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'auth_strategy is managed via operator-computed')): true
+            (contains($error, 'noauth2 disables token validation entirely')): true
+  # spec.extraConfig setting [keystone_authtoken] password must be rejected by
+  # the webhook — the operator owns it via spec.serviceUser.secretRef and a file
+  # value would leak the service password into the namespace-readable ConfigMap.
+  - try:
+    - apply:
+        file: 32-extraconfig-owned-password.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'password is managed via spec.serviceUser.secretRef')): true
+            (contains($error, 'leaks credential material into a namespace-readable ConfigMap')): true
+  # A spec.deployment.resources memory request above its limit must be rejected
+  # by the validating webhook: ResourceRequirements is an embedded upstream type
+  # carrying no cross-field marker.
+  - try:
+    - apply:
+        file: 33-resources-request-above-limit.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'resources.requests.memory')): true
+            (contains($error, 'memory request must not exceed limit')): true
+  # A spec.deployment.topologySpreadConstraints selector that does not equal the
+  # Deployment's own selector labels must be rejected by the validating webhook:
+  # the labels are derived from metadata.name, so no marker can express it.
+  - try:
+    - apply:
+        file: 34-topologyspread-selector-mismatch.yaml
+        expect:
+        - check:
+            ($error != null): true
+            (contains($error, 'topologySpreadConstraints[0].labelSelector')): true
+            (contains($error, 'must equal the Deployment selector labels')): true

--- a/tests/e2e/placement/invalid-cr/test_generate.py
+++ b/tests/e2e/placement/invalid-cr/test_generate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast unit tests for the placement invalid-CR fixture generator.
+
+Mirrors tests/e2e/glance/invalid-cr/test_generate.py: guards the
+canonical-scaffold contract at a layer that runs without a Kubernetes
+cluster — accidental fixture removal/rename is caught here in milliseconds
+instead of waiting for the Chainsaw E2E job to fail at the apply step.
+
+Coverage:
+
+* ``FIXTURES`` lists exactly the generated fixtures the chainsaw suite expects.
+* Every ``Fixture.filename`` is referenced by an ``apply.file:`` entry in
+  ``chainsaw-test.yaml`` — guards against renames or accidental deletions.
+* Filenames are unique within ``FIXTURES``.
+* ``_generate.py --check`` passes in-process, so on-disk drift (either
+  direction, including orphan files) fails the unit test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_GENERATOR = _HERE / "_generate.py"
+_CHAINSAW_TEST = _HERE / "chainsaw-test.yaml"
+
+# Number of fixtures emitted by _generate.py. Bumping this value requires
+# adding the matching Fixture entry AND the matching `file: <name>` line in
+# chainsaw-test.yaml.
+_EXPECTED_FIXTURE_COUNT = 35
+
+
+def _load_generator() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("placement_invalid_cr_generate", _GENERATOR)
+    assert spec and spec.loader, f"failed to load spec for {_GENERATOR}"
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec_module so @dataclass(frozen=True) can resolve
+    # cls.__module__ via sys.modules during class construction.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestFixtures(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.generator = _load_generator()
+        cls.chainsaw = _CHAINSAW_TEST.read_text(encoding="utf-8")
+
+    def test_fixture_count(self) -> None:
+        self.assertEqual(len(self.generator.FIXTURES), _EXPECTED_FIXTURE_COUNT)
+
+    def test_filenames_unique(self) -> None:
+        names = [fixture.filename for fixture in self.generator.FIXTURES]
+        self.assertEqual(len(names), len(set(names)), f"duplicate filenames in FIXTURES: {names}")
+
+    def test_every_fixture_referenced_by_chainsaw(self) -> None:
+        for fixture in self.generator.FIXTURES:
+            self.assertIn(
+                f"file: {fixture.filename}",
+                self.chainsaw,
+                f"{fixture.filename} is not applied by chainsaw-test.yaml",
+            )
+
+    def test_no_drift(self) -> None:
+        argv = sys.argv
+        sys.argv = [str(_GENERATOR), "--check"]
+        try:
+            self.assertEqual(
+                self.generator.main(),
+                0,
+                "fixtures drifted from _generate.py; regenerate them",
+            )
+        finally:
+            sys.argv = argv
+
+    def test_rendered_fixture_carries_spdx_header(self) -> None:
+        for fixture in self.generator.FIXTURES:
+            rendered = fixture.render()
+            self.assertTrue(
+                rendered.startswith("# SPDX-FileCopyrightText:"),
+                f"{fixture.filename} must start with the SPDX header",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/placement/network-policy/00-placement-cr.yaml
+++ b/tests/e2e/placement/network-policy/00-placement-cr.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR with spec.networkPolicy for the NetworkPolicy lifecycle test.
+# Managed mode (clusterRef openstack-db, schema placement_netpol), same shape as
+# the basic-deployment fixture. Placement owns no store backend, so the CR is the
+# only fixture the suite applies.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-netpol
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_netpol
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password
+  networkPolicy:
+    ingress:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openstack

--- a/tests/e2e/placement/network-policy/01-patch-update-ingress.yaml
+++ b/tests/e2e/placement/network-policy/01-patch-update-ingress.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch: add a second ingress source (monitoring namespace).
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-netpol
+  namespace: openstack
+spec:
+  networkPolicy:
+    ingress:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openstack
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring

--- a/tests/e2e/placement/network-policy/02-patch-disable-networkpolicy.yaml
+++ b/tests/e2e/placement/network-policy/02-patch-disable-networkpolicy.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch: unset spec.networkPolicy so the operator deletes the NetworkPolicy.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-netpol
+  namespace: openstack
+spec:
+  networkPolicy: null

--- a/tests/e2e/placement/network-policy/chainsaw-test.yaml
+++ b/tests/e2e/placement/network-policy/chainsaw-test.yaml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the NetworkPolicy sub-reconciler.
+#
+# SCOPE CAVEAT: the default CI CNI (kindnet) does NOT enforce NetworkPolicy,
+# so this suite validates the rendered policy object (ingress on the Placement
+# API port 8778, auto-derived DNS/database/keystone/cache egress) and its
+# lifecycle, not actual traffic enforcement — same scope as the
+# keystone/horizon/glance network-policy suites.
+#
+# The auto-derived egress order is deterministic (DNS, database, keystone,
+# cache):
+#   - DNS      UDP+TCP 53
+#   - database TCP 3306 (spec.database default port)
+#   - keystone TCP 5000 (parsed from spec.keystoneEndpoint)
+#   - cache    TCP 11211 (managed memcached)
+# Unlike glance, placement renders a dedicated keystone egress rule:
+# keystonemiddleware validates every authenticated request server-side, and
+# without that rule the API answers 503 while both readiness signals keep
+# passing (they target the unauthenticated version document). Placement reads
+# and writes nothing but its own database, so there is no object-store egress
+# rule.
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-network-policy
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR with networkPolicy ──────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert NetworkPolicy created with the expected rules ───────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-netpol
+            namespace: openstack
+          status:
+            (conditions[?type == 'NetworkPolicyReady']):
+            - status: "True"
+              reason: NetworkPolicyReady
+    - assert:
+        resource:
+          apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: placement-netpol
+            namespace: openstack
+          spec:
+            # The selector carries no component key, so the policy covers the
+            # API pods and the db-sync pods alike — without the DNS and database
+            # egress, placement-manage cannot reach the schema it migrates.
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: placement
+                app.kubernetes.io/instance: placement-netpol
+            policyTypes:
+            - Ingress
+            - Egress
+            ingress:
+            - ports:
+              - protocol: TCP
+                port: 8778
+            egress:
+            - ports:
+              - protocol: UDP
+                port: 53
+              - protocol: TCP
+                port: 53
+            - ports:
+              - protocol: TCP
+                port: 3306
+            - ports:
+              - protocol: TCP
+                port: 5000
+            - ports:
+              - protocol: TCP
+                port: 11211
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-netpol -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== NetworkPolicy ==="
+          kubectl get networkpolicy placement-netpol -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Add a second ingress source and assert it lands ────────────
+  # Peer arithmetic: the operator appends one peer per declared ingress source
+  # plus one for its own Namespace (so the operator's health check reaches the
+  # API). One source therefore renders 2 peers and the patched two sources
+  # render 3 — `>= 3` is what distinguishes "the patch landed" from "the policy
+  # is unchanged".
+  - try:
+    - patch:
+        file: 01-patch-update-ingress.yaml
+    - assert:
+        resource:
+          apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: placement-netpol
+            namespace: openstack
+          spec:
+            ingress:
+            - (length(from) >= `3`): true
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-netpol -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== NetworkPolicy ==="
+          kubectl get networkpolicy placement-netpol -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 4: Disable networkPolicy and assert deletion ──────────────────
+  - try:
+    - patch:
+        file: 02-patch-disable-networkpolicy.yaml
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-netpol
+            namespace: openstack
+          status:
+            (conditions[?type == 'NetworkPolicyReady']):
+            - status: "True"
+              reason: NetworkPolicyNotRequired
+    - script:
+        content: |
+          if kubectl get networkpolicy placement-netpol -n $NAMESPACE 2>/dev/null; then
+            echo "FAIL: NetworkPolicy should have been deleted"
+            exit 1
+          fi
+          echo "PASS: NetworkPolicy correctly deleted"

--- a/tests/e2e/placement/pod-security-restricted/00-brownfield-db-setup.yaml
+++ b/tests/e2e/placement/pod-security-restricted/00-brownfield-db-setup.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Brownfield MariaDB Database/User/Grant pre-creation for the PSS-restricted
+# E2E test.
+#
+# The Placement CR lives in the labelled `placement-pss-restricted-test`
+# namespace, but `Database.ClusterRef` / `Cache.ClusterRef` are
+# `LocalObjectReference` and the shared provisioning flow (`IsClusterReady` in
+# internal/common/database/flow.go) only looks up MariaDB CRs in the Placement
+# CR's own namespace — cross-namespace lookup is not supported. To reach the
+# cluster's existing `openstack/openstack-db` without copying MariaDB CRs into
+# the test namespace, the test uses brownfield mode (database.host +
+# cache.servers) and pre-creates the Database/User/Grant CRs here, in
+# `openstack`.
+#
+# The User CR manages the canonical `placement` MariaDB user against the
+# existing `openstack/placement-db` Secret (synced from OpenBao by the cluster's
+# `placement-db` ExternalSecret), so the User's SET PASSWORD lands the same
+# value the PSS-namespace `placement-db` Secret carries (copied from the same
+# standalone OpenBao path) — no race. `cleanupPolicy: Skip` keeps the user alive
+# when this test's User CR is deleted, so a sibling test still managing the same
+# canonical user is not stranded mid-flight.
+#
+# All resource names are prefixed `placement-pss-restricted-` and the database
+# name is `placement_pss` so this fixture cannot collide with sibling tests. The
+# Grant scopes the `placement` user's privileges to the test-only
+# `placement_pss` database.
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: placement-pss-restricted-db
+  namespace: openstack
+spec:
+  mariaDbRef:
+    name: openstack-db
+  cleanupPolicy: Skip
+  characterSet: utf8
+  collate: utf8_general_ci
+  name: placement_pss
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: placement-pss-restricted-user
+  namespace: openstack
+spec:
+  mariaDbRef:
+    name: openstack-db
+  cleanupPolicy: Skip
+  name: placement
+  passwordSecretKeyRef:
+    name: placement-db
+    key: password
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: placement-pss-restricted-grant
+  namespace: openstack
+spec:
+  mariaDbRef:
+    name: openstack-db
+  cleanupPolicy: Skip
+  privileges:
+  - "ALL PRIVILEGES"
+  database: placement_pss
+  table: "*"
+  username: placement

--- a/tests/e2e/placement/pod-security-restricted/00-namespace.yaml
+++ b/tests/e2e/placement/pod-security-restricted/00-namespace.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Test namespace + ExternalSecrets fixture for the PSS-restricted E2E test.
+#
+# The namespace carries both `pod-security.kubernetes.io/enforce=restricted`
+# AND `pod-security.kubernetes.io/enforce-version=latest`. Without the
+# version label, kube-apiserver pins to the cluster's current PSS baseline,
+# which can drift on cluster upgrade and surface as a spurious failure;
+# `latest` tracks the newest baseline and is the regression net we want.
+#
+# `keystone-admin` and `placement-db` are ESO-managed: the operator's
+# `reconcileSecrets` gates SecretsReady on the selected secret store and on the
+# ESO-synced credential Secrets, so plain Secrets are not sufficient to reach
+# Ready=True.
+#
+# The shared cluster store is namespace-restricted, so a foreign namespace like
+# this one cannot reach the shared standalone paths through it. Both
+# ExternalSecrets therefore authenticate through this namespace's OWN per-tenant
+# `openbao-tenant-store` (provisioned by the chainsaw Step-1 script via
+# setup-eso-tenant.sh) and read namespace-scoped paths that the eso-tenant
+# policy templates to this namespace:
+#   - the admin password at `bootstrap/placement-pss-restricted-test/pss/admin`
+#   - the `placement` MariaDB user at
+#     `openstack/placement/placement-pss-restricted-test/pss/db`
+# The Step-1 script seeds those two paths by COPYING the values from the shared
+# `bootstrap/openstack/controlplane-keystone/admin` and
+# `openstack/placement/openstack/standalone/db` paths, so the `placement`
+# MariaDB user's password still matches the value the brownfield User CR
+# reconciles onto the same shared MariaDB user — no SET PASSWORD race.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: placement-pss-restricted-test
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keystone-admin
+  namespace: placement-pss-restricted-test
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao-tenant-store
+    kind: SecretStore
+  target:
+    name: keystone-admin
+    creationPolicy: Owner
+  data:
+  - secretKey: password
+    remoteRef:
+      key: bootstrap/placement-pss-restricted-test/pss/admin
+      property: password
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: placement-db
+  namespace: placement-pss-restricted-test
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao-tenant-store
+    kind: SecretStore
+  target:
+    name: placement-db
+    creationPolicy: Owner
+  data:
+  - secretKey: username
+    remoteRef:
+      key: openstack/placement/placement-pss-restricted-test/pss/db
+      property: username
+  - secretKey: password
+    remoteRef:
+      key: openstack/placement/placement-pss-restricted-test/pss/db
+      property: password

--- a/tests/e2e/placement/pod-security-restricted/01-placement-cr.yaml
+++ b/tests/e2e/placement/pod-security-restricted/01-placement-cr.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the PSS-restricted E2E test.
+#
+# Brownfield mode (database.host + cache.servers, no `clusterRef`): the CR lives
+# in the labelled `placement-pss-restricted-test` namespace, but
+# `Database.ClusterRef` / `Cache.ClusterRef` are namespace-local (the shared
+# provisioning flow looks up the MariaDB / Memcached CR in the Placement CR's
+# namespace). Brownfield wiring is the only path that reaches the existing
+# `openstack/openstack-db` and `openstack/openstack-memcached` from this
+# namespace without duplicating MariaDB / Memcached CRs.
+#
+# The `placement_pss` Database/User/Grant are pre-created in the openstack
+# namespace by 00-brownfield-db-setup.yaml. The service-user password and the
+# database credentials are synced into this namespace by the ExternalSecrets in
+# 00-namespace.yaml (reconcileSecrets gates SecretsReady on the per-tenant store
+# and on the ESO-synced credential Secrets, so plain Secrets would never satisfy
+# the gate).
+#
+# `replicas: 1` keeps the test inside the suite's 5-minute assert budget; the
+# regression net we want is "every Pod the operator creates admits under
+# PSS=restricted", which a single replica is sufficient to prove.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-pss
+  namespace: placement-pss-restricted-test
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: openbao-tenant-store
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    host: openstack-db.openstack.svc.cluster.local
+    port: 3306
+    database: placement_pss
+    secretRef:
+      name: placement-db
+  cache:
+    backend: dogpile.cache.pymemcache
+    servers:
+    - "openstack-memcached.openstack.svc:11211"
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/pod-security-restricted/chainsaw-test.yaml
+++ b/tests/e2e/placement/pod-security-restricted/chainsaw-test.yaml
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for a Placement CR reconciling under restricted
+# PodSecurity.
+#
+# Decisions worth knowing before reading the steps:
+#
+#   - Opt-out from per-test namespace (`spec.namespace: ""`): Chainsaw's
+#     per-test namespace plumbing creates a chainsaw-* namespace WITHOUT PSS
+#     labels. To exercise restricted-profile admission we must own the
+#     namespace, so this test sets `spec.namespace: ""` to OPT OUT of the
+#     plumbing entirely; Chainsaw then creates no namespace and the test
+#     applies its own labelled namespace `placement-pss-restricted-test` from
+#     00-namespace.yaml. Chainsaw's applied-resource cleanup deletes that
+#     namespace (and everything in it) when the test finishes.
+#
+#   - Brownfield mode (database.host + cache.servers, no clusterRef): the shared
+#     provisioning flow resolves `Database.ClusterRef` / `Cache.ClusterRef` in
+#     the Placement CR's own namespace, so a CR in
+#     `placement-pss-restricted-test` cannot reach `openstack/openstack-db`
+#     through clusterRef. Brownfield wiring reaches the existing cluster
+#     DB/cache without duplicating infra; the `placement_pss`
+#     Database/User/Grant are pre-created in `openstack` by Step 2.
+#
+#   - ESO-managed Secrets (keystone-admin / placement-db are ExternalSecrets,
+#     not plain Secrets): `reconcileSecrets` gates SecretsReady on the
+#     per-tenant store and the ESO-synced credential Secrets. The Step-1 script
+#     seeds the namespace-scoped OpenBao paths by COPYING the shared standalone
+#     values, then provisions this namespace's per-tenant store via
+#     setup-eso-tenant.sh.
+#
+#   - Zero-PSS-violation event scan (Step 4): the parent controller emits a
+#     `FailedCreate` event with the violation listed verbatim when PSS rejects
+#     a Pod, so a zero-match scan on `violates PodSecurity "restricted:latest"`
+#     is the explicit regression net for any future reconciler that forgets the
+#     restricted securityContext.
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-pod-security-restricted
+spec:
+  # Disable Chainsaw's per-test namespace plumbing so Pods land in our
+  # PSS-labelled namespace.
+  namespace: ""
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the labelled namespace + ESO ExternalSecrets ──────────
+  # Asserts the PSS enforce label is present so a mis-typed label would surface
+  # here, before any Pod is created. Also asserts each ExternalSecret reaches
+  # Ready=True so a regression that broke ESO sync fails here, not deeper in
+  # Step 3 where the operator's SecretsReady condition would be the only signal.
+  - try:
+    - apply:
+        file: 00-namespace.yaml
+    # Provision this namespace's per-tenant OpenBao store and seed its
+    # namespace-scoped admin + db paths by COPYING the shared values, so the two
+    # ExternalSecrets (which authenticate as the eso-tenant identity) can sync
+    # and the `placement` MariaDB user's password still matches the value the
+    # brownfield User CR reconciles onto the same shared user — no SET PASSWORD
+    # race. Chainsaw runs scripts with the test directory as CWD.
+    - script:
+        timeout: 5m
+        shell: bash
+        content: |
+          set -euo pipefail
+          BAO_NS="openbao-system"
+          BAO_POD="openbao-0"
+          TENANT_NS="placement-pss-restricted-test"
+          BAO_TOKEN="$(kubectl get secret openbao-init-keys -n "${BAO_NS}" \
+            -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')"
+          bao_exec() {
+            kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+              env BAO_ADDR="https://127.0.0.1:8200" BAO_TOKEN="${BAO_TOKEN}" \
+              VAULT_CACERT="/openbao/tls/ca.crt" \
+              VAULT_CLIENT_CERT=/openbao/client-tls/tls.crt \
+              VAULT_CLIENT_KEY=/openbao/client-tls/tls.key "$@"
+          }
+          ADMIN_PASS="$(bao_exec bao kv get -mount=kv-v2 -field=password \
+            bootstrap/openstack/controlplane-keystone/admin)"
+          DB_USER="$(bao_exec bao kv get -mount=kv-v2 -field=username \
+            openstack/placement/openstack/standalone/db)"
+          DB_PASS="$(bao_exec bao kv get -mount=kv-v2 -field=password \
+            openstack/placement/openstack/standalone/db)"
+          bao_exec bao kv put -mount=kv-v2 "bootstrap/${TENANT_NS}/pss/admin" \
+            password="${ADMIN_PASS}" >/dev/null
+          bao_exec bao kv put -mount=kv-v2 "openstack/placement/${TENANT_NS}/pss/db" \
+            username="${DB_USER}" password="${DB_PASS}" >/dev/null
+          ../../../../deploy/openbao/bootstrap/setup-eso-tenant.sh "${TENANT_NS}"
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: placement-pss-restricted-test
+            labels:
+              pod-security.kubernetes.io/enforce: restricted
+              pod-security.kubernetes.io/enforce-version: latest
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: keystone-admin
+            namespace: placement-pss-restricted-test
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: placement-db
+            namespace: placement-pss-restricted-test
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+  # ── Step 2: Pre-create brownfield MariaDB Database/User/Grant ──────────
+  # The CRs live in `openstack` (the MariaDB operator's namespace), not in the
+  # test namespace, because MariaDB CRs reference `openstack-db` via a
+  # same-namespace `mariaDbRef`. The User CR manages the canonical `placement`
+  # MariaDB user against the existing `openstack/placement-db` Secret and is
+  # marked `cleanupPolicy: Skip` so this test's User-CR deletion does not drop
+  # the user out from under a sibling test.
+  - try:
+    - apply:
+        file: 00-brownfield-db-setup.yaml
+    - assert:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Database
+          metadata:
+            name: placement-pss-restricted-db
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+    - assert:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: User
+          metadata:
+            name: placement-pss-restricted-user
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+    - assert:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Grant
+          metadata:
+            name: placement-pss-restricted-grant
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+  # ── Step 3: Apply the Placement CR, assert Ready ───────────────────────
+  # The Ready=True signal is the primary end-to-end gate — every Pod the
+  # reconciler creates (API Deployment, db-sync Job) must have been admitted
+  # under restricted PSS for the sub-conditions to flip True.
+  #
+  # The trailing `error` assertions enforce the brownfield-mode invariant: NO
+  # Database/User/Grant CR named after the Placement CR may be created in the
+  # test namespace.
+  - try:
+    - apply:
+        file: 01-placement-cr.yaml
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-pss
+            namespace: placement-pss-restricted-test
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Database
+          metadata:
+            name: placement-pss
+            namespace: placement-pss-restricted-test
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: User
+          metadata:
+            name: placement-pss
+            namespace: placement-pss-restricted-test
+    - error:
+        resource:
+          apiVersion: k8s.mariadb.com/v1alpha1
+          kind: Grant
+          metadata:
+            name: placement-pss
+            namespace: placement-pss-restricted-test
+    catch:
+    - script:
+        content: |
+          NS=placement-pss-restricted-test
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-pss -n "$NS" -o yaml 2>&1 || true
+          echo "=== Pod securityContext (CR namespace) ==="
+          kubectl get pods -n "$NS" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.securityContext}{"\t"}{.spec.containers[*].securityContext}{"\n"}{end}' 2>&1 || true
+          echo "=== Sorted events (last 30, CR namespace) ==="
+          kubectl get events -n "$NS" --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+          echo "=== Job pods ==="
+          for pod in $(kubectl get pods -n "$NS" -l job-name -o name 2>/dev/null); do
+            echo "--- $pod logs ---"
+            kubectl logs -n "$NS" "$pod" --all-containers --tail=100 2>&1 || true
+            echo "--- $pod describe (last 30 lines) ---"
+            kubectl describe -n "$NS" "$pod" 2>&1 | tail -30 || true
+          done
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=100 2>&1 || true
+  # ── Step 4: Assert zero PSS-violation FailedCreate events ──────────────
+  # PSS admission rejection emits a `FailedCreate` event on the Pod's parent
+  # (Deployment/Job) with the violation listed verbatim. A zero-match scan on
+  # `violates PodSecurity "restricted:latest"` is the explicit regression net
+  # for any future reconciler that forgets the restricted securityContext. The
+  # scan is scoped to the test namespace so unrelated FailedCreate events in
+  # `openstack` are not picked up.
+  - try:
+    - script:
+        shell: bash
+        content: |
+          set -euo pipefail
+          NS=placement-pss-restricted-test
+          NEEDLE='violates PodSecurity "restricted:latest"'
+
+          MSGS=$(kubectl get events -n "$NS" \
+            --field-selector reason=FailedCreate \
+            -o jsonpath='{range .items[*]}{.message}{"\n"}{end}')
+          # grep -c returns 1 when zero matches; guard with `|| true` so
+          # `set -e` does not abort before the count check runs.
+          COUNT=$(printf '%s\n' "$MSGS" | grep -cF "$NEEDLE" || true)
+          if [ "$COUNT" -ne 0 ]; then
+            echo "FAIL: $COUNT FailedCreate event(s) carry the PSS-restricted violation:"
+            printf '%s\n' "$MSGS" | grep -F "$NEEDLE" || true
+            exit 1
+          fi
+          echo "OK: zero PSS-restricted FailedCreate events in $NS"
+    catch:
+    - script:
+        content: |
+          NS=placement-pss-restricted-test
+          echo "=== Pod securityContext (CR namespace) ==="
+          kubectl get pods -n "$NS" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.securityContext}{"\t"}{.spec.containers[*].securityContext}{"\n"}{end}' 2>&1 || true
+          echo "=== All FailedCreate events (CR namespace) ==="
+          kubectl get events -n "$NS" --field-selector reason=FailedCreate \
+            -o custom-columns=LAST:.lastTimestamp,OBJ:.involvedObject.kind/.involvedObject.name,MSG:.message 2>&1 || true
+          echo "=== Sorted events (last 30, CR namespace) ==="
+          kubectl get events -n "$NS" --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/release-upgrade/00-placement-cr.yaml
+++ b/tests/e2e/placement/release-upgrade/00-placement-cr.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the release-upgrade E2E test.
+# Managed mode at the initial 2025.2 release: database via clusterRef to
+# openstack-db (schema placement_release_upgrade), cache via clusterRef to
+# openstack-memcached. The database credentials come from the ESO-synced
+# placement-db Secret and the service-user password from the pre-seeded
+# keystone-admin Secret (both deploy/kind/infrastructure). A single replica
+# keeps the rollout observable when 01-patch-upgrade.yaml bumps the release to
+# 2026.1.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-release-upgrade
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_release_upgrade
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/release-upgrade/01-patch-upgrade.yaml
+++ b/tests/e2e/placement/release-upgrade/01-patch-upgrade.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch to trigger a cross-release upgrade from 2025.2 to 2026.1. Both fields
+# move together: release tracking keys on spec.openStackRelease while the
+# db-sync Job and the API pods run spec.image, and the operator refuses a bump
+# that leaves the image untouched (it would promote installedRelease off a Job
+# that migrated nothing).
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-release-upgrade
+  namespace: openstack
+spec:
+  openStackRelease: "2026.1"
+  image:
+    tag: "2026.1"

--- a/tests/e2e/placement/release-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/placement/release-upgrade/chainsaw-test.yaml
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for a cross-release Placement upgrade from 2025.2 to 2026.1.
+# Placement migrates in a single pass: one db-sync Job runs placement-manage db
+# sync, db online_data_migrations, and the placement-status upgrade check. There
+# is no expand-migrate-contract phase machine and no status.upgradePhase field,
+# and this suite pins both absences as hard as it pins the upgrade itself.
+#   (1) Fresh deployment at 2025.2 reaches Ready=True/AllReady with
+#       installedRelease=2025.2 on the :2025.2 image
+#   (2) Patching spec.openStackRelease and spec.image.tag to 2026.1 promotes
+#       installedRelease to 2026.1 and settles Ready=True/AllReady again
+#   (3) The db-sync Job re-runs on the :2026.1 image and succeeds
+#   (4) The Deployment flips to the :2026.1 image and the rollout completes
+#   (5) No db-expand/db-migrate/db-contract Job is ever created
+#   (6) status.upgradePhase stays absent
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-release-upgrade
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR at 2025.2 ────────────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert the pre-upgrade steady state ─────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-release-upgrade
+            namespace: openstack
+          status:
+            installedRelease: "2025.2"
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-release-upgrade
+            namespace: openstack
+          spec:
+            template:
+              spec:
+                containers:
+                - name: placement-api
+                  image: ghcr.io/c5c3/placement:2025.2
+          status:
+            (availableReplicas > `0`): true
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-release-upgrade -n $NAMESPACE -o yaml 2>&1 | tail -60 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-release-upgrade -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Patch release + image tag to trigger the upgrade ────────────
+  - try:
+    - patch:
+        file: 01-patch-upgrade.yaml
+  # ── Step 4: Assert the upgrade completes through the single db-sync ─────
+  - try:
+    # Gate on the settled end state first: installedRelease is promoted only
+    # after the db-sync Job succeeds, and the fresh Job flips DatabaseReady (and
+    # so Ready) back False until it completes, so a stable Ready=True/AllReady
+    # here means the whole flow has drained.
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-release-upgrade
+            namespace: openstack
+          status:
+            installedRelease: "2026.1"
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    - script:
+        timeout: 3m
+        content: |
+          set -eu
+          JOB=placement-release-upgrade-db-sync
+          echo "=== Verifying the db-sync Job re-ran on :2026.1 ==="
+          # RunJob deletes and re-creates a completed Job in place when its
+          # pod-spec-hash changes, so the same-named db-sync Job is replaced on
+          # the :2026.1 image. Poll to ride out the delete/re-create window,
+          # then assert the current Job carries :2026.1 and succeeded.
+          for _ in $(seq 1 30); do
+            IMG=$(kubectl get job "$JOB" -n openstack \
+              -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+            SUCC=$(kubectl get job "$JOB" -n openstack \
+              -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+            case "$IMG" in
+            *:2026.1)
+              if [ "$SUCC" = "1" ]; then
+                echo "OK: $JOB at $IMG succeeded=$SUCC"
+                exit 0
+              fi
+              ;;
+            esac
+            sleep 5
+          done
+          echo "ERROR: $JOB did not reach :2026.1 succeeded=1 (image=$IMG succeeded=$SUCC)"
+          exit 1
+    - script:
+        content: |
+          set -eu
+          echo "=== Verifying no expand-migrate-contract phase Job exists ==="
+          # Placement migrates in one pass. A phase Job here would mean the
+          # operator was wired to the phased flow, which for placement runs
+          # migrations that placement-manage does not implement.
+          for phase in expand migrate contract; do
+            JOB="placement-release-upgrade-db-${phase}"
+            if kubectl get job "$JOB" -n openstack >/dev/null 2>&1; then
+              echo "ERROR: Job $JOB exists; placement runs a single db-sync Job"
+              exit 1
+            fi
+            echo "OK: no Job $JOB"
+          done
+    - script:
+        content: |
+          set -eu
+          echo "=== Verifying status.upgradePhase is absent ==="
+          # The Placement CRD carries no upgradePhase field, so jsonpath resolves
+          # to the empty string. A value here means the field was reintroduced
+          # and the phase machine came with it.
+          PHASE=$(kubectl get placement placement-release-upgrade -n openstack \
+            -o jsonpath='{.status.upgradePhase}')
+          if [ -n "$PHASE" ]; then
+            echo "ERROR: status.upgradePhase is set to '$PHASE'"
+            exit 1
+          fi
+          echo "OK: status.upgradePhase is absent"
+    # The Deployment now runs the :2026.1 image and the single-replica rollout
+    # has fully converged (updatedReplicas == replicas).
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-release-upgrade
+            namespace: openstack
+          spec:
+            template:
+              spec:
+                containers:
+                - name: placement-api
+                  image: ghcr.io/c5c3/placement:2026.1
+          status:
+            (availableReplicas > `0`): true
+            (updatedReplicas == replicas): true
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-release-upgrade -n $NAMESPACE -o yaml 2>&1 | tail -60 || true
+          echo "=== Jobs ==="
+          kubectl get jobs -n $NAMESPACE -o wide 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=80 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=80 --previous 2>&1 || true
+          echo "=== Job logs ==="
+          for job in $(kubectl get jobs -n $NAMESPACE -o name 2>/dev/null); do
+            echo "--- $job ---"
+            kubectl logs -n $NAMESPACE "$job" --all-containers --tail=100 2>&1 || true
+          done
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-release-upgrade -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/e2e/placement/scale/00-placement-cr.yaml
+++ b/tests/e2e/placement/scale/00-placement-cr.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Placement CR fixture for the scaling E2E test (2025.2 release).
+# Managed mode: database via clusterRef to openstack-db (schema
+# placement_scale), cache via clusterRef to openstack-memcached. The database
+# credentials come from the ESO-synced placement-db Secret and the service-user
+# password from the pre-seeded keystone-admin Secret (both
+# deploy/kind/infrastructure).
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-scale
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 3
+  image:
+    repository: ghcr.io/c5c3/placement
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: placement_scale
+    secretRef:
+      name: placement-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: admin
+    projectName: admin
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: keystone-admin
+      key: password

--- a/tests/e2e/placement/scale/01-patch-scale-up.yaml
+++ b/tests/e2e/placement/scale/01-patch-scale-up.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch: scale the Placement API from 3 to 5 replicas.
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-scale
+  namespace: openstack
+spec:
+  deployment:
+    replicas: 5

--- a/tests/e2e/placement/scale/02-patch-scale-to-one.yaml
+++ b/tests/e2e/placement/scale/02-patch-scale-to-one.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Patch: scale the Placement API down to a single replica (PDB flips to
+# maxUnavailable=1 to avoid drain deadlock).
+apiVersion: placement.openstack.c5c3.io/v1alpha1
+kind: Placement
+metadata:
+  name: placement-scale
+  namespace: openstack
+spec:
+  deployment:
+    replicas: 1

--- a/tests/e2e/placement/scale/chainsaw-test.yaml
+++ b/tests/e2e/placement/scale/chainsaw-test.yaml
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for replica scaling and PDB policy.
+# Verifies that patching spec.deployment.replicas propagates to the
+# Deployment and PDB:
+#   - Initial deployment with replicas: 3 (PDB: minAvailable=1)
+#   - Scale up to 5 replicas — updatedReplicas proves new pods started
+#   - Scale down to 1 replica (PDB: maxUnavailable=1)
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: placement-scale
+spec:
+  namespace: openstack
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Apply the Placement CR with replicas: 3 ─────────────────────
+  - try:
+    - apply:
+        file: 00-placement-cr.yaml
+  # ── Step 2: Assert Ready and initial replica count ─────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          spec:
+            replicas: 3
+          status:
+            availableReplicas: 3
+    - assert:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          spec:
+            minAvailable: 1
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-scale -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-scale -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 3: Scale up to 5 and assert rollout completed ─────────────────
+  - try:
+    - patch:
+        file: 01-patch-scale-up.yaml
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          spec:
+            replicas: 5
+          status:
+            availableReplicas: 5
+            updatedReplicas: 5
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-scale -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-scale -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+  # ── Step 4: Scale down to 1 and assert the PDB flips ───────────────────
+  - try:
+    - patch:
+        file: 02-patch-scale-to-one.yaml
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          spec:
+            replicas: 1
+          status:
+            availableReplicas: 1
+            updatedReplicas: 1
+    - assert:
+        resource:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          spec:
+            maxUnavailable: 1
+    - assert:
+        resource:
+          apiVersion: placement.openstack.c5c3.io/v1alpha1
+          kind: Placement
+          metadata:
+            name: placement-scale
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: AllReady
+    catch:
+    - script:
+        content: |
+          echo "=== Placement CR status ==="
+          kubectl get placement placement-scale -n $NAMESPACE -o yaml 2>&1 || true
+          echo "=== Operator pod logs ==="
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 2>&1 || true
+          kubectl logs -n placement-system -l app.kubernetes.io/name=placement-operator --all-containers --tail=60 --previous 2>&1 || true
+          echo "=== Placement API pod logs ==="
+          for pod in $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/instance=placement-scale -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 2>&1 || true
+            kubectl logs -n $NAMESPACE "$pod" --all-containers --tail=60 --previous 2>&1 || true
+          done
+          echo "=== Events ==="
+          kubectl get events -n $NAMESPACE --sort-by='.lastTimestamp' 2>&1 | tail -30 || true

--- a/tests/unit/ci/build_operators_sentinel_test.sh
+++ b/tests/unit/ci/build_operators_sentinel_test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the `Resolve build operators` step of the build-e2e-images job in
+# .github/workflows/ci.yaml drops the `__none__` sentinel that
+# hack/ci-resolve-changes.sh emits when no operator changed.
+#
+# build-e2e-images is the only consumer that reads the e2e-operators matrix
+# without gating on has-e2e-operators — it also runs for the e2e-chaos,
+# e2e-prometheus and e2e-controlplane triggers. On a PR that reaches it through
+# one of those paths alone the matrix is {"operator":["__none__"]}, and an
+# unfiltered sentinel lands in BUILD_OPERATORS, where the next step turns it
+# into `make docker-build OPERATOR=__none__` against a Dockerfile path that does
+# not exist.
+#
+# The step's shell body is extracted from ci.yaml and executed with the two
+# `${{ needs.changes.outputs.* }}` expressions substituted the way Actions
+# substitutes them, so this exercises the real snippet rather than a copy.
+#
+# Usage: bash tests/unit/ci/build_operators_sentinel_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CI_YAML="$PROJECT_ROOT/.github/workflows/ci.yaml"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Extract the `run:` body of the `Resolve build operators` step into a runnable
+# script at $1. Step bodies sit at 10-space indent, so the first non-blank line
+# with less indentation ends the block; the indent is then stripped.
+extract_resolve_step() {
+  local out="$1"
+  awk '
+    /^      - name: Resolve build operators$/ { in_step = 1; next }
+    in_step && /^        run: \|$/            { in_run = 1; next }
+    in_run {
+      if ($0 == "") { print ""; next }
+      if ($0 !~ /^          /) { exit }
+      print substr($0, 11)
+    }
+  ' "$CI_YAML" >"$out"
+}
+
+# Run the extracted step with the supplied matrix JSON and e2e-controlplane
+# flag, and echo the BUILD_OPERATORS value the step appends to GITHUB_ENV.
+# The GHA expressions are replaced together with their surrounding quotes, so
+# the substituted values are shell-expanded exactly as Actions inlines them.
+run_resolve_step() {
+  local matrix="$1" controlplane="$2"
+  local tmp step env_file
+  tmp=$(mktemp -d)
+  step="$tmp/step.sh"
+  env_file="$tmp/github_env"
+
+  extract_resolve_step "$step"
+  sed -i.bak \
+    -e "s|'\${{ needs.changes.outputs.e2e-operators }}'|\"\$E2E_OPERATORS\"|" \
+    -e "s|'\${{ needs.changes.outputs.e2e-controlplane }}'|\"\$E2E_CONTROLPLANE\"|" \
+    "$step"
+
+  E2E_OPERATORS="$matrix" E2E_CONTROLPLANE="$controlplane" GITHUB_ENV="$env_file" \
+    bash "$step" >/dev/null 2>&1
+
+  # BUILD_OPERATORS is written as a heredoc block; collapse it to one line.
+  sed -n '/^BUILD_OPERATORS<<EOF$/,/^EOF$/p' "$env_file" |
+    sed '1d;$d' | tr '\n' ' ' | tr -s ' ' | sed 's/^ *//;s/ *$//'
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_extraction_finds_the_step() {
+  echo "Test: the Resolve build operators body is extractable from ci.yaml"
+
+  local tmp
+  tmp=$(mktemp)
+  extract_resolve_step "$tmp"
+  assert_file_contains "extracted body assembles BUILD_OPERATORS" "$tmp" \
+    'BUILD_OPERATORS<<EOF'
+  rm -f "$tmp"
+}
+
+test_sentinel_matrix_yields_only_the_fixed_union() {
+  echo "Test: the __none__ sentinel never reaches BUILD_OPERATORS"
+
+  # What ci-resolve-changes.sh emits when no operator changed and the job is
+  # reached through the e2e-chaos / e2e-prometheus / e2e-controlplane triggers.
+  local ops
+  ops=$(run_resolve_step '{"operator":["__none__"]}' 'false')
+
+  assert_not_contains "sentinel is filtered out of the build union" "$ops" "__none__"
+  assert_eq "only the fixed keystone/glance/placement union is built" \
+    "keystone glance placement" "$ops"
+}
+
+test_changed_operators_still_union_with_the_fixed_set() {
+  echo "Test: a real operator matrix still unions with keystone/glance/placement"
+
+  local ops
+  ops=$(run_resolve_step '{"operator":["keystone","horizon"]}' 'false')
+
+  assert_eq "changed operators are preserved and deduplicated" \
+    "keystone horizon glance placement" "$ops"
+}
+
+test_controlplane_extras_are_appended() {
+  echo "Test: e2e-controlplane adds c5c3 and horizon on the sentinel path"
+
+  local ops
+  ops=$(run_resolve_step '{"operator":["__none__"]}' 'true')
+
+  assert_not_contains "sentinel is filtered on the controlplane path too" "$ops" "__none__"
+  assert_eq "controlplane extras join the fixed union" \
+    "keystone glance placement c5c3 horizon" "$ops"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_extraction_finds_the_step
+test_sentinel_matrix_yields_only_the_fixed_union
+test_changed_operators_still_union_with_the_fixed_set
+test_controlplane_extras_are_appended
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/deploy/production_posture_test.sh
+++ b/tests/unit/deploy/production_posture_test.sh
@@ -89,11 +89,11 @@ test_production_overlay_unchanged() {
   # remain byte-identical.
   local groups_label=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml/garage-operator.yaml/glance-operator.yaml releases added)"
+    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml/garage-operator.yaml/glance-operator.yaml/placement-operator.yaml releases added)"
   )
   local groups_specs=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/garage-operator.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml :(exclude)deploy/flux-system/releases/glance-operator.yaml"
+    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/garage-operator.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml :(exclude)deploy/flux-system/releases/glance-operator.yaml :(exclude)deploy/flux-system/releases/placement-operator.yaml"
   )
 
   local diff_output=""

--- a/tests/unit/hack/refresh_operator_image_digests_test.sh
+++ b/tests/unit/hack/refresh_operator_image_digests_test.sh
@@ -35,6 +35,7 @@ KEYSTONE_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 C5C3_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 HORIZON_DIGEST="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 GLANCE_DIGEST="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+PLACEMENT_DIGEST="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -70,6 +71,7 @@ if [ "${1:-}" = "buildx" ] && [ "${2:-}" = "imagetools" ] && [ "${3:-}" = "inspe
     *c5c3-operator*)     printf '"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' ;;
     *horizon-operator*)  printf '"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"' ;;
     *glance-operator*)   printf '"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"' ;;
+    *placement-operator*) printf '"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"' ;;
     *) exit 1 ;;
   esac
   exit 0
@@ -86,6 +88,7 @@ if [ "${1:-}" = "get" ] && [ "${2:-}" = "configmap" ]; then
       c5c3-operator-image-digest)     printf 'image:\n  digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n' ;;
       horizon-operator-image-digest)  printf 'image:\n  digest: sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n' ;;
       glance-operator-image-digest)   printf 'image:\n  digest: sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\n' ;;
+      placement-operator-image-digest) printf 'image:\n  digest: sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n' ;;
     esac
   fi
   exit 0
@@ -197,10 +200,10 @@ test_render_digest_configmap_yaml() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: the loop applies all four ConfigMaps and requests reconciles
+# Test 4: the loop applies all five ConfigMaps and requests reconciles
 # ---------------------------------------------------------------------------
 test_refresh_applies_and_annotates_all_operators() {
-  echo "Test: refresh applies 4 ConfigMaps and annotates 4 HelmReleases"
+  echo "Test: refresh applies 5 ConfigMaps and annotates 5 HelmReleases"
   local tmp
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' RETURN
@@ -226,13 +229,17 @@ test_refresh_applies_and_annotates_all_operators() {
   assert_contains "glance ConfigMap applied" "$apply_log" "name: glance-operator-image-digest"
   assert_contains "glance ConfigMap namespace" "$apply_log" "namespace: glance-system"
   assert_contains "glance digest in payload" "$apply_log" "$GLANCE_DIGEST"
+  assert_contains "placement ConfigMap applied" "$apply_log" "name: placement-operator-image-digest"
+  assert_contains "placement ConfigMap namespace" "$apply_log" "namespace: placement-system"
+  assert_contains "placement digest in payload" "$apply_log" "$PLACEMENT_DIGEST"
 
-  assert_eq "four reconcile annotations" "4" "$(grep -c 'annotate helmrelease/' "$tmp/annotate.log")"
+  assert_eq "five reconcile annotations" "5" "$(grep -c 'annotate helmrelease/' "$tmp/annotate.log")"
   assert_contains "keystone reconcile requested" "$annotate_log" "helmrelease/keystone-operator"
   assert_contains "keystone reconcile namespace" "$annotate_log" "-n keystone-system"
   assert_contains "c5c3 reconcile requested" "$annotate_log" "helmrelease/c5c3-operator"
   assert_contains "horizon reconcile requested" "$annotate_log" "helmrelease/horizon-operator"
   assert_contains "glance reconcile requested" "$annotate_log" "helmrelease/glance-operator"
+  assert_contains "placement reconcile requested" "$annotate_log" "helmrelease/placement-operator"
   assert_contains "requestedAt annotation" "$annotate_log" "reconcile.fluxcd.io/requestedAt="
   assert_contains "annotation is idempotent (overwrite)" "$annotate_log" "overwrite"
   assert_contains "pinned log line" "$out" "pinned to"
@@ -251,7 +258,7 @@ test_refresh_skips_annotate_when_digest_unchanged() {
   local out rc=0
   out=$(run_refresh "$tmp" KUBECTL_CM_EXISTS=true) || rc=$?
   assert_eq "refresh succeeds" "0" "$rc"
-  assert_eq "four ConfigMap applies (idempotent re-apply)" "4" "$(grep -c -- '--- kubectl apply' "$tmp/apply.log")"
+  assert_eq "five ConfigMap applies (idempotent re-apply)" "5" "$(grep -c -- '--- kubectl apply' "$tmp/apply.log")"
   assert_eq "no reconcile annotations" "0" "$(grep -c 'annotate' "$tmp/annotate.log")"
   assert_contains "unchanged log line" "$out" "digest unchanged"
 }
@@ -277,7 +284,8 @@ test_refresh_continues_on_resolve_failure() {
   assert_contains "c5c3 ConfigMap still applied" "$apply_log" "name: c5c3-operator-image-digest"
   assert_contains "horizon ConfigMap still applied" "$apply_log" "name: horizon-operator-image-digest"
   assert_contains "glance ConfigMap still applied" "$apply_log" "name: glance-operator-image-digest"
-  assert_eq "three reconcile annotations" "3" "$(grep -c 'annotate helmrelease/' "$tmp/annotate.log")"
+  assert_contains "placement ConfigMap still applied" "$apply_log" "name: placement-operator-image-digest"
+  assert_eq "four reconcile annotations" "4" "$(grep -c 'annotate helmrelease/' "$tmp/annotate.log")"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #770

The placement image (#768) and the placement-operator (#769) merged without a
single CI gate, e2e suite, or deploy-stack entry: `ci.yaml` carried zero
placement references, `tests/e2e/` had no placement directory, and neither the
Flux releases nor the kind overlay nor the OpenBao bootstrap knew the service.
This branch wires placement through all three layers, following the glance and
horizon precedents file by file.

## The change set, in commit order

**`e4a5537f` ci: activate placement across the pipeline matrices**
Adds the enumeration points in `.github/workflows/ci.yaml` and
`cleanup-images.yaml`: the `placement:` paths-filter block, the `helm:` filter
entry, `ALL_OPERATORS`, `FILTER_placement`, both test matrices, the three
helm-validate chart loops, the CRD apply on the c5c3 e2e leg, the e2e-chaos pod
leg (test_dirs, image load, and a deploy step into `placement-system`), the
cleanup matrices, and the `unit-placement` / `integration-placement` codecov
flags. `hack/ci-resolve-changes.sh` is fully generic and gains only the
`FILTER_placement` line in its header contract. `build-e2e-images` unions
placement into its build list only when the chaos leg actually runs, so a run
that skips chaos does not build three unused images. The unit and integration
matrices are pinned by an exact-string grep in the glance and horizon
verification scripts, so both greps move in the same commit — splitting them
would leave one side red.

**`d0f346b9` test(ci): add the placement CI pipeline verification script**
`tests/ci/verify_placement_ci_pipeline.sh` pins the wiring above so a dropped
matrix entry cannot surface late as a chaos suite selecting pods of an operator
that was never installed. It asserts the static wiring plus four behavioural
runs of `hack/ci-resolve-changes.sh` (placement-only, keystone-only, `go_common`,
tag push). Two glance tests have no counterpart: placement ships no tempest
plugin, and with no backing store its chaos leg is pod-kill only.

**`58b148a1` test(e2e): add the placement core chainsaw suites**
`basic-deployment` (2025.2), `basic-deployment-2026-1`, `release-upgrade`,
`deletion-cleanup`, and `healthcheck`. They pin what is placement's own rather
than the scaffolding's: the seven sub-conditions aggregating to `AllReady`;
uwsgi against `--wsgi-file /var/lib/openstack/bin/placement-api` with no
`--pyargv`, finding its config through `OS_PLACEMENT_CONFIG_DIR`; a rendered
`placement.conf` with `[placement_database]` and no `[database]` section; `GET /`
answering 200 with `"versions"` and an unauthenticated `GET /resource_providers`
returning exactly 401 (so a disabled `auth_strategy` at 200 and an unreachable
Keystone at 503 both fail); an upgrade to 2026.1 running one db-sync Job on the
new image with no expand/migrate/contract Job and no `status.upgradePhase`.

**`931e68e0` test(e2e): add the placement gateway, policy, and metrics suites**
`gateway-quick-start-smoke`, `httproute`, `network-policy`,
`pod-security-restricted`, `scale`, plus `tests/e2e/placement-operator/metrics/`.
Notable departures from the glance template: the gateway smoke matches the JSON
version document rather than the oslo healthcheck body (placement mounts no
healthcheck app); no suite carries a backend fixture; the httproute suite
asserts port 8778 and no `timeouts` stanza, and `HTTPRouteNotRequired` after the
gateway removal patch; the network-policy suite pins four auto-derived egress
rules in order (DNS, database, keystone, cache) — placement renders a dedicated
keystone rule and no object-store rule; the PSS suite reaches the database in
brownfield mode because `clusterRef` resolves only in the CR's own namespace.

**`e1025ae1` test(e2e): add the placement invalid-cr corpus and its generator**
`_generate.py` as the single source of truth, `test_generate.py` as its
cluster-free unit suite, a Chainsaw suite with one apply step per fixture, and
35 generated fixtures, each mutating exactly one aspect of the scaffold.
Registered in the Makefile `verify-invalid-cr-fixtures` target.

**`3e378700` test(chaos): add the placement-operator pod-kill suite**
The suite the pod leg already enumerates. Beyond the four-step glance template
it asserts the operational-independence contract: at least one pre-chaos
operator UID disappears, `readyReplicas` returns to desired, and no
`placement-api` workload pod UID changes across the chaos window.

**`92744539` feat(deploy): wire the placement-operator into the Flux and kind stacks**
The HelmRelease with the five glance `dependsOn`, the `placement-system`
Namespace, the kind suspend patch, and the `deploy-infra.sh` un-suspend as one
set — shipping the release without the un-suspend would leave the Placement
CRDs uninstalled on the ControlPlane path and stall the c5c3-operator cache
sync. Also flips the ServiceMonitor under `WITH_PROMETHEUS`.

**`0e13b0e9` feat(deploy): pin the placement-operator image to its deploy-time digest**
Appends the placement tuple to `OPERATOR_DIGEST_TARGETS`. Until now nothing
wrote the `placement-operator-image-digest` ConfigMap the HelmRelease already
referenced, so the release rendered tag-only and a rebuilt `:latest` never
rolled the running operator.

**`517b01a5` feat(kind): terminate a placement HTTPS listener on the shared Gateway**
`https-placement` as the sixth listener on the kind `openstack-gw`, plus the
self-signed `placement-nip-io-tls` Certificate in the infrastructure overlay
(the Certificate CRD only arrives with cert-manager in Phase 1 of
`deploy-infra.sh`). Without it the gateway smoke's request never reached the
projected HTTPRoute.

**`ed979e8f` feat(deploy): seed the standalone placement DB credential in OpenBao**
Every placement fixture selects `database.secretRef.name: placement-db`, but
nothing seeded it. Seeds `openstack/placement/openstack/standalone/db`, adds the
namespace-templated read grant to `eso-tenant.hcl`, and materialises the Secret
through a kind-only ExternalSecret.

**`e7b3f05b` feat(openbao): add the placement dynamic-credential policy and auth role**
The `placement-db-dynamic` templated policy and the `placement-db` auth role,
both dormant until #771 projects a `placement-db-creds` ServiceAccount.

## Divergences from the issue

- **The `setup-database-tenant.sh` per-tenant leg is deferred to #771**, together
  with its three `service_namespace_seeding_test.sh` cases. The
  `database/mariadb/config/placement-<ns>` and `roles/placement-<ns>` pair has no
  consumer before the ControlPlane spec carries `spec.services.placement`, so the
  `placement-<namespace>` derivation would be pinned against a comment rather
  than a real caller. The policy and auth role that the issue groups with it did
  land (`e7b3f05b`), as did the `openbao_onboard_database_tenant` wait-namespace
  candidate in `deploy-infra.sh`, which is inert until that field exists.
- **`invalid-cr` assertion layers:** 22 of the 35 classes are answered by the CRD
  schema and 13 by the validating webhook — the API server checks the structural
  schema and its CEL rules before any validating webhook, so a rule both layers
  carry is answered by the schema. This also reclassifies the omitted
  `openStackRelease`: it hits the CRD *pattern*, not the required-properties
  list, because the defaulting webhook marshals the whole typed object into its
  admission patch and the field carries no `omitempty`.
- **The replicas fixture uses `-1`, not `0`.** `DeploymentSpec.Default()`
  normalizes a zero in the mutating webhook, which runs first, so a CR asking for
  zero replicas is admitted and scaled to three.
- **No long-name fixture:** placement renders no CronJob, so its webhook enforces
  no `metadata.name` bound. Conversely, the corpus adds five extraConfig
  rejections beyond the issue's list, matching what glance pins.
- **`tests/unit/ci/build_operators_sentinel_test.sh` is new and not in the issue.**
  Extending `ALL_OPERATORS` exposed that `build-e2e-images` is the only consumer
  reading the e2e-operators matrix without gating on `has-e2e-operators`; the
  test pins that the step drops the `__none__` sentinel instead of running
  `make docker-build OPERATOR=__none__`.

Non-goals per the issue and untouched here: the `e2e-controlplane*` job wiring
and the c5c3-side dynamic-credential consumers (#771), the documentation set
(#772), tempest, and a backing-store-outage chaos suite.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) bb6d479 with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788083020&installation_model_id=18560&pr_number=792&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F792&signature=5fe78aa13514c81d5869d4f05dc3a3136373bb4e3a194991fc7af843ba317bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->