### PR TITLE
Fix OpenBao API-server egress under post-DNAT NetworkPolicy enforcement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,13 @@ env:
   # helm/kind-action cluster_name and `kind load --name`. Mirrors the
   # CLUSTER_NAME default in hack/deploy-infra.sh.
   KIND_CLUSTER: forge
+  # kind binary version for every e2e job. helm/kind-action defaults to v0.31.0,
+  # whose kindnetd does not yet enforce egress against the post-DNAT destination —
+  # the posture under which the OpenBao instances' NetworkPolicy needs an explicit
+  # API-server allowance. Pinning it here keeps CI on the enforcing build, in
+  # lockstep with the KIND_VERSION in hack/install-test-deps.sh that local
+  # development installs (tests/unit/renovate asserts the two match).
+  KIND_VERSION: v0.32.0
   # Pin tool versions for CI reproducibility (single source of truth).
   CONTROLLER_GEN_VERSION: v0.21.0
   GOFUMPT_VERSION: v0.11.0
@@ -613,6 +620,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # Use composite action for shared Flux CLI + test deps + deploy-infra sequence.
@@ -935,6 +943,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # Resolve which images this operator needs: always its operator image,
@@ -1091,6 +1100,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # Pull the run-scoped images from GHCR: the locally built operator (:dev,
@@ -1245,6 +1255,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # GH-310: Pull pre-built images from GHCR (run-scoped tag).
@@ -1413,6 +1424,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # GH-310: Pull pre-built images from GHCR (run-scoped tag).
@@ -1498,6 +1510,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # Pull the pre-built dev operator images plus the Keystone service image
@@ -1670,6 +1683,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       - name: Load E2E images
@@ -1786,6 +1800,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # The Horizon service image is NOT loaded: External mode never runs a
@@ -1911,6 +1926,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ env.KIND_VERSION }}
           config: hack/kind-config.yaml
           cluster_name: ${{ env.KIND_CLUSTER }}
       # -- Keystone --------------------------------------------------------

--- a/deploy/kind/infrastructure/openbao-instance.yaml
+++ b/deploy/kind/infrastructure/openbao-instance.yaml
@@ -35,6 +35,17 @@
 # The key is never rotated: a static seal that loses its key material seals the
 # instance permanently.
 #
+# API-server egress: spec.network.apiServerEndpointIPs is DELIBERATELY absent here
+# and patched in by hack/deploy-infra.sh, in the same patch that un-pauses the CR.
+# The operator's default-deny NetworkPolicy derives its API-server egress from the
+# in-cluster service VIP on port 443, which kindnet stops honouring from kind 0.32
+# onwards: it enforces egress against the post-DNAT destination, the API server's
+# own endpoint on 6443. Without the explicit allowance the instance loses the API
+# server, raft auto-join times out, and the partial raft state wedges every later
+# initialization attempt. The value cannot live in this file because a kind node
+# address does not survive a cluster re-creation, so the deploy resolves it from
+# EndpointSlice default/kubernetes at apply time.
+#
 # ACCEPTED RISK (openbao-operator upstream): the operator's adoption guard for a
 # pre-existing unseal Secret is metadata carrying the CR's UID — either a
 # controller ownerReference or the openbao.org/owner-uid annotation — and that

--- a/docs/reference/c5c3/controlplane-reconciler.md
+++ b/docs/reference/c5c3/controlplane-reconciler.md
@@ -1467,6 +1467,26 @@ identity, the Kubernetes auth method, and the two policies scoping them) run onc
 against freshly initialised storage, so changing them requires recreating the
 instance and its PVC.
 
+The instance's `spec.network` carries two allowlists. `trustedIngressPeers` names
+the barbican operator's pods and the Barbican API pods, the only sources admitted
+to the API port. `apiServerEndpointIPs` is the egress half, and
+`resolveAPIServerEndpointIPs` resolves it per pass from the EndpointSlice
+`kubernetes` in `default`, deduplicated and sorted. Without it the operator-rendered
+NetworkPolicy allows the API server only at the in-cluster service VIP on port 443,
+which a CNI enforcing egress against the post-DNAT destination never matches, and
+the instance loses the API server: raft auto-join times out, self-init cannot
+complete, and the partial raft state wedges every later initialization attempt.
+Sorting keeps the desired-versus-live comparison from reading endpoint reordering as
+drift, and the read goes through the uncached reader so no cluster-wide EndpointSlice
+informer starts for one well-known object.
+
+That resolution fails closed. An instance created without the egress rules is
+recoverable only by deleting it together with its PVC, so a pass that cannot resolve
+the addresses writes no `OpenBaoCluster` at all and reports
+`BarbicanReady=False/BarbicanOpenBaoError`. Under `rbac.namespaceScoped`, where the
+operator's Role cannot read across into `default`, every dedicated store takes that
+path.
+
 The store, and with it the child, waits until the instance is `Available`
 (`BarbicanReady=False/WaitingForOpenBaoInstance`): a store attached to an
 instance that is still initialising reports `ProvisioningDenied` and would have to

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -62,6 +62,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/c5c3
   KIND_CLUSTER: forge
+  KIND_VERSION: v0.32.0
   CONTROLLER_GEN_VERSION: v0.21.0
   GOFUMPT_VERSION: v0.10.0
   GOLANGCI_LINT_VERSION: v2.12.2
@@ -70,7 +71,14 @@ env:
 `REGISTRY` and `IMAGE_PREFIX` are referenced by the `build-and-push`, `helm-push`,
 `e2e-operator`, and `tempest` jobs to construct image names and registry URLs.
 `KIND_CLUSTER` is the single source of truth for every E2E job's kind cluster name
-(mirroring the `CLUSTER_NAME` default in `hack/deploy-infra.sh`).
+(mirroring the `CLUSTER_NAME` default in `hack/deploy-infra.sh`). `KIND_VERSION` is
+the kind binary every E2E job creates its cluster with, passed to
+`helm/kind-action`'s `version` input. The action defaults to v0.31.0, whose kindnetd
+does not enforce NetworkPolicy egress against the post-DNAT destination; pinning it
+keeps CI on the enforcing build and in lockstep with the `KIND_VERSION` in
+`hack/install-test-deps.sh` that local development installs. Renovate groups the two
+pins so they bump in one pull request, and
+`tests/unit/renovate/workflow_pins_custommanager_test.sh` asserts they agree.
 `CONTROLLER_GEN_VERSION` is used by `verify-codegen` to pin controller-gen to a specific
 version. `GOFUMPT_VERSION` is used by `format-check` to pin gofumpt to a specific version; the same version is mirrored in the Makefile (`GOFUMPT_VERSION ?= v0.10.0`) so
 that `make fmt` and `make format-check` use a consistent version locally.
@@ -555,7 +563,7 @@ validates health of all operators, CRs, and ExternalSecrets.
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 4 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
 | 5 | `chainsaw test` | Runs E2E tests from `tests/e2e/infrastructure/` |
 | 6 | `make deploy-infra` (re-run) | Unchanged-parameter re-run (no `SKIP_KIND_CREATE`) — exercises the script's existing-cluster detection |
@@ -631,7 +639,7 @@ Chainsaw E2E test suites.
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 5 | `kind load docker-image` | Loads operator, 2025.2 service, 2025.2-upgraded, and 2026.1 service images into kind |
 | 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |
