### PR TITLE
fix(renovate): close the range-pin coverage gap and gate automerge on a green suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,7 +321,6 @@ jobs:
   # of skipping their kustomize-build checks. The renovate/ tests pull
   # renovate-config-validator via npx, taking ~30s on a cold runner.
   test-shell:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:

--- a/deploy/kind/base/flux-web.yaml
+++ b/deploy/kind/base/flux-web.yaml
@@ -45,8 +45,10 @@
 # then browse http://localhost:9080
 #
 # Version pin: `spec.inputs[0].version` is a SemVer range locked to the
-# minor track of `FLUX_OPERATOR_VERSION` in hack/deploy-infra.sh (today
-# v0.56.0 → 0.56.x). Bump both together when upgrading the operator.
+# minor track of `FLUX_OPERATOR_VERSION` in hack/deploy-infra.sh.
+# Renovate bumps both pins in one grouped PR: a minor release rewrites
+# the range, patch releases float inside it.
+# tests/unit/deploy/kind_base_flux_web_test.sh asserts the lockstep.
 #
 ---
 apiVersion: fluxcd.controlplane.io/v1

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -38,6 +38,13 @@ native managers cannot see. Auto-merge (patch/minor, 3-day cooldown) is wired **
 onto the custom-regex managers; native-manager PRs always wait for a human merge
 (`config:recommended` does not auto-merge, and no top-level `automerge` is set).
 
+Renovate performs the merge itself: `platformAutomerge` is set to `false` at the top
+level, so an automergeable PR never goes to GitHub's own auto-merge. Renovate merges
+it once every check on the PR head has succeeded, because `ignoreTests` is left unset.
+Note for operators: `main` currently defines no required status checks, and GitHub's
+auto-merge waits for required checks alone. Tightening branch protection is a
+repository-settings change and cannot be made from files in this repository.
+
 The custom managers cover:
 
 - **OpenStack release refs** — git tags in `releases/*/source-refs.yaml` and PyPI pins in `releases/*/test-refs.yaml`.
@@ -352,9 +359,9 @@ modules.
 
 ### Required checks before merge
 
-Renovate auto-merge fires only after the full required-checks set is
-green. The set is enforced by branch protection on `main`; the most
-load-bearing for dependency PRs are:
+Renovate performs the merge itself (`platformAutomerge` is disabled) and
+waits until every check on the PR has succeeded. The checks below are the
+ones to watch when merging a dependency PR by hand:
 
 - `lint`, `format-check`, `govulncheck`
 - `test` (all three modules)
@@ -363,9 +370,9 @@ load-bearing for dependency PRs are:
 - `helm-validate` (when chart files change)
 - `build-e2e-images` (when image or workflow files change)
 
-For a manual merge, wait for the same checks even if Renovate's
-auto-merge would have skipped any of them due to path filters — the
-filters are an optimization, not an exemption.
+Renovate's gate covers every check that runs on the PR. A path filter
+can keep a job from starting at all; a manual merge holds itself to the
+same bar and treats such a job as unverified, not as passed.
 
 ---
 

--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -52,10 +52,16 @@ The custom managers cover:
 - **kind deploy components** — `flux-web.yaml`, `envoy-gateway.yaml`, and `headlamp.yaml` under `deploy/kind/base/`.
 - **K-ORC Flux source** — the `ref.tag` of the K-ORC `GitRepository` in `deploy/flux-system/sources/k-orc.yaml` (github-releases). This closes a drift gap: without it the Flux-applied K-ORC CRDs could fall behind the Renovate-tracked `k-orc/openstack-resource-controller` Go module the operator compiles against.
 - **Go build tooling in `Makefile` / `.github/workflows/*.yaml`** — `gofumpt`, `controller-gen`, `golangci-lint`, and `yq`.
+- **`renovate-config-validator` pin** — the `RENOVATE_VALIDATOR_VERSION` constant in `tests/unit/renovate/`, the Renovate release `test-shell` downloads and executes to validate `renovate.json`.
 
 Major updates are **disabled** for all custom-regex managers — these touch deploy-time
 CRDs, the OpenStack release matrix, and build tooling where a major bump always needs
-human-driven coordination.
+human-driven coordination. The `renovate-config-validator` pin is the one exception: it
+has to follow the major the hosted bot runs, or the validator silently stops checking
+`renovate.json` against the schema that bot enforces. That pin is never automerged
+either — the validator run is the only check that exercises the new release, so a bump
+must not be able to approve itself into a `test-shell` job that runs on `main` and on
+`v*` tag pushes.
 
 Separately, the native `nix` manager keeps the development flake fresh: it maintains
 `flake.lock` (the pinned `nixpkgs` revision) via lock-file maintenance, opening a grouped

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -40,8 +40,11 @@ The workflow triggers on three event types:
 | `push` | `tags: ["v*"]` | Runs on every v-prefixed tag push (triggers publish and release jobs) |
 | `pull_request` | `branches: [main]`, `types: [opened, synchronize, reopened, labeled]` | Runs on every pull request targeting main; includes `labeled` type to support on-demand chaos via `run-chaos` label |
 
-Gate, test, and E2E jobs run **only on `pull_request` events** — every one of them
-carries a `github.event_name == 'pull_request'` guard. Pushes to `main` and tag pushes
+Most gate, test, and E2E jobs run **only on `pull_request` events** — they each carry a
+`github.event_name == 'pull_request'` guard. `test-shell` is the exception. It carries no
+guard and also runs on pushes to `main` and on tag pushes. A breakage that lands on `main`
+therefore turns main's own run red at the commit that caused it, instead of surfacing on
+the next PR branch. Otherwise, pushes to `main` and tag pushes
 (`v*`) run only the publish and release jobs (`build-and-push`,
 `merge-operator-images`, `helm-push`, `github-release`): the merged commit's PR was
 already green, so the E2E suite is not re-run on push
@@ -96,16 +99,17 @@ Jobs that need elevated access declare per-job `permissions:` blocks:
 ## Job Dependency DAG
 
 The workflow defines 27 jobs organised in a directed acyclic graph. Every gate, test,
