### PR TITLE
feat: write remote children unowned with ownership labels and explicit teardown

### DIFF
--- a/docs/reference/target-clusters.md
+++ b/docs/reference/target-clusters.md
@@ -198,23 +198,88 @@ CRD sets are therefore required on the management cluster whatever
 See [Infrastructure Manifests](./infrastructure/infrastructure-manifests.md) for
 the Flux sources and the dependency order these three ride in.
 
-## Owner references dangle on the target
+## Ownership and teardown on the target
 
-::: warning A target cluster must not have the service CRDs installed
-A child written to a target carries an owner reference to a CR that lives on the
-management cluster, so on the target that reference points at nothing. With the
-service CRDs installed there, the target's garbage collector resolves the owner
-as absent and deletes the children. Keep the service CRDs off target clusters
-until #837 replaces the owner references with an explicit remote-cleanup path.
+A child written to a target cluster carries no owner references at all. Nothing
+on that cluster can resolve an owner into the management cluster, so ownership
+is recorded in three labels the operator stamps on every remote child:
+
+| Label | Value |
+| --- | --- |
+| `openstack.c5c3.io/owner-kind` | The owning CR's kind: `Keystone`, `Barbican`, `Horizon`, `Glance`, or `Placement` |
+| `openstack.c5c3.io/owner-name` | The owning CR's name |
+| `openstack.c5c3.io/owner-namespace` | The owning CR's namespace, which is the namespace the child lands in |
+
+The kind is part of the key because a Keystone and a Barbican of the same name
+in the same namespace project into one target namespace, and each has to select
+only its own. Installing the service CRDs on a target cluster is safe: no child
+there points at an owner, so no garbage collector has one to resolve.
+
+A label value may not exceed 63 characters, so the name of a CR that names a
+target cluster may not either. A longer one is refused at the first child write,
+before anything is created.
+
+::: warning One target namespace belongs to one management cluster
+The three labels name the owning CR and say nothing about where it lives. Two
+management clusters that each run these operators, each hold a CR of the same
+kind and name in the same namespace, and each name the same target cluster would
+project into that namespace under one identity: either would take the other's
+children for its own, overwrite their specs, and delete them when its own CR is
+deleted. Give each management cluster its own namespace on a shared target, or
+its own target cluster.
 :::
 
-The same dangling reference is what makes deletion incomplete. Deleting a CR
-removes the MariaDB CRs its finalizer cleans up, and leaves everything else —
-Deployment, Service, ConfigMaps, Secrets, HTTPRoute — running on the target,
-where no garbage collector can resolve the owner that is gone. Horizon installs
-no finalizer at all, so a deleted Horizon leaves its whole projection behind,
-including the Secret carrying the Django `SECRET_KEY`. Delete the CR's namespace
-on the target cluster, or the objects in it, to reclaim them.
+Deleting a CR that names a target cluster tears its children down explicitly.
+The finalizer `openstack.c5c3.io/remote-children` goes on whenever
+`targetClusterRef` is set, and holds the CR in etcd until the sweep has run. The
+sweep deletes every object of that operator's projected kinds the CR owns, in the
+CR's namespace on the target — by the three labels, or by a controller owner
+reference an older operator left on it. It runs after the cleanup
+flows that delete objects by name, the MariaDB CRs and, for Keystone, the backup
+PushSecrets. That PushSecret flow holds the CR across passes until ESO has
+purged the kv-v2 paths, and a sweep running first would delete the PushSecrets
+out from under it. The order also matches the local one, where the cascade
+starts only once every finalizer has released.
+
+The sweep does not wait for the deleted objects to leave etcd. A child holding a
+finalizer of its own, the MariaDB CRs being the slow ones, finishes terminating
+on the target after the CR is gone, the way it does under the local cascade.
+
+Horizon needs no finalizer for a local deletion, since the cascade reclaims
+every child it composes. A Horizon that names a target cluster carries the
+remote-children finalizer and the same sweep.
+
+A `BarbicanSecretStore` whose parent Barbican resolves to a target cluster
+carries that finalizer too, plus the annotation
+`openstack.c5c3.io/children-cluster` naming the cluster. Both are written before
+the first credentials write. Its deletion deletes the AppRole credentials Secret
+on the cluster its parent names and on the annotated one — the same cluster on
+every ordinary teardown — so neither a parent deleted first nor a parent
+re-created against a different target strands it. Only a Secret carrying this
+store's ownership labels is taken. The AppRole on the OpenBao instance stays: it
+is shared instance state, owned by the self-init contract rather than by one
+store.
+
+A cluster deregistered under a CR that is already being deleted holds the
+deletion open. The pass requeues and the finalizer stays on until the two
+five-minute windows run out. Then it is released without a sweep, under a
+`RemoteChildrenAbandoned` warning event naming what went undeleted, and the
+children stay on the unreachable cluster, to be removed there by hand.
+
+::: warning Children written once keep an owner reference from an older operator
+A child written by an operator predating this contract carries an owner
+reference to the management-cluster CR. Children on the Server-Side Apply and
+`CreateOrUpdate` paths shed it on the operator's first pass over them. Children
+created once and never rewritten do not: the immutable config ConfigMaps and
+Secrets, the derived db-connection Secret, the fernet and credential key
+Secrets, the Certificates, and completed Jobs keep the stale reference for as
+long as they exist. The sweep still reaches them — it recognizes the reference as
+readily as the labels — so deleting the CR removes them. Until it is deleted the
+reference is a hazard on a target cluster that has the service CRDs installed:
+that cluster's garbage collector resolves it to a missing object and collects the
+child as an orphan. Delete such a CR and create it anew before the CRDs go onto
+its target cluster; everything it writes afterwards carries the labels alone.
+:::
 
 ## Interim constraints
 
@@ -222,4 +287,3 @@ on the target cluster, or the objects in it, to reclaim them.
 - The capability probes (Gateway API, cert-manager) run against the management cluster, not the target (#839). The API Service selector latch does read the target: it goes through that cluster's own uncached API reader, so a lagging cache cannot re-widen the selector.
 - `KeystoneIdentityBackend` carries no `targetClusterRef`, and its reconciler stays management-side. A backend attached to a Keystone that names a target cluster looks for the parent's Deployment and projection Secret locally, where they do not exist, and holds `ConfigProjected=False` with reason `WaitingForProjection`.
 - RBAC and access packaging for a target cluster, together with the two-cluster development flow, are #841.
-- Garbage-collection-safe ownership for remote children is #837.

--- a/internal/common/apply/apply.go
+++ b/internal/common/apply/apply.go
@@ -8,12 +8,16 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // FieldManager is the Server-Side Apply field manager used by EnsureObject. It
@@ -36,9 +40,80 @@ const FieldManager = "forge-operator"
 // is absorbed as an internal retry rather than surfacing as transient condition
 // noise. On success obj is overwritten with the server response, so callers may
 // read fresh status (e.g. readiness) from obj without an extra Get.
+//
+// A client marked by multicluster.Remote writes to a target cluster, where a
+// reference to owner names a UID that cluster cannot resolve. Such a child is
+// applied with no owner reference at all and carries the ownership labels
+// instead, and a live object those labels do not already name is refused rather
+// than adopted. Every other client takes the local path, unchanged.
 func EnsureObject[T client.Object](ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj T, fieldManager string) error {
+	if multicluster.IsRemote(c) {
+		return ensureRemoteObject(ctx, c, scheme, owner, obj, fieldManager)
+	}
 	if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {
 		return fmt.Errorf("setting owner reference on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	return EnsureUnownedObject(ctx, c, scheme, obj, fieldManager)
+}
+
+// ensureRemoteObject is EnsureObject against a target cluster: obj is claimed by
+// the ownership labels rather than by a controller owner reference and applied
+// unowned, because on that cluster a reference to owner names an absent UID and
+// leaves the child one kind registration away from being collected as an orphan.
+//
+// A same-named object somebody else provisioned is refused instead of adopted.
+// Adopting it would be doubly destructive: the apply overwrites its spec, and
+// the labels stamped on it get it deleted at teardown. The refusal is
+// multicluster.Claim's own, taken on the LIVE object, because that is where the
+// UID and the labels answering "is this ours?" sit. The desired object, which no
+// API server has ever seen, cannot answer for them. Claiming the live object is
+// the check and nothing more: it is thrown away afterwards, and obj is what gets
+// applied.
+//
+// The pre-check reads through multicluster.LiveReader, that is, through the
+// target cluster's own uncached API reader. Reading through c instead would
+// decide adoption from a cache that may still trail the cluster it describes,
+// and would pull every kind this function touches into an informer on the
+// target — including the kinds nothing else there reads.
+//
+// One limit the code cannot show: Server-Side Apply sheds the fields the shared
+// field manager owned and no longer asserts. A remote child written before
+// ownership moved to the labels therefore loses its dangling controller owner
+// reference on the first pass after that move, without anyone rewriting it.
+func ensureRemoteObject[T client.Object](ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj T, fieldManager string) error {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return fmt.Errorf("resolving GVK for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	// The live state is read into a fresh instance and not into a copy of obj: a
+	// typed Get unmarshals the response into whatever it is handed, so every
+	// field the live object omits (its labels, the very thing the ownership check
+	// reads) would survive from the desired object and be taken for live state.
+	fresh, err := scheme.New(gvk)
+	if err != nil {
+		return fmt.Errorf("building an empty %s to read the live %s/%s into: %w",
+			gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+	live := fresh.(client.Object)
+
+	switch err := multicluster.LiveReader(c).Get(ctx, client.ObjectKeyFromObject(obj), live); {
+	case apierrors.IsNotFound(err), meta.IsNoMatchError(err):
+		// Nothing to adopt: the object is absent, or its kind is not installed on
+		// the target cluster at all. The apply reports the second case itself.
+	case err != nil:
+		return fmt.Errorf("checking for a pre-existing %s %s/%s before adopting it: %w",
+			gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+	default:
+		if err := multicluster.Claim(c, scheme, owner, live); err != nil {
+			return err
+		}
+	}
+
+	// Both Claim errors are returned as they are. Each already names the object
+	// it failed on, and prefixing a refusal that spells out what it refuses and
+	// why would only say the same thing twice.
+	if err := multicluster.Claim(c, scheme, owner, obj); err != nil {
+		return err
 	}
 	return EnsureUnownedObject(ctx, c, scheme, obj, fieldManager)
 }

--- a/internal/common/apply/apply_test.go
+++ b/internal/common/apply/apply_test.go
@@ -13,12 +13,18 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
 func newScheme() *runtime.Scheme {
@@ -199,4 +205,215 @@ func TestEnsureObject_rejectsCrossNamespaceOwner(t *testing.T) {
 
 	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(cm), &corev1.ConfigMap{})).NotTo(Succeed(),
 		"nothing may be applied once the owner reference is refused")
+}
+
+// testOwnerLabels are the ownership labels a child of testOwner carries on a
+// target cluster.
+func testOwnerLabels() map[string]string {
+	return map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}
+}
+
+// TestEnsureObject_remoteAppliesLabelledAndUnowned pins the target-cluster path:
+// the child is stamped with the ownership labels and carries no owner reference,
+// because a reference to an owner living on another cluster names a UID this one
+// cannot resolve.
+func TestEnsureObject_remoteAppliesLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+
+	g.Expect(EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)).To(Succeed())
+
+	fetched := &corev1.ConfigMap{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "applied-cm", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.Data).To(HaveKeyWithValue("key", "value"))
+	g.Expect(fetched.Labels).To(Equal(testOwnerLabels()))
+	g.Expect(fetched.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+}
+
+// TestEnsureObject_remoteRefusesForeignObject covers the destructive case the
+// pre-check exists for: a same-named object somebody else provisioned would have
+// its spec overwritten by the apply and would be deleted at teardown by the
+// labels stamped on it. Nothing is written.
+func TestEnsureObject_remoteRefusesForeignObject(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	foreign := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "applied-cm",
+			Namespace: "default",
+			UID:       "foreign-uid",
+			Labels:    map[string]string{"app": "somebody-else"},
+		},
+		Data: map[string]string{"key": "theirs"},
+	}
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner, foreign).Build())
+
+	err := EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing ConfigMap default/applied-cm")))
+
+	fetched := &corev1.ConfigMap{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(foreign), fetched)).To(Succeed())
+	g.Expect(fetched.Data).To(HaveKeyWithValue("key", "theirs"), "the refused object must not be rewritten")
+	g.Expect(fetched.Labels).To(Equal(map[string]string{"app": "somebody-else"}))
+	g.Expect(fetched.ResourceVersion).To(Equal(foreign.ResourceVersion))
+}
+
+// staleCacheCluster stands in for a registered target cluster whose informer
+// cache trails the API server it describes: GetClient answers out of the stale
+// cache, GetAPIReader out of the cluster's actual state. Embedding the interface
+// leaves every other method nil, which panics if anything reaches for one.
+type staleCacheCluster struct {
+	cluster.Cluster
+	cached client.Client
+	live   client.Reader
+}
+
+func (c staleCacheCluster) GetClient() client.Client { return c.cached }
+
+func (c staleCacheCluster) GetAPIReader() client.Reader { return c.live }
+
+// staleCacheResolver registers that cluster under every name.
+type staleCacheResolver struct{ cl cluster.Cluster }
+
+func (r staleCacheResolver) GetCluster(context.Context, mcruntime.ClusterName) (cluster.Cluster, error) {
+	return r.cl, nil
+}
+
+// TestEnsureObject_remotePrecheckReadsLiveState pins where the refusal gets its
+// answer from. A cache is as capable of trailing a target cluster as a local
+// one, and a foreign object it has not caught up on would be read as absent,
+// adopted, overwritten by the apply and deleted at this owner's teardown. The
+// same read through the cache would also pull every kind this function touches
+// into an informer on the target — including the kinds nothing there reads.
+func TestEnsureObject_remotePrecheckReadsLiveState(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	foreign := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "applied-cm",
+			Namespace: "default",
+			UID:       "foreign-uid",
+			Labels:    map[string]string{"app": "somebody-else"},
+		},
+		Data: map[string]string{"key": "theirs"},
+	}
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build()
+	live := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, foreign).Build()
+
+	c, err := multicluster.ResolveChildrenClient(context.Background(),
+		staleCacheResolver{cl: staleCacheCluster{cached: cached, live: live}}, cached,
+		&commonv1.TargetClusterRefSpec{Name: "edge-1"})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)
+
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing ConfigMap default/applied-cm")))
+	g.Expect(cached.Get(context.Background(), client.ObjectKeyFromObject(foreign), &corev1.ConfigMap{})).
+		NotTo(Succeed(), "nothing may have been written while the cache still showed the object as absent")
+}
+
+// TestEnsureObject_remoteReappliesOwnChild is the other side of the refusal: an
+// object already carrying this owner's labels is its child and is applied again,
+// which is the ordinary steady-state pass.
+func TestEnsureObject_remoteReappliesOwnChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	mine := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "applied-cm",
+			Namespace: "default",
+			UID:       "child-uid",
+			Labels:    testOwnerLabels(),
+		},
+		Data: map[string]string{"key": "stale"},
+	}
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner, mine).Build())
+
+	g.Expect(EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)).To(Succeed())
+
+	fetched := &corev1.ConfigMap{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(mine), fetched)).To(Succeed())
+	g.Expect(fetched.Data).To(HaveKeyWithValue("key", "value"))
+	g.Expect(fetched.Labels).To(Equal(testOwnerLabels()))
+	g.Expect(fetched.OwnerReferences).To(BeEmpty())
+}
+
+// TestEnsureObject_remotePropagatesPrecheckError pins that a read the target
+// cluster answers with anything other than "absent" stops the pass: without an
+// answer there is no way to tell our own child from somebody else's object, and
+// applying anyway is the destructive guess.
+func TestEnsureObject_remotePropagatesPrecheckError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	applies := 0
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, key.Name, nil)
+			},
+			Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				applies++
+				return nil
+			},
+		}).
+		Build())
+
+	err := EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)
+	g.Expect(err).To(MatchError(ContainSubstring("checking for a pre-existing ConfigMap default/applied-cm")))
+	g.Expect(apierrors.IsForbidden(err)).To(BeTrue(), "the read error must survive the wrapping")
+	g.Expect(applies).To(BeZero(), "no apply may be attempted while the live state is unknown")
+}
+
+// TestEnsureObject_remoteAppliesWhenKindNotInstalled covers the second tolerated
+// read failure: the target cluster does not serve the child's kind at all, which
+// says as much about a pre-existing object as a NotFound does — there is none.
+// The apply proceeds and reports the missing kind itself.
+func TestEnsureObject_remoteAppliesWhenKindNotInstalled(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	// Only the pre-check's read is answered with the missing kind; the
+	// verification below reads the fake's own state again.
+	precheck := true
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if precheck {
+					precheck = false
+					return &meta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Kind: "ConfigMap"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build())
+
+	g.Expect(EnsureObject(context.Background(), c, s, owner, testConfigMap(), FieldManager)).To(Succeed())
+
+	fetched := &corev1.ConfigMap{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "applied-cm", Namespace: "default"}, fetched)).To(Succeed())
+	g.Expect(fetched.Labels).To(Equal(testOwnerLabels()))
+	g.Expect(fetched.OwnerReferences).To(BeEmpty())
 }

--- a/internal/common/apply/integration_test.go
+++ b/internal/common/apply/integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/c5c3/forge/internal/common/multicluster"
 	envtestutil "github.com/c5c3/forge/internal/common/testutil/envtest"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -100,4 +101,44 @@ func TestIntegration_EnsureObject_takesOverFromUpdate(t *testing.T) {
 	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, fetched)).To(Succeed())
 	g.Expect(fetched.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:1.36"))
 	g.Expect(fetched.OwnerReferences).To(HaveLen(1))
+}
+
+// TestIntegration_EnsureObject_remoteShedsOwnerReference proves the self-heal the
+// target-cluster path relies on, which only a real API server can show: a child
+// written before ownership moved to the labels carries a controller owner
+// reference under the shared field manager, and the first apply that no longer
+// asserts that field is what removes it, because Server-Side Apply drops the
+// fields its manager stops claiming. On a target cluster that reference names a
+// UID nothing there can resolve, so shedding it is the point.
+func TestIntegration_EnsureObject_remoteShedsOwnerReference(t *testing.T) {
+	envtestutil.SkipIfEnvTestUnavailable(t)
+	g := NewGomegaWithT(t)
+
+	c, ctx, _ := envtestutil.SetupEnvTest(t)
+	scheme := envtestutil.SharedScheme()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-apply-remote"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: ns.Name}}
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	// The child as an operator predating the labels left it: same field manager,
+	// owner-referenced.
+	g.Expect(EnsureObject(ctx, c, scheme, owner, integrationDeployment(ns.Name), FieldManager)).To(Succeed())
+	pre := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, pre)).To(Succeed())
+	g.Expect(pre.OwnerReferences).To(HaveLen(1))
+
+	// The same desired object, now written through a target-cluster client. The
+	// pre-check recognizes the reference as this owner's own and re-applies.
+	remote := multicluster.Remote(c)
+	g.Expect(EnsureObject(ctx, remote, scheme, owner, integrationDeployment(ns.Name), FieldManager)).To(Succeed())
+
+	fetched := &appsv1.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: "ssa-demo", Namespace: ns.Name}, fetched)).To(Succeed())
+	g.Expect(fetched.OwnerReferences).To(BeEmpty(),
+		"the apply must shed the reference its field manager no longer asserts")
+	g.Expect(fetched.Labels).To(HaveKeyWithValue(multicluster.OwnerKindLabel, "ConfigMap"))
+	g.Expect(fetched.Labels).To(HaveKeyWithValue(multicluster.OwnerNameLabel, "owner"))
+	g.Expect(fetched.Labels).To(HaveKeyWithValue(multicluster.OwnerNamespaceLabel, ns.Name))
 }

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -19,8 +19,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // RenderINI renders a map of INI sections into an INI format string.
@@ -237,7 +238,7 @@ func CreateImmutableConfigMap(ctx context.Context, c client.Client, scheme *runt
 		Immutable: &immutable,
 	}
 
-	if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
+	if err := multicluster.Claim(c, scheme, owner, cm); err != nil {
 		return "", fmt.Errorf("setting owner reference on ConfigMap %s/%s: %w", namespace, name, err)
 	}
 
@@ -252,8 +253,11 @@ func CreateImmutableConfigMap(ctx context.Context, c client.Client, scheme *runt
 		if getErr := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, existingCM); getErr != nil {
 			return "", fmt.Errorf("fetching existing ConfigMap %s/%s: %w", namespace, name, getErr)
 		}
-		controllerRef := metav1.GetControllerOf(existingCM)
-		if controllerRef == nil || controllerRef.UID != owner.GetUID() {
+		owned, ownErr := multicluster.Controls(scheme, owner, existingCM)
+		if ownErr != nil {
+			return "", fmt.Errorf("checking ownership of existing ConfigMap %s/%s: %w", namespace, name, ownErr)
+		}
+		if !owned {
 			return "", fmt.Errorf("existing ConfigMap %s/%s is not owned by %s/%s",
 				namespace, name, owner.GetNamespace(), owner.GetName())
 		}
@@ -303,7 +307,7 @@ func CreateImmutableSecret(ctx context.Context, c client.Client, scheme *runtime
 		Immutable: &immutable,
 	}
 
-	if err := controllerutil.SetControllerReference(owner, secret, scheme); err != nil {
+	if err := multicluster.Claim(c, scheme, owner, secret); err != nil {
 		return "", fmt.Errorf("setting owner reference on Secret %s/%s: %w", namespace, name, err)
 	}
 
@@ -317,8 +321,11 @@ func CreateImmutableSecret(ctx context.Context, c client.Client, scheme *runtime
 		if getErr := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, existing); getErr != nil {
 			return "", fmt.Errorf("fetching existing Secret %s/%s: %w", namespace, name, getErr)
 		}
-		controllerRef := metav1.GetControllerOf(existing)
-		if controllerRef == nil || controllerRef.UID != owner.GetUID() {
+		owned, ownErr := multicluster.Controls(scheme, owner, existing)
+		if ownErr != nil {
+			return "", fmt.Errorf("checking ownership of existing Secret %s/%s: %w", namespace, name, ownErr)
+		}
+		if !owned {
 			return "", fmt.Errorf("existing Secret %s/%s is not owned by %s/%s",
 				namespace, name, owner.GetNamespace(), owner.GetName())
 		}
@@ -377,13 +384,19 @@ type PruneOptions struct {
 // repeated runs prune and retain the same objects rather than an arbitrary
 // subset.
 //
+// Only ConfigMaps owner owns are pruned, and scheme is what answers that: a
+// ConfigMap on a target cluster carries the ownership labels instead of a
+// controller owner reference, and resolving owner's kind for those labels needs
+// the scheme. Without the label recognition a target cluster's config history
+// would never be pruned and would grow without bound.
+//
 // Known limitation: ConfigMaps created before the ConfigBaseLabelKey label was
 // introduced lack the label and are invisible to the server-side
 // selector used by this function. These pre-existing ConfigMaps will not be
 // pruned but are bounded in number (no new unlabeled ConfigMaps are created
 // after the upgrade) and will be garbage-collected by Kubernetes when the
 // owning CR is deleted, since they carry a controller owner reference.
-func PruneImmutableConfigMaps(ctx context.Context, c client.Client, owner client.Object, opts PruneOptions) error {
+func PruneImmutableConfigMaps(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, opts PruneOptions) error {
 	var allConfigMaps corev1.ConfigMapList
 	if err := c.List(ctx, &allConfigMaps, client.InNamespace(opts.Namespace), client.MatchingLabels{ConfigBaseLabelKey: opts.BaseName}); err != nil {
 		return fmt.Errorf("listing ConfigMaps in namespace %s: %w", opts.Namespace, err)
@@ -392,7 +405,7 @@ func PruneImmutableConfigMaps(ctx context.Context, c client.Client, owner client
 	for i := range allConfigMaps.Items {
 		items = append(items, &allConfigMaps.Items[i])
 	}
-	return pruneImmutableObjects(ctx, c, owner, opts, items, "ConfigMap")
+	return pruneImmutableObjects(ctx, c, scheme, owner, opts, items, "ConfigMap")
 }
 
 // PruneImmutableSecrets deletes stale immutable Secrets previously created by
@@ -400,7 +413,7 @@ func PruneImmutableConfigMaps(ctx context.Context, c client.Client, owner client
 // PruneImmutableConfigMaps. Retain: 0 combined with an empty CurrentName
 // removes every historical Secret for the base name — the full-cleanup path a
 // caller takes when the feature that produced the Secrets is turned off.
-func PruneImmutableSecrets(ctx context.Context, c client.Client, owner client.Object, opts PruneOptions) error {
+func PruneImmutableSecrets(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, opts PruneOptions) error {
 	var allSecrets corev1.SecretList
 	if err := c.List(ctx, &allSecrets, client.InNamespace(opts.Namespace), client.MatchingLabels{ConfigBaseLabelKey: opts.BaseName}); err != nil {
 		return fmt.Errorf("listing Secrets in namespace %s: %w", opts.Namespace, err)
@@ -409,7 +422,7 @@ func PruneImmutableSecrets(ctx context.Context, c client.Client, owner client.Ob
 	for i := range allSecrets.Items {
 		items = append(items, &allSecrets.Items[i])
 	}
-	return pruneImmutableObjects(ctx, c, owner, opts, items, "Secret")
+	return pruneImmutableObjects(ctx, c, scheme, owner, opts, items, "Secret")
 }
 
 // pruneImmutableObjects implements the shared prune algorithm for the
@@ -417,7 +430,7 @@ func PruneImmutableSecrets(ctx context.Context, c client.Client, owner client.Ob
 // (never the CurrentName), sort newest-first with a deterministic name
 // tie-break, and delete everything past the retain count. kind is only used
 // for error/log messages.
-func pruneImmutableObjects(ctx context.Context, c client.Client, owner client.Object, opts PruneOptions, items []client.Object, kind string) error {
+func pruneImmutableObjects(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, opts PruneOptions, items []client.Object, kind string) error {
 	logger := log.FromContext(ctx)
 
 	// Clamp negative retain to 0 to prevent panics from misconfigured values.
@@ -435,8 +448,11 @@ func pruneImmutableObjects(ctx context.Context, c client.Client, owner client.Ob
 		if obj.GetName() == opts.CurrentName {
 			continue
 		}
-		controllerRef := metav1.GetControllerOf(obj)
-		if controllerRef == nil || controllerRef.UID != owner.GetUID() {
+		owned, err := multicluster.Controls(scheme, owner, obj)
+		if err != nil {
+			return fmt.Errorf("checking ownership of %s %s/%s: %w", kind, opts.Namespace, obj.GetName(), err)
+		}
+		if !owned {
 			continue
 		}
 		candidates = append(candidates, obj)

--- a/internal/common/config/config_test.go
+++ b/internal/common/config/config_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 func TestRenderINI(t *testing.T) {
@@ -639,6 +641,103 @@ func TestCreateImmutableConfigMap_rejectsUnownedExisting(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("not owned by"))
 }
 
+// testOwnerLabels are the ownership labels a child of testOwner carries on a
+// target cluster.
+func testOwnerLabels() map[string]string {
+	return map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}
+}
+
+// TestCreateImmutableConfigMap_remoteLabelledAndUnowned pins the target-cluster
+// path: the ConfigMap is stamped with the ownership labels next to the base
+// label and carries no owner reference. The second call proves the AlreadyExists
+// verification recognizes such a label-owned child as its own.
+func TestCreateImmutableConfigMap_remoteLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+	ctx := context.Background()
+
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+	data := map[string]string{"key": "value"}
+
+	name, err := CreateImmutableConfigMap(ctx, c, s, owner, "cfg", "default", data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	created := &corev1.ConfigMap{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, created)).To(Succeed())
+	g.Expect(created.Labels).To(HaveKeyWithValue(ConfigBaseLabelKey, "cfg"))
+	for key, value := range testOwnerLabels() {
+		g.Expect(created.Labels).To(HaveKeyWithValue(key, value))
+	}
+	g.Expect(created.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+
+	again, err := CreateImmutableConfigMap(ctx, c, s, owner, "cfg", "default", data)
+	g.Expect(err).NotTo(HaveOccurred(), "a label-owned ConfigMap must pass the ownership verification")
+	g.Expect(again).To(Equal(name))
+}
+
+// TestCreateImmutableConfigMap_remoteRejectsForeignExisting is the other side of
+// that verification: on a target cluster a same-named object carrying neither
+// this owner's labels nor a reference to it belongs to somebody else, and
+// reporting it as ours would hand the caller a ConfigMap it does not control.
+func TestCreateImmutableConfigMap_remoteRejectsForeignExisting(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+	ctx := context.Background()
+
+	data := map[string]string{"key": "value"}
+
+	// Create once to learn the content-hashed name.
+	c1 := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+	name, err := CreateImmutableConfigMap(ctx, c1, s, owner, "my-config", "default", data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	foreign := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "somebody-else"},
+		},
+	}
+	c2 := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner, foreign).Build())
+
+	_, err = CreateImmutableConfigMap(ctx, c2, s, owner, "my-config", "default", data)
+	g.Expect(err).To(MatchError(ContainSubstring("is not owned by default/test-owner")))
+}
+
+// TestCreateImmutableSecret_remoteLabelledAndUnowned is
+// TestCreateImmutableConfigMap_remoteLabelledAndUnowned for the Secret flavor,
+// which carries its own copy of the create-and-verify sequence.
+func TestCreateImmutableSecret_remoteLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+	ctx := context.Background()
+
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+	data := map[string][]byte{"domain.conf": []byte("[ldap]")}
+
+	name, err := CreateImmutableSecret(ctx, c, s, owner, "my-domains", "default", data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	created := &corev1.Secret{}
+	g.Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, created)).To(Succeed())
+	g.Expect(created.Labels).To(HaveKeyWithValue(ConfigBaseLabelKey, "my-domains"))
+	for key, value := range testOwnerLabels() {
+		g.Expect(created.Labels).To(HaveKeyWithValue(key, value))
+	}
+	g.Expect(created.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+
+	again, err := CreateImmutableSecret(ctx, c, s, owner, "my-domains", "default", data)
+	g.Expect(err).NotTo(HaveOccurred(), "a label-owned Secret must pass the ownership verification")
+	g.Expect(again).To(Equal(name))
+}
+
 func ownedConfigMap(name, namespace, baseName string, owner *corev1.ConfigMap, creationTime time.Time) *corev1.ConfigMap {
 	isController := true
 	return &corev1.ConfigMap{
@@ -679,7 +778,7 @@ func TestPruneImmutableConfigMaps_deletesStaleConfigMaps(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, cm3, cm4, cm5, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -720,7 +819,7 @@ func TestPruneImmutableConfigMaps_retainsNewestByCreationTimestamp(t *testing.T)
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cmZzz, cmAaa, cmBbb, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 1})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 1})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -764,7 +863,7 @@ func TestPruneImmutableConfigMaps_deterministicTieBreakAmongSameTimestamp(t *tes
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cmA, cmB, cmC, cmD, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -799,7 +898,7 @@ func TestPruneImmutableConfigMaps_retainZeroDeletesAllHistorical(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, cm3, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -833,11 +932,11 @@ func TestPruneImmutableConfigMaps_idempotentOnSecondCall(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, cm3, current).Build()
 
 	// First call: should delete cm1 (oldest), retain cm2, cm3, current
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Second call: nothing more to delete
-	err = PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
+	err = PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 2})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -875,7 +974,7 @@ func TestPruneImmutableConfigMaps_ignoresNotFoundOnDelete(t *testing.T) {
 	g.Expect(c.Delete(ctx, cm1)).To(Succeed())
 
 	// Prune with retain=1: should try to delete cm1 (already gone) and succeed
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 1})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 1})
 	g.Expect(err).NotTo(HaveOccurred())
 }
 
@@ -903,7 +1002,7 @@ func TestPruneImmutableConfigMaps_skipsConfigMapsOwnedByDifferentController(t *t
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, otherOwner, cmOther, cmOwned, current).Build()
 
 	// retain=0 should only delete owner's historical ConfigMaps
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -946,7 +1045,7 @@ func TestPruneImmutableConfigMaps_skipsConfigMapsWithoutOwnerReference(t *testin
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, unowned, cmOwned, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -962,6 +1061,65 @@ func TestPruneImmutableConfigMaps_skipsConfigMapsWithoutOwnerReference(t *testin
 	g.Expect(remaining).To(HaveLen(2))
 	g.Expect(remaining).To(ContainElement("my-config-unowned1"))
 	g.Expect(remaining).To(ContainElement(currentName))
+}
+
+// labelOwnedConfigMap returns a historical ConfigMap as it looks on a target
+// cluster: claimed by the ownership labels, with no owner reference at all.
+func labelOwnedConfigMap(name, baseName string, creationTime time.Time) *corev1.ConfigMap {
+	labels := testOwnerLabels()
+	labels[ConfigBaseLabelKey] = baseName
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(creationTime),
+			Labels:            labels,
+		},
+	}
+}
+
+// TestPruneImmutableConfigMaps_remotePrunesLabelOwnedHistory is why the prune
+// takes a scheme: on a target cluster the history carries the ownership labels
+// instead of an owner reference, and a UID comparison would recognize none of it
+// and let the config history grow without bound. A ConfigMap sharing the base
+// label but naming no owner is still somebody else's and is skipped.
+func TestPruneImmutableConfigMaps_remotePrunesLabelOwnedHistory(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+	ctx := context.Background()
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	currentName := "my-config-current1"
+
+	oldest := labelOwnedConfigMap("my-config-aaaaaaaa", "my-config", baseTime)
+	newer := labelOwnedConfigMap("my-config-bbbbbbbb", "my-config", baseTime.Add(1*time.Hour))
+	current := labelOwnedConfigMap(currentName, "my-config", baseTime.Add(2*time.Hour))
+	foreign := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-config-foreign1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(baseTime),
+			Labels:            map[string]string{ConfigBaseLabelKey: "my-config"},
+		},
+	}
+
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).
+		WithObjects(owner, oldest, newer, current, foreign).Build())
+
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 1})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var cmList corev1.ConfigMapList
+	g.Expect(c.List(ctx, &cmList, client.InNamespace("default"))).To(Succeed())
+
+	remaining := make([]string, 0, len(cmList.Items))
+	for _, cm := range cmList.Items {
+		if cm.Name != "test-owner" {
+			remaining = append(remaining, cm.Name)
+		}
+	}
+	g.Expect(remaining).To(ConsistOf(currentName, "my-config-bbbbbbbb", "my-config-foreign1"))
 }
 
 func TestPruneImmutableConfigMaps_neverDeletesCurrentConfigMap(t *testing.T) {
@@ -981,7 +1139,7 @@ func TestPruneImmutableConfigMaps_neverDeletesCurrentConfigMap(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, current).Build()
 
 	// retain=0: delete all historical, but never current
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1013,7 +1171,7 @@ func TestPruneImmutableConfigMaps_noopWhenFewerThanRetain(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, current).Build()
 
 	// retain=3 with only 2 historical: no deletions
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1041,7 +1199,7 @@ func TestPruneImmutableConfigMaps_noopWhenNoHistoricalConfigMaps(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, current).Build()
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1074,7 +1232,7 @@ func TestPruneImmutableConfigMaps_skipsMismatchedPrefix(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cmOther, cmOwned, current).Build()
 
 	// retain=0 should only delete "my-config-" prefixed historical ones
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1112,7 +1270,7 @@ func TestPruneImmutableConfigMaps_handlesOverlappingPrefixCorrectly(t *testing.T
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cmMatch, cmOverlap, current).Build()
 
 	// Prune with baseName "test-config-extra": should only match "test-config-extra-def12345"
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "test-config-extra", Namespace: "default", CurrentName: currentName, Retain: 0})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "test-config-extra", Namespace: "default", CurrentName: currentName, Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1148,7 +1306,7 @@ func TestPruneImmutableConfigMaps_negativeRetainClampedToZero(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, cm1, cm2, current).Build()
 
 	// Negative retain should behave like retain=0: delete all historical, keep current.
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: -5})
+	err := PruneImmutableConfigMaps(ctx, c, s, owner, PruneOptions{BaseName: "my-config", Namespace: "default", CurrentName: currentName, Retain: -5})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var cmList corev1.ConfigMapList
@@ -1281,7 +1439,7 @@ func TestPruneImmutableSecrets_deletesStaleSecrets(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, sec1, sec2, sec3, current).Build()
 