@@ -709,7 +717,7 @@ per-suite test directories explicitly.
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
-| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 3 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 4 | `kind load docker-image` | Loads keystone operator and 2025.2 service images into kind |
 | 5 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack with `WITH_CHAOS_MESH=true` |
@@ -775,7 +783,7 @@ genuine regression of the kind-only Quick Start observability story.
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
-| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 3 | `load-e2e-images` composite | Restores prebuilt operator and service images from the build-e2e-images artifact |
 | 4 | `kind load docker-image` | Loads operator and service images into kind |
 | 5 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack with `WITH_PROMETHEUS: "true"` |
@@ -852,7 +860,7 @@ one under review — which is why the `e2e_controlplane` path filter also watche
 | Step | Action | Details |
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
-| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 2 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 3 | `load-e2e-images` composite | Restores `keystone-operator:dev`, `c5c3-operator:dev`, `keystone:2025.2`, `tempest:2025.2` from GHCR |
 | 4 | `kind load docker-image` | Loads the four images into kind |
 | 5 | `setup-e2e-infra` composite action | Deploys infra with `WITH_CONTROLPLANE=true CONTROLPLANE_OPERATORS=external CONTROLPLANE_NAME=controlplane-keystone` |
@@ -947,7 +955,7 @@ these via `matrix.release`, `matrix.config-dir`, `matrix.cr-name`, and
 | --- | --- | --- |
 | 1 | `actions/checkout@v7` | Checks out the repository (SHA-pinned) |
 | 2 | `actions/setup-go@v6` | Sets up Go with `go-version-file: go.work` |
-| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) |
+| 3 | `helm/kind-action@v1.14.0` | Creates kind cluster (`forge`) at `KIND_VERSION` |
 | 4 | `load-e2e-images` composite action | Pulls run-scoped GHCR tags and re-tags to canonical local refs |
 | 5 | `kind load docker-image` | Loads keystone operator and service images into kind |
 | 6 | `setup-e2e-infra` composite action | Installs Flux CLI, test deps, and deploys infra stack |

--- a/docs/reference/infrastructure/e2e-deployment.md
+++ b/docs/reference/infrastructure/e2e-deployment.md
@@ -349,7 +349,7 @@ Covers the openbao-operator and the proving `OpenBaoCluster` instance:
 | --- | --- | --- | --- |
 | 1 | openbao-operator Deployment ready + HelmRelease Ready | `openbao-operator-system` | `Deployment`, `HelmRelease` |
 | 2 | Unseal-key ExternalSecret SecretSynced, and the instance's `ownerReference` adoption of the Secret it materialized | `openstack` | `ExternalSecret`, `Secret`, `OpenBaoCluster` |
-| 3 | OpenBaoCluster `Available` with `readyReplicas: 1` | `openstack` | `OpenBaoCluster` |
+| 3 | OpenBaoCluster `Available` with `readyReplicas: 1`, `APIServerNetworkReady`, and a non-empty `spec.network.apiServerEndpointIPs` | `openstack` | `OpenBaoCluster` |
 | 4 | Kubernetes auth to AppRole to KV v2 round-trip, including a rejected login with a wrong secret ID | `openstack` | `script` (`kubectl exec` into the instance pod) |
 | 5 | Pod deletion, then the replacement pod reports `sealed: false` without any unseal command | `openstack` | `script` (`kubectl exec` into the instance pod) |
 

--- a/docs/reference/infrastructure/infrastructure-manifests.md
+++ b/docs/reference/infrastructure/infrastructure-manifests.md
@@ -958,7 +958,7 @@ on. All live in the `openstack` namespace except the cluster-scoped ClusterRoleB
 | `Certificate` | `cert-manager.io/v1` | `openbao-instance-tls-ca` | Delivers the trust-domain CA into the fixed-name Secret the operator reads (data key `ca.crt`) |
 | `ServiceAccount` | `v1` | `openbao-instance-provisioner` | Client identity the Kubernetes-auth role `provisioner` binds to |
 | `ClusterRoleBinding` | `rbac.authorization.k8s.io/v1` | `openbao-instance-auth-delegator` | Grants `system:auth-delegator` to the operator-created instance ServiceAccount `openbao-instance-serviceaccount` |
-| `OpenBaoCluster` | `openbao.org/v1alpha1` | `openbao-instance` | Profile `Development`, version `2.6.1`, one replica, 1Gi raft storage, TLS mode `External`, static seal, self-init enabled, applied `paused` |
+| `OpenBaoCluster` | `openbao.org/v1alpha1` | `openbao-instance` | Profile `Development`, version `2.6.1`, one replica, 1Gi raft storage, TLS mode `External`, static seal, self-init enabled, applied `paused`, API-server egress patched in at deploy time |
 
 The instance runs in every kind deploy, so the primitives a managed Barbican secret store
 needs are exercised with no Barbican attached: static-seal auto-unseal, cert-manager TLS
@@ -1049,6 +1049,23 @@ re-seeded while the instance's own PVC survives. No PushSecret targets the path.
 > create Secrets in the namespace before the instance first initializes can plant a seal
 > key of their choosing. Accepted because this instance is CI/dev-only; a production
 > instance must not depend on that guard.
+
+**API-server egress.** The operator wraps the instance pods in a deny-by-default
+NetworkPolicy and derives the API-server egress rule from the in-cluster service VIP on
+port 443. kindnet enforces egress against the post-DNAT destination from kind 0.32
+onwards, and the packet it inspects is addressed to the API server's own endpoint on port
+6443, so the VIP rule never matches. The instance then loses the API server: raft
+auto-join times out, self-init cannot complete, and the partial raft state wedges every
+later initialization attempt, recoverable only by deleting the CR together with its PVC.
+
+`spec.network.apiServerEndpointIPs` closes that gap with one egress rule per address on
+port 6443. The manifest sets no value, because a kind node address does not survive a
+cluster re-creation. `hack/deploy-infra.sh` reads the addresses from the EndpointSlice
+`kubernetes` in `default`, which kube-apiserver maintains itself, and applies them in the
+same patch that un-pauses the CR, so the operator's first reconcile already renders the
+rules. Resolving no address aborts the deploy. The operator reports its own verdict on the
+result as condition `APIServerNetworkReady`, which stays `Unknown` with reason
+`APIServerEndpointIPsRecommended` while only the service VIP is allowed.
 
 **Self-init surface.** The operator renders `spec.selfInit.requests` into OpenBao's
 initialize stanzas, which run once against freshly initialized storage; OpenBao revokes

--- a/hack/deploy-infra.sh
+++ b/hack/deploy-infra.sh
@@ -2519,8 +2519,44 @@ main() {
     -o jsonpath='{.metadata.uid}')
   kubectl patch secret openbao-instance-unseal-key -n openstack --type merge \
     -p "{\"metadata\":{\"ownerReferences\":[{\"apiVersion\":\"openbao.org/v1alpha1\",\"kind\":\"OpenBaoCluster\",\"name\":\"openbao-instance\",\"uid\":\"${openbao_instance_uid}\",\"controller\":true,\"blockOwnerDeletion\":true}]}}"
