### PR TITLE
feat(infra): provision OpenBao instances via the openbao-operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -648,7 +648,7 @@ jobs:
       # still absent.
       - name: Run scoped Chainsaw E2E tests after additive re-run
         run: |
-          chainsaw test --config tests/e2e/chainsaw-config.yaml --report-name chainsaw-report-additive tests/e2e/infrastructure/infra-stack-health tests/e2e/infrastructure/garage-health tests/e2e/infrastructure/flux-web-health tests/e2e/infrastructure/no-prometheus-when-disabled
+          chainsaw test --config tests/e2e/chainsaw-config.yaml --report-name chainsaw-report-additive tests/e2e/infrastructure/infra-stack-health tests/e2e/infrastructure/garage-health tests/e2e/infrastructure/flux-web-health tests/e2e/infrastructure/no-prometheus-when-disabled tests/e2e/infrastructure/openbao-instance
       # Use shared diagnostic dump script.  `always()` (matching every other
       # e2e job) also covers the timeout-cancellation path -- `failure()`
       # alone is skipped when timeout-minutes expires, discarding the cluster

--- a/deploy/flux-system/kustomization.yaml
+++ b/deploy/flux-system/kustomization.yaml
@@ -37,6 +37,10 @@ resources:
   - sources/prometheus-community.yaml
   # First third-party OCI-type HelmRepository (see sources/garage-operator.yaml).
   - sources/garage-operator.yaml
+  # OpenBao instance operator (per-service OpenBao instances; Barbican
+  # secret-store backend). A digest-pinned OCIRepository, not a HelmRepository —
+  # see the manifest for why this chart pins content rather than a version.
+  - sources/openbao-operator.yaml
 
   # HelmRelease operators (deployed via FluxCD).
   # Chaos Mesh is intentionally absent: opt-in via deploy/kind/chaos-mesh/
@@ -55,3 +59,6 @@ resources:
   - releases/c5c3-operator.yaml
   # Garage object store operator (S3 backend for the CI/e2e stack).
   - releases/garage-operator.yaml
+  # OpenBao instance operator (per-service OpenBao instances; Barbican
+  # secret-store backend).
+  - releases/openbao-operator.yaml

--- a/deploy/flux-system/namespaces.yaml
+++ b/deploy/flux-system/namespaces.yaml
@@ -91,6 +91,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: orc-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  # openbao-operator-system hosts the openbao-operator controller; the name
+  # openbao-system is taken by the shared OpenBao instance, and keeping the
+  # operator out of it separates the shared-instance and operator lifecycles.
+  name: openbao-operator-system
 # The chaos-mesh Namespace lives in the opt-in overlay deploy/kind/chaos-mesh/,
 # not here, so the privileged PodSecurity label is created only when Chaos Mesh
 # is actually deployed.

--- a/deploy/flux-system/releases/openbao-operator.yaml
+++ b/deploy/flux-system/releases/openbao-operator.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# openbao-operator (dc-tec/openbao-operator) manages OpenBaoCluster instance
+# CRs: static-seal auto-unseal, cert-manager TLS, declarative self-init, raft
+# snapshots, upgrade strategies. It delivers the per-service OpenBao instances
+# the Barbican secret store builds on and the in-repo proving instance
+# (deploy/kind/infrastructure/openbao-instance.yaml).
+#
+# The operator ships ValidatingAdmissionPolicies and requires Kubernetes >=
+# 1.33. It needs cert-manager for nothing itself, but the instance TLS
+# Certificates do, and the stack's dependency order keeps cert-manager first,
+# so this release dependsOn cert-manager (mirroring garage-operator).
+#
+# ACCEPTED RISK: openbao-operator is a young, single-maintainer, pre-1.0
+# (v0.4.x) project, and unlike garage-operator it sits in the PRODUCTION DATA
+# PATH of every future Barbican secret store. The bet is mitigated by the thin
+# consumed surface (one OpenBaoCluster CR shape), the operator-independent
+# brownfield attachment path on the shared instance, and the open fallback of
+# an in-repo openbao-helm-derived StatefulSet projection. Accepted with issue
+# #803 for the Barbican onboarding (#804).
+#
+# The chart carries no cosign signature Flux can verify, so no spec.verify
+# policy can gate it. It is therefore consumed through a DIGEST-PINNED
+# OCIRepository (deploy/flux-system/sources/openbao-operator.yaml) rather than
+# through a HelmRepository plus a version constraint as with garage-operator.
+# garage-operator's `>=x <1.0.0` range would install every future 0.x release of
+# an individual-owned GHCR namespace within one interval; an exact chart version
+# would still upgrade on its own whenever that tag is re-pushed with different
+# bytes, because Flux tracks the resolved artifact digest and not the tag
+# string. Pinning the digest is what puts a reviewer in front of every change to
+# what runs here — see the source manifest for the Renovate side of it.
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openbao-operator
+  namespace: openbao-operator-system
+spec:
+  interval: 30m
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+  chartRef:
+    kind: OCIRepository
+    name: openbao-operator
+    namespace: flux-system
+  install:
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  # The chart defaults to multi-tenant mode, whose provisioner requires
+  # OpenBaoTenant namespace onboarding and applies restricted Pod Security
+  # labels to tenant namespaces. That is unacceptable for the shared openstack
+  # namespace, which hosts every OpenStack service workload. Single-tenant mode
+  # deploys only the controller, scoped to the one namespace the instance CRs
+  # live in.
+  #
+  # tenancy.mode alone does NOT put the controller in single-tenant mode. At
+  # chart 0.4.2 it selects the single-tenant ClusterRole and drops the
+  # provisioner Deployment, but the controller derives its own tenancy from the
+  # WATCH_NAMESPACE environment variable (empty means multi-tenant), and no
+  # chart template sets it. A controller left in multi-tenant mode waits for the
+  # RoleBinding openbao-operator-tenant-rolebinding that OpenBaoTenant
+  # onboarding creates, and pauses every reconcile until it appears — silently,
+  # at log level V(1), leaving the OpenBaoCluster with an empty status and no
+  # StatefulSet. controller.extraEnv is the chart's documented hook for it.
+  values:
+    tenancy:
+      mode: single
+      targetNamespace: openstack
+    controller:
+      extraEnv:
+        - name: WATCH_NAMESPACE
+          value: openstack

--- a/deploy/flux-system/sources/openbao-operator.yaml
+++ b/deploy/flux-system/sources/openbao-operator.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OCIRepository for the dc-tec/openbao-operator chart. Every other chart in this
+# stack rides an OCI-type HelmRepository; this one does not, because it is the
+# one chart that has to pin CONTENT rather than a version.
+#
+# `0.4.2` on oci://ghcr.io/dc-tec/charts is a MUTABLE tag. A HelmRepository plus
+# an exact chart.spec.version gates version drift only: Flux resolves the tag on
+# every interval and tracks the resulting artifact DIGEST, so re-pushing the tag
+# with different bytes produces a new revision and the HelmRelease upgrades
+# itself — no Git change, no reviewer, cluster-wide operator RBAC over the
+# namespace that holds the instance seal key. spec.verify is not an option
+# either: the publisher attaches a SLSA provenance attestation but no cosign
+# signature, so a verify policy would have nothing to check.
+#
+# ref.digest closes that: it takes precedence over every other ref field, so
+# Flux pulls this exact manifest and a re-pushed tag cannot change what runs.
+# ref.tag rides alongside it as the human-readable version and as Renovate's
+# lookup handle.
+#
+# Renovate's native flux manager does NOT cover this repo — its default file
+# pattern matches only gotk-components.yaml, which the flux-operator setup here
+# never produces — so every Flux pin is tracked by an explicit customManager.
+# The openbao-operator entry in renovate.json bumps tag and digest together in
+# one reviewed PR; tests/unit/renovate/openbao_operator_chart_custommanager_test.sh
+# guards that pairing.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openbao-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  # Unlike a HelmRepository, the url of an OCIRepository is the chart artifact
+  # itself, not the registry namespace it lives in.
+  url: oci://ghcr.io/dc-tec/charts/openbao-operator
+  # `copy` hands the chart tarball to helm-controller unaltered, which is what a
+  # HelmRelease chartRef consumes; the default `extract` would unpack it.
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "0.4.2"
+    digest: "sha256:54406de2e67e62df4119e61b38efd61a82b6bb2954b1f8ff7e7f90fd03249638"

--- a/deploy/kind/infrastructure/kustomization.yaml
+++ b/deploy/kind/infrastructure/kustomization.yaml
@@ -67,6 +67,15 @@ resources:
   # names that hack/deploy-infra.sh filters out on the ControlPlane path).
   - garage-admin-token-externalsecret.yaml
   - garage-s3-credentials-externalsecret.yaml
+  # kind-only: the proving OpenBaoCluster for the openbao-operator primitives
+  # the Barbican onboarding builds on, plus the ExternalSecret that materializes
+  # its static unseal key (seeded in the management OpenBao) so the operator can
+  # adopt it instead of generating its own. Both sit in the openstack namespace
+  # and survive the WITH_CONTROLPLANE shim drop (neither is among the
+  # keystone-admin/keystone-db/mariadb-root-password names). The instance is
+  # CI/dev-only — see the posture rationale in its own file header.
+  - openbao-instance.yaml
+  - openbao-instance-unseal-key-externalsecret.yaml
 
 patches:
   # MariaDB: single replica, no Galera, no MaxScale, standard storage.

--- a/deploy/kind/infrastructure/openbao-instance-unseal-key-externalsecret.yaml
+++ b/deploy/kind/infrastructure/openbao-instance-unseal-key-externalsecret.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# kind-only ExternalSecret for the proving OpenBaoCluster's static unseal key.
+#
+# The management OpenBao is the root of trust for that key: it is seeded by
+# deploy/openbao/bootstrap/write-bootstrap-secrets.sh at the OpenBao path
+# "bootstrap/openstack/openbao-instance/unseal-key" and read through the shared
+# openbao-cluster-store, which allow-lists the openstack namespace. The
+# openbao-operator mounts the materialized Secret at /etc/bao/unseal once it has
+# adopted it through the ownership proof hack/deploy-infra.sh attaches.
+#
+# Like the other deploy/kind/infrastructure/ shims this is CI/dev-only, and it
+# is scoped to the equally kind-only instance in openbao-instance.yaml; the
+# production stack (deploy/eso/) ships none of these static ExternalSecrets.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-instance-unseal-key
+  namespace: openstack
+spec:
+  # Materialize once, never converge. This is not a rotatable credential: the
+  # openbao-operator mounts the key as the instance's STATIC SEAL, so a second,
+  # different value under a live instance makes its raft store undecryptable
+  # for good. A periodic refresh would do exactly that whenever the seed
+  # changes — most plausibly when the management OpenBao loses its raft PVC and
+  # write-bootstrap-secrets.sh re-seeds a fresh random key while the instance's
+  # own PVC survives. CreatedOnce refuses that rather than converging on it; a
+  # fresh cluster gets a fresh Secret and a fresh key.
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: openbao-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: openbao-instance-unseal-key
+    # Orphan, so the controller ownerReference slot stays free for the
+    # OpenBaoCluster. The operator adopts a pre-existing unseal Secret only
+    # against an ownership proof, and the only proof an outside principal can
+    # attach is that ownerReference: its openbao.org/owner-uid annotation is
+    # reserved to the operator's own ServiceAccounts by the
+    # openbao-lock-managed-resource-mutations ValidatingAdmissionPolicy. An
+    # object carries at most one controller ownerReference, so Owner here would
+    # take the slot and leave the instance with no adoptable Secret.
+    # hack/deploy-infra.sh attaches the reference; ESO still stamps
+    # reconcile.external-secrets.io/managed=true, which is what proves the
+    # mounted key came from the management OpenBao and not from the operator's
+    # own blind-create.
+    creationPolicy: Orphan
+  data:
+    - secretKey: key
+      remoteRef:
+        key: bootstrap/openstack/openbao-instance/unseal-key
+        property: key

--- a/deploy/kind/infrastructure/openbao-instance.yaml
+++ b/deploy/kind/infrastructure/openbao-instance.yaml
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Proving OpenBaoCluster instance for the openbao-operator primitives the
+# Barbican onboarding (#804) builds on: static-seal auto-unseal, cert-manager
+# TLS in External mode, declarative self-init, and the AppRole + Kubernetes
+# auth pair a managed Barbican secret store needs.
+#
+# KIND-ONLY, deliberately. Every posture below is a proving posture, not a
+# production one: profile Development (one replica, so no PodDisruptionBudget
+# and no anti-affinity), a static seal whose key material sits in a Secret in
+# the shared openstack namespace, and 1Gi of raft storage on the kind default
+# storage class. The control that defends a production secret store is the
+# Hardened profile — external-KMS unseal and three replicas — which this
+# instance deliberately opts out of in order to exercise the static-seal path.
+# Shipping it from deploy/flux-system/infrastructure/ would put that posture,
+# plus a cluster-scoped RBAC binding and a self-init'd AppRole with no consumer,
+# into every production deployment. The Barbican onboarding is what introduces
+# the production-shaped instance; only the openbao-operator itself ships in the
+# production base (deploy/flux-system/releases/openbao-operator.yaml).
+#
+# Unseal-key custody: the management OpenBao (deploy/flux-system/releases/
+# openbao.yaml) is the root of trust for the instance's static seal.
+#   1. write-bootstrap-secrets.sh seeds a generated 32-byte key at
+#      bootstrap/openstack/openbao-instance/unseal-key.
+#   2. The ExternalSecret openbao-instance-unseal-key-externalsecret.yaml
+#      materializes it as the Secret openbao-instance-unseal-key ONCE
+#      (refreshPolicy: CreatedOnce — a re-materialized key seals the instance
+#      permanently), and this CR starts paused so the operator cannot
+#      blind-create that fixed-name Secret first.
+#   3. hack/deploy-infra.sh attaches a controller ownerReference to this CR on
+#      the materialized Secret and un-pauses the CR, so the operator adopts the
+#      seeded key.
+# The key is never rotated: a static seal that loses its key material seals the
+# instance permanently.
+#
+# ACCEPTED RISK (openbao-operator upstream): the operator's adoption guard for a
+# pre-existing unseal Secret is metadata carrying the CR's UID — either a
+# controller ownerReference or the openbao.org/owner-uid annotation — and that
+# UID is readable by any principal with `get openbaocluster`. It is an ownership
+# marker, not an ownership proof: anyone who can create Secrets in the namespace
+# before the instance first initializes can plant a seal key of their choosing.
+# Accepted here because this instance is CI/dev-only; a production instance must
+# not depend on that guard.
+#
+# self-init is ONE-SHOT. The operator renders spec.selfInit.requests into
+# OpenBao's initialize stanzas, which run once against the freshly initialized
+# storage, after which OpenBao revokes the root token. The list below is
+# therefore the complete permanent configuration of this instance: changing it
+# requires recreating the instance, which means deleting the CR AND its PVC.
+# tests/unit/deploy/openbao_instance_overlay_test.sh pins the request names so
+# an edit cannot land without confronting that. Anything a consumer needs at
+# runtime (minting AppRole secret IDs, writing secrets) goes through the
+# provisioner role below, not through this list.
+#
+# The mount, policy, and role names (barbican/, barbican-secretstore, barbican)
+# are deliberately identical to the ones the brownfield leg provisions on the
+# shared management OpenBao, so the two secret-store e2e legs of the Barbican
+# onboarding differ only in which instance they point at.
+---
+# Server certificate for the instance's API listener. The operator mounts it in
+# External mode and never rotates it; cert-manager owns the renewal.
+#
+# One trust domain backs every OpenBao transport certificate in this stack. The
+# server certificate must chain DIRECTLY to the CA the operator reads from the
+# openbao-instance-tls-ca Secret, which is why both Secrets carry material from
+# the same CA-type ClusterIssuer and no intermediate CA is introduced.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openbao-instance-tls-server
+  namespace: openstack
+spec:
+  secretName: openbao-instance-tls-server
+  # Same 1-year lifetime and 30-day renewBefore as the management OpenBao's
+  # server certificate (openbao-tls-cert.yaml).
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: openbao-ca-issuer
+    kind: ClusterIssuer
+  # Pinned so the EKU is serverAuth alone. openbao-ca-issuer is the same CA the
+  # management OpenBao trusts as tls_client_ca_file behind
+  # tls_require_and_verify_client_cert, and a certificate with no EKU passes
+  # client-auth verification — this keypair lives in the shared openstack
+  # namespace, so without the pin it would be a ready-made client identity for
+  # that mTLS gate.
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  dnsNames:
+    # The operator's internal TLS server name. Its External-mode validation
+    # rejects a server certificate without this SAN, and the pod probes verify
+    # against it (-servername). In-pod clients (the e2e suite) connect over the
+    # loopback address and pass it as VAULT_TLS_SERVER_NAME; no loopback IP SAN
+    # is issued, because such a SAN authenticates "whatever listens on
+    # localhost" rather than this instance.
+    - openbao-cluster-openbao-instance.local
+    - openbao-instance.openstack.svc
+    # Pod DNS through the headless Service (openbao-instance-0 and friends).
+    - "*.openbao-instance.openstack.svc"
+    - openbao-instance-public.openstack.svc
+---
+# Trust bundle for the instance. The operator's External TLS contract reads the
+# CA from the FIXED-NAME Secret openbao-instance-tls-ca, data key ca.crt.
+# cert-manager has no primitive that materializes a CA-only Secret in another
+# namespace, so this minimal Certificate exists solely because every Secret
+# issued by the CA-type ClusterIssuer carries the trust-domain CA in ca.crt. The
+# leaf keypair in it is unused, and the Secret renews together with the CA.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openbao-instance-tls-ca
+  namespace: openstack
+spec:
+  secretName: openbao-instance-tls-ca
+  commonName: openbao-instance-tls-ca
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: openbao-ca-issuer
+    kind: ClusterIssuer
+  # Same EKU pin as the server certificate above: the leaf goes unused, so the
+  # one thing that matters about it is that it cannot be replayed as a client
+  # identity against the management OpenBao's mTLS gate.
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+---
+# Client identity the Kubernetes-auth role "provisioner" (self-init below) binds
+# to. The e2e suite mints tokens for it with `kubectl create token`, and the
+# barbican-operator's runtime writer will use the same primitive.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-instance-provisioner
+  namespace: openstack
+# Every consumer mints a token explicitly and for the openbao-instance audience,
+# so no pod ever needs the auto-mounted default-audience token this would
+# otherwise project.
+automountServiceAccountToken: false
+---
+# OpenBao validates Kubernetes-auth logins with a TokenReview issued under the
+# instance pod's own projected ServiceAccount token. The operator creates that
+# ServiceAccount (<cluster>-serviceaccount), but neither the operator nor its
+# chart grants it TokenReview, so without this binding every login fails with
+# 403 permission denied.
+#
+# The subject is created and garbage-collected by the operator with the CR while
+# this binding is overlay-owned, so deleting the CR leaves the binding dangling:
+# recreating a ServiceAccount under that exact name inherits cluster-wide
+# TokenReview. The operator does not expose the pod ServiceAccount name, so the
+# two lifecycles cannot be coupled here — another reason this instance stays out
+# of the production overlay.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openbao-instance-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: openbao-instance-serviceaccount
+    namespace: openstack
+---
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: openbao-instance
+  namespace: openstack
+spec:
+  # The operator blind-creates the fixed-name unseal Secret (Immutable) on its
+  # first reconcile and adopts a pre-existing one only against an ownership
+  # proof. The key is custodied in the management OpenBao, so the CR must not
+  # reconcile before that key has been materialized: hack/deploy-infra.sh
+  # un-pauses it once the seeded key has synced and carries a controller
+  # ownerReference to this CR.
+  paused: true
+  # The Hardened profile forces an external-KMS unseal (and three replicas); the
+  # proving instance exercises exactly the static-seal path.
+  profile: Development
+  # The static seal needs OpenBao >= 2.4.0; the Barbican onboarding targets 2.6.
+  # The image resolves to docker.io/openbao/openbao:<version>. Renovate tracks
+  # this pin (github-releases openbao/openbao).
+  version: "2.6.1"
+  replicas: 1
+  storage:
+    # No storageClassName: the cluster default carries the raft storage, the
+    # same posture the kind overlay uses for the other single-node instances.
+    size: 1Gi
+  tls:
+    enabled: true
+    # External consumes the two fixed-name cert-manager Secrets above
+    # (openbao-instance-tls-server, openbao-instance-tls-ca). The operator
+    # mounts them and waits for both, but never rotates them.
+    mode: External
+  unseal:
+    # The key material contract is the fixed-name Secret
+    # openbao-instance-unseal-key, data key `key`, mounted at /etc/bao/unseal.
+    # unseal.credentialsSecretRef is only for KMS/transit provider credentials
+    # and is ignored for a static seal, so it stays unset. The key is custodied
+    # in the management OpenBao and materialized by this overlay's
+    # ExternalSecret (see the file header); rotating a static-seal key seals the
+    # instance permanently.
+    type: static
+  selfInit:
+    enabled: true
+    # Order matters: a mount or auth method is enabled before anything writes
+    # under it. Request names use underscores to satisfy the operator's
+    # ^[A-Za-z_][A-Za-z0-9_-]*$ name pattern.
+    requests:
+      - name: barbican_kv
+        operation: create
+        path: sys/mounts/barbican
+        secretEngine:
+          type: kv
+          options:
+            version: "2"
+      - name: barbican_secretstore_policy
+        operation: create
+        path: sys/policies/acl/barbican-secretstore
+        policy:
+          # No delete on metadata/: in KV v2 that verb permanently destroys
+          # every version of a secret and its metadata, which is the only
+          # in-store recovery mechanism tenant key material has. Castellan's
+          # Vault key manager deletes through the data path, where delete is a
+          # recoverable soft delete.
+          policy: |
+            path "barbican/data/*" {
+              capabilities = ["create", "read", "update", "delete", "list"]
+            }
+
+            path "barbican/metadata/*" {
+              capabilities = ["create", "read", "update", "list"]
+            }
+      - name: approle_auth
+        operation: create
+        path: sys/auth/approle
+        authMethod:
+          type: approle
+      # The AppRole identity Barbican's vault_plugin authenticates with. The
+      # TTLs mirror the AppRole role shape on the shared management OpenBao
+      # (deploy/openbao/bootstrap/setup-auth.sh). Minting the secret ID stays
+      # out of self-init: it is runtime work of the barbican-operator.
+      - name: barbican_approle_role
+        operation: create
+        path: auth/approle/role/barbican
+        data:
+          token_policies: "barbican-secretstore"
+          token_ttl: "1h"
+          token_max_ttl: "4h"
+          # 30 days, not a year: a secret ID is a bearer credential with no use
+          # count and no CIDR bound, so its TTL is the only thing that bounds a
+          # leaked one. No automated re-mint exists yet — the shared-instance
+          # twin (deploy/openbao/bootstrap/setup-auth.sh) carries the note on
+          # what that means operationally and why no use cap is set.
+          secret_id_ttl: "720h"
+      - name: kubernetes_auth
+        operation: create
+        path: sys/auth/kubernetes
+        authMethod:
+          type: kubernetes
+      # kubernetes_host is the only required setting: the instance pod's
+      # projected ServiceAccount token and the kube root CA are mounted at the
+      # standard path and supply the reviewer credentials. The authority to run
+      # a TokenReview comes from the auth-delegator binding above.
+      - name: kubernetes_auth_config
+        operation: update
+        path: auth/kubernetes/config
+        data:
+          kubernetes_host: "https://kubernetes.default.svc"
+      # The provisioner is the runtime writer: it hands out the barbican
+      # AppRole's credentials and can read and write the barbican/ KV mount.
+      # Its barbican/ grants are spelled out per KV v2 sub-path rather than as
+      # barbican/*, which would also cover destroy/ and the metadata delete that
+      # permanently removes every version of a secret.
+      - name: provisioner_policy
+        operation: create
+        path: sys/policies/acl/provisioner
+        policy:
+          policy: |
+            path "auth/approle/role/barbican/role-id" {
+              capabilities = ["read"]
+            }
+
+            path "auth/approle/role/barbican/secret-id" {
+              capabilities = ["create", "update"]
+            }
+
+            path "barbican/data/*" {
+              capabilities = ["create", "read", "update", "delete", "list"]
+            }
+
+            path "barbican/metadata/*" {
+              capabilities = ["create", "read", "update", "list"]
+            }
+
+            path "sys/mounts/barbican" {
+              capabilities = ["read", "update"]
+            }
+      - name: provisioner_k8s_role
+        operation: create
+        path: auth/kubernetes/role/provisioner
+        data:
+          bound_service_account_names: "openbao-instance-provisioner"
+          bound_service_account_namespaces: "openstack"
+          # Without an audience the role accepts any default-audience token of
+          # that ServiceAccount, including one auto-mounted into an unrelated
+          # pod. Bound to openbao-instance, only a token deliberately minted for
+          # this instance logs in (kubectl create token --audience).
+          audience: "openbao-instance"
+          token_policies: "provisioner"
+          token_ttl: "1h"
+          token_max_ttl: "4h"