-	err := PruneImmutableSecrets(ctx, c, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: currentName, Retain: 2})
+	err := PruneImmutableSecrets(ctx, c, s, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: currentName, Retain: 2})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var secList corev1.SecretList
@@ -1314,7 +1472,7 @@ func TestPruneImmutableSecrets_retainZeroEmptyCurrentDeletesAll(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, sec1, sec2).Build()
 
-	err := PruneImmutableSecrets(ctx, c, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: "", Retain: 0})
+	err := PruneImmutableSecrets(ctx, c, s, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: "", Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var secList corev1.SecretList
@@ -1338,7 +1496,7 @@ func TestPruneImmutableSecrets_skipsSecretsOwnedByDifferentController(t *testing
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(owner, foreign).Build()
 
-	err := PruneImmutableSecrets(ctx, c, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: "", Retain: 0})
+	err := PruneImmutableSecrets(ctx, c, s, owner, PruneOptions{BaseName: "my-domains", Namespace: "default", CurrentName: "", Retain: 0})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var secList corev1.SecretList

--- a/internal/common/config/integration_test.go
+++ b/internal/common/config/integration_test.go
@@ -175,7 +175,7 @@ func TestIntegration_PruneImmutableConfigMaps(t *testing.T) {
 	// Re-read the owner so we have the UID assigned by the API server.
 	g.Expect(c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: ns.Name}, owner)).To(Succeed())
 
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
+	err := PruneImmutableConfigMaps(ctx, c, scheme, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// List remaining ConfigMaps that match the baseName prefix.
@@ -231,11 +231,11 @@ func TestIntegration_PruneImmutableConfigMaps_idempotent(t *testing.T) {
 	g.Expect(c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: ns.Name}, owner)).To(Succeed())
 
 	// First prune call.
-	err := PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
+	err := PruneImmutableConfigMaps(ctx, c, scheme, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Second prune call (idempotent).
-	err = PruneImmutableConfigMaps(ctx, c, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
+	err = PruneImmutableConfigMaps(ctx, c, scheme, owner, PruneOptions{BaseName: baseName, Namespace: ns.Name, CurrentName: currentName, Retain: 3})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Verify the same result after both calls.

--- a/internal/common/database/connection.go
+++ b/internal/common/database/connection.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/multicluster"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
@@ -230,7 +230,7 @@ func ReconcileConnectionSecret(ctx context.Context, p ConnectionSecretFlowParams
 				ConnectionSecretKey: []byte(connStr),
 			},
 		}
-		if err := controllerutil.SetControllerReference(p.Owner, derived, p.Scheme); err != nil {
+		if err := multicluster.Claim(p.Client, p.Scheme, p.Owner, derived); err != nil {
 			return ctrl.Result{}, "", fmt.Errorf("setting owner reference on derived Secret %s/%s: %w",
 				derived.Namespace, derived.Name, err)
 		}

--- a/internal/common/database/connection_test.go
+++ b/internal/common/database/connection_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/c5c3/forge/internal/common/multicluster"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
@@ -186,6 +187,34 @@ func TestReconcileConnectionSecret_createsStaticSecret(t *testing.T) {
 	g.Expect(conn).To(ContainSubstring("charset=utf8"))
 	g.Expect(derived.OwnerReferences).To(HaveLen(1))
 	g.Expect(derived.OwnerReferences[0].Name).To(Equal("keystone-owner"))
+}
+
+// TestReconcileConnectionSecret_remoteCreatesLabelledAndUnowned pins the
+// target-cluster path: the derived Secret is stamped with the ownership labels
+// and carries no owner reference, because a reference to a CR on another cluster
+// names a UID this one cannot resolve.
+func TestReconcileConnectionSecret_remoteCreatesLabelledAndUnowned(t *testing.T) {
+	g := NewWithT(t)
+	s := connScheme()
+	owner := connOwner()
+	var conds []metav1.Condition
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).
+		WithObjects(owner, upstreamSecret(map[string][]byte{"password": []byte("s3cr3t")})).
+		Build())
+
+	_, digest, err := ReconcileConnectionSecret(context.Background(), connParams(c, s, owner, staticDBSpec(), &conds))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(digest).NotTo(BeEmpty())
+
+	derived := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "keystone-db-connection", Namespace: connNamespace}, derived)).To(Succeed())
+	g.Expect(derived.Data).To(HaveLen(1))
+	g.Expect(derived.Labels).To(Equal(map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "keystone-owner",
+		multicluster.OwnerNamespaceLabel: connNamespace,
+	}))
+	g.Expect(derived.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
 }
 
 func TestReconcileConnectionSecret_dynamicUsesSecretUsername(t *testing.T) {

--- a/internal/common/job/job.go
+++ b/internal/common/job/job.go
@@ -18,9 +18,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/c5c3/forge/internal/common/apply"
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // PodSpecHashAnnotation stores a Job's re-run gate value at creation time. By
@@ -109,6 +109,26 @@ func RunJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Sc
 		return false, nil, fmt.Errorf("getting Job %s/%s: %w", job.Namespace, job.Name, err)
 	}
 
+	// The same claim the create branch makes, on the Job that is actually there.
+	// Everything below reads it as this owner's own — a completion reported as
+	// the owner's, a stale re-run key answered by deleting it — so the claim is
+	// what licenses that. On a target cluster it is a strict test: a live Job of
+	// this name carrying neither an owner reference nor the ownership labels is
+	// somebody else's and is refused rather than adopted and deleted, which is the
+	// only guard there, since no cluster-crossing owner reference exists to be one.
+	// Locally the claim keeps exactly the reach SetControllerReference always had:
+	// it refuses a Job another controller owns and adopts one carrying no
+	// controller reference at all. Narrowing that would change how a
+	// single-cluster install treats a Job of this name it did not create — a
+	// decision about existing deployments rather than about where children live,
+	// so moving ownership does not make it here.
+	//
+	// It is claimed on a copy: the claim exists to answer the ownership question,
+	// and the Job the caller observes must stay what the API server returned.
+	if err := multicluster.Claim(c, scheme, owner, existing.DeepCopy()); err != nil {
+		return false, nil, err
+	}
+
 	if isJobFailed(existing) {
 		// A permanently failed Job (exceeded backoffLimit) is re-run when its
 		// re-run key changes — the desired spec was fixed since the failure
@@ -153,7 +173,7 @@ func RunJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Sc
 // AlreadyExists (old Job still terminating).
 func createJobWithRerunKey(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, job *batchv1.Job, rerunKey string) error {
 	toCreate := job.DeepCopy()
-	if err := controllerutil.SetControllerReference(owner, toCreate, scheme); err != nil {
+	if err := multicluster.Claim(c, scheme, owner, toCreate); err != nil {
 		return fmt.Errorf("setting owner reference on Job %s/%s: %w", job.Namespace, job.Name, err)
 	}
 	if toCreate.Annotations == nil {

--- a/internal/common/job/job_test.go
+++ b/internal/common/job/job_test.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 func newScheme() *runtime.Scheme {
@@ -190,6 +192,106 @@ func TestRunJob_creates(t *testing.T) {
 	g.Expect(created.OwnerReferences).To(HaveLen(1))
 	g.Expect(created.OwnerReferences[0].Name).To(Equal("test-owner"))
 	g.Expect(created.Annotations[PodSpecHashAnnotation]).NotTo(BeEmpty(), "created Job should carry pod-spec hash annotation")
+}
+
+// testOwnerLabels are the ownership labels a child of testOwner carries on a
+// target cluster.
+func testOwnerLabels() map[string]string {
+	return map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}
+}
+
+// TestRunJob_remoteCreatesLabelledAndUnowned pins the target-cluster path: the
+// Job is stamped with the ownership labels and carries no owner reference,
+// because a reference to a CR on another cluster names a UID this one cannot
+// resolve.
+func TestRunJob_remoteCreatesLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		Build())
+
+	ready, _, err := RunJob(context.Background(), c, s, owner, testJob())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+
+	created := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, created)).To(Succeed())
+	g.Expect(created.Labels).To(Equal(testOwnerLabels()))
+	g.Expect(created.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+	g.Expect(created.Annotations[PodSpecHashAnnotation]).NotTo(BeEmpty())
+	g.Expect(created.Spec.Template.Labels).To(BeEmpty(), "the pod template's own labels must stay untouched")
+}
+
+// TestRunJob_remoteRecreatesStaleLabelledAndUnowned covers the recreate path on
+// a target cluster: the replacement of a completed Job whose re-run key changed
+// goes through the same create, so it must be labelled and unowned too.
+func TestRunJob_remoteRecreatesStaleLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	// A completed remote Job: labelled, unowned, and carrying a stale re-run key.
+	stale := testCompletedJobWithHash()
+	stale.Labels = testOwnerLabels()
+	stale.Annotations[PodSpecHashAnnotation] = "stale-key"
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, stale).
+		WithStatusSubresource(stale).
+		Build())
+
+	ready, observed, err := RunJob(context.Background(), c, s, owner, testJob())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "the stale Job is recreated, so this pass reports it unfinished")
+	g.Expect(observed).NotTo(BeNil())
+
+	recreated := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, recreated)).To(Succeed())
+	g.Expect(recreated.Annotations[PodSpecHashAnnotation]).NotTo(Equal("stale-key"))
+	g.Expect(recreated.Labels).To(Equal(testOwnerLabels()))
+	g.Expect(recreated.OwnerReferences).To(BeEmpty())
+}
+
+// TestRunJob_remoteRefusesAForeignJob covers the Job that is already there. A
+// target cluster may already run an OpenStack deployment of its own, and its
+// completed bootstrap or db-sync Job carries no re-run key at all — so the
+// stale-key branch would read it as this owner's, delete it with its pods and
+// its logs, and run its own in place of it.
+func TestRunJob_remoteRefusesAForeignJob(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	foreign := testCompletedJobWithHash()
+	// Nobody else stamps the re-run key, and the API server assigned the UID
+	// that makes this Job live rather than freshly built.
+	foreign.Annotations = nil
+	foreign.UID = "foreign-job-uid"
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, foreign).
+		WithStatusSubresource(foreign).
+		Build())
+
+	ready, _, err := RunJob(context.Background(), c, s, owner, testJob())
+
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing")))
+	g.Expect(ready).To(BeFalse())
+
+	survivor := &batchv1.Job{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-job", Namespace: "default"}, survivor)).To(Succeed())
+	g.Expect(string(survivor.UID)).To(Equal("foreign-job-uid"), "the foreign Job must be the one still standing")
+	g.Expect(survivor.Labels).To(BeEmpty(), "a refused Job must not be marked for this owner's teardown")
 }
 
 func TestRunJob_existingIncomplete(t *testing.T) {

--- a/internal/common/multicluster/ownership.go
+++ b/internal/common/multicluster/ownership.go
@@ -6,6 +6,7 @@ package multicluster
 
 import (
 	"fmt"
+	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -171,6 +172,36 @@ func Claim(c client.Client, scheme *runtime.Scheme, owner, obj client.Object) er
 
 	dropControllerRef(obj, gvk, owner)
 	stampLabels(obj, labels)
+	return nil
+}
+
+// ClaimWithLabels claims obj for owner and rebuilds its labels from labels in
+// one step, for the write sites that own their child's whole label set: the
+// caller's set is authoritative, so a label the operator stopped setting is
+// dropped, and the ownership labels a claim on a target cluster adds survive the
+// rebuild.
+//
+// The two have to happen in this order and that is the whole reason they are one
+// call. On a target cluster the ownership labels are the only mark identifying
+// obj as owner's child, so a rebuild done first would hand Claim an object it no
+// longer recognizes and have it refuse its own child. labels is not mutated.
+func ClaimWithLabels(c client.Client, scheme *runtime.Scheme, owner, obj client.Object, labels map[string]string) error {
+	if err := Claim(c, scheme, owner, obj); err != nil {
+		return err
+	}
+
+	rebuilt := maps.Clone(labels)
+	if IsRemote(c) {
+		ownership, err := OwnerLabels(scheme, owner)
+		if err != nil {
+			return err
+		}
+		if rebuilt == nil {
+			rebuilt = map[string]string{}
+		}
+		maps.Copy(rebuilt, ownership)
+	}
+	obj.SetLabels(rebuilt)
 	return nil
 }
 

--- a/internal/common/multicluster/ownership.go
+++ b/internal/common/multicluster/ownership.go
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// The ownership labels are the target-cluster substitute for a controller owner
+// reference. A reference is resolved by the garbage collector of the cluster the
+// child lives in, and a CR that names a target cluster does not live there: on
+// the target the reference names a UID that is absent, so it either means
+// nothing at all or — once the owner's kind is registered on that cluster too —
+// gets the child collected as an orphan. A child written to a target cluster
+// therefore carries no owner reference and is stamped with these three labels
+// instead, which name its owner unambiguously.
+//
+// They carry the two jobs a reference would have done, and the operator does
+// both by hand because nothing on the target cluster does them for it:
+//
+//   - RECOGNITION. Controls answers "may this CR write to, and delete, this
+//     object?" — from the owner reference for a local child, from these labels
+//     for a remote one. An object carrying neither is nobody's child and is left
+//     alone.
+//   - CLEANUP. No garbage collection cascade reaches a remote child, so the CR's
+//     teardown deletes them explicitly, held open by RemoteChildrenFinalizer.
+//
+// The kind belongs in the vocabulary because name and namespace do not identify
+// an owner on their own: a Keystone and a Barbican both called "openstack" in
+// namespace "openstack" project children into the same target namespace, and
+// each must select only its own.
+const (
+	OwnerKindLabel      = "openstack.c5c3.io/owner-kind"
+	OwnerNameLabel      = "openstack.c5c3.io/owner-name"
+	OwnerNamespaceLabel = "openstack.c5c3.io/owner-namespace"
+)
+
+// MaxOwnerNameLength is the longest metadata.name a CR that projects onto a
+// target cluster may carry. Its name is recorded as a label VALUE, which
+// Kubernetes caps at 63 characters, while metadata.name is a DNS-1123 subdomain
+// capped at 253. Claim refuses a longer name rather than letting every child
+// write fail deep inside the API server on an invalid label value.
+const MaxOwnerNameLength = validation.LabelValueMaxLength
+
+// RemoteChildrenFinalizer is the finalizer a CR carries while children of it
+// exist on a target cluster. Nothing on that cluster deletes them when the CR
+// goes, so the operator has to, and the finalizer is what keeps the CR in etcd
+// long enough to do it. It is shared across the service operators: the children
+// they leave behind differ, the reason the CR has to outlive its own deletion
+// does not.
+const RemoteChildrenFinalizer = "openstack.c5c3.io/remote-children"
+
+// OwnerLabels returns the ownership labels identifying owner as the owner of a
+// remote child.
+//
+// The kind is resolved through the scheme rather than read off the object: a
+// typed CR built in code carries an empty TypeMeta, and the typed client does
+// not populate it on Get either, so reading the kind off the object would stamp
+// an empty label for nearly every caller.
+func OwnerLabels(scheme *runtime.Scheme, owner client.Object) (map[string]string, error) {
+	gvk, err := ownerGVK(scheme, owner)
+	if err != nil {
+		return nil, err
+	}
+	return ownerLabelsFor(gvk, owner), nil
+}
+
+// Remote marks c as the client of a target cluster, so Claim can tell the two
+// kinds of client apart. ResolveChildrenClient applies the mark; the local
+// client is handed out unmarked, which is what keeps single-cluster behavior
+// byte-identical.
+//
+// A client marked here carries no API reader, so LiveReader falls back to c
+// itself. ResolveChildrenClient, which has the resolved cluster in hand, marks
+// with the reader.
+func Remote(c client.Client) client.Client {
+	return remoteClient{Client: c}
+}
+
+// IsRemote reports whether c writes to a target cluster, that is, whether it
+// came out of Remote.
+func IsRemote(c client.Client) bool {
+	_, remote := c.(remoteClient)
+	return remote
+}
+
+// LiveReader returns the reader an ownership decision about c's cluster has to
+// be made from: the target cluster's own uncached API reader when c is a
+// resolved remote client, and c itself otherwise.
+//
+// Two things follow from reading live state rather than through c's cache. An
+// object written to the target moments ago cannot look absent and be adopted on
+// the strength of a cache that has not caught up. And a kind the operator only
+// ever writes — a NetworkPolicy, an HTTPRoute, a PodDisruptionBudget — is not
+// pulled into an informer by the read, which on a cluster-scoped install would
+// start an all-namespaces LIST+WATCH of that kind on the target and hold its
+// every object resident for the lifetime of the process.
+func LiveReader(c client.Client) client.Reader {
+	if remote, marked := c.(remoteClient); marked && remote.reader != nil {
+		return remote.reader
+	}
+	return c
+}
+
+// Controls reports whether owner owns obj: either it is obj's controller owner
+// reference (the local case), or obj carries owner's ownership labels (the
+// remote case, where no usable reference exists). It is the ownership test
+// every write and every delete against a target cluster gates on, so an object
+// somebody else provisioned under a name one of our children happens to want is
+// never reshaped and never deleted.
+func Controls(scheme *runtime.Scheme, owner, obj client.Object) (bool, error) {
+	labels, err := OwnerLabels(scheme, owner)
+	if err != nil {
+		return false, err
+	}
+	return controls(owner, obj, labels), nil
+}
+
+// Claim makes obj a child of owner by the only mechanism the child's cluster
+// permits: a controller owner reference when c writes to the local cluster (so
+// the garbage collection cascade reaps it), the ownership labels when c is a
+// resolved target-cluster client (so the teardown can find and delete it). It is
+// the single decision point, so no projection site has to re-derive which
+// mechanism applies to the client it was handed.
+//
+// The local path is controllerutil.SetControllerReference and nothing else, its
+// error included: a CR that names no target cluster is claimed exactly as it
+// always was.
+//
+// The remote path never sets a reference. It drops one naming owner if it finds
+// it, because on the target cluster such a reference names an absent UID and
+// leaves the child one kind registration away from being collected as an orphan.
+// A live object (its UID is set, so it was read back from the API server) that
+// is neither referenced nor labelled is refused rather than adopted: adopting it
+// would be doubly destructive, since the apply overwrites its spec and the
+// labels stamped on it get it deleted at teardown. Nothing is written to obj in
+// that case.
+func Claim(c client.Client, scheme *runtime.Scheme, owner, obj client.Object) error {
+	if !IsRemote(c) {
+		return controllerutil.SetControllerReference(owner, obj, scheme)
+	}
+
+	gvk, err := ownerGVK(scheme, owner)
+	if err != nil {
+		return err
+	}
+	labels := ownerLabelsFor(gvk, owner)
+
+	if len(owner.GetName()) > MaxOwnerNameLength {
+		return fmt.Errorf("refusing to claim %s %s/%s for %s %s: the owner's name is %d characters, and a name a "+
+			"child records as an ownership label may not exceed %d",
+			kindOf(scheme, obj), obj.GetNamespace(), obj.GetName(), gvk.Kind, owner.GetName(),
+			len(owner.GetName()), MaxOwnerNameLength)
+	}
+
+	if obj.GetUID() != "" && !controls(owner, obj, labels) {
+		return fmt.Errorf("refusing to adopt pre-existing %s %s/%s: it was not created by this %s, so adopting it "+
+			"would overwrite its spec and delete it at teardown",
+			kindOf(scheme, obj), obj.GetNamespace(), obj.GetName(), gvk.Kind)
+	}
+
+	dropControllerRef(obj, gvk, owner)
+	stampLabels(obj, labels)
+	return nil
+}
+
+// remoteClient is the mark Remote puts on a target-cluster client. It adds no
+// behavior: every call goes to the embedded client, and the type exists only so
+// Claim can recognize which cluster it is claiming on.
+//
+// reader is that cluster's uncached API reader, which LiveReader hands out and
+// nothing else reads. It is nil for a client marked by Remote alone, which is
+// every client no cluster was resolved for.
+type remoteClient struct {
+	client.Client
+	reader client.Reader
+}
+
+// ownerGVK resolves owner's kind through the scheme, under the error message
+// every entry point in this file reports that failure with.
+func ownerGVK(scheme *runtime.Scheme, owner client.Object) (schema.GroupVersionKind, error) {
+	gvk, err := apiutil.GVKForObject(owner, scheme)
+	if err != nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("resolving GVK for owner %s/%s: %w",
+			owner.GetNamespace(), owner.GetName(), err)
+	}
+	return gvk, nil
+}
+
+// ownerLabelsFor builds the ownership labels from an already-resolved owner
+// kind, so a caller that needs the kind for something else does not pay for a
+// second scheme lookup.
+func ownerLabelsFor(gvk schema.GroupVersionKind, owner client.Object) map[string]string {
+	return map[string]string{
+		OwnerKindLabel:      gvk.Kind,
+		OwnerNameLabel:      owner.GetName(),
+		OwnerNamespaceLabel: owner.GetNamespace(),
+	}
+}
+
+// controls is Controls against owner's already-resolved labels.
+func controls(owner, obj client.Object, ownerLabels map[string]string) bool {
+	if metav1.IsControlledBy(obj, owner) {
+		return true
+	}
+	labels := obj.GetLabels()
+	for key, value := range ownerLabels {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// kindOf names obj for an error message, from the scheme where it can and from
+// obj's own TypeMeta otherwise, which is how an unstructured object still gets
+// named. A kind no scheme knows leaves the name empty, and the namespace and
+// name in the same message still identify the object.
+func kindOf(scheme *runtime.Scheme, obj client.Object) string {
+	if gvk, err := apiutil.GVKForObject(obj, scheme); err == nil {
+		return gvk.Kind
+	}
+	return obj.GetObjectKind().GroupVersionKind().Kind
+}
+
+// dropControllerRef removes a controller owner reference naming owner from obj.
+// It matches on group, kind and name rather than on UID, so it also reaches the
+// reference a child acquired from a management-cluster owner whose UID means
+// nothing on the target cluster. Every other reference is left where it is.
+func dropControllerRef(obj client.Object, gvk schema.GroupVersionKind, owner client.Object) {
+	refs := obj.GetOwnerReferences()
+	kept := make([]metav1.OwnerReference, 0, len(refs))
+	for _, ref := range refs {
+		if !namesOwner(ref, gvk, owner) {
+			kept = append(kept, ref)
+		}
+	}
+	if len(kept) != len(refs) {
+		obj.SetOwnerReferences(kept)
+	}
+}
+
+// namesOwner reports whether ref is a controller reference to owner.
+func namesOwner(ref metav1.OwnerReference, gvk schema.GroupVersionKind, owner client.Object) bool {
+	if ref.Controller == nil || !*ref.Controller || ref.Kind != gvk.Kind || ref.Name != owner.GetName() {
+		return false
+	}
+	group, err := schema.ParseGroupVersion(ref.APIVersion)
+	return err == nil && group.Group == gvk.Group
+}
+
+// stampLabels merges the ownership labels onto obj's own labels, preserving the
+// ones already there. It touches the top-level labels only: a workload's pod
+// template selects on labels of its own, and rewriting those would orphan the
+// pods the workload already runs.
+func stampLabels(obj client.Object, ownerLabels map[string]string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	for key, value := range ownerLabels {
+		labels[key] = value
+	}
+	obj.SetLabels(labels)
+}

--- a/internal/common/multicluster/ownership_test.go
+++ b/internal/common/multicluster/ownership_test.go
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// A real owner is a service CR, which this package cannot import without
+// depending on the operators it is imported by. A ConfigMap owning a Secret
+// stands in: the ownership rules read the scheme and the object meta, neither of
+// which knows the difference.
+func testOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "openstack",
+		UID:       "owner-uid",
+	}}
+}
+
+func testChild() *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "example-config",
+		Namespace: "openstack",
+	}}
+}
+
+// ownershipScheme knows the owner and child kinds. Its counterpart in the error
+// tests is a bare runtime.NewScheme(), which knows neither.
+func ownershipScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	gomega.NewWithT(t).Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	return scheme
+}
+
+func TestOwnerLabelsNamesTheOwnerByKindNameAndNamespace(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	labels, err := OwnerLabels(ownershipScheme(t), testOwner())
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(labels).To(gomega.Equal(map[string]string{
+		OwnerKindLabel:      "ConfigMap",
+		OwnerNameLabel:      "example",
+		OwnerNamespaceLabel: "openstack",
+	}))
+}
+
+// An owner whose kind the scheme does not know cannot be labelled at all, and
+// the three entry points that need the kind all have to say so rather than stamp
+// an empty label that another CR's children would then match.
+func TestOwnerLabelsUnregisteredOwnerKindFails(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	labels, err := OwnerLabels(runtime.NewScheme(), testOwner())
+
+	g.Expect(labels).To(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving GVK for owner openstack/example")))
+}
+
+func TestControlsUnregisteredOwnerKindFails(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	controlled, err := Controls(runtime.NewScheme(), testOwner(), testChild())
+
+	g.Expect(controlled).To(gomega.BeFalse())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving GVK for owner openstack/example")))
+}
+
+func TestClaimRemoteUnregisteredOwnerKindFails(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	child := testChild()
+	err := Claim(Remote(fake.NewClientBuilder().Build()), runtime.NewScheme(), testOwner(), child)
+
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving GVK for owner openstack/example")))
+	g.Expect(child.GetLabels()).To(gomega.BeEmpty(), "a claim that failed must not have stamped a partial label set")
+}
+
+// The local path has to stay what it was before the seam existed, so it is
+// asserted against controllerutil.SetControllerReference itself rather than
+// against a hand-written expectation of what it produces.
+func TestClaimLocalSetsTheControllerReference(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := ownershipScheme(t)
+	owner := testOwner()
+	claimed, expected := testChild(), testChild()
+
+	g.Expect(Claim(fake.NewClientBuilder().Build(), scheme, owner, claimed)).To(gomega.Succeed())
+	g.Expect(controllerutil.SetControllerReference(owner, expected, scheme)).To(gomega.Succeed())
+
+	g.Expect(claimed.OwnerReferences).To(gomega.Equal(expected.OwnerReferences))
+	g.Expect(claimed.OwnerReferences).To(gomega.HaveLen(1))
+	ref := claimed.OwnerReferences[0]
+	g.Expect(ref.Kind).To(gomega.Equal("ConfigMap"))
+	g.Expect(ref.Name).To(gomega.Equal("example"))
+	g.Expect(ref.UID).To(gomega.Equal(owner.UID))
+	g.Expect(ref.Controller).To(gomega.Equal(ptr.To(true)))
+	g.Expect(ref.BlockOwnerDeletion).To(gomega.Equal(ptr.To(true)))
+	// The labels belong to the remote path only: locally the reference is the
+	// whole claim, and stamping them too would make a local child answer to the
+	// remote teardown's selector.
+	g.Expect(claimed.GetLabels()).To(gomega.BeEmpty())
+}
+
+func TestClaimRemoteStampsTheOwnershipLabelsInsteadOfAReference(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	child := testChild()
+	child.Labels = map[string]string{"app.kubernetes.io/name": "keystone"}
+
+	g.Expect(Claim(Remote(fake.NewClientBuilder().Build()), ownershipScheme(t), testOwner(), child)).To(gomega.Succeed())
+
+	g.Expect(child.Labels).To(gomega.Equal(map[string]string{
+		"app.kubernetes.io/name": "keystone",
+		OwnerKindLabel:           "ConfigMap",
+		OwnerNameLabel:           "example",
+		OwnerNamespaceLabel:      "openstack",
+	}))
+	g.Expect(child.OwnerReferences).To(gomega.BeEmpty(),
+		"a reference to a management-cluster owner names a UID the target cluster cannot resolve")
+}
+
+// A child that already carries a controller reference to its owner is ours, and
+// the claim both keeps it and heals it: the reference goes, the labels arrive.
+// Unrelated references are somebody else's business and stay.
+func TestClaimRemoteDropsTheDanglingControllerReference(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	owner := testOwner()
+	unrelated := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "example",
+		UID:        "someone-else",
+	}
+	child := testChild()
+	child.UID = "child-uid"
+	child.OwnerReferences = []metav1.OwnerReference{unrelated, {
+		APIVersion:         "v1",
+		Kind:               "ConfigMap",
+		Name:               owner.Name,
+		UID:                owner.UID,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}}
+
+	g.Expect(Claim(Remote(fake.NewClientBuilder().Build()), ownershipScheme(t), owner, child)).To(gomega.Succeed())
+
+	g.Expect(child.OwnerReferences).To(gomega.Equal([]metav1.OwnerReference{unrelated}))
+	g.Expect(child.Labels).To(gomega.HaveKeyWithValue(OwnerNameLabel, "example"))
+	g.Expect(child.Labels).To(gomega.HaveKeyWithValue(OwnerKindLabel, "ConfigMap"))
+	g.Expect(child.Labels).To(gomega.HaveKeyWithValue(OwnerNamespaceLabel, "openstack"))
+}
+
+// The destructive case: a live object of the same name that nobody claimed. The
+// apply would overwrite its spec and the labels would get it deleted at
+// teardown, so the claim fails instead and leaves the object alone.
+func TestClaimRemoteRefusesToAdoptAPreExistingObject(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	child := testChild()
+	child.UID = "provisioned-by-somebody-else"
+
+	err := Claim(Remote(fake.NewClientBuilder().Build()), ownershipScheme(t), testOwner(), child)
+
+	g.Expect(err).To(gomega.MatchError("refusing to adopt pre-existing Secret openstack/example-config: it was not " +
+		"created by this ConfigMap, so adopting it would overwrite its spec and delete it at teardown"))
+	g.Expect(child.Labels).To(gomega.BeEmpty(), "a refused object must not be marked as ours")
+}
+
+// A name longer than a label value may be is refused at the claim, the one gate
+// every remote write passes. Left to the API server it would come back as an
+// invalid-label-value rejection from inside each of a dozen write sites, on a
+// CR that had already installed the finalizer holding it open for a teardown.
+func TestClaimRemoteRefusesAnOwnerNameTooLongForALabel(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	owner := testOwner()
+	owner.Name = strings.Repeat("k", MaxOwnerNameLength+1)
+	child := testChild()
+
+	err := Claim(Remote(fake.NewClientBuilder().Build()), ownershipScheme(t), owner, child)
+
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("the owner's name is 64 characters")))
+	g.Expect(child.GetLabels()).To(gomega.BeEmpty(), "a refused claim must not have stamped a partial label set")
+}
+
+// The cap is the remote path's alone. A local child is claimed by a reference
+// naming the owner's UID, which no length rule touches, so the same name is
+// claimed exactly as it always was.
+func TestClaimLocalAcceptsAnOwnerNameTooLongForALabel(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	owner := testOwner()
+	owner.Name = strings.Repeat("k", MaxOwnerNameLength+1)
+	child := testChild()
+
+	g.Expect(Claim(fake.NewClientBuilder().Build(), ownershipScheme(t), owner, child)).To(gomega.Succeed())
+	g.Expect(child.OwnerReferences).To(gomega.HaveLen(1))
+}
+
+// A child the operator has just built has no UID yet, so it cannot be a
+// pre-existing foreign object and is claimed without a read.
+func TestClaimRemoteClaimsAnObjectThatDoesNotExistYet(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	child := testChild()
+
+	g.Expect(Claim(Remote(fake.NewClientBuilder().Build()), ownershipScheme(t), testOwner(), child)).To(gomega.Succeed())
+	g.Expect(child.Labels).To(gomega.HaveKeyWithValue(OwnerNameLabel, "example"))
+}
+
+func TestControlsRecognizesTheControllerReference(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := ownershipScheme(t)
+	owner := testOwner()
+	child := testChild()
+	g.Expect(controllerutil.SetControllerReference(owner, child, scheme)).To(gomega.Succeed())
+
+	controlled, err := Controls(scheme, owner, child)
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(controlled).To(gomega.BeTrue())
+}
+
+func TestControlsRecognizesTheOwnershipLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := ownershipScheme(t)
+	owner := testOwner()
+	child := testChild()
+	labels, err := OwnerLabels(scheme, owner)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	child.Labels = labels
+
+	controlled, err := Controls(scheme, owner, child)
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(controlled).To(gomega.BeTrue())
+}
+
+func TestControlsRejectsAnObjectWithNeitherMark(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	controlled, err := Controls(ownershipScheme(t), testOwner(), testChild())
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(controlled).To(gomega.BeFalse())
+}
+
+// Name and namespace are not enough: two service CRs of different kinds share
+// them routinely, and each would otherwise select and delete the other's
+// children on the target cluster.
+func TestControlsRejectsADifferentOwnerKindOfTheSameName(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := ownershipScheme(t)
+	child := testChild()
+	labels, err := OwnerLabels(scheme, testOwner())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	child.Labels = labels
+
+	// Same name, same namespace, different kind.
+	other := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "openstack",
+		UID:       "other-owner-uid",
+	}}
+	controlled, err := Controls(scheme, other, child)
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(controlled).To(gomega.BeFalse())
+}
+
+func TestRemoteMarksTheClientAndPassesEveryCallThrough(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	seeded := testChild()
+	inner := fake.NewClientBuilder().WithScheme(ownershipScheme(t)).WithObjects(seeded).Build()
+
+	g.Expect(IsRemote(inner)).To(gomega.BeFalse())
+	g.Expect(IsRemote(Remote(inner))).To(gomega.BeTrue())
+
+	// The mark is a wrapper, not a substitute: reads and writes still land on the
+	// cluster the resolver handed out.
+	read := &corev1.Secret{}
+	g.Expect(Remote(inner).Get(context.Background(), client.ObjectKeyFromObject(seeded), read)).To(gomega.Succeed())
+	g.Expect(read.Name).To(gomega.Equal(seeded.Name))
+}
+
+// LiveReader is what keeps an ownership decision off the cache: a client the
+// resolver marked answers with its cluster's uncached reader, and everything
+// else with itself.
+func TestLiveReaderPrefersTheClustersUncachedReader(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := ownershipScheme(t)
+	child := testChild()
+	// The cache has not caught up with the cluster it describes: only the
+	// uncached reader sees the object that is on it.
+	cached := fake.NewClientBuilder().WithScheme(scheme).Build()
+	uncached := fake.NewClientBuilder().WithScheme(scheme).WithObjects(child).Build()
+	key := client.ObjectKeyFromObject(child)
+
+	g.Expect(LiveReader(remoteClient{Client: cached, reader: uncached}).
+		Get(context.Background(), key, &corev1.Secret{})).To(gomega.Succeed())
+
+	missed := LiveReader(Remote(cached)).Get(context.Background(), key, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(missed)).To(gomega.BeTrue(),
+		"a mark carrying no reader falls back to the client it wraps")
+	missed = LiveReader(cached).Get(context.Background(), key, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(missed)).To(gomega.BeTrue(), "an unmarked client is its own reader")
+}