-and E2E job additionally carries a `github.event_name == 'pull_request'` guard; the
-publish and release jobs run only on push events:
+and E2E job except `test-shell` additionally carries a
+`github.event_name == 'pull_request'` guard; the publish and release jobs run only on
+push events:
 
 ```
-Gate Jobs (pull requests only):
+Gate Jobs (pull requests; test-shell also on push):
   lint ────────────────────────┐   (go == 'true')
   format-check                 │   (go == 'true')
   shellcheck ──────────────────┤   (always on PRs)
   feature-ids                  │   (always on PRs)
-  test-shell                   │   (always on PRs)
+  test-shell                   │   (PRs + push: main, tags)
   verify-codegen ──────────────┤   (go == 'true')
   verify-invalid-cr-fixtures ──┤   (always on PRs)
   chainsaw-lint ───────────────┤   (always on PRs)
@@ -295,12 +299,14 @@ Timeout: 8 minutes.
 ### test-shell
 
 Runs every shell unit test under `tests/unit/` (hack/, deploy/, docs/,
-renovate/). Tests read repo files only — no cluster, no untrusted input —
-so the job is unconditional and finishes in well under a minute on a cold
-runner. Tests that depend on `yq` or `kustomize` are written to skip
-gracefully when those tools are missing; the job installs `kustomize`
-explicitly so the deploy/ overlay assertions run their full check set
-(`yq` is preinstalled on ubuntu-latest).
+renovate/). The job carries no event guard, so it runs on pull requests and
+on the push runs for `main` and `v*` tags: a breakage that lands on `main`
+fails main's own run. Tests read repo files only (no cluster, no untrusted
+input) and the job finishes in about a minute on a cold runner. Tests that
+depend on `yq` or `kustomize` are written to skip gracefully when those
+tools are missing; the job installs `kustomize` explicitly so the deploy/
+overlay assertions run their full check set (`yq` is preinstalled on
+ubuntu-latest).
 
 | Step | Action | Details |
 | --- | --- | --- |

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "platformAutomerge": false,
   "nix": {
     "enabled": true,
     "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -306,6 +306,19 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/tests/unit/renovate/.*_test\\.sh$/"
+      ],
+      "matchStrings": [
+        "RENOVATE_VALIDATOR_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "renovate",
+      "datasourceTemplate": "npm",
+      "packageNameTemplate": "renovate",
+      "versioningTemplate": "npm"
     }
   ],
   "packageRules": [
@@ -592,6 +605,15 @@
       "groupName": "nix flake inputs",
       "automerge": false,
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["tests/unit/renovate/**.sh"],
+      "matchPackageNames": ["renovate"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "automerge": false,
+      "minimumReleaseAge": "3 days",
+      "groupName": "renovate-config-validator"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -173,7 +173,8 @@
       "depNameTemplate": "controlplaneio-fluxcd/flux-operator",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "controlplaneio-fluxcd/flux-operator",
-      "versioningTemplate": "semver"
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "npm"
     },
     {
       "customType": "regex",

--- a/tests/unit/ci/test_shell_event_guard_test.sh
+++ b/tests/unit/ci/test_shell_event_guard_test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the test-shell job in .github/workflows/ci.yaml stays reachable
+# from the push runs for main and v* tags.
+#
+# test-shell is the one gate job that deliberately carries no
+# `github.event_name == 'pull_request'` guard: a lockstep breakage that
+# lands on main has to fail main's own run at the commit that caused it
+# instead of surfacing on the next, unrelated PR branch. Nothing else
+# enforces that — re-adding the `if:` during a workflow refactor restores
+# the old behaviour silently and leaves the two claims in
+# docs/reference/ci-cd/ci-workflow.md false. The same is true of the push
+# trigger itself: dropping `main` or `v*` from `on.push` takes the job off
+# those runs without touching the job block.
+#
+# Usage: bash tests/unit/ci/test_shell_event_guard_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CI_YAML="$PROJECT_ROOT/.github/workflows/ci.yaml"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Echo the body of the ci.yaml block whose key line matches $1, where the
+# key sits at $2 spaces of indent: every following line indented deeper,
+# up to the first line at the same or lower indent. Blank lines belong to
+# the block so a step separated by one does not truncate it.
+extract_block() {
+  local key_re="$1" indent="$2"
+  awk -v key_re="$key_re" -v indent="$indent" '
+    !found && $0 ~ key_re { found = 1; next }
+    found {
+      if ($0 ~ /^[[:space:]]*$/) { print; next }
+      match($0, /^ */)
+      if (RLENGTH <= indent) { exit }
+      print
+    }
+  ' "$CI_YAML"
+}
+
+# PASS when the YAML block $2 lists $3 (an ERE) as a whole entry, in flow
+# (`[main]`) or block (`- main`) style, alone or alongside others. A plain
+# substring test would accept a `branches: [main-experiment]` that no
+# longer covers main; pinning one exact spelling would instead turn red
+# when a second branch is added or a formatter switches the style, and
+# name the wrong cause while doing it.
+assert_lists_entry() {
+  local description="$1" block="$2" entry="$3"
+  local boundary='[^A-Za-z0-9_./-]'
+
+  if printf '%s\n' "$block" | grep -qE "(^|${boundary})${entry}(${boundary}|\$)"; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description"
+    echo "    expected a list entry matching: $entry"
+    printf '%s\n' "$block" | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_shell_job_carries_no_event_guard() {
+  echo "Test: the test-shell job block declares no if: key"
+
+  local block
+  block="$(extract_block '^  test-shell:$' 2)"
+
+  # Without this the next check passes vacuously on a renamed job.
+  assert_contains "the test-shell job block is extractable and runs make test-shell" \
+    "$block" "make test-shell"
+
+  # Job-level keys sit at four spaces; step-level keys are deeper, so this
+  # matches the event guard without matching a step's own `if:`.
+  if printf '%s\n' "$block" | grep -qE '^    if:'; then
+    echo "  FAIL: test-shell carries a job-level if: — it must run on push to main and v* tags too"
+    printf '%s\n' "$block" | grep -E '^    if:' | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: test-shell carries no job-level if:"
+    PASS=$((PASS + 1))
+  fi
+}
+
+test_push_trigger_covers_main_and_tags() {
+  echo "Test: on.push still covers the main branch and v* tags"
+
+  local block
+  block="$(extract_block '^  push:$' 2)"
+
+  # The push block carries only branches / tags filters (the paths check
+  # below keeps it that way), so matching the entry inside the block is
+  # as precise as matching the filter line — and survives a second branch
+  # or a block-style rewrite.
+  assert_lists_entry "on.push covers the main branch" "$block" 'main'
+  assert_lists_entry "on.push covers v-prefixed tags" "$block" 'v\*'
+
+  # A paths / paths-ignore filter takes the job off the very runs this guard
+  # exists for — a push to main that only touches tests/ is exactly the
+  # lockstep breakage that has to fail main's own run.
+  if printf '%s\n' "$block" | grep -qE '^ *paths(-ignore)?:'; then
+    echo "  FAIL: on.push carries a paths filter — it can skip test-shell on a push to main"
+    printf '%s\n' "$block" | grep -E '^ *paths(-ignore)?:' | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: on.push carries no paths filter"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_shell_job_carries_no_event_guard
+test_push_trigger_covers_main_and_tags
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/deploy/kind_base_flux_web_test.sh
+++ b/tests/unit/deploy/kind_base_flux_web_test.sh
@@ -130,10 +130,10 @@ test_kustomize_build_emits_resourceset() {
   assert_eq "HelmRelease spec.values.fullnameOverride is flux-web" "flux-web" "$hr_fullname_override"
 }
 
-# --- Test 3: chart version pin is a SemVer range locked to the minor
-#             track shipped by hack/deploy-infra.sh ---
-test_chart_version_pin_is_semver_range() {
-  echo "Test: ResourceSet spec.inputs[0].version is 0.56.x and matches FLUX_OPERATOR_VERSION minor track"
+# --- Test 3: the chart version pin is the SemVer range derived from the
+#             FLUX_OPERATOR_VERSION minor track in hack/deploy-infra.sh ---
+test_chart_version_pin_matches_deploy_infra_minor_track() {
+  echo "Test: ResourceSet spec.inputs[0].version equals the minor track derived from FLUX_OPERATOR_VERSION"
 
   if [[ ! -f "$FLUX_WEB_FILE" ]]; then
     echo "  FAIL: $FLUX_WEB_FILE does not exist"
@@ -141,18 +141,75 @@ test_chart_version_pin_is_semver_range() {
     return
   fi
 
-  if ! command -v yq >/dev/null 2>&1; then
-    echo "  SKIP: yq not installed (1 check skipped)"
-    SKIP=$((SKIP + 1))
-  else
-    local version
-    version="$(yq -r '.spec.inputs[0].version' "$FLUX_WEB_FILE" 2>/dev/null | head -n1)"
-    assert_eq "spec.inputs[0].version pins the 0.56.x SemVer range" "0.56.x" "$version"
+  # Guard with || true so a missing line doesn't abort the script under pipefail.
+  local raw
+  raw="$( { grep -E '^FLUX_OPERATOR_VERSION="v' "$DEPLOY_INFRA_SH" || true; } | head -n1)"
+  if [[ -z "$raw" ]]; then
+    echo "  FAIL: no FLUX_OPERATOR_VERSION=\"v...\" line found in hack/deploy-infra.sh"
+    FAIL=$((FAIL + 2))
+    return
   fi
 
-  assert_file_contains "hack/deploy-infra.sh still declares FLUX_OPERATOR_VERSION=\"v0.56.0\"" \
-    "$DEPLOY_INFRA_SH" \
-    'FLUX_OPERATOR_VERSION="v0.56.0"'
+  local value semver_re='^v[0-9]+\.[0-9]+\.[0-9]+$'
+  value="$(printf '%s\n' "$raw" | sed -E 's/^FLUX_OPERATOR_VERSION="//; s/"$//')"
+  if [[ ! "$value" =~ $semver_re ]]; then
+    echo "  FAIL: FLUX_OPERATOR_VERSION value '$value' does not match $semver_re"
+    FAIL=$((FAIL + 2))
+    return
+  fi
+  echo "  PASS: hack/deploy-infra.sh declares FLUX_OPERATOR_VERSION as a vMAJOR.MINOR.PATCH tag"
+  PASS=$((PASS + 1))
+
+  # v<major>.<minor>.<patch> pins the operator; the chart range floats the patch.
+  local expected_range
+  expected_range="$(printf '%s\n' "$value" | sed -E 's/^v([0-9]+)\.([0-9]+)\.[0-9]+$/\1.\2.x/')"
+
+  # Without yq the lockstep must still be asserted — skipping it here would
+  # leave the whole test green while verifying nothing about the two pins
+  # the file header says move together.
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  NOTE: yq not installed, asserting the derived range via awk"
+    # Read the first entry under `inputs:` rather than scanning the whole
+    # file: the yq path below asserts on spec.inputs[0], and a file-wide
+    # match would accept the derived range on a second entry while
+    # inputs[0] — the pin Flux actually resolves — drifts a minor ahead.
+    #
+    # Extract the value, not the rendered line: the yq path compares the
+    # parsed version, so comparing indentation, quote style and key order
+    # here would let the same file pass on a host with yq and fail on the
+    # test-shell runner without it — pointing the diff at whitespace
+    # instead of at a version mismatch.
+    local first_input
+    first_input="$(awk '
+      /^  inputs:$/ { f = 1; next }
+      f && !/^    / && !/^[[:space:]]*$/ { exit }
+      f && /^    - / { if (++entry > 1) exit }
+      f && entry == 1 && /version:/ {
+        sub(/^.*version:[[:space:]]*/, "")
+        gsub(/["'"'"']/, "")
+        print
+        exit
+      }
+    ' "$FLUX_WEB_FILE")"
+    assert_eq "deploy/kind/base/flux-web.yaml spec.inputs[0].version matches the FLUX_OPERATOR_VERSION minor track in hack/deploy-infra.sh" \
+      "$expected_range" \
+      "$first_input"
+    return
+  fi
+
+  # No 2>/dev/null: a yq that errors out (flag handling changed by a bump,
+  # unreadable file) must read as a tool failure, not as an empty version
+  # that points the mismatch message at the YAML.
+  local raw_version
+  if ! raw_version="$(yq -r '.spec.inputs[0].version' "$FLUX_WEB_FILE")"; then
+    echo "  FAIL: yq could not read .spec.inputs[0].version from $FLUX_WEB_FILE"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_eq "deploy/kind/base/flux-web.yaml spec.inputs[0].version matches the FLUX_OPERATOR_VERSION minor track in hack/deploy-infra.sh" \
+    "$expected_range" \
+    "${raw_version%%$'\n'*}"
 }
 
 # --- Test 4: kind kustomization lists flux-web.yaml after headlamp.yaml ---
@@ -254,7 +311,7 @@ test_production_kustomization_unchanged() {
 # --- Run ---
 test_spdx_header
 test_kustomize_build_emits_resourceset
-test_chart_version_pin_is_semver_range
+test_chart_version_pin_matches_deploy_infra_minor_track
 test_kustomization_lists_flux_web
 test_production_overlay_has_no_flux_web
 test_production_kustomization_unchanged

--- a/tests/unit/renovate/automerge_gating_test.sh
+++ b/tests/unit/renovate/automerge_gating_test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json gates automerge on a fully green check suite
+#
+#   - `platformAutomerge` is disabled, so Renovate performs the merge
+#     itself instead of handing the PR to GitHub's auto-merge, which only
+#     waits for checks marked required by branch protection
+#   - no `ignoreTests: true` anywhere in the file weakens Renovate's
+#     default of merging only once every check on the PR head succeeded
+#
+# Schema validation of renovate.json via `renovate-config-validator`
+# (which transitively pulls Renovate via npx) is intentionally NOT run
+# from this per-feature test to keep local / CI loops fast: the
+# validator fetches the Renovate package on every invocation and taking
+# that hit once per feature touching renovate.json multiplies the cost
+# linearly. The validation is centralised in the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh,
+# which runs against the same renovate.json file — a schema regression
+# in the automerge keys fails that test too, so coverage is preserved
+# without duplicating the npx download.
+#
+# Usage: bash tests/unit/renovate/automerge_gating_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+
+# NOTE renovate-config-validator schema check is run by the
+# sibling tests/unit/renovate/fluxoperator_custommanager_test.sh
+# — see the header of this file for the rationale behind not duplicating
+# the npx-driven validation here.
+
+# --- Test 1: platformAutomerge is disabled at the top level ---
+test_platform_automerge_disabled() {
+  echo "Test: platformAutomerge is disabled so Renovate merges instead of GitHub"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  # Compared as a string against the literal "false": an absent key makes
+  # jq print "null" and a re-enabled key prints "true", so both the
+  # deletion and the flip back to GitHub's auto-merge fail this check.
+  assert_eq "renovate.json sets platformAutomerge to false at the top level" \
+    "false" \
+    "$(jq -r '.platformAutomerge' "$RENOVATE_FILE")"
+
+  # platformAutomerge is settable per packageRule, so the top-level key
+  # alone is not the gate: a nested override would hand exactly the
+  # auto-merged custom-manager PRs back to GitHub's auto-merge, which
+  # waits for required checks alone and main defines none.
+  assert_eq "renovate.json re-enables platformAutomerge at no level" \
+    "0" \
+    "$(jq '[.. | objects | select(.platformAutomerge == true)] | length' "$RENOVATE_FILE")"
+}
+
+# --- Test 2: no ignoreTests anywhere in the config ---
+test_no_ignore_tests_anywhere() {
+  echo "Test: no ignoreTests weakens the all-checks-green automerge default"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  # Recursive descent covers the top level and every nested object,
+  # including each packageRules entry, where an ignoreTests would let
+  # Renovate merge with a red or pending check on the PR head.
+  assert_eq "renovate.json carries no ignoreTests: true at any level" \
+    "0" \
+    "$(jq '[.. | objects | select(.ignoreTests == true)] | length' "$RENOVATE_FILE")"
+}
+
+# --- Run ---
+test_platform_automerge_disabled
+test_no_ignore_tests_anywhere
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/currentvalue_parseable_custommanager_test.sh
+++ b/tests/unit/renovate/currentvalue_parseable_custommanager_test.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify every customManagers entry in renovate.json captures a
+# currentValue that its own versioningTemplate can parse.
+#
+# A versioningTemplate that cannot parse the value the entry's regex
+# captures makes Renovate silently never offer updates for that pin: the
+# manager still matches, the extraction still succeeds, and the version
+# comparison is then dropped without an error. The flux-web chart entry
+# declared `semver` while capturing the range `0.56.x` and went stale
+# unnoticed until the pin was audited by hand.
+#
+# The guard replays each entry's matchStrings over the git-tracked files
+# its managerFilePatterns match and validates every captured value
+# against a per-versioning allow-table. Captures are aggregated per
+# entry, not per file: several workflow-pin entries target all
+# .github/workflows/*.yaml files while their version constant lives in
+# only two of them.
+#
+# Schema validation of renovate.json via `renovate-config-validator`
+# (which transitively pulls Renovate via npx) is intentionally NOT run
+# from this per-feature test to keep local / CI loops fast: the
+# validator fetches the Renovate package on every invocation and taking
+# that hit once per feature touching renovate.json multiplies the cost
+# linearly. The validation is centralised in the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh,
+# which runs against the same renovate.json file.
+#
+# Usage: bash tests/unit/renovate/currentvalue_parseable_custommanager_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+
+# NOTE renovate-config-validator schema check is run by the
+# sibling tests/unit/renovate/fluxoperator_custommanager_test.sh.
+# See the header of this file for the rationale behind not duplicating
+# the npx-driven validation here.
+
+# value_matches_shape <versioningTemplate> <value>
+#
+# Returns 0 when the value has a shape the versioning parses, 1 when it
+# does not, and 2 when the versioning is not in the table. The shapes are
+# deliberately narrower than the full versioning grammars: they only need
+# to catch pins whose captured value the versioning drops.
+value_matches_shape() {
+  local template="$1" value="$2"
+  local semver_shape='^v?[0-9]+\.[0-9]+\.[0-9]+$'
+
+  case "$template" in
+  semver | helm)
+    if [[ "$value" =~ $semver_shape ]]; then return 0; fi
+    return 1
+    ;;
+  npm)
+    # npm additionally accepts x-ranges such as 0.56.x, which semver
+    # rejects.
+    if [[ "$value" =~ $semver_shape ]]; then return 0; fi
+    if [[ "$value" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then return 0; fi
+    return 1
+    ;;
+  pep440)
+    # A release identifier: no range operators, no wildcards.
+    if [[ "$value" =~ ^[0-9][A-Za-z0-9.!+]*$ ]]; then return 0; fi
+    return 1
+    ;;
+  docker)
+    # Any non-empty tag without whitespace is a valid image reference.
+    if [ -z "$value" ]; then return 1; fi
+    if [[ "$value" =~ [[:space:]] ]]; then return 1; fi
+    return 0
+    ;;
+  *)
+    # An unknown versioning is a failure at the call site, not a pass:
+    # the table only grows when someone deliberately states which value
+    # shape the new versioning accepts.
+    return 2
+    ;;
+  esac
+}
+
+# --- Test 1: the allow-table itself, across every branch it offers ---
+test_shape_table_self_check() {
+  echo "Test: allow-table accepts, rejects and fails closed as its call sites expect"
+
+  # versioning|value|expected return code of value_matches_shape.
+  # 0 = the versioning parses the value, 1 = it does not, 2 = the
+  # versioning is not in the table. The first two rows are the pair that
+  # produced the original gap: the flux-web chart pin captured the range
+  # 0.56.x while declaring semver. The last two rows pin the fail-closed
+  # branch, which is the only thing making an untabled versioning a
+  # finding instead of a silent pass.
+  local -a cases=(
+    "semver|0.56.x|1"
+    "npm|0.56.x|0"
+    "semver|v0.56.0|0"
+    "helm|0.56.x|1"
+    "pep440|1.0.0|0"
+    "pep440|>=1.0|1"
+    "docker|3.20|0"
+    "docker||1"
+    "loose|1.0.0|2"
+    "|1.0.0|2"
+  )
+
+  local row tmpl val want rc
+  for row in "${cases[@]}"; do
+    IFS='|' read -r tmpl val want <<<"$row"
+    rc=0
+    value_matches_shape "$tmpl" "$val" || rc=$?
+    assert_eq "value_matches_shape('$tmpl', '$val') returns $want" "$want" "$rc"
+  done
+}
+
+# --- Test 2: replay every entry's matchStrings over its own files and
+#             validate each captured currentValue ---
+test_every_current_value_parses() {
+  echo "Test: every captured currentValue parses as the entry's versioningTemplate"
+
+  local replayed=0 digest_only=0
+  local entry
+
+  # The git index does not change while the test runs, so enumerate the
+  # tracked files once instead of once per managerFilePatterns entry.
+  local all_tracked
+  all_tracked="$(git -C "$PROJECT_ROOT" ls-files)"
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+
+    local label
+    label="$(jq -r '.depNameTemplate // .managerFilePatterns[0]' <<<"$entry")"
+
+    # Entries that pin a digest instead of a version capture no
+    # currentValue and carry no versioningTemplate, so this check has to
+    # run before the versioning lookup.
+    if ! jq -e '[.matchStrings[] | select(contains("(?<currentValue>"))] | length > 0' \
+      <<<"$entry" >/dev/null; then
+      echo "  SKIP (no currentValue capture group): $label"
+      SKIP=$((SKIP + 1))
+      digest_only=$((digest_only + 1))
+      continue
+    fi
+
+    local template
+    template="$(jq -r '.versioningTemplate // ""' <<<"$entry")"
+
+    # Probe the table once per entry so an unknown or missing versioning
+    # is reported here instead of once per captured value.
+    local rc=0
+    value_matches_shape "$template" "1.0.0" || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo "  FAIL: $label: unknown versioningTemplate '$template', add its value shape to value_matches_shape()"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+
+    # Resolve the entry's files: managerFilePatterns are slash-delimited
+    # regexes, so strip the delimiters before matching git-tracked paths.
+    local files="" missing_pattern="" pattern matched raw_pattern
+    while IFS= read -r raw_pattern; do
+      [ -n "$raw_pattern" ] || continue
+      pattern="${raw_pattern#/}"
+      pattern="${pattern%/}"
+      matched="$(printf '%s\n' "$all_tracked" | { grep -E "$pattern" || true; })"
+      if [ -z "$matched" ]; then
+        missing_pattern="$raw_pattern"
+        break
+      fi
+      files="$files$matched"$'\n'
+    done < <(jq -r '.managerFilePatterns[]' <<<"$entry")
+
+    if [ -n "$missing_pattern" ]; then
+      echo "  FAIL: $label: managerFilePatterns entry $missing_pattern matches no git-tracked file"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+
+    local matched_files
+    matched_files="$(printf '%s' "$files" | sort -u)"
+
+    # Replay every matchStrings regex over every matched file and collect
+    # the captures of the whole entry, tagged with their source file.
+    # $entry is fixed for the whole file loop, so extract its matchStrings
+    # once instead of once per matched file.
+    local match_strings
+    match_strings="$(jq -r '.matchStrings[]' <<<"$entry")"
+
+    local values="" captured file match_string value count=0 perl_rc
+    while IFS= read -r file; do
+      [ -n "$file" ] || continue
+
+      # git ls-files reports index entries; a tracked path can be absent
+      # from the worktree (interrupted rebase, sparse checkout, git rm
+      # --cached). Naming that here beats letting perl die mid-loop.
+      if [ ! -r "$PROJECT_ROOT/$file" ]; then
+        echo "  FAIL: $label: tracked file $file is not readable in the worktree"
+        FAIL=$((FAIL + 1))
+        continue
+      fi
+
+      while IFS= read -r match_string; do
+        [ -n "$match_string" ] || continue
+        # Renovate compiles matchStrings with RE2 and falls back to the JS
+        # engine; perl rejects a few patterns both accept. Report that as a
+        # finding on this entry instead of letting the die abort the run
+        # under set -e, which would swallow every remaining entry.
+        perl_rc=0
+        captured="$(REGEX="$match_string" FILE="$PROJECT_ROOT/$file" perl -e '
+          my $re = $ENV{REGEX};
+          local $/;
+          open my $fh, "<", $ENV{FILE} or exit 1;
+          my $content = <$fh>;
+          while ($content =~ /$re/g) {
+            print "$+{currentValue}\n" if defined $+{currentValue};
+          }
+        ')" || perl_rc=$?
+        if [ "$perl_rc" -ne 0 ]; then
+          echo "  FAIL: $label: perl could not apply matchString '$match_string' over $file"
+          FAIL=$((FAIL + 1))
+          continue
+        fi
+        while IFS= read -r value; do
+          [ -n "$value" ] || continue
+          values="$values$file"$'\t'"$value"$'\n'
+          count=$((count + 1))
+        done <<<"$captured"
+      done <<<"$match_strings"
+    done <<<"$matched_files"
+
+    if [ "$count" -eq 0 ]; then
+      echo "  FAIL: $label: matchStrings captured no currentValue in $(printf '%s' "$matched_files" | tr '\n' ' ')"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+
+    local bad=0 source_file
+    while IFS=$'\t' read -r source_file value; do
+      [ -n "$value" ] || continue
+      rc=0
+      value_matches_shape "$template" "$value" || rc=$?
+      if [ "$rc" -ne 0 ]; then
+        echo "  FAIL: $label: captured currentValue '$value' in $source_file does not parse as $template"
+        FAIL=$((FAIL + 1))
+        bad=$((bad + 1))
+      fi
+    done <<<"$values"
+
+    if [ "$bad" -eq 0 ]; then
+      echo "  PASS: $label: $count captured value(s) parse as $template"
+      PASS=$((PASS + 1))
+    fi
+
+    replayed=$((replayed + 1))
+  done < <(jq -c '.customManagers[]' "$RENOVATE_FILE")
+
+  # Exact counts, not a lower bound: the only path that reaches `continue`
+  # without a FAIL is the digest-only classifier, so a misfiring probe
+  # would otherwise move entries from replayed to skipped in bulk while a
+  # single survivor kept the sweep green.
+  local entry_count
+  entry_count="$(jq '.customManagers | length' "$RENOVATE_FILE")"
+  assert_eq "exactly one digest-only customManagers entry is skipped" \
+    "1" "$digest_only"
+  assert_eq "every other customManagers entry was replayed" \
+    "$((entry_count - 1))" "$replayed"
+}
+
+# --- Run ---
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  SKIP: jq not installed (entire test skipped)"
+  SKIP=$((SKIP + 1))
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+if ! command -v perl >/dev/null 2>&1; then
+  echo "  SKIP: perl not installed (entire test skipped)"
+  SKIP=$((SKIP + 1))
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+test_shape_table_self_check
+test_every_current_value_parses
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/envoy_gateway_manager_test.sh
+++ b/tests/unit/renovate/envoy_gateway_manager_test.sh
@@ -9,9 +9,17 @@
 #   - a paired packageRule set that disables majors and automerges minor/patch
 #     with minimumReleaseAge=3 days, groupName=envoy-gateway
 #
-# Prefers `renovate-config-validator` when available (via npx); otherwise
-# performs a regex-only validation using Perl (which speaks the same PCRE
-# syntax Renovate uses).
+# The matchStrings regex is replayed with Perl, which speaks the same
+# PCRE-style syntax Renovate uses.
+#
+# Schema validation of renovate.json via `renovate-config-validator`
+# (which transitively pulls Renovate via npx) is intentionally NOT run
+# from this per-feature test to keep local / CI loops fast: the validator
+# fetches the Renovate package on every invocation and taking that hit
+# once per feature touching renovate.json multiplies the cost linearly.
+# The validation is centralised in the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh, which runs
+# against the same renovate.json file.
 #
 # Usage: bash tests/unit/renovate/envoy_gateway_manager_test.sh
 
@@ -30,32 +38,11 @@ source "$PROJECT_ROOT/tests/lib/assertions.sh"
 RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
 CHART_FILE="$PROJECT_ROOT/deploy/kind/base/envoy-gateway.yaml"
 
-# --- Test 1: renovate.json passes renovate-config-validator when available
-#             ---
-test_renovate_config_valid() {
-  echo "Test: renovate.json validates via renovate-config-validator"
+# NOTE renovate-config-validator schema check is run by the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh over the same
+# renovate.json — see the header of this file.
 
-  if ! command -v npx >/dev/null 2>&1; then
-    echo "  SKIP: npx not installed (1 check skipped)"
-    SKIP=$((SKIP + 1))
-    return
-  fi
-
-  local output status=0
-  output="$(cd "$PROJECT_ROOT" && npx --yes --package renovate@latest -- \
-    renovate-config-validator renovate.json 2>&1)" || status=$?
-
-  if [ "$status" -ne 0 ]; then
-    echo "  FAIL: renovate-config-validator rejected renovate.json"
-    echo "$output" | head -40
-    FAIL=$((FAIL + 1))
-    return
-  fi
-  echo "  PASS: renovate-config-validator accepted renovate.json"
-  PASS=$((PASS + 1))
-}
-
-# --- Test 2: the envoy-gateway customManager entry captures the chart
+# --- Test 1: the envoy-gateway customManager entry captures the chart
 #             version lower bound from deploy/kind/base/envoy-gateway.yaml
 #             ---
 test_custom_manager_regex_captures_version() {
@@ -131,7 +118,7 @@ test_custom_manager_regex_captures_version() {
     "$expected_value" "$captured"
 }
 
-# --- Test 3: the ENVOY_GATEWAY_VERSION customManager entry captures the CRD
+# --- Test 2: the ENVOY_GATEWAY_VERSION customManager entry captures the CRD
 #             asset pin from hack/deploy-infra.sh
 #             ---
 test_deploy_infra_pin_manager_captures_version() {
@@ -193,7 +180,7 @@ test_deploy_infra_pin_manager_captures_version() {
     "$expected_value" "$captured"
 }
 
-# --- Test 4: packageRules for envoy-gateway disable majors and automerge
+# --- Test 3: packageRules for envoy-gateway disable majors and automerge
 #             minor/patch with minimumReleaseAge=3 days, groupName=envoy-gateway
 #             ---
 test_package_rules_disable_majors_and_group() {
@@ -261,7 +248,6 @@ test_package_rules_disable_majors_and_group() {
 }
 
 # --- Run ---
-test_renovate_config_valid
 test_custom_manager_regex_captures_version
 test_deploy_infra_pin_manager_captures_version
 test_package_rules_disable_majors_and_group

--- a/tests/unit/renovate/flux_web_chart_custommanager_test.sh
+++ b/tests/unit/renovate/flux_web_chart_custommanager_test.sh
@@ -52,8 +52,8 @@ test_custom_manager_regex_captures_chart_pin() {
   echo "Test: customManagers regex matches chart version input in deploy/kind/base/flux-web.yaml"
 
   if ! command -v jq >/dev/null 2>&1; then
-    echo "  SKIP: jq not installed (5 checks skipped)"
-    SKIP=$((SKIP + 5))
+    echo "  SKIP: jq not installed (6 checks skipped)"
+    SKIP=$((SKIP + 6))
     return
   fi
 
@@ -68,7 +68,7 @@ test_custom_manager_regex_captures_chart_pin() {
 
   if [ -z "$entry" ]; then
     echo "  FAIL: no customManagers entry with managerFilePatterns targeting deploy/kind/base/flux-web.yaml"
-    FAIL=$((FAIL + 5))
+    FAIL=$((FAIL + 6))
     return
   fi
 
@@ -80,9 +80,13 @@ test_custom_manager_regex_captures_chart_pin() {
     "github-releases" \
     "$(jq -r '.datasourceTemplate' <<<"$entry")"
 
-  assert_eq "customManagers.versioningTemplate is semver" \
-    "semver" \
+  assert_eq "customManagers.versioningTemplate is npm" \
+    "npm" \
     "$(jq -r '.versioningTemplate' <<<"$entry")"
+
+  assert_eq "customManagers.extractVersionTemplate strips the release v prefix" \
+    '^v(?<version>.+)$' \
+    "$(jq -r '.extractVersionTemplate' <<<"$entry")"
 
   # Extract the chart `version` input from flux-web.yaml verbatim, then
   # confirm the matchStrings regex captures the same value via Perl (which

--- a/tests/unit/renovate/flux_web_chart_custommanager_test.sh
+++ b/tests/unit/renovate/flux_web_chart_custommanager_test.sh
@@ -129,8 +129,8 @@ test_package_rules_cover_flux_web() {
   echo "Test: packageRules disable major bumps and automerge minor/patch for deploy/kind/base/flux-web.yaml"
 
   if ! command -v jq >/dev/null 2>&1; then
-    echo "  SKIP: jq not installed (5 checks skipped)"
-    SKIP=$((SKIP + 5))
+    echo "  SKIP: jq not installed (6 checks skipped)"
+    SKIP=$((SKIP + 6))
     return
   fi
 
@@ -164,7 +164,7 @@ test_package_rules_cover_flux_web() {
 
   if [ -z "$minor_rule" ]; then
     echo "  FAIL: no packageRule scoping minor/patch flux-operator updates to deploy/kind/base/flux-web.yaml"
-    FAIL=$((FAIL + 3))
+    FAIL=$((FAIL + 4))
     return
   fi
 
@@ -177,6 +177,14 @@ test_package_rules_cover_flux_web() {
   assert_eq "minor/patch flux-operator rule for flux-web.yaml waits minimumReleaseAge=3 days" \
     "3 days" \
     "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+
+  # The lockstep tests/unit/deploy/kind_base_flux_web_test.sh asserts is
+  # only reachable because both pins move in one PR. Without the group,
+  # a minor bump opens two PRs and each one alone fails that derived-range
+  # assertion, so neither can go green.
+  assert_eq "minor/patch flux-operator rule groups flux-web.yaml and deploy-infra.sh into one PR" \
+    "flux-operator" \
+    "$(jq -r '.groupName' <<<"$minor_rule")"
 }
 
 # --- Run ---

--- a/tests/unit/renovate/fluxoperator_custommanager_test.sh
+++ b/tests/unit/renovate/fluxoperator_custommanager_test.sh
@@ -25,6 +25,17 @@ SKIP=0
 source "$PROJECT_ROOT/tests/lib/assertions.sh"
 
 RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+
+# Pin the validator: test-shell also runs on the push runs for main and
+# v* tags, so `renovate@latest` would fetch and execute an unreviewed
+# Renovate release inside the release pipeline, and a breaking release
+# would turn main red at a commit that changed nothing. Bumped by the
+# renovatebot/renovate customManagers entry in renovate.json, whose
+# packageRule never automerges — the run below is the only check that
+# exercises the new release, so a bump must not approve itself. This is
+# the single pin in the suite; the sibling tests deliberately do not
+# repeat the validator run (and therefore not the constant either).
+RENOVATE_VALIDATOR_VERSION="44.8.0"
 DEPLOY_INFRA_FILE="$PROJECT_ROOT/hack/deploy-infra.sh"
 
 # --- Test 1: renovate.json passes renovate-config-validator ---
@@ -38,7 +49,7 @@ test_renovate_config_valid() {
   fi
 
   local output status=0
-  output="$(cd "$PROJECT_ROOT" && npx --yes --package renovate@latest -- \
+  output="$(cd "$PROJECT_ROOT" && npx --yes --package "renovate@${RENOVATE_VALIDATOR_VERSION}" -- \
     renovate-config-validator renovate.json 2>&1)" || status=$?
 
   if [ "$status" -ne 0 ]; then

--- a/tests/unit/renovate/source_refs_custommanager_test.sh
+++ b/tests/unit/renovate/source_refs_custommanager_test.sh
@@ -10,9 +10,17 @@
 #   - a paired packageRule set that disables majors and automerges minor/patch
 #     with minimumReleaseAge=3 days, groupName="OpenStack upstream tags"
 #
-# Prefers `renovate-config-validator` when available (via npx); otherwise
-# performs a regex-only validation using Perl (which speaks the same PCRE
-# syntax Renovate uses).
+# The matchStrings regex is replayed with Perl, which speaks the same
+# PCRE-style syntax Renovate uses.
+#
+# Schema validation of renovate.json via `renovate-config-validator`
+# (which transitively pulls Renovate via npx) is intentionally NOT run
+# from this per-feature test to keep local / CI loops fast: the validator
+# fetches the Renovate package on every invocation and taking that hit
+# once per feature touching renovate.json multiplies the cost linearly.
+# The validation is centralised in the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh, which runs
+# against the same renovate.json file.
 #
 # Usage: bash tests/unit/renovate/source_refs_custommanager_test.sh
 
@@ -31,28 +39,9 @@ source "$PROJECT_ROOT/tests/lib/assertions.sh"
 RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
 SOURCE_REFS_FILE="$PROJECT_ROOT/releases/2026.1/source-refs.yaml"
 
-test_renovate_config_valid() {
-  echo "Test: renovate.json validates via renovate-config-validator"
-
-  if ! command -v npx >/dev/null 2>&1; then
-    echo "  SKIP: npx not installed (1 check skipped)"
-    SKIP=$((SKIP + 1))
-    return
-  fi
-
-  local output status=0
-  output="$(cd "$PROJECT_ROOT" && npx --yes --package renovate@latest -- \
-    renovate-config-validator renovate.json 2>&1)" || status=$?
-
-  if [ "$status" -ne 0 ]; then
-    echo "  FAIL: renovate-config-validator rejected renovate.json"
-    echo "$output" | head -40
-    FAIL=$((FAIL + 1))
-    return
-  fi
-  echo "  PASS: renovate-config-validator accepted renovate.json"
-  PASS=$((PASS + 1))
-}
+# NOTE renovate-config-validator schema check is run by the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh over the same
+# renovate.json — see the header of this file.
 
 test_custom_manager_regex_captures_depname_and_version() {
   echo "Test: customManagers regex extracts (depName, x.y.z) from source-refs.yaml"
@@ -171,7 +160,6 @@ test_package_rules_disable_majors_and_group() {
     "$(jq -r '.groupName' <<<"$minor_rule")"
 }
 
-test_renovate_config_valid
 test_custom_manager_regex_captures_depname_and_version
 test_package_rules_disable_majors_and_group
 

--- a/tests/unit/renovate/validator_pin_custommanager_test.sh
+++ b/tests/unit/renovate/validator_pin_custommanager_test.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json tracks the RENOVATE_VALIDATOR_VERSION pin the
+# shell test suite feeds to `npx renovate-config-validator`, and pairs it
+# with a packageRule that keeps a bump under human review.
+#
+# Asserts:
+#   - exactly one customManager targets the npm package `renovate` over
+#     tests/unit/renovate/*_test.sh
+#   - its matchStrings regex captures the pin from the real test file and
+#     that capture equals the literal constant
+#   - exactly one test file carries the constant, so the three-way drift
+#     that a hand edit or a partial revert would cause cannot happen
+#   - that file still invokes the validator, so the suite's single schema
+#     check cannot be deleted unnoticed
+#   - exactly one packageRule scopes the pin and no rule scoped to the
+#     same glob automerges: test-shell downloads and executes that
+#     release on `main` and on `v*` tag pushes, and the validator run is
+#     the only check that exercises it — a bump must not be able to
+#     approve itself
+#   - majors are NOT disabled: the validator has to follow the major the
+#     hosted bot runs, or it silently stops checking renovate.json
+#     against the schema that bot enforces
+#
+# Schema validation of renovate.json via `renovate-config-validator` is
+# centralised in the sibling
+# tests/unit/renovate/fluxoperator_custommanager_test.sh — the file that
+# carries the pin asserted here.
+#
+# Usage: bash tests/unit/renovate/validator_pin_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+RENOVATE_TEST_DIR="$PROJECT_ROOT/tests/unit/renovate"
+PIN_FILE="$RENOVATE_TEST_DIR/fluxoperator_custommanager_test.sh"
+
+PKG_NAME="renovate"
+FILE_GLOB="tests/unit/renovate/**.sh"
+
+test_manager_exists_and_regex_matches() {
+  echo "Test: the RENOVATE_VALIDATOR_VERSION pin has a customManager whose regex matches"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (5 checks skipped)"
+    SKIP=$((SKIP + 5))
+    return
+  fi
+
+  local count
+  count="$(jq --arg pkg "$PKG_NAME" '[.customManagers[]
+    | select(.packageNameTemplate == $pkg)] | length' "$RENOVATE_FILE")"
+  assert_eq "exactly one customManager targets the ${PKG_NAME} npm package" "1" "$count"
+
+  local entry
+  entry="$(jq -c --arg pkg "$PKG_NAME" '.customManagers[]
+    | select(.packageNameTemplate == $pkg)' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManager for ${PKG_NAME}"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_contains "manager targets tests/unit/renovate/*_test.sh" \
+    "$(jq -r '.managerFilePatterns[0]' <<<"$entry")" "tests/unit/renovate/"
+  assert_eq "manager uses the npm datasource" \
+    "npm" "$(jq -r '.datasourceTemplate' <<<"$entry")"
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+  if [[ ! -f "$PIN_FILE" ]]; then
+    echo "  FAIL: $PIN_FILE missing"
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  local match_string captured expected_pin
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+  captured="$(REGEX="$match_string" FILE="$PIN_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    if ($content =~ /$re/) { print $+{currentValue} // ""; }
+  ')"
+
+  assert_not_empty "matchStrings regex captures the validator pin" "$captured"
+
+  # Derive the expected pin straight from the test file so a Renovate bump
+  # keeps this test green — never hard-code the version.
+  expected_pin="$(grep -oE '^RENOVATE_VALIDATOR_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$PIN_FILE" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+  assert_eq "captured pin equals the literal RENOVATE_VALIDATOR_VERSION constant" \
+    "$expected_pin" "$captured"
+}
+
+test_pin_is_declared_once() {
+  echo "Test: exactly one test file declares the validator pin and runs the validator"
+
+  # Renovate bumps every occurrence in one PR, so drift only comes from a
+  # hand edit or a partial revert — and then two files run one validator
+  # version while a third runs another, with nothing naming the cause.
+  local pin_files
+  pin_files="$( { grep -rlE '^RENOVATE_VALIDATOR_VERSION="' "$RENOVATE_TEST_DIR" || true; } | wc -l | tr -d ' ')"
+  assert_eq "exactly one tests/unit/renovate file declares RENOVATE_VALIDATOR_VERSION" \
+    "1" "$pin_files"
+
+  # The sibling tests delegate schema validation to this file. Drop the
+  # call and renovate.json stops being checked against the schema the
+  # hosted bot enforces — the pin above still lines up, so nothing else
+  # in the suite goes red.
+  assert_file_contains "the pin file actually invokes renovate-config-validator" \
+    "$PIN_FILE" "renovate-config-validator renovate.json"
+}
+
+test_package_rule_keeps_bumps_under_review() {
+  echo "Test: the paired packageRule proposes every update type but never automerges"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (7 checks skipped)"
+    SKIP=$((SKIP + 7))
+    return
+  fi
+
+  # Exactly one rule: a second one could re-disable majors or flip
+  # automerge back on without this test noticing.
+  local rule_count
+  rule_count="$(jq --arg pkg "$PKG_NAME" --arg glob "$FILE_GLOB" '[.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index($pkg)) != null)
+        and (((.matchFileNames // []) | index($glob)) != null)
+      )] | length' "$RENOVATE_FILE")"
+  assert_eq "exactly one packageRule scopes the validator pin" "1" "$rule_count"
+
+  # The count above only sees rules that name the package. A later rule
+  # scoped to the same glob but without matchPackageNames matches the pin
+  # too, and Renovate lets the later match win — automerge would be back
+  # on with the count still at 1.
+  local automerge_rules
+  automerge_rules="$(jq --arg glob "$FILE_GLOB" '[.packageRules[]
+    | select(((.matchFileNames // []) | index($glob)) != null)
+    | select(.automerge == true)] | length' "$RENOVATE_FILE")"
+  assert_eq "no packageRule automerges anything scoped to ${FILE_GLOB}" \
+    "0" "$automerge_rules"
+
+  local rule
+  rule="$(jq -c --arg pkg "$PKG_NAME" --arg glob "$FILE_GLOB" '.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index($pkg)) != null)
+        and (((.matchFileNames // []) | index($glob)) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$rule" ]; then
+    echo "  FAIL: no packageRule scoping ${PKG_NAME} to ${FILE_GLOB}"
+    FAIL=$((FAIL + 5))
+    return
+  fi
+
+  assert_eq "validator bumps are never automerged" \
+    "false" "$(jq -r '.automerge' <<<"$rule")"
+  assert_eq "validator bumps wait minimumReleaseAge=3 days" \
+    "3 days" "$(jq -r '.minimumReleaseAge' <<<"$rule")"
+  assert_eq "validator bumps are grouped as renovate-config-validator" \
+    "renovate-config-validator" "$(jq -r '.groupName' <<<"$rule")"
+
+  # An `enabled: false` here (or a missing `major` update type) would
+  # freeze the validator on its current major with no PR and no dashboard
+  # entry, while the hosted bot keeps moving.
+  assert_eq "the validator pin is not disabled" \
+    "null" "$(jq -r '.enabled' <<<"$rule")"
+  assert_eq "major validator updates still open a PR" \
+    "true" \
+    "$(jq -r '((.matchUpdateTypes // []) | index("major")) != null' <<<"$rule")"
+}
+
+test_manager_exists_and_regex_matches
+test_pin_is_declared_once
+test_package_rule_keeps_bumps_under_review
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #774

Two independent gaps let a lockstep version pin break while every merge gate stayed green: the flux-web chart range was invisible to Renovate, and Renovate's grouped PR merged without waiting for the check suite. This branch closes both, keeps automerge on for grouped minor/patch updates, and adds the guards that stop either gap from reopening silently.

## Commits, in order

### `a4f3b36e` fix(renovate): let the flux-web chart manager parse its x-range

The custom manager for `deploy/kind/base/flux-web.yaml` declared `semver` versioning. Semver accepts only concrete versions, so the captured pin `0.56.x` was unparseable and the manager never produced an update — the grouped flux-operator PR carried only the `hack/deploy-infra.sh` half of the lockstep.

The entry switches to `npm` versioning, which parses `0.56.x` as an x-range, and gains `"extractVersionTemplate": "^v(?<version>.+)$"` to strip the leading `v` from the GitHub release tag, mirroring the envoy-gateway entry directly below it. `tests/unit/renovate/flux_web_chart_custommanager_test.sh` asserts both.

**Divergence from the issue:** the issue asked for `"rangeStrategy": "replace"` on the flux-operator minor/patch packageRule. It is deliberately left unset. npm versioning already rewrites the range on a minor bump (`0.56.x` → `0.57.x`) and returns it unchanged for patch releases inside the range — exactly what an explicit `replace` yields. Setting it would additionally cost a packageRule of its own, because the config validator rejects `rangeStrategy` combined with `matchUpdateTypes` in one rule.

### `9d3d56ea` test(deploy): derive the flux-web lockstep range from deploy-infra

Test 3 of `tests/unit/deploy/kind_base_flux_web_test.sh` asserted both halves of the lockstep as literals. Renovate never edits the test file, so once the merge gate actually waits for checks, every *complete* grouped bump would sit red until a human edited the stubs — the manual repair that PR #780 had to perform, and something that does not work with automerge at all.

The test now reads `FLUX_OPERATOR_VERSION` from `hack/deploy-infra.sh`, validates it as a `vMAJOR.MINOR.PATCH` tag, derives the minor track, and compares that to the yaml pin. A complete bump passes with no test edit; a partial bump still fails and the message names both files; a missing or malformed pin line fails with the offending value rather than aborting the run under `set -euo pipefail`. The pin comment in `flux-web.yaml` drops its go-stale literal example and points at the test instead.

### `baf45b66` fix(renovate): gate automerge on a fully green check suite

With no required status checks configured on `main`, GitHub's platform automerge waited for nothing: the grouped bump in PR #664 merged one minute after Renovate's final rebase while `test-shell` was red on the PR head.

Top-level `"platformAutomerge": false` moves the merge back into Renovate, which by default (no `ignoreTests`) merges only once every check on the head commit has succeeded. The policy surface is unchanged: same grouping, same minor/patch-only scope, same 3-day `minimumReleaseAge`. `tests/unit/renovate/automerge_gating_test.sh` pins both the `platformAutomerge` value and the absence of `ignoreTests` at any level. The dependency-management doc records the Renovate-side gate and drops the false claim that branch protection on `main` enforces a required-checks set — hardening branch protection stays a repository-settings action outside this repo.

### `7627dcd6` ci: run test-shell on push runs for main and tags

The `if: github.event_name == 'pull_request'` guard kept the push run after a merge from executing the shell-test tripwire, so a breakage that landed on `main` stayed vacuously green there and only surfaced on the next, unrelated PR branch. The guard is removed. The job reads repo files only and finishes in about a minute; no other job `needs:` it, so no edge of the job DAG changes. `docs/reference/ci-cd/ci-workflow.md` loses its three now-false claims that every gate job is PR-only (trigger-events paragraph, DAG intro plus group header and job annotation, `### test-shell` section).