+
+  # The instance's API-server egress, resolved from the live cluster and applied in
+  # the SAME patch as the un-pause, so the operator's very first reconcile already
+  # renders the port-6443 rules.
+  #
+  # The openbao-operator's default-deny NetworkPolicy derives its API-server egress
+  # from the in-cluster service VIP on port 443. kindnet enforces egress against the
+  # POST-DNAT destination from kind 0.32 onwards, so that rule never matches: the
+  # packet it inspects is addressed to the API server's own endpoint on 6443. The
+  # instance then loses the API server, raft auto-join times out, self-init never
+  # completes, and the partial raft state wedges every later initialization attempt
+  # — recoverable only by deleting the CR AND its PVC.
+  #
+  # The addresses are read rather than hardcoded because a kind node address does
+  # not survive a cluster re-creation. EndpointSlice default/kubernetes is where
+  # kube-apiserver publishes them itself, so it needs no controller-manager and
+  # exists on every conformant cluster.
+  # The read runs under `if !` so a failed lookup reports through the same branch as
+  # an empty one, rather than tripping `set -e` and dying without saying why.
+  local api_server_endpoint_ips=""
+  if ! api_server_endpoint_ips="$(kubectl get endpointslice kubernetes -n default -o json |
+    jq -c '[.endpoints[]?.addresses[]?] | unique')"; then
+    api_server_endpoint_ips=""
+  fi
+  if [[ -z "${api_server_endpoint_ips}" || "${api_server_endpoint_ips}" == "[]" ]]; then
+    log "ERROR: no API server address in EndpointSlice default/kubernetes."
+    log "       The OpenBao instance's NetworkPolicy would deny its API-server"
+    log "       egress, wedging the raft store on first initialization. Aborting"
+    log "       rather than un-pausing the instance into that state."
+    exit 1
+  fi
+  log "Pinning the instance's API-server egress to ${api_server_endpoint_ips}..."
+
+  # A JSON merge patch merges objects key by key, so spec.network.trustedIngressPeers
+  # from the overlay survives. A later `kubectl apply -k` re-run cannot drop the
+  # field either: it appears in neither the overlay nor the last-applied annotation.
   kubectl patch openbaocluster openbao-instance -n openstack --type merge \
-    -p '{"spec":{"paused":false}}'
+    -p "{\"spec\":{\"network\":{\"apiServerEndpointIPs\":${api_server_endpoint_ips}},\"paused\":false}}"
 
   # Garage object store (S3 backend for the Glance e2e suites). Its
   # GarageCluster/GarageBucket/GarageKey CRs live in shared-services and are

--- a/operators/c5c3/helm/c5c3-operator/templates/_helpers.tpl
+++ b/operators/c5c3/helm/c5c3-operator/templates/_helpers.tpl
@@ -443,6 +443,20 @@ coordination.k8s.io/leases rule required for leader election.
     - watch
     - create
     - delete
+# discovery.k8s.io - endpointslices
+# Read-only on the single well-known EndpointSlice default/kubernetes, which
+# carries the addresses the API server answers on. A dedicated Barbican secret
+# store projects them into the OpenBaoCluster's
+# spec.network.apiServerEndpointIPs, without which the operator-rendered
+# NetworkPolicy denies the instance its API-server egress on a CNI that enforces
+# against the post-DNAT destination. No list or watch: the name is well known and
+# the read goes through the uncached reader.
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
 # core - events
 - apiGroups:
     - ""

--- a/operators/c5c3/helm/c5c3-operator/tests/clusterrole_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/clusterrole_test.yaml
@@ -1,11 +1,12 @@
 # ClusterRole RBAC rules unit tests.
 # Rules mirror the +kubebuilder:rbac markers on the ControlPlane and
 # CredentialRotation reconcilers (deduplicated), plus the leases rule for
-# leader election — 30 rules total (clustersecretstores read-only and
+# leader election — 31 rules total (clustersecretstores read-only and
 # secretstores read-write are separate rules since the operator provisions the
 # per-tenant SecretStore; the namespaces rule lets reconcileNamespaces ensure the
 # per-service dedicated namespaces; the clusterroles rule is bind-only on the
-# single name system:auth-delegator).
+# single name system:auth-delegator; the endpointslices rule is get-only, for the
+# API-server addresses a dedicated OpenBao instance needs egress to).
 suite: ClusterRole
 templates:
   - templates/clusterrole.yaml
@@ -14,7 +15,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 30
+          count: 31
 
   - it: should grant full CRUD on controlplanes
     asserts:
@@ -581,6 +582,31 @@ tests:
               - watch
               - create
               - delete
+
+  - it: should grant get-only on endpointslices
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+      # list and watch would cover every EndpointSlice in the cluster, and the
+      # operator reads exactly one object under a well-known name.
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: should restrict events to create and patch only
     asserts:

--- a/operators/c5c3/helm/c5c3-operator/tests/role_test.yaml
+++ b/operators/c5c3/helm/c5c3-operator/tests/role_test.yaml
@@ -41,7 +41,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have 30 rules matching ClusterRole
+  - it: should have 31 rules matching ClusterRole
     set:
       rbac:
         namespaceScoped: true
@@ -50,7 +50,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 30
+          count: 31
 
   - it: should grant full CRUD on controlplanes
     set:
@@ -542,6 +542,28 @@ tests:
               - watch
               - create
               - delete
+
+  # The rule is shared with the ClusterRole, so it renders here too. In
+  # namespace-scoped mode it grants nothing usable: the EndpointSlice the operator
+  # reads lives in default, not in the operator's own namespace, so a dedicated
+  # Barbican secret store fails closed on BarbicanOpenBaoError rather than
+  # projecting an instance whose API-server egress would be denied.
+  - it: should grant get-only on endpointslices
+    set:
+      rbac:
+        namespaceScoped: true
+      webhook:
+        enabled: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
 
   - it: should restrict events to create and patch only
     set:

--- a/operators/c5c3/internal/controller/controlplane_controller.go
+++ b/operators/c5c3/internal/controller/controlplane_controller.go
@@ -187,6 +187,7 @@ func (r *ControlPlaneReconciler) apiReader() client.Reader {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts/token,verbs=create
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;delete
 

--- a/operators/c5c3/internal/controller/integration_test.go
+++ b/operators/c5c3/internal/controller/integration_test.go
@@ -28,6 +28,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -1583,6 +1584,24 @@ func TestIntegration_FullReconcile_ManagedToReady(t *testing.T) {
 	g.Expect(instance.Spec.TLS.Mode).To(Equal(openbaov1alpha1.TLSModeExternal))
 	g.Expect(instance.Spec.Unseal).NotTo(BeNil())
 	g.Expect(instance.Spec.Unseal.Type).To(Equal("static"))
+
+	// The API-server egress allowance, resolved from the live cluster rather than
+	// hardcoded: without it the operator-rendered NetworkPolicy admits only the
+	// in-cluster service VIP on port 443, which a CNI enforcing egress against the
+	// post-DNAT destination never matches. envtest's apiserver maintains the
+	// well-known EndpointSlice itself, so the addresses asserted here are the ones a
+	// real cluster would supply.
+	g.Expect(instance.Spec.Network).NotTo(BeNil())
+	apiServerSlice := &discoveryv1.EndpointSlice{}
+	g.Expect(c.Get(ctx, client.ObjectKey{
+		Name: apiServerEndpointSliceName, Namespace: apiServerEndpointSliceNamespace,
+	}, apiServerSlice)).To(Succeed(), "envtest must publish the API server's EndpointSlice")
+	liveAddresses := []string{}
+	for i := range apiServerSlice.Endpoints {
+		liveAddresses = append(liveAddresses, apiServerSlice.Endpoints[i].Addresses...)
+	}
+	g.Expect(liveAddresses).NotTo(BeEmpty())
+	g.Expect(instance.Spec.Network.APIServerEndpointIPs).To(ConsistOf(liveAddresses))
 
 	// self-init is one-shot, so the eight requests and their order are frozen at
 	// create time: a mount or auth method must be enabled before anything writes

--- a/operators/c5c3/internal/controller/reconcile_barbican_openbao.go
+++ b/operators/c5c3/internal/controller/reconcile_barbican_openbao.go
@@ -12,9 +12,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -517,13 +519,21 @@ func (r *ControlPlaneReconciler) ensureBarbicanOpenBaoCluster(
 ) (*openbaov1alpha1.OpenBaoCluster, error) {
 	key := types.NamespacedName{Name: barbicanOpenBaoName(cp), Namespace: cp.BarbicanNamespace()}
 
+	// Resolved before the read, so a cluster whose API-server endpoints cannot be
+	// determined writes no instance at all. See resolveAPIServerEndpointIPs for why
+	// this fails closed rather than projecting without the egress allowance.
+	apiServerIPs, err := r.resolveAPIServerEndpointIPs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	instance := &openbaov1alpha1.OpenBaoCluster{}
-	err := r.Get(ctx, key, instance)
+	err = r.Get(ctx, key, instance)
 	switch {
 	case apierrors.IsNotFound(err):
 		instance.Name = key.Name
 		instance.Namespace = key.Namespace
-		instance.Spec = r.barbicanOpenBaoClusterSpec(cp)
+		instance.Spec = r.barbicanOpenBaoClusterSpec(cp, apiServerIPs)
 		instance.Spec.Storage = openbaov1alpha1.StorageConfig{Size: barbicanOpenBaoStorageSize}
 		if oerr := claimChildOwnership(cp, instance, r.Scheme); oerr != nil {
 			return nil, fmt.Errorf("claiming ownership of OpenBaoCluster %q: %w", key.Name, oerr)
@@ -537,7 +547,7 @@ func (r *ControlPlaneReconciler) ensureBarbicanOpenBaoCluster(
 		if aerr := refuseForeignAdoption(cp, instance, r.Scheme); aerr != nil {
 			return nil, aerr
 		}
-		desired := r.barbicanOpenBaoClusterSpec(cp)
+		desired := r.barbicanOpenBaoClusterSpec(cp, apiServerIPs)
 		desired.Storage = instance.Spec.Storage
 		if !equality.Semantic.DeepEqual(instance.Spec, desired) {
 			instance.Spec = desired
@@ -562,7 +572,9 @@ func (r *ControlPlaneReconciler) ensureBarbicanOpenBaoCluster(
 // from the ControlPlane name, so a re-created ControlPlane of the same name meets
 // the previous instance's data-<instance>-0 PVC — raft storage initialised under a
 // seal key that no longer exists — and never unseals.
-func (r *ControlPlaneReconciler) barbicanOpenBaoClusterSpec(cp *c5c3v1alpha1.ControlPlane) openbaov1alpha1.OpenBaoClusterSpec {
+func (r *ControlPlaneReconciler) barbicanOpenBaoClusterSpec(
+	cp *c5c3v1alpha1.ControlPlane, apiServerIPs []string,
+) openbaov1alpha1.OpenBaoClusterSpec {
 	name, namespace := barbicanOpenBaoName(cp), cp.BarbicanNamespace()
 	return openbaov1alpha1.OpenBaoClusterSpec{
 		Profile:  openbaov1alpha1.ProfileDevelopment,
@@ -582,12 +594,82 @@ func (r *ControlPlaneReconciler) barbicanOpenBaoClusterSpec(cp *c5c3v1alpha1.Con
 		DeletionPolicy: openbaov1alpha1.DeletionPolicyDeletePVCs,
 		Network: &openbaov1alpha1.NetworkConfig{
 			TrustedIngressPeers: barbicanOpenBaoIngressPeers(namespace, r.barbicanOperatorNamespace()),
+			// The API server, addressed by the endpoints it actually answers on.
+			// The openbao-operator's own detection allows the in-cluster service
+			// VIP on port 443, which a CNI enforcing egress against the post-DNAT
+			// destination never matches.
+			APIServerEndpointIPs: apiServerIPs,
 		},
 		SelfInit: &openbaov1alpha1.SelfInitConfig{
 			Enabled:  true,
 			Requests: barbicanOpenBaoSelfInitRequests(name, namespace),
 		},
 	}
+}
+
+// The Kubernetes API server publishes its own endpoints in this EndpointSlice.
+// kube-apiserver maintains it directly rather than through the controller manager,
+// so it is present on every conformant cluster.
+const (
+	apiServerEndpointSliceName      = "kubernetes"
+	apiServerEndpointSliceNamespace = "default"
+)
+
+// resolveAPIServerEndpointIPs returns the addresses the Kubernetes API server
+// answers on, deduplicated and sorted.
+//
+// The openbao-operator renders a deny-by-default NetworkPolicy over the instance
+// pods and derives its API-server egress rule from the in-cluster service VIP on
+// port 443. A CNI that enforces egress against the post-DNAT destination, which
+// kindnet does from kind 0.32 onwards, never matches that rule: the packet it
+// inspects is addressed to the API server's own endpoint on port 6443.
+// spec.network.apiServerEndpointIPs is the upstream remedy, adding one
+// least-privilege egress rule per address on that port. The operator does not
+// auto-detect the addresses, because doing so needs cluster permissions outside
+// its trust model, so they are resolved here instead.
+//
+// The read goes through the uncached reader. A cached Get would have
+// controller-runtime start a cluster-wide EndpointSlice informer to track a single
+// well-known object.
+//
+// Both failure paths return an error rather than a partial answer, and the caller
+// then writes no instance at all. An instance that comes up without these rules
+// does not merely stay unavailable: its raft auto-join times out, self-init never
+// completes, and the partial raft state wedges every later initialisation attempt,
+// recoverable only by deleting the instance together with its PVC.
+func (r *ControlPlaneReconciler) resolveAPIServerEndpointIPs(ctx context.Context) ([]string, error) {
+	key := types.NamespacedName{
+		Name:      apiServerEndpointSliceName,
+		Namespace: apiServerEndpointSliceNamespace,
+	}
+
+	slice := &discoveryv1.EndpointSlice{}
+	if err := r.apiReader().Get(ctx, key, slice); err != nil {
+		return nil, fmt.Errorf("getting EndpointSlice %s/%s: %w",
+			apiServerEndpointSliceNamespace, apiServerEndpointSliceName, err)
+	}
+
+	seen := make(map[string]struct{})
+	ips := make([]string, 0, len(slice.Endpoints))
+	for i := range slice.Endpoints {
+		for _, address := range slice.Endpoints[i].Addresses {
+			if _, duplicate := seen[address]; duplicate {
+				continue
+			}
+			seen[address] = struct{}{}
+			ips = append(ips, address)
+		}
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("EndpointSlice %s/%s carries no API server address",
+			apiServerEndpointSliceNamespace, apiServerEndpointSliceName)
+	}
+
+	// Sorted because ensureBarbicanOpenBaoCluster compares the desired spec against
+	// the live one, and the API server guarantees no endpoint order. Unsorted, a
+	// reordered read would look like drift and rewrite the instance every pass.
+	slices.Sort(ips)
+	return ips, nil
 }
 
 // barbicanOpenBaoIngressPeers names the only two sources allowed to reach the

--- a/operators/c5c3/internal/controller/reconcile_barbican_openbao_test.go
+++ b/operators/c5c3/internal/controller/reconcile_barbican_openbao_test.go
@@ -15,7 +15,9 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,9 +79,53 @@ func barbicanOpenBaoControlPlane() *c5c3v1alpha1.ControlPlane {
 	}
 }
 
-// barbicanOpenBaoReconciler builds a reconciler over a fake client seeded with cp
-// and objs.
+// defaultKubernetesEndpointSlice builds the EndpointSlice kube-apiserver publishes
+// for itself under a well-known name. Seeding it is what makes a fake client
+// resemble the cluster the reconciler actually runs against: every conformant
+// cluster carries one, and resolveAPIServerEndpointIPs reads it on every dedicated
+// secret-store pass.
+//
+// With no addresses given it carries one, which is the single-control-plane shape
+// of a kind cluster.
+func defaultKubernetesEndpointSlice(addresses ...string) *discoveryv1.EndpointSlice {
+	if len(addresses) == 0 {
+		addresses = []string{"172.18.0.2"}
+	}
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apiServerEndpointSliceName,
+			Namespace: apiServerEndpointSliceNamespace,
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   []discoveryv1.Endpoint{{Addresses: addresses}},
+	}
+}
+
+// seedAPIServerEndpointSlice appends the API server's EndpointSlice unless the
+// caller already supplied one, so a test that pins particular addresses keeps
+// control of them without the fake client rejecting a duplicate key.
+func seedAPIServerEndpointSlice(objs []client.Object) []client.Object {
+	for _, o := range objs {
+		if _, ok := o.(*discoveryv1.EndpointSlice); ok {
+			return objs
+		}
+	}
+	return append(objs, defaultKubernetesEndpointSlice())
+}
+
+// barbicanOpenBaoReconciler builds a reconciler over a fake client seeded with cp,
+// objs, and the API server's EndpointSlice.
 func barbicanOpenBaoReconciler(t *testing.T, cp *c5c3v1alpha1.ControlPlane, objs ...client.Object) *ControlPlaneReconciler {
+	t.Helper()
+	return barbicanOpenBaoReconcilerWithExactSeeds(t, cp, seedAPIServerEndpointSlice(objs)...)
+}
+
+// barbicanOpenBaoReconcilerWithExactSeeds seeds exactly what it is given, so a test
+// can model the cluster resolveAPIServerEndpointIPs must refuse to project against:
+// one with no API-server EndpointSlice at all.
+func barbicanOpenBaoReconcilerWithExactSeeds(
+	t *testing.T, cp *c5c3v1alpha1.ControlPlane, objs ...client.Object,
+) *ControlPlaneReconciler {
 	t.Helper()
 	s := barbicanOpenBaoTestScheme(t)
 	seeded := append([]client.Object{cp}, objs...)
@@ -237,6 +283,129 @@ func TestEnsureBarbicanOpenBao_PinsIngressPeers(t *testing.T) {
 		HaveKeyWithValue("kubernetes.io/metadata.name", barbicanOpenBaoTestNamespace))
 	g.Expect(peers[1].PodSelector.MatchLabels).To(
 		HaveKeyWithValue("app.kubernetes.io/name", "barbican"))
+}
+
+// TestEnsureBarbicanOpenBao_ProjectsAPIServerEndpointIPs asserts the API server's
+// endpoint addresses reach the instance's egress allowlist, deduplicated and
+// sorted. Without them the operator-rendered NetworkPolicy allows only the
+// in-cluster service VIP on port 443, which a CNI enforcing egress against the
+// post-DNAT destination never matches, and the instance loses the API server.
+//
+// The sort is load-bearing rather than cosmetic: the projection is compared
+// against the live spec on every pass, and the API server guarantees no endpoint
+// order, so an unsorted list would read as drift and rewrite the instance forever.
+func TestEnsureBarbicanOpenBao_ProjectsAPIServerEndpointIPs(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := barbicanOpenBaoControlPlane()
+	// Deliberately unsorted, and with one address repeated across two endpoints.
+	r := barbicanOpenBaoReconciler(t, cp, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apiServerEndpointSliceName,
+			Namespace: apiServerEndpointSliceNamespace,
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"172.18.0.4", "172.18.0.2"}},
+			{Addresses: []string{"172.18.0.3", "172.18.0.2"}},
+		},
+	})
+
+	_, err := r.ensureBarbicanOpenBao(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	instance := getBarbicanOpenBaoCluster(t, r, cp)
+	g.Expect(instance.Spec.Network).NotTo(BeNil())
+	g.Expect(instance.Spec.Network.APIServerEndpointIPs).To(
+		Equal([]string{"172.18.0.2", "172.18.0.3", "172.18.0.4"}))
+	// The egress allowance is additive to the ingress allowlist, never a
+	// replacement for it.
+	g.Expect(instance.Spec.Network.TrustedIngressPeers).To(HaveLen(2))
+}
+
+// TestEnsureBarbicanOpenBao_TracksAPIServerEndpointDrift asserts a live instance is
+// corrected when the API server's endpoint addresses change, which is what happens
+// when a kind cluster is re-created under a control plane of the same name.
+func TestEnsureBarbicanOpenBao_TracksAPIServerEndpointDrift(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := barbicanOpenBaoControlPlane()
+	r := barbicanOpenBaoReconciler(t, cp, defaultKubernetesEndpointSlice("172.18.0.2"))
+
+	_, err := r.ensureBarbicanOpenBao(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getBarbicanOpenBaoCluster(t, r, cp).Spec.Network.APIServerEndpointIPs).
+		To(Equal([]string{"172.18.0.2"}))
+
+	slice := &discoveryv1.EndpointSlice{}
+	key := types.NamespacedName{
+		Name:      apiServerEndpointSliceName,
+		Namespace: apiServerEndpointSliceNamespace,
+	}
+	g.Expect(r.Get(context.Background(), key, slice)).To(Succeed())
+	slice.Endpoints = []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.7"}}}
+	g.Expect(r.Update(context.Background(), slice)).To(Succeed())
+
+	_, err = r.ensureBarbicanOpenBao(context.Background(), cp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getBarbicanOpenBaoCluster(t, r, cp).Spec.Network.APIServerEndpointIPs).
+		To(Equal([]string{"10.0.0.7"}))
+}
+
+// TestEnsureBarbicanOpenBao_RefusesWithoutAPIServerEndpointSlice asserts the
+// projection fails closed when the EndpointSlice is absent, writing no instance at
+// all.
+//
+// Creating one anyway is the expensive mistake. An instance whose NetworkPolicy
+// denies API-server egress cannot finish self-init, and the partial raft state it
+// leaves behind wedges every later initialisation attempt: recovering it means
+// deleting the instance together with its PVC, so an instance never created is
+// strictly cheaper than one created wrong.
+func TestEnsureBarbicanOpenBao_RefusesWithoutAPIServerEndpointSlice(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := barbicanOpenBaoControlPlane()
+	r := barbicanOpenBaoReconcilerWithExactSeeds(t, cp)
+
+	available, err := r.ensureBarbicanOpenBao(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("getting EndpointSlice default/kubernetes"))
+	g.Expect(available).To(BeFalse())
+
+	instance := &openbaov1alpha1.OpenBaoCluster{}
+	instanceKey := types.NamespacedName{
+		Namespace: cp.BarbicanNamespace(), Name: barbicanOpenBaoName(cp),
+	}
+	g.Expect(apierrors.IsNotFound(r.Get(context.Background(), instanceKey, instance))).To(BeTrue(),
+		"no OpenBaoCluster may be written when the API-server addresses cannot be resolved")
+}
+
+// TestEnsureBarbicanOpenBao_RefusesEmptyAPIServerEndpointSlice asserts the same
+// fail-closed outcome for an EndpointSlice that exists but carries no address. A
+// present-but-empty slice would otherwise project an empty allowlist, which the
+// openbao-operator renders as no egress rule at all — the very posture this
+// resolves.
+func TestEnsureBarbicanOpenBao_RefusesEmptyAPIServerEndpointSlice(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cp := barbicanOpenBaoControlPlane()
+	r := barbicanOpenBaoReconciler(t, cp, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apiServerEndpointSliceName,
+			Namespace: apiServerEndpointSliceNamespace,
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   []discoveryv1.Endpoint{},
+	})
+
+	available, err := r.ensureBarbicanOpenBao(context.Background(), cp)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring(
+		"EndpointSlice default/kubernetes carries no API server address"))
+	g.Expect(available).To(BeFalse())
+
+	instance := &openbaov1alpha1.OpenBaoCluster{}
+	instanceKey := types.NamespacedName{
+		Namespace: cp.BarbicanNamespace(), Name: barbicanOpenBaoName(cp),
+	}
+	g.Expect(apierrors.IsNotFound(r.Get(context.Background(), instanceKey, instance))).To(BeTrue(),
+		"no OpenBaoCluster may be written when the API-server addresses cannot be resolved")
 }
 
 // TestEnsureBarbicanOpenBao_ProjectsSelfInitRequests pins the eight self-init

--- a/operators/c5c3/internal/controller/reconcile_barbican_test.go
+++ b/operators/c5c3/internal/controller/reconcile_barbican_test.go
@@ -251,7 +251,8 @@ func withBarbicanGatesPassed(objs []client.Object) []client.Object {
 func newBarbicanTestReconciler(t *testing.T, objs ...client.Object) *ControlPlaneReconciler {
 	t.Helper()
 	s := barbicanTestScheme(t)
-	cb := fake.NewClientBuilder().WithScheme(s).WithObjects(withBarbicanGatesPassed(objs)...).
+	cb := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(seedAPIServerEndpointSlice(withBarbicanGatesPassed(objs))...).
 		WithStatusSubresource(&c5c3v1alpha1.ControlPlane{}, &barbicanv1alpha1.Barbican{},
 			&openbaov1alpha1.OpenBaoCluster{})
 	return &ControlPlaneReconciler{Client: cb.Build(), Scheme: s}

--- a/renovate.json
+++ b/renovate.json
@@ -304,6 +304,19 @@
         "/\\.github/workflows/.*\\.yaml$/"
       ],
       "matchStrings": [
+        "KIND_VERSION:\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "kubernetes-sigs/kind",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yaml$/"
+      ],
+      "matchStrings": [
         "YQ_VERSION:\\s*\"?(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"?"
       ],
       "depNameTemplate": "mikefarah/yq",
@@ -521,7 +534,6 @@
       "matchPackageNames": [
         "kyverno/chainsaw",
         "fluxcd/flux2",
-        "kubernetes-sigs/kind",
         "kubernetes/kubernetes"
       ],
       "matchUpdateTypes": ["major"],
@@ -533,13 +545,34 @@
       "matchPackageNames": [
         "kyverno/chainsaw",
         "fluxcd/flux2",
-        "kubernetes-sigs/kind",
         "kubernetes/kubernetes"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "minimumReleaseAge": "3 days",
       "groupName": "test tooling (install-test-deps)"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [
+        "hack/install-test-deps.sh",
+        ".github/workflows/ci.yaml"
+      ],
+      "matchPackageNames": ["kubernetes-sigs/kind"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [
+        "hack/install-test-deps.sh",
+        ".github/workflows/ci.yaml"
+      ],
+      "matchPackageNames": ["kubernetes-sigs/kind"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
+      "groupName": "kind"
     },
     {
       "matchManagers": ["custom.regex"],

--- a/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
+++ b/tests/e2e/c5c3/full-controlplane-keystone/chainsaw-test.yaml
@@ -812,6 +812,22 @@ spec:
           assert_eq "dedicated OpenBaoCluster Available" "True" \
             "$(kubectl get openbaoclusters.openbao.org "${BARBICAN_BAO}" -n "${CP_NS}" \
               -o "jsonpath={.status.conditions[?(@.type=='Available')].status}")"
+          # The API-server egress allowance the operator resolves from the live
+          # cluster's EndpointSlice default/kubernetes. APIServerNetworkReady is the
+          # openbao-operator's own verdict on it, and it is Unknown (reason
+          # APIServerEndpointIPsRecommended) whenever only the in-cluster service VIP
+          # is allowed — the posture kindnet stops honouring from kind 0.32 onwards,
+          # where the instance then loses the API server and wedges its raft storage.
+          assert_eq "dedicated OpenBaoCluster APIServerNetworkReady" "True" \
+            "$(kubectl get openbaoclusters.openbao.org "${BARBICAN_BAO}" -n "${CP_NS}" \
+              -o "jsonpath={.status.conditions[?(@.type=='APIServerNetworkReady')].status}")"
+          BAO_API_IPS="$(kubectl get openbaoclusters.openbao.org "${BARBICAN_BAO}" -n "${CP_NS}" \
+            -o 'jsonpath={.spec.network.apiServerEndpointIPs[*]}')"
+          if [ -z "${BAO_API_IPS}" ]; then
+            echo "ERROR: dedicated OpenBaoCluster carries no spec.network.apiServerEndpointIPs"
+            exit 1
+          fi
+          echo "OK: dedicated OpenBaoCluster pins API-server endpoint IPs ('${BAO_API_IPS}')"
           # The image version is deliberately NOT asserted: it is a Renovate-managed
           # pin in the operator (defaultOpenBaoVersion), and a bump PR must not have
           # to edit an e2e fixture to stay green.

--- a/tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml
+++ b/tests/e2e/infrastructure/openbao-instance/chainsaw-test.yaml
@@ -121,8 +121,20 @@ spec:
           metadata:
             name: openbao-instance
             namespace: openstack
+          spec:
+            network:
+              # Patched in by hack/deploy-infra.sh together with the un-pause,
+              # resolved from EndpointSlice default/kubernetes. Empty here means the
+              # operator's NetworkPolicy allows only the in-cluster service VIP on
+              # port 443, which kindnet stops honouring from kind 0.32 onwards.
+              (length(apiServerEndpointIPs) > `0`): true
           status:
             (conditions[?type == 'Available']):
+            - status: "True"
+            # The openbao-operator's own verdict on the egress posture. It reports
+            # Unknown (reason APIServerEndpointIPsRecommended) while only the service
+            # VIP is allowed, so True is what proves the post-DNAT rules are rendered.
+            (conditions[?type == 'APIServerNetworkReady']):
             - status: "True"
             readyReplicas: 1
   # ── Step 4: Kubernetes auth to AppRole to KV round-trip ─────────────────

--- a/tests/unit/deploy/openbao_instance_overlay_test.sh
+++ b/tests/unit/deploy/openbao_instance_overlay_test.sh
@@ -50,6 +50,7 @@ KIND_INFRA_DIR="$PROJECT_ROOT/deploy/kind/infrastructure"
 PROD_INFRA_DIR="$PROJECT_ROOT/deploy/flux-system/infrastructure"
 INSTANCE_FILE="$KIND_INFRA_DIR/openbao-instance.yaml"
 OPERATOR_RELEASE_FILE="$PROJECT_ROOT/deploy/flux-system/releases/openbao-operator.yaml"
+DEPLOY_SCRIPT="$PROJECT_ROOT/hack/deploy-infra.sh"
 
 # The complete permanent configuration of the instance, in declaration order.
 SELF_INIT_REQUESTS="barbican_kv barbican_secretstore_policy approle_auth \
@@ -213,11 +214,53 @@ test_operator_release_runs_multi_tenant() {
   assert_eq "the kind overlay onboards the openstack namespace" "openstack" "$tenant_target"
 }
 
+# --- Test 5: the deploy resolves the API-server egress and patches it with the un-pause ---
+test_deploy_patches_api_server_egress() {
+  echo "Test: hack/deploy-infra.sh resolves the API-server endpoints and patches them with the un-pause"
+
+  if [[ ! -f "$DEPLOY_SCRIPT" ]]; then
+    echo "  FAIL: $DEPLOY_SCRIPT does not exist"
+    FAIL=$((FAIL + 3))
+    return
+  fi
+
+  # The overlay must NOT set the field: a kind node address does not survive a
+  # cluster re-creation, so a hardcoded value would be wrong on the second cluster.
+  if command -v yq >/dev/null 2>&1; then
+    local overlay_ips
+    overlay_ips="$(yq -r \
+      'select(.kind == "OpenBaoCluster") | .spec.network.apiServerEndpointIPs // "null"' \
+      "$INSTANCE_FILE" 2>/dev/null | head -n1)"
+    assert_eq "the overlay hardcodes no API-server endpoint IPs" "null" "$overlay_ips"
+  else
+    echo "  SKIP: yq not installed (1 check skipped)"
+    SKIP=$((SKIP + 1))
+  fi
+
+  # Resolved from the object kube-apiserver maintains for itself.
+  assert_file_contains "the deploy resolves the API-server endpoints from EndpointSlice default/kubernetes" \
+    "$DEPLOY_SCRIPT" "kubectl get endpointslice kubernetes -n default"
+
+  # One patch, not two. Un-pausing first would let the operator render its
+  # NetworkPolicy without the port-6443 egress rules, and the instance wedges its
+  # raft store on that first reconcile — recoverable only by deleting the CR AND
+  # its PVC. The single patch is therefore the contract, not a tidiness preference.
+  # Backslashes are stripped so the assertions hold for either shell quoting style.
+  local unpause_patch
+  unpause_patch="$(grep -A2 'kubectl patch openbaocluster openbao-instance' "$DEPLOY_SCRIPT" |
+    tr -d '\\' | tr '\n' ' ')"
+  assert_contains "the un-pause patch carries apiServerEndpointIPs" \
+    "$unpause_patch" "apiServerEndpointIPs"
+  assert_contains "the un-pause patch still clears spec.paused" \
+    "$unpause_patch" '"paused":false'
+}
+
 # --- Run ---
 test_kind_overlay_renders_paused_instance
 test_production_overlay_renders_no_instance
 test_self_init_request_list_is_pinned
 test_operator_release_runs_multi_tenant
+test_deploy_patches_api_server_egress
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh
+++ b/tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh
@@ -93,7 +93,11 @@ test_adoption_choreography_order() {
   local wait_es proof unpause
   wait_es="$(line_of '^    openbao-instance-unseal-key$')"
   proof="$(line_of 'kubectl patch secret openbao-instance-unseal-key')"
-  unpause="$(line_of '{"spec":{"paused":false}}')"
+  # Located by the command rather than its payload: the same patch also carries
+  # spec.network.apiServerEndpointIPs, so the payload's exact shape is not a stable
+  # anchor. That the patch still clears spec.paused is asserted by
+  # tests/unit/deploy/openbao_instance_overlay_test.sh.
+  unpause="$(line_of 'kubectl patch openbaocluster openbao-instance')"
 
   assert_before "the ExternalSecret is waited for before the ownership proof" \
     "$wait_es" "$proof"
@@ -106,7 +110,11 @@ test_instance_start_is_not_serialized_behind_garage() {
   echo "Test: the un-pause precedes the GarageCluster wait and the Available wait follows it"
 
   local unpause garage_wait available_wait
-  unpause="$(line_of '{"spec":{"paused":false}}')"
+  # Located by the command rather than its payload: the same patch also carries
+  # spec.network.apiServerEndpointIPs, so the payload's exact shape is not a stable
+  # anchor. That the patch still clears spec.paused is asserted by
+  # tests/unit/deploy/openbao_instance_overlay_test.sh.
+  unpause="$(line_of 'kubectl patch openbaocluster openbao-instance')"
   garage_wait="$(line_of 'kubectl wait garagecluster/garage')"
   available_wait="$(line_of 'kubectl wait openbaocluster/openbao-instance')"
 

--- a/tests/unit/renovate/workflow_pins_custommanager_test.sh
+++ b/tests/unit/renovate/workflow_pins_custommanager_test.sh
@@ -3,15 +3,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify renovate.json has customManagers for the four GitHub Actions env-var
+# Verify renovate.json has customManagers for the five GitHub Actions env-var
 # tool pins:
 #   - CONTROLLER_GEN_VERSION → kubernetes-sigs/controller-tools
 #   - GOFUMPT_VERSION        → mvdan/gofumpt
 #   - GOLANGCI_LINT_VERSION  → golangci/golangci-lint
+#   - KIND_VERSION           → kubernetes-sigs/kind
 #   - YQ_VERSION             → mikefarah/yq
 #
 # For each: regex must capture the literal in the workflow file that pins it,
 # and the paired packageRule must disable majors and automerge minor/patch.
+#
+# KIND_VERSION carries one extra obligation. It is pinned twice — in ci.yaml for
+# the e2e clusters and in hack/install-test-deps.sh for local development — and the
+# two must agree, or CI and a developer's kind enforce NetworkPolicy egress
+# differently. Renovate must therefore bump both in ONE pull request; ungrouped it
+# would open two, each leaving the lockstep assertion below red.
 #
 # Usage: bash tests/unit/renovate/workflow_pins_custommanager_test.sh
 
@@ -34,6 +41,7 @@ TOOLS=(
   "CONTROLLER_GEN_VERSION:kubernetes-sigs/controller-tools:.github/workflows/ci.yaml"
   "GOFUMPT_VERSION:mvdan/gofumpt:.github/workflows/ci.yaml"
   "GOLANGCI_LINT_VERSION:golangci/golangci-lint:.github/workflows/ci.yaml"
+  "KIND_VERSION:kubernetes-sigs/kind:.github/workflows/ci.yaml"
   "YQ_VERSION:mikefarah/yq:.github/workflows/verify-container-images.yaml"
 )
 
@@ -92,6 +100,39 @@ test_each_workflow_pin_has_manager() {
   done
 }
 
+test_kind_version_is_pinned_in_lockstep() {
+  echo "Test: the kind pins in ci.yaml and install-test-deps.sh agree, and bump together"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP: jq not installed (3 checks skipped)"
+    SKIP=$((SKIP + 3))
+    return
+  fi
+
+  local ci_file install_file ci_kind install_kind
+  ci_file="$PROJECT_ROOT/.github/workflows/ci.yaml"
+  install_file="$PROJECT_ROOT/hack/install-test-deps.sh"
+
+  ci_kind="$(sed -n 's/^[[:space:]]*KIND_VERSION:[[:space:]]*"\{0,1\}\(v[0-9.]*\)"\{0,1\}[[:space:]]*$/\1/p' \
+    "$ci_file" | head -1)"
+  install_kind="$(sed -n 's/^KIND_VERSION="\(v[0-9.]*\)"$/\1/p' "$install_file" | head -1)"
+
+  assert_not_empty "ci.yaml pins KIND_VERSION" "$ci_kind"
+  # CI creating its clusters with the helm/kind-action default (v0.31.0) while
+  # local development installs a newer kind is how a NetworkPolicy egress posture
+  # that only holds on one of them reaches main unnoticed.
+  assert_eq "the ci.yaml and install-test-deps.sh kind pins agree" "$install_kind" "$ci_kind"
+
+  # One group, so Renovate bumps both files in a single pull request. Two rules
+  # would open two, and each would fail the assertion above until the other landed.
+  local groups
+  groups="$(jq -r '[.packageRules[]
+    | select(((.matchPackageNames // []) | index("kubernetes-sigs/kind")) != null)
+    | select(((.matchUpdateTypes // []) | index("minor")) != null)
+    | .groupName] | unique | join(",")' "$RENOVATE_FILE")"
+  assert_eq "exactly one Renovate group owns the kind pins" "kind" "$groups"
+}
+
 test_workflow_pins_share_a_package_rule() {
   echo "Test: workflow tool pins share a major-disable + minor-automerge packageRule"
 
@@ -139,6 +180,7 @@ test_workflow_pins_share_a_package_rule() {
 }
 
 test_each_workflow_pin_has_manager
+test_kind_version_is_pinned_in_lockstep
 test_workflow_pins_share_a_package_rule
 
 echo ""


### PR DESCRIPTION
Closes #829

The openbao-operator wraps every OpenBaoCluster in a deny-by-default NetworkPolicy and derives its API-server egress rule from the in-cluster service VIP on port 443. kindnet enforces egress against the post-DNAT destination from kind 0.32 onwards, so that rule never matches: the packet it inspects is addressed to the API server's own endpoint on port 6443. The instance then loses the API server, raft auto-join times out, self-init cannot complete, and the partial raft state wedges every later initialization attempt, recoverable only by deleting the CR together with its PVC.

Both affected instances now set `spec.network.apiServerEndpointIPs`, resolved from the live cluster rather than hardcoded, because a kind node address does not survive a cluster re-creation. Both derivations read EndpointSlice `kubernetes` in `default`, which kube-apiserver maintains itself.

## Walkthrough, in commit order

**`75ba182a` feat(c5c3): derive the dedicated OpenBao instance's API-server egress**
`resolveAPIServerEndpointIPs` reads the addresses through the uncached reader (a cached Get would start a cluster-wide EndpointSlice informer for one well-known object) and `barbicanOpenBaoClusterSpec` projects them, deduplicated and sorted. Sorting is load-bearing: the desired spec is compared against the live one each pass, and the API server guarantees no endpoint order, so an unsorted list would read as drift forever. The resolution fails closed, writing no OpenBaoCluster at all and reporting `BarbicanReady=False` / `BarbicanOpenBaoError`, because an instance created without the egress rules is the unrecoverable case. RBAC is get-only on `discovery.k8s.io` endpointslices; this repo commits no controller-gen RBAC output, so the rule goes into the chart's shared `rbacRules` helper and both unittest suites move from 30 rules to 31.

**`02781bde` fix(deploy): pin the proving OpenBao instance's API-server egress**
`hack/deploy-infra.sh` resolves the addresses and applies them in the **same** patch that un-pauses the CR. One patch is the contract rather than a tidiness preference: un-pausing first would let the operator render its NetworkPolicy without the port-6443 rules, and one reconcile in that state wedges the raft store. A JSON merge patch merges objects key by key, so the overlay's `trustedIngressPeers` survives, and a later `kubectl apply -k` cannot drop the field because it appears in neither the overlay nor the last-applied annotation. Resolving no address, or failing the read, aborts the deploy.

**`e157e42a` ci: create e2e clusters with the post-DNAT-enforcing kind**
`helm/kind-action`'s `version` input defaults to v0.31.0, so CI exercised the egress posture nowhere while `hack/install-test-deps.sh` has installed v0.32.0 locally for some time. All nine kind-action steps now take `KIND_VERSION` from the workflow env block. Renovate groups the two kind pins so they bump in one pull request, which is what makes the new lockstep assertion viable: ungrouped, it would open one PR per file and each would sit red until the other landed.

**`c5ec5fc0` docs(reference): record the OpenBao API-server egress posture**
The four reference pages that described the instances and the CI clusters as they were before the allowance existed.

## Verification

Local, all green: `make test`, `make lint` (7 modules), `make test-shell`, `make shellcheck`, `make chainsaw-lint`, `npm run docs:build`, `helm unittest operators/c5c3/helm/c5c3-operator` (176/176), and `make manifests && make generate` with no drift. The envtest integration test asserts the projection against the live EndpointSlice; envtest's apiserver publishes one, so no fixture is seeded there.

Two behaviours were confirmed by watching them fail first: the projection tests fail with the `apiServerEndpointIPs` assignment removed, and the overlay contract test fails 2 of 16 against the pre-change `deploy-infra.sh`.

Not runnable locally: bringing the proving instance to `Available` on a real kind v0.32 cluster, and the nine e2e jobs. That is what this pull request's own CI run exercises for the first time.

## Notes for the reviewer

- The issue named `operators/c5c3/config/rbac/role.yaml`. That file does not exist and neither does any generated RBAC in this repo, so the grant landed in `_helpers.tpl` plus both chart suites, including `role_test.yaml`, which the issue did not list but `helm-validate` requires.
- `tests/unit/hack/deploy_infra_openbao_instance_adoption_test.sh` located the un-pause by its exact payload literal. The payload now carries two keys, so the locator moved to the `kubectl patch` command; the payload itself is asserted by the overlay contract test.
- Under `rbac.namespaceScoped` the operator's Role cannot read across into `default`, so a dedicated secret store takes the fail-closed path there. Documented rather than widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bag4VxwesvrVAeuZKfmxwR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046571&installation_model_id=18560&pr_number=832&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F832&signature=75c07a6b6536d2aa8eb31267d8b793df791d827a047885f48779b66f43a5445e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->