--- a/internal/common/multicluster/resolver.go
+++ b/internal/common/multicluster/resolver.go
@@ -37,6 +37,13 @@ const TargetClusterUnavailable = "TargetClusterUnavailable"
 // nil ref (the CR names no target cluster) both select local, so a
 // single-cluster deployment never leaves the management cluster.
 //
+// A named cluster's client comes back marked as remote, and the local one comes
+// back unmarked. That mark is what Claim reads to decide whether a child is
+// owned by a controller owner reference or by the ownership labels, so a write
+// site never has to know which cluster it is writing to. The mark also carries
+// that cluster's uncached API reader, which LiveReader hands to the write sites
+// that must decide from live state rather than from a cache.
+//
 // The resolver's error is returned unwrapped. Callers put its text straight
 // into a status condition under the TargetClusterUnavailable reason, where the
 // upstream message ("cluster not found" for an unregistered name) is the part
@@ -57,7 +64,7 @@ func ResolveChildrenClient(
 		return nil, err
 	}
 
-	return cl.GetClient(), nil
+	return remoteClient{Client: cl.GetClient(), reader: cl.GetAPIReader()}, nil
 }
 
 // AbandonAfter is how long a terminating CR keeps waiting for a target cluster
@@ -146,7 +153,9 @@ func forgetUnresolvable(name string) {
 // reachable, with no CR left to retry from. AbandonAfter separates the two.
 //
 // The children on a cluster that stays unresolvable are unreachable either way
-// and are left where they are, which is the remote-ownership gap #837 tracks.
+// and are left where they are. Abandoning the cluster is therefore also
+// abandoning them: they keep running on it, and once the finalizers are
+// released no CR remains to reclaim them if it ever comes back.
 func ResolveChildrenClientForDeletion(
 	ctx context.Context,
 	resolver ClusterResolver,

--- a/internal/common/multicluster/resolver_test.go
+++ b/internal/common/multicluster/resolver_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -58,6 +59,8 @@ func TestResolveChildrenClientNilResolverReturnsLocal(t *testing.T) {
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(got).To(gomega.BeIdenticalTo(local))
+	g.Expect(IsRemote(got)).To(gomega.BeFalse(),
+		"a client on the management cluster must keep claiming its children by owner reference")
 }
 
 func TestResolveChildrenClientNilRefSkipsResolver(t *testing.T) {
@@ -70,6 +73,7 @@ func TestResolveChildrenClientNilRefSkipsResolver(t *testing.T) {
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(got).To(gomega.BeIdenticalTo(local))
+	g.Expect(IsRemote(got)).To(gomega.BeFalse())
 	// Not merely "local came back": a CR without a ref must not cost a lookup.
 	g.Expect(resolver.calls).To(gomega.BeEmpty())
 }
@@ -94,15 +98,21 @@ func TestResolveChildrenClientReturnsTargetClusterClient(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	local := fake.NewClientBuilder().Build()
-	remote := fake.NewClientBuilder().Build()
+	onTheTarget := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "there", Namespace: "openstack"}}
+	remote := fake.NewClientBuilder().WithObjects(onTheTarget).Build()
 	resolver := &fakeResolver{cl: fakeCluster{c: remote}}
 
 	got, err := ResolveChildrenClient(context.Background(), resolver, local,
 		&commonv1.TargetClusterRefSpec{Name: "remote-a"})
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(got).To(gomega.BeIdenticalTo(remote))
+	// The mark is what tells every write site to claim its children by label
+	// rather than by an owner reference the target cluster cannot resolve.
+	g.Expect(IsRemote(got)).To(gomega.BeTrue())
 	g.Expect(got).NotTo(gomega.BeIdenticalTo(local))
+	// It is a wrapper, so the calls still land on the target cluster.
+	g.Expect(got.Get(context.Background(), client.ObjectKeyFromObject(onTheTarget), &corev1.ConfigMap{})).
+		To(gomega.Succeed())
 	g.Expect(resolver.calls).To(gomega.Equal([]mcruntime.ClusterName{"remote-a"}))
 }
 
@@ -216,14 +226,20 @@ func TestResolveChildrenClientForDeletionResolvableYieldsTheTargetClient(t *test
 	g := gomega.NewWithT(t)
 
 	local := fake.NewClientBuilder().Build()
-	remote := fake.NewClientBuilder().Build()
+	onTheTarget := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "there", Namespace: "openstack"}}
+	remote := fake.NewClientBuilder().WithObjects(onTheTarget).Build()
 	resolver := &fakeResolver{cl: fakeCluster{c: remote}}
 
 	got, wait := ResolveChildrenClientForDeletion(context.Background(), resolver, local,
 		&commonv1.TargetClusterRefSpec{Name: "remote-a"}, metav1.Now())
 
 	g.Expect(wait).To(gomega.BeFalse())
-	g.Expect(got).To(gomega.BeIdenticalTo(remote))
+	// The deletion path resolves through ResolveChildrenClient, so the teardown
+	// gets the same marked client the projection did and recognizes the children
+	// it has to delete by the same labels it stamped them with.
+	g.Expect(IsRemote(got)).To(gomega.BeTrue())
+	g.Expect(got.Get(context.Background(), client.ObjectKeyFromObject(onTheTarget), &corev1.ConfigMap{})).
+		To(gomega.Succeed())
 }
 
 func TestResolveChildrenClientForDeletionNilRefYieldsLocal(t *testing.T) {
@@ -236,6 +252,7 @@ func TestResolveChildrenClientForDeletionNilRefYieldsLocal(t *testing.T) {
 
 	g.Expect(wait).To(gomega.BeFalse())
 	g.Expect(got).To(gomega.BeIdenticalTo(local))
+	g.Expect(IsRemote(got)).To(gomega.BeFalse())
 	g.Expect(resolver.calls).To(gomega.BeEmpty())
 }
 

--- a/internal/common/multicluster/teardown.go
+++ b/internal/common/multicluster/teardown.go
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// teardownPageSize bounds one LIST the sweep issues. The sweep cannot narrow its
+// lists with a server-side selector — ownership is decided object by object, for
+// the two reasons DeleteRemoteChildren documents — so the API server answers
+// with every object of the kind in the namespace, and a target namespace is
+// shared with everything else deployed into it. Unpaged, a namespace holding
+// tens of thousands of objects would arrive as a single response, per kind,
+// which is enough to have the operator OOMKilled mid-sweep — and it would
+// restart into the same sweep, so the CR would never leave Terminating. Paging
+// caps the peak at one page per kind, at the cost of a round trip per page.
+//
+// The page size is only half of that bound, and the smaller half. What it
+// multiplies is what one item costs, and that is why the sweep lists metadata
+// alone (see DeleteRemoteChildren): a Secret or a ConfigMap is capped at about a
+// megabyte of payload the sweep never reads, so a page of whole objects could
+// exceed the operator's entire memory limit several times over at any page size
+// worth issuing.
+const teardownPageSize = 500
+
+// SweepRemoteChildren is the teardown pass every service operator runs from its
+// deletion path: it deletes what a CR projected onto the target cluster it names
+// and then releases RemoteChildrenFinalizer, the finalizer that held the CR in
+// etcd long enough to do it.
+//
+// It is a no-op for a CR that does not carry the finalizer, which is every CR
+// that keeps its children on the management cluster: those are collected from
+// their owner references, and only a CR naming a target cluster ever carries it.
+// Callers therefore run it unconditionally from their cleanup path.
+//
+// children is what ResolveChildrenClientForDeletion returned. A nil client means
+// the target cluster was deregistered and has stayed unresolvable past
+// AbandonAfter. Its children cannot be reached, so they are left running, a
+// Warning event records that they were, and the finalizer is released anyway:
+// holding it would only strand the CR in Terminating.
+//
+// The sweep reads through the target cluster's uncached API reader rather than
+// through the children client's cache. Its success licenses the finalizer
+// release, and a child the cache has not caught up on would be missed, leaving
+// no CR behind to delete it.
+func SweepRemoteChildren(
+	ctx context.Context,
+	mgmt client.Client,
+	resolver ClusterResolver,
+	recorder record.EventRecorder,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	ref *commonv1.TargetClusterRefSpec,
+	children client.Client,
+	kinds []schema.GroupVersionKind,
+) error {
+	if !controllerutil.ContainsFinalizer(owner, RemoteChildrenFinalizer) {
+		return nil
+	}
+
+	if children == nil {
+		gvk, err := ownerGVK(scheme, owner)
+		if err != nil {
+			return err
+		}
+		recorder.Event(owner, corev1.EventTypeWarning, "RemoteChildrenAbandoned",
+			fmt.Sprintf("Target cluster is no longer registered; releasing the remote-children finalizer without "+
+				"deleting the objects on it labelled as owned by this %s", gvk.Kind))
+	} else {
+		reader, err := ResolveChildrenAPIReader(ctx, resolver, children, ref)
+		if err != nil {
+			return err
+		}
+		if err := DeleteRemoteChildren(ctx, reader, children, scheme, owner, kinds); err != nil {
+			return err
+		}
+	}
+
+	controllerutil.RemoveFinalizer(owner, RemoteChildrenFinalizer)
+	if err := mgmt.Update(ctx, owner); err != nil {
+		return fmt.Errorf("removing remote-children finalizer: %w", err)
+	}
+	return nil
+}
+
+// DeleteRemoteChildren deletes every object of the given kinds that owner owns,
+// in owner's own namespace — every projection in this repo is namespace-scoped
+// into the CR's namespace. It is the cleanup half of the ownership contract: no
+// garbage collection cascade crosses a cluster boundary, so a CR that projected
+// children onto a target cluster deletes them itself, and
+// RemoteChildrenFinalizer is what keeps the CR in etcd long enough to do it.
+//
+// Ownership is decided by Controls, object by object, rather than by a
+// server-side label selector, so the sweep reclaims exactly the set every other
+// write site recognizes as owner's — which also means the API server returns
+// every object of the kind in the namespace, and the sweep pages through them
+// (see teardownPageSize) instead of asking for a shared namespace in one
+// response. Two kinds of child are only reachable this way:
+//
+//   - One written before ownership moved off the owner reference. It carries a
+//     dangling controller reference to owner and no ownership labels, and every
+//     create-once write site (the immutable config objects, the derived
+//     db-connection Secret, the fernet and credential keys, the Certificates,
+//     the Jobs) leaves it exactly as it found it. A selector would not return it,
+//     the sweep would report success, and key material would keep running on the
+//     target with no CR left to reclaim it.
+//   - One belonging to a CR whose name exceeds MaxOwnerNameLength. Such a name
+//     is not a valid label value, so a selector built from it is rejected with a
+//     400 that is neither NotFound nor a no-match — the sweep would fail every
+//     pass and strand the CR in Terminating on a finalizer nothing could release.
+//
+// A local owner is a no-op. writer is unmarked, nil comes back before anything
+// is listed, and the children are left to the owner references that collect
+// them. Callers therefore call this unconditionally from their cleanup path
+// instead of branching on which cluster they wrote to.
+//
+// The pages are metadata-only (PartialObjectMetadataList). Both things the sweep
+// does with an item — deciding ownership from its labels and owner references,
+// and naming it in a delete — live in its metadata, while its payload does not:
+// the swept kinds include Secret and ConfigMap, each capped at about a megabyte,
+// so a page of whole objects would put tens of megabytes of data the sweep never
+// reads into an operator whose memory limit is a fraction of that, and OOMKill it
+// into the same sweep it just restarted from.
+//
+// reader must be the target cluster's uncached API reader, the one
+// ResolveChildrenAPIReader returns. A remote informer cache lags as readily as a
+// local one, and a child it has not caught up on would be missed by a sweep
+// whose success licenses the finalizer release: the CR would leave etcd while
+// that child keeps running with nothing left to delete it.
+//
+// A kind the target cluster does not serve is skipped (meta.IsNoMatchError):
+// without cert-manager there is no Certificate kind, without Gateway API no
+// HTTPRoute, and a kind that is not registered can have no children. Every other
+// list error fails the pass, so the caller keeps its finalizer and sweeps again
+// rather than releasing a CR whose children it never got to see.
+//
+// It does not wait for the deleted objects to leave etcd. A child holding a
+// finalizer of its own (the MariaDB CRs are the slow ones) keeps terminating on
+// the target afterwards, exactly as it does under the local cascade, where the
+// owner is collected while its children are still draining.
+func DeleteRemoteChildren(
+	ctx context.Context,
+	reader client.Reader,
+	writer client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	kinds []schema.GroupVersionKind,
+) error {
+	if !IsRemote(writer) {
+		return nil
+	}
+
+	labels, err := OwnerLabels(scheme, owner)
+	if err != nil {
+		return err
+	}
+
+	for _, gvk := range kinds {
+		listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
+
+		for continueToken, rescanned := "", false; ; {
+			page := &metav1.PartialObjectMetadataList{}
+			page.SetGroupVersionKind(listGVK)
+
+			err := reader.List(ctx, page, client.InNamespace(owner.GetNamespace()),
+				client.Limit(teardownPageSize), client.Continue(continueToken))
+			if meta.IsNoMatchError(err) {
+				break
+			}
+			if apierrors.IsResourceExpired(err) && !rescanned {
+				// A paged list is served from the etcd revision the first page was
+				// read at, and a sweep that deletes its way through a large kind can
+				// outlive that revision's compaction window. The continue token is
+				// then refused for good, so the kind is scanned once more from the
+				// start rather than failing a pass that would only restart here
+				// anyway: deleting is idempotent, and what is left to scan is
+				// smaller than it was. A second expiry does fail the pass, so a
+				// target cluster that expires every scan requeues the CR instead of
+				// pinning a reconcile worker on an unbounded retry.
+				continueToken, rescanned = "", true
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("listing remote %s children for teardown: %w", gvk.Kind, err)
+			}
+
+			for i := range page.Items {
+				child := &page.Items[i]
+				if !controls(owner, child, labels) {
+					continue
+				}
+				// A metadata list leaves its items without a kind, and the delete is
+				// routed by theirs, not by the list's.
+				child.SetGroupVersionKind(gvk)
+				err := writer.Delete(ctx, child, client.PropagationPolicy(metav1.DeletePropagationBackground))
+				if err != nil && !apierrors.IsNotFound(err) {
+					return fmt.Errorf("deleting remote %s %s/%s: %w",
+						gvk.Kind, child.GetNamespace(), child.GetName(), err)
+				}
+			}
+
+			continueToken = page.GetContinue()
+			if continueToken == "" {
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/common/multicluster/teardown_test.go
+++ b/internal/common/multicluster/teardown_test.go
@@ -1,0 +1,508 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// The kinds the sweep is driven with. Deployments are among them so the sweep
+// has to cross an API group and not just two kinds of the core one.
+var (
+	configMapGVK  = corev1.SchemeGroupVersion.WithKind("ConfigMap")
+	secretGVK     = corev1.SchemeGroupVersion.WithKind("Secret")
+	deploymentGVK = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	// A kind a target cluster without cert-manager does not serve.
+	certificateGVK = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"}
+)
+
+// teardownScheme knows the owner kind and every child kind the sweeps below
+// list.
+func teardownScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	g := gomega.NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(appsv1.AddToScheme(scheme)).To(gomega.Succeed())
+	return scheme
+}
+
+// ownedBy stamps owner's ownership labels on obj, which is what Claim did to it
+// when the projection wrote it to the target cluster.
+func ownedBy(t *testing.T, scheme *runtime.Scheme, owner, obj client.Object) client.Object {
+	t.Helper()
+
+	labels, err := OwnerLabels(scheme, owner)
+	gomega.NewWithT(t).Expect(err).NotTo(gomega.HaveOccurred())
+	obj.SetLabels(labels)
+	return obj
+}
+
+// gone reports whether obj is absent from c. Every assertion about what a sweep
+// did, and about what it left alone, is made through it.
+func gone(t *testing.T, c client.Client, obj client.Object) bool {
+	t.Helper()
+
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object))
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	gomega.NewWithT(t).Expect(err).NotTo(gomega.HaveOccurred())
+	return false
+}
+
+func teardownConfigMap(name, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+}
+
+func teardownSecret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+}
+
+func teardownDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+}
+
+// A CR that never named a target cluster keeps the behavior it always had: its
+// children are collected by their owner references. Callers do not branch on
+// that, so the sweep has to recognize the unmarked client and delete nothing at
+// all, including objects whose labels would otherwise select them.
+func TestDeleteRemoteChildrenLocalClientDeletesNothing(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	wouldMatch := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	local := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wouldMatch).Build()
+
+	err := DeleteRemoteChildren(context.Background(), local, local, scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(gone(t, local, wouldMatch)).To(gomega.BeFalse(),
+		"a local child is the garbage collector's business, not the sweep's")
+}
+
+func TestDeleteRemoteChildrenDeletesEveryLabelledChildOfEveryKind(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	configMap := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	secret := ownedBy(t, scheme, owner, teardownSecret("keystone-credentials", "openstack"))
+	deployment := ownedBy(t, scheme, owner, teardownDeployment("keystone", "openstack"))
+	target := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(configMap, secret, deployment).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK, secretGVK, deploymentGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(gone(t, target, configMap)).To(gomega.BeTrue())
+	g.Expect(gone(t, target, secret)).To(gomega.BeTrue())
+	g.Expect(gone(t, target, deployment)).To(gomega.BeTrue())
+}
+
+// A child written before ownership moved off the owner reference carries that
+// reference and no labels, and the create-once write sites — the immutable
+// config objects, the fernet and credential keys, the Certificates, the Jobs —
+// never rewrite it, so nothing ever stamps the labels on it. The sweep decides
+// ownership object by object for exactly this reason: a selector would not
+// return it, the pass would report success, and key material would keep running
+// on the target with no CR left to reclaim it.
+func TestDeleteRemoteChildrenSweepsAChildOwnedByAReferenceAlone(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	legacy := teardownSecret("keystone-fernet-keys", "openstack")
+	legacy.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       owner.Name,
+		UID:        owner.UID,
+		Controller: ptr.To(true),
+	}}
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacy).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{secretGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(gone(t, target, legacy)).To(gomega.BeTrue(),
+		"a child the operator still recognizes has to be one the sweep reaches")
+}
+
+// The sweep runs on a cluster it shares with everybody else's children, so what
+// it leaves standing matters as much as what it removes. The different-kind case
+// is the reason the kind label exists: a Keystone and a Barbican of the same
+// name in the same namespace project into the same target namespace.
+func TestDeleteRemoteChildrenSparesEverythingItDoesNotOwn(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	ours := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	unlabelled := teardownConfigMap("cluster-ca", "openstack")
+	otherName := ownedBy(t, scheme,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "openstack"}},
+		teardownConfigMap("other-config", "openstack"))
+	otherKind := ownedBy(t, scheme,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "openstack"}},
+		teardownConfigMap("barbican-config", "openstack"))
+	otherNamespace := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "other-namespace"))
+	target := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ours, unlabelled, otherName, otherKind, otherNamespace).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(gone(t, target, ours)).To(gomega.BeTrue())
+	g.Expect(gone(t, target, unlabelled)).To(gomega.BeFalse(), "an object nobody claimed is nobody's child")
+	g.Expect(gone(t, target, otherName)).To(gomega.BeFalse(), "another CR's child")
+	g.Expect(gone(t, target, otherKind)).To(gomega.BeFalse(),
+		"a same-named CR of another kind owns this one")
+	g.Expect(gone(t, target, otherNamespace)).To(gomega.BeFalse(), "outside the swept namespace")
+}
+
+// Every operator sweeps the same kind list, and a target cluster is free to
+// serve only part of it. A missing CRD is not a failure to clean up: there can
+// be no children of a kind the cluster does not know, and failing the pass would
+// wedge the CR on a finalizer nothing could ever release.
+func TestDeleteRemoteChildrenSkipsAKindTheTargetDoesNotServe(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	configMap := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "CertificateList" {
+					return &meta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "cert-manager.io", Kind: "Certificate"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{certificateGVK, configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(gone(t, target, configMap)).To(gomega.BeTrue(),
+		"the unserved kind must be skipped, not abort the sweep")
+}
+
+// The list is a moment older than the deletes it drives, so a child that went
+// away in between is already in the state the sweep wanted.
+func TestDeleteRemoteChildrenToleratesAChildDeletedUnderIt(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	configMap := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+				return apierrors.NewNotFound(corev1.Resource("configmaps"), "keystone-config")
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// The sweep lists without a server-side selector, so the API server answers with
+// every object of the kind in a namespace it shares with everything else
+// deployed there. It therefore has to page: a single unbounded response would be
+// decoded into unstructured maps in one go and can OOMKill the operator
+// mid-sweep, which then restarts into the same sweep and never releases the CR.
+func TestDeleteRemoteChildrenPagesThroughAKind(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	// One page per child, so the sweep can only reach the last one by following
+	// the continue token of the page before it.
+	names := []string{"keystone-config", "keystone-policy", "keystone-defaults"}
+	var children []client.Object
+	for _, name := range names {
+		children = append(children, ownedBy(t, scheme, owner, teardownConfigMap(name, "openstack")))
+	}
+
+	var limits []int64
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(children...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// The fake client serves the whole list and ignores Limit/Continue, so
+			// the paging server is emulated here: one name per page, and a continue
+			// token naming the next until the last page carries none.
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				options := &client.ListOptions{}
+				options.ApplyOptions(opts)
+				limits = append(limits, options.Limit)
+
+				index := 0
+				if options.Continue != "" {
+					var err error
+					if index, err = strconv.Atoi(options.Continue); err != nil {
+						return err
+					}
+				}
+				if err := c.List(ctx, list, opts...); err != nil {
+					return err
+				}
+				items, err := meta.ExtractList(list)
+				if err != nil {
+					return err
+				}
+				var page []runtime.Object
+				for _, item := range items {
+					if item.(client.Object).GetName() == names[index] {
+						page = append(page, item)
+					}
+				}
+				if err := meta.SetList(list, page); err != nil {
+					return err
+				}
+				if index+1 < len(names) {
+					list.SetContinue(strconv.Itoa(index + 1))
+				}
+				return nil
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, child := range children {
+		g.Expect(gone(t, target, child)).To(gomega.BeTrue(),
+			"a child on a later page is as much this owner's as one on the first")
+	}
+	g.Expect(limits).To(gomega.Equal([]int64{teardownPageSize, teardownPageSize, teardownPageSize}),
+		"every request is bounded, and the sweep followed the continue token to the last page")
+}
+
+// Paging alone does not bound the sweep: what a page costs is its size times
+// what one item costs, and the swept kinds include Secret and ConfigMap, whose
+// payload the API server caps at about a megabyte each. A page of whole objects
+// would carry tens of megabytes the sweep never reads into an operator limited
+// to a fraction of that. It reads what it uses — labels, owner references, a
+// name — and nothing else.
+func TestDeleteRemoteChildrenListsMetadataOnly(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	payload := teardownSecret("keystone-credentials", "openstack")
+	payload.Data = map[string][]byte{"fernet": []byte("key-material")}
+	secret := ownedBy(t, scheme, owner, payload)
+	var listed []client.ObjectList
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				listed = append(listed, list)
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{secretGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(listed).To(gomega.HaveLen(1))
+	g.Expect(listed[0]).To(gomega.BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}),
+		"the sweep must not pull object payloads it never reads into memory")
+	g.Expect(gone(t, target, secret)).To(gomega.BeTrue(),
+		"a metadata item still carries everything the delete is routed by")
+}
+
+// A paged list is served from the etcd revision its first page was read at, and
+// a sweep deleting its way through a large kind can outlive that revision's
+// compaction window: the continue token is then refused for good. Failing the
+// pass would only restart the same scan from the first page, so the sweep does
+// that itself rather than handing a CR back a finalizer nothing releases.
+func TestDeleteRemoteChildrenRescansAKindWhoseContinueTokenExpired(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	first := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	second := ownedBy(t, scheme, owner, teardownConfigMap("keystone-policy", "openstack"))
+
+	lists := 0
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(first, second).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				lists++
+				if lists == 2 {
+					// The second request is the one carrying the continue token.
+					return apierrors.NewResourceExpired("continue parameter is too old to display a consistent list result")
+				}
+				if err := c.List(ctx, list, opts...); err != nil {
+					return err
+				}
+				items, err := meta.ExtractList(list)
+				if err != nil {
+					return err
+				}
+				if lists == 1 {
+					// A first page of one, so the rest is only reachable through the
+					// token the sweep never gets to redeem.
+					if err := meta.SetList(list, items[:1]); err != nil {
+						return err
+					}
+					list.SetContinue("next")
+				}
+				return nil
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lists).To(gomega.Equal(3), "the expired token is answered by scanning the kind again from the start")
+	g.Expect(gone(t, target, first)).To(gomega.BeTrue())
+	g.Expect(gone(t, target, second)).To(gomega.BeTrue(),
+		"a child left on the page behind an expired token is still this owner's")
+}
+
+// The rescan is taken once per kind. A cluster that expires every scan cannot be
+// swept, and retrying it here would pin a reconcile worker on a kind that never
+// finishes; failing the pass requeues the CR under the controller's own backoff
+// instead, with the finalizer still on it.
+func TestDeleteRemoteChildrenFailsAKindThatKeepsExpiring(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	configMap := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+
+	lists := 0
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				lists++
+				return apierrors.NewResourceExpired("continue parameter is too old to display a consistent list result")
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("listing remote ConfigMap children for teardown")))
+	g.Expect(lists).To(gomega.Equal(2), "one rescan, not a retry loop")
+	g.Expect(gone(t, target, configMap)).To(gomega.BeFalse())
+}
+
+// A list the target cluster refuses says nothing about whether children exist,
+// so the pass has to fail: the caller keeps its finalizer and sweeps again
+// rather than releasing a CR whose children it never saw.
+func TestDeleteRemoteChildrenPropagatesAListError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	secret := ownedBy(t, scheme, owner, teardownSecret("keystone-credentials", "openstack"))
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "SecretList" {
+					return apierrors.NewForbidden(corev1.Resource("secrets"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{secretGVK})
+
+	// The kind is in the message because the sweep spans kinds and the operator
+	// reading the CR's condition has to know which one it lost.
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("listing remote Secret children for teardown")))
+	g.Expect(gone(t, target, secret)).To(gomega.BeFalse())
+}
+
+// An owner whose kind the scheme does not know cannot be labelled, so its
+// children cannot be selected either. Deleting nothing at all is the only safe
+// answer: a partial label set would select another CR's children.
+func TestDeleteRemoteChildrenUnregisteredOwnerKindFailsWithoutDeleting(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	configMap := ownedBy(t, scheme, owner, teardownConfigMap("keystone-config", "openstack"))
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), runtime.NewScheme(), owner,
+		[]schema.GroupVersionKind{configMapGVK})
+
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving GVK for owner openstack/example")))
+	g.Expect(gone(t, target, configMap)).To(gomega.BeFalse())
+}
+
+// A child of a child (a Deployment's ReplicaSet, a MariaDB's StatefulSet) has an
+// owner reference on the target cluster and is collected there. Foreground
+// propagation would make the sweep wait for that cascade before the delete
+// returns, and background is what the local cascade does.
+func TestDeleteRemoteChildrenDeletesWithBackgroundPropagation(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	scheme := teardownScheme(t)
+	owner := testOwner()
+	deployment := ownedBy(t, scheme, owner, teardownDeployment("keystone", "openstack"))
+	var policies []*metav1.DeletionPropagation
+	target := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object,
+				opts ...client.DeleteOption,
+			) error {
+				options := &client.DeleteOptions{}
+				options.ApplyOptions(opts)
+				policies = append(policies, options.PropagationPolicy)
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).Build()
+
+	err := DeleteRemoteChildren(context.Background(), target, Remote(target), scheme, owner,
+		[]schema.GroupVersionKind{deploymentGVK})
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(policies).To(gomega.HaveLen(1))
+	g.Expect(policies[0]).To(gomega.HaveValue(gomega.Equal(metav1.DeletePropagationBackground)))
+}

--- a/internal/common/rotation/rotation.go
+++ b/internal/common/rotation/rotation.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // StagingSecretLabelKey labels staging Secrets so operator watches and
@@ -69,11 +71,12 @@ func ObserveAge(mainSecret, stagingSecret *corev1.Secret, record func(completedA
 
 // EnsureStagingSecret creates (or ensures) an empty staging Secret that the
 // rotation CronJob PATCHes rotated payload into. The operator owns the object's
-// metadata and lifecycle — labels, owner reference — while the CronJob owns the
-// `.data` field via a narrow get+patch RBAC grant. Data is deliberately left nil
-// on creation and untouched on update so the CronJob's PATCH is never clobbered
-// by a reconcile. labels is the complete label set applied on every call
-// (rebuilt so operator-owned labels stay authoritative).
+// metadata and lifecycle — labels and the ownership claim — while the CronJob
+// owns the `.data` field via a narrow get+patch RBAC grant. Data is deliberately
+// left nil on creation and untouched on update so the CronJob's PATCH is never
+// clobbered by a reconcile. labels is the complete label set applied on every
+// call (rebuilt so operator-owned labels stay authoritative), except for the
+// ownership labels a claim on a target cluster adds.
 //
 // It returns the ensured Secret so the caller can thread it into ObserveAge and
 // CommitStaged without re-reading it; its UID/ResourceVersion drive the commit's
@@ -86,9 +89,8 @@ func EnsureStagingSecret(ctx context.Context, c client.Client, scheme *runtime.S
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
-		secret.Labels = labels
 		// Do NOT touch secret.Data — the CronJob's PATCH owns that field.
-		return controllerutil.SetControllerReference(owner, secret, scheme)
+		return multicluster.ClaimWithLabels(c, scheme, owner, secret, labels)
 	}); err != nil {
 		return nil, fmt.Errorf("ensuring staging secret %s: %w", name, err)
 	}
@@ -237,7 +239,7 @@ func EnsureRBAC(ctx context.Context, c client.Client, scheme *runtime.Scheme, ow
 
 	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace}}
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, func() error {
-		return controllerutil.SetControllerReference(owner, sa, scheme)
+		return multicluster.Claim(c, scheme, owner, sa)
 	}); err != nil {
 		return fmt.Errorf("ensuring ServiceAccount %s: %w", saName, err)
 	}
@@ -258,7 +260,7 @@ func EnsureRBAC(ctx context.Context, c client.Client, scheme *runtime.Scheme, ow
 				ResourceNames: []string{stagingSecret},
 			},
 		}
-		return controllerutil.SetControllerReference(owner, role, scheme)
+		return multicluster.Claim(c, scheme, owner, role)
 	}); err != nil {
 		return fmt.Errorf("ensuring Role %s: %w", saName, err)
 	}
@@ -277,7 +279,7 @@ func EnsureRBAC(ctx context.Context, c client.Client, scheme *runtime.Scheme, ow
 				Name:     saName,
 			}
 		}
-		return controllerutil.SetControllerReference(owner, rb, scheme)
+		return multicluster.Claim(c, scheme, owner, rb)
 	}); err != nil {
 		return fmt.Errorf("ensuring RoleBinding %s: %w", saName, err)
 	}