**Scope beyond the issue, and why:** running `test-shell` on `main` and `v*` pushes means the renovate tests' `npx --package renovate@latest -- renovate-config-validator` would fetch and execute an unreviewed Renovate release inside the *release* pipeline, where a breaking release turns `main` red at a commit that changed nothing. This commit therefore also:

- pins the validator to `RENOVATE_VALIDATOR_VERSION="44.8.0"` in `tests/unit/renovate/fluxoperator_custommanager_test.sh`, and centralises the validator run there — `envoy_gateway_manager_test.sh` and `source_refs_custommanager_test.sh` drop their duplicate schema checks (their regex-replay coverage is unchanged, and the same `renovate.json` is still validated once per suite run);
- adds a `customManagers` entry plus packageRule so Renovate bumps that pin. Majors are deliberately *not* disabled for it (the validator must follow the major the hosted bot runs), and it never automerges — the validator run is the only check that exercises the new release, so a bump must not approve itself;
- adds `tests/unit/renovate/validator_pin_custommanager_test.sh` guarding the pin's three-way consistency and the no-automerge rule;
- adds `tests/unit/ci/test_shell_event_guard_test.sh`, which fails if the `if:` guard is re-added during a workflow refactor or if `main` / `v*` disappear from `on.push` — without it, the old behaviour returns silently and the two doc claims become false again.

