### PR TITLE
docs: document Barbican across reference, guides, and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ and Kubebuilder.
 
 The implementation follows a Keystone-first strategy: the Keystone Operator serves as the reference implementation
 establishing patterns for all subsequent operators. The c5c3-operator orchestrates Keystone, Horizon, Glance,
-and Placement children from one ControlPlane resource.
+Placement, and Barbican children from one ControlPlane resource.
 
 The architecture is organized as a Go Workspace monorepo with a shared library (`internal/common/`), individual
 operator modules (`operators/keystone/`, `operators/horizon/`, `operators/glance/`, `operators/placement/`,
-`operators/c5c3/`), container image builds (`images/`), declarative
+`operators/barbican/`, `operators/c5c3/`), container image builds (`images/`), declarative
 infrastructure deployment manifests (`deploy/`), and comprehensive tests at every level (unit, envtest integration,
 Chainsaw E2E).
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,6 +87,17 @@ export default defineConfig({
               { text: 'Standalone Placement', link: '/guides/placement/standalone-placement' },
             ],
           },
+          {
+            text: 'Barbican',
+            collapsed: true,
+            items: [
+              { text: 'Run Barbican on a Dedicated OpenBao', link: '/guides/barbican/barbican-dedicated-openbao' },
+              { text: 'Attach an External OpenBao to Barbican', link: '/guides/barbican/attach-external-openbao' },
+              { text: 'Enable Barbican Operator Metrics', link: '/guides/barbican/enable-barbican-operator-metrics' },
+              { text: 'Enable Barbican Operator NetworkPolicy', link: '/guides/barbican/enable-barbican-operator-networkpolicy' },
+              { text: 'Migrate Barbican DB to Dynamic Credentials', link: '/guides/barbican/migrate-barbican-db-to-dynamic-credentials' },
+            ],
+          },
         ],
       },
       {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -143,6 +143,18 @@ export default defineConfig({
             ],
           },
           {
+            text: 'Barbican',
+            link: '/reference/barbican/',
+            collapsed: true,
+            items: [
+              { text: 'Overview', link: '/reference/barbican/' },
+              { text: 'CRD', link: '/reference/barbican/barbican-crd' },
+              { text: 'Secret Store CRD', link: '/reference/barbican/barbican-secret-store-crd' },
+              { text: 'Controller Events', link: '/reference/barbican/barbican-events' },
+              { text: 'Reconciler Architecture', link: '/reference/barbican/barbican-reconciler' },
+            ],
+          },
+          {
             text: 'c5c3 (ControlPlane)',
             collapsed: true,
             items: [

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -121,11 +121,11 @@ cache) is set — never both — for both `database` and `cache`.
 
 The `ControlPlane` exposes the same free-form configuration escape hatch the
 service CRs carry, at two levels. `spec.globalExtraConfig` applies to every
-INI-configured service the control plane declares (Keystone, Glance, and
-Placement today). `spec.services.<svc>.extraConfig` sets one service's own block.
-Both take the INI `map[section][key] = value` shape the child renders into its
-service config (`keystone.conf`, `glance-api.conf`, `placement.conf`). The
-dashboard is the exception:
+INI-configured service the control plane declares (Keystone, Glance, Placement,
+and Barbican today). `spec.services.<svc>.extraConfig` sets one service's own
+block. Both take the INI `map[section][key] = value` shape the child renders into
+its service config (`keystone.conf`, `glance-api.conf`, `placement.conf`,
+`barbican.conf`). The dashboard is the exception:
 `spec.services.horizon.extraConfig` is a flat map of Django settings, covered in
 [Horizon settings are flat, not INI](#horizon-settings-are-flat-not-ini).
 
@@ -138,7 +138,7 @@ metadata:
 spec:
   openStackRelease: "2025.2"
   # Applied to every INI service the control plane declares (Keystone, Glance,
-  # Placement):
+  # Placement, Barbican):
   globalExtraConfig:
     database:
       pool_timeout: "30"
@@ -169,10 +169,10 @@ render `30`, inherited from the global block.
 
 The option catalog that guards a service CR's own `spec.extraConfig` guards the
 merged result here too, so a global key must be valid against **every** declared
-INI service's catalog. Because `spec.globalExtraConfig` reaches Glance and
-Placement as well, a Keystone-only option placed there is rejected while
-`services.glance` or `services.placement` is declared; the fix is to move that
-key to `spec.services.keystone.extraConfig`.
+INI service's catalog. Because `spec.globalExtraConfig` reaches Glance,
+Placement, and Barbican as well, a Keystone-only option placed there is rejected
+while `services.glance`, `services.placement`, or `services.barbican` is
+declared; the fix is to move that key to `spec.services.keystone.extraConfig`.
 
 ### Horizon settings are flat, not INI
 
@@ -189,8 +189,8 @@ Both a CEL rule and the webhook reject it, with the message
 `services.keystone.extraConfig is forbidden when services.keystone.mode is External`.
 `spec.globalExtraConfig` stays legal but inert in External mode, the same posture
 `spec.globalPolicyOverrides` holds, since no INI-configured workload consumes it.
-Glance, Horizon, and Placement are forbidden entirely in External mode, so their
-blocks cannot appear at all.
+Glance, Horizon, Placement, and Barbican are forbidden entirely in External mode,
+so their blocks cannot appear at all.
 
 ### Admission checks
 
@@ -454,12 +454,12 @@ logging levels, oslo.messaging tuning, experimental Keystone flags —
 `spec.extraConfig` takes a `map[section][key] = value` that is rendered into the
 generated `keystone.conf`.
 
-For the INI-file services (Keystone, Glance, Placement) the operator renders
-configuration through a single precedence chain: `plugins < operator defaults <
-spec.extraConfig`. Each stage is merged key-wise, so a plugin section cannot
-shadow an operator-computed value, the operator defaults win over any colliding
-plugin section, and `spec.extraConfig` is the only door past the operator's own
-defaults.
+For the INI-file services (Keystone, Glance, Placement, Barbican) the operator
+renders configuration through a single precedence chain: `plugins < operator
+defaults < spec.extraConfig`. Each stage is merged key-wise, so a plugin section
+cannot shadow an operator-computed value, the operator defaults win over any
+colliding plugin section, and `spec.extraConfig` is the only door past the
+operator's own defaults.
 
 Each operator ships a registry of the configuration keys it computes. Overriding
 one of those keys through `spec.extraConfig` is honored — the value is rendered —

--- a/docs/guides/barbican/attach-external-openbao.md
+++ b/docs/guides/barbican/attach-external-openbao.md
@@ -136,7 +136,10 @@ credentials your operators issued.
 
 ## 3. Declare the Barbican service
 
-Add the service block to the `ControlPlane` the tutorial created:
+On a devstack built from the tutorial, `services.barbican` is already declared
+with `secretStore: {dedicated: {}}`, so this edit replaces the `dedicated` block
+with the `external` one. A ControlPlane that does not declare the service yet
+adds the whole block:
 
 ```bash
 kubectl edit controlplane controlplane -n openstack
@@ -158,6 +161,18 @@ spec:
           # explicitly. Get it right the first time (see below).
 ```
 
+On a ControlPlane that already ran the dedicated mode, this edit changes the
+store's mode, a field the `BarbicanSecretStore` CRD freezes. The reconciler
+answers that by deleting `controlplane-barbican-store` and recreating it against
+the external server on the next pass, and reports `BarbicanReady=False` with
+reason `RecreatingBarbicanSecretStore` in between. The dedicated instance
+`controlplane-barbican-bao` is left in place: nothing in the switch tears it
+down, and the c5c3-operator only removes it when `services.barbican` is dropped
+under both deletion annotations. It keeps running, with the material Barbican
+wrote through the old store, until you delete it by hand. What that deletion
+destroys is spelled out in step 6 of
+[Run Barbican on a Dedicated OpenBao](./barbican-dedicated-openbao.md).
+
 `external` and `dedicated` are mutually exclusive, and a block naming neither is
 rejected at admission. Two fields are worth setting deliberately:
 
@@ -178,8 +193,10 @@ rejected at admission. Two fields are worth setting deliberately:
 
 On the managed shared database the Barbican DB credential is engine-issued, and
 `setup-database-tenant.sh` provisions an engine connection and role only for the
-services the ControlPlane declares. The run from the tutorial's Step 4 predates
-the block you just added, so repeat it:
+services the ControlPlane declares. It reads the live spec on every run, so a
+tenant setup that ran before `services.barbican` was declared provisioned no
+Barbican pair. Re-run it in that case; the config and role writes are upserts,
+so a repeat on an already-onboarded ControlPlane refreshes the pair in place:
 
 ```bash
 export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n shared-services \

--- a/docs/guides/barbican/attach-external-openbao.md
+++ b/docs/guides/barbican/attach-external-openbao.md
@@ -1,0 +1,313 @@
+---
+title: Attach an External OpenBao to Barbican
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- operator namespace is `barbican-system`; workload (Barbican CR) stays in `openstack`. -->
+
+# How-to: Attach an External OpenBao to Barbican
+
+This guide attaches the Key Manager service to an OpenBao or HashiCorp Vault
+server that already exists, run and hardened outside this control plane. It is
+the production shape of the service: the operator reads two Secrets, verifies the
+credentials in them, and renders the store configuration. It creates no mount, no
+policy, and no AppRole on your server, and it never writes to it.
+
+That read-only posture is what turns the rest of this page into a contract. The
+server side has to be provisioned out of band, in a specific shape, before a
+`ControlPlane` referencing it can converge. Sections 1 and 2 below are that
+shape; sections 3 to 5 attach the service to it on the devstack.
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace. That devstack
+also brings up the proving `OpenBaoCluster` `openbao-instance` in `openstack`,
+which stands in below for the server you already run.
+:::
+
+1. **An OpenBao or HashiCorp Vault server reachable from the cluster over
+   `https://`.** Plain HTTP is rejected at admission: the role ID, the secret ID,
+   and every secret Barbican stores travel that URL. On the devstack the stand-in
+   is `https://openbao-instance.openstack.svc:8200`.
+2. **A token with write access to that server**, for the provisioning in
+   section 1. The operator never has one.
+3. **`jq` on `PATH`** for the condition readouts in section 5.
+
+::: warning Not the shared management OpenBao
+The devstack's other OpenBao, the management instance in the `shared-services`
+namespace, is not a candidate. It requires client certificates on every
+connection, and castellan's vault plugin authenticates with an AppRole and a CA
+bundle only, with no way to present one. Attaching to it produces a connection
+reset that looks like an unreachable server. Use a server that accepts AppRole
+logins, which on this devstack is `openbao-instance`.
+:::
+
+## 1. What the server must carry
+
+Three things, provisioned by you.
+
+**A KV v2 mount.** castellan's vault plugin speaks KV version 2 and nothing else,
+so a version 1 mount is not usable. `kvMountpoint` defaults to `barbican`, which
+matches a mount enabled as `bao secrets enable -path=barbican -version=2 kv`. A
+server that keeps its secrets on the stock `secret/` mount names it explicitly
+instead.
+
+**A policy scoping an identity to that mount.** This is the policy the delivered
+bootstrap writes, and it is the exact grant the operator probes for
+(`deploy/openbao/policies/barbican-secretstore.hcl`):
+
+```hcl
+path "barbican/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "barbican/metadata/*" {
+  capabilities = ["create", "read", "update", "list"]
+}
+```
+
+The absence of `delete` on `metadata/*` is deliberate. In KV v2 a delete on the
+metadata path permanently destroys every version of a secret along with its
+metadata, which is the only in-store recovery path tenant key material has. The
+delete castellan issues goes through `data/`, where it is a recoverable soft
+delete. On a mount other than `barbican`, substitute the mount path in both
+blocks.
+
+**An AppRole carrying that policy.** The shape the bootstrap writes
+(`deploy/openbao/bootstrap/setup-auth.sh`):
+
+```bash
+bao write auth/approle/role/barbican \
+  token_policies=barbican-secretstore \
+  token_ttl=1h \
+  token_max_ttl=4h \
+  secret_id_ttl=720h
+```
+
+`secret_id_num_uses` is left unset on purpose. castellan re-logs in whenever its
+cached token ages out after `token_ttl`, so a use cap would expire the credential
+mid-operation rather than bound it. That leaves `secret_id_ttl` as the only bound
+on a leaked secret ID, and 30 days as a fuse on the credential in use: the plugin
+holds one process-global AppRole session, so an expired secret ID surfaces as
+every secret-store operation failing at once. Nothing re-mints it for a store in
+this mode. The re-mint procedure, under the AppRole Auth heading of the
+[OpenBao Bootstrap reference](../../reference/infrastructure/openbao-bootstrap.md#approle-auth),
+is the control: it reads the stable role ID, mints a replacement secret ID
+straight into the Secret, and destroys the accessor of the one it replaced.
+
+## 2. The two Secrets
+
+The operator resolves both by name in the namespace the Barbican service is
+placed in, and their data keys are fixed by contract rather than selectable per
+CR.
+
+| Secret | Data keys | Required |
+| --- | --- | --- |
+| credentials | `role-id`, `secret-id` | yes |
+| CA bundle | `ca.crt` | only when the server's certificate is not already trusted by the pods' system store |
+
+On the devstack, the e2e suite's helper mints a secret ID against the proving
+instance and writes both Secrets for you. It is the stand-in for the out-of-band
+provisioning a real attachment assumes:
+
+```bash
+tests/e2e/barbican/approle-credentials.sh openstack
+```
+
+It logs in to `openbao-instance` through its Kubernetes auth method as the
+`openbao-instance-provisioner` ServiceAccount, reads the `barbican` AppRole's
+role ID, mints a secret ID, and writes `barbican-brownfield-approle` (role ID and
+secret ID) plus `openbao-instance-ca` (the trust bundle) into the namespace it is
+given. Against a real server, create the same two Secrets by hand from the
+credentials your operators issued.
+
+## 3. Declare the Barbican service
+
+Add the service block to the `ControlPlane` the tutorial created:
+
+```bash
+kubectl edit controlplane controlplane -n openstack
+```
+
+```yaml
+spec:
+  services:
+    barbican:
+      replicas: 1
+      secretStore:
+        external:
+          url: https://openbao-instance.openstack.svc:8200
+          credentialsSecretRef:
+            name: barbican-brownfield-approle
+          caBundleSecretRef:
+            name: openbao-instance-ca
+          # kvMountpoint defaults to "barbican"; a stock secret/ mount sets it
+          # explicitly. Get it right the first time (see below).
+```
+
+`external` and `dedicated` are mutually exclusive, and a block naming neither is
+rejected at admission. Two fields are worth setting deliberately:
+
+- **`kvMountpoint`** is frozen on the projected store: secret material written
+  under one mount is not reachable under another, so the `BarbicanSecretStore`
+  CRD refuses the update rather than re-pointing a live store at material it
+  cannot read. Changing it on the ControlPlane makes the reconciler delete the
+  store and recreate it on the next pass, and everything written under the old
+  mount stays where it is.
+- **`namespace`** scopes every request to an OpenBao or Vault namespace, the
+  enterprise-style multi-tenancy header. It exists only in this mode: a dedicated
+  instance is provisioned at the root namespace. The operator sends it on its own
+  login and capability probe too, so a store whose AppRole lives in a namespace
+  it does not name reports `InvalidCredentials` against credentials that are
+  correct.
+
+## 4. Onboard the barbican database-engine tenant
+
+On the managed shared database the Barbican DB credential is engine-issued, and
+`setup-database-tenant.sh` provisions an engine connection and role only for the
+services the ControlPlane declares. The run from the tutorial's Step 4 predates
+the block you just added, so repeat it:
+
+```bash
+export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n shared-services \
+  -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')
+deploy/openbao/bootstrap/setup-database-tenant.sh openstack controlplane
+unset BAO_TOKEN
+```
+
+This is the management OpenBao's database engine, unrelated to the server the
+secret store points at. The two are separate concerns: one issues the MySQL user
+Barbican's metadata schema is reached with, the other holds the secret material.
+
+## 5. Watch the store validate
+
+Watch the service's own condition, `BarbicanReady`, rather than the
+ControlPlane-wide `Ready`, which also covers every other service:
+
+```bash
+kubectl wait controlplane/controlplane -n openstack \
+  --for=condition=BarbicanReady --timeout=15m
+```
+
+The store CR the ControlPlane projects carries the detail:
+
+```bash
+kubectl get barbicansecretstore controlplane-barbican-store -n openstack \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
+```
+
+Two conditions, not three. `CredentialsReady` reports the login and the
+capability probe; `ConfigProjected` reports that the rendered `barbican.conf` in
+the running Deployment carries this store's section. `ProvisioningReady` is
+removed rather than reported `False`: it belongs to a store the operator
+provisions, and reporting it here would claim a step that never ran.
+
+`CredentialsReady=True/CredentialsAvailable` means the operator logged in with
+the referenced role ID and secret ID and confirmed, through
+`sys/capabilities-self` on `<mount>/data/probe`, that the policy grants all five
+of `create`, `read`, `update`, `delete`, and `list`. The probe path is never
+written to. The check re-runs every 15 minutes, so a secret ID that expires under
+a running deployment surfaces on the store's status rather than only in the API's
+error rate.
+
+### HashiCorp Vault
+
+A Vault server attaches through the same fields, and the projected store keeps
+`type: OpenBao`. The type selects Barbican's `vault_plugin`, which speaks the
+plain Vault HTTP API that OpenBao stays compatible with, so the two servers are
+interchangeable from Barbican's side and do not warrant a second enum value.
+
+## Troubleshooting
+
+Every reason below sits on `CredentialsReady` on the
+`controlplane-barbican-store` CR.
+
+| Reason | Cause | What to do |
+| --- | --- | --- |
+| `WaitingForCredentials` | A referenced Secret is absent, or carries an empty `role-id`, `secret-id`, or `ca.crt`. Routine while GitOps ordering settles. | Create the Secret, or fill the missing key. The message names the Secret and the key. |
+| `InvalidCredentials` | The server rejected the login. The secret ID expired or was destroyed, the role ID belongs to a different AppRole, or the AppRole lives in an OpenBao namespace `namespace` does not name. | Re-mint the secret ID into the credentials Secret, or correct the namespace. |
+| `InsufficientCapabilities` | The login succeeded and the policy behind the AppRole does not grant all five capabilities on `<mount>/data/*`. The message names the ones missing. | Apply the policy from section 1, with the mount path substituted. |
+| `OpenBaoUnreachable` | The server did not answer, or the client could not be built: DNS, a dropped connection, an expired or wrong CA bundle. A NetworkPolicy that does not admit the operator produces a timeout here rather than a refusal. | Check the URL and the bundle in `ca.crt`, then the egress and ingress policies between `barbican-system` and the server. |
+
+## Standalone Barbican, without a ControlPlane
+
+Without a ControlPlane you own the `BarbicanSecretStore` directly, and the same
+two Secrets are resolved in its own namespace. The names below are ones you
+choose; none of the `controlplane-` names from the walkthrough above applies
+here.
+
+```yaml
+apiVersion: barbican.openstack.c5c3.io/v1alpha1
+kind: BarbicanSecretStore
+metadata:
+  name: barbican-store
+  namespace: openstack
+spec:
+  barbicanRef:
+    name: barbican
+  type: OpenBao
+  isDefault: true
+  openBao:
+    server:
+      url: https://openbao.example.com:8200
+      credentialsSecretRef:
+        name: barbican-approle
+      caBundleSecretRef:
+        name: barbican-openbao-ca
+    kvMountpoint: secret
+    namespace: platform/openstack
+```
+
+`server` and `instanceRef` are the two store modes, and the mode is frozen after
+creation for the reason `kvMountpoint` is: switching between them re-points the
+plugin at a different server, where the material written through the old one does
+not exist. The store attaches to a Barbican that does not have to exist yet; a
+dangling `barbicanRef` surfaces as `Ready=False` and resolves when the CR
+appears. See the
+[BarbicanSecretStore CRD API Reference](../../reference/barbican/barbican-secret-store-crd.md)
+for the full field surface.
+
+## See also
+
+- [BarbicanSecretStore CRD](../../reference/barbican/barbican-secret-store-crd.md) —
+  both store modes, the credential contract, and the condition catalog.
+- [OpenBao Bootstrap reference](../../reference/infrastructure/openbao-bootstrap.md#approle-auth) —
+  the AppRole role, its policy, and the secret-ID re-mint procedure.
+- [Run Barbican on a Dedicated OpenBao](./barbican-dedicated-openbao.md) — the
+  self-service mode, for a cluster with no server to attach to.
+- [Barbican Controller Events](../../reference/barbican/barbican-events.md) — the
+  events the store controller emits alongside these conditions.
+
+## Tested by
+
+The read-only attachment this guide describes (the two Secrets, the login and
+capability probe, the absent `ProvisioningReady`, and the rendered
+`[vault_plugin]` section pointing at the configured URL and the mounted CA
+bundle) is asserted on the live CI e2e kind cluster by this suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/barbican/secretstore-brownfield
+```
+
+::: details The store CR the secretstore-brownfield suite applies
+The suite isolates its Barbican from the parallel suite pool, so its CR names are
+the suite's isolation identifiers (Barbican `barbican-store-brownfield`, store
+`barbican-store-brownfield-store`) rather than the `controlplane-barbican` names
+the walkthrough above uses. The server, the two Secrets, and the default
+`kvMountpoint` are the ones from sections 2 and 3.
+
+<<< @/../tests/e2e/barbican/secretstore-brownfield/01-barbican-secretstore.yaml#brownfield-store
+:::

--- a/docs/guides/barbican/barbican-dedicated-openbao.md
+++ b/docs/guides/barbican/barbican-dedicated-openbao.md
@@ -1,0 +1,482 @@
+---
+title: Run Barbican on a Dedicated OpenBao
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- operator namespace is `barbican-system`; workload (Barbican CR) stays in `openstack`. -->
+
+# How-to: Run Barbican on a Dedicated OpenBao
+
+This guide adds the Key Manager service to a running ControlPlane in the mode
+that needs nothing from outside the cluster. With
+`services.barbican.secretStore.dedicated`, the c5c3-operator provisions an
+OpenBao instance for this one Barbican, attaches the secret store to it, and lets
+the barbican-operator mint the AppRole credentials the API pods authenticate
+with. The walkthrough ends with a secret stored and read back from the host, and
+with the teardown that removes the service again.
+
+The instance the ControlPlane provisions is proving-grade. It runs the
+openbao-operator's Development profile at a single replica with no
+PodDisruptionBudget, so any disruption of that one pod stops every secret read
+and write. It is sealed by a static key held in a plain Secret
+(`controlplane-barbican-bao-unseal-key`) in the same namespace as the raft volume
+that key seals, so read access to that namespace's Secrets, or a single etcd or
+namespace backup, yields the ciphertext and the key together. Admission repeats
+that as a warning on every apply. For a production key manager, point the service
+at a hardened server instead: see
+[Attach an External OpenBao to Barbican](./attach-external-openbao.md).
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
+CR named `controlplane` is `Ready` in the `openstack` namespace. That tutorial's
+CR declares no `services.barbican`; step 1 below adds it. Every resource name in
+the examples that follow is one this devstack produces.
+:::
+
+1. **The `python-barbicanclient` plugin on `PATH`.** The `openstack secret`
+   subcommands of step 5 come from it; without it the CLI rejects
+   `secret store` as an unknown command.
+2. **`jq` on `PATH`** for the condition readouts in step 3.
+3. **The OpenBao root token**, for the one-time database-engine onboarding in
+   step 2. On kind it is read from the `openbao-init-keys` Secret, as in the
+   tutorial's Step 4.
+
+## Step 1 — Declare the Barbican service
+
+Barbican is one block on the `ControlPlane` CR. Edit the CR the tutorial created
+and add it beside the existing services:
+
+```bash
+kubectl edit controlplane controlplane -n openstack
+```
+
+```yaml
+spec:
+  services:
+    barbican:
+      replicas: 1
+      # The ControlPlane provisions the OpenBao instance and derives everything
+      # else (its name, its KV mount, its AppRole) by convention, so the block
+      # carries no fields.
+      secretStore:
+        dedicated: {}
+      # The key-manager API on the Barbican listener the kind overlay adds for
+      # barbican.127-0-0-1.nip.io, on the same shared Envoy Gateway as Keystone.
+      publicEndpoint: https://barbican.127-0-0-1.nip.io:8443
+      gateway:
+        parentRef:
+          name: openstack-gw
+        hostname: barbican.127-0-0-1.nip.io
+```
+
+`publicEndpoint` is what carries the `:8443` host port into the public
+key-manager catalog row. Dropped, the operator derives
+`https://barbican.127-0-0-1.nip.io` from the gateway hostname, which is the
+default-443 form and unreachable on a kind cluster mapped to 8443.
+
+The defaulting webhook injects a `barbican` service account into
+`spec.korc.serviceAccounts` (user `barbican`, project `service-barbican`, role
+`service`), so Barbican has a Keystone user to validate tokens as. The database,
+the cache, and the Keystone endpoint are derived from `spec.infrastructure` and
+from the Keystone child's naming convention; none of them is set here.
+
+## Step 2 — Onboard the barbican database-engine tenant
+
+On the managed shared database the Barbican DB credential is engine-issued, and
+`setup-database-tenant.sh` provisions one engine connection and one role per
+declared service. It skips a service the ControlPlane does not declare, so the
+run from the tutorial's Step 4 provisioned no Barbican pair. Re-run it now that
+the block exists:
+
+```bash
+export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n shared-services \
+  -o jsonpath='{.data.init-output}' | base64 -d | jq -r '.root_token')
+deploy/openbao/bootstrap/setup-database-tenant.sh openstack controlplane
+unset BAO_TOKEN
+```
+
+The script is idempotent: it refreshes the pairs of the other services in place
+and adds `database/mariadb/config/barbican-openstack` and
+`database/mariadb/roles/barbican-openstack`. Skipping it parks the next step on
+`BarbicanReady=False` with reason `WaitingForBarbicanDBCredential`, and the
+message names the `database/mariadb/creds/barbican-openstack` path it is waiting
+for.
+
+## Step 3 — Watch BarbicanReady
+
+Watch the service's own condition, `BarbicanReady`, rather than the
+ControlPlane-wide `Ready`. The aggregate also covers Keystone, Horizon, Glance,
+and Placement, so it answers a broader question than the one this guide asks:
+
+```bash
+kubectl wait controlplane/controlplane -n openstack \
+  --for=condition=BarbicanReady --timeout=15m
+```
+
+While it converges, the reason names the step in progress:
+
+```bash
+kubectl get controlplane controlplane -n openstack \
+  -o jsonpath='{.status.conditions[?(@.type=="BarbicanReady")]}' | jq
+```
+
+| Reason | What it is waiting for |
+| --- | --- |
+| `WaitingForKeystone` | `KeystoneReady` is not `True` yet. Barbican validates every token against the Keystone child, so its projection is deferred until then. |
+| `WaitingForServiceAccount` | The injected `barbican` service account has no Keystone user and password yet. |
+| `WaitingForBarbicanDBCredential` | No engine-issued credential has landed. Re-run step 2. |
+| `WaitingForOpenBaoInstance` | The dedicated instance is not `Available`. The store and the child are projected once it serves requests. |
+| `WaitingForBarbican` | The Barbican child exists and is not `Ready` yet (db-sync, rollout, store projection). |
+
+## Step 4 — Inspect what the ControlPlane projected
+
+Three CRs carry the service. Their names are derived from the ControlPlane's:
+
+```bash
+kubectl get barbican controlplane-barbican -n openstack
+kubectl get barbicansecretstore controlplane-barbican-store -n openstack
+kubectl get openbaocluster controlplane-barbican-bao -n openstack
+```
+
+The `BarbicanSecretStore` is the attachment: it points at the Barbican by name
+and at the instance by `openBao.instanceRef`, and it is the Barbican's default
+store. Its `Ready` condition decomposes into `CredentialsReady`,
+`ProvisioningReady`, and `ConfigProjected`:
+
+```bash
+kubectl get barbicansecretstore controlplane-barbican-store -n openstack \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
+```
+
+`ProvisioningReady=True/Provisioned` means the barbican-operator logged in to the
+instance as its provisioner ServiceAccount and found the `barbican/` KV mount and
+the `barbican` AppRole the self-init created. The credentials it mints from that
+AppRole land in `controlplane-barbican-store-approle`, which is owned by the
+store rather than by the Barbican.
+
+Around the instance sits the ensemble the openbao-operator's contracts require.
+Every object is named after the instance:
+
+| Object | Name | Purpose |
+| --- | --- | --- |
+| Secret | `controlplane-barbican-bao-unseal-key` | The static seal key, generated once and never rotated |
+| Secret | `controlplane-barbican-bao-tls-server` | The API listener's cert-manager keypair (External TLS mode) |
+| Secret | `controlplane-barbican-bao-tls-ca` | The trust bundle the operator and the API pods verify against |
+| ServiceAccount | `controlplane-barbican-bao-provisioner` | The identity the barbican-operator's Kubernetes-auth login binds to |
+| Role + RoleBinding | `controlplane-barbican-bao-provisioner-token` | Lets the barbican-operator mint a bound token for that one account |
+| ClusterRoleBinding | `controlplane-barbican-bao-<hash>-auth-delegator` | Grants the instance pods the TokenReview every Kubernetes-auth login needs |
+| OpenBaoTenant | `controlplane-barbican-bao-tenant` | Admits the namespace to the multi-tenant openbao-operator |
+
+```bash
+kubectl get secret,serviceaccount,role,rolebinding -n openstack \
+  | grep controlplane-barbican-bao
+kubectl get clusterrolebinding | grep controlplane-barbican-bao
+```
+
+The auth-delegator binding is cluster-scoped, so its name carries a hash of
+`namespace/instance`: two ControlPlanes of the same name in different namespaces
+derive the same instance name and would otherwise collide on one binding.
+
+No `controlplane-barbican-bao-tenant` appears on this devstack. The kind overlay
+already ships an `OpenBaoTenant` admitting `openstack`, and the operator skips a
+namespace some tenant already targets, because a namespace admitted twice carries
+two finalizers. A ControlPlane whose Barbican lands in a fresh service namespace
+gets its own tenant there.
+
+## Step 5 — Store and read a secret back
+
+The key-manager row is in the catalog once `BarbicanReady` is `True`, and the
+public endpoint is the gateway URL from step 1, so the round-trip runs from the
+host. Export the admin credentials the way the tutorial's Verify step does, and
+leave `OS_REGION_NAME` unset: the projected K-ORC catalog rows carry no region,
+so a region-scoped lookup finds no key-manager endpoint.
+
+```bash
+export OS_AUTH_URL=https://keystone.127-0-0-1.nip.io:8443/v3
+export OS_USERNAME=admin
+export OS_PASSWORD=$(kubectl get secret controlplane-keystone-admin-credentials -n openstack -o jsonpath='{.data.password}' | base64 -d)
+export OS_PROJECT_NAME=admin
+export OS_USER_DOMAIN_NAME=Default
+export OS_PROJECT_DOMAIN_NAME=Default
+
+openstack --insecure catalog list | grep key-manager
+```
+
+Then store a secret, read its payload back, and delete it:
+
+```bash
+HREF=$(openstack --insecure secret store --name roundtrip \
+  --payload 'forge-barbican-payload' -f value -c 'Secret href')
+openstack --insecure secret get -p "$HREF" -f value -c Payload
+openstack --insecure secret delete "$HREF"
+```
+
+A payload that comes back unchanged covers the whole chain in one call: the
+catalog row resolves the endpoint, Barbican validates the token against Keystone,
+and the payload travels through castellan's vault plugin into the dedicated
+OpenBao instance and out again. A catalogue-only check misses every step after
+the first.
+
+`forge-barbican-payload` is a throwaway. Real key material does not belong behind
+`--payload`, which leaves it readable in the process argument vector and in your
+shell history; feed it in from a file or from standard input instead. `--insecure`
+is here because the kind gateway presents a self-signed certificate. It disables
+verification for the whole invocation, including the Keystone call above that
+sends `OS_PASSWORD`, so drop it wherever the gateway presents a certificate you
+trust.
+
+## Step 6 — Remove the service
+
+Dropping the `services.barbican` block is not by itself enough to remove
+anything. Deletion takes an annotation, and destroying the stored secret material
+takes a second one.
+
+::: warning Two opt-ins, and never edit the projected children
+The three CRs of step 4 are **projected** by the c5c3-operator. A knob you set on
+`controlplane-barbican`, `controlplane-barbican-store`, or
+`controlplane-barbican-bao` directly is reverted on the next reconcile, and a
+projected child you delete by hand is recreated. Drive every change from the
+`ControlPlane` CR.
+
+Removing `services.barbican` with no annotation **preserves** the Barbican child,
+its store, and the instance; only the dynamic DB-credential generator is torn
+down, because a live generator would keep issuing MySQL users for a service this
+ControlPlane no longer manages. `BarbicanReady` goes `True` with reason
+`BarbicanNotManaged` and the message names what was kept.
+
+`c5c3.io/allow-barbican-deletion=true` authorises the teardown of the Barbican
+child, its secret store, its DB-credential objects, and its catalog rows.
+
+That first annotation is already destructive on the database side. Deleting the
+Barbican child runs its finalizer, which deletes the MariaDB `Database` CR, and
+the CR the operator projects carries no `cleanupPolicy`, so mariadb-operator
+applies its `Delete` default and drops the `barbican` schema:
+`secret_store_metadata`, every secret and container row, the ACLs, and the
+quotas. The payloads in OpenBao outlive that, but nothing references them any
+more. Back the schema up before the teardown if you intend to come back to these
+secrets.
+
+`c5c3.io/allow-barbican-secret-store-data-deletion=true` is required **on top of**
+it before the teardown reaches the dedicated OpenBao instance. That instance
+carries `deletionPolicy: DeletePVCs`, and the teardown removes the static-seal
+Secret as well, so a recovered volume stays unreadable. There is no snapshot, no
+soft delete, and no grace period: every secret Barbican ever stored is gone the
+moment the delete lands. Set this one only when that is what you mean.
+:::
+
+To remove the service and keep the OpenBao instance, back the schema up first,
+then annotate and drop the block:
+
+```bash
+kubectl annotate controlplane controlplane -n openstack \
+  c5c3.io/allow-barbican-deletion=true
+kubectl edit controlplane controlplane -n openstack   # drop the services.barbican block
+```
+
+Re-declaring `services.barbican` later reattaches to the same instance, but not
+to the same secrets: db-sync recreates the dropped schema empty, so `secret list`
+comes back with nothing and the payloads still in OpenBao stay unreferenced.
+Restoring a `barbican` schema dump taken before the teardown is what brings them
+back.
+
+To destroy the instance with the service, set the second annotation before
+dropping the block:
+
+```bash
+kubectl annotate controlplane controlplane -n openstack \
+  c5c3.io/allow-barbican-secret-store-data-deletion=true
+```
+
+That teardown spans several reconciles. The sweep deletes the `OpenBaoCluster`,
+waits for it to leave etcd, and only then removes the seal Secret, the
+provisioner RBAC, and the cluster-scoped auth-delegator binding. Both annotations
+are read from the CR on every one of those passes. Take one away mid-sweep and
+the next pass returns on the preserve branch with the instance already gone,
+leaving that last group behind. No namespace deletion collects a cluster-scoped
+binding, so the auth-delegator stays until someone removes it by hand.
+
+Wait for the sweep to finish. It has when the instance is gone and the binding
+with it:
+
+```bash
+kubectl get openbaocluster controlplane-barbican-bao -n openstack   # expect NotFound
+kubectl get clusterrolebinding | grep controlplane-barbican-bao     # expect no output
+```
+
+Both annotations survive the teardown on the `ControlPlane`, and nothing in the
+operator clears them: left in place, they authorise the next drop of the block
+without a further confirmation. Remove them once the sweep has finished:
+
+```bash
+kubectl annotate controlplane controlplane -n openstack \
+  c5c3.io/allow-barbican-deletion- \
+  c5c3.io/allow-barbican-secret-store-data-deletion-
+```
+
+On a `ControlPlane` reconciled from Git, set and clear both annotations in the
+manifest, not with `kubectl annotate`. Flux applies server-side and prunes only
+the fields it owns, so an annotation it never saw survives every reconcile:
+setting one out of band leaves a live authorisation on the CR that taking it out
+of Git cannot clear. If you already set one out of band, take it away the same
+way, with the `kubectl annotate ... -` above.
+
+## Standalone Barbican, without a ControlPlane
+
+Without a ControlPlane nothing projects the OpenBao instance, the store, or the
+Barbican child, so you own all three. The names below are ones you choose; they
+are not produced by any devstack, and none of the `controlplane-` names from the
+walkthrough above applies here.
+
+The instance is an `OpenBaoCluster` whose self-init provisions what a managed
+store expects to find: the `barbican/` KV v2 mount, the `barbican-secretstore`
+policy, the `barbican` AppRole carrying it, the Kubernetes auth method, and a
+`provisioner` role the barbican-operator logs in through.
+
+```yaml
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: barbican-bao
+  namespace: openstack
+spec:
+  profile: Development
+  version: "2.6.1"        # the static seal needs >= 2.4.0
+  replicas: 1
+  storage:
+    size: 1Gi
+  tls:
+    enabled: true
+    mode: External        # consumes barbican-bao-tls-server and barbican-bao-tls-ca
+  unseal:
+    type: static          # key material: Secret barbican-bao-unseal-key, data key `key`
+  selfInit:
+    enabled: true
+    requests:
+      - name: barbican_kv
+        operation: create
+        path: sys/mounts/barbican
+        secretEngine:
+          type: kv
+          options:
+            version: "2"
+      # ... the policy, approle, and kubernetes-auth requests
+```
+
+`deploy/kind/infrastructure/openbao-instance.yaml` is the complete worked
+example, with every self-init request spelled out and the objects that have to
+exist beside the CR: the two cert-manager `Certificate`s backing the fixed-name
+TLS Secrets, the provisioner `ServiceAccount`, and the `ClusterRoleBinding` that
+grants the instance pods `system:auth-delegator`, without which every
+Kubernetes-auth login fails with 403. Self-init runs once against freshly
+initialised storage and OpenBao revokes the root token afterwards, so changing
+the request list means recreating the instance and its PVC.
+
+The store attaches to the instance by name and marks itself the default:
+
+```yaml
+apiVersion: barbican.openstack.c5c3.io/v1alpha1
+kind: BarbicanSecretStore
+metadata:
+  name: barbican-store
+  namespace: openstack
+spec:
+  barbicanRef:
+    name: barbican
+  type: OpenBao
+  isDefault: true
+  openBao:
+    instanceRef:
+      name: barbican-bao
+```
+
+`kvMountpoint` is left at its default. A store in `instanceRef` mode is pinned to
+`barbican/` and to the root namespace, because that is the only mount the
+self-init contract provisions.
+
+The Barbican CR names its own database, cache, Keystone endpoint, and service
+user:
+
+```yaml
+apiVersion: barbican.openstack.c5c3.io/v1alpha1
+kind: Barbican
+metadata:
+  name: barbican
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 1
+  image:
+    repository: ghcr.io/c5c3/barbican
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-db
+    database: barbican
+    secretRef:
+      name: barbican-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    username: barbican
+    projectName: service
+    userDomainName: Default
+    projectDomainName: Default
+    secretRef:
+      name: barbican-service-user
+      key: password
+```
+
+The store may be applied before the Barbican CR: the attachment is inverted, so a
+dangling `barbicanRef` surfaces as `Ready=False` and resolves when the CR
+appears. See the
+[Barbican CRD API Reference](../../reference/barbican/barbican-crd.md) for the
+full standalone field surface.
+
+## See also
+
+- [BarbicanSecretStore CRD](../../reference/barbican/barbican-secret-store-crd.md) —
+  both store modes, the credential contract, and the condition catalog.
+- [Barbican Reconciler Architecture](../../reference/barbican/barbican-reconciler.md) —
+  the sub-reconciler pipeline behind the child's `Ready`.
+- [Attach an External OpenBao to Barbican](./attach-external-openbao.md) — the
+  same service against a server run outside this control plane.
+- [Migrate Barbican DB to Dynamic Credentials](./migrate-barbican-db-to-dynamic-credentials.md) —
+  the credential mode step 2 onboards.
+
+## Tested by
+
+The projected chain this guide walks through (the `controlplane-barbican-bao`
+instance, the `controlplane-barbican-store` attachment, the minted AppRole
+Secret, and a secret round-trip through the catalog) is asserted on the live CI
+e2e kind cluster by the first suite below. The second drives a managed store
+directly, without a ControlPlane.
+
+```bash
+chainsaw test --test-dir tests/e2e/c5c3/full-controlplane-keystone
+chainsaw test --test-dir tests/e2e/barbican/secretstore-managed
+```
+
+::: details The store CR the secretstore-managed suite applies
+The suite isolates its Barbican from the parallel suite pool, so its CR names are
+the suite's isolation identifiers (Barbican `barbican-store-managed`, store
+`barbican-store-managed-store`, instance `openbao-instance`) rather than the
+`controlplane-barbican` names the walkthrough above uses.
+
+<<< @/../tests/e2e/barbican/secretstore-managed/01-barbican-secretstore.yaml#managed-store
+:::

--- a/docs/guides/barbican/barbican-dedicated-openbao.md
+++ b/docs/guides/barbican/barbican-dedicated-openbao.md
@@ -41,9 +41,13 @@ KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 ```
 
 Follow that tutorial through to its final **Verify** step, so a `ControlPlane`
-CR named `controlplane` is `Ready` in the `openstack` namespace. That tutorial's
-CR declares no `services.barbican`; step 1 below adds it. Every resource name in
-the examples that follow is one this devstack produces.
+CR named `controlplane` is `Ready` in the `openstack` namespace. Its Step 3 CR
+already carries the `services.barbican` block step 1 shows, so on a devstack
+brought up from it the service is reconciled and step 1 reads as a check. A
+ControlPlane created before that block existed, or from the bundled minimal CR
+(`deploy/kind/controlplane/controlplane.yaml`, keystone and horizon only), gets
+the block added in step 1. Every resource name in the examples that follow is
+one this devstack produces.
 :::
 
 1. **The `python-barbicanclient` plugin on `PATH`.** The `openstack secret`
@@ -97,9 +101,10 @@ from the Keystone child's naming convention; none of them is set here.
 
 On the managed shared database the Barbican DB credential is engine-issued, and
 `setup-database-tenant.sh` provisions one engine connection and one role per
-declared service. It skips a service the ControlPlane does not declare, so the
-run from the tutorial's Step 4 provisioned no Barbican pair. Re-run it now that
-the block exists:
+declared service. It reads the live ControlPlane spec on every run and skips a
+service the CR does not declare, so a tenant setup that ran before
+`services.barbican` was declared provisioned no Barbican pair. Re-run it in that
+case:
 
 ```bash
 export BAO_TOKEN=$(kubectl get secret openbao-init-keys -n shared-services \
@@ -108,12 +113,13 @@ deploy/openbao/bootstrap/setup-database-tenant.sh openstack controlplane
 unset BAO_TOKEN
 ```
 
-The script is idempotent: it refreshes the pairs of the other services in place
-and adds `database/mariadb/config/barbican-openstack` and
-`database/mariadb/roles/barbican-openstack`. Skipping it parks the next step on
-`BarbicanReady=False` with reason `WaitingForBarbicanDBCredential`, and the
-message names the `database/mariadb/creds/barbican-openstack` path it is waiting
-for.
+The script is idempotent: every config and role write is an upsert, so a repeat
+refreshes the pairs of the other services in place and writes
+`database/mariadb/config/barbican-openstack` and
+`database/mariadb/roles/barbican-openstack`, new when the earlier run skipped
+Barbican. Without that pair the next step parks on `BarbicanReady=False` with
+reason `WaitingForBarbicanDBCredential`, and the message names the
+`database/mariadb/creds/barbican-openstack` path it is waiting for.
 
 ## Step 3 — Watch BarbicanReady
 

--- a/docs/guides/barbican/enable-barbican-operator-metrics.md
+++ b/docs/guides/barbican/enable-barbican-operator-metrics.md
@@ -1,0 +1,171 @@
+---
+title: Enable the Barbican Operator Metrics Endpoint
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- operator namespace is `barbican-system`; workload (Barbican CR) stays in `openstack`. -->
+
+# How-to: Enable the Barbican Operator Metrics Endpoint
+
+This guide walks an operator through turning on the Prometheus ServiceMonitor
+shipped with the `barbican-operator` Helm chart, importing the reference Grafana
+dashboard, and verifying that scrape targets transition to `Up`.
+
+The barbican-operator emits the shared sub-reconciler instrumentation under the
+`barbican_operator` prefix, plus per-CR collectors covering the schema migration,
+the recurring clean-up, and the secret store's AppRole rotation:
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `barbican_operator_reconcile_duration_seconds` | histogram | `sub_reconciler` |
+| `barbican_operator_reconcile_errors_total` | counter | `sub_reconciler`, `condition_type` |
+| `barbican_operator_db_sync_total` | counter | `barbican`, `namespace`, `result` |
+| `barbican_operator_db_sync_duration_seconds` | histogram | `barbican`, `namespace` |
+| `barbican_operator_db_clean_total` | counter | `barbican`, `namespace`, `result` |
+| `barbican_operator_db_clean_duration_seconds` | histogram | `barbican`, `namespace` |
+| `barbican_operator_secretstore_remints_total` | counter | `store`, `namespace`, `trigger` |
+
+The clean-up pair has no counterpart on the other service operators. Barbican
+never hard-deletes: deleting a secret, container, or order flips its row to
+deleted, so every Barbican gets a `{name}-db-clean` CronJob and the counter and
+histogram track its terminal runs.
+
+`barbican_operator_secretstore_remints_total` is keyed on the
+`BarbicanSecretStore` CR rather than on its parent Barbican, and its `trigger`
+label carries `proactive` when the operator refreshed the AppRole secret ID
+before its TTL lapsed and `reactive` when the credential had already been
+rejected. The split is what tells a rotation schedule that runs on time from one
+that keeps arriving late.
+
+For the controller-side contract (which sub-reconciler drives which condition),
+see
+[Barbican Reconciler Architecture](../../reference/barbican/barbican-reconciler.md).
+
+::: tip On kind
+If you are running the kind ControlPlane Quick Start, the prometheus-operator
+CRDs, Prometheus, and Grafana are already wrapped behind opt-in flags:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra
+```
+
+`WITH_PROMETHEUS=true` also flips the barbican-operator `ServiceMonitor` for you
+at bring-up (`deploy-infra` patches the barbican-operator HelmRelease), so on a
+fresh kind devstack none of the manual steps below are required. Step 1 is the
+path for a devstack that is **already running** without `WITH_PROMETHEUS`, or for
+non-kind clusters that run their own Prometheus.
+:::
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true WITH_PROMETHEUS=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the barbican-operator
+(namespace `barbican-system`) is running with kube-prometheus-stack scraping it.
+:::
+
+1. A running `barbican-operator` Helm release (namespace `barbican-system`).
+2. The prometheus-operator CRDs (`servicemonitors.monitoring.coreos.com`)
+   installed, and a Prometheus whose `serviceMonitorSelector` covers the
+   operator namespace.
+3. For the per-CR series in Step 3, a `Barbican` CR the operator has already
+   reconciled. On the ControlPlane devstack that is the projected
+   `controlplane-barbican` child, which the ControlPlane only projects when it
+   declares `spec.services.barbican`. See
+   [Run Barbican on a Dedicated OpenBao](./barbican-dedicated-openbao.md).
+
+## Step 1 — Enable the ServiceMonitor
+
+On the tutorial devstacks the `barbican-operator` release is owned by Flux (a
+`HelmRelease`), so set the chart value by patching that HelmRelease rather than
+running a raw `helm upgrade`. Flux's helm-controller reverts any out-of-band
+Helm revision on its next reconcile:
+
+```bash
+kubectl patch helmrelease barbican-operator -n barbican-system --type=merge \
+  -p '{"spec":{"values":{"monitoring":{"serviceMonitor":{"enabled":true}}}}}'
+
+kubectl wait helmrelease/barbican-operator -n barbican-system \
+  --for=condition=Ready --timeout=5m
+```
+
+Confirm the `ServiceMonitor` was rendered:
+
+```bash
+kubectl -n barbican-system get servicemonitor \
+  -l app.kubernetes.io/name=barbican-operator
+```
+
+The chart renders a `ServiceMonitor` scraping the operator's metrics Service on
+the `https`-less metrics port with the shared operator-library labels, at the
+`monitoring.serviceMonitor.interval` the values file defaults to 30s.
+
+::: details Helm-managed installations (non-Flux)
+If you installed the operator directly with Helm (not through Flux), set the
+value with a rolling `helm upgrade` instead:
+
+```bash
+helm upgrade barbican-operator oci://ghcr.io/c5c3/charts/barbican-operator \
+  --namespace barbican-system --reuse-values \
+  --set monitoring.serviceMonitor.enabled=true
+```
+
+Do **not** run this on the tutorial devstacks: there the release is Flux-owned,
+and the helm-controller reverts out-of-band revisions on its next reconcile. Use
+the HelmRelease patch above instead.
+:::
+
+## Step 2 — Import the Grafana dashboard
+
+The reference dashboard ships in-repo at
+`operators/barbican/dashboards/barbican-operator.json` (uid `barbican-operator`):
+per-sub-reconciler duration quantiles, error rate per condition type, db-sync and
+db-clean p95 with their failure rates, secret-store AppRole re-mints per trigger,
+and the controller-runtime end-to-end reconcile histogram. Import it via the
+Grafana UI or provision it from a ConfigMap.
+
+## Step 3 — Verify the target
+
+```bash
+kubectl -n <prometheus-namespace> port-forward svc/prometheus-operated 9090 &
+curl -s 'http://localhost:9090/api/v1/targets' \
+  | jq '.data.activeTargets[] | select(.labels.namespace == "barbican-system") | .health'
+```
+
+Expect `"up"`. Then confirm the series exist:
+
+```bash
+curl -s 'http://localhost:9090/api/v1/query?query=barbican_operator_reconcile_duration_seconds_count' \
+  | jq '.data.result | length'
+```
+
+A non-zero result count means the operator has reconciled at least one Barbican
+CR since the scrape began. The per-CR series fill in later and on their own
+schedules: db-sync publishes when the migration Job terminates, db-clean when the
+CronJob's first run does, and the re-mint counter only once a managed store
+actually rotates its secret ID. A freshly created CR therefore shows the
+reconcile series first and the rest as its jobs complete.
+
+## Tested by
+
+The chart's ServiceMonitor render-and-remove lifecycle is asserted on the CI e2e
+kind cluster by the chainsaw suite below (install with
+`monitoring.serviceMonitor.enabled=true`, assert the `ServiceMonitor` shape,
+uninstall, assert removal). The end-to-end scrape path (a live Prometheus that
+discovers the ServiceMonitor and marks the target Up) is the
+`WITH_PROMETHEUS=true` kind bring-up shown in the tip above, not this suite: the
+e2e cluster ships only the prometheus-operator CRDs, not a Prometheus instance.
+
+```bash
+chainsaw test --test-dir tests/e2e/barbican-operator/metrics
+```

--- a/docs/guides/barbican/enable-barbican-operator-networkpolicy.md
+++ b/docs/guides/barbican/enable-barbican-operator-networkpolicy.md
@@ -1,0 +1,326 @@
+---
+title: Enable the Barbican Operator NetworkPolicy
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- operator namespace is `barbican-system`; workload (Barbican CR) stays in `openstack`. -->
+
+# How-to: Enable the Barbican Operator NetworkPolicy
+
+This guide walks an operator through opting in to the chart-level NetworkPolicy
+that restricts the barbican-operator pod's egress and ingress to the minimum
+required for correct reconciliation.
+
+> **Scope.** This guide covers the NetworkPolicy that protects the
+> **operator pod itself**. For the per-CR NetworkPolicy that protects the
+> Barbican API pods (`spec.networkPolicy` on a Barbican CR), see the
+> [Barbican CRD API Reference](../../reference/barbican/barbican-crd.md).
+> That per-CR policy restricts ingress to TCP 9311 from the sources you list
+> (at least one is required, so an empty list is refused) and derives its egress
+> from the CR: DNS, the database, the Keystone endpoint's port, the cache, and
+> the OpenBao servers of its attached secret stores, with `additionalEgress`
+> appended after it.
+
+---
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step, so the barbican-operator
+is running (namespace `barbican-system`) alongside the projected
+`controlplane-barbican` key manager.
+:::
+
+1. **A CNI that enforces `networking.k8s.io/v1` NetworkPolicy (required for
+   real enforcement).** Confirm with your platform team (Calico, Cilium, and
+   Antrea enforce).
+
+   ::: warning Enforcement cannot be verified on the default devstack CNI
+   The ControlPlane Quick Start kind devstack uses the default `kindnet` CNI,
+   which **silently ignores** NetworkPolicy objects, and kind fixes the CNI at
+   cluster creation so it cannot be swapped in afterwards. The policy object
+   is still created and the operator keeps reconciling, so Step 2 below
+   confirms only the policy's **shape** and that enabling it does **not
+   break** reconciliation. It does **not** prove that packets outside the
+   allow-list are dropped. Real enforcement requires a cluster whose CNI
+   enforces NetworkPolicy, typically your production platform.
+   :::
+2. A running `barbican-operator` Helm release (namespace `barbican-system`).
+3. The ControlPlane declares `spec.services.barbican`. Without it no
+   `controlplane-barbican` child exists and the Step 2 verification has nothing
+   to roll. See
+   [Run Barbican on a Dedicated OpenBao](./barbican-dedicated-openbao.md).
+
+## Step 1 — Enable the policy
+
+The chart guards `networkPolicy.enabled=true` with a fail-closed check:
+`networkPolicy.kubeApiServer.cidrs` and `ports` must both be non-empty, or the
+template refuses to render. Gather the API server CIDRs and ports from the
+`kubernetes` **Endpoints**, the real API server addresses, not the `10.96.0.1`
+Service VIP that `kubectl get service kubernetes` reports. An enforcing CNI
+(Calico, Cilium) DNATs a packet aimed at the VIP to one of those endpoint IPs
+before it evaluates policy, so a rule naming the VIP never matches:
+
+```bash
+kubectl get endpoints kubernetes -n default -o json \
+  | jq -r '.subsets[] | (.addresses[].ip) as $ip | (.ports[].port) as $p | "\($ip)/32 port=\($p)"'
+```
+
+Record **every** endpoint IP the command prints, not just the first. A kind
+devstack reports the one control-plane node's address on the kind bridge
+(`172.18.0.x`), but an HA control plane reports one per API server replica:
+
+```
+10.0.0.10/32 port=6443
+10.0.0.11/32 port=6443
+10.0.0.12/32 port=6443
+```
+
+The rule must cover all of them, or the operator loses its leader-election lease
+whenever it happens to be talking to an excluded replica.
+
+On the tutorial devstacks the `barbican-operator` release is owned by Flux (a
+`HelmRelease`), so set the values by patching its `spec.values`, not with a raw
+`helm upgrade`, which the Flux helm-controller reverts on its next reconcile.
+Substitute the CIDRs and ports from above. The single-CIDR list below stands in
+for the kind case (one control-plane node), so replace `172.18.0.2/32` with the
+address you recorded and extend the list to every IP an HA control plane prints:
+
+```bash
+kubectl patch helmrelease barbican-operator -n barbican-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"enabled":true,"kubeApiServer":{"cidrs":["172.18.0.2/32"],"ports":[6443]}}}}}'
+
+kubectl wait helmrelease/barbican-operator -n barbican-system \
+  --for=condition=Ready --timeout=5m
+```
+
+The rendered policy declares `policyTypes: [Ingress, Egress]`, so both directions
+default-deny and only the rules the chart emits get through: egress to the
+kube-apiserver, to DNS, and to OpenBao on TCP 8200, plus ingress to the webhook
+and metrics ports.
+
+### API egress is not in the chart
+
+The barbican-operator probes `/healthcheck` on the Barbican Service over TCP 9311
+in the workload namespace to set `BarbicanAPIReady`. The chart emits **no** egress
+rule for that port and offers no value to add one, so on an enforcing CNI the
+probe is dropped and every Barbican parks on `BarbicanAPIReady=False` /
+`APIUnhealthy` while the API itself is serving normally. Cover it with a second
+NetworkPolicy of your own selecting the operator pod — policies are additive, so
+its egress rule joins the chart's:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: barbican-operator-api-egress
+  namespace: barbican-system
+spec:
+  podSelector:
+    matchLabels:
+      # The chart's own selector, so this policy attaches to the same pod.
+      app.kubernetes.io/name: barbican-operator
+      app.kubernetes.io/instance: barbican-operator
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openstack
+      ports:
+        - protocol: TCP
+          port: 9311
+```
+
+The ingress leg of that same probe needs nothing from you: when the workload
+namespace runs a per-CR NetworkPolicy, the sub-reconciler appends an
+operator-namespace ingress peer to every policy it renders.
+
+### OpenBao egress
+
+The barbican-operator dials the OpenBao server of every store it reconciles, so
+the chart carries a rule of its own for it, on by default:
+
+```yaml
+networkPolicy:
+  openBao:
+    enabled: true
+```
+
+The rule names TCP 8200 and no peer. A brownfield store points at a user-supplied
+server whose address the chart cannot know, so restricting the destination would
+mean guessing it. Set `openBao.enabled=false` when every store in the cluster is
+reached over a different posture, a non-standard port or an egress proxy already
+covered by another policy, and add the matching rule yourself. With the policy on
+and this rule off, the store controller cannot reach any server and every store
+parks on `CredentialsReady=False` with reason `OpenBaoUnreachable`.
+
+The per-CR policy derives its OpenBao egress differently, so do not read one as
+the model for the other. It emits a **single** destination-unrestricted egress
+rule carrying one port entry per distinct port across the store hosts of that
+Barbican, deduplicated and sorted ascending, and only when at least one
+credential-ready store yields a usable port. Ten stores on ten hosts that all
+listen on 8200 therefore produce one rule with one port.
+
+### Metrics ingress
+
+Metrics ingress is opt-in and separate. `networkPolicy.allowMetricsFrom` is empty
+by default, and with the policy on, an empty list means no ingress rule for the
+metrics port at all, so a Prometheus that scraped the operator before stops
+reaching it. Name the scraping namespace when you enable both this policy and the
+ServiceMonitor from
+[Enable the Barbican Operator Metrics Endpoint](./enable-barbican-operator-metrics.md):
+
+```bash
+kubectl patch helmrelease barbican-operator -n barbican-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"allowMetricsFrom":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"monitoring"}}}]}}}}'
+```
+
+Each entry is rendered verbatim as a `NetworkPolicyPeer`, so a `podSelector`
+narrows it further to the Prometheus pods.
+
+::: details Helm-managed installations (non-Flux)
+If you installed the operator directly with Helm (not through Flux), set the
+values with a rolling `helm upgrade`. The fail-closed guard still requires
+`kubeApiServer.cidrs` and `ports`:
+
+```bash
+helm upgrade barbican-operator oci://ghcr.io/c5c3/charts/barbican-operator \
+  --namespace barbican-system --reuse-values \
+  --set networkPolicy.enabled=true \
+  --set 'networkPolicy.kubeApiServer.cidrs[0]=172.18.0.2/32' \
+  --set 'networkPolicy.kubeApiServer.ports[0]=6443'
+```
+
+Do **not** run this on the tutorial devstacks: there the release is Flux-owned,
+and the helm-controller reverts out-of-band revisions on its next reconcile. Use
+the HelmRelease patch above instead.
+:::
+
+## Step 2 — Verify
+
+On the kind devstack this verifies the policy's **shape** and that enabling it
+does **not break** reconciliation, not traffic enforcement, which the default
+`kindnet` CNI does not apply (see the prerequisite above).
+
+```bash
+kubectl -n barbican-system get networkpolicy
+kubectl -n barbican-system describe networkpolicy barbican-operator
+```
+
+Then confirm reconciliation still works end-to-end by driving a change through
+the `ControlPlane` CR and watching the projected key manager roll out:
+
+```bash
+kubectl patch controlplane controlplane -n openstack --type merge \
+  -p '{"spec":{"services":{"barbican":{"replicas":2}}}}'
+kubectl rollout status deploy/controlplane-barbican -n openstack
+
+# revert
+kubectl patch controlplane controlplane -n openstack --type merge \
+  -p '{"spec":{"services":{"barbican":{"replicas":1}}}}'
+```
+
+Set the replica count on the `ControlPlane` CR, not on the projected
+`controlplane-barbican` child: the c5c3-operator re-asserts the child's
+`spec.deployment.replicas` on every reconcile, so a direct edit of the child is
+reverted.
+
+## Troubleshooting
+
+### Reconcile timeouts / leader-election churn
+
+**Symptom:** operator logs show `Get https://<kube-apiserver>: i/o timeout` or
+leader-election lease renewals fail with `context deadline exceeded`, and the
+`barbican-operator` pod restarts.
+
+**Diagnosis:** the egress allow-list does not match the API server the operator
+actually dials. Either `kubeApiServer.cidrs` is missing one or more of the
+current endpoint IPs (an HA control plane may have added a replica, or a
+control-plane node may have been replaced with a different IP), or your CNI maps
+the API server behind a port that is not in `kubeApiServer.ports`.
+
+**Fix:** re-run the discovery command from Step 1 and update
+`networkPolicy.kubeApiServer.cidrs` to include **every** IP it returns, plus
+every port:
+
+```bash
+kubectl get endpoints kubernetes -n default -o json \
+  | jq -r '.subsets[] | (.addresses[].ip) as $ip | (.ports[].port) as $p | "\($ip)/32 port=\($p)"'
+```
+
+### Every secret store reports OpenBaoUnreachable
+
+**Symptom:** every `BarbicanSecretStore` in the cluster flips to
+`CredentialsReady=False` / `OpenBaoUnreachable` with `context deadline exceeded`,
+including stores that were Ready before the policy went on.
+
+**Diagnosis:** the store controller's egress to the OpenBao API is blocked. A
+dropped packet has no refusal to report, so the client waits out its own deadline
+and reports a timeout rather than a connection error. The usual causes are
+`networkPolicy.openBao.enabled=false` with no replacement rule, or a server that
+listens on a port other than 8200.
+
+**Fix:** re-enable the chart rule. Its port is fixed at 8200 and the chart offers
+no override, so a server on another port needs a second NetworkPolicy of your own
+selecting the operator pod; policies are additive, so its egress rule joins the
+chart's. Verify from the rendered object rather than from the values:
+
+```bash
+kubectl -n barbican-system get networkpolicy barbican-operator \
+  -o jsonpath='{.spec.egress[*].ports}'
+```
+
+### Every Barbican write is rejected
+
+**Symptom:** `kubectl apply` on a `Barbican` or `BarbicanSecretStore` CR fails
+with `failed calling webhook` plus `connection refused` or `no route to host`.
+The `ControlPlane` stalls too: the c5c3-operator projects `controlplane-barbican`
+and `controlplane-barbican-store` through the same admission path, so its
+reconcile fails on the same error.
+
+**Diagnosis:** webhook ingress (9443) is blocked. Both barbican webhooks register
+`failurePolicy=Fail` on create and update, so an unreachable operator turns into
+a cluster-wide rejection of every write to either kind. The usual cause is an API
+server that calls webhooks from an IP that is **not** in `endpoints/kubernetes`,
+for example because it sits behind a front-end proxy.
+`networkPolicy.webhookClients.cidrs` falls back to `kubeApiServer.cidrs` when
+empty, which is wrong in that topology.
+
+**Fix:** discover the actual caller IP (check the API-server audit log or the
+`kube-apiserver` Pod's `--advertise-address`) and set
+`networkPolicy.webhookClients.cidrs` explicitly:
+
+```bash
+kubectl patch helmrelease barbican-operator -n barbican-system --type=merge \
+  -p '{"spec":{"values":{"networkPolicy":{"webhookClients":{"cidrs":["10.1.0.0/24"]}}}}}'
+```
+
+If the wedge blocks you from recovering, set `networkPolicy.enabled=false` with
+the same patch shape. The policy object is removed on the next reconcile and the
+operator reverts to unrestricted pod networking without a pod restart.
+
+## Tested by
+
+Every operator chart carries an equivalent chart-level NetworkPolicy template
+(each chart ships its own copy, not a shared operator-library helper). The
+keystone chart's copy is exercised end-to-end on the CI e2e kind cluster by the
+chainsaw suite below; the barbican chart's copy, including its OpenBao egress
+rule, is pinned by its helm-unittest
+(`operators/barbican/helm/barbican-operator/tests/networkpolicy_test.yaml`).
+
+```bash
+chainsaw test --test-dir tests/e2e/keystone-operator/network-policy-egress
+```

--- a/docs/guides/barbican/migrate-barbican-db-to-dynamic-credentials.md
+++ b/docs/guides/barbican/migrate-barbican-db-to-dynamic-credentials.md
@@ -1,0 +1,277 @@
+---
+title: Migrate Barbican DB to Dynamic Credentials
+quadrant: operator
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Migrate Barbican DB to Dynamic Credentials
+
+This guide takes a managed-mode ControlPlane from a long-lived **static**
+Barbican database credential to **dynamic**, engine-issued credentials, without
+database downtime. It is the operator-facing side of the OpenBao MariaDB database
+secrets engine wired for the Barbican service DB user.
+
+The credential this migration moves is the one Barbican's metadata schema is
+reached with. The secret material itself lives in the service's OpenBao secret
+store, which is a separate concern and is untouched here.
+
+## What changes
+
+- **Before:** the Barbican DB password is a long-lived value materialised from an
+  OpenBao KV path (`openstack/barbican/{namespace}/{name}/db`) into the
+  `{name}-barbican-db-credentials` Secret. Nothing seeds that path, so on the
+  static branch an operator writes it and rotates it by hand.
+- **After:** the c5c3 operator projects a per-ControlPlane
+  [`VaultDynamicSecret`](https://external-secrets.io/) generator that reads
+  short-lived credentials from the OpenBao database engine
+  (`database/mariadb/creds/barbican-{namespace}`, where `{namespace}` is the
+  Barbican service namespace, the ControlPlane's own namespace unless Barbican
+  runs in a dedicated one). The External Secrets Operator re-issues a fresh lease
+  before the previous one expires and materialises the current username and
+  password into the same Secret. No long-lived static DB password remains at
+  rest.
+
+The engine issues an ephemeral MySQL user per lease (for example `v-kube-...`)
+with `ALL PRIVILEGES` on the Barbican database and drops it at lease end.
+
+## Prerequisites
+
+::: info Devstack
+This guide is written against the **[Quick Start (ControlPlane)](../../quick-start-controlplane.md)** devstack. Stand it up first:
+
+```bash
+KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
+```
+
+Follow that tutorial through to its final **Verify** step. On this devstack the
+ControlPlane is `controlplane` in `openstack`, so its projected Barbican is
+`controlplane-barbican` and its DB-credential Secret is
+`controlplane-barbican-db-credentials`. Those are the names the migration below
+manages.
+:::
+
+- The ControlPlane declares `spec.services.barbican`. Without it the operator
+  projects no Barbican child and no DB credential of either kind. See
+  [Run Barbican on a Dedicated OpenBao](./barbican-dedicated-openbao.md).
+- The OpenBao `database` secrets engine is mounted at `database/mariadb` (the
+  `setup-secret-engines.sh` bootstrap step). A greenfield cluster already has it;
+  on a brownfield cluster, re-apply the bootstrap scripts (see below).
+- cert-manager and its `openbao-ca-issuer` ClusterIssuer are installed. They
+  issue the per-ControlPlane mTLS client certificate the generator presents to
+  the OpenBao listener.
+- The External Secrets Operator can request ServiceAccount tokens
+  (`serviceaccounts/token` `create`) so the generator can authenticate to OpenBao
+  as the `barbican-db-creds` ServiceAccount.
+
+## Migration steps
+
+### 1. Re-apply the OpenBao bootstrap on brownfield clusters
+
+The database engine mount, the `barbican-db` Kubernetes-auth role, and the
+`barbican-db-dynamic` policy are written by the (idempotent) bootstrap scripts.
+Re-apply them so a cluster provisioned before Barbican was onboarded picks them
+up:
+
+```bash
+# From the repo root, with BAO_TOKEN exported (the OpenBao root token).
+bash deploy/openbao/bootstrap/setup-secret-engines.sh
+bash deploy/openbao/bootstrap/setup-auth.sh
+bash deploy/openbao/bootstrap/setup-policies.sh
+```
+
+`make deploy-infra` runs these for you on a fresh kind cluster.
+
+### 2. Onboard the per-tenant database-engine role
+
+The engine role for a tenant only exists once its MariaDB is Ready and
+`setup-database-tenant.sh` has configured the connection and role against it:
+
+```bash
+# BAO_TOKEN must be exported; <namespace>/<controlplane> identify the tenant.
+bash deploy/openbao/bootstrap/setup-database-tenant.sh <namespace> <controlplane>
+```
+
+When the ControlPlane declares `spec.services.barbican` on the shared managed
+database, the script provisions the Barbican leg:
+
+- `database/mariadb/config/barbican-<barbican-namespace>`, the connection to the
+  tenant's MariaDB, authenticated as root.
+- `database/mariadb/roles/barbican-<barbican-namespace>`, the role that issues
+  short-lived users on the `barbican` schema (`default_ttl` 48h, `max_ttl` 72h by
+  default; override with `DB_CREDS_DEFAULT_TTL` / `DB_CREDS_MAX_TTL`).
+
+The script reads the live ControlPlane spec on every run and skips a service the
+CR does not declare, so adding `services.barbican` to an existing ControlPlane
+means running it again.
+
+When Barbican lives in a dedicated service namespace, that namespace's MariaDB
+must be Ready first: the script resolves that namespace's root secret and fails
+loudly otherwise. A ControlPlane whose Barbican declares a *dedicated* database is
+skipped, because a dedicated Barbican database is Static-only. The c5c3 admission
+webhook enforces the same rule from the other side and rejects
+`spec.services.barbican.databaseCredentialsMode: Dynamic` on a Barbican that
+declares `dedicatedBackingServices.database`. A Dynamic override on a brownfield
+shared database (one with no `clusterRef`) is rejected for the same reason: no
+engine role exists that could issue its credentials.
+
+The bundled kind ControlPlane declares no `services.barbican`, so the automatic
+onboarding under `make deploy-infra WITH_CONTROLPLANE=true WITH_CONTROLPLANE_CR=true`
+covers no Barbican leg. Run the script yourself after adding the block.
+
+### 3. (Optional) Stage the cutover with `databaseCredentialsMode: Static`
+
+Dynamic is the default effective mode for a managed ControlPlane on the shared
+database. To keep Barbican on a static credential, for example while Keystone and
+Glance already run Dynamic, pin the per-service override so the blast radius
+stays on Barbican:
+
+```yaml
+spec:
+  services:
+    barbican:
+      databaseCredentialsMode: Static
+```
+
+The shared `spec.infrastructure.database.credentialsMode: Static` opts out
+ControlPlane-wide instead; the per-service override scopes the opt-out to
+Barbican alone. Nothing seeds the static KV path, so while staging you must write
+`kv-v2/openstack/barbican/<namespace>/<controlplane>/db` (`username`, `password`)
+by hand, with `username` set to the Barbican child's name
+(`<controlplane>-barbican`), which is the login the operator's MariaDB
+`User`/`Grant` provisions. Remove the override (or set it to `Dynamic`) to cut
+over.
+
+### 4. Upgrade the operators and observe the cutover
+
+Upgrade the c5c3 and barbican operators to a build that includes the dynamic
+engine wiring. On the next reconcile the c5c3 operator projects the generator,
+ServiceAccount, and Certificate, and the ExternalSecret switches to drawing from
+the generator.
+
+On a cluster that ran the static path, delete the materialised credential Secret
+once so the engine-issued value is the only thing that can ever be read from it:
+
+```bash
+kubectl delete secret <controlplane>-barbican-db-credentials -n <namespace>
+```
+
+The ExternalSecret is updated in place (same name, same target Secret), so until
+ESO's first generator-backed sync lands the Secret still holds whatever the
+previous static sync wrote. Deleting it forces ESO to re-materialise from the
+generator immediately instead of at the next refresh.
+
+You do not have to get this right for Barbican to stay up: the c5c3 operator will
+not project `credentialsMode: Dynamic` onto the Barbican child until that
+ExternalSecret reports Ready **and** the Secret behind it carries an
+engine-issued username. While either is outstanding, `BarbicanReady` is `False`
+with reason `WaitingForBarbicanDBCredential`, the running child keeps its current
+mode, and the message names either the
+`database/mariadb/creds/barbican-<namespace>` path from step 2 or the stale
+username it found. A ControlPlane stuck on the path message has not been
+onboarded; re-run step 2. One stuck on the username message is waiting for the
+sync this deletion shortcuts.
+
+Watch for:
+
+- The `controlplane-barbican-db-credentials` ExternalSecret spec changing from
+  static `data[].remoteRef` to `dataFrom[].sourceRef.generatorRef` (kind
+  `VaultDynamicSecret`).
+- The materialised Secret's `username` becoming an engine-issued login rather
+  than `controlplane-barbican`.
+- A Barbican Deployment rollout: the operator stamps a
+  `barbican.c5c3.io/db-connection-hash` pod-template annotation, so a rotated
+  credential rolls the Deployment. The DSN travels in the
+  `OS_DATABASE__CONNECTION` environment variable, which only takes effect on a
+  Pod restart.
+
+The engine's `GRANT` overlaps the pre-existing operator-provisioned `User` and
+`Grant` from the static deployment, so Barbican keeps serving throughout. The
+rolling restart moves it onto an engine-issued login one pod at a time; at two or
+more replicas the API stays answerable across the roll.
+
+### 5. Retire the static credential
+
+Once the ControlPlane reports `BarbicanReady=True` on the dynamic path:
+
+1. Delete the leftover static MariaDB `User` and `Grant` CRs (they carry the
+   long-lived `<controlplane>-barbican` login the engine no longer uses):
+
+   ```bash
+   kubectl delete user,grant <barbican-cr-name> -n <namespace> --ignore-not-found
+   ```
+
+2. Remove the retired static KV secret, if step 3 ever seeded it:
+
+   ```bash
+   # Inside the OpenBao pod, or with a bao client configured for it.
+   bao kv metadata delete kv-v2/openstack/barbican/<namespace>/<controlplane>/db
+   ```
+
+## Rollback
+
+To revert to the static credential, set the mode back to `Static` (the
+per-service `spec.services.barbican.databaseCredentialsMode` override, or the
+shared `spec.infrastructure.database.credentialsMode`), re-seed the KV path
+(step 3), and let the next Static-mode reconcile re-create the `User`/`Grant`.
+Roll back the operators if you also need to remove the generator objects.
+
+## Operational considerations
+
+- **Rotation churn against lease headroom:** the DSN is consumed via an
+  environment variable, so a rotated engine credential only takes effect on a Pod
+  restart and Barbican rolls each time the ExternalSecret re-issues the
+  credential. Every refresh is a new credential; there is no stable value to
+  renew in place. The defaults balance two concerns: the 24h refresh interval
+  keeps the roll cadence to at most once a day, while the 48h `default_ttl`
+  leaves a 24h gap (`default_ttl` minus refresh) in which to roll the pods before
+  the previous, still-in-use lease is revoked. Raise `DB_CREDS_DEFAULT_TTL` /
+  `DB_CREDS_MAX_TTL` (and the operator's refresh interval) to trade churn against
+  lease headroom. Run more than one replica if the roll must not interrupt the
+  API: the Deployment uses the default rolling update, and a single-replica
+  Barbican is unavailable for the length of one pod restart.
+- **Auth-token TTL bounds the lease:** OpenBao revokes a dynamic-secret lease
+  together with the auth token that minted it, so the effective credential
+  lifetime is `min(lease TTL, minting token TTL)`. The `barbican-db` auth role
+  therefore pins `token_ttl` and `token_max_ttl` to 72h, the `DB_CREDS_MAX_TTL`
+  default. When raising `DB_CREDS_*` beyond that, raise the role's TTLs in
+  lockstep. A shorter token silently drops the ephemeral MySQL user under a
+  running Barbican long before the advertised lease end.
+- **The db-clean CronJob rides the same credential.** Barbican never
+  hard-deletes, so a `{name}-db-clean` CronJob runs on a schedule of its own. It
+  reads the DSN at pod start from the derived `{name}-db-connection` Secret, which
+  the operator re-renders from each engine-issued credential. A run that starts
+  after a lease was revoked and before the re-render lands fails and is retried on
+  the next schedule; it removes no rows in between.
+- **Revocation semantics:** revoking a lease runs `DROP USER`, which rejects new
+  connections. Already-open sessions of a dropped user may persist until they
+  disconnect.
+- **ESO or OpenBao outage longer than the lease:** the materialised credential
+  expires before a refresh lands. Running Pods keep pooled connections, but new
+  connections fail until ESO recovers. This surfaces through the Barbican child's
+  own database readiness and, ControlPlane-side, as `BarbicanReady=False`.
+
+## See also
+
+- [OpenBao Bootstrap reference](../../reference/infrastructure/openbao-bootstrap.md) —
+  engines, auth roles, policies, and secret paths.
+- [Barbican CRD API Reference](../../reference/barbican/barbican-crd.md) —
+  `spec.database.credentialsMode` and the fields the ControlPlane projects onto
+  the child.
+- [Migrate Placement DB to Dynamic Credentials](../placement/migrate-placement-db-to-dynamic-credentials.md) —
+  the sibling migration for the Placement service DB user.
+
+## Tested by
+
+The dynamic, engine-issued per-ControlPlane database credential this guide
+migrates to (the projected Dynamic mode, the `VaultDynamicSecret`, the
+generator-backed `controlplane-barbican-db-credentials` ExternalSecret, and the
+transient engine-issued login) is asserted on the live CI e2e kind cluster by
+this chainsaw suite:
+
+```bash
+chainsaw test --test-dir tests/e2e/c5c3/full-controlplane-keystone
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,9 @@ layer — built with the Operator SDK (Go), controller-runtime, and Kubebuilder.
 The implementation follows a Keystone-first strategy. The Keystone operator is
 the reference implementation that establishes the patterns — CRD layout,
 sub-reconciler chain, webhooks, finalizers, instrumentation — replicated by
-every subsequent service operator. Horizon, Glance, and Placement are already
-onboarded on the same scaffolding, and the c5c3-operator ties the services
-together into a single ControlPlane resource.
+every subsequent service operator. Horizon, Glance, Placement, and Barbican are
+already onboarded on the same scaffolding, and the c5c3-operator ties the
+services together into a single ControlPlane resource.
 
 ## Start here
 
@@ -33,8 +33,8 @@ together into a single ControlPlane resource.
   with [Keystone](./reference/keystone/) as the reference implementation and the
   [c5c3-operator](./reference/c5c3/controlplane-crd.md) as the ControlPlane
   orchestration layer. [Horizon](./reference/horizon/),
-  [Glance](./reference/glance/), and [Placement](./reference/placement/) are
-  onboarded on the same conventions.
+  [Glance](./reference/glance/), [Placement](./reference/placement/), and
+  [Barbican](./reference/barbican/) are onboarded on the same conventions.
 - **Shared library.** Common types, conditions, config rendering, and
   Kubernetes helpers in `internal/common/`, plus the Helm chart, operator
   packaging, and rotation scripts. See the

--- a/docs/quick-start-controlplane.md
+++ b/docs/quick-start-controlplane.md
@@ -12,7 +12,8 @@ SPDX-License-Identifier: Apache-2.0
 This guide takes a single **c5c3 ControlPlane** CR from `git clone` to an authenticated
 Keystone API call. Compared with the [Quick Start](./quick-start.md), the
 c5c3-operator now provisions the `MariaDB`, `Memcached`, `Keystone`, `Horizon`,
-`Glance`, and `Placement` children, mints the admin application credential through
+`Glance`, `Placement`, and `Barbican` children, mints the admin application
+credential through
 [K-ORC](https://github.com/k-orc/openstack-resource-controller), mirrors it to
 OpenBao, and registers the identity catalog.
 
@@ -21,7 +22,7 @@ OpenBao, and registers the identity catalog.
 Same toolchain as the [Quick Start](./quick-start.md), plus:
 
 - `make` on `PATH` for `install-test-deps`, `deploy-infra`, and `teardown-infra`
-- The OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/)) on `PATH` for the auth check in Step 6, plus the [`osc-placement`](https://docs.openstack.org/osc-placement/latest/) plugin for the placement check in the same step
+- The OpenStack CLI ([`python-openstackclient`](https://docs.openstack.org/python-openstackclient/latest/)) on `PATH` for the auth check in Step 6, plus two plugins for the other checks in that step: [`osc-placement`](https://docs.openstack.org/osc-placement/latest/) for the placement call and [`python-barbicanclient`](https://docs.openstack.org/python-barbicanclient/latest/) for the `openstack secret` subcommands
 - A stable internet connection while `make deploy-infra` clones K-ORC from GitHub
 - Roughly 8 GB RAM, 2 CPU cores, and 10 GB of free disk for a laptop-sized kind cluster
 - `yq` v4.x on `PATH` for the `KIND_HOST_PORT=8443` override path in Step 2
@@ -74,7 +75,8 @@ KIND_HOST_PORT=8443 WITH_CONTROLPLANE=true make deploy-infra
 
 `WITH_CONTROLPLANE=true` brings up the shared infrastructure and then the
 ControlPlane operator stack (keystone-operator, horizon-operator,
-glance-operator, placement-operator, K-ORC, c5c3-operator) from the published charts — but **not** the `ControlPlane` CR
+glance-operator, placement-operator, barbican-operator, K-ORC, c5c3-operator)
+from the published charts — but **not** the `ControlPlane` CR
 itself; you create and apply that in Step 3. In this mode the ControlPlane provisions its own MariaDB/Memcached
 (managed mode), so deploy-infra does not create the shared ones. `KIND_HOST_PORT=8443`
 maps the Gateway to a non-privileged host port for macOS; on Linux with rootful
@@ -181,6 +183,21 @@ spec:
         parentRef:
           name: openstack-gw
         hostname: placement.127-0-0-1.nip.io
+    barbican:
+      replicas: 1
+      # An OpenBao instance this ControlPlane provisions and owns; its name, its
+      # KV mount, and its AppRole are derived by convention, so the block is empty.
+      secretStore:
+        dedicated: {}
+      # Drop publicEndpoint on the default port 443; the operator then derives
+      # https://barbican.127-0-0-1.nip.io from the gateway hostname.
+      publicEndpoint: https://barbican.127-0-0-1.nip.io:8443
+      # Exposed through the same shared Envoy Gateway, via the seventh HTTPS
+      # listener the kind overlay adds for barbican.127-0-0-1.nip.io.
+      gateway:
+        parentRef:
+          name: openstack-gw
+        hostname: barbican.127-0-0-1.nip.io
 ```
 
 ```bash
@@ -213,9 +230,9 @@ Glance can validate the Keystone tokens it receives; its database and cache
 derive from `spec.infrastructure`, exactly like Keystone's. On the managed
 shared database its DB credential is engine-issued and auto-rotated exactly like
 Keystone's — short-lived leases from the OpenBao database engine, and the Step 4
-onboarding provisions the engine tenant for all three database services
-(keystone, glance, and placement). A `GlanceReady` condition joins the chain —
-gating on `KeystoneReady` plus that injected service account — and
+onboarding provisions the engine tenant for all four database services
+(keystone, glance, placement, and barbican). A `GlanceReady` condition joins
+the chain — gating on `KeystoneReady` plus that injected service account — and
 `status.services` gains a third entry.
 
 The `placement` block projects a Placement child, `controlplane-placement`: the
@@ -231,6 +248,23 @@ overlay adds, `placement.127-0-0-1.nip.io`, and `publicEndpoint` carries the
 `:8443` host port into the public placement catalog row. A `PlacementReady`
 condition joins the chain next to `GlanceReady`, gated the same way, and
 `status.services` gains a fourth entry.
+
+The `barbican` block adds the Key Manager service. `secretStore.dedicated` asks
+for an OpenBao instance this ControlPlane owns, so the operator projects three
+CRs: the Barbican child `controlplane-barbican`, the instance
+`controlplane-barbican-bao`, and the store `controlplane-barbican-store` that
+attaches the two. The defaulting webhook injects a `barbican` service account
+(user `barbican`, role `service`) with a project of its own,
+`service-barbican`. Its database credential is engine-issued from the tenant
+Step 4 onboards, like Glance's and Placement's. The `gateway` block puts the
+key-manager API on the seventh HTTPS listener, `barbican.127-0-0-1.nip.io`, and
+`publicEndpoint` carries the `:8443` host port into the public key-manager
+catalog row. A `BarbicanReady` condition joins the chain beside `GlanceReady`
+and `PlacementReady`, gated the same way, and `status.services` gains a fifth
+entry. The projected instance is proving-grade: one replica, no
+PodDisruptionBudget, sealed by a static key in a plain Secret beside its volume.
+[Run Barbican on a Dedicated OpenBao](./guides/barbican/barbican-dedicated-openbao.md)
+covers the same service step by step, including the external-server alternative.
 
 Applying the CR is not the end of the manual work: a hand-applied ControlPlane
 needs the one-time OpenBao onboarding in Step 4 before the chain can progress
@@ -306,6 +340,15 @@ spec:
         parentRef:
           name: openstack-gw          # same Gateway; sixth listener
         hostname: placement.127-0-0-1.nip.io
+    barbican:
+      replicas: 1
+      secretStore:
+        dedicated: {}                 # OpenBao instance projected beside the child
+      publicEndpoint: https://barbican.127-0-0-1.nip.io:8443
+      gateway:
+        parentRef:
+          name: openstack-gw          # same Gateway; seventh listener
+        hostname: barbican.127-0-0-1.nip.io
   korc:
     adminCredential:
       cloudCredentialsRef:
@@ -332,6 +375,13 @@ spec:
         project:
           name: service-placement    # its own project: two create:true entries
                                      # cannot name the same Keystone project
+          create: true
+        roles:
+          - service
+      - name: barbican               # injected because services.barbican is set
+        userName: barbican           # defaults to the account name
+        project:
+          name: service-barbican     # its own project, for the same reason
           create: true
         roles:
           - service
@@ -405,13 +455,13 @@ ControlPlane. See the
 
 ## Step 5 — Watch the chain reconcile
 
-The aggregate `Ready` flips to `True` once all 13 sub-conditions are met, in
-dependency order (`HorizonReady` gates on `KeystoneReady`; `GlanceReady` and
-`PlacementReady` gate on `KeystoneReady` plus `ServiceAccountsReady`; the K-ORC
-branch runs alongside):
+The aggregate `Ready` flips to `True` once all 14 sub-conditions are met, in
+dependency order (`HorizonReady` gates on `KeystoneReady`; `GlanceReady`,
+`PlacementReady`, and `BarbicanReady` gate on `KeystoneReady` plus
+`ServiceAccountsReady`; the K-ORC branch runs alongside):
 
 ```
-NamespacesReady → InfrastructureReady → ESOTenantStoreReady → DBCredentialsReady → AdminPasswordReady → KeystoneReady → HorizonReady → KORCReady → AdminCredentialReady → CatalogReady → ServiceAccountsReady → GlanceReady → PlacementReady
+NamespacesReady → InfrastructureReady → ESOTenantStoreReady → DBCredentialsReady → AdminPasswordReady → KeystoneReady → HorizonReady → KORCReady → AdminCredentialReady → CatalogReady → ServiceAccountsReady → GlanceReady → PlacementReady → BarbicanReady
 ```
 
 ```bash
@@ -472,6 +522,7 @@ sudo sh -c 'cat >> /etc/hosts <<EOF
 127.0.0.1 horizon.127-0-0-1.nip.io
 127.0.0.1 glance.127-0-0-1.nip.io
 127.0.0.1 placement.127-0-0-1.nip.io
+127.0.0.1 barbican.127-0-0-1.nip.io
 EOF'
 ```
 
@@ -509,8 +560,8 @@ openstack --insecure token issue
 > `foo-keystone-admin-credentials` instead.
 
 > With the default `KIND_HOST_PORT=443` use `https://keystone.127-0-0-1.nip.io/v3`
-> and drop all three `publicEndpoint` lines (keystone, glance, and placement)
-> from the CR in Step 3.
+> and drop all four `publicEndpoint` lines (keystone, glance, placement, and
+> barbican) from the CR in Step 3.
 
 ### Upload a first image
 
@@ -555,12 +606,12 @@ A run aborted before the final `delete` leaves `first-image` behind; delete it
 
 ::: warning Leave OS_REGION_NAME unset
 Do **not** add `OS_REGION_NAME` to the host exports: the projected K-ORC
-catalog rows carry no region, image and placement alike, so a region-scoped
-lookup finds no endpoint. The upload fails with `public endpoint for image
-service in RegionOne region not found`, the placement call with the same message
-under its own service name. Keystone's own bootstrap registers RegionOne
-identity rows, so identity is unaffected. Only the projected rows need the
-filter left clear.
+catalog rows carry no region, image, placement, and key-manager alike, so a
+region-scoped lookup finds no endpoint. The upload fails with `public endpoint
+for image service in RegionOne region not found`, the placement and secret calls
+with the same message under their own service names. Keystone's own bootstrap
+registers RegionOne identity rows, so identity is unaffected. Only the projected
+rows need the filter left clear.
 :::
 
 ### List placement resource classes
@@ -588,6 +639,53 @@ token validation in one command. It needs the `osc-placement` plugin from the
 prerequisites; without it the `openstack` CLI rejects `resource class list` as
 an unknown command. `OS_REGION_NAME` has to stay unset here as well, for the
 reason above.
+
+### Store and retrieve a first secret
+
+With the same `OS_*` variables still exported, confirm the Key Manager service
+reached the catalog:
+
+```bash
+openstack --insecure catalog list
+```
+
+A `key-manager` row proves the ControlPlane registered both endpoints: the
+in-cluster one at `http://controlplane-barbican.openstack.svc:9311` and the
+public one at `https://barbican.127-0-0-1.nip.io:8443`, the `publicEndpoint`
+from Step 3. Store a secret through that public endpoint, read the payload back,
+and delete it again:
+
+```bash
+PAYLOAD='forge-quick-start-payload'
+HREF=$(openstack --insecure secret store --name first-secret \
+  --payload "$PAYLOAD" -f value -c 'Secret href')
+test "$(openstack --insecure secret get -p "$HREF" -f value -c Payload)" = "$PAYLOAD" \
+  && echo "OK: payload came back unchanged from the key manager"
+openstack --insecure secret delete "$HREF"
+```
+
+A payload that survives the round-trip covers the whole key-manager chain in two
+calls: the catalog row resolves the endpoint, Barbican validates the admin token
+against Keystone, and the payload travels through castellan's vault plugin into
+the dedicated `controlplane-barbican-bao` instance and out again. The
+`openstack secret` subcommands come from the `python-barbicanclient` plugin in
+the prerequisites; without it the CLI rejects `secret store` as an unknown
+command. `OS_REGION_NAME` stays unset here too: the key-manager rows carry no
+region either, and with it set the store call fails with `public endpoint for
+key-manager service in RegionOne region not found`.
+
+::: warning Do not substitute real key material into `--payload`
+The literal above is a throwaway, and this snippet is written for a devstack. A
+value passed to `--payload` sits in the process argument vector, where any local
+user reads it out of `ps` or `/proc/<pid>/cmdline` for the life of the call, and
+typing it directly rather than through a variable also leaves it in your shell
+history. Feed real material in from a file or from standard input instead.
+`--insecure` belongs to this devstack for the same reason, and it reaches
+further than the payload: the flag disables certificate verification for the
+whole invocation, including the Keystone call that sends `OS_PASSWORD`. Anything
+that answers on the way collects the admin credential. Drop it anywhere the
+gateway presents a certificate you trust.
+:::
 
 ### Open the Horizon dashboard
 
@@ -630,4 +728,6 @@ make teardown-infra
   its `GlanceBackend` stores, and the reconciler chain.
 - [Placement Operator](./reference/placement/index.md) — the projected Placement
   service, its CRD surface, and the reconciler chain.
+- [Barbican Operator](./reference/barbican/index.md) — the projected Key Manager
+  service, its `BarbicanSecretStore` attachment, and the reconciler chain.
 - [Quick Start](./quick-start.md) — the compact per-service Keystone path.

--- a/docs/reference/barbican/barbican-crd.md
+++ b/docs/reference/barbican/barbican-crd.md
@@ -1,0 +1,281 @@
+---
+title: Barbican CRD
+quadrant: operator
+---
+
+# Barbican CRD
+
+`barbicans.barbican.openstack.c5c3.io/v1alpha1`, kind `Barbican`. The CRD is
+generated from `operators/barbican/api/v1alpha1/barbican_types.go`; the
+validating and defaulting webhooks live in
+`operators/barbican/api/v1alpha1/barbican_webhook.go`. The Helm chart ships a
+synced copy (`make sync-crds` / `make verify-crd-sync`).
+
+One Barbican CR describes the Key Manager API server: its OpenStack release,
+container image, database and cache connections, the Keystone integration, and
+the recurring database clean-up. The secret stores that hold the material
+barbican protects are separate CRs
+([`BarbicanSecretStore`](./barbican-secret-store-crd.md)), so the spec below
+stays close to the plain API-server shape.
+
+`kubectl get barbicans` prints Ready
+(`.status.conditions[?(@.type=='Ready')].status`), Release
+(`.status.installedRelease`), Endpoint (`.status.endpoint`), and Age.
+
+## Spec
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `openStackRelease` | `string` | yes | The OpenStack release the operator deploys and drives; pattern `^\d{4}\.[12]$` (the `YYYY.N` cadence, `N` ∈ {1,2}). It governs install and upgrade schema tracking: `status.installedRelease` is promoted to this value after a successful db-sync. Kept separate from the image tag so digest-pinned images still resolve a schema. It also selects the `barbican-api-paste.ini` layout: from `2026.1` the rendered file carries the oslo `request_id` filter in every pipeline and drops the `repoze.profile` pipeline and filter |
+| `deployment` | `DeploymentSpec` | no | Shared pod-level knobs: `replicas` (default 3), `resources` (defaults: 256Mi request / 512Mi limit memory, 100m/500m CPU), `terminationGracePeriodSeconds`, `preStopSleepSeconds`, `strategy`, `topologySpreadConstraints`, `priorityClassName` |
+| `image` | `ImageSpec` | yes | Container image. `tag` and `digest` are mutually exclusive and one of the two is required (shared CEL rule, re-checked by the webhook). The field carries no immutability rule |
+| `database` | `DatabaseSpec` | yes | MariaDB connection, rendered into `[database]`. One of `clusterRef` (managed) or `host` (brownfield), never both; plus `database`, `secretRef`, and the optional `port`, `credentialsMode`, and `tls`. `credentialsMode` selects how the credential in `secretRef` is provisioned: `Static` (the default) keeps a long-lived password and has the operator manage the MariaDB `User`/`Grant` CRs, `Dynamic` takes short-lived engine-issued credentials and manages neither. `Dynamic` requires `clusterRef`. The mutual-exclusivity and Dynamic-requires-clusterRef rules are inherited from `commonv1.DatabaseSpec`, and so are `replicas` and `storageSize`: both sit in the schema, but only the c5c3 operator's managed-mode projection reads them, so the Barbican operator ignores whatever they say. With `tls` enabled the client keypair is projected into the API pods, the db-sync Job, and the clean-up CronJob alike |
+| `cache` | `CacheSpec` | yes | Memcached backing the keystonemiddleware token cache, rendered as `[keystone_authtoken] memcached_servers`. One of `clusterRef` (managed) or `servers` (brownfield), never both. `backend` is webhook-defaulted to `dogpile.cache.pymemcache`. `replicas` is inherited from `commonv1.CacheSpec` on the same terms as the database counterparts: schema-visible, honoured by the c5c3 operator's managed-mode projection, ignored here |
+| `keystoneEndpoint` | `string` | yes | The Keystone auth URL rendered as `[keystone_authtoken] auth_url`; must match `^https?://` and parse with a host. keystonemiddleware validates a token against it server-side on every authenticated request, so it must be reachable from inside the cluster: use the cluster-local Service URL, not an externally routable address |
+| `keystonePublicEndpoint` | `string` | no | The browser-facing Keystone base URL rendered as `[keystone_authtoken] www_authenticate_uri`, the address a 401 points unauthenticated clients at; must match `^https?://` when set. When empty the operator falls back to `keystoneEndpoint` at render time (see `EffectiveKeystonePublicEndpoint`), which holds only when the internal and public Keystone URLs coincide |
+| `serviceUser` | [`ServiceUserSpec`](#serviceuserspec) | yes | The Keystone service account Barbican authenticates as, and the Secret holding its password |
+| `region` | `string` | no | The Keystone region (`[keystone_authtoken] region_name`); when empty the option is omitted and Barbican uses the catalog's default region |
+| `apiServer` | [`*APIServerSpec`](#apiserverspec) | no | uWSGI process tuning. When nil the reconciler applies the same defaults the webhook writes into a present block |
+| `dbClean` | [`*DBCleanSpec`](#dbcleanspec) | no | Tunes the recurring `barbican-manage db clean` CronJob. A nil block resolves like an empty one: the clean-up is scheduled either way, and the operator resolves the knobs at reconcile time, so the defaulting webhook leaves the block untouched |
+| `gateway` | `*GatewaySpec` | no | External exposure via a Gateway API HTTPRoute forwarding to the `{name}` Service on port 9311; requires `hostname` and `parentRef.name`, and takes an optional `path` (default `/`) and an optional `annotations` map, copied verbatim onto the generated HTTPRoute's metadata for implementation-specific settings such as rate limits or CORS. Setting it also changes what barbican advertises: `[DEFAULT] host_href` and `status.endpoint` become `https://{hostname}`. Removing the block deletes the HTTPRoute |
+| `networkPolicy` | `*NetworkPolicySpec` | no | Ingress restricted to TCP 9311 from the listed sources; egress auto-derived (DNS, the database, the Keystone endpoint's port, the cache, and the OpenBao servers of the projected stores), with `additionalEgress` appended after it. At least one ingress source is required (fail-closed) |
+| `autoscaling` | `*AutoscalingSpec` | no | HPA bounds and CPU/memory utilization targets. At least one of `targetCPUUtilization` or `targetMemoryUtilization` is required, and an unset `minReplicas` resolves to `spec.deployment.replicas`. The bound also sizes the database user's `max_user_connections`, which the operator derives from `maxReplicas` when an HPA owns the replica count |
+| `logging` | `*LoggingSpec` | no | oslo.log settings: `format` (`text`/`json`), `level`, `debug`, `perLoggerLevels`. The defaulting webhook materializes the block (`text`/`INFO`/`debug: false`) and the validating webhook checks the enums and the per-logger map, but the config renderer does not read the field yet, so no `[DEFAULT]` logging key is derived from it. Set the logging options through `spec.extraConfig` until it is wired |
+| `secretStoreRef` | `*SecretStoreRefSpec` | no | Selects the External Secrets store the operator resolves `SecretsReady` against: `kind` (`ClusterSecretStore` \| `SecretStore`, default `ClusterSecretStore`) and a required `name`. When omitted the shared cluster-scoped `openbao-cluster-store` is used. A namespaced store is resolved in the Barbican's own namespace. Normally projected from the owning [ControlPlane](../c5c3/controlplane-crd.md). It selects the ESO store the credential Secrets arrive through and has nothing to do with the secret stores barbican itself writes to |
+| `policyOverrides` | `*PolicySpec` | no | Custom oslo.policy rules. A CEL rule requires at least one of `rules` or `configMapRef`; when set, the operator renders a `policy.yaml` into the config Secret and wires `[oslo_policy] policy_file` at it. Inline `rules` win over `configMapRef` entries of the same name |
+| `middleware` | `[]MiddlewareSpec` | no | WSGI filters inserted into the `barbican-api-keystone` pipeline, the one `composite:main` routes `/v1` to. Each entry carries `name`, `filterFactory`, `position` (`before` or `after` the base filters), and a `config` map rendered as the filter's own paste section. The other pipelines the image ships are rendered verbatim and are unreachable through `composite:main` |
+| `plugins` | `[]PluginSpec` | no | Service plugins or drivers, each with a `name`, a `configSection`, and a `config` map. Modeled as a list-map keyed by `configSection`, so the API server rejects duplicate sections structurally and server-side apply merges entries by section instead of replacing the whole list. Plugin sections lose to the operator defaults on a key collision and to `extraConfig` on top of that |
+| `extraConfig` | `map[string]map[string]string` | no | Free-form INI sections for configuration not covered by explicit fields, the escape hatch for options with no dedicated knob. The render-time merge is `plugins < operator defaults < extraConfig`, so user values win. Overrides of operator-owned keys are honored but surfaced through the `ExtraConfigHealthy` condition and an `ExtraConfigOwnedKeyOverride` Warning event, with three exceptions the validating webhook refuses outright (see [Defaulting and validation](#defaulting-and-validation)). Option names are checked at admission against a per-release option catalog embedded in the operator, selected by `spec.openStackRelease`; a release with no embedded catalog skips the check with an admission warning. The per-store `[secretstore:<name>]` sections are exempt from the catalog scan, since their names come from the attached store CRs and no release catalog can list them. A deprecated-but-accepted option is admitted with a warning naming its replacement. Values are checked for one thing: a newline or carriage return in a section name, key, or value is rejected, because the rendered INI writes each verbatim and a newline would inject config lines past the ownership and catalog gates |
+
+### ServiceUserSpec
+
+The name and domain fields are webhook-defaulted, so a minimal CR need only
+supply the password Secret reference.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `username` | `string` | no | `barbican` | Keystone username (`[keystone_authtoken] username`) |
+| `projectName` | `string` | no | `service` | The project the service user scopes to (`project_name`) |
+| `userDomainName` | `string` | no | `Default` | The domain the service user lives in (`user_domain_name`) |
+| `projectDomainName` | `string` | no | `Default` | The domain the service project lives in (`project_domain_name`) |
+| `secretRef` | `SecretRefSpec` | yes | `key` → `password` | The Secret holding the service-user password; the password is injected as the `OS_KEYSTONE_AUTHTOKEN__PASSWORD` env var and never rendered into config |
+
+Each of the four identity fields is rendered verbatim into
+`[keystone_authtoken]`, so the validating webhook rejects a newline or carriage
+return in any of them. `spec.region` lands in the same section through the same
+renderer and goes through the same check.
+
+### APIServerSpec
+
+Tunes the API server process. It carries the uWSGI block alone: barbican ships
+a WSGI application and no eventlet server, so there is no launch mode to select
+and no worker count to configure outside uWSGI. The sibling Glance operator's
+`workers` field has no counterpart here.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `uwsgi` | [`*UWSGISpec`](#uwsgispec) | no | uWSGI application-server parameters |
+
+### UWSGISpec
+
+The shared `commonv1.UWSGISpec`. A cross-field CEL rule mirrors the webhook:
+`httpKeepAliveTimeout` may only be set when `httpKeepAlive` is true, since the
+`--http-keepalive-timeout` flag is otherwise never emitted. A nil
+`httpKeepAlive` counts as unset and resolves to the default `true`, so only an
+explicit `false` conflicts with a set timeout.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `processes` | `int32` (Minimum=1) | no | `2` | uWSGI worker-process count (`--processes`) |
+| `threads` | `int32` (Minimum=1) | no | `1` | Threads per worker (`--threads`) |
+| `httpKeepAlive` | `*bool` | no | `true` | Enables `--http-keepalive`. A nil-preserving pointer: nil restores the default, an explicit `false` is honored verbatim and drops the flag |
+| `harakiri` | `*int32` (Minimum=1) | no | — | Per-request worker lifetime cap (`--harakiri`, seconds). Omitted from the command when nil, with no hidden default. The webhook requires `harakiri < terminationGracePeriodSeconds − preStopSleepSeconds`, so the worst-case per-request kill fits inside the drain window |
+| `httpKeepAliveTimeout` | `*int32` (Minimum=1) | no | — | Idle timeout of keep-alive connections (`--http-keepalive-timeout`, seconds). Omitted when nil; zero is rejected to avoid the unbounded interpretation |
+
+Raising `processes` raises the pooled connection count: every worker holds at
+least one connection once its app has loaded, because each one syncs the
+secret-store table at start-up. The operator sizes the SQL user's
+`max_user_connections` from the topology (`(pods + 1) × processes × threads + 2`),
+so a raised `processes` needs no manual grant.
+
+### DBCleanSpec
+
+Barbican only soft-deletes, so the operator projects a CronJob running
+`barbican-manage db clean` to hard-delete the rows that fell out of the
+retention window. The block is resolved at reconcile time by `effectiveDBClean`
+(`operators/barbican/internal/controller/reconcile_dbclean.go`) and is left
+alone by the defaulting webhook (`barbican_webhook.go`), so a field left unset
+keeps tracking the operator default across upgrades instead of freezing today's
+value into the stored CR. A nil block resolves like an empty one.
+
+| Field | Type | Required | Resolved default | Description |
+| --- | --- | --- | --- | --- |
+| `retentionDays` | `*int32` (Minimum=1) | no | `90` | How long a soft-deleted row survives before the clean-up hard-deletes it (`--min-days`). Barbican's own default. The floor of one day keeps the sweep from racing rows an in-flight request just wrote. Lowering it applies retroactively at the next firing |
+| `schedule` | `string` | no | `"1 0 * * *"` | The cron expression the CronJob runs on. The validating webhook checks the grammar and the CRD carries no pattern for it: the accepted grammar includes descriptors such as `@daily`, which no regex expresses without also rejecting valid expressions |
+| `softDeleteExpiredSecrets` | `*bool` | no | `true` | Adds the `--soft-delete-expired-secrets` pass, which soft-deletes secrets whose expiration has passed so the same run can purge them under the retention window. The `true` default is a documented deviation from barbican's CLI default of `false`: an expired secret is unusable, and without the pass its row is never soft-deleted and therefore never purged. Set it to `false` for the upstream behaviour |
+| `cleanUnassociatedProjects` | `*bool` | no | `false` | Adds the `--clean-unassociated-projects` pass, which deletes project rows that no longer own a secret, container, or order, along with their quota records. Opt-in: the pass keys off barbican's own associations and not off Keystone, so a project whose secrets were all deleted loses its configured quotas too |
+| `suspend` | `bool` | no | `false` | Pauses the CronJob without deleting it. `DBCleanReady` stays True while suspended, under its own reason, because a paused clean-up is an operator's posture. It is the staging escape hatch for a brownfield database whose backlog has never been cleaned |
+
+The CronJob is also suspended for the length of a schema convergence, whatever
+`suspend` says: `barbican-manage db upgrade` takes DDL locks the clean-up's bulk
+`DELETE`s contend with. Each run carries an `activeDeadlineSeconds` of one hour
+and a `Forbid` concurrency policy, so a wedged run fails instead of accumulating
+one active Job per firing.
+
+### Defaulting and validation
+
+The mutating webhook applies the shared `DeploymentSpec` defaults (replicas 3,
+256Mi/512Mi memory and 100m/500m CPU), materializes the
+`dogpile.cache.pymemcache` cache backend and the `LoggingSpec` baseline, fills
+the `ServiceUserSpec` identity defaults (`barbican` / `service` / `Default` /
+`Default`, `secretRef.key` → `password`), and, only when `spec.apiServer.uwsgi`
+is present, the uWSGI sub-field defaults (`processes` 2, `threads` 1,
+`httpKeepAlive` true). `spec.dbClean` is left untouched, for the reason
+[DBCleanSpec](#dbcleanspec) gives.
+
+`metadata.name` is bounded at 43 characters. The db-clean CronJob is the child
+object with the tightest name budget: Kubernetes caps a CronJob name at 52
+characters, its controller appending an 11-character timestamp suffix to every
+Job it spawns, and the `-db-clean` suffix spends that budget down. The two
+constants say the same thing,
+`MaxBarbicanNameLength = MaxCronJobNameLength − len("-db-clean")` = 52 − 9 = 43.
+The rule runs on create only: the name is immutable, so on update it could only
+fire against an object a pre-upgrade operator already admitted, including the
+finalizer-removal update that completes a deletion, and rejecting that would
+wedge the CR in `Terminating` with no field left to edit. A name the bound would
+reject keeps reconciling: `dbCleanCronJobName` collapses it onto a content-stable
+hash instead of building an object the API server refuses.
+
+The validating webhook accumulates every violation into one admission response,
+reusing the shared validators: replicas floor, image tag/digest exclusivity, the
+database mutual-exclusivity and Dynamic-requires-clusterRef rules, cache
+mutual-exclusivity and its control-character guard, secret-store-ref shape, both
+Keystone endpoint URL shapes, logging enums (including the per-logger-level map,
+which has no schema-layer counterpart), the graceful-termination arithmetic
+(`preStopSleepSeconds < terminationGracePeriodSeconds`, and `harakiri` strictly
+inside the drain window), the `httpKeepAliveTimeout` pairing, the
+`Recreate`-vs-`rollingUpdate` sanity check, autoscaling bounds (including the
+implicit `minReplicas` default from `deployment.replicas`), network-policy
+ingress, gateway hostname and `parentRef.name`, resource requests-vs-limits,
+PriorityClass existence, topology-spread selectors (matching the `barbican` and
+instance labels), and the policy-rule name/value guard.
+
+Two checks are barbican's own. `spec.region`, the four `serviceUser` identity
+fields, and `spec.gateway.hostname` are each rejected for a newline or carriage
+return, because the renderer writes them verbatim and a newline would smuggle a
+whole extra option past the ownership and catalog gates. The hostname is on that
+list because it reaches the renderer as `[DEFAULT] host_href`, and `[DEFAULT]`
+is rendered first, so an injected line lands in a section the operator never
+writes again. `spec.dbClean` carries the second: `retentionDays` has a floor of
+one, and `schedule` is parsed for cron grammar.
+
+Two admission warnings describe what a change deletes, since neither is
+recoverable and both are legitimate operational choices:
+
+| Warning | When |
+| --- | --- |
+| Retention reduction | An update lowers the effective `retentionDays`. The next run hard-deletes every row that fell out of the window between the old and the new value |
+| Brownfield first run | A CR is created against a brownfield database (`spec.database.host`) without `spec.dbClean.suspend`. The first firing applies the window retroactively to a backlog that has never been cleaned |
+
+`spec.extraConfig` is a preserve-unknown-fields map CEL cannot constrain, so its
+guards are webhook-only: an empty section name or option key, a newline or
+carriage return in any section name, key, or value, and an override of a
+`Rejected` owned key. The rejection list is driven by the `Rejected` flag in
+`operators/barbican/api/v1alpha1/config_ownership.go` and holds three entries,
+each a credential the operator delivers through an environment variable:
+
+| Key | Owned by | Why the override is refused |
+| --- | --- | --- |
+| `[keystone_authtoken] password` | `spec.serviceUser.secretRef` | The middleware reads the password from `OS_KEYSTONE_AUTHTOKEN__PASSWORD`, so a file value is inert at runtime and only copies the service password into the config Secret every API pod mounts |
+| `[vault_plugin] approle_secret_id` | the store's credentials Secret | Same shape: the secret ID arrives through `OS_VAULT_PLUGIN__APPROLE_SECRET_ID`, and rendering it would put the AppRole secret into that same Secret |
+| `[vault_plugin] root_token_id` | operator-computed | The vault plugin prefers a root token over AppRole authentication, so a rendered one replaces the mount-scoped AppRole with an unscoped credential in plain text, and both are done the moment the pods load the file |
+
+Every other owned key is honored and reported. The registry covers `[DEFAULT]`
+(`db_auto_create`, `host_href`), `[database] connection`, the
+`[keystone_authtoken]` keys `keystoneauth.Section` renders, the `[secretstore]`
+registry pair, the `[vault_plugin]` options derived from the attached store,
+`[queue] enable`, and `[oslo_policy] policy_file`. Conditionally rendered keys
+are registered unconditionally: the registry records that a key is not the
+user's to set, not that it is currently rendered.
+
+The catalog check re-runs on update only when one of its inputs changed
+(`spec.extraConfig` or `spec.openStackRelease`), so an unrelated edit such as a
+replica change cannot retroactively reject a CR whose `extraConfig` a
+regenerated catalog has since invalidated.
+
+## Status
+
+| Field | Description |
+| --- | --- |
+| `conditions` | List-map keyed by `type`; see the [reconciler reference](./barbican-reconciler.md#conditions) for the vocabulary |
+| `observedGeneration` | The `.metadata.generation` last reconciled |
+| `endpoint` | The Barbican API URL: `https://{gateway.hostname}` when a gateway is set, otherwise the cluster-local Service URL. It is the same value the rendered `[DEFAULT] host_href` carries, so what barbican advertises in its API links and what the CR reports are one value |
+| `installedRelease` | The OpenStack release whose schema is currently installed, promoted to `spec.openStackRelease` after a successful db-sync |
+| `installedImage` | The `spec.image` reference that migrated the schema `installedRelease` names. A digest carries no parseable release, so without this field a `spec.openStackRelease` bump that left `spec.image` untouched would run no migration and still promote `installedRelease`; the release gate compares against it to refuse that transition |
+| `targetRelease` | The `spec.openStackRelease` a release bump is converging to. Stamped when the gate accepts the bump, cleared once `installedRelease` equals the spec release; empty in steady state |
+| `projectedSecretStores` | The attached, credential-ready stores the last valid projection rendered into `barbican.conf`, in section order. A store dropping out of this set is what a detach is detected against |
+| `projectedSecretStoreHosts` | The server URLs that same projection resolved. The NetworkPolicy egress set of an invalid projection is widened from this record and never re-derived from the live store specs, since `spec.openBao.server.url` is mutable and only scheme-checked |
+
+The status carries no `upgradePhase`. Barbican runs no expand-migrate-contract
+phase machine: its migrations apply in one `barbican-manage db upgrade` pass,
+and the release rules the phased flow enforces on its way in (no downgrades, no
+multi-release jumps) are checked by the release gate before any Job runs. See
+[Database](./barbican-reconciler.md#database).
+
+## Sub-Resource Naming Convention
+
+Operator-managed sub-resources (Deployment, Service, PodDisruptionBudget,
+HorizontalPodAutoscaler, NetworkPolicy, HTTPRoute, and the MariaDB
+`Database`/`User`/`Grant`) use the bare CR name with no suffix, matching the
+keystone convention. A Barbican CR named `barbican` in the `openstack` namespace
+is therefore reachable in-cluster at
+`http://barbican.openstack.svc.cluster.local:9311`, since the Service DNS name
+is the CR name.
+
+The content-addressed and derived resources are the exceptions:
+
+| Resource | Name | Notes |
+| --- | --- | --- |
+| Config Secret | `{name}-config-<hash>` | Immutable, content-hashed `barbican.conf` and `barbican-api-paste.ini` (plus `policy.yaml` when applicable); 3 historical retained. A Secret rather than a ConfigMap, because the rendered `barbican.conf` carries the vault plugin's `approle_role_id` and barbican reads one configuration file |
+| DB-connection Secret | `{name}-db-connection` | Derived pymysql DSN, stable name |
+| DB-sync Job | `{name}-db-sync` | `barbican-manage db upgrade` |
+| DB-clean CronJob | `{name}-db-clean` | `barbican-manage db clean`, projected on every Barbican. The plain form holds for every admissible name; an over-long inherited name collapses onto a hash |
+
+The AppRole credentials Secret of a managed store is named after the store, not
+after the Barbican: see
+[Retained Artefacts](./barbican-secret-store-crd.md#retained-artefacts).
+
+## Example
+
+```yaml
+apiVersion: barbican.openstack.c5c3.io/v1alpha1
+kind: Barbican
+metadata:
+  name: barbican
+  namespace: openstack
+spec:
+  openStackRelease: "2025.2"
+  deployment:
+    replicas: 3
+  image:
+    repository: ghcr.io/c5c3/barbican
+    tag: "2025.2"
+  database:
+    clusterRef:
+      name: openstack-mariadb
+    database: barbican
+    secretRef:
+      name: barbican-db
+  cache:
+    clusterRef:
+      name: openstack-memcached
+  keystoneEndpoint: http://keystone.openstack.svc.cluster.local:5000/v3
+  serviceUser:
+    secretRef:
+      name: barbican-keystone
+```
+
+The CR reaches `Ready` once a `BarbicanSecretStore` attached to it is
+credential-ready and marked `isDefault`; until then the API Deployment is not
+created at all, because barbican resolves its secret store at process start and
+exits when none is configured.

--- a/docs/reference/barbican/barbican-events.md
+++ b/docs/reference/barbican/barbican-events.md
@@ -1,0 +1,282 @@
+---
+title: Barbican Controller Events
+quadrant: operator
+---
+
+# Barbican Controller Events
+
+Reference documentation for Kubernetes events emitted by the Barbican operator.
+Two controllers run in the one manager and both record events: the Barbican
+controller on the Barbican CR, the BarbicanSecretStore controller on its own CR.
+They provide observability via `kubectl describe barbican`,
+`kubectl describe barbicansecretstore`, and `kubectl get events` without access
+to controller logs.
+
+Events complement status conditions: conditions reflect current state for
+programmatic consumers, while events provide a timestamped audit trail of
+transitions for human operators and alerting systems.
+
+For the reconciler architecture and sub-reconciler contracts, see
+[Barbican Reconciler Architecture](./barbican-reconciler.md). For the spec and
+status contracts the conditions belong to, see [Barbican CRD](./barbican-crd.md)
+and [BarbicanSecretStore CRD](./barbican-secret-store-crd.md).
+
+---
+
+## Event Conventions
+
+All events follow these conventions:
+
+- **Reason strings** are stable PascalCase identifiers. They are part of the
+  controllers' public API and will not change without a deprecation notice.
+- **Normal** type indicates successful completion of a lifecycle transition.
+- **Warning** type indicates a failure, validation error, or unexpected condition
+  that requires operator attention.
+- **No events are emitted for in-progress/polling states** (e.g. while the
+  db-sync Job is still running). This prevents event noise from repeated requeue
+  cycles.
+- Events on the **Barbican** CR (`involvedObject.kind: Barbican`) come from the
+  recorder named `barbican-controller`; events on the **BarbicanSecretStore** CR
+  come from `barbicansecretstore-controller`. Both names are wired in
+  `operators/barbican/main.go` and are what the `reportingComponent` field
+  selector matches.
+- The Kubernetes API server deduplicates events by (involvedObject, reason,
+  message, source). Repeated identical events increment a counter rather than
+  creating new event objects.
+
+---
+
+## Event Reasons Reference
+
+### Configuration
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `ExtraConfigOwnedKeyOverride` | Warning | `spec.extraConfig` overrides one or more operator-owned configuration keys (the per-service ownership registry) | `spec.extraConfig overrides operator-owned keys: [queue] enable (enabling the queue makes the API hand order processing to a worker that is not deployed, so orders stay pending instead of failing)` |
+
+**Source:** the shared `RecordExtraConfigHealth` in
+`internal/common/config/ownership.go`, called from `reconcileConfig` in
+`reconcile_config.go`
+
+> **Note:** The event is gated on the `ExtraConfigHealthy=False` condition's
+> message. It fires once on the transition into `False` and once more when the
+> overridden-key set changes, never on the steady reconcile poll. Removing the
+> overrides transitions the condition back to `ExtraConfigHealthy=True,
+> Reason=NoOwnedKeysOverridden` without a further event. The condition is
+> informational and is not aggregated into `Ready`. The three credential keys
+> the validating webhook refuses at admission never reach this path. The guard
+> runs before the last-good-retention short-circuit, so it stays maintained even
+> on a pass that re-renders nothing.
+
+### Secret Stores
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `BarbicanSecretStoreSkipped` | Warning | The default store passed its own credential gate, but its credentials Secret cannot be read this pass, or an assembled `[vault_plugin]` option carries a newline | `Skipping secret store openbao-primary: secret "openbao-primary-approle" key "secret-id" not found` |
+| `SecretStoreDetached` | Warning | A store recorded in `status.projectedSecretStores` is absent from the projection this pass renders | `Secret store "openbao-legacy" is no longer projected: its [secretstore:openbao-legacy] section is dropped from barbican.conf, so every secret barbican wrote through that store stops resolving` |
+
+**Source:** `reconcileSecretStores` and `recordProjectedStores` in
+`reconcile_secretstores.go`
+
+> **Note:** `SecretStoreDetached` fires on the pass that de-projects the store,
+> which is the pass the operator would otherwise report as a success. Nothing
+> else marks the loss: the store CR carries no finalizer and its deletion is not
+> validated. The counting violations behind
+> `SecretStoresReady=False / NoDefaultSecretStore` and `MultipleOpenBaoStores`
+> raise **no** event; read those off the condition.
+
+### Database Sync
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `DatabaseSynced` | Normal | The `db-sync` Job completes successfully | `Database schema is up to date` |
+| `DBSyncFailed` | Warning | The `db-sync` Job fails | `db_sync job failed: <error>` |
+| `DBSyncMetricEmissionDeferred` | Warning | Patching the last-observed Job UID annotation fails, deferring `db_sync` metric emission to the next reconcile | `Patching last-observed db-sync Job UID failed; metric emission deferred to the next reconcile: <error>` |
+
+**Source:** the shared `ReconcileSyncJobs` in `internal/common/database/flow.go`
+(`DatabaseSynced` / `DBSyncFailed`); the shared `RecordJobTerminalState` in
+`internal/common/job/terminal.go`, wired through `recordDBJobTerminalState` in
+`db_job_metrics.go` (`DBSyncMetricEmissionDeferred`)
+
+### Release Transitions
+
+The release gate validates a `spec.openStackRelease` change against
+`status.installedRelease` before any migration Job runs. A refused transition
+sets `DatabaseReady=False`, raises one Warning event whose reason names the rule
+that refused it, and returns an error so the controller backs off.
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `VersionParseError` | Warning | The installed or the requested release is not a valid `YYYY.N` string | `parsing requested release "latest": invalid release format "latest": expected YYYY.N` |
+| `DowngradeNotSupported` | Warning | The requested release is older than the installed one | `downgrade from 2026.1 to 2025.2 is not supported` |
+| `UpgradePathInvalid` | Warning | The requested jump is more than one release | `upgrade from 2024.2 to 2026.1 is not sequential; upgrade one release at a time` |
+| `ImageReleaseMismatch` | Warning | The requested release bump leaves `spec.image` at the reference that migrated the installed schema, so no migration would run | `upgrade from 2025.2 to 2026.1 leaves spec.image unchanged (ghcr.io/c5c3/barbican:2025.2), so no migration would run: either bump spec.image in lockstep with spec.openStackRelease, or […] patch status.installedRelease to 2026.1` |
+
+**Source:** `gateReleaseTransition` and `rejectReleaseTransition` in
+`reconcile_database.go`
+
+> **Note:** `ImageReleaseMismatch` has a second trigger that raises **no event**.
+> When a tag-pinned `spec.image` names a different OpenStack release than
+> `spec.openStackRelease`, `checkImageReleaseMismatch` sets `DatabaseReady=False`
+> with that reason and requeues without recording anything, because the check
+> runs on every pass and would otherwise re-fire for as long as the two fields
+> disagree. Read that case off the condition, not the event stream.
+
+### Database Clean-up
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `DBCleanJobFailed` | Warning | The newest terminal Job the `{name}-db-clean` CronJob spawned failed | `Database clean-up Job barbican-db-clean-29387460 failed; inspect its pod logs — the soft-deleted secret, container and order rows keep accumulating until a run succeeds` |
+| `DBCleanMetricEmissionDeferred` | Warning | Patching the last-observed Job UID annotation fails, deferring `db_clean` metric emission to the next reconcile | `Patching last-observed db-clean Job UID failed; metric emission deferred to the next reconcile: <error>` |
+
+**Source:** `reconcileDBClean` in `reconcile_dbclean.go` (`DBCleanJobFailed`);
+the shared `RecordJobTerminalState` (`DBCleanMetricEmissionDeferred`)
+
+> **Note:** A run that wedges instead of failing produces the same event. Each
+> Job carries an `activeDeadlineSeconds` of one hour, so a pod stuck in
+> `ImagePullBackOff` or a `barbican-manage` blocked on a database lock reaches a
+> terminal failure within the hour instead of staying active while
+> `DBCleanReady` keeps reporting a healthy schedule. A suspended clean-up raises
+> no event at all: it reports `DBCleanReady=True` under its own reason, and the
+> only signal that the backlog is growing is that the `db_clean` metric stops
+> incrementing.
+
+### Finalization
+
+Emitted while the finalizer tears a deleted Barbican CR down.
+`FinalizingDatabase` is gated on live MariaDB cleanup work remaining, so
+brownfield CRs (no MariaDB CRs) and repeated requeue polls do not produce noise.
+
+| Reason | Type | Trigger Condition | Example Message |
+| --- | --- | --- | --- |
+| `FinalizingDatabase` | Normal | Deletion begins while MariaDB Database/User/Grant CRs are still live | `Cleaning up MariaDB Database, User, and Grant before removing Barbican` |
+| `DatabaseFinalized` | Normal | MariaDB resources marked for deletion; finalizer released | `MariaDB Database, User, and Grant marked for deletion; releasing finalizer` |
+
+**Source:** `reconcileDelete` in `barbican_controller.go`
+
+### Secret Store Controller
+
+Every waiting and failure state of the BarbicanSecretStore controller goes
+through one helper, which records the False sub-condition and a Warning event
+carrying the same reason and message. None of these states reaches the workqueue
+as an error: an unreachable server or a credential nobody has provided yet is a
+state to report and retry (at 30s), not a reconcile failure. The reason
+vocabulary is therefore identical to the condition reasons documented under
+[Conditions](./barbican-secret-store-crd.md#conditions).
+
+| Reason | Type | Condition it lands on | Trigger Condition |
+| --- | --- | --- | --- |
+| `WaitingForCredentials` | Warning | `CredentialsReady` | A referenced Secret does not carry a non-empty `role-id`, `secret-id`, or `ca.crt` yet |
+| `InvalidCredentials` | Warning | `CredentialsReady` | The server rejects the AppRole credentials, and the re-mint cooldown declines to replace them |
+| `InsufficientCapabilities` | Warning | `CredentialsReady` | The AppRole policy does not grant the required capabilities on the mount's data path |
+| `OpenBaoUnreachable` | Warning | `CredentialsReady` or `ProvisioningReady` | The server did not answer, or the client could not be built |
+| `InstanceNotFound` | Warning | `ProvisioningReady` | The referenced `OpenBaoCluster` does not exist |
+| `WaitingForInstance` | Warning | `ProvisioningReady` | The instance is not Available yet, or its provisioner ServiceAccount is missing |
+| `WaitingForInstanceTLS` | Warning | `ProvisioningReady` | The `<instance>-tls-ca` Secret does not carry the trust bundle yet |
+| `InstanceNotProvisioned` | Warning | `ProvisioningReady` | The KV mount or the AppRole the self-init contract provisions is absent |
+| `ProvisioningDenied` | Warning | `CredentialsReady` or `ProvisioningReady` | The operator may not mint a bound token for the provisioner ServiceAccount, or OpenBao answered 403 |
+
+**Source:** the `fail` and `failOpenBao` helpers in
+`barbicansecretstore_controller.go`
+
+> **Note:** `ConfigProjected=False / WaitingForProjection` raises no event. It is
+> the normal state between a store turning credential-ready and the parent
+> rolling the new config out, so an event per store per install would be noise.
+
+### Reasons that never fire for Barbican
+
+| Reason | Why it cannot occur |
+| --- | --- |
+| `SchemaDriftDetected` | The Job set carries no schema-check command (`SchemaCheckCommand: nil`). `barbican-manage db upgrade` is an idempotent alembic upgrade to head, so a second read-only Job would assert nothing the sync itself has not already established |
+| `UpgradeInitiated`, `ExpandComplete`, `MigrateComplete`, `DeploymentRolloutComplete`, `UpgradeComplete`, `UpgradeAborted`, `UpgradeTargetChanged`, `ExpandFailed`, `MigrateFailed`, `ContractFailed` | These belong to the shared expand-migrate-contract flow. Barbican runs no phase machine and its CR carries no `upgradePhase`; a release bump takes the same single db-sync Job a fresh install takes |
+| `DBSyncInProgress` | A `DatabaseReady=False` condition reason while the Job runs, never an event: the polling states raise none |
+
+---
+
+## Alerting Configuration
+
+Event reason strings are designed to be stable identifiers for alerting rules.
+Use `kubectl get events --field-selector` to filter by reason:
+
+```bash
+# Watch for db-sync failures
+kubectl get events --field-selector reason=DBSyncFailed -w
+
+# Watch for a clean-up run that failed or ran past its deadline
+kubectl get events --field-selector reason=DBCleanJobFailed -w
+
+# Watch for a secret store dropping out of the rendered config
+kubectl get events --field-selector reason=SecretStoreDetached -w
+
+# Watch for all Warning events from the barbican-controller
+kubectl get events --field-selector type=Warning,reportingComponent=barbican-controller -w
+
+# Watch for all Warning events from the store controller
+kubectl get events --field-selector type=Warning,reportingComponent=barbicansecretstore-controller -w
+```
+
+### Prometheus Alertmanager Example
+
+When using [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
+with event metrics enabled, you can alert on specific event reasons:
+
+```yaml
+groups:
+  - name: barbican-events
+    rules:
+      - alert: BarbicanSecretStoreDetached
+        expr: |
+          increase(kube_event_count{
+            reason="SecretStoreDetached",
+            involved_object_kind="Barbican"
+          }[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "A Barbican secret store was de-projected"
+          description: "Secrets written through the detached store no longer resolve. Re-attach the store or restore it from the last-good config."
+```
+
+---
+
+## Event Flow
+
+```text
+BarbicanReconciler.Reconcile()
+  │
+  ├── reconcileDelete() (deletionTimestamp set)
+  │     ├─ MariaDB CRs still live  → Normal  FinalizingDatabase
+  │     └─ MariaDB cleanup done    → Normal  DatabaseFinalized
+  │
+  ├── reconcileSecretStores()
+  │     ├─ credentials unreadable  → Warning BarbicanSecretStoreSkipped
+  │     ├─ store de-projected      → Warning SecretStoreDetached
+  │     └─ no/several defaults     → (condition only, no event)
+  │
+  ├── reconcileConfig()
+  │     └─ spec.extraConfig overrides operator-owned keys → Warning ExtraConfigOwnedKeyOverride
+  │       (gated on transition into ExtraConfigHealthy=False, Reason=OwnedKeysOverridden)
+  │
+  ├── reconcileDBClean()
+  │     ├─ newest terminal run failed → Warning DBCleanJobFailed
+  │     └─ Job-UID patch fails        → Warning DBCleanMetricEmissionDeferred
+  │
+  └── reconcileDatabase()
+        ├─ tag/release mismatch      → (condition only, no event)
+        ├─ release gate refuses      → Warning VersionParseError / DowngradeNotSupported /
+        │                                      UpgradePathInvalid / ImageReleaseMismatch
+        ├─ db_sync fails             → Warning DBSyncFailed
+        ├─ db_sync succeeds          → Normal  DatabaseSynced
+        └─ Job-UID patch fails       → Warning DBSyncMetricEmissionDeferred
+
+BarbicanSecretStoreReconciler.Reconcile()
+  │
+  ├── reconcileManaged()     → Warning InstanceNotFound / WaitingForInstance /
+  │                                    WaitingForInstanceTLS / InstanceNotProvisioned /
+  │                                    ProvisioningDenied / OpenBaoUnreachable /
+  │                                    InvalidCredentials
+  ├── reconcileBrownfield()  → Warning WaitingForCredentials / InvalidCredentials /
+  │                                    InsufficientCapabilities / OpenBaoUnreachable
+  └── config projection observed → (condition only, no event)
+```

--- a/docs/reference/barbican/barbican-reconciler.md
+++ b/docs/reference/barbican/barbican-reconciler.md
@@ -1,0 +1,303 @@
+---
+title: Barbican Reconciler Architecture
+quadrant: operator
+---
+
+# Barbican Reconciler Architecture
+
+The Barbican controller runs the shared table-driven pipeline
+(`internal/common/reconcile`) with eleven sub-reconcilers. Every step is
+instrumented under the `barbican_operator` metrics prefix, and the first step to
+return a non-zero result or an error short-circuits the chain. Conditions and
+the requeue are persisted on every exit path through the shared status skeleton,
+which also skips the write when a pass left status unchanged. A second
+reconciler in the same manager owns the attached
+[`BarbicanSecretStore`](./barbican-secret-store-crd.md) CRs.
+
+Two Prometheus vectors cover the pipeline
+(`barbican_operator_reconcile_duration_seconds`,
+`barbican_operator_reconcile_errors_total`, the latter labelled by
+`sub_reconciler` and `condition_type`). Five per-CR collectors cover the Jobs
+and the store credentials: `barbican_operator_db_sync_total` and
+`barbican_operator_db_clean_total`, each labelled by `barbican`, `namespace`,
+and the terminal `result`; `barbican_operator_db_sync_duration_seconds` and
+`barbican_operator_db_clean_duration_seconds`, labelled by `barbican` and
+`namespace`; and `barbican_operator_secretstore_remints_total`, labelled by
+`store`, `namespace`, and a `trigger` of `proactive` (the operator refreshed the
+AppRole secret ID before its TTL lapsed) or `reactive` (the server had already
+rejected it). The split is what tells a healthy rotation schedule apart from one
+that keeps arriving too late. The Job series are dropped when a Barbican's
+finalizer completes; the re-mint series is keyed by the store CR, so the store
+controller drops it on the pass that observes that store's deletion.
+
+## Pipeline
+
+```text
+Secrets ─► DBConnectionSecret ─► SecretStores ─► Config ─► DBClean ─► Database ─► Deployment ─► ┬─ HTTPRoute
+                                                                                                ├─ HealthCheck
+                                                                                                ├─ HPA
+                                                                                                └─ NetworkPolicy  (parallel)
+```
+
+| Step | What it does | Condition |
+| --- | --- | --- |
+| Secrets | Gates on the selected External Secrets store (`spec.secretStoreRef`, default `openbao-cluster-store`), then the ESO-synced database and service-user credential Secrets; digests the service-user password for the rollout annotation | `SecretsReady` |
+| DBConnectionSecret | Materializes the pymysql DSN into the derived `{name}-db-connection` Secret and digests it; **reports through `SecretsReady`** | `SecretsReady` |
+| SecretStores | Aggregates the attached, credential-ready `BarbicanSecretStore`s into the secret-store sections of `barbican.conf`, records what it projected, and resolves the OpenBao egress hosts | `SecretStoresReady` |
+| Config | Renders `barbican.conf` and `barbican-api-paste.ini` (plus `policy.yaml` when applicable) into an immutable content-hashed Secret, prunes the history down to three, and records the `ExtraConfigHealthy` guard. On an invalid projection it re-renders nothing and returns the Secret name the live Deployment mounts. **Reports through `SecretsReady`** (failure reason `ConfigError`) | `SecretsReady` |
+| DBClean | Projects the `{name}-db-clean` CronJob against the rendered config and reports the newest terminal run it spawned | `DBCleanReady` |
+| Database | Provisions the schema (MariaDB cluster gate, `Database`/`User`/`Grant` in managed mode), gates the requested release against the installed one, runs the `{name}-db-sync` Job, and promotes `installedRelease` | `DatabaseReady` |
+| Deployment | Ensures the API Deployment, Service (port 9311), and PDB, narrows the Service selector to the API component once the rollout has converged, and stamps `status.endpoint`. It creates nothing while the projection is invalid | `DeploymentReady` |
+| HTTPRoute | Full `spec.gateway` lifecycle; reflects the Gateway's Accepted condition. It renders no request timeout, since barbican answers short JSON requests and the gateway implementation's default is the right cap | `HTTPRouteReady` |
+| HealthCheck | HTTP GET of the cluster-local `/healthcheck` app through the shared TTL probe cache. The paste composite routes that path outside the authtoken pipeline, so a 2xx means the WSGI app serves requests without a token or a database round trip | `BarbicanAPIReady` |
+| HPA | Creates/deletes the HorizontalPodAutoscaler | `HPAReady` |
+| NetworkPolicy | Creates/deletes the NetworkPolicy (auto-derived DNS, database, Keystone, cache, and OpenBao egress); refuses an empty ingress list (fail-closed) | `NetworkPolicyReady` |
+
+`DBConnectionSecret` and `Config` reuse `SecretsReady` instead of a dedicated
+`ConfigReady` condition, the same mapping the sibling operators use: both
+produce Secret artefacts that gate the same downstream graph, so a distinct
+`sub_reconciler` label on the error counter disambiguates them during triage
+while the status contract stays minimal.
+
+Two orderings in that chain are decisions rather than data dependencies:
+
+- **DBClean runs ahead of Database.** The clean-up's bulk `DELETE`s contend with
+  the DDL locks a schema migration holds, so the CronJob has to be suspended for
+  the length of a migration. The pipeline short-circuits at the Database step
+  for as long as the sync Job runs, which means a step placed behind it is never
+  reached during the one window that needs pausing. Its only input is the
+  rendered config the CronJob mounts, which the Config step above already
+  produced.
+- **SecretStores never short-circuits.** Every waiting state of that step (no
+  default, several defaults, several OpenBao stores, an unreadable credentials
+  Secret) returns a zero result and no error, so a first install proceeds to the
+  steps that report what is missing. A store's status flip re-enqueues the
+  parent through the `BarbicanSecretStore` watch, which is a faster signal than
+  any requeue interval.
+
+The four members of the parallel group have no inter-dependency once the
+Deployment and Service exist. Each works on its own copy of the CR, sets one
+condition type, and always sets it, so a cluster without Gateway API or without
+autoscaling still resolves the aggregate through the `NotRequired` reasons.
+
+## Conditions
+
+The aggregate `Ready` condition is `True` (reason `AllReady`) when all nine
+sub-conditions are `True`, and `False` (`NotAllReady`) otherwise.
+
+| Type | True reasons | False reasons |
+| --- | --- | --- |
+| `SecretsReady` | `SecretsAvailable` | `SecretStoreNotReady`, `WaitingForDBCredentials`, `WaitingForServiceUserCredentials`, `ConfigError` |
+| `SecretStoresReady` | `AllStoresProjected` | `NoDefaultSecretStore`, `MultipleOpenBaoStores`, `WaitingForSecretStores` |
+| `DBCleanReady` | `DBCleanScheduled`, `DBCleanSuspended` | `DBCleanJobFailed`, `DBCleanBlocked`, `WaitingForSecretStores` |
+| `DatabaseReady` | `DatabaseSynced` | `WaitingForSecretStores`, `WaitingForDatabase`, `DBSyncInProgress`, `DBSyncFailed`, `VersionParseError`, `DowngradeNotSupported`, `UpgradePathInvalid`, `ImageReleaseMismatch`, plus the shared cluster-gate reason the provisioning flow sets while the referenced MariaDB is unavailable |
+| `DeploymentReady` | `DeploymentReady` | `WaitingForSecretStores`, `WaitingForDeployment` |
+| `BarbicanAPIReady` | `APIHealthy` | `APIUnhealthy`, `HealthCheckTimeout`, `ConnectionFailed`, `HealthCheckFailed`, plus the shared pre-endpoint wait the probe flow sets before `status.endpoint` is stamped |
+| `HPAReady` | `HPAReady`, `HPANotRequired` | — (errors propagate) |
+| `NetworkPolicyReady` | `NetworkPolicyReady`, `NetworkPolicyNotRequired` | — (errors propagate) |
+| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled` |
+
+`WaitingForSecretStores` appears on four condition types. On
+`SecretStoresReady` it reports a credentials Secret this pass could not read. On
+`DBCleanReady`, `DatabaseReady`, and `DeploymentReady` it reports the cascade a
+missing default store causes: the CronJob and the migration Job have no config
+Secret to mount, and the API pods have no store to resolve secrets through.
+
+`DBCleanSuspended` is a True reason twice over, once for
+`spec.dbClean.suspend` and once for the pause a schema convergence imposes. The
+migration pause reports `DBCleanBlocked` and `False` instead when the release
+gate rejected the transition it is waiting for: nothing is running, the
+convergence is not coming, and the backlog grows until `spec.openStackRelease`
+and `spec.image` are corrected.
+
+One further condition is set and never aggregated. `ExtraConfigHealthy` reports
+whether `spec.extraConfig` overrides an operator-owned key: `True` with reason
+`NoOwnedKeysOverridden`, `False` with reason `OwnedKeysOverridden` and a message
+naming each overridden key. It stays out of the sub-condition list so an
+override the operator honors reports itself without holding the aggregate down.
+The three credential overrides that would already have done their damage by the
+time a condition could report them are refused at admission; see
+[Defaulting and validation](./barbican-crd.md#defaulting-and-validation).
+
+## Secret-store aggregation
+
+The SecretStores step lists the attached stores through the
+`spec.barbicanRef.name` field index, sorts them by name so the rendered sections
+and the config Secret's content hash are stable across passes, and keeps the
+ones whose `CredentialsReady` condition is True. It never consults the store's
+aggregate `Ready`, which also requires `ConfigProjected` and would deadlock,
+since `ConfigProjected` only turns True after this step projects the store.
+
+What it renders into the one content-hashed config Secret:
+
+- `[secretstore]`, the process-global registry, carrying
+  `enable_multiple_secret_stores = true` and a `stores_lookup_suffix` list of
+  the ready store names.
+- One `[secretstore:<name>]` per ready store, each with
+  `secret_store_plugin = vault_plugin`. The default store's section also carries
+  `global_default = True`; the option is written on that store alone, since a
+  second global default is a configuration error barbican refuses to start with.
+- `[vault_plugin]`, derived from the default store alone. It is process-global,
+  and the single-OpenBao-store rule guarantees the default is the only store
+  that can contribute to it.
+
+`approle_secret_id` is never rendered. The AppRole secret ID reaches the pods as
+the `OS_VAULT_PLUGIN__APPROLE_SECRET_ID` environment variable, sourced from the
+Secret the store itself owns, and its SHA-256 is stamped into a pod-template
+annotation so a re-mint rolls the Deployment. The rendered document is a Secret,
+but every API pod mounts it and the store controller reads it back to observe
+`ConfigProjected`, so the secret ID's only copy stays where the store keeps it.
+The role ID does travel in the file, which is why the config artefact is a
+Secret and not a ConfigMap.
+
+Three historical config Secrets are retained beside the current one, so a
+rollback has something to roll back to. An invalid projection re-renders nothing
+at all: the Config step returns the Secret name the live Deployment mounts, and
+the running pods keep the configuration they started with. Egress follows that
+same last-good record, not the projection this pass could build. The
+NetworkPolicy step widens its OpenBao host set from
+`status.projectedSecretStoreHosts`, because a dropped host means no OpenBao rule
+at all, and with `Egress` in `policyTypes` no rule is a deny. The record is
+written on the valid path alone: re-deriving the URL from the live store spec
+would let anyone able to write a store point `spec.openBao.server.url` at a
+server of their choosing, let the projection go invalid, and have that port land
+in a destination-unrestricted egress rule on API pods they cannot edit.
+
+A store that drops out of `status.projectedSecretStores` raises the
+`SecretStoreDetached` Warning event on the pass that de-projects it, naming what
+the change costs: barbican resolves each stored secret through the
+`secret_stores` row that names the store it was written to, so the material
+written through a de-projected store stops resolving.
+
+## Database
+
+The Database step runs the shared provisioning flow first: a MariaDB cluster
+gate and `Database`/`User`/`Grant` in managed mode, a no-op in brownfield, and no
+`User`/`Grant` under `credentialsMode: Dynamic`, where an external engine issues
+the credential. The SQL user's `max_user_connections` is sized from the CR's own
+topology, `(pods + 1) × processes × threads + 2`, with `pods` taken from
+`spec.autoscaling.maxReplicas` when an HPA owns the replica count. Left unsized,
+the mariadb-operator default of 10 applies, which a raised
+`spec.apiServer.uwsgi.processes` exceeds before a single request is served.
+
+The migration is a single `{name}-db-sync` Job running `barbican-manage db
+upgrade`, one alembic upgrade to head that applies every pending revision in one
+pass. The Job passes no `--config-file`: `barbican-manage` builds its
+oslo.config from the project name and resolves `barbican.conf` through the fixed
+search path, which the mounted config directory is on, so the Job and the API
+pods read the identical file. Because that one pass is idempotent, the Job set
+carries no schema-check command, and `SchemaDriftDetected` never fires for
+Barbican.
+
+A release transition is a `spec.openStackRelease` bump with the image in
+lockstep. There is no phase machine: the release gate validates the requested
+release against `status.installedRelease` before any Job runs, and rejects an
+unparseable release on either side (`VersionParseError`), a downgrade
+(`DowngradeNotSupported`), and a jump of more than one release
+(`UpgradePathInvalid`). Each rejection sets `DatabaseReady=False` with the shared
+reason, raises a Warning event, and returns an error so the controller backs off.
+An accepted bump stamps `status.targetRelease`, the db-sync Job runs on the new
+image, the Deployment rolls onto it, and the sync flow promotes
+`status.installedRelease` on Job success, at which point `targetRelease` is
+cleared and `status.installedImage` records the image that ran the migration.
+
+Two guards keep the release marker honest, one per pinning style. A tag-pinned
+image whose tag names a different release than `spec.openStackRelease` sets
+`DatabaseReady=False / ImageReleaseMismatch` and requeues, since the Job would
+run the wrong `barbican-manage` binary. A release bump that leaves `spec.image`
+untouched is refused under the same reason, because the Job's pod template would
+be identical, the shared flow would short-circuit on the already-completed Job,
+and `installedRelease` would advance off a run of the previous release's binary.
+The second guard compares `status.installedImage`, so it covers a digest-pinned
+image the first one cannot read.
+
+The single pass has one consequence the phased flow does not. This step runs
+ahead of the Deployment step and requeues while the Job runs, so the schema
+reaches release N before a single pod of release N exists: from Job completion
+until the last old pod terminates, release N-1 code serves traffic against a
+release N schema. Whether that window is safe is a property of the alembic
+revisions the target release carries. A release with a non-additive revision (a
+dropped or renamed column) needs the API drained before the upgrade;
+`DatabaseReady` goes True the moment the Job completes and reports nothing about
+the rollout that follows.
+
+## Requeue semantics
+
+| Interval | Used by |
+| --- | --- |
+| 10s | Deployment readiness polling, HTTPRoute acceptance, health-check retry |
+| 15s | ESO secret-gate polling (Secrets, DBConnectionSecret) |
+| 30s | MariaDB and db-sync database wait, the finalizer hold while the MariaDB CRs tear down, and every waiting or failure state of the store controller |
+| 30s TTL | Health-probe cache (a passing `/healthcheck` probe is reused within the TTL) |
+| 15m | Store credential revalidation: every pass for a brownfield store, and for a managed store whose secret ID carries no TTL and has no re-mint timer to ride on |
+
+A managed store with a TTL requeues at its own proactive re-mint threshold, two
+thirds of the recorded lifetime, floored at the 30s retry cadence. That leaves a
+full third of the TTL as the margin in which a failing re-mint can be retried
+while the credential in the pods is still valid.
+
+## Rotation and deletion
+
+- **Credential rotation** happens at the source. The service-user password
+  (`OS_KEYSTONE_AUTHTOKEN__PASSWORD`), the assembled DSN
+  (`OS_DATABASE__CONNECTION`), and the AppRole secret ID
+  (`OS_VAULT_PLUGIN__APPROLE_SECRET_ID`) are all environment-variable-delivered,
+  so a restart is required for a rotation to take effect. Each value is digested
+  into a pod-template annotation, `barbican.c5c3.io/authtoken-hash`,
+  `barbican.c5c3.io/db-connection-hash`, and
+  `barbican.c5c3.io/secret-store-credentials-hash`, so a changed digest rolls the
+  Deployment. Each annotation is omitted while its digest is empty, which is what
+  the requeue and error paths upstream produce, so a short-circuited pass causes
+  no spurious rollout.
+- **Deletion** runs the `barbican.openstack.c5c3.io/finalizer`. It issues Delete
+  on the MariaDB `Database`/`User`/`Grant` CRs before the owner-ref chain
+  disappears, emitting `FinalizingDatabase` while cleanup remains and
+  `DatabaseFinalized` when the finalizer is released. Whether cleanup remains is
+  observed before the Delete, since a Delete flips `DeletionTimestamp` and a
+  post-Delete check would always report nothing live and release immediately.
+  Every other owned resource is namespace-scoped with a controller owner
+  reference, so Kubernetes garbage collection reclaims it. Releasing the
+  finalizer also drops the CR's metric series and evicts its health-probe cache
+  entry. A `BarbicanSecretStore` carries no finalizer at all; see
+  [Retained Artefacts](./barbican-secret-store-crd.md#retained-artefacts).
+
+## Watches
+
+The Barbican controller `Owns` its Deployment, Service, Secret,
+PodDisruptionBudget, HorizontalPodAutoscaler, NetworkPolicy, Job, and CronJob.
+The HTTPRoute is added to the `Owns` set only when the Gateway API CRD is
+installed, probed at setup through the RESTMapper; without it `spec.gateway`
+surfaces `HTTPRouteReady=False / GatewayAPINotInstalled` instead of failing the
+controller at start with an unknown kind. The CR's own status-only updates are
+filtered out, so a status write does not re-wake the controller.
+
+Beyond the owned set it watches:
+
+- **Secrets**, mapped to the Barbican CRs that reference them. One field index
+  holds the deduplicated union of `spec.serviceUser.secretRef.name` and
+  `spec.database.secretRef.name`; a second holds the AppRole credentials and CA
+  bundle Secrets a brownfield store references, so a rotated store credential
+  re-renders the config through the store's parent. A managed store indexes under
+  nothing there, since it references no Secret by name. ESO-managed Secrets are
+  owned by the ExternalSecret controller, so an owner-reference watch alone would
+  never match them.
+- **BarbicanSecretStores**, mapped to their parent, without a generation
+  predicate: the status transitions are the signal. `CredentialsReady` turning
+  True triggers projection and a `DeletionTimestamp` triggers de-projection.
+- **MariaDB** clusters referenced by `spec.database.clusterRef`, so an upstream
+  database outage reflects in `DatabaseReady` without waiting for the periodic
+  requeue.
+- Both the cluster-scoped `ClusterSecretStore` and the namespaced `SecretStore` a
+  Barbican can select, so a backend outage reflects in `SecretsReady` as soon as
+  ESO flips the store's Ready condition. A Barbican that omits
+  `spec.secretStoreRef` resolves to the shared cluster store, so the default
+  fan-out is preserved while a Barbican pinned to a namespaced store is woken
+  only by its own.
+
+The store controller watches two objects of its own, both without a generation
+predicate for the same reason: the parent `Barbican`, whose status flips carry
+the projection landing in the Deployment, and the `OpenBaoCluster` a managed
+store names, whose Available condition is what unblocks a store waiting on it.
+Both resolve through field indexes registered by the Barbican controller's
+`SetupWithManager`, which is the single registration site and therefore runs
+first.

--- a/docs/reference/barbican/barbican-secret-store-crd.md
+++ b/docs/reference/barbican/barbican-secret-store-crd.md
@@ -1,0 +1,332 @@
+---
+title: BarbicanSecretStore CRD
+quadrant: operator
+---
+
+# BarbicanSecretStore CRD
+
+Reference documentation for the BarbicanSecretStore Custom Resource Definition.
+One CR attaches to a [Barbican](./barbican-crd.md) CR via `spec.barbicanRef` and
+describes the backend the secret material itself is written to. Phase 1 ships
+`type: OpenBao`, driven by barbican's vault secret-store plugin.
+
+The attachment is inverted: the store points at the Barbican, so a store is
+added or replaced without editing the Barbican CR. A dedicated controller owns
+the store lifecycle, the AppRole credentials and the per-store conditions, while
+the barbican-side sub-reconciler aggregates the attached, credential-ready
+stores into the rendered `barbican.conf` and promotes the one marked `isDefault`
+to `global_default`. For that controller topology see
+[Barbican Reconciler Architecture](./barbican-reconciler.md).
+
+The CRD is generated from
+`operators/barbican/api/v1alpha1/barbicansecretstore_types.go`; the webhook
+lives in `barbicansecretstore_webhook.go` and the controllers in
+`operators/barbican/internal/controller/barbicansecretstore_controller.go` and
+`reconcile_secretstores.go`.
+
+## API Group and Version
+
+| Field | Value |
+| --- | --- |
+| Group | `barbican.openstack.c5c3.io` |
+| Version | `v1alpha1` |
+| Kind | `BarbicanSecretStore` |
+| List Kind | `BarbicanSecretStoreList` |
+| Scope | Namespaced |
+
+**Printer columns:** `kubectl get barbicansecretstores` shows Ready
+(`.status.conditions[?(@.type=='Ready')].status`), Type (`.spec.type`), Default
+(`.spec.isDefault`), Barbican (`.spec.barbicanRef.name`), and Age.
+
+## Example
+
+```yaml
+apiVersion: barbican.openstack.c5c3.io/v1alpha1
+kind: BarbicanSecretStore
+metadata:
+  name: openbao-primary
+  namespace: openstack
+spec:
+  barbicanRef:
+    name: barbican
+  type: OpenBao
+  isDefault: true
+  openBao:
+    instanceRef:
+      name: openbao-instance
+status:
+  conditions:
+  - type: CredentialsReady
+    status: "True"
+    reason: CredentialsAvailable
+  - type: ProvisioningReady
+    status: "True"
+    reason: Provisioned
+  - type: ConfigProjected
+    status: "True"
+    reason: ConfigProjected
+  - type: Ready
+    status: "True"
+    reason: AllReady
+```
+
+The `metadata.name` (`openbao-primary`) becomes the store identifier: it is the
+suffix of the `[secretstore:openbao-primary]` section barbican reads and one
+entry of the `[secretstore] stores_lookup_suffix` list.
+
+## Spec
+
+### BarbicanSecretStoreSpec
+
+Three schema-level CEL rules hold even when the webhook is down: `barbicanRef`
+and `type` are immutable (UPDATE transition rules), and the `type`/`openBao`
+union rule `(self.type == 'OpenBao') == has(self.openBao)` requires one store
+block matching `spec.type` and no other.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `barbicanRef` | [`BarbicanRefSpec`](#barbicanrefspec) | Yes | — | Names the Barbican CR in the same namespace. **Immutable** (CEL transition rule): re-pointing a store would leave the old deployment with a store nothing manages anymore and race the projection on the new one. Delete and recreate instead. The Barbican need not exist at admission time (GitOps ordering); a dangling reference surfaces as `Ready=False`. |
+| `type` | `BarbicanSecretStoreType` | Yes | — | Store plugin; the enum holds one value, `OpenBao`. A brownfield HashiCorp Vault server attaches under the same value: the plugin talks the KV v2 API, which OpenBao and Vault both serve, so the two are interchangeable from barbican's side. **Immutable**, and for a harder reason than `barbicanRef`: material already written through a store cannot be read back through a different plugin. |
+| `openBao` | [`*OpenBaoStoreSpec`](#openbaostorespec) | When `type: OpenBao` | — | The OpenBao-backed store. Required when `type` is `OpenBao` and forbidden otherwise (union rule). |
+| `isDefault` | `bool` | No | `false` | Marks this store the Barbican global default (`global_default` in its `[secretstore:<name>]` section). **Mutable.** One attached, credential-ready store must carry it and no more than one; the barbican-side sub-reconciler and a sibling-uniqueness webhook both enforce that. |
+| `extraOptions` | `map[string]string` | No | — | Free-form `[vault_plugin]` options not covered by the typed fields, keyed by bare option name. The entries merge into the process-global section every OpenBao store on the same Barbican shares. `MaxProperties=32`, and a CEL rule bounds each key at 256 and each value at 1024 characters. See the [denylist](#extraoptions-denylist). |
+
+### BarbicanRefSpec
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | The referenced Barbican CR's name (`MinLength=1`). |
+
+### SecretNameRefSpec
+
+Unlike `commonv1.SecretRefSpec`, this reference carries no `key` field: the data
+keys are fixed by contract, so there is nothing to select.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | The referenced Secret's name (`MinLength=1`). |
+
+### InstanceRefSpec
+
+Kept apart from `SecretNameRefSpec` so the generated schema describes what the
+name addresses: the OpenBao instance the operator provisions against, not a
+Secret.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | The referenced `OpenBaoCluster`'s name (`MinLength=1`). |
+
+### OpenBaoStoreSpec
+
+Two modes, selected by which of `instanceRef` and `server` is set. Managed mode
+points at an `OpenBaoCluster` this cluster runs: the operator mints the AppRole
+credentials at runtime and owns the KV mount. Brownfield mode points at an
+OpenBao or HashiCorp Vault server elsewhere and is validate-only, the same
+read-only posture K-ORC takes with unmanaged imports: the operator reads the
+referenced Secrets and renders the configuration, and never creates a mount, a
+policy, an AppRole, or secret material on that server.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `instanceRef` | [`*InstanceRefSpec`](#instancerefspec) | Managed mode | — | The `OpenBaoCluster` (`openbao.org/v1alpha1`) in this store's namespace to provision against. Everything else is derived from that name by convention: the server URL `https://<instance>.<namespace>.svc:8200`, the CA Secret `<instance>-tls-ca`, and the provisioner ServiceAccount `<instance>-provisioner` the operator mints a bound token for. |
+| `server` | [`*OpenBaoServerSpec`](#openbaoserverspec) | Brownfield mode | — | An OpenBao or Vault server provisioned outside this operator. |
+| `kvMountpoint` | `string` (MinLength=1) | No | `barbican` | The path the KV v2 engine holding barbican's material is mounted at. A managed store is pinned to the default; a brownfield store names whatever mount its server provides. The default only fills an absent field, so the `MinLength` guard is what rejects an explicitly empty path. |
+| `namespace` | `string` | No | — | Scopes every request to an OpenBao/Vault namespace (the enterprise-style multi-tenancy header). Brownfield only. It also scopes the operator's own login and capability read, since the AppRole lives in that namespace. |
+
+Three further CEL rules shape the block:
+
+| Rule | Message |
+| --- | --- |
+| `has(self.instanceRef) != has(self.server)` | `exactly one of instanceRef or server must be set` |
+| `!has(self.instanceRef) \|\| (self.kvMountpoint == 'barbican' && !has(self.namespace))` | `managed stores (instanceRef) must keep kvMountpoint barbican and leave namespace unset: the self-init contract provisions only the barbican/ mount at the root namespace` |
+| `self.kvMountpoint == oldSelf.kvMountpoint` | `kvMountpoint is immutable: the secret material already written under the old mount is not reachable under a new one` |
+
+A fourth, `has(self.instanceRef) == has(oldSelf.instanceRef)`, freezes the mode
+itself: switching between a managed instance and a brownfield server re-points
+the plugin at a different server entirely. Delete and recreate the store.
+
+### OpenBaoServerSpec
+
+Both Secret references resolve in the store's namespace.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `url` | `string` | Yes | The server's API base URL. `MinLength=1` and pattern `^https://`. TLS is mandatory: the operator's own AppRole login and every secret barbican stores travel this URL, and a plaintext scheme would also make a supplied `caBundleSecretRef` a no-op, leaving a CR that looks TLS-configured and is not. The webhook re-checks the prefix. |
+| `caBundleSecretRef` | `*SecretNameRefSpec` | No | The Secret holding the PEM CA bundle that authenticates the server, under the fixed data key `ca.crt`. Omit it when the server presents a certificate the pods already trust through their system store; the rendered config then omits `ssl_ca_crt_file`, and no bundle is mounted. |
+| `credentialsSecretRef` | `SecretNameRefSpec` | Yes | The Secret holding the AppRole credentials barbican authenticates with, under the fixed data keys `role-id` and `secret-id`. The AppRole is created on the server outside this operator, which only reads the Secret. |
+
+**Credentials data-key contract.** Both modes read the same keys, pinned by
+contract and not selectable per CR (the constants live at the top of
+`barbicansecretstore_types.go`):
+
+| Data key | Where it goes |
+| --- | --- |
+| `role-id` | Rendered as `[vault_plugin] approle_role_id` |
+| `secret-id` | Injected as the `OS_VAULT_PLUGIN__APPROLE_SECRET_ID` env var, never written to the config file |
+| `ca.crt` | Mounted into the API pods; the mount path is what `[vault_plugin] ssl_ca_crt_file` points at |
+
+## extraOptions Denylist
+
+The validating webhook rejects `extraOptions` keys the projection owns, so the
+escape hatch cannot contradict the typed spec. Every key must first match
+`^[A-Za-z0-9_]+$` (letters, digits, underscore); vault plugin option names are
+snake_case, so that is the full legitimate charset, and the pattern runs before
+the exact-match denylist so an embedded newline or a denylist-evading trailing
+space cannot slip through. Values carrying a newline or carriage return are
+rejected as an INI-injection guard.
+
+| Group | Rejected keys |
+| --- | --- |
+| Derived from the typed store spec | `vault_url`, `use_ssl`, `ssl_ca_crt_file`, `approle_role_id`, `approle_secret_id`, `root_token_id`, `kv_mountpoint`, `namespace` |
+| Structural secret-store wiring | `secret_store_plugin`, `crypto_plugin`, `global_default` |
+
+The renderer consults the same predicate when it merges `extraOptions` into the
+plugin section. An exists check alone would only cover the keys the operator
+wrote this pass, which leaves the four it never writes (`root_token_id`,
+`approle_secret_id`, `crypto_plugin`, and `ssl_ca_crt_file` on a store with no
+CA bundle) free to pass through on a CR that reached etcd without the webhook.
+`root_token_id` is the one that matters: the plugin prefers a root token over
+AppRole authentication, so it would defeat the mount-scoped AppRole the managed
+store is built on.
+
+Separately, a store's `metadata.name` becomes its `[secretstore:<name>]` section
+suffix, and barbican resolves that suffix against the flat section namespace of
+one config file. The webhook therefore rejects a name colliding with a reserved
+section: `default` (matched case-insensitively, which covers the upstream
+`DEFAULT`), `database`, `keystone_authtoken`, `secretstore`, `vault_plugin`,
+`queue`, `oslo_policy`, `oslo_middleware`, and `healthcheck`.
+
+## Default-Store Semantics
+
+One attached, credential-ready store must be marked `isDefault`, and no more
+than one. Two gates enforce it:
+
+- **Admission (sibling uniqueness).** When a store under validation sets
+  `isDefault`, the webhook lists its namespace siblings (an uncached read),
+  filters to the same `spec.barbicanRef.name`, skips self and `Terminating`
+  siblings, and rejects if another default already exists. A second rule with
+  the same shape rejects a second `OpenBao`-typed sibling whether or not it is
+  the default, because the `[vault_plugin]` section is process-global.
+- **Reconcile (the counting rule).** The barbican-side sub-reconciler counts the
+  credential-ready defaults. Zero or more than one is an invalid projection: it
+  sets `SecretStoresReady=False / NoDefaultSecretStore`, re-renders nothing, and
+  the config step retains the last-good Secret the live Deployment mounts. More
+  than one credential-ready OpenBao store lands on the same path under
+  `MultipleOpenBaoStores`.
+
+Flipping `isDefault` between siblings re-renders the config Secret: unlike the
+Glance backends split, barbican keeps the default marker inside the per-store
+section (`global_default`) of the one document, so the content hash changes and
+the pods roll.
+
+Deleting a store is not a no-op for the data behind it. Barbican resolves every
+stored secret through the `secret_stores` row naming the store it was written
+to, so once a `[secretstore:<name>]` section is gone, every secret written under
+it stops resolving. Nothing else says so: the store CR carries no finalizer, its
+deletion is not validated, and the parent re-renders as soon as the remaining
+stores form a valid projection. The `SecretStoreDetached` Warning event fires on
+the pass that de-projects the store and names that consequence.
+
+### Conditions
+
+The `BarbicanSecretStoreReconciler` is the single writer of this status. The
+barbican-side sub-reconciler reads `CredentialsReady` alone (never the aggregate
+`Ready`, which also requires `ConfigProjected` and would deadlock, since
+`ConfigProjected` only turns True after the projection lands) and writes the
+aggregated `SecretStoresReady` condition onto the Barbican CR instead.
+
+| Type | Owner | Status | Reason | Meaning |
+| --- | --- | --- | --- | --- |
+| `CredentialsReady` | BarbicanSecretStore | True | `CredentialsAvailable` | The credentials in hand are accepted by the server: a managed store's minted pair passed a login probe, a brownfield store's referenced pair logged in and holds the `create`, `read`, `update`, `delete`, `list` capabilities on the mount's data path |
+| `CredentialsReady` | BarbicanSecretStore | False | `WaitingForCredentials` | The referenced Secret does not carry a non-empty `role-id`, `secret-id`, or `ca.crt` yet |
+| `CredentialsReady` | BarbicanSecretStore | False | `InvalidCredentials` | The server rejects the credentials. A managed store re-mints once, at most once per ten minutes, and reports the rejection in between |
+| `CredentialsReady` | BarbicanSecretStore | False | `InsufficientCapabilities` | The AppRole policy does not grant all five capabilities on the probe path |
+| `CredentialsReady` | BarbicanSecretStore | False | `OpenBaoUnreachable` | The server did not answer, or the client could not be built |
+| `ProvisioningReady` | BarbicanSecretStore | True | `Provisioned` | The referenced `OpenBaoCluster` is Available and carries the `barbican` KV mount and the `barbican` AppRole |
+| `ProvisioningReady` | BarbicanSecretStore | False | `InstanceNotFound` | No `OpenBaoCluster` of that name exists in the store's namespace |
+| `ProvisioningReady` | BarbicanSecretStore | False | `WaitingForInstance` | The instance is not Available yet, or its provisioner ServiceAccount does not exist |
+| `ProvisioningReady` | BarbicanSecretStore | False | `WaitingForInstanceTLS` | The `<instance>-tls-ca` Secret does not carry the `ca.crt` trust bundle yet |
+| `ProvisioningReady` | BarbicanSecretStore | False | `InstanceNotProvisioned` | The instance is up but the self-init requests (`barbican_kv`, `approle_auth`, `barbican_approle_role`) did not run: the mount or the AppRole is missing |
+| `ProvisioningReady` | BarbicanSecretStore | False | `ProvisioningDenied` | The operator may not mint a bound token for the provisioner ServiceAccount, or OpenBao answered 403. The TokenRequest grant is namespace- and account-scoped by design and is rendered per `rbac.secretStoreNamespaces` key, so an unlisted namespace lands here |
+| `ConfigProjected` | BarbicanSecretStore | True | `ConfigProjected` | The parent Barbican Deployment mounts a `barbican.conf` carrying this store's `[secretstore:<name>]` section |
+| `ConfigProjected` | BarbicanSecretStore | False | `WaitingForProjection` | The projection has not landed in the Deployment yet |
+| `Ready` | BarbicanSecretStore | True | `AllReady` | Every sub-condition of the store's mode is True |
+| `Ready` | BarbicanSecretStore | False | `NotAllReady` | At least one is not |
+| `SecretStoresReady` | Barbican | True | `AllStoresProjected` | Every attached store is credential-ready and projected, with a valid default |
+| `SecretStoresReady` | Barbican | False | `NoDefaultSecretStore` | Zero or more than one credential-ready store is marked `isDefault`; last-good config is retained |
+| `SecretStoresReady` | Barbican | False | `MultipleOpenBaoStores` | More than one credential-ready store is of type `OpenBao`; the reconcile-time backstop for a store that bypassed admission |
+| `SecretStoresReady` | Barbican | False | `WaitingForSecretStores` | The default store passed its own credential gate, but its credentials Secret could not be read this pass, or an assembled option carried a control character |
+
+`ProvisioningReady` is managed-mode only. A brownfield store has no instance
+this operator provisions, so the condition is removed from the status on every
+pass and the aggregate is derived from the remaining two, which keeps a store
+that used to name an `instanceRef` from waiting on a condition nothing sets.
+
+**Per-store fault isolation.** When the default store's credentials Secret
+cannot be read, or an assembled `[vault_plugin]` value carries a control
+character, the barbican-side step keeps the last-good configuration, emits a
+`BarbicanSecretStoreSkipped` Warning event on the Barbican CR, and waits for the
+store watch. None of the waiting states returns an error or a requeue: a store's
+status flip re-enqueues the parent.
+
+## Immutability and Validation Summary
+
+Schema-layer rules (CEL and kubebuilder markers, enforced even when the webhook
+is down): the `barbicanRef` and `type` transition rules, the `type`/`openBao`
+union, the `OpenBao` type enum, the `instanceRef`/`server` union, the managed
+mount-and-namespace pin, the `kvMountpoint` and mode transition rules, the
+`^https://` URL pattern, the `MinLength` guards on every reference name, and the
+`extraOptions` `MaxProperties` and key/value length bounds.
+
+Webhook rules (defense in depth plus what CEL cannot express): the union
+re-checks, the `https://` prefix re-check, the reserved-section collision guard
+on `metadata.name`, the `extraOptions` key pattern and denylist, the
+INI-injection guard on `extraOptions` values, the single-default sibling check,
+and the single-OpenBao-store sibling check. The `kvMountpoint` default
+(`barbican`) is materialized by the defaulting webhook for callers that bypass
+it.
+
+`metadata.name` is bounded at 55 characters, checked on create only for the
+reason the [Barbican CRD](./barbican-crd.md#defaulting-and-validation) gives for
+its own bound: the operator derives the AppRole credentials Secret by appending
+`-approle`, and a Secret name is capped at the 63 characters of a DNS label, so
+`MaxBarbicanSecretStoreNameLength = 63 − len("-approle")`.
+
+## Chainsaw E2E Tests
+
+The managed flow (an `OpenBaoCluster` in the suite, the minted `-approle`
+Secret, and the rendered store section) lives in
+`tests/e2e/barbican/secretstore-managed`. The brownfield flow, where the AppRole
+is seeded outside the operator and the store is validate-only, lives in
+`tests/e2e/barbican/secretstore-brownfield`. Flipping `isDefault` between two
+attached stores and re-rendering `global_default` lives in
+`tests/e2e/barbican/default-secretstore-switch`. The detach path lives in
+`tests/e2e/barbican/deletion-cleanup`. The rejection corpus lives in
+`tests/e2e/barbican/invalid-barbicansecretstore-cr` and covers the union rules,
+the managed-mode pins, the reserved names, the name bound, the `extraOptions`
+guards, the transition rules, and both sibling rules.
+
+## Retained Artefacts
+
+A managed store's AppRole credentials live in a Secret named after the store,
+`<store>-approle`, carrying `role-id` and `secret-id` under the contract keys.
+The operator writes it with a controller owner reference to the store CR, so
+Kubernetes garbage collection reclaims it when the store is deleted. There is no
+finalizer, and that is the design: the AppRole itself is shared instance state
+the self-init contract owns rather than state of this CR, so revoking it on
+delete would break every other store on the same instance. Deleting a store
+detaches it and nothing more.
+
+Two annotations on that Secret carry the re-mint timer:
+
+| Annotation | Value |
+| --- | --- |
+| `barbican.c5c3.io/secret-id-minted-at` | RFC 3339 timestamp of the mint |
+| `barbican.c5c3.io/secret-id-ttl-seconds` | The TTL the server returned; `0` means the secret ID does not expire |
+
+They are the only record there is. OpenBao hands a secret ID out once and offers
+no read-back, so the operator re-mints at two thirds of the recorded TTL and
+verifies the credentials in hand with a login probe otherwise. A brownfield
+store's Secrets are referenced, never written: the operator reads `role-id`,
+`secret-id`, and (when `caBundleSecretRef` is set) `ca.crt`, and leaves their
+lifecycle to whoever created them.

--- a/docs/reference/barbican/index.md
+++ b/docs/reference/barbican/index.md
@@ -1,0 +1,94 @@
+---
+title: Barbican Operator
+quadrant: operator
+---
+
+# Barbican Operator
+
+The Barbican operator deploys and manages the OpenStack Key Manager service as
+a Kubernetes-native workload. It is the fifth service operator built on the
+shared scaffolding the Keystone operator established (`internal/common`, the
+`operator-library` Helm chart, the parameterized operator image), after
+Keystone, Horizon, Glance, and Placement.
+
+Barbican keeps secret metadata in its own MariaDB schema and hands the secret
+material itself to a secret-store plugin. That store is modeled out-of-band as
+a [`BarbicanSecretStore`](./barbican-secret-store-crd.md) CR attached through
+`spec.barbicanRef`, the same inverted attachment `GlanceBackend` uses, so a
+store is added or replaced without editing the Barbican CR. Phase 1 ships one
+store type, `OpenBao`.
+
+## Design decisions
+
+The v1 operator resolves the onboarding decisions as follows:
+
+- **No message bus.** The rendered config carries `[queue] enable = false`. The
+  only workload the operator projects is the API Deployment: there is no
+  `barbican-worker` consumer behind the queue, and no retry or keystone-listener
+  daemon either. The queue only moves asynchronous order processing to such a
+  worker, so with none deployed an enabled queue would leave orders pending
+  instead of failing them. The key is therefore operator-owned, and an
+  `extraConfig` override of it is reported through `ExtraConfigHealthy`.
+- **One OpenBao store per Barbican.** The vault plugin reads its server URL,
+  its AppRole and its mount from the process-global `[vault_plugin]` section,
+  which every store in one `barbican.conf` shares. A second OpenBao store would
+  not get a second server: both `[secretstore:<name>]` sections would resolve to
+  the same plugin configuration and whichever rendered last would decide where
+  the other one's secrets are written. `validateSiblingOpenBaoUniqueness` in
+  `operators/barbican/api/v1alpha1/barbicansecretstore_webhook.go` rejects the
+  second store at admission, and the aggregation step carries the fail-closed
+  backstop for a CR that reached etcd without the webhook
+  (`SecretStoresReady=False / MultipleOpenBaoStores`).
+- **No upgrade phase machine.** The CR has no `upgradePhase` status field. A
+  release bump runs the one `{name}-db-sync` Job, which chains nothing:
+  `barbican-manage db upgrade` is a single alembic upgrade to head that applies
+  every pending revision in one pass. Status tracks the release through
+  `installedRelease`, `installedImage`, and `targetRelease`, the same posture
+  the Placement operator uses. Upgrade paths stay sequential and a downgrade is
+  refused before any Job runs.
+- **Config mounted at `/etc/barbican`.** Barbican accepts no `--config-dir` and
+  resolves both of its startup files by name: oslo.config loads `barbican.conf`
+  from its fixed search path, and the API app looks `barbican-api-paste.ini` up
+  the same way. `/etc/barbican` is the one directory that can carry either, so
+  the rendered config Secret mounts as that whole directory
+  (`barbicanConfigDir` in `operators/barbican/internal/controller/reconcile_config.go`)
+  and shadows the image's own copy. The db-sync Job and the clean-up CronJob
+  mount it at the same path and therefore pass no `--config-file`.
+- **The clean-up CronJob is always scheduled.** Barbican never hard-deletes:
+  deleting a secret, container, or order flips its row to deleted, so the tables
+  grow for the lifetime of the deployment. Every Barbican gets the
+  `{name}-db-clean` CronJob; `spec.dbClean` only varies its retention window,
+  schedule, extra passes, and suspension. An unbounded soft-delete backlog is a
+  deferred outage rather than a posture worth offering.
+
+## Owned resources
+
+For a Barbican CR named `{name}` the operator manages:
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| Deployment | `{name}` | The Barbican API pods (port 9311) |
+| Service | `{name}` | ClusterIP in front of the API pods on port 9311 |
+| PodDisruptionBudget | `{name}` | `minAvailable: 1` (or `maxUnavailable: 1` at a single replica); the selector excludes Job pods |
+| HorizontalPodAutoscaler | `{name}` | Only when `spec.autoscaling` is set |
+| NetworkPolicy | `{name}` | Only when `spec.networkPolicy` is set |
+| HTTPRoute | `{name}` | Only when `spec.gateway` is set |
+| Secret | `{name}-config-<hash>` | Immutable, content-hashed `barbican.conf` and `barbican-api-paste.ini` (plus `policy.yaml` when applicable; 3 historical retained) |
+| Secret | `{name}-db-connection` | Derived pymysql DSN, consumed via `OS_DATABASE__CONNECTION` |
+| Job | `{name}-db-sync` | Schema migration (`barbican-manage db upgrade`) |
+| CronJob | `{name}-db-clean` | The recurring `barbican-manage db clean` sweep |
+| MariaDB `Database` / `User` / `Grant` | `{name}` | Managed mode only (`spec.database.clusterRef`); a brownfield database is left alone |
+
+The AppRole credentials Secret of a managed store, `<store>-approle`, is owned
+by its `BarbicanSecretStore` and not by the Barbican; see
+[Retained Artefacts](./barbican-secret-store-crd.md#retained-artefacts).
+
+## Reference pages
+
+- [Barbican CRD](./barbican-crd.md) — the full `spec`/`status` contract
+- [BarbicanSecretStore CRD](./barbican-secret-store-crd.md) — the attached
+  secret store, its credentials, and its conditions
+- [Controller Events](./barbican-events.md) — the Kubernetes events the two
+  controllers emit
+- [Reconciler Architecture](./barbican-reconciler.md) — the sub-reconciler
+  pipeline, conditions, and requeue semantics

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -9,8 +9,8 @@ Reference documentation for the c5c3-operator ControlPlane Custom Resource
 Definition. The ControlPlane CRD is the top-level aggregate that
 projects an OpenStack control plane: it owns the shared infrastructure
 references (database, cache), a curated set of per-service specs (today:
-Keystone, Horizon, Glance, and Placement), and the K-ORC (OpenStack Resource Controller)
-integration that
+Keystone, Horizon, Glance, Placement, and Barbican), and the K-ORC (OpenStack
+Resource Controller) integration that
 bootstraps and rotates the admin application credential. The reconciler (L2)
 materializes this aggregate into the individual per-service CRs — see the
 [ControlPlane Reconciler reference](./controlplane-reconciler.md) for the
@@ -203,8 +203,8 @@ status:
 | `infrastructure` | [`*InfrastructureSpec`](#infrastructurespec) | Conditional | managed-mode defaulted | Shared backing services (database, cache) the control plane's services connect to. **Required** when `services.keystone.mode` is `Managed` (or unset, or `services.keystone` unset) — the defaulting webhook materializes a managed-mode `database`/`cache` when omitted, and the validating webhook rejects a non-External ControlPlane without it. **Forbidden** in **External** mode (an External ControlPlane provisions no backing services; phase 2 relaxes this to optional). The mode-conditional required/forbidden rule is webhook-enforced because CEL cannot span `spec.infrastructure` and `spec.services.keystone`; see [InfrastructureSpec](#infrastructurespec) and [Validation Rules](#validation-rules). |
 | `services` | [`ServicesSpec`](#servicesspec) | Yes | — | Per-service configuration projected into the individual service CRs. |
 | `globalPolicyOverrides` | [`*commonv1.PolicySpec`](../keystone/keystone-crd.md#policyspec) | No | `nil` | oslo.policy overrides applied across every service in the control plane. Per-service overrides (e.g. `services.keystone.policyOverrides`) take precedence over these global rules when both are set. |
-| `globalExtraConfig` | `map[string]map[string]string` | No | `nil` | Free-form INI sections (`section` → `key` → `value`) applied to every INI-configured service the control plane declares (Keystone, Glance, and Placement today). Merged **key by key** with each service's own `extraConfig`: sections are unioned, the per-service value wins per key, and a global key with no per-service counterpart stays effective, before the merged result is projected onto that service's child. **Never** applies to Horizon, which renders flat Django settings rather than INI. Legal but **inert** in External mode, the same posture as `globalPolicyOverrides`. Admission validates the merged result per declared INI service against that service's option catalog and operator-owned-key registry — see [ExtraConfig admission checks](#extraconfig-admission-checks). |
-| `secretStoreRef` | [`*commonv1.SecretStoreRefSpec`](#secretstorerefspec) | No | `nil` (defaults to the shared cluster store `openbao-cluster-store`) | Selects the External Secrets store the control plane routes its ExternalSecrets and backup PushSecrets through, and is **projected onto the Keystone, Horizon, Glance, and Placement children** — so operators normally set the store here rather than on the individual service CRs. **Mutable:** switching stores is supported — the operator moves the fernet/credential key material in place, never re-creating it. When omitted, defaults to the shared cluster-scoped `ClusterSecretStore` named `openbao-cluster-store`, so existing deployments are unchanged; set `{kind: SecretStore, name: <store>}` to reach OpenBao as a per-tenant identity resolved in the ControlPlane's own namespace. See [SecretStoreRefSpec](#secretstorerefspec). |
+| `globalExtraConfig` | `map[string]map[string]string` | No | `nil` | Free-form INI sections (`section` → `key` → `value`) applied to every INI-configured service the control plane declares (Keystone, Glance, Placement, and Barbican today). Merged **key by key** with each service's own `extraConfig`: sections are unioned, the per-service value wins per key, and a global key with no per-service counterpart stays effective, before the merged result is projected onto that service's child. **Never** applies to Horizon, which renders flat Django settings rather than INI. Legal but **inert** in External mode, the same posture as `globalPolicyOverrides`. Admission validates the merged result per declared INI service against that service's option catalog and operator-owned-key registry — see [ExtraConfig admission checks](#extraconfig-admission-checks). |
+| `secretStoreRef` | [`*commonv1.SecretStoreRefSpec`](#secretstorerefspec) | No | `nil` (defaults to the shared cluster store `openbao-cluster-store`) | Selects the External Secrets store the control plane routes its ExternalSecrets and backup PushSecrets through, and is **projected onto the Keystone, Horizon, Glance, Placement, and Barbican children** — so operators normally set the store here rather than on the individual service CRs. **Mutable:** switching stores is supported — the operator moves the fernet/credential key material in place, never re-creating it. When omitted, defaults to the shared cluster-scoped `ClusterSecretStore` named `openbao-cluster-store`, so existing deployments are unchanged; set `{kind: SecretStore, name: <store>}` to reach OpenBao as a per-tenant identity resolved in the ControlPlane's own namespace. See [SecretStoreRefSpec](#secretstorerefspec). |
 | `korc` | [`KORCSpec`](#korcspec) | No | defaulted | K-ORC integration used to bootstrap and rotate the admin application credential and any declared bootstrap resources. Optional — the defaulting webhook fills `adminCredential` (cloudCredentialsRef, passwordSecretRef, applicationCredential restriction/rotation) from well-known defaults when omitted. |
 
 ### SecretStoreRefSpec
@@ -775,11 +775,12 @@ same path as a shared instance:
 
 On the managed **shared** database, `credentialsMode: Dynamic` — short-lived,
 engine-issued credentials from the OpenBao database engine — is the **default**
-for every database consumer: Keystone, Glance, and Placement. Glance is no
-longer forced onto `Static`. It carries a glance-scoped engine role, the
-`glance-db-dynamic` policy, and the `glance-db` auth role; Placement carries the
-same three under its own names (`placement-{namespace}`, `placement-db-dynamic`,
-`placement-db`). Both sets come from
+for every database consumer: Keystone, Glance, Placement, and Barbican. Glance is
+no longer forced onto `Static`. It carries a glance-scoped engine role, the
+`glance-db-dynamic` policy, and the `glance-db` auth role; Placement and Barbican
+carry the same three under their own names (`placement-{namespace}`,
+`placement-db-dynamic`, `placement-db` and `barbican-{namespace}`,
+`barbican-db-dynamic`, `barbican-db`). All three sets come from
 `deploy/openbao/bootstrap/setup-database-tenant.sh` and `setup-auth.sh`, with
 the policies under `deploy/openbao/policies/`, the way Keystone's do.
 
@@ -1432,7 +1433,7 @@ truth.
 | `DatabaseSpec` | `infrastructure.database` | [Keystone CRD → DatabaseSpec](../keystone/keystone-crd.md#databasespec) |
 | `CacheSpec` | `infrastructure.cache` | [Keystone CRD → CacheSpec](../keystone/keystone-crd.md#cachespec) |
 | `SecretRefSpec` | `korc.adminCredential.passwordSecretRef` | [Keystone CRD → SecretRefSpec](../keystone/keystone-crd.md#secretrefspec) |
-| `SecretStoreRefSpec` | `secretStoreRef` (projected onto the Keystone, Horizon, Glance, and Placement children) | [Keystone CRD → SecretStoreRefSpec](../keystone/keystone-crd.md#secretstorerefspec) |
+| `SecretStoreRefSpec` | `secretStoreRef` (projected onto the Keystone, Horizon, Glance, Placement, and Barbican children) | [Keystone CRD → SecretStoreRefSpec](../keystone/keystone-crd.md#secretstorerefspec) |
 | `PolicySpec` | `globalPolicyOverrides`, `services.keystone.policyOverrides` | [Keystone CRD → PolicySpec](../keystone/keystone-crd.md#policyspec) |
 
 > **Note on `DatabaseSpec.tls` / `CacheSpec`:** the `commonv1` shapes carry the

--- a/docs/reference/c5c3/controlplane-crd.md
+++ b/docs/reference/c5c3/controlplane-crd.md
@@ -311,9 +311,9 @@ that adopts a pre-existing MariaDB/Memcached leaves its topology untouched.
 ## ServicesSpec
 
 Declares the per-service configuration of the control plane. Today
-Keystone, the Horizon dashboard, the Glance image service, and the Placement
-service are modeled; additional services are added as fields as the operator
-grows.
+Keystone, the Horizon dashboard, the Glance image service, the Placement
+service, and the Barbican key manager are modeled; additional services are added
+as fields as the operator grows.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -321,6 +321,7 @@ grows.
 | `horizon` | [`*ServiceHorizonSpec`](#servicehorizonspec) | No | `nil` | Configuration for the Horizon dashboard projected by the reconciler. Optional: when unset, this ControlPlane manages no dashboard and `HorizonReady` is reported as not-managed (`HorizonNotManaged`), so the aggregate `Ready` is not blocked. **Forbidden in External mode** — the dashboard needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Horizon child by default; set the `c5c3.io/allow-horizon-deletion: "true"` annotation to opt in to deleting the child on unset. |
 | `glance` | [`*ServiceGlanceSpec`](#serviceglancespec) | No | `nil` | Configuration for the Glance image service projected by the reconciler. Optional: when unset, this ControlPlane manages no image service and `GlanceReady` is reported as not-managed (`GlanceNotManaged`), so the aggregate `Ready` is not blocked. The projection is **gated on `KeystoneReady`** — Glance validates every token against the ControlPlane's Keystone child. **Forbidden in External mode** — Glance needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Glance child by default; set the `c5c3.io/allow-glance-deletion: "true"` annotation to opt in to deleting the child (and its `GlanceBackend` children and DB-credential ExternalSecret) on unset. The dynamic DB-credential generator is torn down on unset regardless of the annotation — preserving a running service does not imply preserving a credential minter. |
 | `placement` | [`*ServicePlacementSpec`](#serviceplacementspec) | No | `nil` | Configuration for the Placement service projected by the reconciler. Optional: when unset, this ControlPlane manages no placement service and `PlacementReady` is reported as not-managed (`PlacementNotManaged`), so the aggregate `Ready` is not blocked. The projection is **gated on `KeystoneReady`** (Placement validates every token against the ControlPlane's Keystone child) and on the injected `placement` service account being Ready. **Forbidden in External mode**: Placement needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Placement child by default; set the `c5c3.io/allow-placement-deletion: "true"` annotation to opt in to deleting the child (with its DB-credential ExternalSecret and the placement catalog CRs) on unset. The dynamic DB-credential generator is torn down on unset regardless of the annotation, so no credential minter outlives the service. |
+| `barbican` | [`*ServiceBarbicanSpec`](#servicebarbicanspec) | No | `nil` | Configuration for the Barbican key manager projected by the reconciler. Optional: when unset, this ControlPlane manages no key manager and `BarbicanReady` is reported as not-managed (`BarbicanNotManaged`), so the aggregate `Ready` is not blocked. The projection is **gated on `KeystoneReady`** (Barbican validates every token against the ControlPlane's Keystone child) and on the injected `barbican` service account being Ready. **Forbidden in External mode**: Barbican needs its own External-mode design. Flipping it from set to `nil` preserves the previously-projected Barbican child by default; set the `c5c3.io/allow-barbican-deletion: "true"` annotation to opt in to deleting the child (with its `BarbicanSecretStore`, its DB-credential ExternalSecret, and the key-manager catalog CRs) on unset. The dynamic DB-credential generator is torn down on unset regardless of the annotation. Destroying a **dedicated** OpenBao instance and the secrets in it takes a second annotation on top, `c5c3.io/allow-barbican-secret-store-data-deletion: "true"`; see [ServiceBarbicanSecretStoreSpec](#servicebarbicansecretstorespec). |
 
 ---
 
@@ -536,6 +537,144 @@ Placement.
 
 ---
 
+## ServiceBarbicanSpec
+
+A **curated local subset** of the knobs the ControlPlane exposes for the Barbican
+key manager, mirroring `ServiceKeystoneSpec` and `ServicePlacementSpec`. The
+reconciler (L2) **projects** it into a
+[`Barbican`](../barbican/barbican-crd.md) CR; the database, cache, and Keystone
+endpoint of that child are **derived** from the ControlPlane
+(`infrastructure.*` and the Keystone child's naming convention) rather than set
+here. `spec.apiServer` and `spec.dbClean` on the child are not projected, so the
+barbican operator's own uWSGI parameters and clean-up schedule stay
+authoritative.
+
+The curated fields match the Placement ones plus
+[`secretStore`](#servicebarbicansecretstorespec), which no other service has.
+Barbican keeps its secret material in an OpenBao (or API-compatible Vault) KV
+mount rather than in its own database, so the store is part of the service's
+definition.
+
+Forbidden entirely when `services.keystone.mode` is `External` (Barbican needs
+its own External-mode design), so, like `ServicePlacementSpec`, none of its
+fields carry per-field External-mode forbid-rules.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `replicas` | `*int32` | No | `nil` | Overrides the number of Barbican API replicas. When `nil` the reconciler projects the shared default of 3 (`commonv1.DefaultReplicas`). Minimum 1. |
+| `image` | [`*commonv1.ImageSpec`](../keystone/keystone-crd.md#imagespec) | No | `nil` | Overrides the Barbican container image. When `nil` the reconciler derives `ghcr.io/c5c3/barbican:{spec.openStackRelease}`. When set, the validating webhook mirrors the `commonv1.ImageSpec` tag/digest XOR, so an override naming neither or both is rejected at admission. |
+| `gateway` | [`*commonv1.GatewaySpec`](#gatewayspec) | No | `nil` | Exposes the projected Barbican API externally via a Gateway API HTTPRoute. When `nil` (the default) no HTTPRoute is projected and the Barbican API is reachable in-cluster only. When a `gateway` is set its `hostname` must be non-empty and a usable DNS name, enforced at admission by the validating webhook. |
+| `publicEndpoint` | `string` | No | `""` | Externally routable Barbican endpoint URL (e.g. `https://barbican.127-0-0-1.nip.io:8443`). Used **only** for the K-ORC public key-manager catalog Endpoint, the URL every client resolves to store and read its secret material; it is projected into no child CR, so the validating webhook is the only gate on it. When set, it must match `^https?://`, parse to a bare origin with a host (no path, query, or fragment, since the Barbican API is served at the root and clients append the API path to the catalog URL), and be at most 512 characters; a single trailing slash is tolerated. When a `gateway` is configured the scheme must be `https` and the host must equal `gateway.hostname` (the port may differ); see [Validation Rules](#validation-rules). Without a gateway an `http://` value stays admissible for development and raises an admission warning, because every call carries the caller's scoped Keystone token and the secret payload to this URL. When empty and `gateway` is set, the reconciler derives `https://{gateway.hostname}` (the default-443 form); set it explicitly when the externally reachable port differs (e.g. a kind host-port mapping like `:8443`). |
+| `databaseCredentialsMode` | `string` (`Static` \| `Dynamic`) | No | `""` (inherits `spec.infrastructure.database.credentialsMode`) | Per-service override of the ControlPlane-wide credentials mode for the managed **shared** database, so a staged migration can run Barbican on one mode while another service stays on the other. Empty (the default) **inherits** the shared mode, and is not materialized by the defaulting webhook, so "inherit" stays distinguishable from an explicit override. A `Dynamic` override is **rejected** when Barbican declares a [dedicated](#barbicandedicatedbackingservicesspec) database (dedicated is `Static`-only; set `dedicatedBackingServices.database.credentialsMode` instead, see [Credential modes](#credential-modes)) and when the shared database is **brownfield** (`clusterRef` unset); `Static` is always admitted. |
+| `extraConfig` | `map[string]map[string]string` | No | `nil` | Free-form INI sections for the Barbican service. Merged **key by key** with `spec.globalExtraConfig` (this per-service value winning per key) and the merged result projected onto the Barbican child's `spec.extraConfig`. Admission runs shape, operator-owned-key, and option-catalog checks on the merged block; the always-rejected owned keys are the three credential ones (`[keystone_authtoken] password`, `[vault_plugin] approle_secret_id`, and `[vault_plugin] root_token_id`). Each arrives through an environment override at runtime, so a file value is inert and would only copy credential material into the config Secret every API pod mounts. See [ExtraConfig admission checks](#extraconfig-admission-checks). |
+| `secretStore` | [`ServiceBarbicanSecretStoreSpec`](#servicebarbicansecretstorespec) | Yes | — | The secret-store backend the key manager writes its secret material to. Required: a Barbican with no store attached parks on `SecretStoresReady=False/NoDefaultSecretStore` for as long as it exists, so a store-less service block would only ever project a child that can never reach Ready. |
+| `dedicatedBackingServices` | [`*BarbicanDedicatedBackingServicesSpec`](#barbicandedicatedbackingservicesspec) | No | `nil` (shares the ControlPlane-wide instances) | Opts Barbican **out** of the shared `spec.infrastructure` instances and gives it a `database` and/or `cache` of its own. Barbican consumes both classes, so it can take either or both dedicated; a declared block must name at least one. |
+| `namespace` | [`*ServiceNamespaceSpec`](#service-namespaces) | No | `nil` (placed in the ControlPlane's namespace) | Places the Barbican service, and the backing services, secret store, dedicated OpenBao instance, and credential material that follow it, in a namespace of its own. Create-only: the validating webhook freezes the block after creation. See [Service Namespaces](#service-namespaces). |
+
+The logical database name is not exposed here. The projection forces it to
+`barbican` on the child, because the OpenBao database engine grants the dynamic
+Barbican credential access to that schema alone; any other name would be issued
+a credential it cannot use.
+
+Setting `services.barbican` makes the defaulting webhook inject a `barbican`
+entry into [`spec.korc.serviceAccounts`](#serviceaccountspec): project
+`service-barbican` with `create: true`, role `service`, and a `targetNamespace`
+naming the namespace Barbican is placed in whenever that differs from the
+ControlPlane's. It creates its own project rather than reusing Glance's
+`service`, since two `create: true` entries naming one project would each adopt
+the other's Keystone row. That account is the Keystone user the projected child
+authenticates as, so the validating webhook also requires it: a CR that reaches
+admission without the entry is rejected instead of projecting a Barbican with no
+service user.
+
+Setting `services.barbican` bounds the ControlPlane's own name too. The projected
+child is `{controlplane.Name}-barbican`, and the Barbican CRD caps
+`metadata.name` at **43** characters so the barbican operator's db-clean CronJob
+name (`{name}-db-clean`) still fits the API server's 52-character CronJob bound.
+The ControlPlane name may therefore be at most **34** characters while
+`services.barbican` is set. The rule runs on create and on the update that newly
+enables Barbican.
+
+### ServiceBarbicanSecretStoreSpec
+
+Selects the secret-store backend of the Barbican service, in one of two modes.
+`dedicated` has the ControlPlane provision an OpenBao instance for this Barbican
+and wire the store to it; `external` points the service at an OpenBao or
+HashiCorp Vault server run outside this control plane, whose AppRole credentials
+the operator only reads.
+
+The two modes address different servers with different credentials, so one of
+them must be set and not the other. A type-level CEL `XValidation` rule on
+`ServiceBarbicanSecretStoreSpec` carries the union
+(`has(self.dedicated) != has(self.external)`), with the message
+`exactly one of dedicated or external must be set`, and the validating webhook
+mirrors it, so an API server old enough to skip `x-kubernetes-validations`
+cannot admit a block naming neither.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `dedicated` | [`*BarbicanDedicatedSecretStoreSpec`](#barbicandedicatedsecretstorespec) | Conditional | `nil` | Has the ControlPlane provision an OpenBao instance for this Barbican and attach the store to it. Required when `external` is unset, forbidden otherwise. |
+| `external` | [`*BarbicanExternalSecretStoreSpec`](#barbicanexternalsecretstorespec) | Conditional | `nil` | Attaches the store to an OpenBao or HashiCorp Vault server provisioned outside this control plane. Required when `dedicated` is unset, forbidden otherwise. |
+
+### BarbicanDedicatedSecretStoreSpec
+
+Field-less. The instance name, its KV mount, and the AppRole credentials are all
+derived by convention from the ControlPlane, so there is nothing left to spell
+out.
+
+The instance the operator provisions is **proving-grade**. It runs the
+openbao-operator's `Development` profile at a single replica with no
+PodDisruptionBudget, so any disruption of that one pod stops every secret read
+and write. It is sealed by a static key held in a plain Secret
+(`{instance}-unseal-key`) in the same namespace as the raft volume that key
+seals, so read access to that namespace's Secrets, or a single etcd or namespace
+backup, yields both the ciphertext and the key. Admission repeats this as a
+warning on every apply. A production key manager belongs on
+[`external`](#barbicanexternalsecretstorespec), against a hardened server with a
+KMS unseal and a real replica count. See
+[reconcileBarbican](./controlplane-reconciler.md#reconcilebarbican) for the
+ensemble the reconciler projects around it.
+
+### BarbicanExternalSecretStoreSpec
+
+Addresses an OpenBao or HashiCorp Vault server provisioned outside this control
+plane. The operator reads the referenced Secrets and renders the store
+configuration; it never creates a mount, a policy, or an AppRole on such a
+server. The field surface mirrors the barbican module's `OpenBaoServerSpec` /
+`OpenBaoStoreSpec`, so a value admitted here can never be rejected downstream by
+the [`BarbicanSecretStore`](../barbican/barbican-secret-store-crd.md) CRD.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `url` | `string` | Yes | — | The server's API base URL, e.g. `https://openbao.example.com:8200`. TLS is mandatory (`MinLength` 1, pattern `^https://`, mirrored by the webhook): the operator's AppRole login and every secret barbican stores travel this URL, so a plaintext scheme would put the role ID, the secret ID, and the keys and certificates the service exists to protect on the wire in the clear. |
+| `credentialsSecretRef` | [`barbicanv1alpha1.SecretNameRefSpec`](../barbican/barbican-secret-store-crd.md#secretnamerefspec) | Yes | — | References the Secret holding the AppRole credentials barbican authenticates with, under the fixed data keys `role-id` and `secret-id`. The barbican operator reads it from the store's namespace, so place the Secret in the namespace the Barbican service is placed in (`services.barbican.namespace`, or the ControlPlane's own). |
+| `caBundleSecretRef` | [`*barbicanv1alpha1.SecretNameRefSpec`](../barbican/barbican-secret-store-crd.md#secretnamerefspec) | No | `nil` | References the Secret holding the PEM CA bundle that authenticates the server, under the fixed data key `ca.crt`. Resolves in the same namespace as `credentialsSecretRef`. Omit it when the server presents a certificate the pods already trust through their system store. |
+| `kvMountpoint` | `string` | No | `barbican` | The path the KV v2 secrets engine holding barbican's secret material is mounted at on that server. The `+kubebuilder:default` only fills an absent field, so the `MinLength` 1 marker is what rejects an explicitly empty mount path. |
+| `namespace` | `string` | No | `""` | Scopes every request to an OpenBao/Vault namespace (the enterprise-style multi-tenancy header). Brownfield only, which is the only mode this block describes: a dedicated instance is provisioned at the root namespace. |
+
+### BarbicanDedicatedBackingServicesSpec
+
+Declares the backing-service instances the Barbican service gets for itself
+instead of the ControlPlane-wide shared ones, on the same contract as
+[`KeystoneDedicatedBackingServicesSpec`](#dedicatedbackingservices). Barbican
+consumes both a database and a cache, so it can take either or both dedicated; a
+class left unset resolves to the ControlPlane-wide instance in
+`spec.infrastructure`.
+
+The block is optional, but a declared one must name at least one class. A CEL
+`XValidation` rule (`has(self.database) || has(self.cache)`) rejects an empty
+block, which would request nothing, with the message
+`dedicatedBackingServices must declare at least one backing-service class (database, cache)`.
+The Barbican child CRD requires `spec.cache`, so the effective cache has to
+resolve on every path the projection takes.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `database` | [`*commonv1.DatabaseSpec`](../keystone/keystone-crd.md#databasespec) | No | `nil` (shares `spec.infrastructure.database`) | Gives Barbican its own database cluster. In managed mode `clusterRef.name` defaults to `{controlplane}-barbican-db`. A dedicated **managed** database is **`Static`-only** — the defaulting webhook materializes `credentialsMode: Static` and an explicit `Dynamic` is rejected, for the same reason as Keystone (see [Credential modes](#credential-modes)): the OpenBao database engine is bootstrapped once per namespace against the shared cluster, so no engine role can issue credentials for a dedicated instance. Seed and rotate the credential at the OpenBao source. |
+| `cache` | [`*commonv1.CacheSpec`](../keystone/keystone-crd.md#cachespec) | No | `nil` (shares `spec.infrastructure.cache`) | Gives Barbican its own cache. In managed mode `clusterRef.name` defaults to `{controlplane}-barbican-cache`. |
+
+---
+
 ## DedicatedBackingServices
 
 By default every service a ControlPlane manages connects to the **shared**
@@ -605,6 +744,12 @@ and keep sharing the cache.
 
 Glance consumes both a database and a cache, so it can take either or both
 dedicated; a class left unset resolves to the ControlPlane-wide instance.
+
+`BarbicanDedicatedBackingServicesSpec` carries the same two classes on the same
+terms and is documented under
+[ServiceBarbicanSpec](#barbicandedicatedbackingservicesspec); its managed
+`clusterRef.name` defaults are `{controlplane}-barbican-db` and
+`{controlplane}-barbican-cache`.
 
 Declaring the block with **no class set** is rejected — it would request nothing.
 Omit it entirely to share.
@@ -693,7 +838,8 @@ resolve to a single child CR that both projections then fight over — silently
 voiding the isolation the opt-in exists for — so the validating webhook rejects
 the duplicate. The derived defaults (`{controlplane}-keystone-db`,
 `{controlplane}-keystone-cache`, `{controlplane}-horizon-cache`,
-`{controlplane}-glance-db`, `{controlplane}-glance-cache`) never collide
+`{controlplane}-glance-db`, `{controlplane}-glance-cache`,
+`{controlplane}-barbican-db`, `{controlplane}-barbican-cache`) never collide
 with each other or with the shared defaults (`openstack-db`,
 `openstack-memcached`).
 

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -128,6 +128,9 @@ kinds (`ClusterSecretStore` and `SecretStore`):
 | `Glance` | `Owns()` | Re-reconciles when the projected Glance image-service child status changes |
 | `GlanceBackend` | `Owns()` | Re-reconciles when a projected GlanceBackend child status changes |
 | `Placement` | `Owns()` | Re-reconciles when the projected Placement child status changes |
+| `Barbican` | `Owns()` | Re-reconciles when the projected Barbican key-manager child status changes |
+| `BarbicanSecretStore` | `Owns()` | Re-reconciles when the projected BarbicanSecretStore status changes |
+| `OpenBaoCluster`, `OpenBaoTenant` | `Owns()` | Re-reconciles when the OpenBao instance provisioned for a dedicated Barbican secret store, or the tenant admitting its namespace, changes. The openbao-operator is installed only for that mode, so a ControlPlane without one runs on a cluster that never serves these kinds; both legs sit behind the discovery probe with the other sibling-operator kinds (`probeOptionalWatches`, which skips the leg and registers a leader-gated re-check that restarts the operator once the CRD appears) |
 | K-ORC `ApplicationCredential` | `Owns()` | Re-reconciles when the minted admin credential's `Available` condition or `status.id` changes |
 | K-ORC `Service` | `Owns()` | Re-reconciles when the identity catalog Service changes |
 | K-ORC `Endpoint` | `Owns()` | Re-reconciles when the public identity Endpoint changes |
@@ -138,7 +141,7 @@ kinds (`ClusterSecretStore` and `SecretStore`):
 | `Secret` | `Watches()` | Maps Secret events to referencing ControlPlane CRs via the `ControlPlaneSecretNameIndexKey` field indexer (`secretToControlPlaneMapper`) |
 | `ClusterSecretStore` | `Watches()` | Per-ref fan-out via `storeToControlPlaneMapper` (bound to the shared `watch.StoreRefFanOut` for the cluster kind): a status change on a cluster-scoped store enqueues only the ControlPlanes whose effective `spec.secretStoreRef` resolves to it |
 | `SecretStore` | `Watches()` | The namespaced twin, scoped to the store's own namespace, so a ControlPlane pinned to a per-tenant `SecretStore` reacts to its backend health (`storeToControlPlaneMapper` for the namespaced kind) |
-| projected service children + `Namespace` (cross-namespace) | `Watches()` | Label-predicate twin of the `Owns()` rows for a service placed in a namespace of its own: a cross-namespace child carries no owner reference (Kubernetes forbids one), so `Keystone` / `Horizon` / `Glance` / `GlanceBackend` / `Placement` / `MariaDB` / `Memcached` / `ExternalSecret` — and the `Namespace` itself — are watched a second time through the ownership labels the projections stamp (`crossNamespaceChildHandler` gated by `crossNamespaceChildPredicate`), so same-namespace children keep flowing through `Owns()` alone and neither leg double-enqueues the other's objects |
+| projected service children + `Namespace` (cross-namespace) | `Watches()` | Label-predicate twin of the `Owns()` rows for a service placed in a namespace of its own: a cross-namespace child carries no owner reference (Kubernetes forbids one), so `Keystone` / `Horizon` / `Glance` / `GlanceBackend` / `Placement` / `Barbican` / `BarbicanSecretStore` / `OpenBaoCluster` / `OpenBaoTenant` / `MariaDB` / `Memcached` / `ExternalSecret` — and the `Namespace` itself — are watched a second time through the ownership labels the projections stamp (`crossNamespaceChildHandler` gated by `crossNamespaceChildPredicate`), so same-namespace children keep flowing through `Owns()` alone and neither leg double-enqueues the other's objects |
 
 The `Secret` watch uses `Watches()` with a `MapFunc` rather than `Owns()`
 because the admin-password Secret
@@ -222,6 +225,10 @@ RBAC markers on the two reconcilers generate the required ClusterRole. The
 | `memcached.c5c3.io` | `memcacheds` | get, list, watch, create, update, patch, delete |
 | `keystone.openstack.c5c3.io` | `keystones` | get, list, watch, create, update, patch, delete |
 | `placement.openstack.c5c3.io` | `placements` | get, list, watch, create, update, patch, delete |
+| `barbican.openstack.c5c3.io` | `barbicans`, `barbicansecretstores` | get, list, watch, create, update, patch, delete |
+| `openbao.org` | `openbaoclusters`, `openbaotenants` | get, list, watch, create, update, patch, delete |
+| `rbac.authorization.k8s.io` | `roles`, `rolebindings`, `clusterrolebindings` | get, create, patch, delete |
+| `rbac.authorization.k8s.io` | `clusterroles` (`resourceNames: system:auth-delegator`) | bind |
 | `openstack.k-orc.cloud` | `applicationcredentials`, `services`, `endpoints` | get, list, watch, create, update, patch, delete |
 | `external-secrets.io` | `externalsecrets`, `pushsecrets` | get, list, watch, create, update, patch, delete |
 | `external-secrets.io` | `clustersecretstores`, `secretstores` | get, list, watch |
@@ -253,9 +260,14 @@ details that privilege-escalation path. Two specifics apply to this operator:
 - It amplifies the exposure itself: `reconcileAdminPassword` and `reconcileKORC`
   project the OpenStack admin password **in cleartext** into a `clouds.yaml`
   `Secret`, so cluster-wide read access exposes every projected admin password.
-- Unlike the keystone operator, this `ClusterRole` holds no `roles` /
-  `rolebindings` verbs, so it lacks the RoleBinding-forgery escalation
-  primitive — the cluster-wide Secret read is the dominant risk.
+- It writes RBAC. The dedicated Barbican secret store needs `get`, `create`,
+  `patch`, and `delete` on `roles`, `rolebindings`, and `clusterrolebindings` to
+  give the OpenBao instance its TokenReview and the barbican operator a bound
+  provisioner token. What a forged binding can grant is still capped by the API
+  server's privilege-escalation check: the operator holds `escalate` nowhere and
+  `bind` only on `system:auth-delegator` (narrowed by `resourceNames`), so it can
+  hand out no permission it does not already hold. The cluster-wide Secret read
+  therefore remains the dominant risk.
 
 A single-namespace deployment — one where no service is placed in a namespace of
 its own — co-locates every projected resource in the ControlPlane's own
@@ -371,6 +383,13 @@ grants. The markers therefore add `core/namespaces` with
 │  ║  │ reconcilePlacement       │  Project the Placement child CR                  ║ │
 │  ║  │ (gate: KS + placement SA)│  Sets: PlacementReady (not-managed when unset)   ║ │
 │  ║  └────────┬─────────────────┘  Requeue: 5s gated / 15s child not Ready         ║ │
+│  ║           │                                                                    ║ │
+│  ║           ▼                                                                    ║ │
+│  ║  ┌──────────────────────────┐                                                  ║ │
+│  ║  │ reconcileBarbican        │  Project the Barbican child, its secret store,   ║ │
+│  ║  │ (gate: KS + barbican SA) │  and a dedicated OpenBao instance                ║ │
+│  ║  └────────┬─────────────────┘  Sets: BarbicanReady (not-managed when unset)    ║ │
+│  ║                                Requeue: 5s gated / 15s instance or child       ║ │
 │  ║                                                                                ║ │
 │  ║  member requeues → ShortestRequeue · member errors → errors.Join               ║ │
 │  ╚═══════════╤════════════════════════════════════════════════════════════════════╝ │
@@ -402,19 +421,20 @@ in `instrumenter.Instrument` (see
 error counter are emitted under a stable `sub_reconciler` label.
 
 **Phase 2 — the tail group.** Horizon, KORC, AdminCredential, Catalog,
-ServiceAccounts, Glance and Placement are the seven named members of one
-`commonreconcile.RunSequentialGroup`, embedded as the pipeline's final **bare
-(unnamed)** `Step`. The group members self-instrument through
+ServiceAccounts, Glance, Placement and Barbican are the eight named members of
+one `commonreconcile.RunSequentialGroup`, embedded as the pipeline's final
+**bare (unnamed)** `Step`. The group members self-instrument through
 `instrumenter.Instrument` — following the keystone self-instrumenting-group
 convention — which is why the enclosing group step carries no `sub_reconciler`
 name of its own. `RunSequentialGroup` attempts **every** member on **every**
 pass and never short-circuits: each member self-gates on the conditions it needs
 (Horizon on `KeystoneReady`; KORC until the admin-password Secret is readable;
 AdminCredential on `KORCReady`; Catalog and ServiceAccounts on
-`AdminCredentialReady`; Glance on `KeystoneReady` and the glance service
-account's per-account readiness; Placement on `KeystoneReady` and the placement
-service account's per-account readiness), so running all of them each pass is
-safe.
+`AdminCredentialReady`; Glance, Placement and Barbican on `KeystoneReady` and
+their own service account's per-account readiness), so running all of them each
+pass is safe. Barbican carries one gate the others do not: on a dedicated secret
+store it holds the projection until the OpenBao instance it provisions serves
+requests.
 
 ```go
 pipeline := []commonreconcile.Step{
@@ -431,7 +451,7 @@ pipeline := []commonreconcile.Step{
             []commonreconcile.Step{
                 {Name: "Horizon", Fn: /* ... */},
                 // KORC, AdminCredential, Catalog, ServiceAccounts, Glance,
-                // Placement
+                // Placement, Barbican
             })
     }},
 }
@@ -448,8 +468,8 @@ This guarantees:
 2. **Group (phase 2) — every member runs each pass.** No member's non-zero
    result or error prevents a later member from running, so a still-converging
    or failing Horizon no longer parks KORC, the
-   AdminCredential/Catalog/ServiceAccounts identity bootstrap, Glance, or
-   Placement. Each member's condition therefore always persists.
+   AdminCredential/Catalog/ServiceAccounts identity bootstrap, Glance,
+   Placement, or Barbican. Each member's condition therefore always persists.
 3. **Group result aggregation.** When no member errors, the group result is the
    **shortest** member requeue (`commonreconcile.ShortestRequeue`) and the error
    is nil. When one or more members error, the group returns `ctrl.Result{}`
@@ -510,7 +530,7 @@ The aggregated sub-condition types (the source-of-truth `subConditionTypes`
 slice in `controlplane_controller.go`) are:
 
 ```text
-NamespacesReady, InfrastructureReady, ESOTenantStoreReady, DBCredentialsReady, KeystoneReady, HorizonReady, GlanceReady, PlacementReady, KORCReady, AdminCredentialReady, AdminPasswordReady, CatalogReady, ServiceAccountsReady
+NamespacesReady, InfrastructureReady, ESOTenantStoreReady, DBCredentialsReady, KeystoneReady, HorizonReady, GlanceReady, PlacementReady, BarbicanReady, KORCReady, AdminCredentialReady, AdminPasswordReady, CatalogReady, ServiceAccountsReady
 ```
 
 The `Ready` condition carries `ObservedGeneration = cp.Generation` so clients can
@@ -529,7 +549,7 @@ fields that the schema declared but the reconciler previously never wrote:
 | Field | Value |
 | --- | --- |
 | `status.updatePhase` | Fixed at `Idle` — the release-update state machine is not implemented and the other `UpdatePhase` values are reserved, so "no update in progress" is the current state |
-| `status.services` | one entry per managed service, in a stable order: `keystone` (present when `spec.services.keystone` is set), then `horizon` (present when `spec.services.horizon` is set), then `glance` (present when `spec.services.glance` is set), then `placement` (present when `spec.services.placement` is set). Each entry's `ready` mirrors the matching `KeystoneReady` / `HorizonReady` / `GlanceReady` / `PlacementReady` sub-condition (via `conditions.AllTrue`) and `release` is `spec.openStackRelease`; an unmanaged service is omitted rather than reported |
+| `status.services` | one entry per managed service, in a stable order: `keystone` (present when `spec.services.keystone` is set), then `horizon` (present when `spec.services.horizon` is set), then `glance` (present when `spec.services.glance` is set), then `placement` (present when `spec.services.placement` is set), then `barbican` (present when `spec.services.barbican` is set). Each entry's `ready` mirrors the matching `KeystoneReady` / `HorizonReady` / `GlanceReady` / `PlacementReady` / `BarbicanReady` sub-condition (via `conditions.AllTrue`) and `release` is `spec.openStackRelease`; an unmanaged service is omitted rather than reported |
 
 ---
 
@@ -1330,6 +1350,175 @@ labels.
 | Placement create/update fails | False | `PlacementError` | returns the error |
 | Placement child Ready | True | `PlacementReady` | — |
 
+### reconcileBarbican
+
+| Aspect | Value |
+| --- | --- |
+| File | `reconcile_barbican.go`, `reconcile_barbican_openbao.go`, `reconcile_barbican_dbcredentials.go` |
+| Condition | `BarbicanReady` |
+| Gate | `KeystoneReady == True` (Barbican validates every token against the Keystone child) **and** the injected `barbican` service account being Ready |
+| Projects / Owns | a trio in `cp.BarbicanNamespace()`: one `Barbican` child `{controlplane.Name}-barbican` (`barbicanNameSuffix`), one `BarbicanSecretStore` `{controlplane.Name}-barbican-store` (`barbicanSecretStoreNameSuffix`), and — on a dedicated secret store only — one `OpenBaoCluster` `{controlplane.Name}-barbican-bao` (`barbicanOpenBaoNameSuffix`) with the ensemble below. Plus, on a managed database only, the per-ControlPlane DB-credential objects in the same namespace: in **Dynamic** mode (the managed-shared default) a ServiceAccount `barbican-db-creds`, an mTLS client Certificate `{controlplane.Name}-barbican-db-openbao-client`, a `VaultDynamicSecret` generator reading `database/mariadb/creds/barbican-{barbican-namespace}` (auth role `barbican-db`), and a generator-backed `ExternalSecret` `{controlplane.Name}-barbican-db-credentials`; in the **Static** opt-out a KV-backed `ExternalSecret` of the same name reading `openstack/barbican/{barbican-namespace}/{controlplane.Name}/db` (properties `username`, `password`). Only when `spec.services.barbican` is set |
+| Requeue | `keystoneInfraGateRequeueAfter` = **5s** while gated on Keystone; `korcRequeueAfter` = **10s** while the `barbican` service account is not yet Ready; `dbCredentialsRequeueAfter` = **10s** while the Dynamic DB credential has not landed; `infraRequeueAfter` = **15s** while the OpenBao instance is not Available, while the secret store is being recreated, and while the child is not Ready |
+
+`reconcileBarbican` runs last in the tail group, after `reconcileServiceAccounts`
+(and after `reconcileGlance` and `reconcilePlacement`), because it gates on the
+per-account readiness that stage computes into status in the same pass. It is
+optional: `spec.services.barbican` unset means this ControlPlane manages no key
+manager, and the sub-reconciler reports `BarbicanReady=True` /
+`BarbicanNotManaged` so the aggregate is not blocked (staged adoption).
+
+Unsetting the block deletes nothing on its own.
+`c5c3.io/allow-barbican-deletion: "true"` opts in to releasing the child, its
+secret store, its DB-credential ExternalSecret, and the key-manager catalog
+K-ORC CRs; destroying a dedicated OpenBao instance takes a second annotation on
+top of that one. Each object is only removed while this ControlPlane still owns
+it, so a foreign object colliding on a name is left alone. See
+[Barbican secret-store teardown](#barbican-secret-store-teardown) for the order
+and for what each annotation authorises.
+
+The credential minter comes down either way. On the preserve branch the
+`VaultDynamicSecret`, its client Certificate, and the `barbican-db-creds`
+ServiceAccount are torn down before the condition is written: a live generator
+keeps issuing a fresh MySQL user with all privileges on the `barbican` schema at
+every refresh interval, for a service this ControlPlane no longer manages, behind
+a `BarbicanReady=True` condition that surfaces none of it.
+
+When managed, the projection follows the same thin discipline as its Keystone,
+Horizon, Glance, and Placement siblings:
+
+- **Image:** repository defaults to `ghcr.io/c5c3/barbican` with the tag derived
+  from `spec.openStackRelease`; `spec.services.barbican.image` overrides the
+  whole image reference when set.
+- **Database:** a DeepCopy of the **effective** database
+  (`effectiveBarbicanDatabase`: Barbican's
+  [dedicated](./controlplane-crd.md#barbicandedicatedbackingservicesspec)
+  database when it opted into one, the shared `spec.infrastructure.database`
+  otherwise) with its logical database name forced to `barbican`. The name is
+  fixed: the pre-wired OpenBao bootstrap grants the dynamic credential access to
+  that schema alone. In managed mode (`clusterRef` set) the
+  `secretRef` is repointed at the operator-owned
+  `{controlplane.Name}-barbican-db-credentials` Secret (key `password`), and the
+  projected `credentialsMode` is the **effective** mode: `Dynamic`
+  (engine-issued) by default on the managed shared database, drawn from the
+  engine role `barbican-{barbican-ns}` that `setup-database-tenant.sh`
+  provisions, flipped to `Static` by the shared-block opt-out or the per-service
+  `services.barbican.databaseCredentialsMode` override, and always `Static` for a
+  dedicated barbican database (fail-closed even when the stored mode says
+  otherwise). A brownfield database keeps the user-supplied `secretRef` and
+  `credentialsMode`.
+- **Cache:** a DeepCopy of the **effective** cache (`effectiveBarbicanCache`).
+- **Keystone endpoint:** `keystoneEndpoint` is derived top-down via
+  `barbicanKeystoneEndpoint(cp)`, always the cluster-local
+  `{controlplane.Name}-keystone` Service URL (the same URL K-ORC authenticates
+  against) and never the external `publicEndpoint` or gateway hostname, because
+  Barbican validates tokens server-side and the pods have to reach it
+  in-cluster. `keystonePublicEndpoint` is a pass-through of the Keystone
+  service's own public endpoint, the URL Barbican advertises on a 401 (empty when
+  Keystone is not externally exposed, in which case the child falls back to the
+  internal endpoint).
+- **Service user:** derived from the auto-injected `barbican` service account,
+  its `username`, project, and user/project domains, with the password read from
+  the account's materialized consumer Secret
+  `{controlplane.Name}-service-account-barbican-credentials`.
+- **ExtraConfig:** `spec.globalExtraConfig` merged with
+  `services.barbican.extraConfig` (the per-service value winning key by key),
+  assigned unconditionally so clearing the ControlPlane block reverts the child
+  instead of pinning the last projected value.
+- **Gateway / Replicas / SecretStoreRef / Region:** `gateway` is a DeepCopy of
+  `spec.services.barbican.gateway` (a nil source clears it, tearing the HTTPRoute
+  down); `replicas` defaults to `commonv1.DefaultReplicas`, overridden by
+  `spec.services.barbican.replicas`; the resolved store selection and
+  `spec.region` are projected through. `spec.apiServer` and `spec.dbClean` are
+  not set, so the child-side uWSGI parameters and clean-up schedule keep tracking
+  the barbican operator's defaults.
+
+The DB-credential objects are ensured **before** the child, so the Secret it
+references exists when the barbican operator resolves it. In `Dynamic` mode the
+projection is held (`WaitingForBarbicanDBCredential`) until the generator-backed
+ExternalSecret reports Ready **and** the Secret it targets carries an
+engine-issued username.
+
+#### The dedicated OpenBao ensemble
+
+A `secretStore.dedicated` Barbican gets an OpenBao instance of its own in the
+Barbican service namespace, projected by `ensureBarbicanOpenBao` in dependency
+order before the store that points at it. Every object is named after the
+instance `{controlplane.Name}-barbican-bao`, because the openbao-operator derives
+several of its own object names from that name:
+
+| Object | Name | Purpose |
+| --- | --- | --- |
+| `OpenBaoTenant` | `{instance}-tenant` | Admits the service namespace to the openbao-operator |
+| `Secret` | `{instance}-unseal-key` | The static-seal key, under data key `key`. Written before the CR exists, or the operator blind-creates an immutable Secret of its own and the generated key is lost |
+| `Certificate` (cert-manager) | `{instance}-tls-server`, `{instance}-tls-ca` | The two fixed-name Secrets the instance's `External` TLS mode consumes |
+| `ServiceAccount` | `{instance}-provisioner` | The identity the Kubernetes-auth role `provisioner` binds to, which the barbican operator logs in with |
+| `Role` + `RoleBinding` | `{instance}-provisioner-token` | Let the barbican operator mint a bound token for that account |
+| `ClusterRoleBinding` | `{instance}-{hash}-auth-delegator` | Grants the TokenReview every Kubernetes-auth login is validated with. Cluster-scoped, so the name folds in eight bytes of `sha256("{namespace}/{instance}")`: two ControlPlanes of the same name in different namespaces derive the same instance name and would otherwise collide on one binding |
+
+The instance runs the `Development` profile at a single replica with a static
+seal (see
+[BarbicanDedicatedSecretStoreSpec](./controlplane-crd.md#barbicandedicatedsecretstorespec)
+for what that posture costs) and `deletionPolicy: DeletePVCs`. The deletion policy
+is not optional: the instance name is derived from the ControlPlane name, so a
+re-created ControlPlane of the same name would meet the previous instance's
+`data-{instance}-0` PVC, raft storage initialised under a seal key that no longer
+exists, and never unseal. Its self-init requests (the KV mount, the AppRole
+identity, the Kubernetes auth method, and the two policies scoping them) run once
+against freshly initialised storage, so changing them requires recreating the
+instance and its PVC.
+
+The store, and with it the child, waits until the instance is `Available`
+(`BarbicanReady=False/WaitingForOpenBaoInstance`): a store attached to an
+instance that is still initialising reports `ProvisioningDenied` and would have to
+be re-driven from a failure state.
+
+#### Projecting the secret store
+
+`reconcileBarbicanSecretStore` projects the one
+[`BarbicanSecretStore`](../barbican/barbican-secret-store-crd.md) the service
+attaches to. It references its Barbican by name (inverted attachment), so it can
+be applied before the child exists.
+
+A store whose frozen fields moved cannot be updated: the CRD's transition rules
+reject the write, and the loop would re-attempt it on every requeue with no
+self-heal. `barbicanSecretStoreImmutableDrift` compares the four fields the CRD
+freezes (the `barbicanRef`, the `type`, the store mode `instanceRef` vs
+`server`, and the KV mountpoint); when one moved, the live store is deleted and
+recreated on the
+next pass, with `BarbicanReady=False/RecreatingBarbicanSecretStore` reported in
+between. The AppRole credentials the barbican operator minted for it carry its
+owner reference, so they are collected with it rather than left pointing at the
+retired mount.
+
+Every write routes through `ensureUnownedOrOwned`, and the prune sweep deletes
+only c5c3-owned stores carrying the Barbican child's name prefix, so a
+hand-created store attached to the same Barbican is never pruned or overwritten.
+
+The key-manager catalog entry, a `key-manager`-type K-ORC `Service` with an
+internal and a public `Endpoint`, is registered by
+[`reconcileCatalog`](#reconcilecatalog) rather than here. A child placed outside
+the ControlPlane's namespace (`services.barbican.namespace`) carries no owner
+reference: it is stamped with the ownership labels and applied unowned, and the
+finalizer sweeps it by those labels.
+
+| Path | Status | Reason | Notes |
+| --- | --- | --- | --- |
+| `spec.services.barbican` unset | True | `BarbicanNotManaged` | staged adoption; the child, its store, and the catalog CRs are preserved unless `c5c3.io/allow-barbican-deletion: "true"` is set, and the dedicated OpenBao instance until `c5c3.io/allow-barbican-secret-store-data-deletion: "true"` is set on top of it. The dynamic DB-credential generator, ServiceAccount, and client Certificate are torn down either way. The message names whichever annotation is still missing |
+| `KeystoneReady` not True | False | `WaitingForKeystone` | requeue 5s; no Barbican CR is projected while Keystone is unready |
+| no `barbican` service account declared | False | `ServiceAccountNotDeclared` | no requeue; admission was bypassed (the defaulting webhook injects it), so it fails loud rather than projecting a Barbican with no Keystone user |
+| `barbican` service account not yet Ready | False | `WaitingForServiceAccount` | requeue 10s; deferred until its Keystone user and password are provisioned |
+| DB-credential ensure or read fails (Dynamic generator objects or Static ExternalSecret) | False | `BarbicanDBCredentialError` | returns the error (managed database only) |
+| Dynamic DB credential not yet materialised | False | `WaitingForBarbicanDBCredential` | requeue 10s; the message names the `database/mariadb/creds/barbican-<namespace>` path, which only exists once `setup-database-tenant.sh` has onboarded the tenant, or the non-engine-issued username it found in the target Secret |
+| provisioning the dedicated OpenBao ensemble fails | False | `BarbicanOpenBaoError` | returns the error |
+| dedicated OpenBao instance not yet `Available` | False | `WaitingForOpenBaoInstance` | requeue 15s; the store and the child are projected once it serves requests |
+| `BarbicanSecretStore` project or prune fails | False | `BarbicanSecretStoreError` | returns the error |
+| projected `BarbicanSecretStore` rejected (HTTP 422 Invalid) | False | `BarbicanSecretStoreProjectionRejected` | returns the error; reconcile `services.barbican.secretStore` to a valid projection to recover |
+| live store's frozen fields moved, so it was deleted | False | `RecreatingBarbicanSecretStore` | requeue 15s; recreated on the next pass |
+| Barbican child not yet Ready | False | `WaitingForBarbican` | requeue 15s |
+| projected Barbican spec rejected (HTTP 422 Invalid) | False | `BarbicanProjectionRejected` | returns the error; the projection violates a Barbican CRD/webhook rule, so reconcile the ControlPlane spec to a valid projection to recover |
+| Barbican create/update fails | False | `BarbicanError` | returns the error |
+| Barbican child Ready | True | `BarbicanReady` | — |
+
 ### reconcileKORC
 
 | Aspect | Value |
@@ -1646,7 +1835,7 @@ OpenBao:
 | File | `reconcile_catalog.go` (Managed), `reconcile_catalog_external.go` (External) |
 | Condition | `CatalogReady` |
 | Gate | `AdminCredentialReady == True`, **and** every catalog child reports `Available` |
-| Owns | Managed mode: a K-ORC identity `Service` (`{controlplane.Name}-identity-service`) and its public `Endpoint` (`{controlplane.Name}-identity-endpoint`), plus — when `spec.services.glance` is set — an image `Service` (`{controlplane.Name}-image-service`) with an internal **and** a public `Endpoint` (`{controlplane.Name}-image-endpoint-internal` / `{controlplane.Name}-image-endpoint-public`), and the same pair of interfaces for a placement `Service` (`{controlplane.Name}-placement-service`, Endpoints `{controlplane.Name}-placement-endpoint-internal` / `{controlplane.Name}-placement-endpoint-public`) when `spec.services.placement` is set. External mode: the same identity `Service` plus one `Endpoint` per interface (`{controlplane.Name}-identity-endpoint-{interface}`), all unmanaged imports, plus one managed `Service`/`Endpoint` set per declared entry (`{controlplane.Name}-catalog-{type}[-{interface}]`). All in `childNamespace(cp)` |
+| Owns | Managed mode: a K-ORC identity `Service` (`{controlplane.Name}-identity-service`) and its public `Endpoint` (`{controlplane.Name}-identity-endpoint`), plus — when `spec.services.glance` is set — an image `Service` (`{controlplane.Name}-image-service`) with an internal **and** a public `Endpoint` (`{controlplane.Name}-image-endpoint-internal` / `{controlplane.Name}-image-endpoint-public`), the same pair of interfaces for a placement `Service` (`{controlplane.Name}-placement-service`, Endpoints `{controlplane.Name}-placement-endpoint-internal` / `{controlplane.Name}-placement-endpoint-public`) when `spec.services.placement` is set, and again for a key-manager `Service` (`{controlplane.Name}-key-manager-service`, Endpoints `{controlplane.Name}-key-manager-endpoint-internal` / `{controlplane.Name}-key-manager-endpoint-public`) when `spec.services.barbican` is set. External mode: the same identity `Service` plus one `Endpoint` per interface (`{controlplane.Name}-identity-endpoint-{interface}`), all unmanaged imports, plus one managed `Service`/`Endpoint` set per declared entry (`{controlplane.Name}-catalog-{type}[-{interface}]`). All in `childNamespace(cp)` |
 | Requeue | `korcRequeueAfter` = **10s** while gated, while a child is not yet Available, or on a terminal K-ORC failure |
 
 `reconcileCatalog` drives `CatalogReady`. Everything up to and including the
@@ -1691,6 +1880,24 @@ suffix, and the CR names follow the generic convention:
 `{controlplane.Name}-placement-service` and
 `{controlplane.Name}-placement-endpoint-{interface}`.
 
+`spec.services.barbican` adds the fourth row, a `key-manager`-type `Service`
+named `barbican` with both Endpoints. The `internal` one advertises the
+in-cluster Barbican API Service URL
+`http://{controlplane.Name}-barbican.<barbican-namespace>.svc:9311`
+(`barbicanEndpointURL`); the `public` one resolves through the same preference
+order (`barbicanCatalogURL`: an explicit `services.barbican.publicEndpoint`,
+then `https://{gateway.hostname}`, then that in-cluster URL). The Barbican API is
+served at the root, so there is no `/v3` path suffix here either. The CR names
+take the OpenStack service type: `{controlplane.Name}-key-manager-service` and
+`{controlplane.Name}-key-manager-endpoint-{interface}`, while the catalog row
+they register is named `barbican`.
+
+No managed row carries a region: `managedCatalogService` and
+`managedCatalogEndpoint` set the management policy, the credentials ref, and the
+resource block (type/name/enabled, and interface/URL/serviceRef), and nothing
+else. The region every client filters on comes from the `clouds.yaml`
+`region_name` the admin credential renders from `spec.region`.
+
 Registering the child CRs only instructs K-ORC to create the catalog entries — it
 does not mean they exist in Keystone — so `CatalogReady` is gated on both children
 reporting `Available` for their current generation (`korcAvailableUpToDate`, which
@@ -1708,7 +1915,7 @@ surfaced as the distinct `CatalogFailed` reason instead of a false-positive Read
 | Endpoint create/update fails | False | `EndpointError` | returns the error |
 | a catalog entry's Service/Endpoint reports a terminal K-ORC error | False | `CatalogFailed` | requeue 10s (Service before its Endpoints, so the root stuck dependency surfaces) |
 | a catalog entry's Service/Endpoint registered but not yet Available | False | `WaitingForCatalog` | requeue 10s |
-| every catalog entry registered and Available | True | `CatalogRegistered` | message counts the registered entries — identity always, plus the image (Glance) entry when `spec.services.glance` is set and the placement entry when `spec.services.placement` is set |
+| every catalog entry registered and Available | True | `CatalogRegistered` | message counts the registered entries: identity always, plus the image (Glance) entry when `spec.services.glance` is set, the placement entry when `spec.services.placement` is set, and the key-manager (Barbican) entry when `spec.services.barbican` is set |
 
 #### External mode — import-first
 
@@ -1805,6 +2012,14 @@ is owned by the imports.
 managed K-ORC `User` and `Project` with an operator-generated, OpenBao-backed,
 rotatable password. It is **mode-independent**: the same rules apply against a
 managed in-cluster Keystone and an external one.
+
+Not every entry is hand-written. Declaring a service makes the defaulting webhook
+inject the account that service authenticates to Keystone as, each with role
+`service` and a `targetNamespace` naming the namespace its service is placed in:
+`glance` in project `service`, `placement` in `service-placement`, and `barbican`
+in `service-barbican`. The projects differ because each injected entry carries
+`create: true`, and two such entries naming one project would each adopt the
+other's Keystone row, which the validating webhook rejects as a duplicate.
 
 Per declared entry it, in order:
 
@@ -2139,9 +2354,14 @@ projected. On deletion it:
    and credential material that follow it — carries no owner reference, so no GC
    cascade reaches it; releasing the finalizer first would strand every one of
    them. `teardownDedicatedNamespaces` deletes them by hand, in order: the
-   service children (`Keystone`/`Horizon`) first, waiting for them (their
-   operators run a sequenced ESO cleanup through the tenant store in the same
-   namespace), then the namespace per its lifecycle. A **`Managed`** namespace is
+   service children (`Keystone`/`Horizon`, and for a Barbican placed apart its
+   `Barbican`, `BarbicanSecretStore` and `OpenBaoCluster` together) first,
+   waiting for them (their operators run a sequenced ESO cleanup through the
+   tenant store in the same namespace), then the namespace per its lifecycle. The
+   OpenBao instance belongs in that wait set because its own finalizer runs under
+   the tenant RBAC living in the same namespace: deleting the namespace first
+   reaps that RBAC out from under it and leaves the instance unfinalizable, with
+   the namespace stuck `Terminating`. A **`Managed`** namespace is
    deleted, which cascades everything left in it — but only when it carries the
    ownership labels; an unlabelled one is left standing with a **Warning**
    `NamespaceNotOwned`, because the operator never destroys a namespace it did
@@ -2153,10 +2373,19 @@ projected. On deletion it:
    `orcTeardownStallTimeout` the sweep stops waiting, emits a **Warning**
    `NamespaceTeardownStalled` naming what is stuck, and releases anyway — a wedged
    child must not make a namespace undeletable forever.
-4. **Releases the finalizer once the ORC CRs, PushSecrets, and cross-namespace
+4. **Removes the auth-delegator `ClusterRoleBinding` by hand.** A dedicated
+   Barbican secret store places one cluster-scoped object,
+   `{instance}-{hash}-auth-delegator`. A namespaced owner cannot own it, so no GC
+   cascade collects it, and the per-namespace sweep in step 3 reaches it only
+   when Barbican was placed in a namespace of its own. `deleteBarbicanAuthDelegatorBinding`
+   therefore runs on every ControlPlane teardown, Barbican or not, reading through
+   the uncached API reader (a cached read would install a cluster-wide
+   `ClusterRoleBinding` informer for one object) and deleting only a binding
+   carrying this ControlPlane's ownership labels.
+5. **Releases the finalizer once the ORC CRs, PushSecrets, and cross-namespace
    children are gone**, letting GC cascade-delete the same-namespace Keystone,
    the infrastructure, and the remaining children.
-5. **Releases an unmanaged-only remainder immediately.** K-ORC re-fetches the
+6. **Releases an unmanaged-only remainder immediately.** K-ORC re-fetches the
    imported resource through an *authenticated* actuator before releasing any
    finalizer, and the unmanaged imports authenticate with the admin application
    credential whose revocation step 1 already triggered — so once every CR
@@ -2165,13 +2394,13 @@ projected. On deletion it:
    `openstack.k-orc.cloud/*` finalizers right away and emits a **Normal**
    `ORCImportsReleased` event. An import's deletion is CR-only, so the external
    installation is untouched and nothing is orphaned.
-6. **Bounds the wait.** If managed ORC CRs stay Terminating longer than the
+7. **Bounds the wait.** If managed ORC CRs stay Terminating longer than the
    `orcTeardownStallTimeout` (5 minutes) — typically because Keystone is already
    gone and K-ORC cannot revoke — the reconciler force-removes the stuck
    `openstack.k-orc.cloud/*` finalizers (preserving any non-K-ORC finalizers),
    emits a **Warning** `ORCTeardownStalled` event, and releases the ControlPlane
    finalizer so deletion completes rather than wedging forever.
-7. **Names what the escape orphaned.** The escape strips the very finalizer that
+8. **Names what the escape orphaned.** The escape strips the very finalizer that
    would have revoked the credential or removed the catalog row, so every
    `Managed` CR it releases leaves its OpenStack resource behind with no
    Kubernetes object naming it. A second **Warning**, `ORCResourcesOrphaned`,
@@ -2229,6 +2458,48 @@ The `{name}-admin-app-credential-backup` PushSecret is the one child kept on
 | `Endpoint` (K-ORC) | `{name}-identity-endpoint-{interface}` | ControlPlane CR | External mode only; one unmanaged import per interface (`public`, `internal`, `admin`) |
 | `Service` (K-ORC) | `{name}-catalog-{type}` | ControlPlane CR | External mode only; one managed CR per declared `managedEntries` entry |
 | `Endpoint` (K-ORC) | `{name}-catalog-{type}-{interface}` | ControlPlane CR | External mode only; one managed CR per declared entry endpoint |
+
+#### Barbican secret-store teardown
+
+Unsetting `spec.services.barbican` takes a different path from deleting the
+ControlPlane, and `deleteOrphanedBarbican` gates it on two annotations rather
+than one. `c5c3.io/allow-barbican-deletion: "true"` releases the
+`BarbicanSecretStore` (first, so its controller can still reach the server while
+it finalizes), then the `Barbican` child, the DB-credential objects, and the
+key-manager catalog CRs. Reaching the dedicated OpenBao instance takes
+`c5c3.io/allow-barbican-secret-store-data-deletion: "true"` on top: the instance
+carries `deletionPolicy: DeletePVCs`, so the delete wipes the raft volume, and
+the teardown removes the static-seal Secret with it, leaving even a recovered
+volume unreadable. Without the second annotation the instance, its PVC, its seal
+key and the rest of the ensemble stand, and `BarbicanReady` says so, so
+re-declaring the service reattaches to the same instance.
+
+It does not reattach to the same secrets. The first annotation already deletes
+the `Barbican` child, whose finalizer deletes the MariaDB `Database` CR, and
+`database.BuildDatabase` sets no `cleanupPolicy`, so mariadb-operator applies its
+`Delete` default and drops the schema. The secret and container rows,
+`secret_store_metadata`, the ACLs and the quotas go with it, and db-sync recreates
+the schema empty on the next projection, leaving the surviving OpenBao payloads
+unreferenced. A dump of the `barbican` schema taken before the teardown is the
+only thing that makes the preserve branch a round trip.
+
+With both set the order is store, child, credentials, catalog rows, then the
+`OpenBaoCluster`. The sweep then **waits** for the instance to leave etcd before
+deleting the `OpenBaoTenant` and the rest of the ensemble. The tenant is what
+admits the namespace to the openbao-operator, and the instance's own finalizer
+runs under that admission, so removing it first would leave the instance
+unfinalizable. Each object is ownership-checked, and an object already gone is
+tolerated.
+
+Both annotations are read from the live CR on every reconcile of that sweep, so
+the decision is not latched. Removing one while the instance is still finalizing
+resumes on the preserve branch after the `OpenBaoCluster` is already deleted, and
+the ensemble behind it is never swept. The cluster-scoped auth-delegator binding
+is the object that then has nothing left to collect it.
+
+Deleting the **ControlPlane** takes the ensemble down either way, with no second
+opt-in: tearing down a whole control plane is already an explicit destructive
+act.
 
 #### External-mode deletion resource set
 
@@ -2364,6 +2635,7 @@ The `condition_type` label is resolved from the package-private
 | `DBCredentials` | `DBCredentialsReady` |
 | `Keystone` | `KeystoneReady` |
 | `Placement` | `PlacementReady` |
+| `Barbican` | `BarbicanReady` |
 | `KORC` | `KORCReady` |
 | `AdminCredential` | `AdminCredentialReady` |
 | `AdminPassword` | `AdminPasswordReady` |
@@ -2483,6 +2755,10 @@ operators/c5c3/
     │   │                                        children, DB-credential ExternalSecret)
     │   ├── reconcile_placement.go              reconcilePlacement projection (Placement child)
     │   ├── reconcile_placement_dbcredentials.go Placement DB-credential names, OpenBao paths, mode
+    │   ├── reconcile_barbican.go               reconcileBarbican projection (Barbican +
+    │   │                                        BarbicanSecretStore children, orphan teardown)
+    │   ├── reconcile_barbican_openbao.go       Dedicated OpenBao instance and its ensemble
+    │   ├── reconcile_barbican_dbcredentials.go Barbican DB-credential names, OpenBao paths, mode
     │   ├── reconcile_korc.go                   reconcileKORC (AC mint/re-mint, drift detection)
     │   ├── reconcile_admincredential.go        reconcileAdminCredential (assemble + push + re-push
     │   │                                        nudges, semantic clouds.yaml gate)
@@ -2511,6 +2787,9 @@ operators/c5c3/
     │   ├── reconcile_glance_test.go            Glance projection tests
     │   ├── reconcile_placement_test.go         Placement projection tests
     │   ├── reconcile_placement_dbcredentials_test.go Placement DB-credential tests
+    │   ├── reconcile_barbican_test.go          Barbican projection tests
+    │   ├── reconcile_barbican_openbao_test.go  Dedicated OpenBao ensemble tests
+    │   ├── reconcile_barbican_dbcredentials_test.go Barbican DB-credential tests
     │   ├── reconcile_korc_test.go              K-ORC mint/re-mint tests
     │   ├── reconcile_admincredential_test.go   AdminCredential tests
     │   ├── reconcile_catalog_test.go           Catalog (managed-mode) tests

--- a/docs/reference/ci-cd/container-images.md
+++ b/docs/reference/ci-cd/container-images.md
@@ -707,4 +707,5 @@ the user via `USER openstack` without needing its own user creation step.
 The `# DEVIATION` comment appears in `images/python-base/Dockerfile` (where the
 user is created) and in every service Dockerfile that uses it instead of a
 per-service user (`images/keystone/Dockerfile`, `images/horizon/Dockerfile`,
-`images/glance/Dockerfile`, `images/placement/Dockerfile`).
+`images/glance/Dockerfile`, `images/placement/Dockerfile`,
+`images/barbican/Dockerfile`).

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -961,9 +961,9 @@ on. All live in the `openstack` namespace except the cluster-scoped ClusterRoleB
 | `OpenBaoCluster` | `openbao.org/v1alpha1` | `openbao-instance` | Profile `Development`, version `2.6.1`, one replica, 1Gi raft storage, TLS mode `External`, static seal, self-init enabled, applied `paused` |
 
 The instance runs in every kind deploy, so the primitives a managed Barbican secret store
-needs are exercised before Barbican itself lands: static-seal auto-unseal, cert-manager
-TLS in External mode, declarative self-init, and the AppRole and Kubernetes-auth methods
-a service and its operator log in with.
+needs are exercised with no Barbican attached: static-seal auto-unseal, cert-manager TLS
+in External mode, declarative self-init, and the AppRole and Kubernetes-auth methods a
+service and its operator log in with.
 
 **Why it is kind-only.** Everything above is a proving posture, not a production one. The
 `Development` profile is what keeps the instance on a single node — one replica, so no
@@ -973,8 +973,10 @@ external-KMS unseal and three replicas, is the production control, and this inst
 deliberately opts out of it to exercise the static-seal path. Shipping that from
 `deploy/flux-system/infrastructure/` would put it, a cluster-scoped RBAC binding, and a
 self-initialized AppRole with no consumer into every production deployment. Only the
-[openbao-operator](#openbao-operator) itself ships in the production base; the
-production-shaped instance arrives with the Barbican onboarding.
+[openbao-operator](#openbao-operator) itself ships in the production base. The dedicated
+instance a ControlPlane projects for a managed Barbican secret store carries the same
+proving-grade `Development` profile; a `Hardened` production-shaped instance is still
+future work.
 [`tests/unit/deploy/openbao_instance_overlay_test.sh`](https://github.com/c5c3/forge/blob/main/tests/unit/deploy/openbao_instance_overlay_test.sh)
 asserts both directions of that split.
 

--- a/operators/c5c3/internal/controller/reconcile_barbican.go
+++ b/operators/c5c3/internal/controller/reconcile_barbican.go
@@ -62,10 +62,11 @@ const barbicanDeletionAllowedAnnotation = "c5c3.io/allow-barbican-deletion"
 // dedicated OpenBao ensemble.
 //
 // It is separate because the two annotations authorise different things. For
-// Keystone, Horizon, Glance and Placement, and for the Barbican child itself, the
-// worst case behind the shared annotation is a redeployable stateless workload.
-// Here the instance carries DeletionPolicy DeletePVCs, so deleting it wipes the
-// raft volume; the teardown also removes the static-seal Secret, so even a
+// Keystone, Horizon, Glance and Placement the worst case behind the shared
+// annotation is a redeployable stateless workload; for the Barbican child it also
+// drops the schema indexing the stored secrets, which deleteOrphanedBarbican
+// spells out. Here the instance carries DeletionPolicy DeletePVCs, so deleting it
+// wipes the raft volume; the teardown also removes the static-seal Secret, so even a
 // recovered volume is unreadable. There is no snapshot, no soft delete and no
 // grace period in between: every secret Barbican ever stored — the private keys
 // and certificates the service exists to hold for its tenants — is gone the moment
@@ -750,7 +751,13 @@ func (r *ControlPlaneReconciler) deleteOrphanedBarbican(ctx context.Context, cp 
 	// SECRETS, and destroying them takes its own opt-in on top of the one that got
 	// us here (see barbicanStoreDataDeletionAllowedAnnotation). Without it the
 	// service is gone and the store it wrote through stands, so re-declaring
-	// services.barbican reattaches to the same material.
+	// services.barbican reattaches to the same INSTANCE — but not to the same
+	// secrets: the Barbican child deleted above finalizes its MariaDB Database CR,
+	// which database.BuildDatabase leaves without a cleanupPolicy, so the
+	// mariadb-operator Delete default drops the schema holding
+	// secret_store_metadata and the secret rows. The payloads survive in the raft
+	// volume with nothing left referencing them; only a schema dump taken before
+	// the teardown makes this branch a round trip.
 	if !barbicanStoreDataDeletionAllowed(cp) {
 		log.FromContext(ctx).Info("preserving the dedicated OpenBao instance and its stored secrets; "+
 			"set the data-deletion annotation to destroy them with the service",

--- a/tests/e2e/barbican/secretstore-brownfield/01-barbican-secretstore.yaml
+++ b/tests/e2e/barbican/secretstore-brownfield/01-barbican-secretstore.yaml
@@ -15,6 +15,7 @@
 # against, addressed by its Service URL rather than by instanceRef. TLS is
 # mandatory on the URL: the role ID, the secret ID, and every secret barbican
 # stores travel it.
+# region brownfield-store
 apiVersion: barbican.openstack.c5c3.io/v1alpha1
 kind: BarbicanSecretStore
 metadata:
@@ -32,3 +33,4 @@ spec:
         name: openbao-instance-ca
       credentialsSecretRef:
         name: barbican-brownfield-approle
+# endregion brownfield-store

--- a/tests/e2e/barbican/secretstore-managed/01-barbican-secretstore.yaml
+++ b/tests/e2e/barbican/secretstore-managed/01-barbican-secretstore.yaml
@@ -12,6 +12,7 @@
 #
 # kvMountpoint is left at its default: a managed store is pinned to the barbican/
 # mount, which is the only one the self-init contract provisions.
+# region managed-store
 apiVersion: barbican.openstack.c5c3.io/v1alpha1
 kind: BarbicanSecretStore
 metadata:
@@ -25,3 +26,4 @@ spec:
   openBao:
     instanceRef:
       name: openbao-instance
+# endregion managed-store

--- a/tests/unit/docs/barbican_crd_naming_convention_test.sh
+++ b/tests/unit/docs/barbican_crd_naming_convention_test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the docs/reference/barbican/barbican-crd.md "Sub-Resource Naming
+# Convention" section shipped with:
+#   1. The section heading "## Sub-Resource Naming Convention" exists.
+#   2. The section asserts the bare-CR-name convention — checks for the bare
+#      `barbican.openstack.svc.cluster.local:9311` Service DNS example.
+#   3. The section names the four derived-resource exceptions: the
+#      content-hashed config Secret, the derived db-connection Secret, the
+#      db-sync Job, and the db-clean CronJob.
+#
+# Usage: bash tests/unit/docs/barbican_crd_naming_convention_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+CRD_DOC="$PROJECT_ROOT/docs/reference/barbican/barbican-crd.md"
+SECTION_HEADING="Sub-Resource Naming Convention"
+
+# section_body prints the lines of $CRD_DOC between the "## $SECTION_HEADING"
+# heading and the next "## " heading. Tests 2 and 3 assert against that body
+# rather than the whole file, so deleting the section fails the gate even when
+# the same strings still appear elsewhere in the doc.
+#
+# A missing $CRD_DOC yields an empty body instead of an awk failure: test 1
+# already reports the missing file, and under `set -e` a failing awk inside the
+# `body="$(section_body)"` assignment of test 3 would abort the script before it
+# prints its results line.
+section_body() {
+  [[ -f "$CRD_DOC" ]] || return 0
+
+  awk -v h="^## ${SECTION_HEADING}[[:space:]]*\$" '
+    $0 ~ h { f = 1; next }
+    f && /^## / { exit }
+    f { print }
+  ' "$CRD_DOC"
+}
+
+# --- Test 1: heading exists ---
+test_heading_exists() {
+  echo "Test: '## Sub-Resource Naming Convention' heading exists"
+
+  if [[ ! -f "$CRD_DOC" ]]; then
+    echo "  FAIL: $CRD_DOC does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_file_contains \
+    "barbican-crd.md carries the naming-convention heading" \
+    "$CRD_DOC" \
+    "^## Sub-Resource Naming Convention"
+}
+
+# --- Test 2: bare-name Service DNS example ---
+test_bare_name_dns_example() {
+  echo "Test: section shows the bare-CR-name Service DNS example"
+
+  assert_contains \
+    "the naming-convention section shows the bare Service DNS name" \
+    "$(section_body)" \
+    "barbican.openstack.svc.cluster.local:9311"
+}
+
+# --- Test 3: the derived-resource exceptions are documented ---
+test_derived_names_documented() {
+  echo "Test: section documents the four derived-resource naming exceptions"
+
+  local body
+  body="$(section_body)"
+
+  assert_contains \
+    "the section documents the {name}-config-<hash> Secret" \
+    "$body" \
+    "config-<hash>"
+  assert_contains \
+    "the section documents the {name}-db-connection Secret" \
+    "$body" \
+    "-db-connection"
+  assert_contains \
+    "the section documents the {name}-db-sync Job" \
+    "$body" \
+    "-db-sync"
+  assert_contains \
+    "the section documents the {name}-db-clean CronJob" \
+    "$body" \
+    "-db-clean"
+}
+
+# --- Run all tests ---
+echo "=== barbican CRD naming-convention doc tests ==="
+echo ""
+test_heading_exists
+echo ""
+test_bare_name_dns_example
+echo ""
+test_derived_names_documented
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/docs/barbican_secret_store_crd_naming_convention_test.sh
+++ b/tests/unit/docs/barbican_secret_store_crd_naming_convention_test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the docs/reference/barbican/barbican-secret-store-crd.md reference page
+# documents the CRD's conditions and its retained-artefact naming convention.
+# Like GlanceBackend, a BarbicanSecretStore projects no Service of its own — it
+# renders one store section into the referenced Barbican's config — so the
+# vocabulary it must pin down is the condition set (per-store plus the
+# Barbican-side aggregate), the AppRole credentials Secret named after the
+# store, and the fixed credentials data-key contract.
+#
+#   1. The "### Conditions" section exists and documents every condition type:
+#      the per-store CredentialsReady / ProvisioningReady / ConfigProjected, the
+#      aggregate Ready reason AllReady, the Barbican-side NoDefaultSecretStore
+#      reason, and the BarbicanSecretStoreSkipped fault-isolation event.
+#   2. The "## Retained Artefacts" section documents the <store>-approle Secret
+#      and the fixed data keys it carries (role-id, secret-id, and the ca.crt
+#      trust bundle a brownfield store references).
+#
+# Usage: bash tests/unit/docs/barbican_secret_store_crd_naming_convention_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck source=tests/lib/assertions.sh
+source "$PROJECT_ROOT/tests/lib/assertions.sh"
+
+CRD_DOC="$PROJECT_ROOT/docs/reference/barbican/barbican-secret-store-crd.md"
+SECTION_HEADING="Retained Artefacts"
+
+# section_body prints the lines of $CRD_DOC between the "## $SECTION_HEADING"
+# heading and the next "## " heading. Test 2 asserts against that body rather
+# than the whole file: role-id, secret-id, and ca.crt all occur in the spec and
+# condition tables further up, so an unscoped grep would still pass with the
+# section's data-key contract deleted.
+#
+# A missing $CRD_DOC yields an empty body instead of an awk failure: test 1
+# already reports the missing file, and under `set -e` a failing awk inside the
+# `body="$(section_body)"` assignment would abort the script before it prints its
+# results line.
+section_body() {
+  [[ -f "$CRD_DOC" ]] || return 0
+
+  awk -v h="^## ${SECTION_HEADING}[[:space:]]*\$" '
+    $0 ~ h { f = 1; next }
+    f && /^## / { exit }
+    f { print }
+  ' "$CRD_DOC"
+}
+
+# --- Test 1: conditions section documents the full condition set ---
+test_conditions_documented() {
+  echo "Test: '### Conditions' section documents the reconciler's condition set"
+
+  if [[ ! -f "$CRD_DOC" ]]; then
+    echo "  FAIL: $CRD_DOC does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  assert_file_contains "conditions heading present" \
+    "$CRD_DOC" \
+    '^### Conditions'
+  assert_file_contains "documents CredentialsReady" \
+    "$CRD_DOC" \
+    'CredentialsReady'
+  assert_file_contains "documents ProvisioningReady" \
+    "$CRD_DOC" \
+    'ProvisioningReady'
+  assert_file_contains "documents ConfigProjected" \
+    "$CRD_DOC" \
+    'ConfigProjected'
+  assert_file_contains "documents the aggregate Ready reason AllReady" \
+    "$CRD_DOC" \
+    'AllReady'
+  assert_file_contains "documents the NoDefaultSecretStore reason" \
+    "$CRD_DOC" \
+    'NoDefaultSecretStore'
+  assert_file_contains "documents the BarbicanSecretStoreSkipped fault-isolation event" \
+    "$CRD_DOC" \
+    'BarbicanSecretStoreSkipped'
+}
+
+# --- Test 2: retained-artefact Secret naming and data-key contract ---
+test_retained_artefact_naming() {
+  echo "Test: '## Retained Artefacts' documents the AppRole Secret and its keys"
+
+  assert_file_contains "retained-artefacts heading present" \
+    "$CRD_DOC" \
+    '^## Retained Artefacts'
+
+  local body
+  body="$(section_body)"
+
+  assert_contains "documents the <store>-approle Secret name" \
+    "$body" \
+    '<store>-approle'
+  assert_contains "documents the role-id data key" \
+    "$body" \
+    'role-id'
+  assert_contains "documents the secret-id data key" \
+    "$body" \
+    'secret-id'
+  assert_contains "documents the ca.crt trust-bundle data key" \
+    "$body" \
+    'ca.crt'
+}
+
+# --- Run ---
+echo "=== BarbicanSecretStore CRD naming-convention doc tests ==="
+echo ""
+test_conditions_documented
+echo ""
+test_retained_artefact_naming
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #810

Barbican's implementation landed with #807, #808 and #809, but the service
had no user-facing documentation: no `docs/reference/barbican/`, no
`docs/guides/barbican/`, ControlPlane reference pages describing a control
plane of four, and a quick start that never mentioned the key manager. This
branch writes that layer against the merged implementation — it documents,
it does not change behaviour.

## Commits, in order

**`8b38c9cf` test(e2e): mark secret-store fixture regions for guide imports**
Wraps the `BarbicanSecretStore` manifest in the managed and the brownfield
chainsaw fixture in VitePress `# region` / `# endregion` markers
(`managed-store`, `brownfield-store`), so the guides can code-import the
fixtures instead of duplicating YAML that then drifts. Comment lines only —
no key, value or fixture semantics changed.

**`de9a62ec` docs(reference): add the Barbican reference set**
Adds the five pages the sibling operators carry under
`docs/reference/barbican/`, and a Barbican block in the Reference sidebar
between Placement and c5c3.

- `index.md` — the design decisions the v1 operator settled: the queue stays
  off and no worker workload is projected, at most one OpenBao-typed store
  per Barbican because `[vault_plugin]` is process-global, release tracking
  without an upgrade-phase machine, the whole `/etc/barbican` directory
  mounted because barbican accepts no `--config-dir`, and the db-clean
  CronJob on every Barbican. Plus the owned-resources table.
- `barbican-crd.md` — every `BarbicanSpec` field, the nested
  `ServiceUserSpec` / `APIServerSpec` / `UWSGISpec` / `DBCleanSpec` types,
  the webhook rules including the 43-character name bound, the status
  fields, the sub-resource naming convention, and a minimal CR.
- `barbican-secret-store-crd.md` — the satellite CRD: the two OpenBao modes
  and their CEL pins, the fixed `role-id` / `secret-id` / `ca.crt`
  credential contract, the `extraOptions` denylist and reserved section
  names, default-store semantics with the per-store conditions, the
  immutability summary, the chainsaw suites, and the `<store>-approle`
  Secret.
- `barbican-events.md` — the reachable event reasons per topic for both
  recorders, and the shared reasons that cannot fire here.
- `barbican-reconciler.md` — the eleven-step pipeline with its two ordering
  decisions, the condition vocabulary, the secret-store aggregation, the
  single-pass database flow, and the watches.

**`f481ea37` test(docs): pin the Barbican CRD page naming conventions**
Two shell unit tests under `tests/unit/docs/`, discovered by the existing
`make test-shell` glob, so a later rewrite that drops a heading or renames a
projected artefact fails the gate instead of leaving the page describing
something the operator no longer does.

- `barbican_crd_naming_convention_test.sh` follows the placement test: it
  asserts the `## Sub-Resource Naming Convention` heading, then matches the
  Service DNS example and the four derived-resource exceptions against the
  awk-extracted section body alone, so the same strings elsewhere on the
  page cannot keep the gate green once the section is gone.
- `barbican_secret_store_crd_naming_convention_test.sh` follows the
  glance-backend test with whole-file assertions on the `### Conditions` and
  `## Retained Artefacts` strings. The AppRole Secret is pinned as
  `<store>-approle` rather than the bare suffix, because a pattern starting
  with a dash reaches `grep` as a bundle of short options.

**`6c8a64de` docs(guides): add the five Barbican guides**
Adds `docs/guides/barbican/` and registers it as a collapsed Barbican group
in the Guides sidebar after Placement.

The two store guides cover the halves of the secret-store contract.
`barbican-dedicated-openbao.md` walks the self-service mode on the
ControlPlane devstack — the `services.barbican` block, the re-run of
`setup-database-tenant.sh` the new block needs, the projected trio
(`controlplane-barbican`, `-store`, `-bao`) with the ensemble around the
instance, a host-side secret round-trip, and the teardown behind its two
opt-in annotations — and states the proving-grade posture of the provisioned
instance (Development profile, one replica, no PDB, static seal key in a
plain Secret) up front.

`attach-external-openbao.md` is the interface an existing OpenBao or Vault
has to implement: the KV v2 mount, the verbatim `barbican-secretstore`
policy including the deliberate absence of `delete` on `metadata/*`, the
AppRole shape with its unset `secret_id_num_uses` and a pointer to the
re-mint runbook, the two fixed-key Secrets, and the read-only posture the
operator holds against such a server. Its primary path attaches to the kind
proving instance `openbao-instance`, not to the mTLS-guarded management
OpenBao in shared-services, which the vault plugin cannot authenticate to.

The remaining three mirror their Placement counterparts:
`enable-barbican-operator-metrics.md` (ServiceMonitor opt-in, the
`barbican_operator_` series including the db-clean pair and the secretstore
re-mint counter), `enable-barbican-operator-networkpolicy.md` (the
chart-level policy plus its OpenBao egress toggle, and the per-CR policy's
single destination-unrestricted OpenBao rule with one port entry per
distinct store-host port), and
`migrate-barbican-db-to-dynamic-credentials.md`.

**`314d6523` docs(quick-start): store and retrieve a first secret**
Extends the ControlPlane quick start with the Key Manager service, so the
tutorial CR now drives five services and the Verify step ends on a secret
that survives a round-trip through the projected Barbican.

The `services.barbican` block joins both CR listings after placement: one
replica, `secretStore.dedicated`, and the gateway plus `publicEndpoint` pair
that puts the API on the seventh HTTPS listener the kind overlay adds for
`barbican.127-0-0-1.nip.io`. The new Step 6 subsection asserts the
`key-manager` catalog row and then runs the round-trip the e2e verify Job
runs: `secret store`, `secret get` with a payload comparison, `secret
delete`. The region caveat is repeated there and in the existing
`OS_REGION_NAME` warning, because the key-manager rows carry no region
either. Follow-on corrections the added block forces: the readiness chain
gains `BarbicanReady` and its count goes from 13 to 14, the Step 4 engine
tenant now covers four database services, the `/etc/hosts` fallback gains
the barbican hostname, and the `KIND_HOST_PORT=443` note names four
`publicEndpoint` lines.

**`3f52fb68` docs(guides): align the store guides with the extended quick start**
Ordering consequence of the commit above: with the quick start now declaring
`services.barbican` in both of its Step 3 listings, a devstack built from
that tutorial reconciles the Key Manager service before either store guide
is opened, and both guides still claimed the tutorial leaves it undeclared.

The dedicated-OpenBao guide now reads its step 1 as a check on such a
devstack and names the two baselines that still need the block added: a
ControlPlane created before the quick start carried it, and one created from
the bundled minimal CR, which declares keystone and horizon only. Its
database-engine step becomes conditional too — `setup-database-tenant.sh`
reads the live spec and skips undeclared services, and every config and role
write is an upsert, so repeating the run is safe either way. The
external-OpenBao guide frames its service block as replacing `dedicated: {}`
and records what the reconciler does on that switch: the store mode is
frozen by the CRD, so `controlplane-barbican-store` is deleted and recreated
(`BarbicanReady=False`, reason `RecreatingBarbicanSecretStore`), while the
dedicated `controlplane-barbican-bao` instance stays in place untouched.

**`58efae7d` docs(reference): absorb Barbican into the ControlPlane pages**
`controlplane-crd.md` gains a `services.barbican` row and a
`ServiceBarbicanSpec` section covering every field of the struct, with
subsections for the `dedicated`/`external` union, the field-less dedicated
store and its proving-grade posture, the external store's
URL/credentials/CA/mount surface, and the dedicated backing-service block;
the `{controlplane}-barbican-db` and `-barbican-cache` clusterRef defaults
join the name-collision list.

`controlplane-reconciler.md` gains a `reconcileBarbican` section (the
Keystone and service-account gates, the projected child trio and the
dedicated OpenBao ensemble around it, the immutable-drift
delete-and-recreate of the secret store, and the complete `BarbicanReady`
reason vocabulary), and Barbican joins the sections it now belongs to: the
watches table, the RBAC markers, the reconcile flow and its tail group, the
`key-manager` catalog row, the injected service accounts, the teardown
ordering, and the metrics condition map. The blast-radius note claiming the
ClusterRole holds no `roles` or `rolebindings` verbs no longer matched the
markers; it now describes what the ensemble grants and what caps it.

**`2de03c78` docs: sweep the onboarded-service enumerations for Barbican**
Extends the remaining four-service enumerations and retires the two
sentences that described Barbican as pending: `README.md` and
`docs/index.md` (orchestrated-service sentences, operator-module list,
overview bullet linking the new reference set),
`docs/guides/advanced-configuration.md` (the `globalExtraConfig` audience
and its YAML comment, the rendered-config filename list, the catalog-reach
sentence, the External-mode forbid list, the precedence chain),
`controlplane-crd.md` (the same enumerations restated one page over),
`container-images.md` (`images/barbican/Dockerfile`), and
`infrastructure-manifests.md`, whose proving-instance section still promised
a production-shaped instance "with the Barbican onboarding" — what a
ControlPlane projects is another Development-profile instance, and a
Hardened one is still future work.

## Divergences from the issue

- **One code file changed, comments only.** The issue's Non-Goals state that
  the only edits outside `docs/` are the two region markers and the two
  shell tests. `2de03c78` also touches
  `operators/c5c3/internal/controller/reconcile_barbican.go` — both hunks
  are comment prose. Writing the teardown documentation surfaced that two
  existing comments overstated what survives a Barbican teardown: the
  re-declare path reattaches to the same *instance*, but not to the same
  secrets, because the deleted Barbican child finalizes its MariaDB
  `Database` CR without a `cleanupPolicy`, so the schema holding
  `secret_store_metadata` and the secret rows is dropped and the payloads
  are left in the raft volume with nothing referencing them. The comments
  now say that; no code path changed.
- **No architecture chapter.** Dropped per the issue's own Non-Goals — the
  `architecture/` submodule was removed from this repo and
  `barbican-reconciler.md` carries the content.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789035303&installation_model_id=18560&pr_number=831&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F831&signature=c95c9b078dba21abba4185137cdad4cf183028d4dc8c2288209089aba8a96e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->