--- a/internal/common/rotation/rotation_test.go
+++ b/internal/common/rotation/rotation_test.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 func rotationScheme(t *testing.T) *runtime.Scheme {
@@ -84,6 +86,97 @@ func TestEnsureStagingSecret_CreatesOwnedEmpty(t *testing.T) {
 	g.Expect(secret.Data).To(gomega.BeNil(), "staging data is owned by the CronJob PATCH, not this call")
 	g.Expect(secret.Labels).To(gomega.HaveKeyWithValue(StagingSecretLabelKey, "fernet-keys"))
 	g.Expect(secret.OwnerReferences).To(gomega.HaveLen(1))
+}
+
+// rotationOwnerLabels are the ownership labels a child of rotationOwner carries
+// on a target cluster.
+func rotationOwnerLabels() map[string]string {
+	return map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "keystone",
+		multicluster.OwnerNamespaceLabel: "openstack",
+	}
+}
+
+// TestEnsureStagingSecret_remoteLabelledAndUnowned pins the target-cluster path:
+// the staging Secret keeps the caller's rotation labels and gains the ownership
+// labels on top, and carries no owner reference, because a reference to a CR on
+// another cluster names a UID this one cannot resolve.
+func TestEnsureStagingSecret_remoteLabelledAndUnowned(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	owner := rotationOwner()
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+
+	_, err := EnsureStagingSecret(context.Background(), c, s, owner, "keystone-fernet-keys-rotation",
+		map[string]string{StagingSecretLabelKey: "fernet-keys"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	fetched := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), apitypes.NamespacedName{Namespace: "openstack", Name: "keystone-fernet-keys-rotation"}, fetched)).To(gomega.Succeed())
+	g.Expect(fetched.Labels).To(gomega.HaveKeyWithValue(StagingSecretLabelKey, "fernet-keys"))
+	for key, value := range rotationOwnerLabels() {
+		g.Expect(fetched.Labels).To(gomega.HaveKeyWithValue(key, value))
+	}
+	g.Expect(fetched.OwnerReferences).To(gomega.BeEmpty(), "a remote child must carry no owner reference")
+}
+
+// TestEnsureStagingSecret_remoteRebuildKeepsOwnershipLabels covers the steady
+// state, where the rebuild of the operator-owned labels meets a live Secret: the
+// ownership labels are the only thing marking it as this owner's child, so
+// dropping them would have the next pass refuse the Secret as somebody else's.
+// A label the operator no longer sets is still dropped.
+func TestEnsureStagingSecret_remoteRebuildKeepsOwnershipLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	owner := rotationOwner()
+
+	live := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "keystone-fernet-keys-rotation",
+		Namespace: "openstack",
+		UID:       "live-uid",
+		Labels:    rotationOwnerLabels(),
+	}}
+	live.Labels[StagingSecretLabelKey] = "fernet-keys"
+	live.Labels["forge.c5c3.io/retired"] = "yes"
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner, live).Build())
+
+	_, err := EnsureStagingSecret(context.Background(), c, s, owner, "keystone-fernet-keys-rotation",
+		map[string]string{StagingSecretLabelKey: "fernet-keys"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	fetched := &corev1.Secret{}
+	g.Expect(c.Get(context.Background(), apitypes.NamespacedName{Namespace: "openstack", Name: "keystone-fernet-keys-rotation"}, fetched)).To(gomega.Succeed())
+	g.Expect(fetched.Labels).To(gomega.HaveKeyWithValue(StagingSecretLabelKey, "fernet-keys"))
+	for key, value := range rotationOwnerLabels() {
+		g.Expect(fetched.Labels).To(gomega.HaveKeyWithValue(key, value))
+	}
+	g.Expect(fetched.Labels).NotTo(gomega.HaveKey("forge.c5c3.io/retired"), "the caller's set stays authoritative")
+	g.Expect(fetched.OwnerReferences).To(gomega.BeEmpty())
+}
+
+// TestEnsureRBAC_remoteLabelledAndUnowned pins the same claim for the CronJob's
+// RBAC: on a target cluster the ServiceAccount and its Role are labelled rather
+// than referenced.
+func TestEnsureRBAC_remoteLabelledAndUnowned(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := rotationScheme(t)
+	owner := rotationOwner()
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(owner).Build())
+
+	g.Expect(EnsureRBAC(context.Background(), c, s, owner, "keystone-fernet-rotate", "keystone-fernet-keys", "keystone-fernet-keys-rotation")).To(gomega.Succeed())
+
+	key := apitypes.NamespacedName{Namespace: "openstack", Name: "keystone-fernet-rotate"}
+	sa := &corev1.ServiceAccount{}
+	g.Expect(c.Get(context.Background(), key, sa)).To(gomega.Succeed())
+	g.Expect(sa.Labels).To(gomega.Equal(rotationOwnerLabels()))
+	g.Expect(sa.OwnerReferences).To(gomega.BeEmpty())
+
+	role := &rbacv1.Role{}
+	g.Expect(c.Get(context.Background(), key, role)).To(gomega.Succeed())
+	g.Expect(role.Labels).To(gomega.Equal(rotationOwnerLabels()))
+	g.Expect(role.OwnerReferences).To(gomega.BeEmpty())
+	g.Expect(role.Rules).To(gomega.HaveLen(2), "the claim must not disturb the least-privilege rules")
 }
 
 func TestEnsureRBAC_LeastPrivilege(t *testing.T) {

--- a/internal/common/tls/tls.go
+++ b/internal/common/tls/tls.go
@@ -14,7 +14,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // EnsureCertificate creates a cert-manager Certificate if it does not exist or
@@ -26,7 +27,7 @@ func EnsureCertificate(ctx context.Context, c client.Client, scheme *runtime.Sch
 	err := c.Get(ctx, client.ObjectKeyFromObject(cert), existing)
 
 	if apierrors.IsNotFound(err) {
-		if err := controllerutil.SetControllerReference(owner, cert, scheme); err != nil {
+		if err := multicluster.Claim(c, scheme, owner, cert); err != nil {
 			return false, fmt.Errorf("setting owner reference on Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
 		}
 		if err := c.Create(ctx, cert); err != nil {
@@ -38,7 +39,28 @@ func EnsureCertificate(ctx context.Context, c client.Client, scheme *runtime.Sch
 		return false, fmt.Errorf("getting Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
 	}
 
-	if !apiequality.Semantic.DeepEqual(existing.Spec, cert.Spec) {
+	// The same claim the create branch makes, on the object that is actually
+	// about to be rewritten. A Certificate of this name somebody else provisioned
+	// is refused rather than adopted: its spec would be replaced and reissued
+	// under the operator's issuer, dnsNames and secretName, breaking the workload
+	// that depends on it. On a target cluster the claim is also what stamps the
+	// ownership labels, so a Certificate this operator does own is picked up by
+	// the teardown sweep.
+	before := existing.DeepCopy()
+	if err := multicluster.Claim(c, scheme, owner, existing); err != nil {
+		return false, err
+	}
+
+	// The claim mutates metadata in place, and the Update below is the only thing
+	// that carries those mutations to the cluster. A Certificate written before
+	// ownership moved to the labels still has its spec, so a spec-only gate would
+	// recompute the claim and throw it away on every pass: the dangling controller
+	// reference would stay on the object, and the target's garbage collector
+	// resolves it to a missing owner and collects the Certificate as an orphan the
+	// moment the owner's kind is registered there.
+	claimed := !apiequality.Semantic.DeepEqual(before.ObjectMeta, existing.ObjectMeta)
+
+	if claimed || !apiequality.Semantic.DeepEqual(existing.Spec, cert.Spec) {
 		existing.Spec = cert.Spec
 		if err := c.Update(ctx, existing); err != nil {
 			return false, fmt.Errorf("updating Certificate %s/%s: %w", cert.Namespace, cert.Name, err)

--- a/internal/common/tls/tls_test.go
+++ b/internal/common/tls/tls_test.go
@@ -15,8 +15,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 func newScheme() *runtime.Scheme {
@@ -73,6 +76,141 @@ func TestEnsureCertificate_creates(t *testing.T) {
 	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-cert", Namespace: "default"}, created)).To(Succeed())
 	g.Expect(created.OwnerReferences).To(HaveLen(1))
 	g.Expect(created.OwnerReferences[0].Name).To(Equal("test-owner"))
+}
+
+// TestEnsureCertificate_remoteCreatesLabelledAndUnowned pins the target-cluster
+// path: the Certificate is stamped with the ownership labels and carries no
+// owner reference, because a reference to a CR on another cluster names a UID
+// this one cannot resolve.
+func TestEnsureCertificate_remoteCreatesLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner).
+		Build())
+
+	ready, err := EnsureCertificate(context.Background(), c, s, owner, testCertificate())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+
+	created := &certmanagerv1.Certificate{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-cert", Namespace: "default"}, created)).To(Succeed())
+	g.Expect(created.Labels).To(Equal(map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}))
+	g.Expect(created.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+}
+
+// TestEnsureCertificate_remoteRefusesAForeignCertificate is the update side of
+// the claim. A Certificate of this name on a shared target cluster may well be
+// somebody else's: rewriting its spec reissues it under this operator's issuer,
+// dnsNames and secretName, and breaks the workload consuming the Secret it
+// keeps renewing.
+func TestEnsureCertificate_remoteRefusesAForeignCertificate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	foreign := testCertificate()
+	foreign.Spec.IssuerRef.Name = "someone-elses-issuer"
+	foreign.Spec.SecretName = "someone-elses-tls"
+	// Live: read back from the API server, which is what the claim recognizes.
+	foreign.UID = "foreign-certificate-uid"
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, foreign).
+		Build())
+
+	ready, err := EnsureCertificate(context.Background(), c, s, owner, testCertificate())
+
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing")))
+	g.Expect(ready).To(BeFalse())
+
+	untouched := &certmanagerv1.Certificate{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-cert", Namespace: "default"}, untouched)).To(Succeed())
+	g.Expect(untouched.Spec.IssuerRef.Name).To(Equal("someone-elses-issuer"))
+	g.Expect(untouched.Spec.SecretName).To(Equal("someone-elses-tls"))
+	g.Expect(untouched.Labels).To(BeEmpty(), "a refused Certificate must not be marked for this owner's teardown")
+}
+
+// The other side of that recognition: a Certificate this owner does own is
+// updated as it always was, and on a target cluster the claim also stamps the
+// ownership labels the teardown selects on.
+func TestEnsureCertificate_remoteUpdatesItsOwnCertificate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	mine := testCertificate()
+	mine.Spec.DNSNames = []string{"stale.example.com"}
+	mine.UID = "my-certificate-uid"
+	mine.Labels = map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, mine).
+		Build())
+
+	_, err := EnsureCertificate(context.Background(), c, s, owner, testCertificate())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &certmanagerv1.Certificate{}
+	g.Expect(c.Get(context.Background(), client.ObjectKey{Name: "test-cert", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Spec.DNSNames).To(Equal([]string{"test.example.com"}))
+	g.Expect(updated.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+}
+
+// TestEnsureCertificate_remoteClaimReachesAConvergedCertificate covers the
+// Certificate this operator wrote before ownership moved off the owner
+// reference: it carries a dangling reference to a CR on the management cluster,
+// no ownership labels, and — being converged — the very spec the operator would
+// write. The claim corrects the metadata in memory either way, so a spec-only
+// update gate would discard that correction on every pass: the reference would
+// stay, the target's garbage collector would collect the Certificate as an
+// orphan once the owner's kind is registered there, and the teardown sweep would
+// never see it.
+func TestEnsureCertificate_remoteClaimReachesAConvergedCertificate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := newScheme()
+	owner := testOwner()
+
+	stale := testCertificate()
+	stale.UID = "my-certificate-uid"
+	stale.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       owner.Name,
+		UID:        owner.UID,
+		Controller: ptr.To(true),
+	}}
+
+	c := multicluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(owner, stale).
+		Build())
+
+	_, err := EnsureCertificate(context.Background(), c, s, owner, testCertificate())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	claimed := &certmanagerv1.Certificate{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(stale), claimed)).To(Succeed())
+	g.Expect(claimed.OwnerReferences).To(BeEmpty(),
+		"the reference names a UID this cluster resolves to nothing, so it must reach the cluster dropped")
+	g.Expect(claimed.Labels).To(Equal(map[string]string{
+		multicluster.OwnerKindLabel:      "ConfigMap",
+		multicluster.OwnerNameLabel:      "test-owner",
+		multicluster.OwnerNamespaceLabel: "default",
+	}), "the labels are what the teardown sweep selects on")
 }
 
 func TestEnsureCertificate_existingNotReady(t *testing.T) {

--- a/internal/common/types/types.go
+++ b/internal/common/types/types.go
@@ -328,12 +328,14 @@ type SecretStoreRefSpec struct {
 // it is rejected, because each of those strands the children already created
 // on the previously selected cluster.
 //
-// A remote child carries an owner reference to a CR that lives on a different
-// cluster, so that reference dangles. Until issue #837 replaces the owner
-// references with an explicit remote-cleanup path, a target cluster must not
-// have the service CRDs installed: with the CRDs present its garbage collector
-// resolves the owner reference to a missing object and deletes the children.
-// Without them it cannot resolve the reference at all and leaves them alone.
+// A child written to the target carries no owner reference, since nothing on
+// that cluster resolves one into the management cluster. Three labels name the
+// owner instead: openstack.c5c3.io/owner-kind, openstack.c5c3.io/owner-name,
+// and openstack.c5c3.io/owner-namespace. Deleting the CR deletes the children
+// that carry its labels, under a finalizer the CR installs whenever the ref is
+// set, so a target cluster may have the service CRDs installed. A cluster
+// deregistered past the abandon window is the exception: its children cannot be
+// reached and stay behind on it.
 type TargetClusterRefSpec struct {
 	// Name is the registered target cluster's name. It must be a non-empty
 	// DNS-1123 subdomain (the Kubernetes object-name grammar), matching

--- a/operators/barbican/api/v1alpha1/barbican_types.go
+++ b/operators/barbican/api/v1alpha1/barbican_types.go
@@ -181,12 +181,15 @@ type BarbicanSpec struct {
 	// behaves exactly like a single-cluster one. The field is immutable (see the
 	// transition rules on this spec).
 	//
-	// A remote child carries an owner reference to a CR that lives on a
-	// different cluster, so that reference dangles. Until issue #837 replaces
-	// the owner references with an explicit remote-cleanup path, a target
-	// cluster must not have the service CRDs installed: with the CRDs present
-	// its garbage collector resolves the owner reference to a missing object and
-	// deletes the children.
+	// A child written to the target carries no owner reference, since nothing
+	// on that cluster resolves one into the management cluster. Three labels
+	// name the owner instead: openstack.c5c3.io/owner-kind,
+	// openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+	// Deleting the CR deletes the children that carry its labels, under a
+	// finalizer the CR installs whenever the ref is set, so a target cluster
+	// may have the service CRDs installed. A cluster deregistered past the
+	// abandon window is the exception: its children cannot be reached and stay
+	// behind on it.
 	// +optional
 	TargetClusterRef *commonv1.TargetClusterRefSpec `json:"targetClusterRef,omitempty"`
 

--- a/operators/barbican/config/crd/bases/barbican.openstack.c5c3.io_barbicans.yaml
+++ b/operators/barbican/config/crd/bases/barbican.openstack.c5c3.io_barbicans.yaml
@@ -1535,12 +1535,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/barbican/helm/barbican-operator/crds/barbican.openstack.c5c3.io_barbicans.yaml
+++ b/operators/barbican/helm/barbican-operator/crds/barbican.openstack.c5c3.io_barbicans.yaml
@@ -1538,12 +1538,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/barbican/internal/controller/barbican_controller.go
+++ b/operators/barbican/internal/controller/barbican_controller.go
@@ -253,6 +253,31 @@ type BarbicanReconciler struct {
 	healthProbeCache healthcheck.ProbeCache
 }
 
+// barbicanRemoteChildKinds are the kinds a Barbican CR projects into the
+// namespace of the target cluster it names, and the kinds
+// reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
+// deleted. Nothing on the target cluster collects them, so a kind missing from
+// this list is a kind that keeps running after its CR is gone.
+//
+// The list is cross-checked against the create verbs of the kubebuilder RBAC
+// markers on this controller below: the operator can only leave behind what it
+// is allowed to create.
+var barbicanRemoteChildKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	corev1.SchemeGroupVersion.WithKind("Service"),
+	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+	corev1.SchemeGroupVersion.WithKind("Secret"),
+	batchv1.SchemeGroupVersion.WithKind("Job"),
+	batchv1.SchemeGroupVersion.WithKind("CronJob"),
+	policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+	autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+	networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+	httpRouteGVK,
+	mariadbv1alpha1.GroupVersion.WithKind("Database"),
+	mariadbv1alpha1.GroupVersion.WithKind("User"),
+	mariadbv1alpha1.GroupVersion.WithKind("Grant"),
+}
+
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicans/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicans/finalizers,verbs=update
@@ -317,7 +342,18 @@ func (r *BarbicanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return r.updateStatus(ctx, &barbican, statusBefore,
 				ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil)
 		}
-		return r.reconcileDelete(ctx, children, &barbican)
+		if result, err := r.reconcileDelete(ctx, children, &barbican); !result.IsZero() || err != nil {
+			return result, err
+		}
+		// The label-selected sweep runs after the named MariaDB cleanup, never
+		// before it: that flow waits one pass on the CRs it deletes by name, and a
+		// sweep running first would delete them out from under it. The ordering
+		// mirrors the local one, where the garbage collection cascade starts only
+		// once every finalizer has been released.
+		if err := r.reconcileDeleteRemoteChildren(ctx, children, &barbican); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Resolve the client every child object of this CR is read and written with.
@@ -345,6 +381,20 @@ func (r *BarbicanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	} else if added {
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// The remote-children finalizer goes on only when the CR projects onto a
+	// target cluster. A local CR keeps the garbage collection cascade, which
+	// reaps its children from their owner references, so it has nothing for this
+	// finalizer to hold the CR open for. spec.targetClusterRef is immutable, so
+	// the condition cannot flip under a live CR.
+	if barbican.Spec.TargetClusterRef != nil {
+		if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, &barbican,
+			commonmulticluster.RemoteChildrenFinalizer); err != nil {
+			return ctrl.Result{}, err
+		} else if added {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Snapshot the persisted status so updateStatus can skip the write when a
@@ -505,9 +555,9 @@ func (r *BarbicanReconciler) reconcileParallelGroup(
 // the per-CR metrics, evicts the health-probe cache, and releases the finalizer.
 //
 // A nil children client means the target cluster this CR named is no longer
-// registered. Its MariaDB CRs cannot be reached, so they are left behind (the
-// remote-ownership gap #837 tracks) and the finalizer is released anyway:
-// holding it would only strand the CR in Terminating.
+// registered. Its MariaDB CRs cannot be reached, so they stay behind on a
+// cluster that has not resolved for the whole abandon window, and the finalizer
+// is released anyway: holding it would only strand the CR in Terminating.
 func (r *BarbicanReconciler) reconcileDelete(ctx context.Context, children client.Client, barbican *barbicanv1alpha1.Barbican) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(barbican, barbicanFinalizer) {
 		return ctrl.Result{}, nil
@@ -551,6 +601,16 @@ func (r *BarbicanReconciler) reconcileDelete(ctx context.Context, children clien
 	// name/namespace never serves a stale probe keyed on the deleted CR's UID.
 	r.healthProbeCache.Evict(key)
 	return ctrl.Result{}, nil
+}
+
+// reconcileDeleteRemoteChildren deletes everything this Barbican projected onto
+// the target cluster it names and releases the remote-children finalizer, as
+// commonmulticluster.SweepRemoteChildren documents. reconcileDelete above
+// deletes the three MariaDB CRs it tracks by name; this pass is what reaches the
+// rest, selected on the ownership labels Claim stamped on them.
+func (r *BarbicanReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, barbican *barbicanv1alpha1.Barbican) error {
+	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
+		barbican, barbican.Spec.TargetClusterRef, children, barbicanRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given

--- a/operators/barbican/internal/controller/barbican_controller_test.go
+++ b/operators/barbican/internal/controller/barbican_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
@@ -398,4 +400,163 @@ func TestSecretNameIndexResolvesBarbican(t *testing.T) {
 
 	g.Expect(list.Items).To(HaveLen(1))
 	g.Expect(list.Items[0].Name).To(Equal(testBarbicanName))
+}
+
+// --- remote children -------------------------------------------------------
+
+// ownedRemoteChild stamps the ownership labels the projection wrote on a child
+// it put on the target cluster, so the sweep selects it exactly as it would
+// there.
+func ownedRemoteChild(t *testing.T, owner, child client.Object) client.Object {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(testScheme(), owner)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	child.SetLabels(labels)
+	return child
+}
+
+// terminatingRemoteBarbican returns a Barbican that names a target cluster and
+// is being deleted, carrying the remote-children finalizer plus a foreign one so
+// the CR survives the release and the test can read back which finalizers the
+// pass dropped.
+func terminatingRemoteBarbican(t *testing.T) (*BarbicanReconciler, *barbicanv1alpha1.Barbican) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	barbican.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	barbican.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	deletedAt := metav1.NewTime(time.Now())
+	barbican.DeletionTimestamp = &deletedAt
+
+	r := newBarbicanTestReconciler(barbican)
+	var terminating barbicanv1alpha1.Barbican
+	g.Expect(r.Get(context.Background(), barbicanRequest.NamespacedName, &terminating)).To(Succeed())
+	return r, &terminating
+}
+
+// TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild is the whole point
+// of the finalizer: no garbage collection cascade crosses the cluster boundary,
+// so the objects this CR projected have to be deleted by name from here, across
+// every API group they live in. What the sweep leaves standing matters as much:
+// a target cluster carries other people's objects, and an object nobody claimed
+// or another CR claimed is not ours to remove.
+func TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteBarbican(t)
+
+	deployment := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: testBarbicanName, Namespace: testNamespace}})
+	service := ownedRemoteChild(t, terminating,
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: testBarbicanName, Namespace: testNamespace}})
+	cronJob := ownedRemoteChild(t, terminating,
+		&batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: testBarbicanName + "-db-clean", Namespace: testNamespace}})
+	grant := ownedRemoteChild(t, terminating,
+		&mariadbv1alpha1.Grant{ObjectMeta: metav1.ObjectMeta{Name: testBarbicanName, Namespace: testNamespace}})
+	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: testNamespace}}
+	foreign := ownedRemoteChild(t,
+		&barbicanv1alpha1.Barbican{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: testNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other-config", Namespace: testNamespace}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(deployment, service, cronJob, grant, unlabelled, foreign).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, child := range []client.Object{deployment, service, cronJob, grant} {
+		err := target.Get(ctx, client.ObjectKeyFromObject(child), child.DeepCopyObject().(client.Object))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "%T %s must be swept", child, child.GetName())
+	}
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(unlabelled), &corev1.ConfigMap{})).To(Succeed(),
+		"an object nobody claimed is nobody's child")
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(foreign), &corev1.Secret{})).To(Succeed(),
+		"another Barbican's child must survive this one's teardown")
+
+	updated := getBarbican(t, r.Client)
+	g.Expect(updated.Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"a completed sweep must release the remote-children finalizer and nothing else")
+}
+
+// TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases covers the
+// deregistered target cluster. Its children cannot be reached, so holding the
+// finalizer would only strand the CR in Terminating; the objects left running
+// are announced rather than silently dropped. Any attempt to sweep through the
+// nil client would fault, which is what proves nothing was deleted.
+func TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteBarbican(t)
+
+	err := r.reconcileDeleteRemoteChildren(context.Background(), nil, terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(collectEvents(r.Recorder.(*record.FakeRecorder))).
+		To(ContainElement(ContainSubstring("RemoteChildrenAbandoned")))
+	g.Expect(getBarbican(t, r.Client).Finalizers).NotTo(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"an unreachable target cluster must not pin the CR forever")
+}
+
+// TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer is the guard
+// against a CR that leaves etcd while its children keep running. A list the
+// target cluster refuses says nothing about whether children exist, so the pass
+// has to fail and sweep again on the next one.
+func TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteBarbican(t)
+
+	child := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: testBarbicanName, Namespace: testNamespace}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "DeploymentList" {
+					return apierrors.NewForbidden(appsv1.Resource("deployments"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).To(MatchError(ContainSubstring("listing remote Deployment children for teardown")))
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed())
+	g.Expect(getBarbican(t, r.Client).Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"a failed sweep must keep the finalizer so the next pass retries")
+}
+
+// TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster verifies that a
+// CR naming a target cluster is pinned before anything is projected onto it, so
+// a deletion issued between this pass and the next still funnels through the
+// sweep.
+func TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	barbican.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	barbican.Finalizers = []string{barbicanFinalizer} // skip the database finalizer-add requeue
+	r := newBarbicanTestReconciler(barbican)
+
+	res, err := r.Reconcile(context.Background(), barbicanRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{Requeue: true}),
+		"the pass installing the finalizer must requeue before any sub-reconciler runs")
+	g.Expect(getBarbican(t, r.Client).Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+}
+
+// TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer pins the other
+// half. A CR that keeps its children on the management cluster has nothing for
+// the sweep to do, and a finalizer it does not need is one more thing that can
+// block its deletion.
+func TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican() // no spec.targetClusterRef: children stay local
+	barbican.Finalizers = []string{barbicanFinalizer}
+	r := newBarbicanTestReconciler(barbican)
+
+	_, err := r.Reconcile(context.Background(), barbicanRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getBarbican(t, r.Client).Finalizers).To(ConsistOf(barbicanFinalizer),
+		"a local CR must keep the finalizer set it always had")
 }