--- a/deploy/openbao/bootstrap/setup-auth.sh
+++ b/deploy/openbao/bootstrap/setup-auth.sh
@@ -232,6 +232,37 @@ main() {
     secret_id_ttl=8760h
   log "AppRole provisioner role written."
 
+  # The AppRole identity Barbican's vault_plugin logs in with on the brownfield
+  # leg, where Barbican attaches to this shared instance instead of a dedicated
+  # one. Minting a secret ID stays out of bootstrap: for the managed mode it is
+  # runtime work owned by the barbican-operator, and the brownfield e2e mints
+  # one at test time with the root-token `bao` exec it already has.
+  #
+  # secret_id_ttl is the only bound on a leaked secret ID — it carries no use
+  # count and no CIDR bound — so it is 30 days here rather than the year the
+  # older roles above use. It mirrors the barbican role of the proving instance
+  # (deploy/kind/infrastructure/openbao-instance.yaml).
+  #
+  # NO AUTOMATED RE-MINT EXISTS YET. Until the barbican-operator owns it, this
+  # TTL is a 30-day fuse on a hand-minted secret ID, and it burns silently:
+  # Barbican's vault_plugin holds one process-global AppRole session, so expiry
+  # surfaces as every secret-store operation failing at once with no metric to
+  # warn ahead of it. The re-mint procedure in
+  # docs/reference/infrastructure/openbao-bootstrap.md is the control in the
+  # meantime — an operator has to learn about the expiry from that procedure
+  # rather than from an outage.
+  #
+  # secret_id_num_uses is deliberately NOT set. castellan's Vault key manager
+  # re-logs in whenever its cached token ages out (token_ttl 1h), so any use cap
+  # would expire the credential mid-operation instead of bounding it.
+  log "Writing AppRole barbican role..."
+  bao_exec bao write auth/approle/role/barbican \
+    token_policies=barbican-secretstore \
+    token_ttl=1h \
+    token_max_ttl=4h \
+    secret_id_ttl=720h
+  log "AppRole barbican role written."
+
   log "=== Done ==="
 }
 