### `b1a3b1e3` test(renovate): guard every captured currentValue as parseable

The generic guard for the class of bug the first commit fixed. `tests/unit/renovate/currentvalue_parseable_custommanager_test.sh` replays every `customManagers` entry's `matchStrings` over the git-tracked files its `managerFilePatterns` match, and validates each captured `currentValue` against a per-versioning allow-table. Captures aggregate per entry, because several workflow-pin entries match files that do not carry their constant. Entries with no `currentValue` capture group (the k-orc digest entry) are reported as skipped; an unknown `versioningTemplate` fails, so the table grows deliberately. A self-check pins the table with the shapes that caused the original gap: `semver` must reject `0.56.x`, `npm` must accept it.

## Notes for the reviewer

- The npm range-replace behaviour (`0.56.x` rewritten to `0.57.x`) is verified against the Renovate docs but cannot be exercised by any test here; the first real flux-operator minor release is the end-to-end proof.
- The issue's acceptance criterion expecting `ls tests/unit/renovate/ | wc -l` to print 21 is now 22, because of the extra `validator_pin_custommanager_test.sh` described above.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788367252&installation_model_id=18560&pr_number=801&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F801&signature=9c8c77abad7a03990796454f77a82d4c5a63dce4922fc2634d15aa934b664903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->