--- a/operators/barbican/internal/controller/barbicansecretstore_controller.go
+++ b/operators/barbican/internal/controller/barbicansecretstore_controller.go
@@ -7,6 +7,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ import (
 	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	"github.com/c5c3/forge/internal/common/secrets"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
 	"github.com/c5c3/forge/internal/common/watch"
 	barbicanv1alpha1 "github.com/c5c3/forge/operators/barbican/api/v1alpha1"
 	"github.com/c5c3/forge/operators/barbican/internal/metrics"
@@ -124,6 +126,16 @@ const (
 	// #nosec G101 -- annotation key naming the mint TTL, not a credential.
 	secretIDTTLSecondsAnnotation = "barbican.c5c3.io/secret-id-ttl-seconds"
 )
+
+// childrenClusterAnnotation names the target cluster this store's credentials
+// Secret was minted onto. The store itself has no target field: it inherits one
+// from its parent Barbican, and the teardown has to reach that cluster after the
+// parent may already be gone. Stamping the resolved name on the store is what
+// keeps the deletion independent of the parent's own lifetime. Both inputs it is
+// derived from are immutable, so the operator never has cause to rewrite what it
+// wrote — but it is an ordinary annotation on a user-created CR, so the value is
+// reconciled against the resolved name rather than trusted for being present.
+const childrenClusterAnnotation = "openstack.c5c3.io/children-cluster"
 
 // The values of the trigger label on the re-mint counter.
 const (
@@ -229,12 +241,23 @@ func barbicanSecretStoreInstanceRefExtractor(obj client.Object) []string {
 // only reads it (a ready store gates config projection) and writes an aggregated
 // condition onto the Barbican CR instead.
 //
-// There is deliberately NO finalizer. A managed store's credentials Secret is
-// owned by the CR and garbage-collected with it, and the AppRole itself is
-// shared instance state the self-init contract owns, not this CR — revoking it
-// on delete would break every other store on the same instance. Deleting a store
-// therefore only detaches it, and the parent Barbican de-projects the dropped
-// section on its next pass.
+// A store has two deletion lifecycles, and which one applies follows from where
+// its parent Barbican places its workload:
+//
+//   - Local parent. The credentials Secret is owned by the store CR and
+//     garbage-collected with it, so the store carries no finalizer and deleting
+//     it only detaches it.
+//   - Remote parent (the Barbican names spec.targetClusterRef). The Secret lives
+//     on that cluster, where an owner reference to this CR means nothing, so it
+//     is unowned and carries the ownership labels instead. The store records the
+//     cluster in the childrenClusterAnnotation and carries
+//     multicluster.RemoteChildrenFinalizer, and its deletion removes the Secret
+//     explicitly: no garbage collection cascade crosses the cluster boundary.
+//
+// The AppRole is shared instance state the self-init contract owns either way,
+// not this CR, and is never revoked: revoking it on delete would break every
+// other store on the same instance. In both cases the parent Barbican
+// de-projects the dropped section on its next pass.
 type BarbicanSecretStoreReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
@@ -267,7 +290,7 @@ type BarbicanSecretStoreReconciler struct {
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicansecretstores/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicansecretstores/finalizers,verbs=update
 // +kubebuilder:rbac:groups=barbican.openstack.c5c3.io,resources=barbicans,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // The TokenRequest grant is namespace-bound, not part of the operator's
 // ClusterRole: a cluster-wide grant would let anyone reaching this operator's
@@ -292,12 +315,20 @@ func (r *BarbicanSecretStoreReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, fmt.Errorf("fetching BarbicanSecretStore: %w", err)
 	}
 
-	// No finalizer (see the type doc): a deleting store only sheds its metric
-	// series, so the re-mint counter does not keep reporting a CR that is gone.
-	// Status is left untouched — writing to a terminating object is a no-op at
-	// best and a conflict at worst.
+	// A deleting store sheds its metric series on every pass, so the re-mint
+	// counter does not keep reporting a CR that is gone; the eviction is
+	// idempotent, which matters because the remote teardown below can requeue for
+	// minutes. Status is left untouched — writing to a terminating object is a
+	// no-op at best and a conflict at worst.
+	//
+	// A local store is done here (see the type doc): its credentials Secret is
+	// collected from the owner reference. Only a store whose Secret sits on a
+	// target cluster carries the finalizer, and only that one has cleanup to do.
 	if store.DeletionTimestamp != nil {
 		metrics.DeleteForBarbicanSecretStore(store.Name, store.Namespace)
+		if controllerutil.ContainsFinalizer(&store, commonmulticluster.RemoteChildrenFinalizer) {
+			return r.reconcileDeleteRemoteCredentials(ctx, &store)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -315,9 +346,17 @@ func (r *BarbicanSecretStoreReconciler) Reconcile(ctx context.Context, req ctrl.
 // Barbican, so it opens by resolving that parent's target cluster into the
 // children client the rest of the pass reads and writes with.
 func (r *BarbicanSecretStoreReconciler) reconcileNormal(ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore) (ctrl.Result, error) {
-	children, result, err := r.resolveChildren(ctx, store)
+	children, childrenCluster, result, err := r.resolveChildren(ctx, store)
 	if children == nil {
 		return result, err
+	}
+
+	// Both marks go on before anything is minted onto the target cluster, so a
+	// Secret can never exist there without a finalizer that deletes it.
+	if commonmulticluster.IsRemote(children) {
+		if result, err := r.ensureRemoteTeardownMarks(ctx, store, childrenCluster); !result.IsZero() || err != nil {
+			return result, err
+		}
 	}
 
 	spec := store.Spec.OpenBao
@@ -350,7 +389,9 @@ func (r *BarbicanSecretStoreReconciler) reconcileNormal(ctx context.Context, sto
 // with: the one the PARENT Barbican's spec.targetClusterRef selects. The store
 // has no target field of its own, so the AppRole credentials Secret it mints and
 // the OpenBao instance it authenticates against land wherever the parent's
-// workload runs — the same cluster the API pods read them from.
+// workload runs — the same cluster the API pods read them from. It also returns
+// the name of that cluster, empty for a parent that keeps its workload local, so
+// the caller can record it on the store for the teardown.
 //
 // A parent that does not exist holds the pass on CredentialsReady=False and
 // requeues, the same treatment an unresolvable target gets. Guessing the local
@@ -364,26 +405,231 @@ func (r *BarbicanSecretStoreReconciler) reconcileNormal(ctx context.Context, sto
 // on CredentialsReady, the store's first gate condition.
 func (r *BarbicanSecretStoreReconciler) resolveChildren(
 	ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore,
-) (client.Client, ctrl.Result, error) {
+) (client.Client, string, ctrl.Result, error) {
 	var parent barbicanv1alpha1.Barbican
 	parentKey := client.ObjectKey{Namespace: store.Namespace, Name: store.Spec.BarbicanRef.Name}
 	if err := r.Get(ctx, parentKey, &parent); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return nil, ctrl.Result{}, fmt.Errorf("fetching parent Barbican %s: %w", parentKey, err)
+			return nil, "", ctrl.Result{}, fmt.Errorf("fetching parent Barbican %s: %w", parentKey, err)
 		}
 		r.setCondition(store, conditionTypeCredentialsReady, metav1.ConditionFalse,
 			conditionReasonWaitingForParent,
 			fmt.Sprintf("parent Barbican %s does not exist; the cluster this store's credentials belong on is unknown", parentKey))
-		return nil, ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
+		return nil, "", ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
 	}
 
 	children, err := commonmulticluster.ResolveChildrenClient(ctx, r.Resolver, r.Client, parent.Spec.TargetClusterRef)
 	if err != nil {
 		r.setCondition(store, conditionTypeCredentialsReady, metav1.ConditionFalse,
 			commonmulticluster.TargetClusterUnavailable, err.Error())
-		return nil, ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
+		return nil, "", ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
 	}
-	return children, ctrl.Result{}, nil
+
+	var childrenCluster string
+	if parent.Spec.TargetClusterRef != nil {
+		childrenCluster = parent.Spec.TargetClusterRef.Name
+	}
+	return children, childrenCluster, ctrl.Result{}, nil
+}
+
+// ensureRemoteTeardownMarks records what the deletion path needs to find the
+// credentials Secret again: the annotation naming the cluster it is minted onto,
+// and the finalizer that keeps the store in etcd long enough to delete it. Both
+// are written before the mint, so a Secret on a target cluster always has a
+// finalizer behind it.
+//
+// The order between them is the invariant, and it is why this is two writes
+// rather than one: the annotation goes first, so a crash between them leaves an
+// annotation without a finalizer (which costs nothing, since nothing was minted
+// either) and never a finalizer whose handler cannot name the cluster it has to
+// clean up on. The name is derived from two immutable fields, so a second pass
+// finds the annotation it wrote and neither write repeats.
+func (r *BarbicanSecretStoreReconciler) ensureRemoteTeardownMarks(
+	ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore, childrenCluster string,
+) (ctrl.Result, error) {
+	// Compared against the resolved name, not merely tested for presence: the
+	// store is a user-created CR, so a principal who may update it can put any
+	// value under this key — an empty one included — before the operator's first
+	// pass. Left standing, that value would send the teardown at a cluster the
+	// Secret was never minted onto, or at none at all, and the credentials would
+	// be abandoned on the real target while the CR reported a clean deletion.
+	if store.Annotations[childrenClusterAnnotation] != childrenCluster {
+		if store.Annotations == nil {
+			store.Annotations = map[string]string{}
+		}
+		store.Annotations[childrenClusterAnnotation] = childrenCluster
+		if err := r.Update(ctx, store); err != nil {
+			return ctrl.Result{}, fmt.Errorf("recording the children cluster on the store: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, store, commonmulticluster.RemoteChildrenFinalizer); err != nil {
+		return ctrl.Result{}, err
+	} else if added {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// reconcileDeleteRemoteCredentials deletes the AppRole credentials Secret this
+// store minted onto a target cluster and then releases the remote-children
+// finalizer. Nothing on that cluster collects the Secret: it carries the
+// ownership labels rather than an owner reference, because a reference to a CR
+// living on the management cluster names a UID the target's garbage collector
+// cannot resolve.
+//
+// The AppRole behind those credentials is NOT touched. It is shared instance
+// state the self-init contract provisions, and every other store on the same
+// instance authenticates with it; only the Secret holding this store's secret ID
+// is this CR's to remove.
+//
+// The clusters to visit are named by the parent Barbican wherever it can still
+// be read and by the annotation the normal path stamped, which are usually the
+// same one and are each visited when they are not (see childrenClusters). The
+// annotation is what lets the store be deleted after its parent already is,
+// which is the ordinary order when a whole namespace goes.
+func (r *BarbicanSecretStoreReconciler) reconcileDeleteRemoteCredentials(
+	ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore,
+) (ctrl.Result, error) {
+	clusters, err := r.childrenClusters(ctx, store)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(clusters) == 0 {
+		// Neither mark survived: the annotation is absent and the parent is gone
+		// too, so nothing names the cluster the Secret is on. Waiting cannot
+		// produce the name, but the parent may still be terminating and about to
+		// be read one more time, so the store waits out the same window an
+		// unresolvable cluster gets before it gives the Secret up.
+		if r.now().Sub(store.DeletionTimestamp.Time) < commonmulticluster.AbandonAfter {
+			return ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
+		}
+		r.Recorder.Event(store, corev1.EventTypeWarning, "RemoteChildrenAbandoned",
+			"Neither this store nor a parent Barbican names the cluster its AppRole credentials Secret was minted onto; "+
+				"releasing the remote-children finalizer without deleting it")
+		return r.releaseRemoteChildrenFinalizer(ctx, store)
+	}
+
+	for _, cluster := range clusters {
+		children, wait := commonmulticluster.ResolveChildrenClientForDeletion(ctx, r.Resolver, r.Client,
+			&commonv1.TargetClusterRefSpec{Name: cluster}, *store.DeletionTimestamp)
+		if wait {
+			return ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil
+		}
+		if children == nil {
+			r.Recorder.Event(store, corev1.EventTypeWarning, "RemoteChildrenAbandoned",
+				fmt.Sprintf("Target cluster %s is no longer registered; releasing the remote-children finalizer without "+
+					"deleting the AppRole credentials Secret on it", cluster))
+			continue
+		}
+
+		if err := r.deleteRemoteCredentialsSecret(ctx, children, cluster, store); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return r.releaseRemoteChildrenFinalizer(ctx, store)
+}
+
+// childrenClusters names every cluster this store's credentials Secret may sit
+// on: the parent Barbican's target wherever the parent can still answer, and the
+// annotation the normal path stamped. They name the same cluster on every
+// ordinary teardown, and then this is one name. An empty result means neither
+// source answered, which is the parent having been deleted inside the crash
+// window between the annotation write and the finalizer add.
+//
+// Both are visited when they disagree, because neither source is authoritative
+// on its own and picking one leaves a live AppRole secret ID on the other with
+// no CR left to reclaim it:
+//
+//   - The parent can be gone, which is the ordinary order when a whole namespace
+//     is deleted, and it can also have been deleted and re-created under the same
+//     name against a different target since the mint. Its
+//     spec.targetClusterRef is immutable, but immutability is a transition rule
+//     the API server evaluates on UPDATE, and a delete/create pair is not one.
+//   - The annotation is an ordinary field of a user-created CR: anyone who may
+//     update the store can put a different registered cluster under that key, and
+//     nothing corrects the value once the store carries a deletionTimestamp,
+//     since the API server takes annotation writes on a terminating object and
+//     ensureRemoteTeardownMarks no longer runs.
+//
+// Visiting a cluster the Secret was never minted onto costs one read that finds
+// nothing, and the delete is gated on ownership either way (see
+// deleteRemoteCredentialsSecret), so a planted name cannot reach anything that
+// is not this store's own child.
+func (r *BarbicanSecretStoreReconciler) childrenClusters(ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore) ([]string, error) {
+	var clusters []string
+
+	var parent barbicanv1alpha1.Barbican
+	parentKey := client.ObjectKey{Namespace: store.Namespace, Name: store.Spec.BarbicanRef.Name}
+	switch err := r.Get(ctx, parentKey, &parent); {
+	case err == nil:
+		if parent.Spec.TargetClusterRef != nil {
+			clusters = append(clusters, parent.Spec.TargetClusterRef.Name)
+		}
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("fetching parent Barbican %s: %w", parentKey, err)
+	}
+
+	// A store carrying the finalizer minted somewhere, and the annotation is the
+	// only record of where that survives its parent.
+	annotated := store.Annotations[childrenClusterAnnotation]
+	if annotated != "" && !slices.Contains(clusters, annotated) {
+		clusters = append(clusters, annotated)
+	}
+	return clusters, nil
+}
+
+// deleteRemoteCredentialsSecret removes the credentials Secret from the named
+// target cluster, and only when this store owns it. A Secret of the same name
+// that somebody else provisioned there carries no ownership labels of ours and
+// is left standing: the store name is not a reservation on that namespace. That
+// gate is also what makes it safe to visit every cluster childrenClusters
+// returns rather than to pick one of them.
+func (r *BarbicanSecretStoreReconciler) deleteRemoteCredentialsSecret(
+	ctx context.Context, children client.Client, cluster string, store *barbicanv1alpha1.BarbicanSecretStore,
+) error {
+	credsKey := client.ObjectKey{Namespace: store.Namespace, Name: store.Name + approleSecretNameSuffix}
+
+	// Read through the target cluster's uncached API reader, never through the
+	// children client's cache. A NotFound here licenses the finalizer release, so
+	// a Secret the cache has not caught up on — an operator restart, a cluster
+	// engaged moments ago — would leave a live OpenBao secret ID materialized on
+	// the target with no CR left to delete it.
+	var creds corev1.Secret
+	if err := commonmulticluster.LiveReader(children).Get(ctx, credsKey, &creds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("fetching the AppRole credentials Secret %s for teardown: %w", credsKey, err)
+	}
+
+	owned, err := commonmulticluster.Controls(r.Scheme, store, &creds)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		log.FromContext(ctx).Info("leaving a foreign Secret of the store's credentials name behind",
+			"secret", credsKey, "targetCluster", cluster)
+		return nil
+	}
+
+	if err := children.Delete(ctx, &creds); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting the AppRole credentials Secret %s: %w", credsKey, err)
+	}
+	return nil
+}
+
+// releaseRemoteChildrenFinalizer drops the finalizer and persists the store, the
+// single exit of every teardown path above.
+func (r *BarbicanSecretStoreReconciler) releaseRemoteChildrenFinalizer(
+	ctx context.Context, store *barbicanv1alpha1.BarbicanSecretStore,
+) (ctrl.Result, error) {
+	controllerutil.RemoveFinalizer(store, commonmulticluster.RemoteChildrenFinalizer)
+	if err := r.Update(ctx, store); err != nil {
+		return ctrl.Result{}, fmt.Errorf("removing remote-children finalizer: %w", err)
+	}
+	return ctrl.Result{}, nil
 }
 
 // reconcileManaged provisions the store against the OpenBaoCluster it names: it
@@ -584,7 +830,11 @@ func (r *BarbicanSecretStoreReconciler) mintCredentials(
 		}
 		creds.Annotations[secretIDMintedAtAnnotation] = mintedAt.Format(time.RFC3339)
 		creds.Annotations[secretIDTTLSecondsAnnotation] = strconv.FormatInt(ttlSeconds, 10)
-		return controllerutil.SetControllerReference(store, creds, r.Scheme)
+		// A local Secret is claimed by a controller owner reference, one on a
+		// target cluster by the ownership labels the teardown selects on. The
+		// mutate touches no labels of its own, so the claim is the only writer of
+		// them and nothing can drop what it stamped.
+		return commonmulticluster.Claim(children, r.Scheme, store, creds)
 	}); err != nil {
 		return false, ctrl.Result{}, fmt.Errorf("writing the AppRole credentials Secret %s: %w", credsKey, err)
 	}

--- a/operators/barbican/internal/controller/barbicansecretstore_controller_test.go
+++ b/operators/barbican/internal/controller/barbicansecretstore_controller_test.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -314,6 +316,20 @@ func (f *storeFixture) reconcile(t *testing.T, store *barbicanv1alpha1.BarbicanS
 	return f.reconciler.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: client.ObjectKeyFromObject(store),
 	})
+}
+
+// reconcileRemote drives a store whose parent names a target cluster past its
+// two teardown marks and returns the result of the pass that does the work. The
+// annotation and the finalizer are written one per pass, each requeuing so the
+// next pass reads its own write back.
+func (f *storeFixture) reconcileRemote(t *testing.T, store *barbicanv1alpha1.BarbicanSecretStore) (reconcile.Result, error) {
+	t.Helper()
+	for range 2 {
+		if result, err := f.reconcile(t, store); err != nil {
+			return result, err
+		}
+	}
+	return f.reconcile(t, store)
 }
 
 // store re-reads the reconciled store.
@@ -1351,26 +1367,39 @@ func TestSecretStoreReconcile_ConfigProjection(t *testing.T) {
 // reaches for one.
 type fakeTargetCluster struct {
 	cluster.Cluster
-	c client.Client
+	c      client.Client
+	reader client.Reader
 }
 
 func (f fakeTargetCluster) GetClient() client.Client { return f.c }
 
-// A fake client is read-your-writes, so it stands in for the cluster's uncached
-// reader as readily as for its cached client.
-func (f fakeTargetCluster) GetAPIReader() client.Reader { return f.c }
+// GetAPIReader answers with the cluster's uncached reader. A test that sets none
+// gets the client itself, which for a fake is read-your-writes anyway.
+func (f fakeTargetCluster) GetAPIReader() client.Reader {
+	if f.reader != nil {
+		return f.reader
+	}
+	return f.c
+}
 
 // childrenResolver registers exactly one cluster under every name and records
 // the names it was asked for, so a test can prove which ref the store resolved —
-// or that it resolved none at all.
+// or that it resolved none at all. reader is the cluster's uncached view, set
+// only by the test that has the cache trail it. byName overrides children per
+// name, for the tests that need two clusters to hold different objects.
 type childrenResolver struct {
 	children client.Client
+	reader   client.Reader
+	byName   map[string]client.Client
 	names    []mcruntime.ClusterName
 }
 
 func (r *childrenResolver) GetCluster(_ context.Context, name mcruntime.ClusterName) (cluster.Cluster, error) {
 	r.names = append(r.names, name)
-	return fakeTargetCluster{c: r.children}, nil
+	if c, named := r.byName[string(name)]; named {
+		return fakeTargetCluster{c: c}, nil
+	}
+	return fakeTargetCluster{c: r.children, reader: r.reader}, nil
 }
 
 // targetedBarbican returns the parent Barbican placing its workload on the named
@@ -1385,7 +1414,7 @@ func targetedBarbican(target string) *barbicanv1alpha1.Barbican {
 // API a managed store reads its instance from, and deliberately WITHOUT the
 // barbican group — a store read or a status write misrouted to it then fails
 // with "no kind is registered" instead of passing on an empty result.
-func childrenFake(t *testing.T, objs ...client.Object) client.Client {
+func childrenFake(t *testing.T, objs ...client.Object) client.WithWatch {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
@@ -1416,9 +1445,10 @@ func TestSecretStoreReconcile_MintsCredentialsOnParentTargetCluster(t *testing.T
 	resolver := &childrenResolver{children: children}
 	f.reconciler.Resolver = resolver
 
-	_, err := f.reconcile(t, store)
+	_, err := f.reconcileRemote(t, store)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(resolver.names).To(Equal([]mcruntime.ClusterName{"edge-1"}),
+	g.Expect(resolver.names).NotTo(BeEmpty())
+	g.Expect(resolver.names).To(HaveEach(mcruntime.ClusterName("edge-1")),
 		"the store resolves the target its parent names, having none of its own")
 
 	credsKey := client.ObjectKey{Namespace: testNamespace, Name: testStoreName + approleSecretNameSuffix}
@@ -1508,6 +1538,468 @@ func TestSecretStoreReconcile_MissingParentHoldsCredentials(t *testing.T) {
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
 		"no credential may be minted while the target cluster is unknown")
 	g.Expect(f.bao.configs).To(BeEmpty(), "the server is not contacted either")
+}
+
+// --- remote teardown -------------------------------------------------------
+
+// terminatingRemoteStore returns a managed store that minted its credentials
+// onto childrenCluster and is now being deleted. It carries the remote-children
+// finalizer plus a foreign one, so the CR survives the release and a test can
+// read back which finalizer the pass dropped. An empty childrenCluster leaves
+// the annotation off, which is the crash window between the two teardown marks.
+func terminatingRemoteStore(childrenCluster string, deletedAt time.Time) *barbicanv1alpha1.BarbicanSecretStore {
+	store := testManagedStore()
+	if childrenCluster != "" {
+		store.Annotations = map[string]string{childrenClusterAnnotation: childrenCluster}
+	}
+	store.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	timestamp := metav1.NewTime(deletedAt)
+	store.DeletionTimestamp = &timestamp
+	return store
+}
+
+// claimedByStore stamps the ownership labels the remote claim writes, so a
+// Secret on the target cluster is recognizable as this store's child — the mark
+// that stands in for the owner reference no cross-cluster owner can carry.
+func claimedByStore(t *testing.T, store *barbicanv1alpha1.BarbicanSecretStore, secret *corev1.Secret) *corev1.Secret {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(testScheme(), store)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	secret.Labels = labels
+	return secret
+}
+
+// credentialsKey names the AppRole credentials Secret of the fixture store.
+var credentialsKey = client.ObjectKey{Namespace: testNamespace, Name: testStoreName + approleSecretNameSuffix}
+
+// TestSecretStoreReconcile_RemoteStoreStampsTheAnnotationBeforeTheFinalizer
+// pins the ordering the teardown depends on. The finalizer commits this
+// controller to deleting a Secret on another cluster; the annotation is the only
+// record of which cluster that is once the parent Barbican is gone. Writing them
+// in this order means a crash between the two writes leaves an annotation
+// without a finalizer, which costs nothing, and never a finalizer whose handler
+// cannot name its cluster.
+func TestSecretStoreReconcile_RemoteStoreStampsTheAnnotationBeforeTheFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := testManagedStore()
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	children := childrenFake(t, testInstance(true), testCASecret())
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}),
+		"the mark is read back from etcd on the next pass, not trusted in memory")
+	marked := f.store(t)
+	g.Expect(marked.Annotations).To(HaveKeyWithValue(childrenClusterAnnotation, "edge-1"))
+	g.Expect(marked.Finalizers).To(BeEmpty(), "the annotation is written first, on a pass of its own")
+	g.Expect(children.Get(ctx, credentialsKey, &corev1.Secret{})).NotTo(Succeed(),
+		"nothing is minted before both marks are on the store")
+
+	result, err = f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	marked = f.store(t)
+	g.Expect(marked.Finalizers).To(ConsistOf(commonmulticluster.RemoteChildrenFinalizer))
+	g.Expect(marked.Annotations).To(HaveKeyWithValue(childrenClusterAnnotation, "edge-1"),
+		"a finalizer never exists without the annotation naming the cluster it cleans up on")
+	g.Expect(children.Get(ctx, credentialsKey, &corev1.Secret{})).NotTo(Succeed())
+
+	_, err = f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(children.Get(ctx, credentialsKey, &corev1.Secret{})).To(Succeed(),
+		"the credential lands only once the teardown can find it again")
+}
+
+// TestSecretStoreReconcile_RemoteStoreCorrectsAPlantedAnnotation covers the
+// annotation as what it is: an ordinary field of a user-created CR. Anyone who
+// may update the store can put a value under that key before the operator's
+// first pass, and a stamp guarded on presence alone would keep it. The teardown
+// would then resolve a cluster the credentials were never minted onto — or, for
+// the empty value, none at all — abandon the live AppRole secret ID on the real
+// target, and release the finalizer reporting a clean deletion.
+func TestSecretStoreReconcile_RemoteStoreCorrectsAPlantedAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	store := testManagedStore()
+	store.Annotations = map[string]string{childrenClusterAnnotation: ""}
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	f.reconciler.Resolver = &childrenResolver{children: childrenFake(t, testInstance(true), testCASecret())}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	g.Expect(f.store(t).Annotations).To(HaveKeyWithValue(childrenClusterAnnotation, "edge-1"),
+		"the resolved cluster is authoritative, not whatever the annotation already said")
+}
+
+// TestSecretStoreReconcile_RemoteCredentialsAreClaimedByLabel pins how the
+// Secret is owned on a cluster the store CR does not live on. An owner reference
+// there names a UID the target's garbage collector cannot resolve, so the claim
+// is three labels instead, and they are what the teardown selects on.
+func TestSecretStoreReconcile_RemoteCredentialsAreClaimedByLabel(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := testManagedStore()
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	children := childrenFake(t, testInstance(true), testCASecret())
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	_, err := f.reconcileRemote(t, store)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var creds corev1.Secret
+	g.Expect(children.Get(ctx, credentialsKey, &creds)).To(Succeed())
+	g.Expect(creds.OwnerReferences).To(BeEmpty())
+	g.Expect(creds.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerKindLabel, "BarbicanSecretStore"))
+	g.Expect(creds.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerNameLabel, testStoreName))
+	g.Expect(creds.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerNamespaceLabel, testNamespace))
+}
+
+// TestSecretStoreReconcile_RemintDoesNotRefuseItsOwnRemoteSecret covers the
+// second pass over a Secret that is already there. The claim refuses to adopt a
+// live object it does not own, and a Secret read back from the API server is
+// live by definition (it has a UID), so a re-mint that could not recognize its
+// own child would fail every rotation from the first one on.
+func TestSecretStoreReconcile_RemintDoesNotRefuseItsOwnRemoteSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := testManagedStore()
+	store.Annotations = map[string]string{childrenClusterAnnotation: "edge-1"}
+	store.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer}
+
+	// Minted an hour ago against a one-hour TTL, so the pass is past the
+	// proactive threshold and re-mints. The UID is the one the API server would
+	// have assigned; the fake client assigns none on Create.
+	live := claimedByStore(t, store, testMintedSecret(testClock.Add(-time.Hour), "3600", testSecretID))
+	live.UID = types.UID("live-credentials-uid")
+
+	bao := newProvisionedFakeClient()
+	bao.secretIDs = []string{"fresh-secret-id"}
+	f := newStoreFixture(bao, store, targetedBarbican("edge-1"))
+	children := childrenFake(t, testInstance(true), testCASecret(), live)
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	_, err := f.reconcile(t, store)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var creds corev1.Secret
+	g.Expect(children.Get(ctx, credentialsKey, &creds)).To(Succeed())
+	g.Expect(creds.Data).To(HaveKeyWithValue(barbicanv1alpha1.OpenBaoSecretIDKey, []byte("fresh-secret-id")))
+	g.Expect(creds.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerNameLabel, testStoreName),
+		"the claim survives the update that re-mints")
+	g.Expect(condition(f.store(t), conditionTypeCredentialsReady).Status).To(Equal(metav1.ConditionTrue))
+}
+
+// TestSecretStoreReconcile_RemoteMintRefusesAForeignSecret is the other side of
+// that recognition. A live Secret of the same name that nobody claimed belongs
+// to whoever put it there: overwriting its data and stamping the ownership
+// labels on it would also get it deleted at this store's teardown.
+func TestSecretStoreReconcile_RemoteMintRefusesAForeignSecret(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := testManagedStore()
+	store.Annotations = map[string]string{childrenClusterAnnotation: "edge-1"}
+	store.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer}
+
+	foreign := managedApproleSecret(testStoreName, "someone-elses-role", "someone-elses-secret")
+	foreign.UID = types.UID("foreign-credentials-uid")
+
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	children := childrenFake(t, testInstance(true), testCASecret(), foreign)
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	_, err := f.reconcile(t, store)
+
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing")))
+	var untouched corev1.Secret
+	g.Expect(children.Get(ctx, credentialsKey, &untouched)).To(Succeed())
+	g.Expect(untouched.Data).To(HaveKeyWithValue(barbicanv1alpha1.OpenBaoSecretIDKey, []byte("someone-elses-secret")))
+	g.Expect(untouched.Labels).To(BeEmpty())
+}
+
+// TestSecretStoreDelete_DeletesRemoteCredentialsWithoutTheParent is what the
+// finalizer is for. The Secret sits on a cluster no garbage collection cascade
+// reaches from here, and the parent Barbican that named that cluster is already
+// gone — the ordinary order when a whole namespace is deleted. The annotation is
+// what still answers where to clean up.
+func TestSecretStoreDelete_DeletesRemoteCredentialsWithoutTheParent(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("edge-1", testClock)
+	creds := claimedByStore(t, store, managedApproleSecret(testStoreName, testRoleID, testSecretID))
+	f := newStoreFixtureWithoutParent(newProvisionedFakeClient(), store)
+	children := childrenFake(t, creds)
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	err = children.Get(ctx, credentialsKey, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"nothing on the target cluster deletes the Secret, so the teardown has to")
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_ForeignSecretOfTheSameNameSurvives keeps the teardown as
+// narrow as the claim: the store name reserves nothing in a namespace it shares,
+// and a Secret carrying none of this store's ownership labels is not its to
+// delete. Leaving it standing must still release the finalizer, or the CR would
+// hang on an object it may never touch.
+func TestSecretStoreDelete_ForeignSecretOfTheSameNameSurvives(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("edge-1", testClock)
+	foreign := managedApproleSecret(testStoreName, "someone-elses-role", "someone-elses-secret")
+	f := newStoreFixtureWithoutParent(newProvisionedFakeClient(), store)
+	children := childrenFake(t, foreign)
+	f.reconciler.Resolver = &childrenResolver{children: children}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	var survivor corev1.Secret
+	g.Expect(children.Get(ctx, credentialsKey, &survivor)).To(Succeed())
+	g.Expect(survivor.Data).To(HaveKeyWithValue(barbicanv1alpha1.OpenBaoSecretIDKey, []byte("someone-elses-secret")))
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"a Secret this store may not delete must not pin it either")
+}
+
+// TestSecretStoreDelete_ReadsTheCredentialsThroughTheUncachedReader pins where
+// the teardown looks. A NotFound is what licenses the finalizer release, so a
+// Secret the target's informer cache has not caught up on — an operator
+// restarted, a cluster engaged moments ago — would be reported as already gone
+// and left behind: a live OpenBao role ID and secret ID materialized on a
+// cluster with no CR left to delete them.
+func TestSecretStoreDelete_ReadsTheCredentialsThroughTheUncachedReader(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("edge-1", testClock)
+	creds := claimedByStore(t, store, managedApproleSecret(testStoreName, testRoleID, testSecretID))
+	children := childrenFake(t, creds)
+	// One cluster, two views of it: the cache has not caught up with the Secret
+	// the API server already serves.
+	stale := interceptor.NewClient(children, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if key == credentialsKey {
+				return apierrors.NewNotFound(corev1.Resource("secrets"), key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	f := newStoreFixtureWithoutParent(newProvisionedFakeClient(), store)
+	f.reconciler.Resolver = &childrenResolver{children: stale, reader: children}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	err = children.Get(ctx, credentialsKey, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"the credential must be deleted from live state, not declared gone by a cache")
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_FallsBackToTheParentTargetRef covers the crash window
+// between the two teardown marks: a store that carries the finalizer without the
+// annotation. The parent Barbican still names the cluster, so the cleanup runs
+// off it rather than giving up.
+func TestSecretStoreDelete_FallsBackToTheParentTargetRef(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("", testClock)
+	creds := claimedByStore(t, store, managedApproleSecret(testStoreName, testRoleID, testSecretID))
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	children := childrenFake(t, creds)
+	resolver := &childrenResolver{children: children}
+	f.reconciler.Resolver = resolver
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	g.Expect(resolver.names).To(ConsistOf(mcruntime.ClusterName("edge-1")))
+	err = children.Get(ctx, credentialsKey, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_PlantedAnnotationCannotDivertTheSweep is the
+// deletion-path half of the guard the normal path carries. Nothing corrects the
+// annotation once the store has a deletionTimestamp — the API server takes
+// annotation writes on a terminating object, and the normal path no longer runs
+// — so a planted name must not be able to send the teardown somewhere else and
+// have the finalizer released on a live AppRole secret ID abandoned on the real
+// target. The parent still names that target, so the Secret goes; the planted
+// cluster is visited too, and finds nothing to take.
+func TestSecretStoreDelete_PlantedAnnotationCannotDivertTheSweep(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("planted-edge", testClock)
+	creds := claimedByStore(t, store, managedApproleSecret(testStoreName, testRoleID, testSecretID))
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-1"))
+	children := childrenFake(t, creds)
+	planted := childrenFake(t)
+	resolver := &childrenResolver{byName: map[string]client.Client{"edge-1": children, "planted-edge": planted}}
+	f.reconciler.Resolver = resolver
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	g.Expect(resolver.names).To(HaveExactElements(
+		mcruntime.ClusterName("edge-1"), mcruntime.ClusterName("planted-edge")),
+		"the cluster the parent names is visited, and first")
+	err = children.Get(ctx, credentialsKey, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"the finalizer may only be released once the real Secret is gone")
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_ReachesTheClusterOnlyTheAnnotationStillNames covers the
+// parent that answers with the wrong cluster. spec.targetClusterRef is immutable
+// under a CEL transition rule, and a transition rule is evaluated on UPDATE
+// only: deleting the parent Barbican and re-creating it under the same name
+// against another target moves it without one ever firing. The annotation still
+// names where this store minted, so the Secret there is deleted rather than left
+// holding a live secret ID with no CR to reclaim it.
+func TestSecretStoreDelete_ReachesTheClusterOnlyTheAnnotationStillNames(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := terminatingRemoteStore("edge-1", testClock)
+	creds := claimedByStore(t, store, managedApproleSecret(testStoreName, testRoleID, testSecretID))
+	// The parent was re-created against edge-2 since the mint; nothing on it
+	// records that this store's Secret is still on edge-1.
+	f := newStoreFixture(newProvisionedFakeClient(), store, targetedBarbican("edge-2"))
+	minted := childrenFake(t, creds)
+	current := childrenFake(t)
+	resolver := &childrenResolver{byName: map[string]client.Client{"edge-1": minted, "edge-2": current}}
+	f.reconciler.Resolver = resolver
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	g.Expect(resolver.names).To(ContainElement(mcruntime.ClusterName("edge-1")),
+		"the cluster the annotation names is visited even while the parent answers")
+	err = minted.Get(ctx, credentialsKey, &corev1.Secret{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+		"a Secret the parent no longer points at is still this store's to delete")
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_WithoutAnyClusterNameWaitsThenAbandons covers the one
+// state neither mark answers: no annotation and no parent either. Waiting cannot
+// produce the name, but a parent deleted moments ago may still be readable on
+// the next pass, so the store sits out the abandon window before it gives the
+// Secret up rather than stranding itself in Terminating.
+func TestSecretStoreDelete_WithoutAnyClusterNameWaitsThenAbandons(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	waiting := terminatingRemoteStore("", testClock)
+	f := newStoreFixtureWithoutParent(newProvisionedFakeClient(), waiting)
+
+	result, err := f.reconcile(t, waiting)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(commonreconcile.RequeueSecretPolling))
+	g.Expect(f.store(t).Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+	g.Expect(f.warnings()).To(BeEmpty(), "nothing is abandoned while the name may still appear")
+
+	// The same store, deleted longer ago than the window: the Secret is given up,
+	// and it is announced rather than dropped silently.
+	abandoned := terminatingRemoteStore("", testClock.Add(-2*commonmulticluster.AbandonAfter))
+	f = newStoreFixtureWithoutParent(newProvisionedFakeClient(), abandoned)
+
+	result, err = f.reconcile(t, abandoned)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	g.Expect(f.warnings()).To(ContainElement(ContainSubstring("RemoteChildrenAbandoned")))
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_AbandonsAnUnresolvableTargetCluster covers the cluster
+// the store can name but nothing can reach: deregistering a target is a
+// documented operation, and the store that minted onto it carries the finalizer
+// by then. Its Secret is unreachable either way, so the CR is released rather
+// than left Terminating — but only after the window, because engagement is
+// asynchronous and a cluster that has not been engaged yet looks the same.
+func TestSecretStoreDelete_AbandonsAnUnresolvableTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	abandonAfter := commonmulticluster.AbandonAfter
+	t.Cleanup(func() { commonmulticluster.AbandonAfter = abandonAfter })
+	commonmulticluster.AbandonAfter = time.Millisecond
+
+	// Deleted at wall-clock now: the two windows the resolver weighs run against
+	// the real clock, not this controller's injected one.
+	store := terminatingRemoteStore("deregistered-edge", time.Now())
+	f := newStoreFixtureWithoutParent(newProvisionedFakeClient(), store)
+	f.reconciler.Resolver = unresolvableResolver{}
+
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(commonreconcile.RequeueSecretPolling),
+		"the first pass this process fails to resolve on starts the window, it does not end it")
+	g.Expect(f.store(t).Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+	time.Sleep(10 * commonmulticluster.AbandonAfter)
+
+	result, err = f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	g.Expect(f.warnings()).To(ContainElement(ContainSubstring("RemoteChildrenAbandoned")))
+	g.Expect(f.store(t).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestSecretStoreDelete_LocalStoreCarriesNoTeardownMarks pins the unchanged half.
+// A store whose parent keeps its workload on the management cluster owns its
+// Secret by owner reference, so the cascade collects it: no annotation, no
+// finalizer, and deleting the CR takes it straight out of etcd.
+func TestSecretStoreDelete_LocalStoreCarriesNoTeardownMarks(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	store := testManagedStore()
+	f := newStoreFixture(newProvisionedFakeClient(),
+		append(projectedConfigObjects(), store, testInstance(true), testCASecret())...)
+
+	_, err := f.reconcile(t, store)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	local := f.store(t)
+	g.Expect(local.Annotations).NotTo(HaveKey(childrenClusterAnnotation))
+	g.Expect(local.Finalizers).To(BeEmpty())
+	creds := f.credentialsSecret(t)
+	g.Expect(creds.OwnerReferences).To(HaveLen(1), "the cascade needs the reference the labels stand in for remotely")
+	g.Expect(creds.Labels).NotTo(HaveKey(commonmulticluster.OwnerKindLabel))
+
+	g.Expect(f.reconciler.Delete(ctx, local)).To(Succeed())
+	result, err := f.reconcile(t, store)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.IsZero()).To(BeTrue())
+	err = f.reconciler.Get(ctx, client.ObjectKeyFromObject(store), &barbicanv1alpha1.BarbicanSecretStore{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no finalizer holds a local store back")
 }
 
 // --- watch mappers ---------------------------------------------------------

--- a/operators/barbican/internal/controller/barbicansecretstore_controller_test.go
+++ b/operators/barbican/internal/controller/barbicansecretstore_controller_test.go
@@ -1356,6 +1356,10 @@ type fakeTargetCluster struct {
 
 func (f fakeTargetCluster) GetClient() client.Client { return f.c }
 
+// A fake client is read-your-writes, so it stands in for the cluster's uncached
+// reader as readily as for its cached client.
+func (f fakeTargetCluster) GetAPIReader() client.Reader { return f.c }
+
 // childrenResolver registers exactly one cluster under every name and records
 // the names it was asked for, so a test can prove which ref the store resolved —
 // or that it resolved none at all.

--- a/operators/barbican/internal/controller/reconcile_config.go
+++ b/operators/barbican/internal/controller/reconcile_config.go
@@ -145,7 +145,7 @@ func (r *BarbicanReconciler) reconcileConfig(ctx context.Context, children clien
 		markConfigFailed(barbican, err)
 		return ctrl.Result{}, "", fmt.Errorf("creating config Secret: %w", err)
 	}
-	if err := config.PruneImmutableSecrets(ctx, children, barbican, config.PruneOptions{
+	if err := config.PruneImmutableSecrets(ctx, children, r.Scheme, barbican, config.PruneOptions{
 		BaseName:    barbican.Name + "-config",
 		Namespace:   barbican.Namespace,
 		CurrentName: secretName,

--- a/operators/glance/api/v1alpha1/glance_types.go
+++ b/operators/glance/api/v1alpha1/glance_types.go
@@ -240,12 +240,15 @@ type GlanceSpec struct {
 	// behaves exactly like a single-cluster one. The field is immutable (see the
 	// transition rules on this spec).
 	//
-	// A remote child carries an owner reference to a CR that lives on a
-	// different cluster, so that reference dangles. Until issue #837 replaces
-	// the owner references with an explicit remote-cleanup path, a target
-	// cluster must not have the service CRDs installed: with the CRDs present
-	// its garbage collector resolves the owner reference to a missing object and
-	// deletes the children.
+	// A child written to the target carries no owner reference, since nothing
+	// on that cluster resolves one into the management cluster. Three labels
+	// name the owner instead: openstack.c5c3.io/owner-kind,
+	// openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+	// Deleting the CR deletes the children that carry its labels, under a
+	// finalizer the CR installs whenever the ref is set, so a target cluster
+	// may have the service CRDs installed. A cluster deregistered past the
+	// abandon window is the exception: its children cannot be reached and stay
+	// behind on it.
 	// +optional
 	TargetClusterRef *commonv1.TargetClusterRefSpec `json:"targetClusterRef,omitempty"`
 

--- a/operators/glance/config/crd/bases/glance.openstack.c5c3.io_glances.yaml
+++ b/operators/glance/config/crd/bases/glance.openstack.c5c3.io_glances.yaml
@@ -1867,12 +1867,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/glance/helm/glance-operator/crds/glance.openstack.c5c3.io_glances.yaml
+++ b/operators/glance/helm/glance-operator/crds/glance.openstack.c5c3.io_glances.yaml
@@ -1870,12 +1870,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/glance/internal/controller/glance_controller.go
+++ b/operators/glance/internal/controller/glance_controller.go
@@ -269,6 +269,31 @@ func markConfigFailed(glance *glancev1alpha1.Glance, err error) {
 	glanceSkeleton.MarkFailed(glance, "SecretsReady", conditionReasonConfigError, err)
 }
 
+// glanceRemoteChildKinds are the kinds a Glance CR projects into the namespace
+// of the target cluster it names, and the kinds reconcileDeleteRemoteChildren
+// sweeps by ownership label when that CR is deleted. Nothing on the target
+// cluster collects them, so a kind missing from this list is a kind that keeps
+// running after its CR is gone.
+//
+// The list is cross-checked against the create verbs of the kubebuilder RBAC
+// markers on this controller below: the operator can only leave behind what it
+// is allowed to create.
+var glanceRemoteChildKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	corev1.SchemeGroupVersion.WithKind("Service"),
+	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+	corev1.SchemeGroupVersion.WithKind("Secret"),
+	batchv1.SchemeGroupVersion.WithKind("Job"),
+	batchv1.SchemeGroupVersion.WithKind("CronJob"),
+	policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+	autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+	networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+	httpRouteGVK,
+	mariadbv1alpha1.GroupVersion.WithKind("Database"),
+	mariadbv1alpha1.GroupVersion.WithKind("User"),
+	mariadbv1alpha1.GroupVersion.WithKind("Grant"),
+}
+
 // +kubebuilder:rbac:groups=glance.openstack.c5c3.io,resources=glances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=glance.openstack.c5c3.io,resources=glances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=glance.openstack.c5c3.io,resources=glances/finalizers,verbs=update
@@ -334,7 +359,18 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return r.updateStatus(ctx, &glance, statusBefore,
 				ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil)
 		}
-		return r.reconcileDelete(ctx, children, &glance)
+		if result, err := r.reconcileDelete(ctx, children, &glance); !result.IsZero() || err != nil {
+			return result, err
+		}
+		// The label-selected sweep runs after the named MariaDB cleanup, never
+		// before it: that flow waits one pass on the CRs it deletes by name, and a
+		// sweep running first would delete them out from under it. The ordering
+		// mirrors the local one, where the garbage collection cascade starts only
+		// once every finalizer has been released.
+		if err := r.reconcileDeleteRemoteChildren(ctx, children, &glance); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Resolve the client every child object of this CR is read and written with.
@@ -362,6 +398,20 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	} else if added {
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// The remote-children finalizer goes on only when the CR projects onto a
+	// target cluster. A local CR keeps the garbage collection cascade, which
+	// reaps its children from their owner references, so it has nothing for this
+	// finalizer to hold the CR open for. spec.targetClusterRef is immutable, so
+	// the condition cannot flip under a live CR.
+	if glance.Spec.TargetClusterRef != nil {
+		if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, &glance,
+			commonmulticluster.RemoteChildrenFinalizer); err != nil {
+			return ctrl.Result{}, err
+		} else if added {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Snapshot the persisted status so updateStatus can skip the write when a
@@ -510,9 +560,9 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // the per-CR metrics, evicts the health-probe cache, and releases the finalizer.
 //
 // A nil children client means the target cluster this CR named is no longer
-// registered. Its MariaDB CRs cannot be reached, so they are left behind (the
-// remote-ownership gap #837 tracks) and the finalizer is released anyway:
-// holding it would only strand the CR in Terminating.
+// registered. Its MariaDB CRs cannot be reached, so they stay behind on a
+// cluster that has not resolved for the whole abandon window, and the finalizer
+// is released anyway: holding it would only strand the CR in Terminating.
 func (r *GlanceReconciler) reconcileDelete(ctx context.Context, children client.Client, glance *glancev1alpha1.Glance) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(glance, glanceFinalizer) {
 		return ctrl.Result{}, nil
@@ -556,6 +606,16 @@ func (r *GlanceReconciler) reconcileDelete(ctx context.Context, children client.
 	// name/namespace never serves a stale probe keyed on the deleted CR's UID.
 	r.evictHealthProbe(client.ObjectKeyFromObject(glance))
 	return ctrl.Result{}, nil
+}
+
+// reconcileDeleteRemoteChildren deletes everything this Glance projected onto
+// the target cluster it names and releases the remote-children finalizer, as
+// commonmulticluster.SweepRemoteChildren documents. reconcileDelete above
+// deletes the three MariaDB CRs it tracks by name; this pass is what reaches the
+// rest, selected on the ownership labels Claim stamped on them.
+func (r *GlanceReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, glance *glancev1alpha1.Glance) error {
+	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
+		glance, glance.Spec.TargetClusterRef, children, glanceRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given

--- a/operators/glance/internal/controller/glance_controller_test.go
+++ b/operators/glance/internal/controller/glance_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
@@ -354,4 +356,185 @@ func TestRegisterGlanceBackendIndexes_RegistersBothKeys(t *testing.T) {
 	idx := &recordingFieldIndexer{}
 	g.Expect(registerGlanceBackendIndexes(context.Background(), idx)).To(Succeed())
 	g.Expect(idx.keys).To(ConsistOf(GlanceBackendGlanceRefIndexKey, GlanceBackendSecretNameIndexKey))
+}
+
+// --- remote children -------------------------------------------------------
+
+// ownedRemoteChild stamps the ownership labels the projection wrote on a child
+// it put on the target cluster, so the sweep selects it exactly as it would
+// there.
+func ownedRemoteChild(t *testing.T, owner, child client.Object) client.Object {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(testScheme(), owner)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	child.SetLabels(labels)
+	return child
+}
+
+// terminatingRemoteGlance returns a Glance that names a target cluster and is
+// being deleted, carrying the remote-children finalizer plus a foreign one so
+// the CR survives the release and the test can read back which finalizers the
+// pass dropped.
+func terminatingRemoteGlance(t *testing.T) (*GlanceReconciler, *glancev1alpha1.Glance) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	glance.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	glance.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	deletedAt := metav1.NewTime(time.Now())
+	glance.DeletionTimestamp = &deletedAt
+
+	r := newGlanceTestReconciler(glance)
+	var terminating glancev1alpha1.Glance
+	g.Expect(r.Get(context.Background(), glanceRequest.NamespacedName, &terminating)).To(Succeed())
+	return r, &terminating
+}
+
+// TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild is the whole point
+// of the finalizer: no garbage collection cascade crosses the cluster boundary,
+// so the objects this CR projected have to be deleted by name from here, across
+// every API group they live in. What the sweep leaves standing matters as much:
+// a target cluster carries other people's objects, and an object nobody claimed
+// or another CR claimed is not ours to remove.
+func TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteGlance(t)
+
+	deployment := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-glance", Namespace: "default"}})
+	service := ownedRemoteChild(t, terminating,
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-glance", Namespace: "default"}})
+	cronJob := ownedRemoteChild(t, terminating,
+		&batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "test-glance-db-purge", Namespace: "default"}})
+	grant := ownedRemoteChild(t, terminating,
+		&mariadbv1alpha1.Grant{ObjectMeta: metav1.ObjectMeta{Name: "test-glance", Namespace: "default"}})
+	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: "default"}}
+	foreign := ownedRemoteChild(t,
+		&glancev1alpha1.Glance{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other-backends", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(deployment, service, cronJob, grant, unlabelled, foreign).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, child := range []client.Object{deployment, service, cronJob, grant} {
+		err := target.Get(ctx, client.ObjectKeyFromObject(child), child.DeepCopyObject().(client.Object))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "%T %s must be swept", child, child.GetName())
+	}
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(unlabelled), &corev1.ConfigMap{})).To(Succeed(),
+		"an object nobody claimed is nobody's child")
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(foreign), &corev1.Secret{})).To(Succeed(),
+		"another Glance's child must survive this one's teardown")
+
+	updated := getGlance(t, r.Client, "test-glance")
+	g.Expect(updated.Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"a completed sweep must release the remote-children finalizer and nothing else")
+}
+
+// TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases covers the
+// deregistered target cluster. Its children cannot be reached, so holding the
+// finalizer would only strand the CR in Terminating; the objects left running
+// are announced rather than silently dropped. Any attempt to sweep through the
+// nil client would fault, which is what proves nothing was deleted.
+func TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteGlance(t)
+
+	err := r.reconcileDeleteRemoteChildren(context.Background(), nil, terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(collectEvents(r.Recorder.(*record.FakeRecorder))).
+		To(ContainElement(ContainSubstring("RemoteChildrenAbandoned")))
+	g.Expect(getGlance(t, r.Client, "test-glance").Finalizers).NotTo(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"an unreachable target cluster must not pin the CR forever")
+}
+
+// TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp pins the guard a
+// local CR relies on. It never carries the finalizer, its children are collected
+// from their owner references, and a sweep running anyway would delete objects
+// on the management cluster that the cascade already owns.
+func TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	r := newGlanceTestReconciler(glance)
+
+	child := ownedRemoteChild(t, glance,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-glance", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), glance)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed(),
+		"a CR without the finalizer must not sweep anything")
+	g.Expect(collectEvents(r.Recorder.(*record.FakeRecorder))).To(BeEmpty())
+}
+
+// TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer is the guard
+// against a CR that leaves etcd while its children keep running. A list the
+// target cluster refuses says nothing about whether children exist, so the pass
+// has to fail and sweep again on the next one.
+func TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteGlance(t)
+
+	child := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-glance", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "DeploymentList" {
+					return apierrors.NewForbidden(appsv1.Resource("deployments"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).To(MatchError(ContainSubstring("listing remote Deployment children for teardown")))
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed())
+	g.Expect(getGlance(t, r.Client, "test-glance").Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"a failed sweep must keep the finalizer so the next pass retries")
+}
+
+// TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster verifies that a
+// CR naming a target cluster is pinned before anything is projected onto it, so
+// a deletion issued between this pass and the next still funnels through the
+// sweep.
+func TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	glance.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	glance.Finalizers = []string{glanceFinalizer} // skip the database finalizer-add requeue
+	r := newGlanceTestReconciler(glance)
+
+	res, err := r.Reconcile(context.Background(), glanceRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{Requeue: true}),
+		"the pass installing the finalizer must requeue before any sub-reconciler runs")
+	g.Expect(getGlance(t, r.Client, "test-glance").Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+}
+
+// TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer pins the other
+// half. A CR that keeps its children on the management cluster has nothing for
+// the sweep to do, and a finalizer it does not need is one more thing that can
+// block its deletion.
+func TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance() // no spec.targetClusterRef: children stay local
+	glance.Finalizers = []string{glanceFinalizer}
+	r := newGlanceTestReconciler(glance)
+
+	_, err := r.Reconcile(context.Background(), glanceRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getGlance(t, r.Client, "test-glance").Finalizers).To(ConsistOf(glanceFinalizer),
+		"a local CR must keep the finalizer set it always had")
 }

--- a/operators/glance/internal/controller/glancebackend_controller_test.go
+++ b/operators/glance/internal/controller/glancebackend_controller_test.go
@@ -97,6 +97,10 @@ type fakeTargetCluster struct {
 
 func (f fakeTargetCluster) GetClient() client.Client { return f.c }
 
+// A fake client is read-your-writes, so it stands in for both the cached client
+// and the uncached reader the write sites read live state through.
+func (f fakeTargetCluster) GetAPIReader() client.Reader { return f.c }
+
 // childrenResolver registers exactly one cluster under every name and records
 // the names it was asked for, so a test can prove which ref a backend resolved —
 // or that it resolved none at all.

--- a/operators/glance/internal/controller/reconcile_backends.go
+++ b/operators/glance/internal/controller/reconcile_backends.go
@@ -194,7 +194,7 @@ func (r *GlanceReconciler) reconcileBackends(ctx context.Context, children clien
 	if err != nil {
 		return ctrl.Result{}, backendsProjection{}, fmt.Errorf("creating backends Secret: %w", err)
 	}
-	if err := config.PruneImmutableSecrets(ctx, children, glance, config.PruneOptions{
+	if err := config.PruneImmutableSecrets(ctx, children, r.Scheme, glance, config.PruneOptions{
 		BaseName:    glance.Name + "-backends",
 		Namespace:   glance.Namespace,
 		CurrentName: secretName,

--- a/operators/glance/internal/controller/reconcile_config.go
+++ b/operators/glance/internal/controller/reconcile_config.go
@@ -178,7 +178,7 @@ func (r *GlanceReconciler) reconcileConfig(ctx context.Context, children client.
 		markConfigFailed(glance, err)
 		return ctrl.Result{}, configArtifacts{}, fmt.Errorf("creating config ConfigMap: %w", err)
 	}
-	if err := config.PruneImmutableConfigMaps(ctx, children, glance, config.PruneOptions{
+	if err := config.PruneImmutableConfigMaps(ctx, children, r.Scheme, glance, config.PruneOptions{
 		BaseName:    glance.Name + "-config",
 		Namespace:   glance.Namespace,
 		CurrentName: configMapName,

--- a/operators/horizon/api/v1alpha1/horizon_types.go
+++ b/operators/horizon/api/v1alpha1/horizon_types.go
@@ -201,12 +201,15 @@ type HorizonSpec struct {
 	// behaves exactly like a single-cluster one. The field is immutable (see the
 	// transition rules on this spec).
 	//
-	// A remote child carries an owner reference to a CR that lives on a
-	// different cluster, so that reference dangles. Until issue #837 replaces
-	// the owner references with an explicit remote-cleanup path, a target
-	// cluster must not have the service CRDs installed: with the CRDs present
-	// its garbage collector resolves the owner reference to a missing object and
-	// deletes the children.
+	// A child written to the target carries no owner reference, since nothing
+	// on that cluster resolves one into the management cluster. Three labels
+	// name the owner instead: openstack.c5c3.io/owner-kind,
+	// openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+	// Deleting the CR deletes the children that carry its labels, under a
+	// finalizer the CR installs whenever the ref is set, so a target cluster
+	// may have the service CRDs installed. A cluster deregistered past the
+	// abandon window is the exception: its children cannot be reached and stay
+	// behind on it.
 	// +optional
 	TargetClusterRef *commonv1.TargetClusterRefSpec `json:"targetClusterRef,omitempty"`
 

--- a/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/config/crd/bases/horizon.openstack.c5c3.io_horizons.yaml
@@ -1128,12 +1128,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
+++ b/operators/horizon/helm/horizon-operator/crds/horizon.openstack.c5c3.io_horizons.yaml
@@ -1131,12 +1131,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/horizon/internal/controller/horizon_controller.go
+++ b/operators/horizon/internal/controller/horizon_controller.go
@@ -6,8 +6,12 @@
 //
 // Horizon is the deliberately thin operator profile: a stateless Django/WSGI
 // dashboard with no database, message bus, fernet, bootstrap, or upgrade
-// machinery, and no finalizer — every owned resource is namespace-scoped and
-// garbage-collected via ownerReferences when the CR is deleted.
+// machinery. A CR that keeps its children on the management cluster carries no
+// finalizer either: every owned resource is namespace-scoped and
+// garbage-collected via ownerReferences when the CR is deleted. Only a CR that
+// projects onto a target cluster is finalized, because no garbage collection
+// cascade crosses a cluster boundary and the operator has to delete those
+// children itself.
 package controller
 
 import (
@@ -28,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -153,6 +158,27 @@ var httpRouteGVK = schema.GroupVersionKind{
 	Kind:    "HTTPRoute",
 }
 
+// horizonRemoteChildKinds are the kinds a Horizon CR projects into the namespace
+// of the target cluster it names, and the kinds reconcileDeleteRemoteChildren
+// sweeps by ownership label when that CR is deleted. Nothing on the target
+// cluster collects them, so a kind missing from this list is a kind that keeps
+// running after its CR is gone.
+//
+// The list is cross-checked against the create verbs of the kubebuilder RBAC
+// markers on this controller below: the operator can only leave behind what it
+// is allowed to create. It is the shortest of the operators' lists, because
+// horizon composes no Secret, Job, CronJob, or MariaDB CR — it reads the
+// SECRET_KEY Secret that ESO materializes rather than writing one.
+var horizonRemoteChildKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	corev1.SchemeGroupVersion.WithKind("Service"),
+	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+	policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+	autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+	networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+	httpRouteGVK,
+}
+
 // +kubebuilder:rbac:groups=horizon.openstack.c5c3.io,resources=horizons,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=horizon.openstack.c5c3.io,resources=horizons/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=horizon.openstack.c5c3.io,resources=horizons/finalizers,verbs=update
@@ -180,20 +206,45 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("fetching Horizon: %w", err)
 	}
 
-	// No finalizer: every owned resource is namespace-scoped and reclaimed by
-	// Kubernetes garbage collection via ownerReferences, so a deleting CR
-	// needs no cleanup pass — skip all work and let GC finish.
+	// A CR whose children stay on the management cluster carries no finalizer:
+	// every owned resource is namespace-scoped and reclaimed by Kubernetes
+	// garbage collection via ownerReferences, so a deleting CR needs no cleanup
+	// pass — skip all work and let GC finish.
 	//
-	// That holds on the management cluster. Children written to a target
-	// cluster carry an owner reference to a CR that does not exist there, and
-	// the target's garbage collector cannot resolve it while the Horizon CRD is
-	// absent — which is what the reference documentation requires target
-	// clusters to be. Deleting such a CR therefore leaves its Deployment,
-	// Service, HTTPRoute, and Secret running on the target, unowned and
-	// unreconciled. That is the remote-ownership gap #837 tracks, and it is the
-	// same leak the other four operators take for everything their finalizers
-	// do not delete.
+	// A CR that projects onto a target cluster carries the remote-children
+	// finalizer and sweeps instead. Its children are written unowned there (an
+	// owner reference would name a UID that cluster cannot resolve) and no
+	// cascade crosses the boundary, so the projection is deleted from here. A
+	// target cluster that stays unresolvable past the abandon window is the one
+	// case that keeps the projection.
+	//
+	// The sweep resolves through the deletion variant, which never fails the
+	// pass: a CR whose cluster was deregistered after the finalizer went on would
+	// otherwise short-circuit on the unresolvable ref on every pass and stay
+	// Terminating forever. A target that has not resolved yet requeues instead of
+	// being given up on — engagement is asynchronous, so an operator restart
+	// looks exactly like a deregistration until the provider has synced.
 	if !horizon.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(&horizon, commonmulticluster.RemoteChildrenFinalizer) {
+			children, wait := commonmulticluster.ResolveChildrenClientForDeletion(
+				ctx, r.Resolver, r.Client, horizon.Spec.TargetClusterRef, *horizon.DeletionTimestamp)
+			if wait {
+				// The hold goes on the CR, not only into the operator's log. It is a
+				// deliberate state a CR can sit in for minutes, and "Terminating,
+				// waiting on the target cluster" has to be distinguishable from a
+				// wedged finalizer without correlating logs across replicas.
+				statusBefore := horizon.Status.DeepCopy()
+				horizonSkeleton.MarkFailed(&horizon, "SecretsReady",
+					commonmulticluster.TargetClusterUnavailable,
+					fmt.Errorf("target cluster %s does not resolve; waiting at least %s before abandoning its children",
+						horizon.Spec.TargetClusterRef.Name, commonmulticluster.AbandonAfter))
+				return r.updateStatus(ctx, &horizon, statusBefore,
+					ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil)
+			}
+			if err := r.reconcileDeleteRemoteChildren(ctx, children, &horizon); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		log.FromContext(ctx).V(1).Info("Horizon resource is being deleted; owned resources are garbage-collected via ownerReferences")
 		r.evictHealthProbe(client.ObjectKeyFromObject(&horizon))
 		return ctrl.Result{}, nil
@@ -207,14 +258,30 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Resolve the client every child object of this CR is read and written
 	// with. The embedded client stays on the management cluster (the CR and its
 	// status live there); children carries everything the CR projects into the
-	// target cluster. The deletion short-circuit above already returned, so a
-	// terminating CR never reaches this resolution — it installs no finalizer,
-	// so there is nothing here that could keep it from leaving etcd.
+	// target cluster. The deletion branch above already returned, so a
+	// terminating CR never reaches this resolution: it fails the pass on an
+	// unresolvable ref, which would keep a finalized CR from ever reaching its
+	// sweep.
 	children, err := commonmulticluster.ResolveChildrenClient(ctx, r.Resolver, r.Client, horizon.Spec.TargetClusterRef)
 	if err != nil {
 		horizonSkeleton.MarkFailed(&horizon, "SecretsReady", commonmulticluster.TargetClusterUnavailable, err)
 		return r.updateStatus(ctx, &horizon, statusBefore,
 			ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil)
+	}
+
+	// The remote-children finalizer is horizon's first and only finalizer, and
+	// it goes on only when the CR projects onto a target cluster. A local CR
+	// keeps the garbage collection cascade, which reaps its children from their
+	// owner references, so it stays finalizer-free: a finalizer it does not need
+	// is one more deletion-time step that can fail. spec.targetClusterRef is
+	// immutable, so the condition cannot flip under a live CR.
+	if horizon.Spec.TargetClusterRef != nil {
+		if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, &horizon,
+			commonmulticluster.RemoteChildrenFinalizer); err != nil {
+			return ctrl.Result{}, err
+		} else if added {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Run the sub-reconciler pipeline. Steps are attempted in dependency
@@ -313,6 +380,15 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// through updateStatus, which recomputes the aggregate Ready condition.
 	result, err := commonreconcile.RunPipeline(ctx, instrumenter.Instrument, pipeline)
 	return r.updateStatus(ctx, &horizon, statusBefore, result, err)
+}
+
+// reconcileDeleteRemoteChildren deletes everything this Horizon projected onto
+// the target cluster it names, selected on the ownership labels Claim stamped on
+// those objects, and releases the remote-children finalizer that held the CR in
+// etcd for it, as commonmulticluster.SweepRemoteChildren documents.
+func (r *HorizonReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, horizon *horizonv1alpha1.Horizon) error {
+	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
+		horizon, horizon.Spec.TargetClusterRef, children, horizonRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given

--- a/operators/horizon/internal/controller/horizon_controller_test.go
+++ b/operators/horizon/internal/controller/horizon_controller_test.go
@@ -12,11 +12,20 @@ import (
 
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/c5c3/forge/internal/common/conditions"
@@ -167,6 +176,241 @@ func TestUpdateStatus_SkipsWriteWhenUnchanged(t *testing.T) {
 	_, err := r.updateStatus(context.Background(), h, snapshot, ctrl.Result{}, nil)
 	g.Expect(err).NotTo(HaveOccurred(),
 		"an unchanged status must skip the write; the failing Status().Update proves it was not called")
+}
+
+// --- remote children -------------------------------------------------------
+
+// horizonKey is the namespaced name of the CR every fixture in this file builds.
+var horizonKey = types.NamespacedName{Namespace: "default", Name: "test-horizon"}
+
+// ownedRemoteChild stamps the ownership labels the projection wrote on a child
+// it put on the target cluster, so the sweep selects it exactly as it would
+// there.
+func ownedRemoteChild(t *testing.T, owner, child client.Object) client.Object {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(testScheme(), owner)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	child.SetLabels(labels)
+	return child
+}
+
+// terminatingRemoteHorizon returns a Horizon that names a target cluster and is
+// being deleted, carrying the remote-children finalizer plus a foreign one so
+// the CR survives the release and the test can read back which finalizers the
+// pass dropped.
+func terminatingRemoteHorizon(t *testing.T) (*HorizonReconciler, *horizonv1alpha1.Horizon) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	h := testHorizon()
+	h.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	h.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	deletedAt := metav1.NewTime(time.Now())
+	h.DeletionTimestamp = &deletedAt
+
+	r := newTestReconciler(testScheme(), h)
+	var terminating horizonv1alpha1.Horizon
+	g.Expect(r.Get(context.Background(), horizonKey, &terminating)).To(Succeed())
+	return r, &terminating
+}
+
+// getHorizon reads the CR back from the reconciler's client.
+func getHorizon(t *testing.T, r *HorizonReconciler) *horizonv1alpha1.Horizon {
+	t.Helper()
+	var got horizonv1alpha1.Horizon
+	NewGomegaWithT(t).Expect(r.Get(context.Background(), horizonKey, &got)).To(Succeed())
+	return &got
+}
+
+// TestReconcileDeleteRemoteChildren_SweepsEveryProjectedKind is the whole point
+// of the finalizer: no garbage collection cascade crosses the cluster boundary,
+// so the dashboard projection has to be deleted by name from here, across every
+// API group it lives in. What the sweep leaves standing matters as much: a
+// target cluster carries other people's objects, and an object nobody claimed or
+// another CR claimed is not ours to remove.
+func TestReconcileDeleteRemoteChildren_SweepsEveryProjectedKind(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteHorizon(t)
+
+	projected := []client.Object{
+		ownedRemoteChild(t, terminating,
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon-config", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+		ownedRemoteChild(t, terminating,
+			&gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
+	}
+	g.Expect(projected).To(HaveLen(len(horizonRemoteChildKinds)),
+		"every kind the sweep covers needs a child here, or the list grew untested")
+
+	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: "default"}}
+	foreign := ownedRemoteChild(t,
+		&horizonv1alpha1.Horizon{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "other-horizon", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(append([]client.Object{unlabelled, foreign}, projected...)...).Build()
+
+	ctx := context.Background()
+	g.Expect(r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)).To(Succeed())
+
+	for _, child := range projected {
+		err := target.Get(ctx, client.ObjectKeyFromObject(child), child.DeepCopyObject().(client.Object))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "%T %s must be swept", child, child.GetName())
+	}
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(unlabelled), &corev1.ConfigMap{})).To(Succeed(),
+		"an object nobody claimed is nobody's child")
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(foreign), &appsv1.Deployment{})).To(Succeed(),
+		"another Horizon's child must survive this one's teardown")
+
+	g.Expect(getHorizon(t, r).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"a completed sweep must release the remote-children finalizer and nothing else")
+}
+
+// TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer is the guard
+// against a CR that leaves etcd while its children keep running. A list the
+// target cluster refuses says nothing about whether children exist, so the pass
+// has to fail and sweep again on the next one.
+func TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteHorizon(t)
+
+	child := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "DeploymentList" {
+					return apierrors.NewForbidden(appsv1.Resource("deployments"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).To(MatchError(ContainSubstring("listing remote Deployment children for teardown")))
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed())
+	g.Expect(getHorizon(t, r).Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"a failed sweep must keep the finalizer so the next pass retries")
+}
+
+// TestReconcile_TerminatingCR_UnresolvableTargetWaitsThenAbandons walks both
+// halves of the deletion resolution. Cluster engagement is asynchronous, so a
+// registered cluster does not resolve either while the provider is still syncing
+// after an operator restart: the first pass has to wait and say so on the CR
+// rather than give up on children that are perfectly reachable. Once the window
+// is out the finalizer is released anyway, or a deregistered target cluster —
+// a documented operation — would strand the CR in Terminating forever.
+func TestReconcile_TerminatingCR_UnresolvableTargetWaitsThenAbandons(t *testing.T) {
+	g := NewGomegaWithT(t)
+	// The window this process has to sit out starts on its own first failure to
+	// resolve, so it has to be compressed for the second pass to reach past it.
+	abandonAfter := commonmulticluster.AbandonAfter
+	t.Cleanup(func() { commonmulticluster.AbandonAfter = abandonAfter })
+	commonmulticluster.AbandonAfter = time.Millisecond
+
+	h := testHorizon()
+	h.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "deregistered"}
+	// A foreign finalizer keeps the CR in etcd so the test can read back which
+	// finalizers the pass released.
+	h.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	// Terminating for far longer than the window, which by itself must not be
+	// enough: giving up on a CR the moment the operator comes back would strand
+	// its children.
+	deletedAt := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	h.DeletionTimestamp = &deletedAt
+	// A child of this CR on the management cluster: an abandoning pass must
+	// delete nothing anywhere, and the local client is the only one it holds.
+	survivor := ownedRemoteChild(t, h,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}})
+	r := newTestReconciler(testScheme(), h, survivor)
+	r.Resolver = unresolvableResolver{}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: horizonKey}
+	res, err := r.Reconcile(ctx, req)
+
+	g.Expect(err).NotTo(HaveOccurred(), "a target cluster that is gone must not fail the deletion pass")
+	g.Expect(res.RequeueAfter).To(Equal(commonreconcile.RequeueSecretPolling),
+		"the first pass this process fails to resolve on starts the window, it does not end it")
+	waiting := getHorizon(t, r)
+	g.Expect(waiting.Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+	cond := conditions.GetCondition(waiting.Status.Conditions, "SecretsReady")
+	g.Expect(cond).NotTo(BeNil(), "a terminating CR waiting on its target cluster must say so on itself")
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.TargetClusterUnavailable))
+	g.Expect(cond.Message).To(ContainSubstring("before abandoning its children"))
+
+	time.Sleep(10 * commonmulticluster.AbandonAfter)
+	res, err = r.Reconcile(ctx, req)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue(), "the deletion resolves once the window is out")
+	g.Expect(getHorizon(t, r).Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"an unreachable target cluster must not pin the CR forever")
+	// The abandoned projection is announced rather than silently dropped.
+	g.Expect(r.Recorder.(*record.FakeRecorder).Events).To(Receive(ContainSubstring("Warning RemoteChildrenAbandoned")))
+	g.Expect(r.Get(ctx, client.ObjectKeyFromObject(survivor), &appsv1.Deployment{})).To(Succeed(),
+		"an abandoning pass has no client to sweep with and must delete nothing")
+}
+
+// TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster verifies that a
+// CR naming a target cluster is pinned before anything is projected onto it, so
+// a deletion issued between this pass and the next still funnels through the
+// sweep.
+func TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	h := testHorizon()
+	// A nil resolver keeps the children local, which is all this pass needs: the
+	// finalizer decision reads spec.targetClusterRef, not the resolved client.
+	h.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	r := newTestReconciler(testScheme(), h)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: horizonKey})
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{Requeue: true}),
+		"the pass installing the finalizer must requeue before any sub-reconciler runs")
+	g.Expect(getHorizon(t, r).Finalizers).To(ConsistOf(commonmulticluster.RemoteChildrenFinalizer))
+}
+
+// TestReconcile_LocalCRDeletesInstantlyWithoutAFinalizer pins the other half.
+// A CR that keeps its children on the management cluster has nothing for the
+// sweep to do, and a finalizer it does not need is one more thing that can block
+// its deletion — so it carries none and leaves etcd the moment it is deleted.
+func TestReconcile_LocalCRDeletesInstantlyWithoutAFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	h := testHorizon() // no spec.targetClusterRef: children stay local
+	child := ownedRemoteChild(t, h,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}})
+	r := newTestReconciler(testScheme(), h, child)
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: horizonKey}
+
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getHorizon(t, r).Finalizers).To(BeEmpty(), "a local Horizon must stay finalizer-free")
+
+	g.Expect(r.Delete(ctx, getHorizon(t, r))).To(Succeed())
+	var gone horizonv1alpha1.Horizon
+	g.Expect(apierrors.IsNotFound(r.Get(ctx, horizonKey, &gone))).To(BeTrue(),
+		"nothing holds the CR, so the delete takes it out of etcd right away")
+
+	res, err := r.Reconcile(ctx, req)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	// The fake client runs no garbage collector, so the child standing here says
+	// only one thing: the operator itself deleted nothing.
+	g.Expect(r.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed(),
+		"a local CR's children belong to the garbage collection cascade, not to a sweep")
 }
 
 func TestHorizonSecretNameExtractor(t *testing.T) {

--- a/operators/horizon/internal/controller/reconcile_config.go
+++ b/operators/horizon/internal/controller/reconcile_config.go
@@ -391,7 +391,7 @@ func cacheLocations(horizon *horizonv1alpha1.Horizon) []any {
 // currently active one.
 func (r *HorizonReconciler) pruneStaleConfigMaps(ctx context.Context, children client.Client, horizon *horizonv1alpha1.Horizon, configMapName string) error {
 	baseName := fmt.Sprintf("%s-config", horizon.Name)
-	return config.PruneImmutableConfigMaps(ctx, children, horizon, config.PruneOptions{
+	return config.PruneImmutableConfigMaps(ctx, children, r.Scheme, horizon, config.PruneOptions{
 		BaseName:    baseName,
 		Namespace:   horizon.Namespace,
 		CurrentName: configMapName,

--- a/operators/keystone/api/v1alpha1/keystone_types.go
+++ b/operators/keystone/api/v1alpha1/keystone_types.go
@@ -186,12 +186,15 @@ type KeystoneSpec struct {
 	// behaves exactly like a single-cluster one. The field is immutable (see the
 	// transition rules on this spec).
 	//
-	// A remote child carries an owner reference to a CR that lives on a
-	// different cluster, so that reference dangles. Until issue #837 replaces
-	// the owner references with an explicit remote-cleanup path, a target
-	// cluster must not have the service CRDs installed: with the CRDs present
-	// its garbage collector resolves the owner reference to a missing object and
-	// deletes the children.
+	// A child written to the target carries no owner reference, since nothing
+	// on that cluster resolves one into the management cluster. Three labels
+	// name the owner instead: openstack.c5c3.io/owner-kind,
+	// openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+	// Deleting the CR deletes the children that carry its labels, under a
+	// finalizer the CR installs whenever the ref is set, so a target cluster
+	// may have the service CRDs installed. A cluster deregistered past the
+	// abandon window is the exception: its children cannot be reached and stay
+	// behind on it.
 	// +optional
 	TargetClusterRef *commonv1.TargetClusterRefSpec `json:"targetClusterRef,omitempty"`
 

--- a/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/config/crd/bases/keystone.openstack.c5c3.io_keystones.yaml
@@ -1580,12 +1580,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
+++ b/operators/keystone/helm/keystone-operator/crds/keystone.openstack.c5c3.io_keystones.yaml
@@ -1583,12 +1583,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -727,9 +727,9 @@ func (r *KeystoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 // finalizers or via GC.
 //
 // A nil children client means the target cluster this CR named is no longer
-// registered. Its MariaDB CRs cannot be reached, so they are left behind (the
-// remote-ownership gap #837 tracks) and the finalizer is released anyway:
-// holding it would only strand the CR in Terminating.
+// registered. Its MariaDB CRs cannot be reached, so they are left behind and
+// the finalizer is released anyway: holding it would only strand the CR in
+// Terminating.
 func (r *KeystoneReconciler) reconcileDelete(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(keystone, keystoneFinalizer) {
 		return ctrl.Result{}, nil
@@ -800,8 +800,8 @@ func (r *KeystoneReconciler) reconcileDeleteOpenBao(ctx context.Context, childre
 
 	// A nil children client means the target cluster holding the PushSecrets is
 	// no longer registered. ESO cannot be waited on across a cluster that
-	// cannot be reached, so the kv-v2 paths stay as they are (#837) and the
-	// finalizer is released rather than blocking the CR forever.
+	// cannot be reached, so the kv-v2 paths stay as they are and the finalizer
+	// is released rather than blocking the CR forever.
 	if children == nil {
 		r.Recorder.Event(keystone, corev1.EventTypeWarning, "RemoteChildrenAbandoned",
 			"Target cluster is no longer registered; releasing the openbao-finalizer without deleting the backup PushSecrets on it")

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -319,6 +320,38 @@ var certificateGVK = schema.GroupVersionKind{
 	Kind:    "Certificate",
 }
 
+// keystoneRemoteChildKinds are the kinds a Keystone CR projects into the
+// namespace of the target cluster it names, and the kinds
+// reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
+// deleted. Nothing on the target cluster collects them, so a kind missing from
+// this list is a kind that keeps running after its CR is gone.
+//
+// The list is cross-checked against the create verbs of the kubebuilder RBAC
+// markers on this controller below: the operator can only leave behind what it
+// is allowed to create. ExternalSecret is the one create verb deliberately not
+// swept: the marker grants it, but no code composes an ExternalSecret, so no
+// Keystone owns one.
+var keystoneRemoteChildKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	corev1.SchemeGroupVersion.WithKind("Service"),
+	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+	corev1.SchemeGroupVersion.WithKind("Secret"),
+	corev1.SchemeGroupVersion.WithKind("ServiceAccount"),
+	rbacv1.SchemeGroupVersion.WithKind("Role"),
+	rbacv1.SchemeGroupVersion.WithKind("RoleBinding"),
+	batchv1.SchemeGroupVersion.WithKind("Job"),
+	batchv1.SchemeGroupVersion.WithKind("CronJob"),
+	policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+	autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+	networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+	httpRouteGVK,
+	certificateGVK,
+	esov1alpha1.SchemeGroupVersion.WithKind("PushSecret"),
+	mariadbv1alpha1.GroupVersion.WithKind("Database"),
+	mariadbv1alpha1.GroupVersion.WithKind("User"),
+	mariadbv1alpha1.GroupVersion.WithKind("Grant"),
+}
+
 // +kubebuilder:rbac:groups=keystone.openstack.c5c3.io,resources=keystones,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=keystone.openstack.c5c3.io,resources=keystones/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=keystone.openstack.c5c3.io,resources=keystones/finalizers,verbs=update
@@ -397,6 +430,14 @@ func (r *KeystoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if result, err := r.reconcileDeleteOpenBao(ctx, children, &keystone); !result.IsZero() || err != nil {
 			return r.updateStatus(ctx, &keystone, statusBefore, result, err)
 		}
+		// The label-selected sweep runs after the two named cleanup flows, never
+		// before them: it would delete the backup PushSecrets out from under the
+		// ESO purge the OpenBao flow waits for. The ordering mirrors the local
+		// one, where the garbage collection cascade starts only once every
+		// finalizer has been released.
+		if err := r.reconcileDeleteRemoteChildren(ctx, children, &keystone); err != nil {
+			return r.updateStatus(ctx, &keystone, statusBefore, ctrl.Result{}, err)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -433,6 +474,20 @@ func (r *KeystoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	} else if added {
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// The remote-children finalizer goes on only when the CR projects onto a
+	// target cluster. A local CR keeps the garbage collection cascade, which
+	// reaps its children from their owner references, so it has nothing for this
+	// finalizer to hold the CR open for. spec.targetClusterRef is immutable, so
+	// the condition cannot flip under a live CR.
+	if keystone.Spec.TargetClusterRef != nil {
+		if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, &keystone,
+			commonmulticluster.RemoteChildrenFinalizer); err != nil {
+			return ctrl.Result{}, err
+		} else if added {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Run the sub-reconciler pipeline. Steps are attempted in dependency order;
@@ -821,6 +876,16 @@ func (r *KeystoneReconciler) hasLiveOpenBaoBackupPushSecrets(ctx context.Context
 		}
 	}
 	return false, nil
+}
+
+// reconcileDeleteRemoteChildren deletes everything this Keystone projected onto
+// the target cluster it names and releases the remote-children finalizer, as
+// commonmulticluster.SweepRemoteChildren documents. The two cleanup flows above
+// it delete the handful of objects they track by name; this pass is what reaches
+// the rest, selected on the ownership labels Claim stamped on them.
+func (r *KeystoneReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone) error {
+	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
+		keystone, keystone.Spec.TargetClusterRef, children, keystoneRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given

--- a/operators/keystone/internal/controller/keystone_controller_test.go
+++ b/operators/keystone/internal/controller/keystone_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
@@ -4296,4 +4297,209 @@ func TestReconcileDeleteRemovesRotationAgeSeries(t *testing.T) {
 		To(BeNil(), "reconcileDelete MUST remove the fernet rotation-age gauge series")
 	g.Expect(findMetricByLabels(t, ctrlmetrics.Registry, "keystone_operator_key_rotation_age_seconds", credLabels)).
 		To(BeNil(), "reconcileDelete MUST remove the credential rotation-age gauge series")
+}
+
+// remoteChildrenScheme is the scheme the target-cluster fake client is built
+// with: testScheme plus cert-manager, so every kind in
+// keystoneRemoteChildKinds is registered and the sweep's unstructured Lists
+// all resolve. A target cluster that does not serve one of them is the
+// teardown helper's own concern and is covered there.
+func remoteChildrenScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := testScheme()
+	NewGomegaWithT(t).Expect(certmanagerv1.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+// ownedRemoteChild stamps the ownership labels the projection wrote on a child
+// it put on the target cluster, so the sweep selects it exactly as it would
+// there.
+func ownedRemoteChild(t *testing.T, s *runtime.Scheme, owner, child client.Object) client.Object {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(s, owner)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	child.SetLabels(labels)
+	return child
+}
+
+// terminatingRemoteKeystone returns a Keystone that names a target cluster and
+// is being deleted, carrying the remote-children finalizer plus a foreign one
+// so the CR survives the release and the test can read back which finalizers
+// the pass dropped.
+func terminatingRemoteKeystone(t *testing.T) (*KeystoneReconciler, *keystonev1alpha1.Keystone) {
+	t.Helper()
+	ks := testKeystone()
+	ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	ks.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	r := newTestReconciler(ks)
+	return r, markKeystoneTerminating(t, r.Client, ks)
+}
+
+// TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild is the whole point
+// of the finalizer: no garbage collection cascade crosses the cluster
+// boundary, so the objects this CR projected have to be deleted by name from
+// here, across every API group they live in. What the sweep leaves standing
+// matters as much: a target cluster carries other people's objects, and an
+// object nobody claimed or another CR claimed is not ours to remove.
+func TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteKeystone(t)
+
+	s := remoteChildrenScheme(t)
+	deployment := ownedRemoteChild(t, s, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone", Namespace: "default"}})
+	service := ownedRemoteChild(t, s, terminating,
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-api", Namespace: "default"}})
+	pushSecret := ownedRemoteChild(t, s, terminating,
+		&esov1alpha1.PushSecret{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-fernet-backup", Namespace: "default"}})
+	grant := ownedRemoteChild(t, s, terminating,
+		&mariadbv1alpha1.Grant{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone", Namespace: "default"}})
+	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: "default"}}
+	foreign := ownedRemoteChild(t, s,
+		&keystonev1alpha1.Keystone{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other-credentials", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(deployment, service, pushSecret, grant, unlabelled, foreign).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, child := range []client.Object{deployment, service, pushSecret, grant} {
+		err := target.Get(ctx, client.ObjectKeyFromObject(child), child.DeepCopyObject().(client.Object))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+			"%T %s must be swept", child, child.GetName())
+	}
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(unlabelled), &corev1.ConfigMap{})).To(Succeed(),
+		"an object nobody claimed is nobody's child")
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(foreign), &corev1.Secret{})).To(Succeed(),
+		"another Keystone's child must survive this one's teardown")
+
+	var updated keystonev1alpha1.Keystone
+	g.Expect(r.Get(ctx, client.ObjectKeyFromObject(terminating), &updated)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(&updated, commonmulticluster.RemoteChildrenFinalizer)).To(BeFalse(),
+		"a completed sweep must release the finalizer")
+	g.Expect(updated.Finalizers).To(ConsistOf("foreign.example.com/keep-alive"))
+}
+
+// TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases covers the
+// deregistered target cluster. Its children cannot be reached, so holding the
+// finalizer would only strand the CR in Terminating; the objects left running
+// are announced rather than silently dropped. Any attempt to sweep through the
+// nil client would fault, which is what proves nothing was deleted.
+func TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteKeystone(t)
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, nil, terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	expectEvent(g, r, "Warning RemoteChildrenAbandoned")
+
+	var updated keystonev1alpha1.Keystone
+	g.Expect(r.Get(ctx, client.ObjectKeyFromObject(terminating), &updated)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(&updated, commonmulticluster.RemoteChildrenFinalizer)).To(BeFalse(),
+		"an unreachable target cluster must not pin the CR forever")
+}
+
+// TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp pins the guard a
+// local CR relies on. It never carries the finalizer, its children are
+// collected from their owner references, and a sweep running anyway would
+// delete objects on the management cluster that the cascade already owns.
+func TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := testKeystone()
+	r := newTestReconciler(ks)
+
+	s := remoteChildrenScheme(t)
+	child := ownedRemoteChild(t, s, ks,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(s).WithObjects(child).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), ks)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed(),
+		"a CR without the finalizer must not sweep anything")
+	expectNoEvent(g, r)
+}
+
+// TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer is the guard
+// against a CR that leaves etcd while its children keep running. A list the
+// target cluster refuses says nothing about whether children exist, so the
+// pass has to fail and sweep again on the next one.
+func TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemoteKeystone(t)
+
+	s := remoteChildrenScheme(t)
+	child := ownedRemoteChild(t, s, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-keystone", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(s).WithObjects(child).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "DeploymentList" {
+					return apierrors.NewForbidden(appsv1.Resource("deployments"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).To(MatchError(ContainSubstring("listing remote Deployment children for teardown")))
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed())
+
+	var updated keystonev1alpha1.Keystone
+	g.Expect(r.Get(ctx, client.ObjectKeyFromObject(terminating), &updated)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(&updated, commonmulticluster.RemoteChildrenFinalizer)).To(BeTrue(),
+		"a failed sweep must keep the finalizer so the next pass retries")
+}
+
+// TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster verifies that
+// a CR naming a target cluster is pinned before anything is projected onto it,
+// so a deletion issued between this pass and the next still funnels through
+// the sweep.
+func TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := testKeystone()
+	ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	r := newTestReconciler(ks)
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: ks.Name, Namespace: ks.Namespace}}
+	result, err := r.Reconcile(ctx, req)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}),
+		"the pass installing the finalizer must requeue before any sub-reconciler runs")
+
+	var updated keystonev1alpha1.Keystone
+	g.Expect(r.Get(ctx, req.NamespacedName, &updated)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(&updated, commonmulticluster.RemoteChildrenFinalizer)).To(BeTrue())
+}
+
+// TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer pins the other
+// half. A CR that keeps its children on the management cluster has nothing for
+// the sweep to do, and a finalizer it does not need is one more thing that can
+// block its deletion.
+func TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := testKeystone() // No spec.targetClusterRef: children stay local.
+	r := newTestReconciler(ks)
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: ks.Name, Namespace: ks.Namespace}}
+	_, err := r.Reconcile(ctx, req)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var updated keystonev1alpha1.Keystone
+	g.Expect(r.Get(ctx, req.NamespacedName, &updated)).To(Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(&updated, commonmulticluster.RemoteChildrenFinalizer)).To(BeFalse(),
+		"a local CR must keep the finalizer set it always had")
 }

--- a/operators/keystone/internal/controller/multicluster_integration_test.go
+++ b/operators/keystone/internal/controller/multicluster_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,6 +47,7 @@ import (
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	kubeconfigprovider "sigs.k8s.io/multicluster-runtime/providers/kubeconfig"
 
+	"github.com/c5c3/forge/internal/common/apply"
 	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonenvtest "github.com/c5c3/forge/internal/common/testutil/envtest"
@@ -59,8 +61,10 @@ import (
 // management cluster with a second envtest environment registered as target
 // cluster, and walks the target-cluster lifecycle: registration, a CR that
 // projects its children onto the target, a CR that keeps them local, a CR
-// naming an unregistered cluster, deregistration under a running CR, and a
-// registration Secret the provider cannot parse.
+// naming an unregistered cluster, deregistration under a running CR, a
+// registration Secret the provider cannot parse, re-registration of the cluster
+// that was deregistered, and the deletion of a targeted CR sweeping every child
+// it projected off the target.
 func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 	testutil.SkipIfEnvTestUnavailable(t)
 
@@ -83,6 +87,11 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		unknownKeystone  = "mc-unknown-keystone"
 		brokenNamespace  = "mc-broken"
 		brokenKeystone   = "mc-broken-keystone"
+
+		// The teardown CR gets its own namespace on both clusters so its sweep
+		// is observed against a namespace no earlier subtest wrote to.
+		teardownNamespace = "mc-teardown"
+		teardownKeystone  = "mc-teardown-keystone"
 
 		// engageTimeout bounds cluster engagement: the provider has to parse
 		// the kubeconfig, build a cluster, and sync its cache before
@@ -233,6 +242,48 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		g.Expect(simulators.SimulateMariaDBReady(ctx, targetClient, mariadbKey, 1)).
 			To(Succeed(), "simulate the MariaDB cluster ready")
 
+		// A Service as the operator wrote it before ownership moved to the
+		// labels: claimed by a controller owner reference to a Keystone UID this
+		// cluster cannot resolve. It is seeded before the CR so the reconciler
+		// meets it on its first pass and has to heal it. Two properties of the
+		// seed are load-bearing, and the test would prove nothing without
+		// either:
+		//
+		//   - The ownership labels. The adoption pre-check refuses a live object
+		//     it does not already own, because adopting one would overwrite a
+		//     stranger's spec and delete it at teardown. Unlabelled, this
+		//     Service would make the reconciler report that refusal instead of
+		//     applying over it.
+		//   - The field manager. Server-Side Apply drops a field only when the
+		//     manager that owns it stops asserting it. Written under any manager
+		//     other than the operator's own, the dangling reference would
+		//     survive every apply the operator makes.
+		staleService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      targetKeystone,
+				Namespace: targetNamespace,
+				Labels: map[string]string{
+					commonmulticluster.OwnerKindLabel:      "Keystone",
+					commonmulticluster.OwnerNameLabel:      targetKeystone,
+					commonmulticluster.OwnerNamespaceLabel: targetNamespace,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: keystonev1alpha1.GroupVersion.String(),
+					Kind:       "Keystone",
+					Name:       targetKeystone,
+					// A UID nothing on either cluster carries, which is what a
+					// reference across a cluster boundary always degenerates to.
+					UID:        types.UID("11111111-2222-3333-4444-555555555555"),
+					Controller: ptr.To(true),
+				}},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 5000, Protocol: corev1.ProtocolTCP}},
+			},
+		}
+		g.Expect(apply.EnsureUnownedObject(ctx, targetClient, targetScheme, staleService, apply.FieldManager)).
+			To(Succeed(), "seed the stale Service under the operator's own field manager")
+
 		ks := integrationManagedKeystone(targetKeystone, targetNamespace)
 		ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: targetClusterName}
 		g.Expect(mgmtClient.Create(ctx, ks)).To(Succeed())