--- a/deploy/openbao/bootstrap/setup-secret-engines.sh
+++ b/deploy/openbao/bootstrap/setup-secret-engines.sh
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Idempotent script to enable OpenBao secret engines (KV v2, PKI, and the
-# MariaDB database secrets engine). Guards each enable operation by checking
-# whether the path already exists.
+# Idempotent script to enable OpenBao secret engines (KV v2, PKI, the MariaDB
+# database secrets engine, and the Barbican KV v2 mount). Guards each enable
+# operation by checking whether the path already exists.
 
 set -euo pipefail
 
@@ -92,6 +92,30 @@ enable_database() {
 }
 
 # ---------------------------------------------------------------------------
+# enable_barbican_kv
+# Enables the KV v2 secret engine at path barbican/. Skips if the path already
+# exists.
+#
+# This is the mount for the Barbican brownfield secret-store leg: the
+# attachment target Barbican's vault_plugin (via castellan) reads and writes
+# when a deployment attaches Barbican to this shared instance instead of a
+# dedicated one. It mirrors the barbican/ mount the proving instance self-inits
+# (deploy/kind/infrastructure/openbao-instance.yaml).
+# ---------------------------------------------------------------------------
+enable_barbican_kv() {
+  local path="barbican/"
+
+  if secrets_list | grep -qx "${path}"; then
+    log "Secret engine already enabled at ${path}. Skipping."
+    return 0
+  fi
+
+  log "Enabling KV v2 secret engine at ${path} ..."
+  bao_exec bao secrets enable -path=barbican -version=2 kv
+  log "KV v2 secret engine enabled at ${path}."
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
@@ -102,6 +126,7 @@ main() {
   enable_kv_v2
   enable_pki
   enable_database
+  enable_barbican_kv
 
   log "=== Done ==="
 }

--- a/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
+++ b/deploy/openbao/bootstrap/write-bootstrap-secrets.sh
@@ -193,6 +193,20 @@ main() {
     "access-key-id=${GENERATED_GK_ACCESS_KEY}" \
     "secret-access-key=${GENERATED_PASSWORD}"
 
+  # Static unseal key of the proving OpenBao instance
+  # (deploy/kind/infrastructure/openbao-instance.yaml). This OpenBao stays the
+  # root of trust for it: the key is generated in-pod (@generate) and
+  # materialized into the openstack namespace by the kind-only ExternalSecret
+  # deploy/kind/infrastructure/openbao-instance-unseal-key-externalsecret.yaml,
+  # where the openbao-operator adopts it for the instance's static seal (see the
+  # adoption choreography in hack/deploy-infra.sh).
+  #
+  # write_secret_if_missing is the guard that keeps re-runs from rotating it: a
+  # static-seal key that changes seals the instance permanently. No
+  # mark_eso_managed: no PushSecret targets this path.
+  write_secret_if_missing "kv-v2/bootstrap/openstack/openbao-instance/unseal-key" \
+    "key=${GENERATED_PASSWORD}"
+
   # per-ControlPlane bootstrap seeding. For each MANAGED-mode
   # "<namespace>/<controlplane>" identity in KORC_CONTROLPLANES (default
   # "openstack/controlplane"), seed the per-CR Model B admin password and Horizon

--- a/deploy/openbao/policies/barbican-secretstore.hcl
+++ b/deploy/openbao/policies/barbican-secretstore.hcl
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Barbican secret-store policy — grants full read/write access to the KV v2
+# mount barbican/, where Barbican stores its tenant secrets.
+# Bound to the barbican AppRole via the approle/ auth mount (see setup-auth.sh,
+# the barbican role). The consumer is Barbican's vault_plugin via castellan,
+# which talks the plain Vault-compatible HTTP API that OpenBao keeps compatible.
+#
+# This is the brownfield twin of the barbican-secretstore policy the proving
+# instance self-inits (deploy/kind/infrastructure/openbao-instance.yaml): same
+# mount, policy, and role names, so a deployment attaching Barbican to this
+# shared instance differs from the dedicated one only in which instance it
+# points at.
+#
+# No wiring is needed to apply it: setup-policies.sh writes every *.hcl file in
+# this directory.
+
+path "barbican/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# No delete: in KV v2 a DELETE on metadata/ permanently destroys every version
+# of a secret and its metadata, which removes the only in-store recovery path
+# tenant key material has. The soft delete castellan's Vault key manager issues
+# goes through data/ above and is undeletable-safe.
+path "barbican/metadata/*" {
+  capabilities = ["create", "read", "update", "list"]
+}

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -561,7 +561,7 @@ validates health of all operators, CRs, and ExternalSecrets.
 | 6 | `make deploy-infra` (re-run) | Unchanged-parameter re-run (no `SKIP_KIND_CREATE`) — exercises the script's existing-cluster detection |
 | 7 | `chainsaw test --report-name chainsaw-report-rerun` | Re-runs the full infrastructure suite to prove the healthy stack is left unchanged |
 | 8 | `make deploy-infra` with `WITH_METRICS_SERVER=true` | Additive re-run — the script's Phase-3 wait gates the new metrics-server HelmRelease on Ready |
-| 9 | `chainsaw test --report-name chainsaw-report-additive` | Scoped run over infra-stack-health, garage-health, flux-web-health, and no-prometheus-when-disabled; the metrics-server absence suite is deliberately excluded |
+| 9 | `chainsaw test --report-name chainsaw-report-additive` | Scoped run over infra-stack-health, garage-health, flux-web-health, no-prometheus-when-disabled, and openbao-instance; the metrics-server absence suite is deliberately excluded |
 | 10 | `hack/ci-dump-diagnostics.sh` (on failure) | Dumps HelmReleases, pods, events, Flux logs |
 | 11 | Upload JUnit report | Uploads test results as artifact (14-day retention) |
 

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -293,7 +293,7 @@ of the `changes` job matches. It depends only on `changes` — not on the `lint`
 8. Re-run `make deploy-infra` with unchanged parameters (no `SKIP_KIND_CREATE`, exercises the script's existing-cluster detection)
 9. Re-run the full infrastructure suite (report `chainsaw-report-rerun`) to prove the healthy stack is left unchanged
 10. Re-run `make deploy-infra` with `WITH_METRICS_SERVER=true` (additive leg — the script's Phase-3 wait gates the new metrics-server HelmRelease on Ready)
-11. Run a scoped Chainsaw suite (report `chainsaw-report-additive`) over infra-stack-health, garage-health, flux-web-health, and no-prometheus-when-disabled, skipping the metrics-server absence suite it would now rightly fail
+11. Run a scoped Chainsaw suite (report `chainsaw-report-additive`) over infra-stack-health, garage-health, flux-web-health, no-prometheus-when-disabled, and openbao-instance, skipping the metrics-server absence suite it would now rightly fail
 12. Dump diagnostic info on failure (`kubectl get`, `flux logs` for troubleshooting)
 13. Upload JUnit report as workflow artifact (SHA-pinned `actions/upload-artifact`, `if: always()`)
 
@@ -340,6 +340,18 @@ Covers the Garage object store (the S3 backend for the Glance e2e suites):
 | 2 | Credential ExternalSecrets SecretSynced | `openstack` | `ExternalSecret` (x2) |
 | 3 | GarageCluster `Running`; GarageBucket / GarageKey `Ready` | `openstack` | `GarageCluster`, `GarageBucket`, `GarageKey` |
 | 4 | S3 put + list with the imported key over path-style HTTP | `openstack` | `script` (throwaway `aws-cli` pod) |
+
+**File:** `tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml`
+
+Covers the openbao-operator and the proving `OpenBaoCluster` instance:
+
+| # | Assertion | Namespace | Resource |
+| --- | --- | --- | --- |
+| 1 | openbao-operator Deployment ready + HelmRelease Ready | `openbao-operator-system` | `Deployment`, `HelmRelease` |
+| 2 | Unseal-key ExternalSecret SecretSynced, and the instance's `ownerReference` adoption of the Secret it materialized | `openstack` | `ExternalSecret`, `Secret`, `OpenBaoCluster` |
+| 3 | OpenBaoCluster `Available` with `readyReplicas: 1` | `openstack` | `OpenBaoCluster` |
+| 4 | Kubernetes auth to AppRole to KV v2 round-trip, including a rejected login with a wrong secret ID | `openstack` | `script` (`kubectl exec` into the instance pod) |
+| 5 | Pod deletion, then the replacement pod reports `sealed: false` without any unseal command | `openstack` | `script` (`kubectl exec` into the instance pod) |
 
 ## Pinned Tool Versions
 

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -24,6 +24,7 @@ deploy/
     │   ├── mariadb-operator.yaml         MariaDB Operator Helm chart registry
     │   ├── external-secrets.yaml         External Secrets Operator Helm chart registry
     │   ├── openbao.yaml                  OpenBao Helm chart registry
+    │   ├── openbao-operator.yaml         OpenBao Operator OCI chart artifact (digest-pinned OCIRepository)
     │   ├── c5c3-charts.yaml              C5C3 shared OCI chart registry
     │   ├── k-orc.yaml                    K-ORC (OpenStack Resource Controller) Helm chart registry
     │   ├── prometheus-community.yaml     Prometheus Community OCI chart registry
@@ -36,6 +37,7 @@ deploy/
     │   ├── external-secrets.yaml         External Secrets Operator
     │   ├── memcached-operator.yaml       Memcached Operator (from c5c3-charts)
     │   ├── openbao.yaml                  OpenBao HA Raft cluster
+    │   ├── openbao-operator.yaml         OpenBao Operator (per-service OpenBao instances)
     │   ├── keystone-operator.yaml        Keystone Operator (from c5c3-charts)
     │   ├── glance-operator.yaml          Glance Operator (from c5c3-charts)
     │   ├── placement-operator.yaml       Placement Operator (from c5c3-charts)
@@ -50,12 +52,16 @@ deploy/
         └── memcached.yaml                Memcached cluster for OpenStack
 ```
 
+The proving `OpenBaoCluster` instance is **not** part of this tree. It is CI/dev-only and
+lives at `deploy/kind/infrastructure/openbao-instance.yaml` — see
+[OpenBao Proving Instance](#openbao-proving-instance).
+
 All YAML files carry the SPDX Apache-2.0 license header (3 lines: copyright, blank
 comment, license identifier).
 
 ## Namespaces
 
-Twelve `Namespace` resources are defined in `namespaces.yaml` and included as the first
+Fifteen `Namespace` resources are defined in `namespaces.yaml` and included as the first
 entry in the base kustomization. Kustomize applies `Namespace` resources before other
 resource kinds, ensuring target namespaces exist before any namespaced resources are
 created.
@@ -69,9 +75,12 @@ created.
 | `memcached-system` | Memcached Operator |
 | `garage-system` | Garage Operator (S3 object store for the CI/e2e stack) |
 | `keystone-system` | Keystone Operator controller (workload CRs continue to live in `openstack`) |
+| `horizon-system` | Horizon Operator controller (Horizon CRs and the operator-managed dashboard live in `openstack`) |
 | `glance-system` | Glance Operator controller (Glance/GlanceBackend CRs and the operator-managed payload live in `openstack`) |
-| `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster, Garage cluster) |
+| `placement-system` | Placement Operator controller (Placement CRs and the operator-managed payload live in `openstack`) |
+| `openstack` | Infrastructure instance CRs (MariaDB cluster, Memcached cluster, Garage cluster; on kind also the OpenBao proving instance) |
 | `openbao-system` | OpenBao HA Raft cluster |
+| `openbao-operator-system` | openbao-operator controller. It stays out of `openbao-system` so the shared OpenBao cluster and the operator that manages per-service instances keep separate lifecycles |
 | `c5c3-system` | c5c3-operator controller; the `ControlPlane` and its child CRs are created in the `ControlPlane`'s own namespace |
 | `orc-system` | K-ORC (OpenStack Resource Controller) and its installer resources |
 
@@ -142,6 +151,15 @@ namespace, and poll at `interval: 1h`.
 | `sources/prometheus-community.yaml` | `prometheus-community` | `oci://ghcr.io/prometheus-community/charts` | OCI |
 | `sources/garage-operator.yaml` | `garage-operator` | `oci://ghcr.io/rajsinghtech/charts` | OCI |
 
+**The openbao-operator chart is sourced from an OCIRepository, not a HelmRepository.**
+`sources/openbao-operator.yaml` addresses the chart artifact directly
+(`oci://ghcr.io/dc-tec/charts/openbao-operator`) and pins `spec.ref.digest` next to
+`spec.ref.tag`. A HelmRepository can only carry a chart *version*, and on a mutable OCI
+tag that gates version drift alone: Flux resolves the tag on every interval and tracks
+the resulting artifact digest, so a re-pushed tag upgrades the release with no Git change
+and no reviewer. See [OpenBao Operator](#openbao-operator) for why that matters for this
+particular chart.
+
 **K-ORC is sourced from Git, not Helm.** K-ORC publishes no Helm chart (its
 `github.io` page serves no Helm index), so `sources/k-orc.yaml` is a `GitRepository`
 — still `source.toolkit.fluxcd.io/v1`, in `flux-system`, polling at `interval: 1h`
@@ -159,13 +177,14 @@ OCI-type sources (`spec.type: oci`). `c5c3-charts` hosts internally-built operat
 charts (e.g., memcached-operator) in the GitHub Container Registry;
 `prometheus-community` hosts Prometheus community charts (e.g.,
 prometheus-operator-crds); `garage-operator` is the first **third-party** OCI-type
-source and hosts the upstream garage-operator chart. For every OCI-type source the
-registry URL is the chart *namespace* and the chart name lives in the HelmRelease's
-`chart.spec.chart`. All other repositories use standard HTTPS Helm registries.
+source and hosts the upstream garage-operator chart. For every OCI-type HelmRepository
+the registry URL is the chart *namespace* and the chart name lives in the HelmRelease's
+`chart.spec.chart` — the OCIRepository above is the exception, because it names one
+artifact. All other repositories use standard HTTPS Helm registries.
 
 ## HelmRelease Operators
 
-Eleven HelmRelease CRs deploy the infrastructure operators and CRD charts (K-ORC is
+Fourteen HelmRelease CRs deploy the infrastructure operators and CRD charts (K-ORC is
 applied separately via a Flux `Kustomization` — see
 [K-ORC (OpenStack Resource Controller)](#k-orc-openstack-resource-controller)). All use
 `apiVersion: helm.toolkit.fluxcd.io/v2` and share these common settings:
@@ -193,8 +212,10 @@ mariadb-operator-crds     (no dependencies)
 ├── external-secrets      dependsOn: cert-manager
 ├── memcached-operator    dependsOn: cert-manager, prometheus-operator-crds
 ├── garage-operator       dependsOn: cert-manager
+├── openbao-operator      dependsOn: cert-manager
 ├── openbao               dependsOn: cert-manager
 ├── keystone-operator     dependsOn: cert-manager, mariadb-operator, memcached-operator, external-secrets
+├── horizon-operator      dependsOn: cert-manager, memcached-operator, external-secrets, keystone-operator
 ├── glance-operator       dependsOn: cert-manager, mariadb-operator, memcached-operator, external-secrets, keystone-operator
 ├── placement-operator    dependsOn: cert-manager, mariadb-operator, memcached-operator, external-secrets, keystone-operator
 └── c5c3-operator         dependsOn: keystone-operator, external-secrets, mariadb-operator, memcached-operator
@@ -372,6 +393,83 @@ pre-1.0 (v0.6.x) project. It is accepted for **test infrastructure only** — ne
 production dependency of the operators — and the consuming surface is deliberately thin
 (three instance CRs plus two ExternalSecrets), so a later provider swap stays local to
 this layer.
+
+### OpenBao Operator
+
+**File:** `deploy/flux-system/releases/openbao-operator.yaml`
+
+| Property | Value |
+| --- | --- |
+| Target namespace | `openbao-operator-system` |
+| Chart | `openbao-operator` |
+| Version constraint | `0.4.2`, pinned by artifact digest |
+| Source | `openbao-operator` OCIRepository, referenced via `spec.chartRef` |
+| Dependencies | `cert-manager` in `cert-manager` namespace |
+
+The [openbao-operator](https://github.com/dc-tec/openbao-operator) manages
+`OpenBaoCluster` instances: static-seal auto-unseal, cert-manager TLS in External mode,
+declarative self-init, raft snapshots, and upgrade strategies. It delivers the
+per-service OpenBao instances a Barbican secret store builds on. The in-repo instance it
+manages is described under [OpenBao Proving Instance](#openbao-proving-instance). The
+shared management OpenBao ([OpenBao](#openbao) below) stays on the upstream Helm chart
+and is untouched by this operator.
+
+The chart ships ValidatingAdmissionPolicies and requires Kubernetes 1.33 or newer. The
+operator needs no certificate of its own from cert-manager, but the instance TLS
+Certificates do, and `dependsOn: cert-manager` keeps this release behind the same base
+layer as garage-operator.
+
+**Helm values:**
+
+| Key | Value | Purpose |
+| --- | --- | --- |
+| `tenancy.mode` | `single` | Deploy the controller alone, scoped to one namespace |
+| `tenancy.targetNamespace` | `openstack` | The namespace the instance CRs live in |
+| `controller.extraEnv[].WATCH_NAMESPACE` | `openstack` | What actually puts the controller in single-tenant mode |
+
+The chart defaults to multi-tenant mode, whose provisioner requires `OpenBaoTenant`
+onboarding per namespace and applies restricted Pod Security labels to the tenant
+namespaces it onboards. The shared `openstack` namespace cannot take those labels: it
+hosts every OpenStack service workload. Single-tenant mode leaves the provisioner out.
+
+`tenancy.mode` does not reach the controller. At chart 0.4.2 it selects the
+single-tenant `ClusterRole` and drops the provisioner `Deployment`, but the controller
+reads its own tenancy from the `WATCH_NAMESPACE` environment variable, and no chart
+template sets it. A controller that starts without `WATCH_NAMESPACE` runs multi-tenant
+and pauses every reconcile until the `openbao-operator-tenant-rolebinding` RoleBinding
+appears in the namespace, which only `OpenBaoTenant` onboarding creates. It logs that
+pause at `V(1)`, so the visible symptom is an `OpenBaoCluster` that keeps an empty status
+and never gets a `StatefulSet`. `controller.extraEnv` is the chart's documented hook, and
+the value must match `tenancy.targetNamespace`: the controller watches the first while
+the chart scopes its RBAC to the second.
+
+**Accepted risk (decided 2026-08-05):** openbao-operator is a young, single-maintainer,
+pre-1.0 (v0.4.x) project, and unlike garage-operator it sits in the production data path
+of every future Barbican secret store. Three things bound the exposure. The consumed
+surface is a single `OpenBaoCluster` CR shape. A Barbican secret store can also attach to
+the shared management OpenBao, where the bootstrap scripts provision the same mount,
+policy, and AppRole role without this operator taking part (see the
+[OpenBao bootstrap reference](./openbao-bootstrap.md)). And an in-repo StatefulSet
+projection derived from the openbao Helm chart stays available as a fallback. Accepted
+for the Barbican onboarding.
+
+**Why the chart is pinned by digest.** The chart carries no cosign signature Flux can
+verify, so no `spec.verify` policy can gate it, and the operator holds cluster-wide RBAC
+over the namespace that stores the instance seal key. Two weaker pins were rejected. The
+`>=x <1.0.0` range garage-operator uses would install every future 0.x release of an
+individual-owned GHCR namespace within the 30-minute reconcile interval. An exact chart
+version on a HelmRepository is not enough either: `0.4.2` is a mutable OCI tag, Flux
+tracks the resolved artifact digest rather than the tag string, and re-pushing that tag
+with different bytes would upgrade the release on its own — no Git change, no reviewer.
+Pinning `spec.ref.digest` on the OCIRepository is what makes every change to what runs
+here a reviewed commit.
+
+Renovate keeps that pin from becoming a freeze. Its native Flux manager does not cover
+this repository — the default file pattern matches only `gotk-components.yaml`, which the
+flux-operator setup never produces — so the pin is tracked by an explicit
+`customManagers` entry in `renovate.json` that rewrites the tag and the digest in the same
+pull request. The entry never automerges: every bump of this operator is a human
+decision.
 
 ### OpenBao
 
@@ -554,7 +652,9 @@ keystone-operator release above (a `c5c3-operator-image-digest` ConfigMap in
 ## HelmRelease–HelmRepository Cross-Reference
 
 Each HelmRelease `sourceRef.name` must match a HelmRepository `metadata.name` in
-`sources/`. This table shows the mapping:
+`sources/`. This table shows the mapping. The `openbao-operator` release is the one
+exception: it names its source through `spec.chartRef` instead, because that source is an
+OCIRepository.
 
 | HelmRelease | `sourceRef.name` | HelmRepository file |
 | --- | --- | --- |
@@ -566,7 +666,9 @@ Each HelmRelease `sourceRef.name` must match a HelmRepository `metadata.name` in
 | `memcached-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `openbao` | `openbao` | `sources/openbao.yaml` |
 | `garage-operator` | `garage-operator` | `sources/garage-operator.yaml` |
+| `openbao-operator` | `openbao-operator` (`chartRef`) | `sources/openbao-operator.yaml` |
 | `keystone-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
+| `horizon-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `glance-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `placement-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
 | `c5c3-operator` | `c5c3-charts` | `sources/c5c3-charts.yaml` |
@@ -789,6 +891,166 @@ back from Garage and there is no cross-namespace Secret plumbing:
    OpenBao. Glance later reads the identical `s3-credentials` path from its own namespace
    through its tenant store.
 
+### OpenBao Proving Instance
+
+**File:** `deploy/kind/infrastructure/openbao-instance.yaml`
+
+Five resources declare the proving instance: the single-replica `OpenBaoCluster` that the
+[openbao-operator](#openbao-operator) manages, plus the TLS and RBAC objects it depends
+on. All live in the `openstack` namespace except the cluster-scoped ClusterRoleBinding:
+
+| Kind | API version | Name | Purpose |
+| --- | --- | --- | --- |
+| `Certificate` | `cert-manager.io/v1` | `openbao-instance-tls-server` | Server certificate for the API listener, carrying the SAN `openbao-cluster-openbao-instance.local` that the operator's External-mode validation requires |
+| `Certificate` | `cert-manager.io/v1` | `openbao-instance-tls-ca` | Delivers the trust-domain CA into the fixed-name Secret the operator reads (data key `ca.crt`) |
+| `ServiceAccount` | `v1` | `openbao-instance-provisioner` | Client identity the Kubernetes-auth role `provisioner` binds to |
+| `ClusterRoleBinding` | `rbac.authorization.k8s.io/v1` | `openbao-instance-auth-delegator` | Grants `system:auth-delegator` to the operator-created instance ServiceAccount `openbao-instance-serviceaccount` |
+| `OpenBaoCluster` | `openbao.org/v1alpha1` | `openbao-instance` | Profile `Development`, version `2.6.1`, one replica, 1Gi raft storage, TLS mode `External`, static seal, self-init enabled, applied `paused` |
+
+The instance runs in every kind deploy, so the primitives a managed Barbican secret store
+needs are exercised before Barbican itself lands: static-seal auto-unseal, cert-manager
+TLS in External mode, declarative self-init, and the AppRole and Kubernetes-auth methods
+a service and its operator log in with.
+
+**Why it is kind-only.** Everything above is a proving posture, not a production one. The
+`Development` profile is what keeps the instance on a single node — one replica, so no
+PodDisruptionBudget and no anti-affinity — and the static seal keeps its key material in
+a Secret in the shared `openstack` namespace. `Hardened`, the profile that forces an
+external-KMS unseal and three replicas, is the production control, and this instance
+deliberately opts out of it to exercise the static-seal path. Shipping that from
+`deploy/flux-system/infrastructure/` would put it, a cluster-scoped RBAC binding, and a
+self-initialized AppRole with no consumer into every production deployment. Only the
+[openbao-operator](#openbao-operator) itself ships in the production base; the
+production-shaped instance arrives with the Barbican onboarding.
+[`tests/unit/deploy/openbao_instance_overlay_test.sh`](https://github.com/c5c3/forge/blob/main/tests/unit/deploy/openbao_instance_overlay_test.sh)
+asserts both directions of that split.
+
+**Two Certificates, one trust domain.** The operator's External TLS contract reads two
+fixed-name Secrets, `<cluster>-tls-server` and `<cluster>-tls-ca`. cert-manager has no
+primitive that materializes a CA-only Secret in another namespace, so
+`openbao-instance-tls-ca` is a minimal Certificate that exists for one reason: every
+Secret issued by a CA-type ClusterIssuer carries the trust-domain CA in `ca.crt`. Its
+leaf keypair goes unused. Both Certificates are issued by `openbao-ca-issuer`, the same
+root as the management OpenBao's server and client certificates, so the server
+certificate chains directly to the CA the operator hands the instance. The operator
+mounts both Secrets and waits for them, but never rotates them; cert-manager owns the
+renewal.
+
+Because `openbao-ca-issuer` is also what the management OpenBao trusts as
+`tls_client_ca_file` behind `tls_require_and_verify_client_cert`, both Certificates pin
+`usages` to `digital signature`, `key encipherment`, and `server auth`. Without the pin
+cert-manager emits no EKU at all, and a certificate without an EKU passes client-auth
+verification — these Secrets live in the shared workload namespace, so they would be
+ready-made client identities for that mTLS gate. For the same reason the server
+certificate carries no loopback IP SAN: such a SAN authenticates whatever listens on
+localhost rather than this instance. In-pod clients connect over the loopback address and
+verify against the operator's own SAN by passing `VAULT_TLS_SERVER_NAME`.
+
+**TokenReview authority.** OpenBao validates a Kubernetes-auth login by issuing a
+TokenReview under the instance pod's own projected ServiceAccount token. The operator
+creates that ServiceAccount (`<cluster>-serviceaccount`), and neither the operator nor
+its chart grants it TokenReview, so `openbao-instance-auth-delegator` supplies the
+binding. Without it every login fails with 403 permission denied. The binding is
+overlay-owned while its subject is created and garbage-collected by the operator with the
+CR, so deleting the CR leaves it dangling — the operator exposes no way to point the
+instance at a ServiceAccount whose lifecycle the overlay controls, which is one more
+reason the instance stays out of the production overlay.
+
+**Unseal-key custody.** The management OpenBao is the root of trust for the static seal:
+
+1. `write-bootstrap-secrets.sh` seeds a generated key at
+   `bootstrap/openstack/openbao-instance/unseal-key` (key `key`), behind the
+   `write_secret_if_missing` guard.
+2. The ExternalSecret
+   `deploy/kind/infrastructure/openbao-instance-unseal-key-externalsecret.yaml` reads that
+   path through the shared `openbao-cluster-store` and materializes the Secret
+   `openbao-instance-unseal-key` in `openstack`. It is `refreshPolicy: CreatedOnce`: the
+   Secret is materialized once and never converged again. Its target is
+   `creationPolicy: Orphan`, which leaves the Secret's single controller `ownerReference`
+   slot free for step 4.
+3. The CR is applied with `spec.paused: true`. The operator blind-creates the same
+   fixed-name Secret with a random key on its first reconcile and adopts a pre-existing
+   one only against an ownership proof, so it must not run first.
+4. `hack/deploy-infra.sh` syncs the ExternalSecret, patches a controller `ownerReference`
+   to the CR onto the materialized Secret, un-pauses the CR, and later waits for condition
+   `Available`. The operator accepts either that reference or its
+   `openbao.org/owner-uid` annotation as proof, but the
+   `openbao-lock-managed-resource-mutations` ValidatingAdmissionPolicy the operator chart
+   ships reserves the annotation for the operator's own ServiceAccounts and denies every
+   other writer, so the reference is the only proof the deploy can attach.
+5. The operator adopts the Secret and mounts the key at `/etc/bao/unseal`, where the
+   static seal reads it on every start. Nothing ever sends an unseal command.
+
+The key is never rotated, and both ends enforce that rather than assume it: a static seal
+whose key material changes seals the instance permanently, with no path back to the
+stored data. `write_secret_if_missing` keeps the seed side from re-generating it, and
+`refreshPolicy: CreatedOnce` keeps the consuming side from re-materializing a changed
+seed — the case that arises when the management OpenBao loses its raft PVC and is
+re-seeded while the instance's own PVC survives. No PushSecret targets the path.
+
+> **Accepted risk (openbao-operator upstream).** The operator's adoption guard is metadata
+> carrying the CR's UID, and that UID is readable by any principal with
+> `get openbaocluster`. It is an ownership marker, not an ownership proof: anyone able to
+> create Secrets in the namespace before the instance first initializes can plant a seal
+> key of their choosing. Accepted because this instance is CI/dev-only; a production
+> instance must not depend on that guard.
+
+**Self-init surface.** The operator renders `spec.selfInit.requests` into OpenBao's
+initialize stanzas, which run once against freshly initialized storage; OpenBao revokes
+the root token afterwards. The list below is therefore the instance's complete permanent
+configuration:
+
+| Requests | Paths | Result |
+| --- | --- | --- |
+| `barbican_kv` | `sys/mounts/barbican` | KV v2 mount `barbican/` |
+| `barbican_secretstore_policy` | `sys/policies/acl/barbican-secretstore` | Policy `barbican-secretstore`: create/read/update/delete/list on `barbican/data/*`, and the same minus `delete` on `barbican/metadata/*` |
+| `approle_auth`, `barbican_approle_role` | `sys/auth/approle`, `auth/approle/role/barbican` | AppRole role `barbican` with `token_policies=barbican-secretstore`, `token_ttl=1h`, `token_max_ttl=4h`, `secret_id_ttl=720h` |
+| `kubernetes_auth`, `kubernetes_auth_config` | `sys/auth/kubernetes`, `auth/kubernetes/config` | Kubernetes auth mount, `kubernetes_host=https://kubernetes.default.svc` |
+| `provisioner_policy`, `provisioner_k8s_role` | `sys/policies/acl/provisioner`, `auth/kubernetes/role/provisioner` | Policy `provisioner` (read the barbican role ID, create the secret ID, the same `barbican/` data and metadata grants as above, read/update on `sys/mounts/barbican`) and the Kubernetes role bound to the `openbao-instance-provisioner` ServiceAccount in `openstack`, `audience=openbao-instance` |
+
+No policy grants `delete` on `barbican/metadata/*`. In KV v2 that verb permanently
+destroys every version of a secret and its metadata, which is the only in-store recovery
+mechanism tenant key material has; castellan's Vault key manager deletes through
+`barbican/data/*`, where the delete is a recoverable soft delete. `secret_id_ttl` is 30
+days rather than a year for a related reason: an AppRole secret ID carries no use count
+and no CIDR bound, so its TTL is the only thing that bounds a leaked one.
+
+The Kubernetes-auth role is audience-bound. Without `audience`, the role accepts any
+default-audience token of that ServiceAccount, including one auto-mounted into an
+unrelated pod; bound to `openbao-instance`, only a token minted deliberately for this
+instance logs in (`kubectl create token --audience=openbao-instance`). The ServiceAccount
+itself sets `automountServiceAccountToken: false`, since every consumer mints explicitly.
+
+> **Self-init is one-shot.** Changing the request list on a running instance changes
+> nothing. The stanzas only run against freshly initialized storage, so a different
+> configuration means recreating the instance: delete the CR **and** its PVC. Runtime
+> work (minting AppRole secret IDs, writing secrets) goes through the `provisioner` role
+> instead. Because that failure is silent — the CR reconciles, `Available` stays `True`,
+> and the new request is simply never applied —
+> [`tests/unit/deploy/openbao_instance_overlay_test.sh`](https://github.com/c5c3/forge/blob/main/tests/unit/deploy/openbao_instance_overlay_test.sh)
+> pins the request names, so an edit cannot land without confronting it.
+
+**Shared names with the brownfield leg.** The mount, policy, and role names (`barbican/`,
+`barbican-secretstore`, `barbican`) match the ones the bootstrap scripts provision on the
+shared management OpenBao (`enable_barbican_kv` in `setup-secret-engines.sh`,
+`deploy/openbao/policies/barbican-secretstore.hcl`, and the `barbican` AppRole role in
+`setup-auth.sh`; see the
+[OpenBao bootstrap reference](./openbao-bootstrap.md#setup-secret-enginessh)). A
+deployment that attaches Barbican to the shared instance instead of a dedicated one
+therefore differs only in which instance it points at.
+
+[`tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml`](https://github.com/c5c3/forge/blob/main/tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml)
+locks the whole path: the operator Deployment and its HelmRelease, the unseal-key
+ExternalSecret reporting `SecretSynced` **and** the instance's `ownerReference` adoption of
+the Secret it materialized, the CR reporting `Available`, a Kubernetes-auth login that reads
+the AppRole role ID and mints a secret ID, a rejected login with a wrong secret ID, and a
+KV v2 round-trip on `barbican/`. The last step triggers a rolling restart through
+`spec.runtime.restartAt` on the CR and waits for the replacement pod to come back unsealed.
+It does not delete the pod directly: the operator ships a `ValidatingAdmissionPolicy` that
+denies any mutation of the resources it manages, so a restart has to go through the parent
+CR. The suite issues no unseal command anywhere, which is what makes that step a proof of
+the static seal.
+
 ### Admin Credential Chain
 
 The c5c3-operator mints a single restricted admin Application Credential per cluster and
@@ -887,17 +1149,18 @@ The base kustomization uses `apiVersion: kustomize.config.k8s.io/v1beta1` and in
 namespaces, the FluxInstance CR, HelmRepository sources, and HelmRelease operators.
 These resources do not depend on any custom CRDs.
 
-**Resource count:** 24 files producing 37 Kubernetes resources.
+**Resource count:** 26 files producing 40 Kubernetes resources.
 
 | Category | Count | Resources |
 | --- | --- | --- |
-| Namespace | 14 | cert-manager, mariadb-system, external-secrets, monitoring, memcached-system, garage-system, keystone-system, horizon-system, glance-system, placement-system, openstack, openbao-system, c5c3-system, orc-system |
+| Namespace | 15 | cert-manager, mariadb-system, external-secrets, monitoring, memcached-system, garage-system, keystone-system, horizon-system, glance-system, placement-system, openstack, openbao-system, openbao-operator-system, c5c3-system, orc-system |
 | FluxInstance | 1 | flux (drives the flux-operator) |
 | HelmRepository | 7 | cert-manager, mariadb-operator, external-secrets, openbao, c5c3-charts, prometheus-community, garage-operator |
+| OCIRepository | 1 | openbao-operator |
 | GitRepository | 1 | k-orc |
-| HelmRelease | 13 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, garage-operator, openbao, keystone-operator, horizon-operator, glance-operator, placement-operator, c5c3-operator |
+| HelmRelease | 14 | cert-manager, prometheus-operator-crds, mariadb-operator-crds, mariadb-operator, external-secrets, memcached-operator, garage-operator, openbao, openbao-operator, keystone-operator, horizon-operator, glance-operator, placement-operator, c5c3-operator |
 | Kustomization | 1 | k-orc |
-| **Total** | **37** | |
+| **Total** | **40** | |
 
 The `chaos-mesh` HelmRepository, HelmRelease, and Namespace ship in the
 kind-only opt-in overlay at `deploy/kind/chaos-mesh/` and are not
@@ -911,20 +1174,26 @@ The infrastructure kustomization includes CRD-dependent resources that require t
 operator CRDs to be installed first. This kustomization must be applied after the base
 kustomization and after operators have finished installing their CRDs.
 
-**Resource count:** 5 manifests producing 10 Kubernetes resources (the
-`db-ca-issuer.yaml` manifest declares two resources: a CA Certificate and the
-CA-type ClusterIssuer that signs from it; `garage.yaml` declares four).
+**Resource count:** 6 manifests producing 11 Kubernetes resources (the
+`db-ca-issuer.yaml` and `openbao-ca-issuer.yaml` manifests declare two resources each: a
+CA Certificate and the CA-type ClusterIssuer that signs from it; `garage.yaml` declares
+four).
 
 | Category | Count | Resources |
 | --- | --- | --- |
 | ClusterIssuer | 3 | `selfsigned-cluster-issuer`, `openstack-db-ca-issuer`, `openbao-ca-issuer` (all require cert-manager CRDs) |
-| Certificate | 2 | `openstack-db-ca`, `openbao-ca` — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
+| Certificate (CA keypairs) | 2 | `openstack-db-ca`, `openbao-ca` — both CA keypair Secrets in the `cert-manager` namespace, signed by `selfsigned-cluster-issuer` |
 | MariaDB | 1 | `openstack-db` (requires mariadb-operator CRDs; TLS enabled per [MariaDB Galera Cluster](#mariadb-galera-cluster)) |
 | Memcached | 1 | `openstack-memcached` (requires memcached-operator CRDs) |
 | GarageCluster / GarageBucket / GarageKey | 4 | `garage`, `glance-images`, `glance-images-2`, `glance-s3` (require garage-operator CRDs; see [Garage Object Store](#garage-object-store)) |
-| **Total** | **10** | |
+| **Total** | **11** | |
 
-<!-- NOTE: count excludes openbao-tls-cert.yaml and the ../../eso overlay that
+The proving instance's own five resources (two Certificates, a ServiceAccount, a
+ClusterRoleBinding, and the `OpenBaoCluster`) are not counted here: they ship in the kind
+overlay — see [OpenBao Proving Instance](#openbao-proving-instance).
+
+<!-- NOTE: count excludes openbao-tls-cert.yaml, openbao-client-tls-cert.yaml,
+and the ../../eso overlay that
 the infrastructure kustomization also references. Those resources are documented
 in their own reference pages (reference/infrastructure/openbao-bootstrap.md and
 the ESO reference docs); a full audit of the kustomization resource list is out
@@ -939,8 +1208,8 @@ of scope here. -->
 kubectl apply -k deploy/flux-system/
 ```
 
-This applies 33 resources: 12 namespaces, 1 FluxInstance, 8 sources
-(7 HelmRepository + 1 GitRepository for K-ORC), 11 HelmRelease operators, and
+This applies 40 resources: 15 namespaces, 1 FluxInstance, 9 sources
+(8 HelmRepository + 1 GitRepository for K-ORC), 14 HelmRelease operators, and
 1 Kustomization (K-ORC). FluxCD resolves the dependency graph between
 HelmReleases and installs operators in the correct order. Wait for all operators to
 finish installing before proceeding to step 2.
@@ -956,9 +1225,9 @@ ClusterIssuer, the `openstack-db-ca-issuer` ClusterIssuer plus its backing CA
 `Certificate`, the `openbao-ca-issuer` ClusterIssuer plus
 its backing CA `Certificate`, the MariaDB Galera cluster, the
 Memcached cluster, and the Garage object store (`GarageCluster` / `GarageBucket` /
-`GarageKey`). These resources require CRDs that are installed by the operator
-HelmReleases in step 1. If CRDs are not yet available, the apply will fail — wait
-for the operators to finish installing and retry.
+`GarageKey`). These resources require CRDs that are installed
+by the operator HelmReleases in step 1. If CRDs are not yet available, the apply will
+fail — wait for the operators to finish installing and retry.
 
 > **`hack/deploy-infra.sh` ordering.** The end-to-end deploy script applies the
 > three TLS-prerequisite manifests (`cluster-issuer.yaml`, `openbao-tls-cert.yaml`,
@@ -1018,6 +1287,14 @@ Infrastructure instance CRs (e.g., a new database, cache, or object-store cluste
 the same pattern: add a file in `infrastructure/` and list it in
 `infrastructure/kustomization.yaml` (see [Garage Object Store](#garage-object-store) and
 its single-node kind patch for a multi-CR example).
+
+**Attaching a Barbican secret store.** Two targets are already provisioned. The shared
+management OpenBao carries the brownfield outputs from the bootstrap scripts: the KV v2
+mount `barbican/`, the policy `barbican-secretstore`, and the AppRole role `barbican`
+(see the [OpenBao bootstrap reference](./openbao-bootstrap.md)). For a dedicated instance,
+[OpenBao Proving Instance](#openbao-proving-instance) is the template: the same three
+names, self-initialized by the openbao-operator, plus the Kubernetes-auth role a service
+operator authenticates with to mint the AppRole secret ID.
 
 ## Design Decisions
 

--- a/docs/reference/infrastructure/openbao-bootstrap.md
+++ b/docs/reference/infrastructure/openbao-bootstrap.md
@@ -96,7 +96,7 @@ deploy/
 │   ├── bootstrap/
 │   │   ├── common.sh                   Shared functions (log, bao_exec) sourced by all scripts
 │   │   ├── init-unseal.sh              Initialize and unseal the cluster
-│   │   ├── setup-secret-engines.sh     Enable KV v2, PKI, and MariaDB database engines
+│   │   ├── setup-secret-engines.sh     Enable KV v2 (kv-v2/, barbican/), PKI, and MariaDB database engines
 │   │   ├── setup-database-tenant.sh     Provision a per-ControlPlane DB engine connection + role
 │   │   ├── setup-eso-tenant.sh          Provision a per-ControlPlane ESO identity (SA + mTLS cert + namespaced SecretStore)
 │   │   ├── setup-auth.sh              Configure Kubernetes and AppRole auth
@@ -113,6 +113,7 @@ deploy/
 │       ├── keystone-db-dynamic.hcl     Per-tenant dynamic DB credential read policy
 │       ├── glance-db-dynamic.hcl       Per-tenant dynamic Glance DB credential read policy
 │       ├── placement-db-dynamic.hcl    Per-tenant dynamic Placement DB credential read policy
+│       ├── barbican-secretstore.hcl    Barbican secret-store policy on the KV v2 mount barbican/
 │       └── pki-issuer.hcl             cert-manager PKI issuing policy
 ├── eso/
 │   ├── kustomization.yaml              Kustomize entrypoint (renders ONLY the ClusterSecretStore)
@@ -164,7 +165,7 @@ on the successful completion of the previous step:
 3. setup-auth.sh            Configure Kubernetes auth + AppRole
        │
        ▼
-4. setup-policies.sh        Apply 11 HCL least-privilege policies
+4. setup-policies.sh        Apply 12 HCL least-privilege policies
        │
        ▼
 5. write-bootstrap-secrets.sh  Generate and seed initial passwords
@@ -289,7 +290,8 @@ requires the exported keys, so ensure they are recoverable before deletion.
 
 ### setup-secret-engines.sh
 
-**Purpose:** Enable the KV version 2, PKI, and MariaDB `database` secret engines.
+**Purpose:** Enable the KV version 2, PKI, and MariaDB `database` secret engines, plus
+the Barbican KV v2 mount.
 
 **File:** `deploy/openbao/bootstrap/setup-secret-engines.sh`
 
@@ -300,6 +302,7 @@ requires the exported keys, so ensure they are recoverable before deletion.
 | KV v2 | `kv-v2/` | `version=2` |
 | PKI | `pki/` | `max-lease-ttl=87600h` (10 years) |
 | database | `database/mariadb/` | mount only; per-tenant connections/roles are added later by `setup-database-tenant.sh` |
+| KV v2 | `barbican/` | `version=2`, enabled by `enable_barbican_kv`; the mount for the Barbican brownfield secret-store leg, where Barbican attaches to this shared instance instead of a dedicated one |
 
 **Idempotency:** Before enabling each engine, the script checks `bao secrets list
 -format=json` for the mount path. If the path already exists, the engine enable is
@@ -312,6 +315,13 @@ later by `setup-database-tenant.sh` once its MariaDB is Ready. The engine issues
 short-lived, auto-revoked Keystone service-DB credentials at
 `database/mariadb/creds/keystone-{namespace}` (keyed on the namespace alone —
 one ControlPlane per namespace makes it a unique, collision-free tenant key).
+
+**Barbican mount:** `enable_barbican_kv` enables a second KV v2 engine at `barbican/`,
+the path Barbican's `vault_plugin` reads and writes through castellan. It is the
+brownfield half of the Barbican secret store: the same mount name, policy name, and
+AppRole role name that the proving `OpenBaoCluster` self-initializes on a dedicated
+instance, so the two only differ in which instance Barbican points at. Like every other
+engine here the enable is guarded by a `bao secrets list` check.
 
 ### setup-database-tenant.sh
 
@@ -405,7 +415,7 @@ for the full procedure.
 ### setup-auth.sh
 
 **Purpose:** Configure Kubernetes authentication for 4 cluster contexts and AppRole
-authentication for CI/CD pipelines.
+authentication for CI/CD pipelines and the Barbican secret store.
 
 **File:** `deploy/openbao/bootstrap/setup-auth.sh`
 
@@ -480,6 +490,76 @@ their Kubernetes host and CA configuration is deferred until those clusters are 
 | Mount Path | Role | Policy | Token TTL | Max TTL | Secret ID TTL |
 | --- | --- | --- | --- | --- | --- |
 | `approle/` | `provisioner` | `ci-cd-provisioner` | 1h | 4h | `8760h` (1 year) |
+| `approle/` | `barbican` | `barbican-secretstore` | 1h | 4h | `720h` (30 days) |
+
+The `barbican` role is the identity Barbican's `vault_plugin` logs in with on the
+brownfield leg. Minting a secret ID stays out of bootstrap: for a managed deployment that
+is runtime work owned by the barbican-operator, and the brownfield e2e mints one at test
+time with the root-token `bao` exec it already has.
+
+A secret ID carries no use count and no CIDR bound, so `secret_id_ttl` is the only thing
+that bounds a leaked one. On the `barbican` role it is 30 days rather than the year the
+older `provisioner` role uses, matching the `barbican` role of the proving instance
+([OpenBao Proving Instance](./infrastructure-manifests.md#openbao-proving-instance)).
+
+**Re-minting the barbican secret ID.**
+Nothing re-mints the secret ID automatically yet — that becomes runtime work of the
+barbican-operator. Until then the 30-day TTL is a fuse on a hand-minted credential, and it
+burns silently: Barbican's `vault_plugin` holds one process-global AppRole session, so an
+expired secret ID surfaces as every secret-store operation failing at once, with no metric
+that warns ahead of it. Re-mint before the 30 days elapse, and after any Barbican
+deployment that has been running against a hand-minted credential for a month:
+
+```bash
+# BAO_TOKEN must be exported first — see Running the Full Bootstrap above.
+cd deploy/openbao/bootstrap
+source ./common.sh
+
+# The role ID is stable across re-mints; only the secret ID rotates.
+bao_exec bao read -field=role_id auth/approle/role/barbican/role-id
+
+# Mint a fresh secret ID straight into the Secret the deployment reads it from.
+# Replace <secret> and <namespace> with the Secret backing
+# vault_plugin.approle_secret_id. -force is required because the write carries
+# no data.
+kubectl create secret generic <secret> \
+  --namespace <namespace> \
+  --from-literal=approle_secret_id="$(bao_exec bao write \
+    -field=secret_id -force auth/approle/role/barbican/secret-id)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The secret ID stays inside that pipeline on purpose. `bao_exec` is a `kubectl exec`, so
+printing the credential first would put it in the terminal's scrollback, in a recorded
+session, or — if the procedure is ever wrapped in automation — in job logs that outlive
+the 30-day TTL by a wide margin and are readable by everyone with access to them. The
+credential carries no use count and no CIDR bound, so that TTL is the only thing bounding
+a leaked copy.
+
+Restart the Barbican API pods afterwards: the plugin reads the credential once at process
+start.
+
+To see how much of the fuse is left, list the role's live secret-ID accessors and look one
+up — the response carries its `expiration_time`:
+
+```bash
+bao_exec bao list auth/approle/role/barbican/secret-id
+
+bao_exec bao write auth/approle/role/barbican/secret-id-accessor/lookup \
+  secret_id_accessor=<accessor-from-the-list-above>
+```
+
+Destroy the accessor of the credential the restarted pods no longer use, so a copy of the
+old secret ID cannot log in for the rest of its 30 days:
+
+```bash
+bao_exec bao write auth/approle/role/barbican/secret-id-accessor/destroy \
+  secret_id_accessor=<accessor-of-the-replaced-secret-id>
+```
+
+`secret_id_num_uses` is deliberately left unset on the role. castellan's Vault key manager
+re-logs in whenever its cached token ages out (`token_ttl` is 1h), so a use cap would
+expire the credential mid-operation rather than bound it.
 
 **Idempotency:** Before enabling each auth method, the script checks `bao auth list
 -format=json` for the mount path. If the path already exists, the auth enable is
@@ -538,6 +618,7 @@ into the KV v2 secret engine.
 | `kv-v2/infrastructure/mariadb` | `root-password` | MariaDB root password |
 | `kv-v2/bootstrap/openstack/garage/admin-token` | `token` | Garage Admin API token — the operator authenticates to Garage's Admin API with it. Read by the kind-only `garage-admin-token` ExternalSecret (`GarageCluster.spec.admin.adminTokenSecretRef`). Seeded unconditionally (Garage is base infrastructure, not per-ControlPlane). |
 | `kv-v2/bootstrap/openstack/garage/s3-credentials` | `access-key-id`, `secret-access-key` | Garage S3 key pair, **imported** by the `GarageKey` (not minted by the operator). `access-key-id` is `GK`-prefixed (`@generate-gk`), as Garage requires. Read by the kind-only `garage-s3-credentials` ExternalSecret; Glance later reads the same path from its own namespace. |
+| `kv-v2/bootstrap/openstack/openbao-instance/unseal-key` | `key` | Static unseal key of the proving `OpenBaoCluster` (kind-only). Seeded unconditionally and **never rotated**: `write_secret_if_missing` guards the seed side and the consuming ExternalSecret's `refreshPolicy: CreatedOnce` guards the other, because a static seal whose key material changes seals the instance permanently. |
 | `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | Static Keystone DB credential for **standalone** (non-ControlPlane) Keystone demos only (username is `keystone`), read by the kind-only `keystone-db` ExternalSecret. Brownfield-only. |
 
 **Mode note:** `KORC_CONTROLPLANES` lists **Managed-mode** ControlPlane
@@ -591,7 +672,7 @@ password versions untouched.
 
 ## HCL Access Control Policies
 
-Ten HCL policies enforce least-privilege access for each consumer type. All policy
+Twelve HCL policies enforce least-privilege access for each consumer type. All policy
 paths under the KV v2 engine include the `data/` prefix, which is required by the
 OpenBao/Vault KV v2 API for read and write operations.
 
@@ -621,6 +702,7 @@ Ceph client key for Nova and Nova compute configuration, not broader secret path
 | `push-ceph-keys` | `kv-v2/data/ceph/*` | `create`, `update`, `read` | PushSecret for Ceph client keys |
 | `ci-cd-provisioner` | `kv-v2/data/*` (create/update/read), `kv-v2/metadata/*` (read/list) | `create`, `update`, `read`, `list` | CI/CD pipeline secret provisioning |
 | `pki-issuer` | `pki/issue/*`, `pki/sign/*` | `create`, `update` | cert-manager PKI certificate issuing |
+| `barbican-secretstore` | `barbican/data/*` (plus `barbican/metadata/*` without `delete`) | `create`, `read`, `update`, `delete`, `list` | Barbican's secret store on the shared instance, bound to the `barbican` AppRole role. The consumer is Barbican's `vault_plugin` via castellan, which speaks the Vault-compatible HTTP API that OpenBao keeps compatible. No `delete` on `metadata/`: in KV v2 that verb permanently destroys every version of a secret, the only in-store recovery path tenant key material has, while castellan deletes through `data/*` where the delete is a recoverable soft delete. Same grants as the `barbican-secretstore` policy the proving `OpenBaoCluster` self-initializes. |
 | `keystone-db-dynamic` | <code v-pre>database/mariadb/creds/keystone-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}</code> | `read` | Per-tenant dynamic Keystone DB credential reads (bound to the `keystone-db` role). The path is scoped by ACL identity templating to the caller's own service-account namespace (exact match, no wildcard), so a token minted in one namespace cannot read another tenant's creds path. Read-only: a dynamic engine has no static password to push, so the deferred `push-keystone-db.hcl` is unnecessary and not created (#439). |
 | `glance-db-dynamic` | <code v-pre>database/mariadb/creds/glance-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}</code> | `read` | Per-tenant dynamic Glance DB credential reads (bound to the `glance-db` role) — the Glance analogue of `keystone-db-dynamic`, and fully keystone-independent. The path is scoped by ACL identity templating to the caller's own service-account namespace (exact match, no wildcard), so a token minted in one namespace cannot read another tenant's creds path. Read-only: a dynamic engine has no static password to push. |
 | `placement-db-dynamic` | <code v-pre>database/mariadb/creds/placement-{{identity.entity.aliases.KUBERNETES_MANAGEMENT_ACCESSOR.metadata.service_account_namespace}}</code> | `read` | Per-tenant dynamic Placement DB credential reads (bound to the `placement-db` role), on the same terms as the Glance policy. The path is scoped by ACL identity templating to the caller's own service-account namespace (exact match, no wildcard). The `placement-db-creds` SA name is what keeps a Placement generator off a Keystone creds path when both services share a namespace. Read-only: a dynamic engine has no static password to push. |
@@ -657,6 +739,7 @@ All secrets are stored under the `kv-v2/` mount point (KV version 2 engine).
 | `kv-v2/infrastructure/mariadb` | `root-password` | `write-bootstrap-secrets.sh` | On kind the overlay's `mariadb-root-password` ExternalSecret; in production a non-kind Flux MariaDB baseline provides the `mariadb-root-password` Secret itself |
 | `kv-v2/bootstrap/openstack/garage/admin-token` | `token` | `write-bootstrap-secrets.sh` (unconditional; Garage is base infra) | The kind overlay's `garage-admin-token` ExternalSecret → `GarageCluster.spec.admin.adminTokenSecretRef` |
 | `kv-v2/bootstrap/openstack/garage/s3-credentials` | `access-key-id` (`GK`-prefixed), `secret-access-key` | `write-bootstrap-secrets.sh` (unconditional) | The kind overlay's `garage-s3-credentials` ExternalSecret → `GarageKey.spec.importKey.secretRef`; Glance later reads the same path from its own namespace |
+| `kv-v2/bootstrap/openstack/openbao-instance/unseal-key` | `key` | `write-bootstrap-secrets.sh` (unconditional) | The kind overlay's `openbao-instance-unseal-key` ExternalSecret (`refreshPolicy: CreatedOnce`) → the Secret the openbao-operator mounts as the proving instance's static seal. Never rotated |
 | `kv-v2/openstack/keystone/openstack/standalone/db` | `username`, `password` | `write-bootstrap-secrets.sh` (standalone/brownfield only) | The kind overlay's `keystone-db` ExternalSecret, serving standalone (non-ControlPlane) Keystone demos |
 
 **Note:** The stage-(a) per-ControlPlane static path

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -418,22 +418,30 @@ wait_for_fluxinstance() {
 }
 
 # ---------------------------------------------------------------------------
-# reconcile_helmrepository_sources — Force a reconcile of every HelmRepository
-# in flux-system by annotating with reconcile.fluxcd.io/requestedAt — the
-# kubectl-only equivalent of `flux reconcile source helm`.
+# reconcile_helmrepository_sources — Force a reconcile of every Flux chart
+# source in flux-system by annotating with reconcile.fluxcd.io/requestedAt —
+# the kubectl-only equivalent of `flux reconcile source helm` / `... source oci`.
 #
-# A no-op when no HelmRepositories exist (the for-loop body simply does not
-# run). Each annotate failure is tolerated (`|| true`) so a transient API
-# error on one repo does not abort the whole bootstrap.
+# Both source kinds are covered. Most charts ride a HelmRepository, but a chart
+# pinned by artifact digest rather than by version is an OCIRepository
+# (openbao-operator), and it is hard-gated by wait_for_helmreleases below.
+# Leaving it out would let a failed first registry fetch sit out the source's
+# 1h interval while the release wait runs into its timeout.
+#
+# A no-op when no such sources exist (the for-loop body simply does not run).
+# Each annotate failure is tolerated (`|| true`) so a transient API error on
+# one source does not abort the whole bootstrap.
 # ---------------------------------------------------------------------------
 reconcile_helmrepository_sources() {
-  log "Reconciling HelmRepository sources..."
-  local repos
-  repos=$(kubectl get helmrepository -n flux-system -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
-  for repo in ${repos}; do
-    kubectl annotate "helmrepository/${repo}" \
-      "reconcile.fluxcd.io/requestedAt=$(date +%s%N)" \
-      --overwrite -n flux-system || true
+  log "Reconciling Flux chart sources..."
+  local kind names name
+  for kind in helmrepository ocirepository; do
+    names=$(kubectl get "${kind}" -n flux-system -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
+    for name in ${names}; do
+      kubectl annotate "${kind}/${name}" \
+        "reconcile.fluxcd.io/requestedAt=$(date +%s%N)" \
+        --overwrite -n flux-system || true
+    done
   done
 }
 
@@ -2052,10 +2060,11 @@ main() {
       --type merge -p '{"spec":{"suspend":true}}' 2>/dev/null || true
   fi
 
-  # Force-reconcile HelmRepository sources so chart indexes are available
-  # before HelmReleases attempt to resolve charts. Without this, the
-  # helm-controller may see unindexed sources and wait until the next
-  # reconcile interval (up to 1h) before retrying.
+  # Force-reconcile the Flux chart sources (HelmRepository and OCIRepository)
+  # so chart indexes and pinned artifacts are available before HelmReleases
+  # attempt to resolve charts. Without this, the helm-controller may see
+  # unindexed or unfetched sources and wait until the next reconcile interval
+  # (up to 1h) before retrying.
   reconcile_helmrepository_sources
 
   # Step 4: Wait for HelmReleases to become Ready (two phases)
@@ -2094,15 +2103,15 @@ main() {
   log "Phase 3: Waiting for remaining HelmReleases..."
   # Build the release list dynamically so chaos-mesh is only awaited when the
   # opt-in overlay was applied. The surviving non-chaos order is
-  # preserved exactly as before; garage-operator is appended as the last base
-  # release, and chaos-mesh after it, to avoid moving any other release's
-  # relative position.
-  local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)
+  # preserved exactly as before; garage-operator and openbao-operator are
+  # appended as the last base releases, and chaos-mesh after them, to avoid
+  # moving any other release's relative position.
+  local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator openbao-operator)
   if [[ "${WITH_CHAOS_MESH}" == "true" ]]; then
     helm_releases+=(chaos-mesh)
   fi
   # kube-prometheus-stack is appended last so the relative
-  # ordering of the eight base releases (and chaos-mesh) is preserved exactly.
+  # ordering of the nine base releases (and chaos-mesh) is preserved exactly.
   local release_wait_timeout="${HELMRELEASE_TIMEOUT}"
   if [[ "${WITH_PROMETHEUS}" == "true" ]]; then
     helm_releases+=(kube-prometheus-stack)
@@ -2115,7 +2124,7 @@ main() {
     fi
   fi
   # metrics-server is appended last (after chaos-mesh and kube-prometheus-stack)
-  # so the relative ordering of the eight base releases is preserved exactly.
+  # so the relative ordering of the nine base releases is preserved exactly.
   if [[ "${WITH_METRICS_SERVER}" == "true" ]]; then
     helm_releases+=(metrics-server)
   fi
@@ -2159,6 +2168,9 @@ main() {
   # envoyproxies.gateway.envoyproxy.io is installed by the envoy-gateway
   # HelmRelease (Phase 3 above) and is required by the EnvoyProxy CR in
   # deploy/kind/infrastructure/envoy-nodeport.yaml.
+  # openbaoclusters.openbao.org is registered by the openbao-operator
+  # HelmRelease (Phase 3 above); waiting on it keeps the overlay apply from
+  # racing that registration.
   wait_for_crds "${POD_TIMEOUT}" \
     memcacheds.memcached.c5c3.io \
     clustersecretstores.external-secrets.io \
@@ -2167,7 +2179,8 @@ main() {
     envoyproxies.gateway.envoyproxy.io \
     garageclusters.garage.rajsingh.info \
     garagebuckets.garage.rajsingh.info \
-    garagekeys.garage.rajsingh.info
+    garagekeys.garage.rajsingh.info \
+    openbaoclusters.openbao.org
 
   # Invalidate kubectl's client-side discovery cache so that the newly
   # registered CRDs are visible to kubectl apply.

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -2312,6 +2312,53 @@ main() {
       keystone-admin keystone-db mariadb-root-password
   fi
 
+  # Proving OpenBao instance (deploy/kind/infrastructure/openbao-instance.yaml).
+  # Same apply-before-dependency reason as the Garage block below: Step 5 applies
+  # the CR before Step 7 seeds its unseal key in OpenBao.
+  #
+  # The adoption choreography exists because the openbao-operator blind-creates
+  # the fixed-name Secret openbao-instance-unseal-key (Immutable, random key) on
+  # its first reconcile, and accepts a pre-existing one only against an ownership
+  # proof. The overlay therefore applies the CR paused; here the seeded key is
+  # synced into that Secret, the proof is attached, and only then is the CR
+  # un-paused, so the operator adopts the key custodied in the management
+  # OpenBao.
+  #
+  # The proof is a controller ownerReference to the CR, NOT the operator's
+  # openbao.org/owner-uid annotation. The operator accepts either one, but its
+  # own ValidatingAdmissionPolicy openbao-lock-managed-resource-mutations
+  # reserves that annotation for its own ServiceAccounts and denies every other
+  # writer — clusterwide, at failurePolicy: Fail, and without restricting itself
+  # to resources the operator already manages. An annotate here is rejected, so
+  # the ownerReference is the only proof this script can attach.
+  #
+  # This runs BEFORE the Garage block and its readiness wait is collected after
+  # it: the instance depends on nothing Garage provides, and everything the
+  # un-pause starts (image pull, PVC bind, the two cert-manager Secrets,
+  # self-init, unseal) is wall-clock on every deploy otherwise.
+  #
+  # The ExternalSecret is refreshPolicy: CreatedOnce, so this annotation only
+  # breaks ESO's backoff from the Step 5 apply against a still-sealed OpenBao —
+  # it cannot re-materialize the key of a live instance (that would seal it
+  # permanently).
+  log "Forcing openbao-instance unseal-key ExternalSecret sync..."
+  kubectl annotate externalsecret/openbao-instance-unseal-key -n openstack \
+    "force-sync=${now}" --overwrite || true
+  wait_for_externalsecrets "openstack" "${EXTERNALSECRET_TIMEOUT}" \
+    openbao-instance-unseal-key
+
+  # Attach the ownership proof to the ESO-materialized Secret so the operator
+  # adopts it, then un-pause. The ExternalSecret is creationPolicy: Orphan for
+  # exactly this reason: an object carries at most one controller
+  # ownerReference, so ESO must leave that slot free.
+  local openbao_instance_uid
+  openbao_instance_uid=$(kubectl get openbaocluster openbao-instance -n openstack \
+    -o jsonpath='{.metadata.uid}')
+  kubectl patch secret openbao-instance-unseal-key -n openstack --type merge \
+    -p "{\"metadata\":{\"ownerReferences\":[{\"apiVersion\":\"openbao.org/v1alpha1\",\"kind\":\"OpenBaoCluster\",\"name\":\"openbao-instance\",\"uid\":\"${openbao_instance_uid}\",\"controller\":true,\"blockOwnerDeletion\":true}]}}"
+  kubectl patch openbaocluster openbao-instance -n openstack --type merge \
+    -p '{"spec":{"paused":false}}'
+
   # Garage object store (S3 backend for the Glance e2e suites). Its
   # GarageCluster/GarageBucket/GarageKey CRs and the two ESO ExternalSecrets are
   # applied on BOTH paths — they are not among the MariaDB/Memcached/standalone-
@@ -2344,6 +2391,12 @@ main() {
   kubectl wait garagecluster/garage -n openstack \
     --for=jsonpath='{.status.phase}'=Running --timeout="${POD_TIMEOUT}s"
   log "GarageCluster CR is Running."
+
+  # Collect the readiness of the proving OpenBao instance un-paused above.
+  log "Waiting for the OpenBaoCluster CR to become Available..."
+  kubectl wait openbaocluster/openbao-instance -n openstack \
+    --for=condition=Available --timeout="${POD_TIMEOUT}s"
+  log "OpenBaoCluster CR is Available."
 
   if [[ "${WITH_CONTROLPLANE}" != "true" ]]; then
     # Trigger MariaDB operator re-reconciliation.

--- a/renovate.json
+++ b/renovate.json
@@ -220,6 +220,33 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/deploy/flux-system/sources/openbao-operator\\.yaml$/"
+      ],
+      "matchStrings": [
+        "tag: \"(?<currentValue>[^\"]+)\"\\n\\s*digest: \"(?<currentDigest>sha256:[a-f0-9]{64})\""
+      ],
+      "depNameTemplate": "ghcr.io/dc-tec/charts/openbao-operator",
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/dc-tec/charts/openbao-operator",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/deploy/kind/infrastructure/openbao-instance\\.yaml$/"
+      ],
+      "matchStrings": [
+        "\\n  version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "openbao/openbao",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "openbao/openbao",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/Makefile$/",
         "/\\.github/workflows/.*\\.yaml$/"
       ],
@@ -443,6 +470,30 @@
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "k-orc"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/flux-system/sources/openbao-operator.yaml"],
+      "matchPackageNames": ["ghcr.io/dc-tec/charts/openbao-operator"],
+      "automerge": false,
+      "minimumReleaseAge": "3 days",
+      "groupName": "openbao-operator chart"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/kind/infrastructure/openbao-instance.yaml"],
+      "matchPackageNames": ["openbao/openbao"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["deploy/kind/infrastructure/openbao-instance.yaml"],
+      "matchPackageNames": ["openbao/openbao"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": false,
+      "minimumReleaseAge": "3 days",
+      "groupName": "OpenBao instance version"
     },
     {
       "matchManagers": ["custom.regex"],

--- a/tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Chainsaw E2E test for the proving OpenBaoCluster instance
+# (deploy/kind/infrastructure/openbao-instance.yaml) and the openbao-operator
+# that manages it. Auto-discovered by the e2e-infra job, which runs
+# `chainsaw test tests/e2e/infrastructure/` after `make deploy-infra`.
+#
+# Covers:
+#   - openbao-operator Deployment available + its HelmRelease Ready
+#   - The unseal-key ExternalSecret SecretSynced AND the instance's adoption of
+#     the Secret it materialized: the custody chain from the seed in the
+#     management OpenBao through the shared cluster store into the Secret the
+#     operator actually mounts as this instance's seal
+#   - The OpenBaoCluster reporting Available with readyReplicas 1
+#   - The consumer path a managed Barbican secret store needs, end to end: a
+#     Kubernetes-auth login with a ServiceAccount token, reading the barbican
+#     AppRole role ID, minting a secret ID, a rejected login with a wrong
+#     secret ID, a real AppRole login, and a KV v2 write plus read-back on the
+#     barbican/ mount. Self-init revokes the root token, so Kubernetes auth is
+#     the only entry the suite has, which is exactly the entry Barbican gets
+#   - Restart survival: after an operator-driven rolling restart the replacement
+#     pod comes back unsealed by itself. The suite issues no unseal command
+#     anywhere, which is what makes it a proof of the static seal
+#
+# Suites run with parallel: 4 (tests/e2e/chainsaw-config.yaml). This is the only
+# suite that touches the proving instance, so the restart in the last step
+# cannot disturb a sibling suite.
+#
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: openbao-instance
+spec:
+  # Extended assert timeout (~5min) for operator startup, the two cert-manager
+  # Certificates the instance waits for, and the StatefulSet/PVC the
+  # OpenBaoCluster drives.
+  timeouts:
+    assert: 5m
+  steps:
+  # ── Step 1: Operator Deployment + HelmRelease ───────────────────────────
+  # The chart's fullname helper renders the Deployment as
+  # "openbao-operator-controller" for a release named openbao-operator.
+  # Single-tenant mode (tenancy.mode: single) renders the controller only, no
+  # provisioner Deployment.
+  - try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: openbao-operator-controller
+            namespace: openbao-operator-system
+          status:
+            (availableReplicas > `0`): true
+    - assert:
+        resource:
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: openbao-operator
+            namespace: openbao-operator-system
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+  # ── Step 2: Unseal-key ExternalSecret + its adoption ────────────────────
+  # Reads bootstrap/openstack/openbao-instance/unseal-key from the management
+  # OpenBao through the shared cluster store. SecretSynced proves the seed
+  # reached a Secret; the ownership check below proves it reached THIS
+  # instance's seal. Without it the suite would still pass on a Secret the
+  # operator blind-created with a random key of its own, and every later step —
+  # including the restart survival in Step 5 — would pass with it.
+  - try:
+    - assert:
+        resource:
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: openbao-instance-unseal-key
+            namespace: openstack
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+              reason: SecretSynced
+    - script:
+        content: |
+          set -eu
+          # The Secret must be the one ESO materialized, not one the operator
+          # blind-created with a key of its own. ESO stamps this label on every
+          # target it writes, whatever the creationPolicy; the ownerReference it
+          # would otherwise set is not available as the marker here, because the
+          # OpenBaoCluster holds that slot (see below).
+          ES_MANAGED="$(kubectl get secret openbao-instance-unseal-key -n openstack \
+            -o 'jsonpath={.metadata.labels.reconcile\.external-secrets\.io/managed}')"
+          if [ "${ES_MANAGED}" != "true" ]; then
+            echo "ERROR: the mounted unseal Secret was not materialized by ESO (managed label '${ES_MANAGED}')"
+            exit 1
+          fi
+          # ...and the instance must have adopted exactly that Secret. The
+          # operator accepts a controller ownerReference carrying the CR's UID as
+          # its ownership proof; its openbao.org/owner-uid annotation is the
+          # other accepted form, but the operator's own ValidatingAdmissionPolicy
+          # reserves that one for its ServiceAccounts, so the deploy attaches
+          # this one.
+          CR_UID="$(kubectl get openbaocluster openbao-instance -n openstack \
+            -o 'jsonpath={.metadata.uid}')"
+          SECRET_UID="$(kubectl get secret openbao-instance-unseal-key -n openstack \
+            -o "jsonpath={.metadata.ownerReferences[?(@.controller==true)].uid}")"
+          if [ -z "${CR_UID}" ] || [ "${SECRET_UID}" != "${CR_UID}" ]; then
+            echo "ERROR: the ESO-materialized unseal Secret is not adopted by the instance (controller owner uid '${SECRET_UID}' vs CR uid '${CR_UID}')"
+            exit 1
+          fi
+          echo "OK: the instance adopted the ESO-materialized unseal Secret (ESO-managed, controller ownerReference matches the CR)"
+  # ── Step 3: OpenBaoCluster instance CR ──────────────────────────────────
+  - try:
+    - assert:
+        resource:
+          apiVersion: openbao.org/v1alpha1
+          kind: OpenBaoCluster
+          metadata:
+            name: openbao-instance
+            namespace: openstack
+          status:
+            (conditions[?type == 'Available']):
+            - status: "True"
+            readyReplicas: 1
+  # ── Step 4: Kubernetes auth to AppRole to KV round-trip ─────────────────
+  # Every OpenBao call runs through `kubectl exec` into the instance pod with
+  # the CLI env the bootstrap scripts use against the shared instance
+  # (BAO_ADDR, VAULT_CACERT on the mounted trust bundle). The server
+  # certificate carries no loopback IP SAN — such a SAN authenticates whatever
+  # listens on localhost rather than this instance — so the loopback connection
+  # is verified against the operator's own SAN via VAULT_TLS_SERVER_NAME. No
+  # probe pod and no probe image: unlike the garage-health S3 step this suite
+  # adds no digest-pinned, Renovate-managed fixture.
+  #
+  # The negative path is first-class. A login with the real role ID and a wrong
+  # secret ID must fail AND hand out nothing, otherwise the round-trip below
+  # would prove nothing about the AppRole credentials it just minted.
+  - try:
+    - script:
+        timeout: 3m
+        content: |
+          set -eu
+          BAO_NS=openstack
+          BAO_POD=openbao-instance-0
+          BAO_ADDR="https://127.0.0.1:8200"
+          VAULT_CACERT="/etc/bao/tls/ca.crt"
+          VAULT_TLS_SERVER_NAME="openbao-cluster-openbao-instance.local"
+
+          # bao_exec <token> <args...> runs the bao CLI in the instance pod.
+          # Tokens travel in the environment and are never echoed.
+          bao_exec() {
+            _token="$1"
+            shift
+            kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+              env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" \
+                  VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" \
+                  BAO_TOKEN="${_token}" "$@"
+          }
+
+          # 1. Kubernetes auth. The JWT is handed to the exec'd shell as an
+          #    environment variable rather than interpolated into the bao
+          #    command line. The role is audience-bound, so the token is minted
+          #    for openbao-instance rather than the pod default audience.
+          JWT="$(kubectl create token openbao-instance-provisioner -n "${BAO_NS}" \
+            --audience=openbao-instance)"
+          PTOKEN="$(kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+            env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" \
+                VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" JWT="${JWT}" \
+            sh -c 'bao write -field=token auth/kubernetes/login role=provisioner jwt="$JWT"')"
+          if [ -z "${PTOKEN}" ]; then
+            echo "ERROR: Kubernetes auth role provisioner returned no token"
+            exit 1
+          fi
+          echo "OK: Kubernetes auth issued a provisioner token for ServiceAccount openbao-instance-provisioner"
+
+          # 2. Read the barbican AppRole role ID with that token.
+          ROLE_ID="$(bao_exec "${PTOKEN}" \
+            bao read -field=role_id auth/approle/role/barbican/role-id)"
+          if [ -z "${ROLE_ID}" ]; then
+            echo "ERROR: auth/approle/role/barbican/role-id returned nothing"
+            exit 1
+          fi
+          echo "OK: provisioner read the barbican AppRole role ID"
+
+          # 3. Mint a secret ID. The mint takes no payload, hence -force.
+          SECRET_ID="$(bao_exec "${PTOKEN}" \
+            bao write -force -field=secret_id auth/approle/role/barbican/secret-id)"
+          if [ -z "${SECRET_ID}" ]; then
+            echo "ERROR: minting a barbican AppRole secret ID returned nothing"
+            exit 1
+          fi
+          echo "OK: provisioner minted a barbican AppRole secret ID"
+
+          # 4. Negative path: the real role ID with a well-formed but wrong
+          #    secret ID. The CLI reports the rejection on stderr, so that line
+          #    in the step log is expected.
+          if OUT="$(kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+            env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" \
+                VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" \
+                ROLE_ID="${ROLE_ID}" \
+            sh -c 'bao write -field=token auth/approle/login role_id="$ROLE_ID" secret_id=00000000-0000-0000-0000-000000000000')"; then
+            echo "ERROR: AppRole login with a wrong secret ID succeeded"
+            exit 1
+          fi
+          if [ -n "${OUT}" ]; then
+            echo "ERROR: the rejected AppRole login still emitted a token"
+            exit 1
+          fi
+          echo "OK: AppRole login with a wrong secret ID was rejected and emitted no token"
+
+          # 5. Real AppRole login with the minted pair.
+          ATOKEN="$(kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+            env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" \
+                VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" \
+                ROLE_ID="${ROLE_ID}" SECRET_ID="${SECRET_ID}" \
+            sh -c 'bao write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"')"
+          if [ -z "${ATOKEN}" ]; then
+            echo "ERROR: AppRole login with the minted secret ID returned no token"
+            exit 1
+          fi
+          echo "OK: AppRole login with the minted secret ID issued a token"
+
+          # 6. KV v2 round-trip on the barbican/ mount with the AppRole token.
+          #    The probe value carries the current epoch second and the shell
+          #    PID so a re-run cannot pass on a stale read ($RANDOM is a
+          #    bashism and chainsaw runs these scripts under sh).
+          PROBE_PATH="barbican/e2e/openbao-instance"
+          PROBE_VALUE="probe-$(date +%s)-$$"
+          bao_exec "${ATOKEN}" bao kv put "${PROBE_PATH}" probe="${PROBE_VALUE}" >/dev/null
+          READ_BACK="$(bao_exec "${ATOKEN}" bao kv get -field=probe "${PROBE_PATH}")"
+          if [ "${READ_BACK}" != "${PROBE_VALUE}" ]; then
+            echo "ERROR: read-back mismatch on ${PROBE_PATH}: wrote '${PROBE_VALUE}', read '${READ_BACK}'"
+            exit 1
+          fi
+          echo "OK: the AppRole token wrote and read back ${PROBE_PATH} on the barbican/ mount"
+  # ── Step 5: Restart survival ────────────────────────────────────────────
+  # Replace the instance pod and prove the replacement comes back unsealed. The
+  # step issues NO unseal command, and neither does anything else in this
+  # suite: the static seal reads its key from the mounted Secret on its own.
+  #
+  # The restart is driven through spec.runtime.restartAt on the CR, not through
+  # `kubectl delete pod`. The operator ships a ValidatingAdmissionPolicy
+  # (openbao-lock-managed-resource-mutations) that denies CREATE/UPDATE/DELETE
+  # on every resource carrying app.kubernetes.io/managed-by=openbao-operator
+  # plus an openbao.org/ label, for every principal except its own
+  # ServiceAccounts and a fixed list of kube system controllers — so a direct
+  # delete of the instance pod is rejected at admission, whatever RBAC the
+  # caller holds. restartAt is the operator's own restart primitive: it lands as
+  # a Pod template annotation, which makes a new StatefulSet revision, and the
+  # statefulset controller (exempt in that policy) does the replacing.
+  #
+  # The replacement is identified by a CHANGED pod UID. A bare
+  # `kubectl wait --for=condition=Ready` right after the patch can match the
+  # still-terminating pod, and the OpenBaoCluster condition lags the rollout
+  # the same way, so both are polled instead of asserted once.
+  - try:
+    - script:
+        timeout: 5m
+        content: |
+          set -eu
+          BAO_NS=openstack
+          BAO_POD=openbao-instance-0
+          BAO_ADDR="https://127.0.0.1:8200"
+          VAULT_CACERT="/etc/bao/tls/ca.crt"
+          VAULT_TLS_SERVER_NAME="openbao-cluster-openbao-instance.local"
+
+          OLD_UID="$(kubectl get pod "${BAO_POD}" -n "${BAO_NS}" \
+            -o 'jsonpath={.metadata.uid}')"
+          if [ -z "${OLD_UID}" ]; then
+            echo "ERROR: pod ${BAO_NS}/${BAO_POD} not found"
+            exit 1
+          fi
+          # A restart is triggered by a CHANGE of the value, so a re-run of this
+          # suite against the same cluster needs a value the previous run cannot
+          # have written. Second resolution is enough: the suite runs once per
+          # chainsaw invocation, and the CI job's three invocations are whole
+          # deploy-infra runs apart.
+          kubectl patch openbaocluster openbao-instance -n "${BAO_NS}" \
+            --type=merge \
+            -p "{\"spec\":{\"runtime\":{\"restartAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}}"
+
+          # 40 polls x 5s = 200s for the pod and 12 x 5s = 60s for the CR,
+          # inside the 5m step timeout together with the rollout above.
+          # One GET per poll, not one per field: three round-trips would both
+          # eat the budget the sleeps are sized against (so a failing run would
+          # be killed by the step timeout before it prints its own diagnosis)
+          # and mix fields read across the replacement boundary.
+          NEW_UID=""
+          PHASE=""
+          READY=""
+          for _ in $(seq 1 40); do
+            STATE="$(kubectl get pod "${BAO_POD}" -n "${BAO_NS}" -o \
+              "jsonpath={.metadata.uid} {.status.phase} {.status.conditions[?(@.type=='Ready')].status}" \
+              2>/dev/null || true)"
+            NEW_UID="$(printf '%s' "${STATE}" | cut -d' ' -f1)"
+            PHASE="$(printf '%s' "${STATE}" | cut -d' ' -f2)"
+            READY="$(printf '%s' "${STATE}" | cut -d' ' -f3)"
+            if [ -n "${NEW_UID}" ] && [ "${NEW_UID}" != "${OLD_UID}" ] &&
+               [ "${PHASE}" = "Running" ] && [ "${READY}" = "True" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "${NEW_UID}" ] || [ "${NEW_UID}" = "${OLD_UID}" ] ||
+             [ "${PHASE}" != "Running" ] || [ "${READY}" != "True" ]; then
+            echo "ERROR: ${BAO_POD} did not come back (uid '${NEW_UID}', phase '${PHASE}', ready '${READY}')"
+            kubectl get pod "${BAO_POD}" -n "${BAO_NS}" -o wide || true
+            exit 1
+          fi
+          echo "OK: ${BAO_POD} was recreated with a new pod UID and is Ready again"
+
+          AVAILABLE=""
+          for _ in $(seq 1 12); do
+            AVAILABLE="$(kubectl get openbaocluster openbao-instance -n "${BAO_NS}" \
+              -o "jsonpath={.status.conditions[?(@.type=='Available')].status}" 2>/dev/null || true)"
+            if [ "${AVAILABLE}" = "True" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ "${AVAILABLE}" != "True" ]; then
+            echo "ERROR: OpenBaoCluster openbao-instance reports Available='${AVAILABLE}' after the restart"
+            exit 1
+          fi
+          echo "OK: OpenBaoCluster openbao-instance is Available again"
+
+          # `bao status` exits non-zero while the instance is sealed, so the
+          # exit code is tolerated and the JSON body decides. jq is not part of
+          # the openbao image; grep on the JSON is.
+          STATUS_JSON="$(kubectl exec -n "${BAO_NS}" "${BAO_POD}" -- \
+            env BAO_ADDR="${BAO_ADDR}" VAULT_CACERT="${VAULT_CACERT}" \
+                VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" \
+            bao status -format=json || true)"
+          if ! echo "${STATUS_JSON}" | grep -Eq '"sealed"[[:space:]]*:[[:space:]]*false'; then
+            echo "ERROR: ${BAO_POD} is not unsealed after the restart"
+            echo "${STATUS_JSON}"
+            exit 1
+          fi
+          echo "OK: ${BAO_POD} came back unsealed without any unseal command"

--- a/tests/unit/deploy/barbican_secretstore_bootstrap_test.sh
+++ b/tests/unit/deploy/barbican_secretstore_bootstrap_test.sh
@@ -1,0 +1,398 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the three OpenBao bootstrap scripts provision the Barbican secret-store
+# leg, and provision it exactly once.
+#
+#   - setup-secret-engines.sh must mount KV v2 at barbican/ when the engine list
+#     lacks it (including on a fresh instance whose list is empty), and must skip
+#     the enable when it is already mounted. A second enable on an existing mount
+#     is an error, so a re-run of the bootstrap would fail the whole script.
+#   - setup-auth.sh must upsert the approle role Barbican's vault_plugin logs in
+#     with, bound to the barbican-secretstore policy alone. A second policy on
+#     that role widens what a leaked Barbican secret ID reaches.
+#   - that policy must exist and grant what the role is bound to. setup-policies.sh
+#     derives every policy name from its file basename, so token_policies=
+#     barbican-secretstore is a string coupling to a file — a rename on either
+#     side leaves the role bound to a policy OpenBao does not have.
+#   - write-bootstrap-secrets.sh must seed the proving instance's unseal key when
+#     it is missing and NEVER rewrite it. The key is the instance's static seal:
+#     a rotated value seals the instance permanently, with no path back to the
+#     stored data.
+#
+# All three scripts are driven with a recording kubectl stub, so nothing touches
+# a cluster or an OpenBao. The stub answers the lookups each script makes on the
+# way to the behavior under test and appends every invocation to a log file, so
+# the assertions can check the exact arguments that reached the pod.
+#
+# Usage: bash tests/unit/deploy/barbican_secretstore_bootstrap_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ENGINES_SCRIPT="$PROJECT_ROOT/deploy/openbao/bootstrap/setup-secret-engines.sh"
+AUTH_SCRIPT="$PROJECT_ROOT/deploy/openbao/bootstrap/setup-auth.sh"
+SEED_SCRIPT="$PROJECT_ROOT/deploy/openbao/bootstrap/write-bootstrap-secrets.sh"
+POLICY_FILE="$PROJECT_ROOT/deploy/openbao/policies/barbican-secretstore.hcl"
+
+# The static seal key of the proving OpenBao instance
+# (deploy/kind/infrastructure/openbao-instance.yaml).
+UNSEAL_PATH="kv-v2/bootstrap/openstack/openbao-instance/unseal-key"
+
+# A typical engine map of an already-bootstrapped instance, minus barbican/.
+ENGINES_WITHOUT_BARBICAN='{"kv-v2/":{},"pki/":{},"database/mariadb/":{}}'
+ENGINES_WITH_BARBICAN='{"kv-v2/":{},"pki/":{},"database/mariadb/":{},"barbican/":{}}'
+# A fresh instance: no engine is mounted yet.
+ENGINES_EMPTY='{}'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# make_kubectl <dir> <log> <secrets_json> <readable_kv_path>
+# Installs a recording kubectl stub in <dir>. Every invocation's argument string
+# lands in <log>; the canned answers are the ones the scripts branch on:
+#
+#   - `bao secrets list` returns <secrets_json>, the engine map
+#     setup-secret-engines.sh pipes through `jq -r 'keys[]'`.
+#   - `bao auth list` returns an empty map, so setup-auth.sh enables its mounts
+#     (the enables themselves are recorded and swallowed).
+#   - `bao kv get` succeeds only for <readable_kv_path> — that is the existence
+#     probe write_secret_if_missing reads. Every other path reports a miss and is
+#     therefore seeded.
+#
+# Everything else (engine enables, role writes, kv puts, metadata puts) is
+# recorded and answered with exit 0, so each script runs to completion.
+make_kubectl() {
+  local dir="$1" log="$2" secrets_json="$3" readable_kv_path="$4"
+  mkdir -p "$dir"
+  : >"$log"
+  cat >"$dir/kubectl" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>"${log}"
+
+case "\$*" in
+  *"bao secrets list"*)
+    printf '%s' '${secrets_json}'
+    ;;
+  *"bao auth list"*)
+    printf '%s' '{}'
+    ;;
+  *"bao kv get"*)
+    if [[ -n "${readable_kv_path}" && "\$*" == *"${readable_kv_path}"* ]]; then
+      printf '%s' '{"data":{"data":{}}}'
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+}
+
+# make_failing_kubectl <dir> <log>
+# A recording kubectl stub whose every invocation fails: the OpenBao pod is
+# unreachable.
+make_failing_kubectl() {
+  local dir="$1" log="$2"
+  mkdir -p "$dir"
+  : >"$log"
+  cat >"$dir/kubectl" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>"${log}"
+exit 1
+STUB
+  chmod +x "$dir/kubectl"
+}
+
+# run_bootstrap <stub_dir> <script>
+# Runs a bootstrap script with the kubectl stub prepended to PATH. Echoes the
+# combined stdout/stderr; returns the script's exit code. KORC_CONTROLPLANES is
+# pinned so a change to the script's default identity cannot move these tests.
+run_bootstrap() {
+  local stub_dir="$1" script="$2"
+  (
+    PATH="$stub_dir:$PATH"
+    BAO_TOKEN="dummy-token"
+    KORC_CONTROLPLANES="openstack/controlplane"
+    export PATH BAO_TOKEN KORC_CONTROLPLANES
+    bash "$script"
+  ) 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test: the barbican mount is created when it is absent
+# ---------------------------------------------------------------------------
+test_mounts_barbican_kv_when_absent() {
+  echo "Test: setup-secret-engines.sh mounts barbican KV v2 when it is absent"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_WITHOUT_BARBICAN" ""
+
+  local output calls
+  output="$(run_bootstrap "$tmp" "$ENGINES_SCRIPT")"
+  calls="$(cat "$tmp/calls.log")"
+
+  assert_contains "the barbican mount is created as KV version 2" \
+    "$calls" "bao secrets enable -path=barbican -version=2 kv"
+  assert_contains "the created mount is reported" \
+    "$output" "KV v2 secret engine enabled at barbican/."
+  assert_not_contains "an engine already in the list is not re-enabled" \
+    "$calls" "bao secrets enable -path=kv-v2"
+}
+
+# ---------------------------------------------------------------------------
+# Test: a fresh instance mounts barbican too
+# ---------------------------------------------------------------------------
+# The engine list of an uninitialized OpenBao is an empty JSON object, which
+# `jq -r 'keys[]'` turns into no output at all. A guard reading that as "the
+# path is there" would leave the brownfield leg without its mount.
+test_mounts_barbican_kv_on_an_empty_engine_list() {
+  echo "Test: setup-secret-engines.sh mounts barbican KV v2 on an empty engine list"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_EMPTY" ""
+
+  local exit_code calls
+  run_bootstrap "$tmp" "$ENGINES_SCRIPT" >/dev/null
+  exit_code=$?
+  calls="$(cat "$tmp/calls.log")"
+
+  assert_eq "the run succeeds" "0" "$exit_code"
+  assert_contains "the barbican mount is created on a fresh instance" \
+    "$calls" "bao secrets enable -path=barbican -version=2 kv"
+  assert_contains "the other engines are created as well" \
+    "$calls" "bao secrets enable -path=kv-v2 -version=2 kv"
+}
+
+# ---------------------------------------------------------------------------
+# Test: an existing barbican mount is left alone
+# ---------------------------------------------------------------------------
+test_skips_the_barbican_mount_when_it_exists() {
+  echo "Test: setup-secret-engines.sh skips the barbican mount when it exists"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_WITH_BARBICAN" ""
+
+  local output exit_code calls
+  output="$(run_bootstrap "$tmp" "$ENGINES_SCRIPT")"
+  exit_code=$?
+  calls="$(cat "$tmp/calls.log")"
+
+  assert_eq "the re-run succeeds" "0" "$exit_code"
+  assert_contains "the skip is logged" \
+    "$output" "already enabled at barbican/"
+  assert_not_contains "the existing mount is not enabled a second time" \
+    "$calls" "bao secrets enable -path=barbican"
+}
+
+# ---------------------------------------------------------------------------
+# Test: the barbican approle role binds the barbican-secretstore policy alone
+# ---------------------------------------------------------------------------
+test_writes_the_barbican_approle_role() {
+  echo "Test: setup-auth.sh writes the barbican AppRole role"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_WITHOUT_BARBICAN" ""
+
+  local exit_code role_call role_calls policies
+  run_bootstrap "$tmp" "$AUTH_SCRIPT" >/dev/null
+  exit_code=$?
+  role_calls="$(grep -c "auth/approle/role/barbican" "$tmp/calls.log")"
+  role_call="$(grep "auth/approle/role/barbican" "$tmp/calls.log")"
+  policies="$(printf '%s\n' "$role_call" | tr ' ' '\n' | grep '^token_policies=')"
+
+  assert_eq "the run succeeds" "0" "$exit_code"
+  assert_eq "the role is written exactly once" "1" "$role_calls"
+  assert_contains "the role is an upsert on the approle mount" \
+    "$role_call" "bao write auth/approle/role/barbican"
+  assert_eq "the role binds the barbican-secretstore policy and nothing else" \
+    "token_policies=barbican-secretstore" "$policies"
+  assert_contains "the issued token lives for an hour" "$role_call" "token_ttl=1h"
+  assert_contains "the issued token cannot be renewed past four hours" \
+    "$role_call" "token_max_ttl=4h"
+  # The secret ID carries no use count and no CIDR bound, so its TTL is the only
+  # thing bounding a leaked one — 30 days, a window a rotation loop can meet.
+  assert_contains "the secret ID expires after 30 days" \
+    "$role_call" "secret_id_ttl=720h"
+}
+
+# ---------------------------------------------------------------------------
+# Test: the policy the barbican role is bound to exists and grants the mount
+# ---------------------------------------------------------------------------
+# setup-policies.sh names each policy after its file basename, so the role's
+# token_policies=barbican-secretstore resolves to this file and nothing else.
+test_barbican_secretstore_policy_backs_the_role() {
+  echo "Test: the barbican-secretstore policy exists and grants the barbican/ mount"
+
+  if [[ ! -f "$POLICY_FILE" ]]; then
+    echo "  FAIL: $POLICY_FILE does not exist — the role is bound to a policy that is never written"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_file_contains "the policy grants the KV v2 data path" \
+    "$POLICY_FILE" 'path "barbican/data/\*"'
+  assert_file_contains "the policy grants the KV v2 metadata path" \
+    "$POLICY_FILE" 'path "barbican/metadata/\*"'
+
+  # A DELETE on metadata/ destroys every version of a secret permanently — the
+  # one KV v2 operation Barbican's tenant key material has no recovery from.
+  local metadata_caps
+  metadata_caps="$(sed -n '/path "barbican\/metadata\/\*"/,/}/p' "$POLICY_FILE" \
+    | grep 'capabilities')"
+  assert_not_contains "the metadata path grants no irreversible delete" \
+    "$metadata_caps" '"delete"'
+}
+
+# ---------------------------------------------------------------------------
+# Test: the unseal key is seeded when it is missing
+# ---------------------------------------------------------------------------
+test_seeds_the_unseal_key_when_it_is_missing() {
+  echo "Test: write-bootstrap-secrets.sh seeds the unseal key when it is missing"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # No path is readable, so every probe reports a miss.
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_WITHOUT_BARBICAN" ""
+
+  local exit_code write_call
+  run_bootstrap "$tmp" "$SEED_SCRIPT" >/dev/null
+  exit_code=$?
+  write_call="$(grep "bao kv put" "$tmp/calls.log" | grep "BAO_KV_PATH=$UNSEAL_PATH")"
+
+  assert_eq "the run succeeds" "0" "$exit_code"
+  assert_not_empty "the unseal key is written" "$write_call"
+  assert_contains "the key is generated inside the pod, never on the host" \
+    "$write_call" "sys/tools/random/32"
+  assert_contains "the path travels as an environment variable" \
+    "$write_call" "BAO_KV_PATH=$UNSEAL_PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Test: an existing unseal key is never rewritten
+# ---------------------------------------------------------------------------
+# A rewrite is unrecoverable: the openbao-operator has already handed the seeded
+# value to the proving instance as its static seal, so a second, different key
+# leaves the instance sealed for good.
+test_never_rewrites_an_existing_unseal_key() {
+  echo "Test: write-bootstrap-secrets.sh never rewrites an existing unseal key"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # The unseal key is readable; every other seed path still reports a miss.
+  make_kubectl "$tmp" "$tmp/calls.log" "$ENGINES_WITHOUT_BARBICAN" "$UNSEAL_PATH"
+
+  local output exit_code puts
+  output="$(run_bootstrap "$tmp" "$SEED_SCRIPT")"
+  exit_code=$?
+  puts="$(grep "bao kv put" "$tmp/calls.log")"
+
+  assert_eq "the re-run succeeds" "0" "$exit_code"
+  assert_contains "the skip is logged for the unseal key" \
+    "$output" "Secret '$UNSEAL_PATH' already exists"
+  assert_not_contains "the stored key is left untouched" \
+    "$puts" "BAO_KV_PATH=$UNSEAL_PATH"
+  assert_not_empty "the other bootstrap secrets are still seeded" "$puts"
+}
+
+# ---------------------------------------------------------------------------
+# Test: every bootstrap script refuses to run without a token
+# ---------------------------------------------------------------------------
+test_every_bootstrap_script_demands_a_token() {
+  echo "Test: the bootstrap scripts refuse to run without BAO_TOKEN"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_failing_kubectl "$tmp" "$tmp/calls.log"
+
+  local script name output exit_code
+  for script in "$ENGINES_SCRIPT" "$AUTH_SCRIPT" "$SEED_SCRIPT"; do
+    name="$(basename "$script")"
+    output="$(
+      PATH="$tmp:$PATH" env -u BAO_TOKEN bash "$script" 2>&1
+    )"
+    exit_code=$?
+    assert_nonzero_exit "$name exits non-zero without a token" "$exit_code"
+    assert_contains "$name names the missing token" \
+      "$output" "BAO_TOKEN must be set"
+  done
+
+  assert_eq "no script reaches the OpenBao pod without a token" \
+    "" "$(cat "$tmp/calls.log")"
+}
+
+# ---------------------------------------------------------------------------
+# Test: an unreachable OpenBao aborts the engine setup
+# ---------------------------------------------------------------------------
+# The failing `bao secrets list` itself does not abort: it sits in an `if`
+# condition, where set -e does not fire, and an unreadable list is
+# indistinguishable from an empty one. The abort comes from the first enable
+# that fails, and it must be an abort — continuing would walk through the
+# remaining mounts reporting success for engines that were never created.
+test_aborts_when_openbao_is_unreachable() {
+  echo "Test: setup-secret-engines.sh aborts when OpenBao is unreachable"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_failing_kubectl "$tmp" "$tmp/calls.log"
+
+  local output exit_code calls
+  output="$(run_bootstrap "$tmp" "$ENGINES_SCRIPT")"
+  exit_code=$?
+  calls="$(cat "$tmp/calls.log")"
+
+  assert_nonzero_exit "the script exits non-zero" "$exit_code"
+  assert_not_contains "the barbican mount is not attempted after the failure" \
+    "$calls" "bao secrets enable -path=barbican"
+  assert_not_contains "no further mount is attempted after the failure" \
+    "$calls" "bao secrets enable -path=pki"
+  assert_not_contains "the run does not report success" "$output" "=== Done ==="
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+test_mounts_barbican_kv_when_absent
+test_mounts_barbican_kv_on_an_empty_engine_list
+test_skips_the_barbican_mount_when_it_exists
+test_writes_the_barbican_approle_role
+test_barbican_secretstore_policy_backs_the_role
+test_seeds_the_unseal_key_when_it_is_missing
+test_never_rewrites_an_existing_unseal_key
+test_every_bootstrap_script_demands_a_token
+test_aborts_when_openbao_is_unreachable
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/deploy/openbao_instance_overlay_test.sh
+++ b/tests/unit/deploy/openbao_instance_overlay_test.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the kind-only posture of the proving OpenBao instance:
+#
+#   - kustomize build deploy/kind/infrastructure renders exactly one
+#     OpenBaoCluster/openbao-instance, and it renders `paused: true` — the
+#     operator blind-creates the fixed-name unseal Secret on its first
+#     reconcile, so it must not run before hack/deploy-infra.sh has
+#     materialized and stamped the key custodied in the management OpenBao.
+#   - the same build renders exactly one ExternalSecret/openbao-instance-unseal-key,
+#     and that ExternalSecret is refreshPolicy: CreatedOnce. The Secret is the
+#     instance's STATIC SEAL: a second, different value under a live instance
+#     makes its raft store undecryptable for good, so the ExternalSecret must
+#     materialize once and never converge.
+#   - kustomize build deploy/flux-system/infrastructure renders ZERO of either.
+#     Profile Development (one replica, no PDB, no anti-affinity), a static seal
+#     whose key sits in a Secret in the shared openstack namespace, 1Gi of raft
+#     storage and a cluster-scoped auth-delegator binding are a proving posture,
+#     not a production one; the production instance arrives with the Barbican
+#     onboarding.
+#   - spec.selfInit.requests still carries exactly the pinned request names.
+#     self-init is ONE-SHOT — the stanzas run only against freshly initialized
+#     storage — so a request added to a CR whose PVC survived is silently never
+#     applied. Pinning the list here means such an edit cannot land without
+#     confronting that.
+#   - the openbao-operator HelmRelease sets WATCH_NAMESPACE, which is what
+#     actually puts the controller in single-tenant mode. tenancy.mode only
+#     shapes the chart's own output; a controller without WATCH_NAMESPACE waits
+#     forever for tenant onboarding and never reconciles the instance.
+#
+# Usage: bash tests/unit/deploy/openbao_instance_overlay_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+KIND_INFRA_DIR="$PROJECT_ROOT/deploy/kind/infrastructure"
+PROD_INFRA_DIR="$PROJECT_ROOT/deploy/flux-system/infrastructure"
+INSTANCE_FILE="$KIND_INFRA_DIR/openbao-instance.yaml"
+OPERATOR_RELEASE_FILE="$PROJECT_ROOT/deploy/flux-system/releases/openbao-operator.yaml"
+
+# The complete permanent configuration of the instance, in declaration order.
+SELF_INIT_REQUESTS="barbican_kv barbican_secretstore_policy approle_auth \
+barbican_approle_role kubernetes_auth kubernetes_auth_config provisioner_policy \
+provisioner_k8s_role"
+
+# --- Test 1: the kind overlay renders the paused CR and its ExternalSecret ---
+test_kind_overlay_renders_paused_instance() {
+  echo "Test: kustomize build deploy/kind/infrastructure renders the paused OpenBaoCluster + its ExternalSecret"
+
+  if ! command -v kustomize >/dev/null 2>&1 || ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: kustomize or yq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local rendered
+  if ! rendered="$(kustomize build "$KIND_INFRA_DIR" 2>&1)"; then
+    echo "  FAIL: kustomize build $KIND_INFRA_DIR failed:"
+    echo "$rendered" | head -20
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  local cr_count paused es_count refresh_policy creation_policy
+  cr_count="$(printf '%s\n' "$rendered" | yq -r \
+    '[select(.kind == "OpenBaoCluster" and .metadata.name == "openbao-instance")] | length' \
+    2>/dev/null | awk '{s+=$1} END {print s+0}')"
+  paused="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "OpenBaoCluster" and .metadata.name == "openbao-instance") | .spec.paused' \
+    2>/dev/null | head -n1)"
+  es_count="$(printf '%s\n' "$rendered" | yq -r \
+    '[select(.kind == "ExternalSecret" and .metadata.name == "openbao-instance-unseal-key")] | length' \
+    2>/dev/null | awk '{s+=$1} END {print s+0}')"
+  refresh_policy="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "ExternalSecret" and .metadata.name == "openbao-instance-unseal-key") | .spec.refreshPolicy' \
+    2>/dev/null | head -n1)"
+  creation_policy="$(printf '%s\n' "$rendered" | yq -r \
+    'select(.kind == "ExternalSecret" and .metadata.name == "openbao-instance-unseal-key") | .spec.target.creationPolicy' \
+    2>/dev/null | head -n1)"
+
+  assert_eq "the kind overlay renders exactly one OpenBaoCluster/openbao-instance" "1" "$cr_count"
+  assert_eq "the rendered instance starts paused" "true" "$paused"
+  assert_eq "the kind overlay renders exactly one ExternalSecret/openbao-instance-unseal-key" \
+    "1" "$es_count"
+  assert_eq "the unseal-key ExternalSecret materializes once and never converges" \
+    "CreatedOnce" "$refresh_policy"
+  # Orphan keeps the single controller-ownerReference slot free for the
+  # OpenBaoCluster. Under Owner, ESO takes it, hack/deploy-infra.sh can attach
+  # no ownership proof the operator accepts — its openbao.org/owner-uid
+  # annotation is denied to outside writers by the operator's own
+  # ValidatingAdmissionPolicy — and the instance never adopts the custodied key.
+  assert_eq "the unseal-key ExternalSecret leaves the controller ownerReference slot free" \
+    "Orphan" "$creation_policy"
+}
+
+# --- Test 2: the production overlay renders neither ---
+test_production_overlay_renders_no_instance() {
+  echo "Test: kustomize build deploy/flux-system/infrastructure renders no proving instance"
+
+  if ! command -v kustomize >/dev/null 2>&1 || ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: kustomize or yq not installed (2 checks skipped)"
+    SKIP=$((SKIP + 2))
+    return
+  fi
+
+  local rendered
+  if ! rendered="$(kustomize build "$PROD_INFRA_DIR" 2>&1)"; then
+    echo "  FAIL: kustomize build $PROD_INFRA_DIR failed:"
+    echo "$rendered" | head -20
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  local cr_count es_count
+  cr_count="$(printf '%s\n' "$rendered" | yq -r \
+    '[select(.kind == "OpenBaoCluster")] | length' 2>/dev/null | awk '{s+=$1} END {print s+0}')"
+  es_count="$(printf '%s\n' "$rendered" | yq -r \
+    '[select(.kind == "ExternalSecret" and .metadata.name == "openbao-instance-unseal-key")] | length' \
+    2>/dev/null | awk '{s+=$1} END {print s+0}')"
+
+  assert_eq "the production overlay renders zero OpenBaoCluster resources" "0" "$cr_count"
+  assert_eq "the production overlay renders zero openbao-instance-unseal-key ExternalSecrets" \
+    "0" "$es_count"
+}
+
+# --- Test 3: the one-shot self-init request list is pinned ---
+test_self_init_request_list_is_pinned() {
+  echo "Test: spec.selfInit.requests carries exactly the pinned request names"
+
+  if [[ ! -f "$INSTANCE_FILE" ]]; then
+    echo "  FAIL: $INSTANCE_FILE does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local actual expected
+  actual="$(yq -r 'select(.kind == "OpenBaoCluster") | .spec.selfInit.requests[].name' \
+    "$INSTANCE_FILE" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')"
+  expected="$(printf '%s' "$SELF_INIT_REQUESTS" | tr -s ' \\\n' ' ' | sed 's/ *$//')"
+
+  assert_eq "self-init is one-shot: changing this list means recreating the instance (CR AND PVC)" \
+    "$expected" "$actual"
+}
+
+# --- Test 4: the operator release really reaches single-tenant mode ---
+test_operator_release_sets_watch_namespace() {
+  echo "Test: the openbao-operator HelmRelease puts the controller in single-tenant mode"
+
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "  SKIP: yq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  # tenancy.mode alone is not enough. At chart 0.4.2 it picks the single-tenant
+  # ClusterRole and drops the provisioner, but the controller reads its tenancy
+  # from WATCH_NAMESPACE and no chart template sets that variable. Without it
+  # the controller runs multi-tenant and pauses every reconcile waiting for the
+  # RoleBinding openbao-operator-tenant-rolebinding that OpenBaoTenant
+  # onboarding would create — silently, at V(1), leaving the OpenBaoCluster with
+  # an empty status and no StatefulSet until deploy-infra's Available wait
+  # times out.
+  local mode target watch_ns
+  mode="$(yq -r '.spec.values.tenancy.mode' "$OPERATOR_RELEASE_FILE" 2>/dev/null | head -n1)"
+  target="$(yq -r '.spec.values.tenancy.targetNamespace' "$OPERATOR_RELEASE_FILE" 2>/dev/null | head -n1)"
+  watch_ns="$(yq -r \
+    '.spec.values.controller.extraEnv[] | select(.name == "WATCH_NAMESPACE") | .value' \
+    "$OPERATOR_RELEASE_FILE" 2>/dev/null | head -n1)"
+
+  assert_eq "the release requests single-tenant mode" "single" "$mode"
+  assert_eq "WATCH_NAMESPACE is set, so the controller actually runs single-tenant" \
+    "openstack" "$watch_ns"
+  # The two must agree: the controller watches WATCH_NAMESPACE, while the chart
+  # scopes its RBAC to tenancy.targetNamespace. A mismatch grants the controller
+  # rights in one namespace and points it at another.
+  assert_eq "the watched namespace matches the namespace the chart scopes RBAC to" \
+    "$target" "$watch_ns"
+}
+
+# --- Run ---
+test_kind_overlay_renders_paused_instance
+test_production_overlay_renders_no_instance
+test_self_init_request_list_is_pinned
+test_operator_release_sets_watch_namespace
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/deploy/production_posture_test.sh
+++ b/tests/unit/deploy/production_posture_test.sh
@@ -34,7 +34,12 @@
 # openbao.yaml is therefore excluded from the byte-identity check.
 #
 # In addition, any net-new file under deploy/flux-system/sources/ must contain
-# ONLY HelmRepository objects (no HelmRelease / Gateway controller leakage).
+# ONLY Flux SOURCE objects — HelmRepository, OCIRepository, GitRepository — so
+# that no HelmRelease / Gateway controller leaks into the sources directory.
+# OCIRepository joined the list for the openbao-operator chart, which pins an
+# artifact digest (a HelmRepository can only carry a chart version, which does
+# not gate a re-pushed OCI tag); GitRepository is what sources/k-orc.yaml has
+# always been.
 #
 # Skipped when the run is not inside a git worktree (e.g., shipped tarballs)
 # or when origin/main is unavailable.
@@ -89,11 +94,11 @@ test_production_overlay_unchanged() {
   # remain byte-identical.
   local groups_label=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml/garage-operator.yaml/glance-operator.yaml/placement-operator.yaml releases added)"
+    "deploy/flux-system/releases (excluding chaos-mesh.yaml relocated, openbao.yaml edited in place, external-secrets.yaml edited in place, keystone-operator.yaml/horizon-operator.yaml edited in place for the image-digest valuesFrom, and the c5c3-operator.yaml/k-orc.yaml/garage-operator.yaml/glance-operator.yaml/placement-operator.yaml/openbao-operator.yaml releases added)"
   )
   local groups_specs=(
     "deploy/flux-system/fluxinstance.yaml"
-    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/garage-operator.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml :(exclude)deploy/flux-system/releases/glance-operator.yaml :(exclude)deploy/flux-system/releases/placement-operator.yaml"
+    "deploy/flux-system/releases :(exclude)deploy/flux-system/releases/chaos-mesh.yaml :(exclude)deploy/flux-system/releases/openbao.yaml :(exclude)deploy/flux-system/releases/external-secrets.yaml :(exclude)deploy/flux-system/releases/c5c3-operator.yaml :(exclude)deploy/flux-system/releases/k-orc.yaml :(exclude)deploy/flux-system/releases/garage-operator.yaml :(exclude)deploy/flux-system/releases/keystone-operator.yaml :(exclude)deploy/flux-system/releases/horizon-operator.yaml :(exclude)deploy/flux-system/releases/glance-operator.yaml :(exclude)deploy/flux-system/releases/placement-operator.yaml :(exclude)deploy/flux-system/releases/openbao-operator.yaml"
   )
 
   local diff_output=""
@@ -123,9 +128,9 @@ test_production_overlay_unchanged() {
 }
 
 # --- Test 2: any added file under deploy/flux-system/sources/ contains
-#             only HelmRepository objects ---
-test_added_sources_are_helmrepository_only() {
-  echo "Test: added deploy/flux-system/sources/* files contain only HelmRepository objects"
+#             only Flux source objects ---
+test_added_sources_are_flux_sources_only() {
+  echo "Test: added deploy/flux-system/sources/* files contain only Flux source objects"
 
   if ! preflight; then
     echo "  SKIP: git / origin/main unavailable (1 check skipped)"
@@ -152,12 +157,12 @@ test_added_sources_are_helmrepository_only() {
     if [[ ! -f "$abs" ]]; then
       continue
     fi
-    # Extract all `kind:` values from the file; any non-HelmRepository value
-    # is a policy violation.
+    # Extract all `kind:` values from the file; anything that is not a Flux
+    # chart/artifact source is a policy violation.
     local offending
-    offending="$(awk '/^kind:[[:space:]]+/{print $2}' "$abs" | grep -vE '^HelmRepository$' || true)"
+    offending="$(awk '/^kind:[[:space:]]+/{print $2}' "$abs" | grep -vE '^(HelmRepository|OCIRepository|GitRepository)$' || true)"
     if [[ -n "$offending" ]]; then
-      echo "  FAIL: $path contains non-HelmRepository kinds: $(echo "$offending" | tr '\n' ',' )"
+      echo "  FAIL: $path contains non-source kinds: $(echo "$offending" | tr '\n' ',' )"
       violations=$((violations + 1))
     fi
   done <<< "$added"
@@ -167,13 +172,13 @@ test_added_sources_are_helmrepository_only() {
     return
   fi
 
-  echo "  PASS: all added sources files contain only HelmRepository objects"
+  echo "  PASS: all added sources files contain only Flux source objects"
   PASS=$((PASS + 1))
 }
 
 # --- Run ---
 test_production_overlay_unchanged
-test_added_sources_are_helmrepository_only
+test_added_sources_are_flux_sources_only
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/unit/hack/deploy_infra_chaos_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_chaos_flag_test.sh
@@ -168,12 +168,12 @@ test_chaos_mesh_not_in_default_helm_releases() {
     "$DEPLOY_INFRA_SH" \
     'memcached-operator chaos-mesh envoy-gateway'
 
-  # The new dynamic array must include the eight non-chaos releases in order
+  # The new dynamic array must include the nine non-chaos releases in order
   # and append chaos-mesh inside the gate.
   assert_file_contains \
-    "helm_releases array preserves the eight non-chaos releases in the documented order" \
+    "helm_releases array preserves the nine non-chaos releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator openbao-operator)'
 
   assert_file_contains \
     "chaos-mesh is appended only inside the WITH_CHAOS_MESH gate" \

--- a/tests/unit/hack/deploy_infra_dizzy_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_dizzy_flag_test.sh
@@ -207,14 +207,14 @@ test_phase3_append_is_gated() {
   assert_file_not_contains \
     "deploy-infra.sh does not hard-code dizzy-victoria-metrics in the base wait list" \
     "$DEPLOY_INFRA_SH" \
-    'garage-operator dizzy-victoria-metrics'
+    'openbao-operator dizzy-victoria-metrics'
 
   # The base array line is pinned byte-for-byte (copied verbatim from the
   # script) so an accidental reorder or rename of a base release trips here.
   assert_file_contains \
     "helm_releases base array line is byte-identical to the expected literal" \
     "$DEPLOY_INFRA_SH" \
-    'local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
+    'local helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator openbao-operator)'
 
   # The dynamic append exists.
   assert_file_contains \

--- a/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_metrics_server_flag_test.sh
@@ -163,7 +163,7 @@ test_metrics_server_kustomize_is_gated() {
 # Test 7: metrics-server appended to helm-release wait list
 # The Phase 3 wait list must NOT statically include metrics-server; it must be
 # appended dynamically inside the WITH_METRICS_SERVER gate, after the
-# kube-prometheus-stack append, so the relative ordering of the seven base
+# kube-prometheus-stack append, so the relative ordering of the nine base
 # releases is preserved.
 # ---------------------------------------------------------------------------
 test_metrics_server_appended_dynamically() {
@@ -175,11 +175,11 @@ test_metrics_server_appended_dynamically() {
     "$DEPLOY_INFRA_SH" \
     'envoy-gateway metrics-server'
 
-  # The base array must preserve the eight non-opt-in releases in order.
+  # The base array must preserve the nine non-opt-in releases in order.
   assert_file_contains \
-    "helm_releases array preserves the eight non-opt-in releases in the documented order" \
+    "helm_releases array preserves the nine non-opt-in releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator openbao-operator)'
 
   # The dynamic append must be guarded by WITH_METRICS_SERVER.
   assert_file_contains \

--- a/tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh
+++ b/tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the unseal-key adoption choreography in hack/deploy-infra.sh keeps its
+# ordering contract. Every step of it only works in one order, and getting it
+# wrong is silent: the openbao-operator blind-creates the fixed-name Secret
+# openbao-instance-unseal-key (Immutable, random key) on its first reconcile and
+# adopts a pre-existing one only against an ownership proof, so an instance that
+# reconciles too early comes up on a key nobody custodies — and every e2e
+# assertion still passes.
+#
+# The assertions are static line-ordering checks over the script text, in the
+# style of the sibling deploy_infra_gateway_crds_test.sh wiring checks:
+#
+#   1. openbaoclusters.openbao.org is in the wait_for_crds argument list, so the
+#      overlay apply cannot race the operator's CRD registration.
+#   2. The ExternalSecret is waited for BEFORE the ownership proof is attached —
+#      the patch targets a Secret that ESO has not necessarily materialized yet.
+#   3. The proof lands BEFORE the un-pause — the operator adopts on its first
+#      reconcile, and an unproven Secret is not adopted.
+#   4. The un-pause lands BEFORE the blocking GarageCluster wait, and the
+#      instance's own readiness wait is collected AFTER it. The instance depends
+#      on nothing Garage provides, so serializing it behind that wait is pure
+#      wall-clock on every deploy.
+#   5. The proof is a controller ownerReference and NOT the operator's
+#      openbao.org/owner-uid annotation. The operator accepts either, but the
+#      openbao-lock-managed-resource-mutations ValidatingAdmissionPolicy the
+#      chart ships reserves that annotation for the operator's own
+#      ServiceAccounts and denies every other writer, clusterwide and at
+#      failurePolicy: Fail. Writing it here aborts the whole deploy.
+#
+# Usage: bash tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEPLOY_INFRA_SH="$PROJECT_ROOT/hack/deploy-infra.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+# line_of <pattern>
+# Prints the 1-based line number of the FIRST line matching <pattern>, or the
+# empty string when there is no match.
+line_of() {
+  grep -n -- "$1" "$DEPLOY_INFRA_SH" | head -1 | cut -d: -f1
+}
+
+# assert_before <description> <earlier-line> <later-line>
+assert_before() {
+  local description="$1" earlier="$2" later="$3"
+  if [[ -z "$earlier" || -z "$later" ]]; then
+    echo "  FAIL: $description (a required call site is missing: earlier='$earlier' later='$later')"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$earlier" -lt "$later" ]]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description (line $earlier is not before line $later)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test 1: the OpenBaoCluster CRD is awaited before the overlay apply ---
+test_openbaocluster_crd_is_awaited() {
+  echo "Test: wait_for_crds covers openbaoclusters.openbao.org"
+
+  assert_file_contains "the CRD the overlay's OpenBaoCluster needs is awaited" \
+    "$DEPLOY_INFRA_SH" "openbaoclusters.openbao.org"
+
+  # The name must sit inside the wait_for_crds argument list, not merely
+  # somewhere in the file: the list is what blocks the apply.
+  local in_arg_list
+  in_arg_list="$(sed -n '/wait_for_crds "${POD_TIMEOUT}"/,/^$/p' "$DEPLOY_INFRA_SH" \
+    | grep -c 'openbaoclusters.openbao.org' || true)"
+  assert_eq "openbaoclusters.openbao.org is an argument of wait_for_crds" \
+    "1" "${in_arg_list// /}"
+}
+
+# --- Test 2: sync → ownership proof → un-pause, in that order ---
+test_adoption_choreography_order() {
+  echo "Test: the unseal-key ExternalSecret is synced, then proven, then the CR is un-paused"
+
+  local wait_es proof unpause
+  wait_es="$(line_of '^    openbao-instance-unseal-key$')"
+  proof="$(line_of 'kubectl patch secret openbao-instance-unseal-key')"
+  unpause="$(line_of '{"spec":{"paused":false}}')"
+
+  assert_before "the ExternalSecret is waited for before the ownership proof" \
+    "$wait_es" "$proof"
+  assert_before "the ownership proof lands before the un-pause" \
+    "$proof" "$unpause"
+}
+
+# --- Test 3: the instance is started before the Garage wait, collected after ---
+test_instance_start_is_not_serialized_behind_garage() {
+  echo "Test: the un-pause precedes the GarageCluster wait and the Available wait follows it"
+
+  local unpause garage_wait available_wait
+  unpause="$(line_of '{"spec":{"paused":false}}')"
+  garage_wait="$(line_of 'kubectl wait garagecluster/garage')"
+  available_wait="$(line_of 'kubectl wait openbaocluster/openbao-instance')"
+
+  assert_before "the instance is un-paused before the blocking GarageCluster wait" \
+    "$unpause" "$garage_wait"
+  assert_before "its readiness is collected after that wait, not before it" \
+    "$garage_wait" "$available_wait"
+}
+
+# --- Test 4: the proof is an ownerReference, never the reserved annotation ---
+test_proof_is_an_owner_reference() {
+  echo "Test: the ownership proof is a controller ownerReference, not the owner-uid annotation"
+
+  # The openbao-lock-managed-resource-mutations ValidatingAdmissionPolicy the
+  # operator chart ships denies this annotation to every principal outside the
+  # operator's own ServiceAccounts, clusterwide and at failurePolicy: Fail.
+  # Writing it does not degrade the deploy, it aborts it.
+  local stamp
+  stamp="$(line_of 'openbao.org/owner-uid=')"
+  if [[ -z "$stamp" ]]; then
+    echo "  PASS: the deploy does not write the operator-reserved openbao.org/owner-uid annotation"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: hack/deploy-infra.sh writes openbao.org/owner-uid at line $stamp, which the openbao-operator ValidatingAdmissionPolicy denies"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # An object carries at most one controller ownerReference, so this only works
+  # while the ExternalSecret leaves that slot free (creationPolicy: Orphan).
+  assert_file_contains "the Secret is patched with an ownerReference to the OpenBaoCluster" \
+    "$DEPLOY_INFRA_SH" 'ownerReferences.*OpenBaoCluster'
+  assert_file_contains "that ownerReference claims the controller slot" \
+    "$DEPLOY_INFRA_SH" 'ownerReferences.*controller.*true'
+}
+
+# --- Run ---
+test_openbaocluster_crd_is_awaited
+test_adoption_choreography_order
+test_instance_start_is_not_serialized_behind_garage
+test_proof_is_an_owner_reference
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
+++ b/tests/unit/hack/deploy_infra_prometheus_flag_test.sh
@@ -193,7 +193,7 @@ test_dashboard_copy_precedes_apply() {
 # Test 8: kube-prometheus-stack appended to helm-release wait list
 # The Phase 3 wait list must NOT statically include kube-prometheus-stack;
 # it must be appended dynamically inside the WITH_PROMETHEUS gate, after the
-# chaos-mesh append, so the relative ordering of the seven base releases is
+# chaos-mesh append, so the relative ordering of the nine base releases is
 # preserved.
 # ---------------------------------------------------------------------------
 test_kube_prometheus_stack_appended_dynamically() {
@@ -205,11 +205,11 @@ test_kube_prometheus_stack_appended_dynamically() {
     "$DEPLOY_INFRA_SH" \
     'envoy-gateway kube-prometheus-stack'
 
-  # The base array must preserve the eight non-opt-in releases in order.
+  # The base array must preserve the nine non-opt-in releases in order.
   assert_file_contains \
-    "helm_releases array preserves the eight non-opt-in releases in the documented order" \
+    "helm_releases array preserves the nine non-opt-in releases in the documented order" \
     "$DEPLOY_INFRA_SH" \
-    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator)'
+    'helm_releases=(prometheus-operator-crds openbao mariadb-operator-crds mariadb-operator external-secrets memcached-operator envoy-gateway garage-operator openbao-operator)'
 
   # The dynamic append must be guarded by WITH_PROMETHEUS.
   assert_file_contains \

--- a/tests/unit/hack/deploy_infra_reconcile_sources_test.sh
+++ b/tests/unit/hack/deploy_infra_reconcile_sources_test.sh
@@ -30,28 +30,35 @@ source "$PROJECT_ROOT/tests/lib/assertions.sh"
 # Helpers
 # ---------------------------------------------------------------------------
 
-# install_kubectl_stub <dir> <repos...>
+# install_kubectl_stub <dir> <helmrepositories> <ocirepositories>
 # Writes a stub `kubectl` into <dir> that:
-#   - on `kubectl get helmrepository ...`  → prints the space-joined <repos>
-#   - on `kubectl annotate helmrepository/<name> ...` → appends one line per
+#   - on `kubectl get helmrepository ...` → prints the space-joined
+#     <helmrepositories>
+#   - on `kubectl get ocirepository ...`  → prints the space-joined
+#     <ocirepositories>
+#   - on `kubectl annotate <kind>/<name> ...` → appends one line per
 #     invocation to ${KUBECTL_ANNOTATE_LOG}
 # All other invocations exit 0 silently. The stub captures argv into the log
 # in a fixed format so the test can assert on each annotate call.
 install_kubectl_stub() {
   local dir="$1"
-  shift
+  local helm_repos="$2"
+  local oci_repos="$3"
   mkdir -p "$dir"
-  local repos="$*"
   local log_file="${KUBECTL_ANNOTATE_LOG}"
 
   cat >"$dir/kubectl" <<STUB
 #!/bin/bash
 # Stub kubectl for tests/unit/hack/deploy_infra_reconcile_sources_test.sh.
 if [[ "\$1" == "get" && "\$2" == "helmrepository" ]]; then
-  printf '%s' "${repos}"
+  printf '%s' "${helm_repos}"
   exit 0
 fi
-if [[ "\$1" == "annotate" && "\$2" == helmrepository/* ]]; then
+if [[ "\$1" == "get" && "\$2" == "ocirepository" ]]; then
+  printf '%s' "${oci_repos}"
+  exit 0
+fi
+if [[ "\$1" == "annotate" && ( "\$2" == helmrepository/* || "\$2" == ocirepository/* ) ]]; then
   printf '%s\n' "annotate \$*" >>"${log_file}"
   exit 0
 fi
@@ -88,14 +95,14 @@ test_reconcile_annotates_each_repo() {
   KUBECTL_ANNOTATE_LOG="$tmp/annotate.log"
   : >"$KUBECTL_ANNOTATE_LOG"
 
-  install_kubectl_stub "$tmp" "bitnami fluxcd-community jetstack"
+  install_kubectl_stub "$tmp" "bitnami fluxcd-community jetstack" ""
 
   local output exit_code
   output="$(run_reconcile "$tmp")"
   exit_code=$?
 
   assert_eq "reconcile_helmrepository_sources exits 0 on happy path" "0" "$exit_code"
-  assert_contains "log line announces reconcile step" "$output" "Reconciling HelmRepository sources..."
+  assert_contains "log line announces reconcile step" "$output" "Reconciling Flux chart sources..."
 
   local annotate_count
   annotate_count="$(wc -l <"$KUBECTL_ANNOTATE_LOG" | tr -d ' ')"
@@ -120,7 +127,7 @@ test_reconcile_annotates_each_repo() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 2: empty list — when no HelmRepositories exist, no annotate is invoked
+# Test 2: empty list — when no chart sources exist, no annotate is invoked
 #
 # ---------------------------------------------------------------------------
 test_reconcile_empty_list_is_noop() {
@@ -133,18 +140,55 @@ test_reconcile_empty_list_is_noop() {
   KUBECTL_ANNOTATE_LOG="$tmp/annotate.log"
   : >"$KUBECTL_ANNOTATE_LOG"
 
-  install_kubectl_stub "$tmp" ""
+  install_kubectl_stub "$tmp" "" ""
 
   local output exit_code
   output="$(run_reconcile "$tmp")"
   exit_code=$?
 
   assert_eq "reconcile_helmrepository_sources exits 0 with empty list" "0" "$exit_code"
-  assert_contains "log line announces reconcile step" "$output" "Reconciling HelmRepository sources..."
+  assert_contains "log line announces reconcile step" "$output" "Reconciling Flux chart sources..."
 
   local annotate_count
   annotate_count="$(wc -l <"$KUBECTL_ANNOTATE_LOG" | tr -d ' ')"
-  assert_eq "kubectl annotate not invoked when no HelmRepositories exist" "0" "$annotate_count"
+  assert_eq "kubectl annotate not invoked when no chart sources exist" "0" "$annotate_count"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: OCIRepository sources are nudged too.
+#
+# A chart pinned by artifact digest is an OCIRepository, not a HelmRepository —
+# openbao-operator is the one such source in this stack, and it is hard-gated
+# by wait_for_helmreleases. If the nudge enumerated HelmRepositories only, a
+# failed first registry fetch would sit out the source's 1h interval while the
+# release wait ran into its timeout.
+# ---------------------------------------------------------------------------
+test_reconcile_annotates_ocirepositories() {
+  echo "Test: reconcile_helmrepository_sources annotates OCIRepository sources"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  KUBECTL_ANNOTATE_LOG="$tmp/annotate.log"
+  : >"$KUBECTL_ANNOTATE_LOG"
+
+  install_kubectl_stub "$tmp" "bitnami jetstack" "openbao-operator"
+
+  local output exit_code
+  output="$(run_reconcile "$tmp")"
+  exit_code=$?
+
+  assert_eq "reconcile_helmrepository_sources exits 0 with both source kinds" "0" "$exit_code"
+
+  local annotate_count
+  annotate_count="$(wc -l <"$KUBECTL_ANNOTATE_LOG" | tr -d ' ')"
+  assert_eq "kubectl annotate called once per source across both kinds" "3" "$annotate_count"
+
+  assert_file_contains "annotate invoked for the openbao-operator OCIRepository" \
+    "$KUBECTL_ANNOTATE_LOG" "ocirepository/openbao-operator"
+  assert_file_contains "annotate still invoked for HelmRepositories" \
+    "$KUBECTL_ANNOTATE_LOG" "helmrepository/bitnami"
 }
 
 # ---------------------------------------------------------------------------
@@ -152,6 +196,7 @@ test_reconcile_empty_list_is_noop() {
 # ---------------------------------------------------------------------------
 test_reconcile_annotates_each_repo
 test_reconcile_empty_list_is_noop
+test_reconcile_annotates_ocirepositories
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/unit/renovate/openbao_instance_version_custommanager_test.sh
+++ b/tests/unit/renovate/openbao_instance_version_custommanager_test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify renovate.json tracks the OpenBaoCluster version pin in
+# deploy/kind/infrastructure/openbao-instance.yaml and pairs it with the
+# expected packageRules.
+#
+# The pin rides no Flux chart: the openbao-operator resolves it into the
+# instance image itself, so no native manager sees it. Left untracked it goes
+# stale silently, and the proving instance stops following the OpenBao line the
+# Barbican onboarding targets.
+#
+# Asserts:
+#   - exactly one customManager targets openbao/openbao over the instance
+#     manifest with the github-releases datasource and the extractVersionTemplate
+#     that strips the v prefix of the upstream release tags
+#   - its matchStrings regex captures the current pin from the real manifest
+#     exactly once — the manifest carries five apiVersion lines and a kv engine
+#     `version: "2"` the regex must not reach — and that capture equals the
+#     literal version of the OpenBaoCluster spec
+#   - a paired packageRule disables majors
+#   - a paired packageRule proposes minor/patch after a 3-day cooldown but never
+#     automerges — the bump has to stay inside the openbao-operator's supported
+#     version window, which only a human can confirm
+#
+# Usage: bash tests/unit/renovate/openbao_instance_version_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+INSTANCE_FILE="$PROJECT_ROOT/deploy/kind/infrastructure/openbao-instance.yaml"
+
+PKG_NAME="openbao/openbao"
+INSTANCE_PATH="deploy/kind/infrastructure/openbao-instance.yaml"
+
+test_manager_exists_and_regex_matches() {
+  echo "Test: the OpenBaoCluster version pin has a customManager whose regex matches"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+  if [[ ! -f "$INSTANCE_FILE" ]]; then
+    echo "  FAIL: $INSTANCE_FILE missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local count
+  count="$(jq --arg pkg "$PKG_NAME" '[.customManagers[]
+    | select(.packageNameTemplate == $pkg)] | length' "$RENOVATE_FILE")"
+  assert_eq "exactly one customManager targets ${PKG_NAME}" "1" "$count"
+
+  local entry
+  entry="$(jq -c --arg pkg "$PKG_NAME" '.customManagers[]
+    | select(.packageNameTemplate == $pkg)' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManager for ${PKG_NAME}"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_contains "manager targets the OpenBao instance manifest" \
+    "$(jq -r '.managerFilePatterns[0]' <<<"$entry")" "openbao-instance"
+  assert_eq "manager uses the github-releases datasource" \
+    "github-releases" "$(jq -r '.datasourceTemplate' <<<"$entry")"
+  assert_eq "manager strips the v prefix of the upstream release tags" \
+    '^v(?<version>.+)$' "$(jq -r '.extractVersionTemplate' <<<"$entry")"
+
+  local match_string captures captured match_count expected_pin
+  match_string="$(jq -r '.matchStrings[0]' <<<"$entry")"
+  captures="$(REGEX="$match_string" FILE="$INSTANCE_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/; open my $fh, "<", $ENV{FILE} or die $!;
+    my $content = <$fh>;
+    while ($content =~ /$re/g) {
+      print "$+{currentValue}\n" if defined $+{currentValue};
+    }
+  ')"
+  captured="$(printf '%s\n' "$captures" | head -1)"
+  match_count="$(printf '%s\n' "$captures" | grep -c . || true)"
+
+  assert_not_empty "matchStrings regex captures the instance version pin" "$captured"
+  # A regex loose enough to reach an apiVersion line or the kv engine's
+  # version: "2" would hand Renovate a second, bogus dep to bump.
+  assert_eq "matchStrings regex captures exactly one value in the manifest" \
+    "1" "$match_count"
+
+  # Derive the expected pin straight from the manifest so a Renovate bump keeps
+  # this test green — never hard-code the version.
+  expected_pin="$(grep -oE '^  version: "[0-9]+\.[0-9]+\.[0-9]+"' "$INSTANCE_FILE" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+  assert_eq "captured pin equals the literal OpenBaoCluster spec.version" \
+    "$expected_pin" "$captured"
+}
+
+test_package_rules() {
+  echo "Test: paired packageRules gate OpenBao instance major vs minor/patch updates"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local major_rule minor_rule
+  major_rule="$(jq -c --arg path "$INSTANCE_PATH" --arg pkg "$PKG_NAME" '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index($path)) != null
+        and (((.matchPackageNames // []) | index($pkg)) != null)
+        and (((.matchUpdateTypes // []) | index("major")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  minor_rule="$(jq -c --arg path "$INSTANCE_PATH" --arg pkg "$PKG_NAME" '.packageRules[]
+    | select(
+        ((.matchFileNames // []) | index($path)) != null
+        and (((.matchPackageNames // []) | index($pkg)) != null)
+        and (((.matchUpdateTypes // []) | index("minor")) != null)
+      )' "$RENOVATE_FILE" | head -1)"
+
+  if [ -z "$major_rule" ]; then
+    echo "  FAIL: no packageRule disabling majors for $INSTANCE_PATH"
+    FAIL=$((FAIL + 1))
+  else
+    assert_eq "major OpenBao instance updates are disabled" \
+      "false" "$(jq -r '.enabled' <<<"$major_rule")"
+  fi
+
+  if [ -z "$minor_rule" ]; then
+    echo "  FAIL: no packageRule for minor/patch OpenBao instance updates"
+    FAIL=$((FAIL + 2))
+    return
+  fi
+
+  assert_eq "minor/patch instance updates are not automerged (operator support window)" \
+    "false" "$(jq -r '.automerge' <<<"$minor_rule")"
+  assert_eq "minor/patch instance rule waits minimumReleaseAge=3 days" \
+    "3 days" "$(jq -r '.minimumReleaseAge' <<<"$minor_rule")"
+}
+
+test_manager_exists_and_regex_matches
+test_package_rules
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/renovate/openbao_operator_chart_custommanager_test.sh
+++ b/tests/unit/renovate/openbao_operator_chart_custommanager_test.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the openbao-operator chart is delivered under a content pin, and that
+# the pin is Renovate-tracked.
+#
+# The chart is unsigned, so no Flux spec.verify policy can gate it, and the
+# operator holds cluster-wide RBAC over the namespace that stores the instance
+# seal key. An exact chart.spec.version on a HelmRepository does NOT gate that:
+# `0.4.2` on oci://ghcr.io/dc-tec/charts is a mutable tag, Flux tracks the
+# resolved artifact digest rather than the tag string, and a re-pushed tag
+# therefore upgrades the release on its own within one interval — no Git change,
+# no reviewer. Only an OCIRepository ref.digest closes it.
+#
+# The second half is what keeps the pin from becoming a freeze: Renovate's
+# native flux manager does not cover this repo (its default file pattern matches
+# only gotk-components.yaml), so without an explicit customManager the operator
+# would sit on 0.4.2 forever with no update signal. The manager must capture the
+# tag and the digest in ONE matchString so Renovate rewrites both in the same
+# reviewed PR; capturing the tag alone would leave the digest behind and Flux
+# would keep pulling the old artifact.
+#
+# A hand-edit can still split the pair, and no file-local assertion can see it:
+# the tag and the digest only disagree relative to the registry. The last test
+# therefore resolves the pinned tag upstream and compares.
+#
+# Usage: bash tests/unit/renovate/openbao_operator_chart_custommanager_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+RENOVATE_FILE="$PROJECT_ROOT/renovate.json"
+SOURCE_FILE="$PROJECT_ROOT/deploy/flux-system/sources/openbao-operator.yaml"
+RELEASE_FILE="$PROJECT_ROOT/deploy/flux-system/releases/openbao-operator.yaml"
+
+CHART_PACKAGE="ghcr.io/dc-tec/charts/openbao-operator"
+SOURCE_PATH="deploy/flux-system/sources/openbao-operator.yaml"
+
+# Read the customManager entry once; every test that needs it re-reads through
+# this helper so a missing entry is reported per test instead of aborting.
+chart_manager_entry() {
+  jq -c --arg path "sources/openbao-operator" '.customManagers[]
+    | select((.managerFilePatterns // []) | join(",") | contains($path))' \
+    "$RENOVATE_FILE" | head -1
+}
+
+# --- Test 1: the source pins chart content, not a chart version ---
+test_source_is_digest_pinned_ocirepository() {
+  echo "Test: the chart source is a digest-pinned OCIRepository"
+
+  assert_file_contains "source declares kind OCIRepository" \
+    "$SOURCE_FILE" "kind: OCIRepository"
+  assert_file_contains "source url addresses the chart artifact itself" \
+    "$SOURCE_FILE" "url: oci://ghcr.io/dc-tec/charts/openbao-operator"
+  assert_file_contains "source selects the Helm chart layer unaltered" \
+    "$SOURCE_FILE" "operation: copy"
+
+  # ref.digest takes precedence over every other ref field, so this line is the
+  # control: without it the mutable tag decides what runs.
+  local digest_line
+  digest_line="$(grep -E '^[[:space:]]*digest:[[:space:]]*"sha256:[a-f0-9]{64}"' "$SOURCE_FILE" | head -1)"
+  assert_not_empty "source pins ref.digest to a full sha256 digest" "$digest_line"
+
+  assert_file_not_contains "source is no longer a HelmRepository" \
+    "$SOURCE_FILE" "kind: HelmRepository"
+}
+
+# --- Test 2: the release consumes that source, not a resolvable version ---
+test_release_consumes_the_pinned_source() {
+  echo "Test: the HelmRelease consumes the pinned source via chartRef"
+
+  assert_file_contains "release references the OCIRepository by chartRef" \
+    "$RELEASE_FILE" "kind: OCIRepository"
+
+  # A chart.spec.version would reintroduce Flux-side tag resolution alongside
+  # the digest pin, so neither the version key nor a sourceRef may come back.
+  assert_file_not_contains "release declares no chart.spec version constraint" \
+    "$RELEASE_FILE" "version:"
+  assert_file_not_contains "release declares no HelmRepository sourceRef" \
+    "$RELEASE_FILE" "sourceRef:"
+}
+
+# --- Test 3: a customManager tracks the pin with the docker datasource ---
+test_custom_manager_tracks_the_chart() {
+  echo "Test: a customManager tracks the openbao-operator chart pin"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (4 checks skipped)"
+    SKIP=$((SKIP + 4))
+    return
+  fi
+
+  local entry
+  entry="$(chart_manager_entry)"
+
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting $SOURCE_PATH"
+    FAIL=$((FAIL + 4))
+    return
+  fi
+
+  assert_eq "chart customManager.datasourceTemplate is docker" \
+    "docker" \
+    "$(jq -r '.datasourceTemplate' <<<"$entry")"
+  assert_eq "chart customManager.depNameTemplate is the chart artifact" \
+    "$CHART_PACKAGE" \
+    "$(jq -r '.depNameTemplate' <<<"$entry")"
+  assert_eq "chart customManager.packageNameTemplate is the chart artifact" \
+    "$CHART_PACKAGE" \
+    "$(jq -r '.packageNameTemplate' <<<"$entry")"
+  assert_eq "chart customManager.versioningTemplate is docker" \
+    "docker" \
+    "$(jq -r '.versioningTemplate' <<<"$entry")"
+}
+
+# --- Test 4: the regex captures tag and digest together ---
+test_regex_captures_tag_and_digest_together() {
+  echo "Test: the customManager regex captures ref.tag and ref.digest in one match"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "  SKIP: perl not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local entry match_string
+  entry="$(chart_manager_entry)"
+  if [ -z "$entry" ]; then
+    echo "  FAIL: no customManagers entry targeting $SOURCE_PATH"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  # One matchString must carry BOTH groups: Renovate rewrites the whole matched
+  # span, so a split pair would update the tag and leave the digest stale.
+  assert_eq "exactly one matchString captures both currentValue and currentDigest" \
+    "1" \
+    "$(jq '[.matchStrings[]
+           | select(contains("(?<currentValue>") and contains("(?<currentDigest>"))]
+          | length' <<<"$entry")"
+
+  match_string="$(jq -r '.matchStrings[]
+    | select(contains("(?<currentValue>") and contains("(?<currentDigest>"))' <<<"$entry" | head -1)"
+
+  local captured
+  captured="$(REGEX="$match_string" FILE="$SOURCE_FILE" perl -e '
+    my $re = $ENV{REGEX};
+    local $/;
+    open my $fh, "<", $ENV{FILE} or exit 1;
+    my $content = <$fh>;
+    if ($content =~ /$re/) {
+      printf "%s|%s", $+{currentValue} // "", $+{currentDigest} // "";
+    }
+  ')"
+
+  local expected_tag expected_digest
+  expected_tag="$(grep -E '^[[:space:]]*tag:' "$SOURCE_FILE" | head -1 | sed -E 's/.*tag:[[:space:]]*"([^"]+)".*/\1/')"
+  expected_digest="$(grep -E '^[[:space:]]*digest:' "$SOURCE_FILE" | head -1 | sed -E 's/.*digest:[[:space:]]*"([^"]+)".*/\1/')"
+
+  assert_eq "regex captures the ref.tag as currentValue" \
+    "$expected_tag" "${captured%%|*}"
+  assert_eq "regex captures the ref.digest as currentDigest" \
+    "$expected_digest" "${captured##*|}"
+}
+
+# --- Test 5: the paired packageRule never automerges the chart ---
+test_package_rule_never_automerges() {
+  echo "Test: the paired packageRule reviews chart bumps instead of automerging"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local rules
+  rules="$(jq -c --arg pkg "$CHART_PACKAGE" --arg path "$SOURCE_PATH" '[.packageRules[]
+    | select(
+        (((.matchPackageNames // []) | index($pkg)) != null)
+        or (((.matchFileNames // []) | index($path)) != null)
+      )]' "$RENOVATE_FILE")"
+
+  if [ "$(jq 'length' <<<"$rules")" = "0" ]; then
+    echo "  FAIL: no packageRule scoping updates for $CHART_PACKAGE"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  # An operator in the production data path never merges itself: every bump of
+  # this chart is a human decision, so no matching rule may set automerge.
+  assert_eq "no rule automerges the openbao-operator chart" \
+    "0" \
+    "$(jq '[.[] | select(.automerge == true)] | length' <<<"$rules")"
+  assert_eq "a rule holds new chart releases for 3 days" \
+    "1" \
+    "$(jq '[.[] | select(.minimumReleaseAge == "3 days")] | length' <<<"$rules")"
+  assert_eq "the chart rule groupName is openbao-operator chart" \
+    "openbao-operator chart" \
+    "$(jq -r '[.[] | select(.groupName != null)][0].groupName' <<<"$rules")"
+}
+
+# --- Test 6: tag and digest describe the same upstream artifact ---
+#
+# Tests 1 and 4 are self-consistent by construction: they compare the file
+# against itself, so they stay green when a hand-edit (a merge-conflict
+# resolution on a Renovate PR, a bump made ahead of Renovate) advances ref.tag
+# and leaves ref.digest behind. Flux would not notice either — ref.digest takes
+# precedence, so the tag is decoration and the cluster keeps running the old
+# chart while every local signal, including the docs table, reads as bumped.
+# Only the registry can settle whether the two agree, so this test resolves the
+# tag and compares.
+#
+# Skips rather than fails when the registry cannot be reached: an offline
+# workstation or a rate-limited runner must not turn the suite red.
+test_tag_and_digest_agree_upstream() {
+  echo "Test: ref.tag and ref.digest resolve to the same upstream artifact"
+
+  if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: curl or jq not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local tag digest registry repository
+  tag="$(grep -E '^[[:space:]]*tag:' "$SOURCE_FILE" | head -1 | sed -E 's/.*tag:[[:space:]]*"([^"]+)".*/\1/')"
+  digest="$(grep -E '^[[:space:]]*digest:' "$SOURCE_FILE" | head -1 | sed -E 's/.*digest:[[:space:]]*"([^"]+)".*/\1/')"
+  registry="${CHART_PACKAGE%%/*}"
+  repository="${CHART_PACKAGE#*/}"
+
+  # GHCR serves public packages to an anonymous pull token, so no credential is
+  # needed here.
+  local token
+  token="$(curl -sS --max-time 20 \
+    "https://${registry}/token?service=${registry}&scope=repository:${repository}:pull" \
+    2>/dev/null | jq -r '.token // empty')"
+
+  if [ -z "$token" ]; then
+    echo "  SKIP: ${registry} unreachable — cannot resolve ${tag} (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  local resolved
+  resolved="$(curl -sS --max-time 20 -I \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+    "https://${registry}/v2/${repository}/manifests/${tag}" 2>/dev/null \
+    | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }' | head -1)"
+
+  if [ -z "$resolved" ]; then
+    echo "  SKIP: ${registry} did not resolve tag ${tag} (1 check skipped)"
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
+  assert_eq "ref.tag ${tag} resolves to the pinned ref.digest" \
+    "$digest" "$resolved"
+}
+
+test_source_is_digest_pinned_ocirepository
+test_release_consumes_the_pinned_source
+test_custom_manager_tracks_the_chart
+test_regex_captures_tag_and_digest_together
+test_package_rule_never_automerges
+test_tag_and_digest_agree_upstream
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #803

Delivers the `dc-tec/openbao-operator` into the stack, adds a kind-only proving
`OpenBaoCluster` that exercises the instance primitives the Barbican onboarding
(#804) builds on — static-seal auto-unseal, cert-manager TLS in `External` mode,
one-shot self-init, AppRole plus Kubernetes auth — and provisions the brownfield
attachment target (`barbican/` mount, `barbican-secretstore` policy, `barbican`
AppRole role) on the existing shared management OpenBao.

## Commit walkthrough

**`54afc165` feat(infra): deliver the openbao-operator via Flux**

Adds `deploy/flux-system/sources/openbao-operator.yaml`, the HelmRelease
`deploy/flux-system/releases/openbao-operator.yaml` (`dependsOn: cert-manager`,
`crds: CreateReplace`, 3 remediation retries), the `openbao-operator-system`
Namespace, and both paths in the flux-system kustomization.
`tests/unit/deploy/production_posture_test.sh` carve-out is extended, since it
otherwise fails on any addition under `releases/`.

Two deliberate choices are recorded in the manifest headers: `tenancy.mode:
single` with `targetNamespace: openstack` (the chart's default multi-tenant
provisioner applies restricted Pod Security labels to the namespaces it
onboards, which the shared `openstack` namespace hosting every OpenStack
workload cannot take), and the accepted risk of running a young,
single-maintainer, pre-1.0 project in the production data path, together with
its mitigations (one consumed CR shape, an operator-independent brownfield path,
an in-repo StatefulSet fallback).

**`f20b4d43` feat(infra): gate deploy-infra on the openbao-operator**

`openbao-operator` joins the Phase 3 HelmRelease wait list as the last base
release, and `openbaoclusters.openbao.org` joins the Step 5 CRD wait — HelmRelease
Ready does not imply CRD registration, so the infrastructure overlay apply could
otherwise race it. The four flag tests that pin the base-array line byte-for-byte
(chaos, metrics-server, prometheus, dizzy) move with it.

**`8c887198` feat(infra): add the OpenBao proving instance to the kind stack**

`deploy/kind/infrastructure/openbao-instance.yaml` — two cert-manager
Certificates (`openbao-instance-tls-server` carrying the SAN the operator's
External-mode validation requires, and `openbao-instance-tls-ca`, whose leaf is
unused and which exists only to deliver the trust-domain CA in `ca.crt`), the
provisioner ServiceAccount, a `system:auth-delegator` ClusterRoleBinding for the
operator-created instance ServiceAccount (without it every Kubernetes-auth login
fails the TokenReview), and the `OpenBaoCluster` itself with its one-shot
self-init list.

The unseal-key custody chain runs from the management OpenBao outward:
`write-bootstrap-secrets.sh` seeds `bootstrap/openstack/openbao-instance/unseal-key`,
an ExternalSecret with `refreshPolicy: CreatedOnce` materializes it, and
`deploy-infra.sh` syncs it, stamps the operator's `owner-uid` marker on the
materialized Secret and un-pauses the CR — the CR is applied paused because the
operator otherwise blind-creates that fixed-name Secret with a random key of its
own. Both ends refuse to rotate: a rewritten static-seal key seals the instance
permanently. The un-pause runs before the blocking GarageCluster wait and the
instance's readiness is collected after it, so image pull, PVC bind, cert wait,
self-init and unseal are not serialized behind Garage.

Both Certificates pin `usages` to server auth: without the pin cert-manager
emits no EKU, and an EKU-less certificate passes client-auth verification —
which would make either Secret a ready-made client identity against the
management OpenBao's mTLS gate in the shared namespace. No policy grants
`delete` on `barbican/metadata/*`, where KV v2 destroys every version
irrecoverably.

Two unit tests pin the result: an overlay test (kind renders the paused CR plus
its `CreatedOnce` ExternalSecret, production renders neither) and a static
ordering test over the sync/stamp/un-pause sequence.

**`bc618878` feat(infra): provision the Barbican brownfield leg on shared OpenBao**

The `barbican/` KV v2 mount, the `barbican-secretstore` policy, and the
`barbican` AppRole role on the shared instance, riding the existing four-script
bootstrap (`setup-policies.sh` auto-applies every file in
`deploy/openbao/policies`). The names mirror what the proving instance
self-inits, so the meta's two secret-store e2e legs differ only in their target.
The AppRole secret-ID TTL is bounded at 720h rather than the year the older
provisioner role uses — a secret ID carries no use count and no CIDR bound, so
its TTL is the only bound there is. Secret-ID minting stays out of bootstrap;
it is runtime work owned by the barbican-operator.

**`0a643e02` test(deploy): cover the Barbican secret-store bootstrap with stubs**

A recording `kubectl` stub drives all three touched bootstrap scripts, so the
assertions check the exact arguments that reached the pod: mount created when
absent (including the empty-engine-list case), enable skipped when present, the
exact AppRole role write, unseal-key seed skipped when the probe hits, the
`BAO_TOKEN must be set` abort, and a non-zero exit when the pod is unreachable.

**`6ad1eb06` test(e2e): prove the OpenBao instance primitives end to end**

`tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml`: operator
Deployment and HelmRelease health, the unseal-key ExternalSecret `SecretSynced`
**and** adopted (ESO ownerReference plus the operator's owner-uid marker — the
custody chain would otherwise go unproven, since every later step also passes on
a Secret the operator blind-created), `Available` with `readyReplicas: 1`, the
full consumer path (Kubernetes-auth login with an audience-scoped token, role-ID
read, secret-ID mint, AppRole login, KV v2 write and read-back, plus the negative
wrong-secret-ID leg), and restart survival with no unseal command anywhere in the
suite. Both script steps drive the `bao` CLI through `kubectl exec`, so no probe
image and no new Renovate-managed pin. The suite is auto-discovered by e2e-infra
and appended to the scoped additive re-run list in `ci.yaml`.

**`e63363cf` chore(renovate): track the OpenBao instance version pin**

The `OpenBaoCluster` `version` rides no Helm chart, so no native manager sees it:
a regex customManager tracks it against the `openbao/openbao` github-releases
(v-prefixed tags vs an unprefixed pin, hence `extractVersionTemplate`), majors
disabled, minor/patch human-reviewed with a 3-day cooldown so the pin stays
inside the operator's supported window. A second customManager keeps the
operator chart's `tag` and `digest` bumping together. Both are guarded by
regression tests that derive their expectations from the live manifests.

**`0a103127` docs(infra): document the openbao-operator and proving instance**

Operator release section (property table, single-tenant values and why, risk
acceptance, pinning rationale), the proving-instance CR section (five resources,
why two Certificates, the custody chain, the one-shot self-init surface), and
the brownfield rows in the OpenBao bootstrap reference. The enumerations these
invalidate are corrected — three of them were already short of the tree before
this change (horizon-operator, horizon-system, placement-system, one policy).

## Divergences from the issue

- **The proving instance is kind-only.** The issue places it in
  `deploy/flux-system/infrastructure/`; it ships in `deploy/kind/infrastructure/`
  instead. Every posture it carries is a proving posture (Development profile,
  one replica, a static seal key in the shared namespace, 1Gi raft storage,
  a cluster-scoped RBAC binding, a self-init'd AppRole with no consumer), and
  shipping it from the production base would put all of it into every
  deployment. Only the operator ships in the production base; the
  production-shaped instance arrives with the Barbican onboarding.
- **Chart delivery is a digest-pinned `OCIRepository` + `chartRef`, not a
  HelmRepository with the issue's `">=0.4.2 <1.0.0"` range.** The chart carries
  no cosign signature, so no `spec.verify` policy can gate it. A range would
  install every future 0.x release of an individually-owned GHCR namespace
  within one interval, and even an exact `chart.spec.version` self-upgrades when
  a mutable tag is re-pushed, because Flux tracks the resolved artifact digest.
  This is the first chart in the stack sourced this way; it also required
  teaching `reconcile_helmrepository_sources` about OCIRepositories, since the
  release is hard-gated by the wait list.
- **Two TLS Certificates instead of the issue's single `openbao-instance-tls`.**
  The operator's External-mode contract reads server keypair and CA from two
  fixed-name Secrets, and cert-manager has no primitive that materializes a
  CA-only Secret.
- **An extra Renovate customManager and its regression test** for the operator
  chart's tag/digest pair, beyond the instance-version manager the issue lists —
  a consequence of the OCIRepository decision above.

Two commit messages carry framing that predates the final diff and a reviewer
should read past them: `54afc165` describes the source as "an OCI-type
HelmRepository" pinned by exact chart version, and the closing paragraph of
`e63363cf` states the two new Flux files need no custom rule because the native
flux manager covers them, while that same commit adds the chart tag/digest
customManager. The manifests, the docs, and the tests reflect the digest-pinned
`OCIRepository` design described above.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788509844&installation_model_id=18560&pr_number=813&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F813&signature=2f8ab901e1560f2ea0d73ec41684db24c1897e94c423a4d819bca6b11264e539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