@@ -268,11 +319,28 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		// The workload itself.
 		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &appsv1.Deployment{}, "Deployment", eventuallyLongTimeout)
 		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &corev1.Service{}, "Service", eventuallyTimeout)
-		multiclusterEventuallyExists(t, ctx, targetClient,
-			client.ObjectKey{Namespace: targetNamespace, Name: fmt.Sprintf("%s-fernet-keys", targetKeystone)},
-			&corev1.Secret{}, "fernet-keys Secret", eventuallyTimeout)
-		g.Expect(multiclusterConfigMapNames(t, ctx, targetClient, targetNamespace, targetKeystone+"-config-")).
-			To(HaveLen(1), "expected exactly one rendered config ConfigMap on the target cluster")
+		fernetKey := client.ObjectKey{Namespace: targetNamespace, Name: fmt.Sprintf("%s-fernet-keys", targetKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, fernetKey, &corev1.Secret{}, "fernet-keys Secret", eventuallyTimeout)
+		configMaps := multiclusterConfigMapNames(t, ctx, targetClient, targetNamespace, targetKeystone+"-config-")
+		g.Expect(configMaps).To(HaveLen(1), "expected exactly one rendered config ConfigMap on the target cluster")
+
+		// Every child is claimed by the ownership labels and by nothing else. A
+		// reference would name a UID this cluster cannot resolve, and the labels
+		// are the only handle the teardown sweep has on these objects.
+		multiclusterExpectRemoteOwnership(t, ctx, targetClient, childKey,
+			&appsv1.Deployment{}, "Deployment", targetKeystone, targetNamespace)
+		multiclusterExpectRemoteOwnership(t, ctx, targetClient, childKey,
+			&mariadbv1alpha1.Database{}, "MariaDB Database", targetKeystone, targetNamespace)
+		multiclusterExpectRemoteOwnership(t, ctx, targetClient,
+			client.ObjectKey{Namespace: targetNamespace, Name: configMaps[0]},
+			&corev1.ConfigMap{}, "config ConfigMap", targetKeystone, targetNamespace)
+		multiclusterExpectRemoteOwnership(t, ctx, targetClient, fernetKey,
+			&corev1.Secret{}, "fernet-keys Secret", targetKeystone, targetNamespace)
+
+		// The seeded Service is the self-heal: its dangling controller owner
+		// reference is gone, shed by the apply that no longer asserts it.
+		multiclusterExpectRemoteOwnership(t, ctx, targetClient, childKey,
+			&corev1.Service{}, "Service", targetKeystone, targetNamespace)
 
 		// None of it on the management cluster, where only the CR lives.
 		multiclusterExpectAbsent(t, ctx, mgmtClient, childKey, &appsv1.Deployment{}, "Deployment")
@@ -281,9 +349,7 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		multiclusterExpectAbsent(t, ctx, mgmtClient, childKey, &mariadbv1alpha1.User{}, "MariaDB User")
 		multiclusterExpectAbsent(t, ctx, mgmtClient, childKey, &mariadbv1alpha1.Grant{}, "MariaDB Grant")
 		multiclusterExpectAbsent(t, ctx, mgmtClient, dbSyncKey, &batchv1.Job{}, "db-sync Job")
-		multiclusterExpectAbsent(t, ctx, mgmtClient,
-			client.ObjectKey{Namespace: targetNamespace, Name: fmt.Sprintf("%s-fernet-keys", targetKeystone)},
-			&corev1.Secret{}, "fernet-keys Secret")
+		multiclusterExpectAbsent(t, ctx, mgmtClient, fernetKey, &corev1.Secret{}, "fernet-keys Secret")
 		g.Expect(multiclusterConfigMapNames(t, ctx, mgmtClient, targetNamespace, targetKeystone+"-config-")).
 			To(BeEmpty(), "no config ConfigMap should be rendered on the management cluster")
 
@@ -295,6 +361,8 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 			"the main finalizer should be on the CR")
 		g.Expect(controllerutil.ContainsFinalizer(ksAfter, keystoneOpenBaoFinalizer)).To(BeTrue(),
 			"the OpenBao finalizer should be on the CR")
+		g.Expect(controllerutil.ContainsFinalizer(ksAfter, commonmulticluster.RemoteChildrenFinalizer)).To(BeTrue(),
+			"the remote-children finalizer should be on a CR whose children live on another cluster")
 	})
 
 	t.Run("CR without a ref keeps its children local", func(t *testing.T) {
@@ -318,6 +386,14 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 
 		multiclusterExpectAbsent(t, ctx, targetClient, childKey, &appsv1.Deployment{}, "Deployment")
 		multiclusterExpectAbsent(t, ctx, targetClient, fernetKey, &corev1.Secret{}, "fernet-keys Secret")
+
+		// The garbage collection cascade reaps these children from their owner
+		// references, so there is nothing for the remote-children finalizer to
+		// hold the CR open for.
+		ksAfter := &keystonev1alpha1.Keystone{}
+		g.Expect(mgmtClient.Get(ctx, types.NamespacedName{Name: localKeystone, Namespace: localNamespace}, ksAfter)).To(Succeed())
+		g.Expect(controllerutil.ContainsFinalizer(ksAfter, commonmulticluster.RemoteChildrenFinalizer)).To(BeFalse(),
+			"a CR that keeps its children local must not carry the remote-children finalizer")
 	})
 
 	t.Run("CR naming an unregistered cluster creates nothing", func(t *testing.T) {
@@ -458,6 +534,174 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 			multiclusterExpectAbsent(t, ctx, c, fernetKey, &corev1.Secret{}, "fernet-keys Secret")
 		}
 	})
+
+	t.Run("re-registering the target cluster engages it again", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// The deregistration subtest deleted this Secret, and the teardown
+		// subtest below needs the cluster reachable again. Re-registering under
+		// a name the provider already tore down is a case of its own: what
+		// GetCluster answers with afterwards has to be a freshly built cluster,
+		// not the disengaged one.
+		kubeconfig, err := commonenvtest.KubeconfigBytes(targetCfg, targetClusterName)
+		g.Expect(err).NotTo(HaveOccurred(), "build kubeconfig for the target environment")
+
+		g.Expect(mgmtClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      targetClusterName,
+				Namespace: clustersNamespace,
+				Labels:    map[string]string{"sigs.k8s.io/multicluster-runtime-kubeconfig": "true"},
+			},
+			Data: map[string][]byte{"kubeconfig": kubeconfig},
+		})).To(Succeed(), "recreate the registration Secret")
+
+		g.Eventually(func() error {
+			_, err := mcMgr.GetCluster(ctx, mcruntime.ClusterName(targetClusterName))
+			return err
+		}, engageTimeout, pollInterval).Should(Succeed(),
+			"the provider should engage the target cluster again")
+	})
+
+	t.Run("deleting a targeted CR sweeps its children off the target cluster", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Everything the CR needs is seeded on the target cluster, as in the
+		// first targeted subtest, but in a namespace of its own so the sweep is
+		// observed against objects only this CR produced. Nothing on this
+		// envtest environment runs a controller, so what disappears here
+		// disappeared because the operator deleted it.
+		multiclusterEnsureNamespace(t, ctx, mgmtClient, teardownNamespace)
+		multiclusterEnsureNamespace(t, ctx, targetClient, teardownNamespace)
+		createPrerequisites(t, ctx, targetClient, teardownNamespace)
+
+		mariadbKey := client.ObjectKey{Namespace: teardownNamespace, Name: "mariadb"}
+		g.Expect(targetClient.Create(ctx, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{Name: mariadbKey.Name, Namespace: mariadbKey.Namespace},
+		})).To(Succeed(), "create the MariaDB cluster CR on the target cluster")
+		g.Expect(simulators.SimulateMariaDBReady(ctx, targetClient, mariadbKey, 1)).
+			To(Succeed(), "simulate the MariaDB cluster ready")
+
+		ks := integrationManagedKeystone(teardownKeystone, teardownNamespace)
+		ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: targetClusterName}
+		g.Expect(mgmtClient.Create(ctx, ks)).To(Succeed())
+
+		crKey := types.NamespacedName{Name: teardownKeystone, Namespace: teardownNamespace}
+		childKey := client.ObjectKey{Namespace: teardownNamespace, Name: teardownKeystone}
+
+		waitForCondition(t, ctx, mgmtClient, crKey, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+		waitForCondition(t, ctx, mgmtClient, crKey, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Database{}, "MariaDB Database", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateDatabaseReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.User{}, "MariaDB User", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateUserReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Grant{}, "MariaDB Grant", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateGrantReady(ctx, targetClient, childKey)).To(Succeed())
+
+		dbSyncKey := client.ObjectKey{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-db-sync", teardownKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, dbSyncKey, &batchv1.Job{}, "db-sync Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, dbSyncKey)).To(Succeed())
+
+		schemaCheckKey := client.ObjectKey{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-schema-check", teardownKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, schemaCheckKey, &batchv1.Job{}, "schema-check Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, schemaCheckKey)).To(Succeed())
+
+		waitForCondition(t, ctx, mgmtClient, crKey, "DatabaseReady", metav1.ConditionTrue, eventuallyLongTimeout)
+
+		// Every kind the sweep has to reach must be on the cluster before the
+		// deletion, or its absence afterwards would prove nothing.
+		fernetKey := client.ObjectKey{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-fernet-keys", teardownKeystone)}
+		dbConnectionKey := client.ObjectKey{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-db-connection", teardownKeystone)}
+		fernetRotateKey := client.ObjectKey{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-fernet-rotate", teardownKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &appsv1.Deployment{}, "Deployment", eventuallyLongTimeout)
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &corev1.Service{}, "Service", eventuallyTimeout)
+		multiclusterEventuallyExists(t, ctx, targetClient, fernetKey, &corev1.Secret{}, "fernet-keys Secret", eventuallyTimeout)
+		multiclusterEventuallyExists(t, ctx, targetClient, dbConnectionKey, &corev1.Secret{}, "db-connection Secret", eventuallyTimeout)
+		multiclusterEventuallyExists(t, ctx, targetClient, fernetRotateKey, &batchv1.CronJob{}, "fernet rotation CronJob", eventuallyTimeout)
+		g.Expect(multiclusterConfigMapNames(t, ctx, targetClient, teardownNamespace, teardownKeystone+"-config-")).
+			To(HaveLen(1), "expected exactly one rendered config ConfigMap on the target cluster")
+
+		// The OpenBao cleanup flow runs before the sweep and waits for ESO to
+		// adopt and then release the backup PushSecrets. No ESO runs on this
+		// cluster, so the test plays both halves; without it the CR would sit in
+		// Terminating for the ten-minute adoption timeout.
+		backupKeys := []client.ObjectKey{
+			{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-fernet-keys-backup", teardownKeystone)},
+			{Namespace: teardownNamespace, Name: fmt.Sprintf("%s-credential-keys-backup", teardownKeystone)},
+		}
+		for _, key := range backupKeys {
+			multiclusterEventuallyExists(t, ctx, targetClient, key, &esov1alpha1.PushSecret{}, "backup PushSecret", eventuallyLongTimeout)
+			addESOFinalizerToPushSecret(t, ctx, targetClient, key)
+		}
+
+		g.Expect(mgmtClient.Delete(ctx, ks)).To(Succeed(), "delete the targeted Keystone CR")
+
+		g.Eventually(func(ig Gomega) {
+			for _, key := range backupKeys {
+				ps := &esov1alpha1.PushSecret{}
+				ig.Expect(targetClient.Get(ctx, key, ps)).To(Succeed(),
+					"PushSecret %s should still exist while the ESO finalizer is held", key)
+				ig.Expect(ps.GetDeletionTimestamp().IsZero()).To(BeFalse(),
+					"PushSecret %s should be Terminating once the OpenBao flow issued its Delete", key)
+			}
+		}, eventuallyTimeout, pollInterval).Should(Succeed())
+		for _, key := range backupKeys {
+			clearESOFinalizerFromPushSecret(t, ctx, targetClient, key)
+		}
+
+		g.Eventually(func() bool {
+			return apierrors.IsNotFound(mgmtClient.Get(ctx, crKey, &keystonev1alpha1.Keystone{}))
+		}, eventuallyLongTimeout, pollInterval).Should(BeTrue(),
+			"the CR should leave etcd once all three finalizers are released")
+
+		// The sweep does not wait for the objects it deleted, and a delete is
+		// asynchronous, so each child is polled until it is gone rather than
+		// read once.
+		swept := []struct {
+			key  client.ObjectKey
+			obj  client.Object
+			what string
+		}{
+			{childKey, &appsv1.Deployment{}, "Deployment"},
+			{childKey, &corev1.Service{}, "Service"},
+			{fernetKey, &corev1.Secret{}, "fernet-keys Secret"},
+			{dbConnectionKey, &corev1.Secret{}, "db-connection Secret"},
+			{dbSyncKey, &batchv1.Job{}, "db-sync Job"},
+			{schemaCheckKey, &batchv1.Job{}, "schema-check Job"},
+			{fernetRotateKey, &batchv1.CronJob{}, "fernet rotation CronJob"},
+			{childKey, &mariadbv1alpha1.Database{}, "MariaDB Database"},
+			{childKey, &mariadbv1alpha1.User{}, "MariaDB User"},
+			{childKey, &mariadbv1alpha1.Grant{}, "MariaDB Grant"},
+		}
+		g.Eventually(func(ig Gomega) {
+			for _, child := range swept {
+				ig.Expect(apierrors.IsNotFound(targetClient.Get(ctx, child.key, child.obj))).
+					To(BeTrue(), "%s %s should be swept off the target cluster", child.what, child.key)
+			}
+			// Every ConfigMap this Keystone projected is content-addressed —
+			// the rendered config and the two rotation scripts — so the CR's
+			// name is all they have in common and the prefix is the only way
+			// to ask for them.
+			ig.Expect(multiclusterConfigMapNames(t, ctx, targetClient, teardownNamespace, teardownKeystone)).
+				To(BeEmpty(), "no ConfigMap of this Keystone should survive the sweep")
+			cronJobs := &batchv1.CronJobList{}
+			ig.Expect(targetClient.List(ctx, cronJobs, client.InNamespace(teardownNamespace))).To(Succeed())
+			ig.Expect(cronJobs.Items).To(BeEmpty(), "no CronJob should survive the sweep")
+		}, eventuallyLongTimeout, pollInterval).Should(Succeed())
+
+		// What the CR only ever read stays. The sweep selects on the ownership
+		// labels, and the operator never stamped them on the input Secrets or on
+		// the MariaDB cluster CR, so a sweep that took these would be taking
+		// somebody else's objects.
+		g.Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: teardownNamespace, Name: "keystone-db"},
+			&corev1.Secret{})).To(Succeed(), "the database credentials Secret should survive the teardown")
+		g.Expect(targetClient.Get(ctx, client.ObjectKey{Namespace: teardownNamespace, Name: "keystone-admin"},
+			&corev1.Secret{})).To(Succeed(), "the admin password Secret should survive the teardown")
+		g.Expect(targetClient.Get(ctx, mariadbKey, &mariadbv1alpha1.MariaDB{})).
+			To(Succeed(), "the MariaDB cluster CR should survive the teardown")
+	})
 }
 
 // multiclusterKeystonePaths returns the Keystone CRD and webhook manifest
@@ -504,6 +748,47 @@ func multiclusterEventuallyExists(
 	g.Eventually(func() error {
 		return c.Get(ctx, key, obj)
 	}, timeout, pollInterval).Should(Succeed(), "%s %s should exist", what, key)
+}
+
+// multiclusterExpectRemoteOwnership polls c until the object at key is claimed
+// the way a remote child has to be: by the three ownership labels naming the
+// Keystone owner, and by no owner reference at all. It polls rather than reads
+// once because the projection is asynchronous, and because an object that was
+// seeded with a stale reference only loses it on the operator's first apply.
+func multiclusterExpectRemoteOwnership(
+	t testing.TB,
+	ctx context.Context,
+	c client.Client,
+	key client.ObjectKey,
+	obj client.Object,
+	what, ownerName, ownerNamespace string,
+) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	want := map[string]string{
+		commonmulticluster.OwnerKindLabel:      "Keystone",
+		commonmulticluster.OwnerNameLabel:      ownerName,
+		commonmulticluster.OwnerNamespaceLabel: ownerNamespace,
+	}
+
+	g.Eventually(func() error {
+		if err := c.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		if refs := obj.GetOwnerReferences(); len(refs) != 0 {
+			return fmt.Errorf("%s %s still carries owner references: %v", what, key, refs)
+		}
+		labels := obj.GetLabels()
+		for label, value := range want {
+			if labels[label] != value {
+				return fmt.Errorf("%s %s label %s is %q, want %q", what, key, label, labels[label], value)
+			}
+		}
+		return nil
+	}, eventuallyTimeout, pollInterval).Should(Succeed(),
+		"%s %s should be labelled as owned by Keystone %s/%s and carry no owner reference",
+		what, key, ownerNamespace, ownerName)
 }
 
 // multiclusterExpectAbsent asserts the object at key does not exist on c. A

--- a/operators/keystone/internal/controller/reconcile_config.go
+++ b/operators/keystone/internal/controller/reconcile_config.go
@@ -514,7 +514,7 @@ func (r *KeystoneReconciler) configMapExists(ctx context.Context, children clien
 // currently active one.
 func (r *KeystoneReconciler) pruneStaleConfigMaps(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone, configMapName string) error {
 	baseName := fmt.Sprintf("%s-config", keystone.Name)
-	return config.PruneImmutableConfigMaps(ctx, children, keystone, config.PruneOptions{
+	return config.PruneImmutableConfigMaps(ctx, children, r.Scheme, keystone, config.PruneOptions{
 		BaseName:    baseName,
 		Namespace:   keystone.Namespace,
 		CurrentName: configMapName,

--- a/operators/keystone/internal/controller/reconcile_federation.go
+++ b/operators/keystone/internal/controller/reconcile_federation.go
@@ -1199,7 +1199,7 @@ func (r *KeystoneReconciler) pruneStaleFederationSecrets(ctx context.Context, ch
 	if federationSecretName == "" {
 		retain = 0
 	}
-	return config.PruneImmutableSecrets(ctx, children, keystone, config.PruneOptions{
+	return config.PruneImmutableSecrets(ctx, children, r.Scheme, keystone, config.PruneOptions{
 		BaseName:    federationSecretBaseName(keystone),
 		Namespace:   keystone.Namespace,
 		CurrentName: federationSecretName,

--- a/operators/keystone/internal/controller/reconcile_federation.go
+++ b/operators/keystone/internal/controller/reconcile_federation.go
@@ -24,10 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/c5c3/forge/internal/common/config"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	"github.com/c5c3/forge/internal/common/secrets"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -672,9 +672,16 @@ func (r *KeystoneReconciler) lastKnownGoodProviderMetadata(ctx context.Context, 
 
 // newestFederationSecret returns the newest content-hashed federation Secret
 // owned by keystone (name tie-break for same-second creations), or nil when
-// none exists. Shared by the OIDC and SAML last-known-good metadata fallbacks so
-// a transient IdP metadata-endpoint outage on a cache miss does not tear
-// federation down.
+// none exists. Ownership is read from the controller reference locally and from
+// the ownership labels on a target cluster, so the fallback also finds the copy
+// a remote projection wrote. Shared by the OIDC and SAML last-known-good
+// metadata fallbacks so a transient IdP metadata-endpoint outage on a cache miss
+// does not tear federation down.
+//
+// Every lookup failure yields nil, the same answer as "no copy exists". The
+// callers turn a nil into the original errProviderMetadataUnavailable, which
+// keeps the fault per-backend; surfacing a lookup error instead would fail the
+// whole projection and take the healthy siblings down with it.
 func (r *KeystoneReconciler) newestFederationSecret(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone) *corev1.Secret {
 	baseName := federationSecretBaseName(keystone)
 	var list corev1.SecretList
@@ -689,7 +696,11 @@ func (r *KeystoneReconciler) newestFederationSecret(ctx context.Context, childre
 		if !strings.HasPrefix(s.Name, prefix) {
 			continue
 		}
-		if ref := metav1.GetControllerOf(s); ref == nil || ref.UID != keystone.UID {
+		mine, err := commonmulticluster.Controls(r.Scheme, keystone, s)
+		if err != nil {
+			return nil
+		}
+		if !mine {
 			continue
 		}
 		if newest == nil {
@@ -1082,7 +1093,7 @@ func (r *KeystoneReconciler) ensureOIDCCryptoPassphrase(ctx context.Context, chi
 		},
 		Data: map[string][]byte{"passphrase": []byte(passphrase)},
 	}
-	if err := controllerutil.SetControllerReference(keystone, &secret, r.Scheme); err != nil {
+	if err := commonmulticluster.Claim(children, r.Scheme, keystone, &secret); err != nil {
 		return "", fmt.Errorf("setting owner reference on crypto passphrase Secret: %w", err)
 	}
 	if err := children.Create(ctx, &secret); err != nil {

--- a/operators/keystone/internal/controller/reconcile_federation_saml.go
+++ b/operators/keystone/internal/controller/reconcile_federation_saml.go
@@ -25,8 +25,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	"github.com/c5c3/forge/internal/common/secrets"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -242,7 +242,7 @@ func (r *KeystoneReconciler) ensureSAMLSPKeypair(ctx context.Context, children c
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{"tls.crt": crt, "tls.key": k},
 	}
-	if err := controllerutil.SetControllerReference(keystone, &secret, r.Scheme); err != nil {
+	if err := commonmulticluster.Claim(children, r.Scheme, keystone, &secret); err != nil {
 		return nil, nil, nil, fmt.Errorf("setting owner reference on SP keypair Secret: %w", err)
 	}
 	if err := children.Create(ctx, &secret); err != nil {
@@ -528,7 +528,7 @@ func (r *KeystoneReconciler) ensureSAMLSPMetadataSecret(ctx context.Context, chi
 			},
 			Data: desired,
 		}
-		if err := controllerutil.SetControllerReference(keystone, &secret, r.Scheme); err != nil {
+		if err := commonmulticluster.Claim(children, r.Scheme, keystone, &secret); err != nil {
 			return fmt.Errorf("setting owner reference on SP metadata Secret: %w", err)
 		}
 		if err := children.Create(ctx, &secret); err != nil {

--- a/operators/keystone/internal/controller/reconcile_federation_test.go
+++ b/operators/keystone/internal/controller/reconcile_federation_test.go
@@ -12,13 +12,17 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonconditions "github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/config"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -615,6 +619,64 @@ func TestRenderOIDCBackend_DiscoveryModeEgressPortsFromDocument(t *testing.T) {
 	// 443 from the issuer + authorization_endpoint, plus the endpoint-specific
 	// ports the sidecar would otherwise be blocked from reaching.
 	g.Expect(render.egressPorts).To(ConsistOf(int32(443), int32(9443), int32(7443)))
+}
+
+// testFederationSecret returns a content-hashed federation Secret candidate for
+// the newestFederationSecret tests, created at the given offset from a fixed
+// base time so the newest-wins tie-break is deterministic.
+func testFederationSecret(nameSuffix string, ageOffset time.Duration, labels map[string]string) *corev1.Secret {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	labels[config.ConfigBaseLabelKey] = "test-keystone-federation"
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-keystone-federation-" + nameSuffix,
+			Namespace:         "default",
+			Labels:            labels,
+			CreationTimestamp: metav1.Time{Time: base.Add(ageOffset)},
+		},
+	}
+}
+
+// TestNewestFederationSecret_OwnershipFilter pins which candidates the
+// last-known-good fallback may read from: the locally referenced Secret, the
+// remote one marked by the ownership labels alone, and never a Secret that is
+// nobody's child — even when that one is the newest of the three.
+func TestNewestFederationSecret_OwnershipFilter(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := testFederationKeystone()
+
+	referenced := testFederationSecret("aaa", 0, map[string]string{})
+	referenced.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: keystonev1alpha1.GroupVersion.String(),
+		Kind:       "Keystone",
+		Name:       ks.Name,
+		UID:        ks.UID,
+		Controller: ptr.To(true),
+	}}
+	labelled := testFederationSecret("bbb", time.Hour, map[string]string{
+		commonmulticluster.OwnerKindLabel:      "Keystone",
+		commonmulticluster.OwnerNameLabel:      ks.Name,
+		commonmulticluster.OwnerNamespaceLabel: ks.Namespace,
+	})
+	foreign := testFederationSecret("ccc", 2*time.Hour, map[string]string{})
+
+	r := newTestReconciler(referenced, labelled, foreign)
+
+	newest := r.newestFederationSecret(context.Background(), r.Client, ks)
+	g.Expect(newest).NotTo(BeNil())
+	g.Expect(newest.Name).To(Equal(labelled.Name),
+		"the label-owned Secret is a candidate and is newer than the referenced one; the foreign Secret is not a candidate at all")
+}
+
+// TestNewestFederationSecret_ForeignOnlyYieldsNil covers the empty result: a
+// Secret carrying neither an owner reference nor the ownership labels leaves the
+// fallback with nothing to reuse.
+func TestNewestFederationSecret_ForeignOnlyYieldsNil(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ks := testFederationKeystone()
+	r := newTestReconciler(testFederationSecret("aaa", 0, map[string]string{}))
+
+	g.Expect(r.newestFederationSecret(context.Background(), r.Client, ks)).To(BeNil())
 }
 
 // TestProviderMetadataEgressPorts covers the discovery-document port extraction:

--- a/operators/keystone/internal/controller/reconcile_fernet.go
+++ b/operators/keystone/internal/controller/reconcile_fernet.go
@@ -19,11 +19,11 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/config"
 	"github.com/c5c3/forge/internal/common/job"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	"github.com/c5c3/forge/internal/common/secrets"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
@@ -211,7 +211,7 @@ func (r *KeystoneReconciler) createKeysSecret(ctx context.Context, children clie
 		Data: data,
 	}
 
-	if err := controllerutil.SetControllerReference(keystone, secret, r.Scheme); err != nil {
+	if err := commonmulticluster.Claim(children, r.Scheme, keystone, secret); err != nil {
 		return fmt.Errorf("setting owner reference on keys secret %s: %w", secretName, err)
 	}
 

--- a/operators/keystone/internal/controller/reconcile_fernet_test.go
+++ b/operators/keystone/internal/controller/reconcile_fernet_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/database"
 	"github.com/c5c3/forge/internal/common/deployment"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	"github.com/c5c3/forge/internal/common/naming"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
@@ -128,6 +129,42 @@ func TestReconcileFernetKeys_NoSecret_CreatesSecretAndRequeues(t *testing.T) {
 	g.Expect(cond.Reason).To(Equal("GeneratingKeys"))
 
 	expectEvent(g, r, "Normal FernetKeysGenerated")
+}
+
+// TestReconcileFernetKeys_RemoteChildLabelledAndUnowned pins the target-cluster
+// path of the keys Secret: it is stamped with the ownership labels and carries
+// no owner reference, because a reference to a CR on another cluster names a UID
+// that cluster cannot resolve.
+func TestReconcileFernetKeys_RemoteChildLabelledAndUnowned(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := fernetTestScheme()
+	ks := fernetTestKeystone()
+
+	children := commonmulticluster.Remote(fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ks).
+		Build())
+
+	r := &KeystoneReconciler{
+		Client:   children,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.reconcileFernetKeys(context.Background(), children, ks, "test-keystone-config-abc123", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var secret corev1.Secret
+	g.Expect(children.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "test-keystone-fernet-keys",
+	}, &secret)).To(Succeed())
+	g.Expect(secret.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+	g.Expect(secret.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerKindLabel, "Keystone"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerNameLabel, "test-keystone"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue(commonmulticluster.OwnerNamespaceLabel, "default"))
+	// The claim adds to the operator's label set rather than replacing it.
+	g.Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
 }
 
 func TestReconcileFernetKeys_SecretAlreadyExists(t *testing.T) {

--- a/operators/keystone/internal/controller/reconcile_identitybackends.go
+++ b/operators/keystone/internal/controller/reconcile_identitybackends.go
@@ -686,7 +686,7 @@ func (r *KeystoneReconciler) pruneStaleDomainsSecrets(ctx context.Context, child
 	if domainsSecretName == "" {
 		retain = 0
 	}
-	return config.PruneImmutableSecrets(ctx, children, keystone, config.PruneOptions{
+	return config.PruneImmutableSecrets(ctx, children, r.Scheme, keystone, config.PruneOptions{
 		BaseName:    domainsSecretBaseName(keystone),
 		Namespace:   keystone.Namespace,
 		CurrentName: domainsSecretName,

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c5c3/forge/internal/common/config"
 	"github.com/c5c3/forge/internal/common/deployment"
 	"github.com/c5c3/forge/internal/common/job"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	"github.com/c5c3/forge/internal/common/rotation"
 	"github.com/c5c3/forge/internal/common/secrets"
 	esov1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
@@ -324,9 +325,8 @@ func (r *KeystoneReconciler) ensureAdminPasswordPushSourceSecret(ctx context.Con
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, children, secret, func() error {
-		secret.Labels = commonLabels(keystone)
 		// Do NOT touch secret.Data — applyAdminPasswordRotation owns it.
-		return controllerutil.SetControllerReference(keystone, secret, r.Scheme)
+		return commonmulticluster.ClaimWithLabels(children, r.Scheme, keystone, secret, commonLabels(keystone))
 	}); err != nil {
 		return nil, fmt.Errorf("ensuring admin password push-source secret %s: %w", adminPasswordNextSecretName(keystone), err)
 	}

--- a/operators/keystone/internal/controller/reconcile_passwordrotation.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation.go
@@ -298,7 +298,7 @@ func (r *KeystoneReconciler) teardownPasswordRotation(ctx context.Context, child
 
 	// Delete every script ConfigMap (CurrentName="", Retain=0 prunes all
 	// hash-suffixed ConfigMaps for this base name owned by the CR).
-	if err := config.PruneImmutableConfigMaps(ctx, children, keystone, config.PruneOptions{
+	if err := config.PruneImmutableConfigMaps(ctx, children, r.Scheme, keystone, config.PruneOptions{
 		BaseName:  adminPasswordRotateScriptBaseName(keystone),
 		Namespace: keystone.Namespace,
 	}); err != nil {

--- a/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
+++ b/operators/keystone/internal/controller/reconcile_passwordrotation_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	"github.com/c5c3/forge/internal/common/naming"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -162,6 +163,104 @@ func TestEnsureAdminPasswordPushSourceSecret_CreatesOwnedEmptySecret(t *testing.
 	g.Expect(sec.Data).To(BeEmpty())
 	g.Expect(metav1.GetControllerOf(&sec)).NotTo(BeNil())
 	g.Expect(metav1.GetControllerOf(&sec).UID).To(Equal(ks.UID))
+}
+
+// pwRotationOwnerLabels are the ownership labels a child of pwRotationTestKeystone()
+// carries on a target cluster.
+func pwRotationOwnerLabels() map[string]string {
+	return map[string]string{
+		commonmulticluster.OwnerKindLabel:      "Keystone",
+		commonmulticluster.OwnerNameLabel:      "test-keystone",
+		commonmulticluster.OwnerNamespaceLabel: "default",
+	}
+}
+
+// TestEnsureAdminPasswordPushSourceSecret_RemoteChildLabelledAndUnowned pins the
+// target-cluster path of the push-source Secret: it is stamped with the
+// ownership labels and carries no owner reference, because a reference to a CR
+// on another cluster names a UID that cluster cannot resolve.
+func TestEnsureAdminPasswordPushSourceSecret_RemoteChildLabelledAndUnowned(t *testing.T) {
+	g := NewWithT(t)
+	ks := pwRotationTestKeystone()
+	s := pwRotationTestScheme()
+	children := commonmulticluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(ks).Build())
+	r := &KeystoneReconciler{Client: children, Scheme: s, Recorder: record.NewFakeRecorder(20)}
+
+	_, err := r.ensureAdminPasswordPushSourceSecret(context.Background(), children, ks)
+	g.Expect(err).To(Succeed())
+
+	var sec corev1.Secret
+	g.Expect(children.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordNextSecretName(ks), Namespace: ks.Namespace,
+	}, &sec)).To(Succeed())
+	g.Expect(sec.OwnerReferences).To(BeEmpty(), "a remote child must carry no owner reference")
+	for key, value := range pwRotationOwnerLabels() {
+		g.Expect(sec.Labels).To(HaveKeyWithValue(key, value))
+	}
+	g.Expect(sec.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(sec.Data).To(BeEmpty(), "applyAdminPasswordRotation owns .data")
+}
+
+// TestEnsureAdminPasswordPushSourceSecret_RemoteRebuildKeepsOwnershipLabels
+// covers the steady state, where the rebuild of the operator-owned labels meets
+// a live Secret. The ownership labels are the only mark identifying it as the
+// CR's child there, so a rebuild that dropped them would hand the claim an
+// object it no longer recognizes and have it refuse the Secret it wrote itself
+// one reconcile earlier. A label the operator no longer sets is still dropped.
+func TestEnsureAdminPasswordPushSourceSecret_RemoteRebuildKeepsOwnershipLabels(t *testing.T) {
+	g := NewWithT(t)
+	ks := pwRotationTestKeystone()
+	s := pwRotationTestScheme()
+
+	live := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      adminPasswordNextSecretName(ks),
+		Namespace: ks.Namespace,
+		UID:       "live-uid",
+		Labels:    pwRotationOwnerLabels(),
+	}}
+	live.Labels["forge.c5c3.io/retired"] = "yes"
+	children := commonmulticluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(ks, live).Build())
+	r := &KeystoneReconciler{Client: children, Scheme: s, Recorder: record.NewFakeRecorder(20)}
+
+	_, err := r.ensureAdminPasswordPushSourceSecret(context.Background(), children, ks)
+	g.Expect(err).To(Succeed())
+
+	var sec corev1.Secret
+	g.Expect(children.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordNextSecretName(ks), Namespace: ks.Namespace,
+	}, &sec)).To(Succeed())
+	g.Expect(sec.OwnerReferences).To(BeEmpty())
+	for key, value := range pwRotationOwnerLabels() {
+		g.Expect(sec.Labels).To(HaveKeyWithValue(key, value))
+	}
+	g.Expect(sec.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-keystone"))
+	g.Expect(sec.Labels).NotTo(HaveKey("forge.c5c3.io/retired"), "the operator's label set stays authoritative")
+}
+
+// TestEnsureAdminPasswordPushSourceSecret_RemoteRefusesForeignSecret covers the
+// collision the claim exists for: a Secret of the same name that nobody
+// provisioned as this CR's child is left alone instead of being adopted, since
+// adopting it would overwrite it and delete it at teardown.
+func TestEnsureAdminPasswordPushSourceSecret_RemoteRefusesForeignSecret(t *testing.T) {
+	g := NewWithT(t)
+	ks := pwRotationTestKeystone()
+	s := pwRotationTestScheme()
+	foreign := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      adminPasswordNextSecretName(ks),
+		Namespace: ks.Namespace,
+		UID:       "foreign-uid",
+	}}
+	children := commonmulticluster.Remote(fake.NewClientBuilder().WithScheme(s).WithObjects(ks, foreign).Build())
+	r := &KeystoneReconciler{Client: children, Scheme: s, Recorder: record.NewFakeRecorder(20)}
+
+	_, err := r.ensureAdminPasswordPushSourceSecret(context.Background(), children, ks)
+	g.Expect(err).To(MatchError(ContainSubstring("refusing to adopt pre-existing Secret")))
+
+	var sec corev1.Secret
+	g.Expect(children.Get(context.Background(), types.NamespacedName{
+		Name: adminPasswordNextSecretName(ks), Namespace: ks.Namespace,
+	}, &sec)).To(Succeed())
+	g.Expect(sec.Labels).To(BeEmpty(), "the refused Secret must not be stamped")
 }
 
 func TestEnsureStagingSecret_AdminPasswordLabel(t *testing.T) {

--- a/operators/placement/api/v1alpha1/placement_types.go
+++ b/operators/placement/api/v1alpha1/placement_types.go
@@ -174,12 +174,15 @@ type PlacementSpec struct {
 	// behaves exactly like a single-cluster one. The field is immutable (see the
 	// transition rules on this spec).
 	//
-	// A remote child carries an owner reference to a CR that lives on a
-	// different cluster, so that reference dangles. Until issue #837 replaces
-	// the owner references with an explicit remote-cleanup path, a target
-	// cluster must not have the service CRDs installed: with the CRDs present
-	// its garbage collector resolves the owner reference to a missing object and
-	// deletes the children.
+	// A child written to the target carries no owner reference, since nothing
+	// on that cluster resolves one into the management cluster. Three labels
+	// name the owner instead: openstack.c5c3.io/owner-kind,
+	// openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+	// Deleting the CR deletes the children that carry its labels, under a
+	// finalizer the CR installs whenever the ref is set, so a target cluster
+	// may have the service CRDs installed. A cluster deregistered past the
+	// abandon window is the exception: its children cannot be reached and stay
+	// behind on it.
 	// +optional
 	TargetClusterRef *commonv1.TargetClusterRefSpec `json:"targetClusterRef,omitempty"`
 

--- a/operators/placement/config/crd/bases/placement.openstack.c5c3.io_placements.yaml
+++ b/operators/placement/config/crd/bases/placement.openstack.c5c3.io_placements.yaml
@@ -1418,12 +1418,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/placement/helm/placement-operator/crds/placement.openstack.c5c3.io_placements.yaml
+++ b/operators/placement/helm/placement-operator/crds/placement.openstack.c5c3.io_placements.yaml
@@ -1421,12 +1421,15 @@ spec:
                   behaves exactly like a single-cluster one. The field is immutable (see the
                   transition rules on this spec).
 
-                  A remote child carries an owner reference to a CR that lives on a
-                  different cluster, so that reference dangles. Until issue #837 replaces
-                  the owner references with an explicit remote-cleanup path, a target
-                  cluster must not have the service CRDs installed: with the CRDs present
-                  its garbage collector resolves the owner reference to a missing object and
-                  deletes the children.
+                  A child written to the target carries no owner reference, since nothing
+                  on that cluster resolves one into the management cluster. Three labels
+                  name the owner instead: openstack.c5c3.io/owner-kind,
+                  openstack.c5c3.io/owner-name, and openstack.c5c3.io/owner-namespace.
+                  Deleting the CR deletes the children that carry its labels, under a
+                  finalizer the CR installs whenever the ref is set, so a target cluster
+                  may have the service CRDs installed. A cluster deregistered past the
+                  abandon window is the exception: its children cannot be reached and stay
+                  behind on it.
                 properties:
                   name:
                     description: |-

--- a/operators/placement/internal/controller/placement_controller.go
+++ b/operators/placement/internal/controller/placement_controller.go
@@ -196,6 +196,32 @@ type PlacementReconciler struct {
 	healthProbeCache healthcheck.ProbeCache
 }
 
+// placementRemoteChildKinds are the kinds a Placement CR projects into the
+// namespace of the target cluster it names, and the kinds
+// reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
+// deleted. Nothing on the target cluster collects them, so a kind missing from
+// this list is a kind that keeps running after its CR is gone.
+//
+// The list is cross-checked against the create verbs of the kubebuilder RBAC
+// markers on this controller below: the operator can only leave behind what it
+// is allowed to create. CronJob is the one kind the sibling operators sweep and
+// this one does not: the markers grant create on jobs alone, because placement
+// renders no CronJob.
+var placementRemoteChildKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	corev1.SchemeGroupVersion.WithKind("Service"),
+	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+	corev1.SchemeGroupVersion.WithKind("Secret"),
+	batchv1.SchemeGroupVersion.WithKind("Job"),
+	policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+	autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+	networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+	httpRouteGVK,
+	mariadbv1alpha1.GroupVersion.WithKind("Database"),
+	mariadbv1alpha1.GroupVersion.WithKind("User"),
+	mariadbv1alpha1.GroupVersion.WithKind("Grant"),
+}
+
 // +kubebuilder:rbac:groups=placement.openstack.c5c3.io,resources=placements,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=placement.openstack.c5c3.io,resources=placements/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=placement.openstack.c5c3.io,resources=placements/finalizers,verbs=update
@@ -258,7 +284,18 @@ func (r *PlacementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return r.updateStatus(ctx, &placement, statusBefore,
 				ctrl.Result{RequeueAfter: commonreconcile.RequeueSecretPolling}, nil)
 		}
-		return r.reconcileDelete(ctx, children, &placement)
+		if result, err := r.reconcileDelete(ctx, children, &placement); !result.IsZero() || err != nil {
+			return result, err
+		}
+		// The label-selected sweep runs after the named MariaDB cleanup, never
+		// before it: that flow waits one pass on the CRs it deletes by name, and a
+		// sweep running first would delete them out from under it. The ordering
+		// mirrors the local one, where the garbage collection cascade starts only
+		// once every finalizer has been released.
+		if err := r.reconcileDeleteRemoteChildren(ctx, children, &placement); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Resolve the client every child object of this CR is read and written with.
@@ -286,6 +323,20 @@ func (r *PlacementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	} else if added {
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// The remote-children finalizer goes on only when the CR projects onto a
+	// target cluster. A local CR keeps the garbage collection cascade, which
+	// reaps its children from their owner references, so it has nothing for this
+	// finalizer to hold the CR open for. spec.targetClusterRef is immutable, so
+	// the condition cannot flip under a live CR.
+	if placement.Spec.TargetClusterRef != nil {
+		if added, err := commonreconcile.EnsureFinalizer(ctx, r.Client, &placement,
+			commonmulticluster.RemoteChildrenFinalizer); err != nil {
+			return ctrl.Result{}, err
+		} else if added {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Snapshot the persisted status so updateStatus can skip the write when a
@@ -402,9 +453,9 @@ func (r *PlacementReconciler) parallelSteps(children client.Client) []commonreco
 // the per-CR metrics, evicts the health-probe cache, and releases the finalizer.
 //
 // A nil children client means the target cluster this CR named is no longer
-// registered. Its MariaDB CRs cannot be reached, so they are left behind (the
-// remote-ownership gap #837 tracks) and the finalizer is released anyway:
-// holding it would only strand the CR in Terminating.
+// registered. Its MariaDB CRs cannot be reached, so they stay behind on a
+// cluster that has not resolved for the whole abandon window, and the finalizer
+// is released anyway: holding it would only strand the CR in Terminating.
 func (r *PlacementReconciler) reconcileDelete(ctx context.Context, children client.Client, placement *placementv1alpha1.Placement) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(placement, placementFinalizer) {
 		return ctrl.Result{}, nil
@@ -448,6 +499,16 @@ func (r *PlacementReconciler) reconcileDelete(ctx context.Context, children clie
 	// name/namespace never serves a stale probe keyed on the deleted CR's UID.
 	r.healthProbeCache.Evict(key)
 	return ctrl.Result{}, nil
+}
+
+// reconcileDeleteRemoteChildren deletes everything this Placement projected onto
+// the target cluster it names and releases the remote-children finalizer, as
+// commonmulticluster.SweepRemoteChildren documents. reconcileDelete above
+// deletes the three MariaDB CRs it tracks by name; this pass is what reaches the
+// rest, selected on the ownership labels Claim stamped on them.
+func (r *PlacementReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, placement *placementv1alpha1.Placement) error {
+	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
+		placement, placement.Spec.TargetClusterRef, children, placementRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given

--- a/operators/placement/internal/controller/placement_controller_test.go
+++ b/operators/placement/internal/controller/placement_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
@@ -341,4 +343,185 @@ func TestRegisterPlacementIndexes_RegistersSecretNameKey(t *testing.T) {
 	idx := &recordingFieldIndexer{}
 	g.Expect(registerPlacementIndexes(context.Background(), idx)).To(Succeed())
 	g.Expect(idx.keys).To(ConsistOf(PlacementSecretNameIndexKey))
+}
+
+// --- remote children -------------------------------------------------------
+
+// ownedRemoteChild stamps the ownership labels the projection wrote on a child
+// it put on the target cluster, so the sweep selects it exactly as it would
+// there.
+func ownedRemoteChild(t *testing.T, owner, child client.Object) client.Object {
+	t.Helper()
+	labels, err := commonmulticluster.OwnerLabels(testScheme(), owner)
+	NewGomegaWithT(t).Expect(err).NotTo(HaveOccurred())
+	child.SetLabels(labels)
+	return child
+}
+
+// terminatingRemotePlacement returns a Placement that names a target cluster and
+// is being deleted, carrying the remote-children finalizer plus a foreign one so
+// the CR survives the release and the test can read back which finalizers the
+// pass dropped.
+func terminatingRemotePlacement(t *testing.T) (*PlacementReconciler, *placementv1alpha1.Placement) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	placement.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	placement.Finalizers = []string{commonmulticluster.RemoteChildrenFinalizer, "foreign.example.com/keep-alive"}
+	deletedAt := metav1.NewTime(time.Now())
+	placement.DeletionTimestamp = &deletedAt
+
+	r := newPlacementTestReconciler(placement)
+	var terminating placementv1alpha1.Placement
+	g.Expect(r.Get(context.Background(), placementRequest.NamespacedName, &terminating)).To(Succeed())
+	return r, &terminating
+}
+
+// TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild is the whole point
+// of the finalizer: no garbage collection cascade crosses the cluster boundary,
+// so the objects this CR projected have to be deleted by name from here, across
+// every API group they live in. What the sweep leaves standing matters as much:
+// a target cluster carries other people's objects, and an object nobody claimed
+// or another CR claimed is not ours to remove.
+func TestReconcileDeleteRemoteChildren_SweepsEveryLabelledChild(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemotePlacement(t)
+
+	deployment := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}})
+	service := ownedRemoteChild(t, terminating,
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}})
+	job := ownedRemoteChild(t, terminating,
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-placement-db-sync", Namespace: "default"}})
+	grant := ownedRemoteChild(t, terminating,
+		&mariadbv1alpha1.Grant{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}})
+	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: "default"}}
+	foreign := ownedRemoteChild(t,
+		&placementv1alpha1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other-db-connection", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(deployment, service, job, grant, unlabelled, foreign).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, child := range []client.Object{deployment, service, job, grant} {
+		err := target.Get(ctx, client.ObjectKeyFromObject(child), child.DeepCopyObject().(client.Object))
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "%T %s must be swept", child, child.GetName())
+	}
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(unlabelled), &corev1.ConfigMap{})).To(Succeed(),
+		"an object nobody claimed is nobody's child")
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(foreign), &corev1.Secret{})).To(Succeed(),
+		"another Placement's child must survive this one's teardown")
+
+	updated := getPlacement(t, r.Client, "test-placement")
+	g.Expect(updated.Finalizers).To(ConsistOf("foreign.example.com/keep-alive"),
+		"a completed sweep must release the remote-children finalizer and nothing else")
+}
+
+// TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases covers the
+// deregistered target cluster. Its children cannot be reached, so holding the
+// finalizer would only strand the CR in Terminating; the objects left running
+// are announced rather than silently dropped. Any attempt to sweep through the
+// nil client would fault, which is what proves nothing was deleted.
+func TestReconcileDeleteRemoteChildren_NilChildrenAbandonsAndReleases(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemotePlacement(t)
+
+	err := r.reconcileDeleteRemoteChildren(context.Background(), nil, terminating)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(collectEvents(r.Recorder.(*record.FakeRecorder))).
+		To(ContainElement(ContainSubstring("RemoteChildrenAbandoned")))
+	g.Expect(getPlacement(t, r.Client, "test-placement").Finalizers).NotTo(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"an unreachable target cluster must not pin the CR forever")
+}
+
+// TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp pins the guard a
+// local CR relies on. It never carries the finalizer, its children are collected
+// from their owner references, and a sweep running anyway would delete objects
+// on the management cluster that the cascade already owns.
+func TestReconcileDeleteRemoteChildren_WithoutFinalizerIsANoOp(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	r := newPlacementTestReconciler(placement)
+
+	child := ownedRemoteChild(t, placement,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), placement)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed(),
+		"a CR without the finalizer must not sweep anything")
+	g.Expect(collectEvents(r.Recorder.(*record.FakeRecorder))).To(BeEmpty())
+}
+
+// TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer is the guard
+// against a CR that leaves etcd while its children keep running. A list the
+// target cluster refuses says nothing about whether children exist, so the pass
+// has to fail and sweep again on the next one.
+func TestReconcileDeleteRemoteChildren_SweepFailureKeepsFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	r, terminating := terminatingRemotePlacement(t)
+
+	child := ownedRemoteChild(t, terminating,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}})
+	target := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(child).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if list.GetObjectKind().GroupVersionKind().Kind == "DeploymentList" {
+					return apierrors.NewForbidden(appsv1.Resource("deployments"), "", nil)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	ctx := context.Background()
+	err := r.reconcileDeleteRemoteChildren(ctx, commonmulticluster.Remote(target), terminating)
+
+	g.Expect(err).To(MatchError(ContainSubstring("listing remote Deployment children for teardown")))
+	g.Expect(target.Get(ctx, client.ObjectKeyFromObject(child), &appsv1.Deployment{})).To(Succeed())
+	g.Expect(getPlacement(t, r.Client, "test-placement").Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer),
+		"a failed sweep must keep the finalizer so the next pass retries")
+}
+
+// TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster verifies that a
+// CR naming a target cluster is pinned before anything is projected onto it, so
+// a deletion issued between this pass and the next still funnels through the
+// sweep.
+func TestReconcile_InstallsRemoteChildrenFinalizerForATargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	placement.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: "target"}
+	placement.Finalizers = []string{placementFinalizer} // skip the database finalizer-add requeue
+	r := newPlacementTestReconciler(placement)
+
+	res, err := r.Reconcile(context.Background(), placementRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{Requeue: true}),
+		"the pass installing the finalizer must requeue before any sub-reconciler runs")
+	g.Expect(getPlacement(t, r.Client, "test-placement").Finalizers).To(ContainElement(commonmulticluster.RemoteChildrenFinalizer))
+}
+
+// TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer pins the other
+// half. A CR that keeps its children on the management cluster has nothing for
+// the sweep to do, and a finalizer it does not need is one more thing that can
+// block its deletion.
+func TestReconcile_LocalCRNeverCarriesTheRemoteChildrenFinalizer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement() // no spec.targetClusterRef: children stay local
+	placement.Finalizers = []string{placementFinalizer}
+	r := newPlacementTestReconciler(placement)
+
+	_, err := r.Reconcile(context.Background(), placementRequest)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getPlacement(t, r.Client, "test-placement").Finalizers).To(ConsistOf(placementFinalizer),
+		"a local CR must keep the finalizer set it always had")
 }

--- a/operators/placement/internal/controller/reconcile_config.go
+++ b/operators/placement/internal/controller/reconcile_config.go
@@ -109,7 +109,7 @@ func (r *PlacementReconciler) reconcileConfig(ctx context.Context, children clie
 		markConfigFailed(placement, err)
 		return ctrl.Result{}, "", fmt.Errorf("creating config ConfigMap: %w", err)
 	}
-	if err := config.PruneImmutableConfigMaps(ctx, children, placement, config.PruneOptions{
+	if err := config.PruneImmutableConfigMaps(ctx, children, r.Scheme, placement, config.PruneOptions{
 		BaseName:    placement.Name + "-config",
 		Namespace:   placement.Namespace,
 		CurrentName: configMapName,


### PR DESCRIPTION
A child an operator writes to a target cluster cannot be owned by a controller
owner reference: the reference is resolved by the garbage collector of the
cluster the child lives in, and the CR that owns it lives on the management
cluster. On the target it names a UID that is absent, so it means nothing there
until the owner's kind gets registered on that cluster too, at which point the
child is collected as an orphan. Deletion has the mirror-image gap: no garbage
collection cascade crosses a cluster boundary, so deleting a targeted CR left
its whole projection running on the target.

This branch moves remote ownership onto three labels and an explicit teardown.
A child written to a target cluster carries no owner reference and is stamped
with the owner's kind, name, and namespace; the CR sweeps the labelled objects
from the target while a conditional finalizer holds it in etcd. A CR that names
no target cluster is untouched: the same seams take the local path, owner
references and the GC cascade included.

Closes #837

## Change set, in commit order

**`e2dcdaa2` feat(common): add the remote ownership labels and claim seam**
New `internal/common/multicluster/ownership.go`: the three ownership labels
(`openstack.c5c3.io/owner-{kind,name,namespace}` — kind is required because a
Keystone and a Barbican of the same name project into the same target
namespace), `OwnerLabels`, `Controls` as the dual recognition test (controller
reference locally, labels remotely), and `Claim` as the single decision point —
`controllerutil.SetControllerReference` on a local client, labels plus
reference-stripping on a remote one, and a refusal to adopt a live object
carrying neither. `RemoteChildrenFinalizer` and the `Remote` marker land here
unused; the next two commits consume them.

**`e2123cfa` feat(common): mark resolved target-cluster clients as remote**
`ResolveChildrenClient` wraps the children client of a CR that names a cluster,
so `Claim` can pick the ownership mechanism at the single place the client is
handed out rather than having every write site re-derive it from the spec. The
nil-resolver and nil-ref paths return the local client unmarked; the deletion
resolver inherits the mark; the API reader is not a `client.Client` and stays
unwrapped.

**`cf56c482` feat(common): write remote SSA children unowned behind labels**
`apply.EnsureObject` branches on the mark. The remote path reads the live object
first and hands *that* object to `Claim`, which is where the UID and labels
answering "is this ours?" sit, and lets `Claim` refuse a foreign object in its
own words — adopting one would overwrite its spec and get it deleted at
teardown. NotFound and a kind the target does not serve mean there is nothing to
adopt; every other read error stops the pass. The live state is read into a
fresh instance from the scheme, not into a copy of the desired object, so a
response that omits labels cannot inherit the desired object's. The local path
is byte-identical, error text included.

**`1703ec3c` feat(common): thread the ownership claim through the flow helpers**
The staging Secret, rotation RBAC, cert-manager Certificate, Job, derived
db-connection Secret, and the immutable ConfigMap/Secret history go through
`Claim`. Recognition moves with it: the immutable-config AlreadyExists
verification and the prune filter compared controller-reference UIDs, so a
label-owned remote child would have failed verification and been skipped by the
prune, letting a remote CR's config history grow without bound. Both ask
`Controls` now; the prune functions take the scheme for it (nine call sites).
`EnsureStagingSecret` claims *before* its label rebuild — the rebuild is a full
replacement, and remotely the labels are the only ownership mark.

**`8046bfce` feat(keystone): claim direct child writes on the children client**
The five remaining hand-written `SetControllerReference` sites route through
`Claim` on the client that performs the write. The admin-password push-source
Secret claims before its label rebuild, same reason. The last-known-good
federation Secret lookup asked for a controller reference naming the CR, which
no remote copy carries; it asks `Controls` now, and a lookup failure still
yields nil so the fault stays per-backend.

**`6589a964` feat(common): add the ownership-selected remote-children teardown**
New `teardown.go`. Ownership is decided per object by the same `Controls` every
write site gates on, not by a server-side selector: a child written before
ownership moved off the owner reference carries the reference and no labels and
is never rewritten by a create-once site, so a selector would miss it and the
sweep would report success while key material kept running. It also survives an
owner whose name is no valid label value. A local owner is a no-op, so callers
invoke the sweep unconditionally. The sweep lists through the target's uncached
API reader — a lagging remote cache would hide a child from a sweep whose
success licenses the finalizer release. A kind the target does not serve is
skipped; every other list error fails the pass.

**`8a8d4a18` / `a807fe25` / `dd1d765e` / `4654aed1` / `92fad76a` — the five
workload operators.** Each gets `reconcileDeleteRemoteChildren` and installs
`RemoteChildrenFinalizer` only when `spec.targetClusterRef` is set (the field is
immutable, so the condition cannot flip under a live CR). Each kind list is
cross-checked against the create verbs of that controller's RBAC markers.
Ordering: the sweep runs after the named MariaDB and OpenBao cleanup flows —
ahead of them it would delete the backup PushSecrets the ESO purge waits on and
take the named MariaDB CRs out from under a flow that waits a pass on them.
An unresolvable target past the abandon window releases the finalizer without a
sweep under the existing `RemoteChildrenAbandoned` warning.

- **barbican** additionally tears down the `BarbicanSecretStore` AppRole
  credentials Secret. The store records its resolved cluster in an annotation
  and *then* takes the finalizer, so a crash between the two writes can leave an
  annotation without a finalizer but never a finalizer whose handler cannot name
  its cluster. Naming the cluster on the store is what lets it be deleted after
  its parent already is. The AppRole itself is untouched: shared instance state.
- **horizon** had no finalizer at all and short-circuited deletion; it gets its
  first deletion branch. A local Horizon stays finalizer-free and deletes
  instantly, as before.

**`f5cfd733` test(keystone): prove remote ownership and teardown on dual
envtest** The projection subtest now reads back the Deployment, MariaDB
Database, rendered config ConfigMap, and fernet-keys Secret on the target and
asserts the three labels and zero owner references; the targeted CR carries the
finalizer and the local one does not. The SSA self-heal is proven from a seeded
Service — labelled (an unlabelled seed would prove the adoption refusal instead)
and written under the operator's own field manager (SSA drops a field only when
its owning manager stops asserting it). A new teardown subtest drives a second
targeted CR to full projection in a fresh namespace on both clusters, deletes
it, waits for it to leave etcd, and polls every projected kind until gone
(ConfigMaps by prefix, since their names are content-addressed) while asserting
the input Secrets and the MariaDB cluster CR survive. It plays ESO's part for
the backup PushSecrets, since no ESO runs on envtest.

**`f4a663b3` docs: replace the dangling-owner warning with the ownership
contract** `docs/reference/target-clusters.md` and the six `TargetClusterRef`
doc comments told the reader to keep the service CRDs off a target cluster.
They state the actual contract now, including what the sweep does *not* do (it
never waits for objects to leave etcd; a cluster deregistered past the abandon
window keeps its children). The CRD descriptions come out of those comments, so
the five `config/crd/bases` files and their Helm copies move with them —
description text only; with descriptions stripped the schemas compare equal.
The old warning survives as a migration note: create-once children (immutable
config, fernet and credential keys, Certificates, completed Jobs) do not shed a
stale reference, so such a CR must be deleted and recreated before the service
CRDs go onto its target.

## Divergences from the issue

All of these are visible in the diff and argued in the commit messages or doc
comments; flagging them here so a reviewer does not have to diff the spec.

- **`DeleteRemoteChildren` decides ownership per object, not by a server-side
  label selector**, and drops the issue's `namespace` parameter in favor of
  `owner.GetNamespace()`. The issue specified the three labels as a list
  selector; that would silently miss pre-labels children and fail every pass for
  an owner whose name is no valid label value (`6589a964`).
- **The sweep pages** (`teardownPageSize = 500`) and lists
  `PartialObjectMetadataList`, with a one-shot rescan on `ResourceExpired`.
  Consequence of dropping the selector: the API server returns every object of
  the kind in a shared namespace, and an unpaged list of whole Secrets and
  ConfigMaps could OOMKill the operator into the sweep it just restarted from.
- **`SweepRemoteChildren`** wraps the caller-side sequence (finalizer check,
  abandon event, reader resolution, delete, finalizer release) that the issue
  left to be written five times in the five controllers.
- **`MaxOwnerNameLength`**: `Claim` refuses a CR whose name exceeds the 63-char
  label-value cap rather than letting every child write fail inside the API
  server on an invalid label value.
- **`LiveReader`**: the remote client carries the target's uncached API reader,
  so `EnsureObject`'s adoption pre-check reads live state. The issue accepted a
  cache-race window here and documented it as not closed; the branch closes it,
  and also avoids pulling write-only kinds (NetworkPolicy, HTTPRoute, PDB) into
  informers on the target.
- **`ClaimWithLabels`**: the claim-then-rebuild-labels ordering the staging
  Secret and the admin-password push-source Secret need, factored into one
  helper instead of open-coded at both sites.
- The **`BarbicanSecretStore` secrets RBAC marker** gains `delete`, as specified;
  the chart's `rbacRules` union is unchanged.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789162311&installation_model_id=18560&pr_number=844&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F844&signature=27c3dc54b440a9cc36a96c97987c2d37308e05c323656fb209c9e8e9c9dab6d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->