### PR TITLE
feat(multicluster): correct remote drift through cross-cluster child watches

### DIFF
--- a/docs/reference/target-clusters.md
+++ b/docs/reference/target-clusters.md
@@ -173,6 +173,27 @@ The Barbican secret store mints a token through the target's TokenRequest API,
 so the operator's credentials there need the corresponding RBAC. Packaging the
 access a target cluster has to grant is #841.
 
+Registering a cluster is a commitment to let every service operator cache it in
+full. Each one watches, on every registered cluster, the kinds it projects there
+and the inputs it reads (both enumerated in the next section), so its
+credentials there need cluster-wide `list` and `watch` on all of them —
+including `secrets`, `roles` and `rolebindings`. The operator install that
+engages target clusters is cluster-scoped (see the next section), so those
+informers are not restricted to a namespace: each operator process holds every
+object of every watched kind, in every namespace of every registered cluster,
+resident for its lifetime. Two consequences are worth weighing before a cluster
+is registered rather than after:
+
+- Anyone who obtains the operator's target-cluster credentials can read every
+  Secret in every namespace of that cluster, and a heap dump or an exec into one
+  operator pod yields the same material.
+- The memory the operator needs scales with the whole fleet, not with the
+  namespaces it projects into.
+
+Restricting those caches to the namespaces that actually hold projecting CRs is
+#841. Until it lands, do not register a target cluster you are not willing to
+grant fleet-wide read on and to cache in full.
+
 ## Prerequisites on the management cluster
 
 Target clusters need a cluster-scoped operator install. The registration Secrets
@@ -183,11 +204,38 @@ switching target clusters off: the operator engages no cluster and reads no
 Secret it has no grant for. Left on, the widened Secret informer would fail to
 sync and the manager would not start.
 
-The operators' child watches stay local: each controller registers its watches
-against the management-cluster cache, so a controller whose children all live on
-a target still needs the child kinds installed at home. The three third-party
-CRD sets are therefore required on the management cluster whatever
-`targetClusterRef` says.
+Every service operator watches, on each registered cluster, the kinds it
+projects there and the inputs it reads: the credential Secrets, the database CR
+for the services that have one, the OpenBao instance a Barbican secret store
+waits on, and the ESO SecretStores and ClusterSecretStores. A child event maps
+back to the owning CR through the ownership labels, an input event through the
+same mappers the management-side watches use. A Deployment deleted on a target,
+or a database password rotated there, is corrected within watch latency,
+whatever cluster the infrastructure runs on. Engagement is provider-level: a
+registered cluster serves one informer per watched kind to each service
+operator, whether or not a CR names it — see the target-cluster prerequisites
+above for what that costs. A watch is set up on a cluster only when that cluster
+serves the kind, and the check runs once, as the cluster is engaged. A CRD
+installed on a target after that is watched from the next engagement on, after a
+registration-Secret rotation or an operator restart.
+
+A child is matched to its owner only in the namespace that owner lives in, which
+is the namespace its children land in. The ownership labels are readable and
+writable by anyone with access to the target namespace, so an object carrying
+them anywhere else is not treated as a child at all.
+
+Nor is an event on a cluster the CR does not name. Because a leg is engaged on
+every registered cluster, an event only reaches a CR if that CR's
+`targetClusterRef` names the cluster the event came from — read from the CR on
+the management cluster, never from the object that raised the event. Both the
+child watches and the input watches apply it: without it, anyone able to create
+an object in one shared namespace on any registered cluster could name any CR in
+the fleet and have the operator reconcile it on their timing.
+
+The watches against the management cluster register at builder time, so a
+controller whose children all live on a target still needs the child kinds
+installed at home. The three third-party CRD sets are therefore required on the
+management cluster whatever `targetClusterRef` says.
 
 | CRD set | Installed in this repo from |
 | --- | --- |
@@ -283,7 +331,6 @@ its target cluster; everything it writes afterwards carries the labels alone.
 
 ## Interim constraints
 
-- Drift on a target cluster is corrected on CR events and requeues only. The operators do not watch child objects on target clusters, so an edit made directly on the target survives until the next pass (#838).
 - The capability probes (Gateway API, cert-manager) run against the management cluster, not the target (#839). The API Service selector latch does read the target: it goes through that cluster's own uncached API reader, so a lagging cache cannot re-widen the selector.
 - `KeystoneIdentityBackend` carries no `targetClusterRef`, and its reconciler stays management-side. A backend attached to a Keystone that names a target cluster looks for the parent's Deployment and projection Secret locally, where they do not exist, and holds `ConfigProjected=False` with reason `WaitingForProjection`.
 - RBAC and access packaging for a target cluster, together with the two-cluster development flow, are #841.

--- a/internal/common/bootstrap/controller_options.go
+++ b/internal/common/bootstrap/controller_options.go
@@ -36,25 +36,34 @@ const (
 	rateLimiterMaxDelay = 30 * time.Second
 )
 
-// ControllerOptions builds the shared controller.Options every operator's
-// SetupWithManager applies: MaxConcurrentReconciles lets independent CRs
-// reconcile in parallel instead of serialising at the controller-runtime
-// default of 1 (a value <= 0 falls back to DefaultMaxConcurrentReconciles so
-// the zero value is safe for programmatically constructed reconcilers), and
-// the tuned RateLimiter caps per-item failure backoff at 30s rather than the
-// default 1000s.
-func ControllerOptions(maxConcurrentReconciles int) crcontroller.Options {
+// TypedControllerOptions builds the shared controller.TypedOptions every
+// operator's SetupWithManager applies: MaxConcurrentReconciles lets
+// independent CRs reconcile in parallel instead of serialising at the
+// controller-runtime default of 1 (a value <= 0 falls back to
+// DefaultMaxConcurrentReconciles so the zero value is safe for
+// programmatically constructed reconcilers), and the tuned RateLimiter caps
+// per-item failure backoff at 30s rather than the default 1000s. The request
+// type is a parameter so a multicluster controller, whose builder works on
+// mcreconcile.Request, gets the same defaults; ControllerOptions is the
+// reconcile.Request instantiation.
+func TypedControllerOptions[request comparable](maxConcurrentReconciles int) crcontroller.TypedOptions[request] {
 	if maxConcurrentReconciles <= 0 {
 		maxConcurrentReconciles = DefaultMaxConcurrentReconciles
 	}
-	return crcontroller.Options{
+	return crcontroller.TypedOptions[request]{
 		MaxConcurrentReconciles: maxConcurrentReconciles,
-		RateLimiter:             rateLimiter(),
+		RateLimiter:             typedRateLimiter[request](),
 	}
 }
 
-// rateLimiter builds the controllers' workqueue rate limiter. It is the same
-// composition as workqueue.DefaultTypedControllerRateLimiter — a per-item
+// ControllerOptions is TypedControllerOptions instantiated over
+// reconcile.Request, the request type of a single-cluster controller.
+func ControllerOptions(maxConcurrentReconciles int) crcontroller.Options {
+	return TypedControllerOptions[reconcile.Request](maxConcurrentReconciles)
+}
+
+// typedRateLimiter builds the controllers' workqueue rate limiter. It is the
+// same composition as workqueue.DefaultTypedControllerRateLimiter — a per-item
 // exponential failure limiter maxed against a 10 qps / 100 burst token bucket
 // — but with the per-item cap lowered from the controller-runtime default of
 // 1000s to rateLimiterMaxDelay (30s). The 1000s default is far too
@@ -62,9 +71,9 @@ func ControllerOptions(maxConcurrentReconciles int) crcontroller.Options {
 // off toward a ~16-minute retry. Lowering only the per-item cap keeps the
 // overall 10 qps / 100-burst ceiling intact while bounding failure backoff to
 // 30s.
-func rateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
+func typedRateLimiter[request comparable]() workqueue.TypedRateLimiter[request] {
 	return workqueue.NewTypedMaxOfRateLimiter(
-		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimiterBaseDelay, rateLimiterMaxDelay),
-		&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		workqueue.NewTypedItemExponentialFailureRateLimiter[request](rateLimiterBaseDelay, rateLimiterMaxDelay),
+		&workqueue.TypedBucketRateLimiter[request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)
 }

--- a/internal/common/bootstrap/controller_options_test.go
+++ b/internal/common/bootstrap/controller_options_test.go
@@ -10,32 +10,45 @@ import (
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 )
 
-// TestControllerOptions_ConcurrencyFallback verifies the worker count falls
-// back to the shared default when unset (<= 0) and passes an explicit
-// positive value through unchanged.
-func TestControllerOptions_ConcurrencyFallback(t *testing.T) {
+// assertConcurrencyFallback asserts the worker count an options constructor
+// yields: the shared default when the value is unset (<= 0), and an explicit
+// positive value unchanged. It takes the constructor rather than calling one,
+// so each entry point is exercised through its own signature.
+func assertConcurrencyFallback[request comparable](
+	t *testing.T,
+	options func(int) crcontroller.TypedOptions[request],
+) {
+	t.Helper()
 	g := gomega.NewWithT(t)
 
-	g.Expect(ControllerOptions(0).MaxConcurrentReconciles).
+	g.Expect(options(0).MaxConcurrentReconciles).
 		To(gomega.Equal(DefaultMaxConcurrentReconciles), "zero value must fall back to the default")
-	g.Expect(ControllerOptions(-1).MaxConcurrentReconciles).
+	g.Expect(options(-1).MaxConcurrentReconciles).
 		To(gomega.Equal(DefaultMaxConcurrentReconciles), "negative value must fall back to the default")
-	g.Expect(ControllerOptions(8).MaxConcurrentReconciles).
+	g.Expect(options(8).MaxConcurrentReconciles).
 		To(gomega.Equal(8), "explicit positive value must pass through")
 }
 
-// TestControllerOptions_RateLimiter verifies the tuned failure limiter starts
-// at the base delay, grows exponentially, caps at rateLimiterMaxDelay rather
-// than the controller-runtime default of 1000s, and resets on Forget.
-func TestControllerOptions_RateLimiter(t *testing.T) {
+// assertTunedRateLimiter asserts the tuned failure limiter starts at the base
+// delay, grows exponentially, caps at rateLimiterMaxDelay rather than the
+// controller-runtime default of 1000s, and resets on Forget. req is the
+// workqueue item the limiter is driven with, which is the only thing that
+// differs between the two instantiations.
+func assertTunedRateLimiter[request comparable](
+	t *testing.T,
+	rl workqueue.TypedRateLimiter[request],
+	req request,
+) {
+	t.Helper()
 	g := gomega.NewWithT(t)
 
-	rl := ControllerOptions(0).RateLimiter
 	g.Expect(rl).NotTo(gomega.BeNil())
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cr"}}
 
 	// The first failure retries after the base delay (the token bucket is
 	// within burst, so the exponential limiter dominates the MaxOf).
@@ -48,7 +61,7 @@ func TestControllerOptions_RateLimiter(t *testing.T) {
 	// exceeds rateLimiterMaxDelay (the whole point of the tuning: the default
 	// would keep climbing toward ~1000s).
 	var last time.Duration
-	for i := 0; i < 40; i++ {
+	for range 40 {
 		last = rl.When(req)
 		g.Expect(last).To(gomega.BeNumerically("<=", rateLimiterMaxDelay),
 			"per-item backoff must never exceed the tuned cap")
@@ -58,4 +71,40 @@ func TestControllerOptions_RateLimiter(t *testing.T) {
 	// Forget resets the exponential counter so a recovered CR retries fast again.
 	rl.Forget(req)
 	g.Expect(rl.When(req)).To(gomega.Equal(rateLimiterBaseDelay), "Forget must reset the backoff")
+}
+
+// singleClusterRequest is the workqueue item of a classic controller.
+var singleClusterRequest = reconcile.Request{
+	NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cr"},
+}
+
+// multiClusterRequest is the same item as a multicluster controller sees it,
+// carrying the cluster name that makes it a distinct key.
+var multiClusterRequest = mcreconcile.Request{Request: singleClusterRequest, ClusterName: "target"}
+
+// TestControllerOptions_ConcurrencyFallback verifies the worker count falls
+// back to the shared default when unset (<= 0) and passes an explicit
+// positive value through unchanged.
+func TestControllerOptions_ConcurrencyFallback(t *testing.T) {
+	assertConcurrencyFallback(t, ControllerOptions)
+}
+
+// TestControllerOptions_RateLimiter verifies the reconcile.Request
+// instantiation carries the tuned failure limiter.
+func TestControllerOptions_RateLimiter(t *testing.T) {
+	assertTunedRateLimiter(t, ControllerOptions(0).RateLimiter, singleClusterRequest)
+}
+
+// TestTypedControllerOptions_ConcurrencyFallback verifies the generic variant
+// applies the same worker-count fallback as ControllerOptions when
+// instantiated over the multicluster request type.
+func TestTypedControllerOptions_ConcurrencyFallback(t *testing.T) {
+	assertConcurrencyFallback(t, TypedControllerOptions[mcreconcile.Request])
+}
+
+// TestTypedControllerOptions_RateLimiter verifies the generic variant carries
+// the same tuned failure limiter when its items are cluster-scoped multicluster
+// requests, whose extra field makes them a different comparable key.
+func TestTypedControllerOptions_RateLimiter(t *testing.T) {
+	assertTunedRateLimiter(t, TypedControllerOptions[mcreconcile.Request](0).RateLimiter, multiClusterRequest)
 }

--- a/internal/common/multicluster/watch.go
+++ b/internal/common/multicluster/watch.go
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
+	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// ChildToOwner maps a child on a target cluster back to the CR that owns it,
+// reading the ownership labels. It is the target-cluster counterpart of
+// handler.EnqueueRequestForOwner, which has nothing to go on where a child
+// carries no owner reference.
+//
+// An object whose owner-kind is not ownerKind, or which is missing either half
+// of its owner's name, maps to no request at all. Both cases are ordinary: the
+// children of every CR projecting into a shared target namespace arrive through
+// the same watch, and an object nobody stamped is nobody's child.
+//
+// So does an object claiming an owner in another namespace. A child lands in
+// its owner's own namespace — that is what Claim stamps and what the teardown
+// sweep lists by — so the labels are trusted only where the operator's own
+// writes could have put them. Without that constraint the trust the labels
+// carry inside a projected namespace would extend to every namespace of the
+// cluster: anyone able to create a labelled object anywhere on it could name an
+// arbitrary CR and have the operator reconcile it on their timing.
+//
+// The namespace is as far as this can go on its own. Write access inside a
+// projected namespace amounts to control of the children only on the cluster
+// the CR actually projects onto, and nothing an object carries says which
+// cluster it was seen on. That half of the check belongs to the watch leg,
+// where the engaged cluster is known: see RemoteRequests.
+func ChildToOwner(ownerKind string) handler.MapFunc {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
+		labels := obj.GetLabels()
+		if labels[OwnerKindLabel] != ownerKind {
+			return nil
+		}
+
+		name, namespace := labels[OwnerNameLabel], labels[OwnerNamespaceLabel]
+		if name == "" || namespace == "" || obj.GetNamespace() != namespace {
+			return nil
+		}
+
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+		}}
+	}
+}
+
+// LocalRequests turns a map function into the event-handler factory a
+// multicluster watch takes, pinning every request it produces to the local
+// cluster. The factory ignores which cluster it is engaged for, because the CR
+// a request names never lives there: an operator's CRs are all on the
+// management cluster, whatever cluster their children were projected onto.
+//
+// The empty ClusterName is what holds the workqueue to one key per CR. A
+// request is deduplicated by its whole value, cluster name included, so a child
+// event from cluster A and an event on the CR itself would otherwise become two
+// items and reconcile the same CR concurrently. The upstream
+// EnqueueRequestsFromMapFunc cannot produce that, since it overwrites the
+// cluster name with the one the event was delivered from; the preserving
+// variant leaves the choice to the map function, and this one always chooses
+// local.
+func LocalRequests(fn handler.MapFunc) mchandler.TypedEventHandlerFunc[client.Object, mcreconcile.Request] {
+	return func(_ mcruntime.ClusterName, _ cluster.Cluster) handler.TypedEventHandler[client.Object, mcreconcile.Request] {
+		return mchandler.TypedEnqueueRequestsFromMapFuncWithClusterPreservation(
+			func(ctx context.Context, obj client.Object) []mcreconcile.Request {
+				var requests []mcreconcile.Request
+				for _, req := range fn(ctx, obj) {
+					requests = append(requests, mcreconcile.Request{Request: req})
+				}
+				return requests
+			})
+	}
+}
+
+// TargetClusterFunc reports the name of the target cluster the CR at key
+// projects onto, read from the management cluster where that CR lives. A CR
+// naming no target cluster keeps its children local and answers with the empty
+// string, which no engaged provider cluster is called.
+//
+// It is what a remote watch leg gates its requests on, so it has to answer from
+// the CR itself: everything a target cluster carries is writable by whoever can
+// write to that cluster, and that is precisely the claim being checked.
+type TargetClusterFunc func(ctx context.Context, key types.NamespacedName) (string, error)
+
+// TargetClusterOf builds the TargetClusterFunc of one CR type from the
+// management cluster's reader and the CR's own target-cluster ref. Every
+// converted operator needs the same lookup over a different CR type, and the
+// two lines a call site spends on it are the accessor, which is the only part
+// that differs.
+//
+// The read costs no API call and no second informer: a controller's own For leg
+// already holds every CR of its kind in the local cache this reads through.
+func TargetClusterOf[T any, PT interface {
+	*T
+	client.Object
+}](c client.Reader, ref func(PT) *commonv1.TargetClusterRefSpec) TargetClusterFunc {
+	return func(ctx context.Context, key types.NamespacedName) (string, error) {
+		cr := PT(new(T))
+		if err := c.Get(ctx, key, cr); err != nil {
+			return "", err
+		}
+		if target := ref(cr); target != nil {
+			return target.Name, nil
+		}
+		return "", nil
+	}
+}
+
+// RemoteRequests is LocalRequests for a leg watching the target clusters: it
+// pins every request to the local cluster the same way, and drops the ones
+// naming a CR that does not project onto the cluster the event came from.
+//
+// That second half is the only place the cluster dimension can be checked at
+// all. A leg is engaged on every provider cluster the builder offers it, not on
+// the ones some CR happens to name, so without this gate every registered
+// cluster is an event source for every CR — and what a leg maps by is the
+// ownership labels or a name, both of which anyone able to create an object on
+// any target cluster can write. Toggling such an object in a loop would pin
+// somebody else's CR to continuous reconciliation, against the management
+// cluster, its own target, and every backing service behind it. The per-item
+// rate limiter is no help there: it backs off items that errored, and these
+// reconciles succeed.
+//
+// A CR that cannot be read is not reconciled. NotFound is the ordinary answer —
+// a child outliving the CR that projected it, an event naming a CR that never
+// existed — and is silent. Anything else is logged, because a CR that exists
+// and cannot be read is a leg that has quietly stopped correcting drift.
+func RemoteRequests(
+	fn handler.MapFunc,
+	targets TargetClusterFunc,
+) mchandler.TypedEventHandlerFunc[client.Object, mcreconcile.Request] {
+	return func(name mcruntime.ClusterName, cl cluster.Cluster) handler.TypedEventHandler[client.Object, mcreconcile.Request] {
+		return LocalRequests(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			var requests []reconcile.Request
+			for _, req := range fn(ctx, obj) {
+				target, err := targets(ctx, req.NamespacedName)
+				if err != nil {
+					if !apierrors.IsNotFound(err) {
+						log.FromContext(ctx).Error(err, "reading the CR an event on a target cluster names; "+
+							"dropping the event rather than reconciling on the strength of the object alone",
+							"cr", req.NamespacedName, "cluster", name)
+					}
+					continue
+				}
+				if target == string(name) {
+					requests = append(requests, req)
+				}
+			}
+			return requests
+		})(name, cl)
+	}
+}
+
+// LocalReconciler adapts a classic reconciler to the multicluster request type
+// by dropping the cluster name and forwarding the request as it stands. Every
+// converted controller reconciles CRs on the management cluster only, so its
+// Reconcile keeps the signature it has, and the cluster a CR's children belong
+// on is read from the CR's own target-cluster ref rather than from the request.
+func LocalReconciler(r reconcile.Reconciler) mcreconcile.Reconciler {
+	return mcreconcile.Func(func(ctx context.Context, req mcreconcile.Request) (reconcile.Result, error) {
+		return r.Reconcile(ctx, req.Request)
+	})
+}
+
+// ClusterServesKind reports, per engaged cluster, whether that cluster's
+// RESTMapper serves gvk. It is the filter a watch leg has to carry on any kind
+// not every target cluster installs: without it, a leg on an absent kind fails
+// the engagement of that whole cluster and the provider retries it under
+// backoff, so one missing CRD costs every other watch on that cluster too. With
+// it the leg alone is skipped and the rest of the engagement proceeds.
+//
+// The filter is asked once, when the cluster is engaged. A CRD installed after
+// that is watched only once the cluster is engaged again.
+//
+// A no-match answer — the cluster genuinely does not serve the kind — is the
+// ordinary one this filter is for. Discovery can also fail for reasons that say
+// nothing about gvk: the target's API server briefly unreachable, a 429 under
+// throttling, an aggregated APIService reporting Available=False, which fails
+// the group lookup for every group the mapper has not already cached. Those
+// answers skip the leg too, because the two ways of being wrong are not the
+// same size. A leg skipped on a kind the cluster does serve costs that one
+// kind's drift correction on that one cluster until the cluster is engaged
+// again — the latch a CRD installed later already sits behind. A leg engaged on
+// a kind the cluster does not serve costs the engagement of the whole cluster,
+// and where the discovery failure is a persistent one — a broken APIService
+// stays broken until somebody fixes it — the provider's retry meets the same
+// answer every time, so every CR projecting onto that cluster loses every watch
+// it has, for as long as it lasts, over one optional kind. The error is logged,
+// because a leg missing for this reason is worth reading the reason for.
+//
+// The mapping probe is spelled out here rather than taken from
+// gateway.IsGVKAvailable, which is the same check: the gateway package reaches
+// this one through apply and so cannot be imported back.
+func ClusterServesKind(gvk schema.GroupVersionKind) mcbuilder.ClusterFilterFunc {
+	return func(name mcruntime.ClusterName, cl cluster.Cluster) bool {
+		mapper := cl.GetRESTMapper()
+		if mapper == nil {
+			return false
+		}
+
+		_, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err == nil {
+			return true
+		}
+		if !meta.IsNoMatchError(err) {
+			log.Log.WithName("multicluster-watch").Error(err,
+				"probing whether a target cluster serves a kind failed; skipping the leg until the cluster "+
+					"is engaged again rather than risking the engagement of the whole cluster",
+				"cluster", name, "gvk", gvk)
+		}
+		return false
+	}
+}
+
+// EngageLocalCluster and EngageNoProviderClusters are the option pair every leg
+// watching the management cluster carries, and has to: once a provider is
+// configured, the builder's per-leg default is the inverse of the
+// single-cluster one — provider clusters yes, local no — so an unpinned leg
+// would quietly stop watching the management cluster, taking every CR event
+// with it. They are the local counterpart of RemoteWatchOptions, named here so
+// the reason lives in one place rather than in a comment beside every leg.
+//
+// Both are values built from an immutable option, so sharing them across every
+// controller is safe.
+var (
+	EngageLocalCluster       = mcbuilder.WithEngageWithLocalCluster(true)
+	EngageNoProviderClusters = mcbuilder.WithEngageWithProviderClusters(false)
+)
+
+// RemoteWatchOptions is the option set every leg watching a target cluster
+// carries: provider clusters only, and among those only the ones serving gvk.
+// Spelling the three in one place is what keeps them together, because each is
+// silent on its own — a leg left on the builder's default watches the wrong
+// side, and one without the filter fails the whole engagement of a cluster
+// missing the kind rather than just itself.
+func RemoteWatchOptions(gvk schema.GroupVersionKind) []mcbuilder.WatchesOption {
+	return []mcbuilder.WatchesOption{
+		mcbuilder.WithEngageWithLocalCluster(false),
+		mcbuilder.WithEngageWithProviderClusters(true),
+		mcbuilder.WithClusterFilter(ClusterServesKind(gvk)),
+	}
+}
+
+// AddInputWatch adds the pair of legs an input object needs — one on the
+// management cluster, one on the clusters a CR can project onto — both mapping
+// obj's events through fn, and returns the builder so the call chains.
+//
+// The remote leg is not the child watch over again. An input is written by
+// something other than the operator: ESO writes a Secret, the MariaDB operator
+// its cluster CR. Neither carries the ownership labels, so ChildToOwner maps
+// them to nothing and only a leg of their own makes a rotation or an outage on
+// the target reach the CR at watch latency rather than at the next periodic
+// requeue, exactly as it does management-side.
+//
+// The same fn serves both legs because every caller's mappers resolve CRs
+// through field indexes on the LOCAL cache, which is where the CRs are whatever
+// cluster delivered the event.
+//
+// The kind the remote leg filters clusters by is resolved from obj through the
+// scheme rather than spelled out beside it. The two have to describe the same
+// kind and nothing would have checked that: a filter naming a kind the target
+// serves while the leg watches one it does not engages the leg anyway, which is
+// the whole-cluster engagement failure ClusterServesKind exists to prevent, and
+// the mismatch the other way drops the input watch without a word.
+//
+// targets gates the remote leg alone (see RemoteRequests). An input is named
+// rather than labelled, so what the mapper matches on is a name somebody else
+// can take on a cluster the CR never projects onto; the local leg needs no gate,
+// because the management cluster is where the CR itself lives.
+func AddInputWatch(
+	b *mcbuilder.Builder,
+	scheme *runtime.Scheme,
+	targets TargetClusterFunc,
+	obj client.Object,
+	fn handler.MapFunc,
+) (*mcbuilder.Builder, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("resolving input kind for remote watch: %w", err)
+	}
+
+	return b.
+		Watches(obj, LocalRequests(fn), EngageLocalCluster, EngageNoProviderClusters).
+		Watches(obj, RemoteRequests(fn, targets), RemoteWatchOptions(gvk)...), nil
+}
+
+// AddRemoteChildWatches adds one watch leg per projected kind to b: provider
+// clusters only, mapping a labelled child back to the CR its ownership labels
+// name, and skipping the clusters that do not serve the kind. It returns the
+// builder, so the call chains with the rest of a controller's setup, and leaves
+// b untouched when kinds is empty.
+//
+// kinds is the operator's own sweep list, the one its teardown deletes through.
+// Driving both from a single list is the point: a kind added to a projection
+// later gets its watch and its teardown from the same edit, and a kind that is
+// swept but not watched is a child whose drift nothing notices.
+//
+// The owner is taken as an object and its kind resolved through the scheme,
+// the same way the write side derives the label it stamps. A hand-typed kind
+// would be a second source of truth for one value, and getting it wrong costs
+// no compile error and no runtime error — every child would map to nothing and
+// the drift correction this adds would simply be off.
+//
+// targets is what keeps a leg engaged on one cluster from waking a CR that
+// projects onto another (see RemoteRequests). The ownership labels a child is
+// matched by are writable by anyone who can create an object on any registered
+// cluster, and only the CR itself says which cluster its children belong on.
+//
+// extra carries per-kind options a caller needs on top of the three set here, a
+// predicate for instance. A nil map means none for any kind. A key naming a
+// kind outside kinds is refused rather than ignored: the options would be
+// silently dropped, and a predicate that vanishes reads as reconcile churn in
+// production rather than as a wiring mistake.
+func AddRemoteChildWatches(
+	b *mcbuilder.Builder,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	targets TargetClusterFunc,
+	kinds []schema.GroupVersionKind,
+	extra map[schema.GroupVersionKind][]mcbuilder.WatchesOption,
+) (*mcbuilder.Builder, error) {
+	resolved, err := ownerGVK(scheme, owner)
+	if err != nil {
+		return nil, err
+	}
+	ownerKind := resolved.Kind
+
+	for gvk := range extra {
+		if !slices.Contains(kinds, gvk) {
+			return nil, fmt.Errorf("remote watch options given for %s, which is not a projected child kind", gvk)
+		}
+	}
+
+	for _, gvk := range kinds {
+		obj, err := scheme.New(gvk)
+		if err != nil {
+			return nil, fmt.Errorf("building remote watch object for %s: %w", gvk, err)
+		}
+
+		child, ok := obj.(client.Object)
+		if !ok {
+			return nil, fmt.Errorf("building remote watch object for %s: %T carries no object metadata", gvk, obj)
+		}
+
+		opts := append(RemoteWatchOptions(gvk), extra[gvk]...)
+
+		b = b.Watches(child, RemoteRequests(ChildToOwner(ownerKind), targets), opts...)
+	}
+
+	return b, nil
+}

--- a/internal/common/multicluster/watch_test.go
+++ b/internal/common/multicluster/watch_test.go
@@ -1,0 +1,556 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// watchOwnerKind is the owner kind every test below maps back to. Barbican
+// stands in for the other operator projecting into the same target namespace.
+const watchOwnerKind = "Keystone"
+
+// ownerRequest is what a fully stamped child has to map to: the owner on the
+// management cluster, never the cluster the child was seen on.
+var ownerRequest = reconcile.Request{
+	NamespacedName: types.NamespacedName{Namespace: "openstack", Name: "example"},
+}
+
+// watchChildLabels is a complete ownership stamp, the one Claim writes onto a
+// child of the owner named by ownerRequest.
+func watchChildLabels() map[string]string {
+	return map[string]string{
+		OwnerKindLabel:      watchOwnerKind,
+		OwnerNameLabel:      "example",
+		OwnerNamespaceLabel: "openstack",
+	}
+}
+
+// watchChild is an object on a target cluster carrying labels, in the namespace
+// a child of ownerRequest's owner lands in. Its own name differs from its
+// owner's on purpose: a map function reading the name off the object rather
+// than off the labels would produce the wrong request.
+func watchChild(labels map[string]string) *corev1.Secret {
+	return watchChildIn("openstack", labels)
+}
+
+// watchChildIn is watchChild in a namespace of its own, for the case where the
+// object's namespace and the namespace its labels claim disagree.
+func watchChildIn(namespace string, labels map[string]string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "example-config",
+		Namespace: namespace,
+		Labels:    labels,
+	}}
+}
+
+// httpRouteGVK is a kind not every target cluster installs, which is the case
+// ClusterServesKind exists for.
+var httpRouteGVK = schema.GroupVersionKind{
+	Group:   "gateway.networking.k8s.io",
+	Version: "v1",
+	Kind:    "HTTPRoute",
+}
+
+// mapperCluster answers about the kinds it serves and nothing else. Embedding
+// the interface leaves every other method nil, so a filter reaching past the
+// RESTMapper panics rather than passing quietly.
+type mapperCluster struct {
+	cluster.Cluster
+	mapper meta.RESTMapper
+}
+
+func (m mapperCluster) GetRESTMapper() meta.RESTMapper { return m.mapper }
+
+// erroringMapper fails every mapping with an error that is not a no-match: the
+// throttled or briefly unreachable target cluster, or the one whose aggregated
+// discovery an unrelated broken APIService fails, whose answer says nothing
+// about whether it serves the kind.
+type erroringMapper struct {
+	meta.RESTMapper
+}
+
+func (erroringMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, errors.New("etcdserver: request timed out")
+}
+
+// watchTargetsFor builds the TargetClusterFunc a remote leg gates on over the
+// CR stand-ins the fake client holds. A ConfigMap plays the CR — this package
+// knows no service CR — and its targetCluster key plays spec.targetClusterRef,
+// absent for a CR that keeps its children on the management cluster.
+func watchTargetsFor(t *testing.T, crs ...client.Object) TargetClusterFunc {
+	t.Helper()
+
+	c := fake.NewClientBuilder().WithScheme(ownershipScheme(t)).WithObjects(crs...).Build()
+	return TargetClusterOf(c, func(cr *corev1.ConfigMap) *commonv1.TargetClusterRefSpec {
+		name, named := cr.Data["targetCluster"]
+		if !named {
+			return nil
+		}
+		return &commonv1.TargetClusterRefSpec{Name: name}
+	})
+}
+
+// watchOwnerCR is the CR stand-in ownerRequest names, projecting onto cluster.
+// An empty cluster is a CR that names none.
+func watchOwnerCR(cluster string) *corev1.ConfigMap {
+	cr := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      ownerRequest.Name,
+		Namespace: ownerRequest.Namespace,
+	}}
+	if cluster != "" {
+		cr.Data = map[string]string{"targetCluster": cluster}
+	}
+	return cr
+}
+
+// mcQueue is the workqueue a multicluster event handler writes into.
+type mcQueue = workqueue.TypedRateLimitingInterface[mcreconcile.Request]
+
+// newMCQueue builds the real controller workqueue rather than a recording fake,
+// so the deduplication a pinned cluster name buys is what the assertions read.
+func newMCQueue() mcQueue {
+	return workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[mcreconcile.Request]())
+}
+
+// A remote child carries no owner reference, so the labels are the only link
+// back to the CR. This is the mapping the whole watch leg exists to make.
+func TestChildToOwnerMapsALabelledChildToItsOwner(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	requests := ChildToOwner(watchOwnerKind)(context.Background(), watchChild(watchChildLabels()))
+
+	g.Expect(requests).To(gomega.ConsistOf(ownerRequest))
+}
+
+// The children of every CR projecting into a shared target namespace arrive
+// through the same watch, so the map function is constantly asked about objects
+// it must say nothing about. A half-stamped object is one of them: a request
+// naming an empty name or namespace would reconcile whatever CR answered to it.
+func TestChildToOwnerIgnoresWhatItDoesNotOwn(t *testing.T) {
+	without := func(key string) map[string]string {
+		labels := watchChildLabels()
+		delete(labels, key)
+		return labels
+	}
+	anotherOwner := watchChildLabels()
+	anotherOwner[OwnerKindLabel] = "Barbican"
+
+	for name, labels := range map[string]map[string]string{
+		"nothing stamped it at all": nil,
+		"no owner kind":             without(OwnerKindLabel),
+		"no owner name":             without(OwnerNameLabel),
+		"no owner namespace":        without(OwnerNamespaceLabel),
+		"another operator's child":  anotherOwner,
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			requests := ChildToOwner(watchOwnerKind)(context.Background(), watchChild(labels))
+
+			g.Expect(requests).To(gomega.BeEmpty())
+		})
+	}
+}
+
+// The operator stamps a child in its owner's own namespace and nowhere else, so
+// an object claiming an owner somewhere else was stamped by somebody else. The
+// labels are forgeable by anyone who can create an object, and a target cluster
+// has namespaces this operator never projects into; trusting them there would
+// let a principal with create access in any of them name any CR in the fleet and
+// have it reconciled on their timing.
+func TestChildToOwnerIgnoresAChildClaimingAnOwnerInAnotherNamespace(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	forged := watchChildIn("someone-elses-ns", watchChildLabels())
+
+	requests := ChildToOwner(watchOwnerKind)(context.Background(), forged)
+
+	g.Expect(requests).To(gomega.BeEmpty(),
+		"a labelled object outside its claimed owner's namespace is not a child this operator wrote")
+}
+
+// The event arrives from a provider cluster and the CR it names lives on the
+// management cluster, so the request has to come out with an empty cluster
+// name. Anything else gives the workqueue a second key for the same CR and lets
+// a child event and a CR event reconcile it concurrently.
+func TestLocalRequestsPinsEveryEventToTheLocalCluster(t *testing.T) {
+	child := watchChild(watchChildLabels())
+	ctx := context.Background()
+
+	// A nil cluster proves the factory reaches for neither of its arguments,
+	// and a non-empty cluster name that it does not carry one through.
+	eventHandler := LocalRequests(ChildToOwner(watchOwnerKind))("remote-a", nil)
+
+	for name, fire := range map[string]func(mcQueue){
+		"create": func(q mcQueue) {
+			eventHandler.Create(ctx, event.TypedCreateEvent[client.Object]{Object: child}, q)
+		},
+		"update": func(q mcQueue) {
+			eventHandler.Update(ctx, event.TypedUpdateEvent[client.Object]{ObjectOld: child, ObjectNew: child}, q)
+		},
+		"delete": func(q mcQueue) {
+			eventHandler.Delete(ctx, event.TypedDeleteEvent[client.Object]{Object: child}, q)
+		},
+		"generic": func(q mcQueue) {
+			eventHandler.Generic(ctx, event.TypedGenericEvent[client.Object]{Object: child}, q)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			queue := newMCQueue()
+			defer queue.ShutDown()
+
+			fire(queue)
+
+			// The update case fires the map function twice, once per object,
+			// so one item also says the two collapsed onto one key.
+			g.Expect(queue.Len()).To(gomega.Equal(1))
+
+			got, _ := queue.Get()
+			g.Expect(got.Request).To(gomega.Equal(ownerRequest))
+			g.Expect(got.ClusterName).To(gomega.BeEmpty(),
+				"a request naming the cluster the event came from would be a second workqueue key for one CR")
+		})
+	}
+}
+
+// Most events on a shared target namespace map to nothing, and the handler has
+// to leave the queue alone rather than enqueue an empty request that would
+// reconcile a CR with no name.
+func TestLocalRequestsEnqueuesNothingWhenNothingMaps(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	queue := newMCQueue()
+	defer queue.ShutDown()
+
+	LocalRequests(ChildToOwner(watchOwnerKind))("remote-a", nil).
+		Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: watchChild(nil)}, queue)
+
+	g.Expect(queue.Len()).To(gomega.BeZero())
+}
+
+// Every input mapper the converted controllers wrap fans out — one Secret or
+// one SecretStore names as many CRs as reference it — so the conversion from
+// reconcile.Request to the multicluster one has to carry all of them, not just
+// the first.
+func TestLocalRequestsEnqueuesEveryRequestAFanOutMapperNames(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	second := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "openstack", Name: "second"},
+	}
+	fanOut := func(context.Context, client.Object) []reconcile.Request {
+		return []reconcile.Request{ownerRequest, second}
+	}
+
+	queue := newMCQueue()
+	defer queue.ShutDown()
+
+	LocalRequests(fanOut)("remote-a", nil).
+		Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: watchChild(nil)}, queue)
+
+	g.Expect(queue.Len()).To(gomega.Equal(2), "a mapper naming several CRs must enqueue every one of them")
+
+	var got []reconcile.Request
+	for range 2 {
+		item, _ := queue.Get()
+		g.Expect(item.ClusterName).To(gomega.BeEmpty())
+		got = append(got, item.Request)
+	}
+	g.Expect(got).To(gomega.ConsistOf(ownerRequest, second))
+}
+
+// A leg is engaged on every registered cluster, not on the ones a CR names, so
+// the cluster an event arrived from is the half of the ownership claim the
+// object itself cannot carry. Everything on a target cluster — the ownership
+// labels included — is writable by whoever can write to that cluster, so
+// without this gate anyone with create access in one shared namespace could
+// name any CR in the fleet and have it reconciled on their timing, indefinitely
+// and without the rate limiter noticing (its backoff applies to items that
+// errored, and these reconciles succeed).
+func TestRemoteRequestsDropsEventsFromAClusterTheCRDoesNotProjectOnto(t *testing.T) {
+	child := watchChild(watchChildLabels())
+
+	for name, tc := range map[string]struct {
+		cr      *corev1.ConfigMap
+		enqueue bool
+	}{
+		"the CR projects onto this cluster":    {cr: watchOwnerCR("remote-a"), enqueue: true},
+		"the CR projects onto another cluster": {cr: watchOwnerCR("remote-b")},
+		"the CR keeps its children local":      {cr: watchOwnerCR("")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			queue := newMCQueue()
+			defer queue.ShutDown()
+
+			RemoteRequests(ChildToOwner(watchOwnerKind), watchTargetsFor(t, tc.cr))("remote-a", nil).
+				Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: child}, queue)
+
+			if !tc.enqueue {
+				g.Expect(queue.Len()).To(gomega.BeZero(),
+					"an event from a cluster the CR does not project onto must not reconcile it")
+				return
+			}
+
+			g.Expect(queue.Len()).To(gomega.Equal(1))
+			got, _ := queue.Get()
+			g.Expect(got.Request).To(gomega.Equal(ownerRequest))
+			g.Expect(got.ClusterName).To(gomega.BeEmpty())
+		})
+	}
+}
+
+// The labels are the forgeable half of the pair and the CR is the trusted one,
+// so an event whose CR cannot be read is dropped rather than admitted. A child
+// outliving the CR that projected it is the ordinary case.
+func TestRemoteRequestsDropsEventsNamingACRThatDoesNotExist(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	queue := newMCQueue()
+	defer queue.ShutDown()
+
+	RemoteRequests(ChildToOwner(watchOwnerKind), watchTargetsFor(t))("remote-a", nil).
+		Create(context.Background(), event.TypedCreateEvent[client.Object]{
+			Object: watchChild(watchChildLabels()),
+		}, queue)
+
+	g.Expect(queue.Len()).To(gomega.BeZero())
+}
+
+// The gate is applied per request, not per event: an input mapper names as many
+// CRs as reference the object, and they need not all project onto the cluster
+// the event came from.
+func TestRemoteRequestsGatesEveryRequestOfAFanOutMapperOnItsOwnCR(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	elsewhere := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "openstack", Name: "second"},
+	}
+	fanOut := func(context.Context, client.Object) []reconcile.Request {
+		return []reconcile.Request{ownerRequest, elsewhere}
+	}
+	secondCR := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: elsewhere.Name, Namespace: elsewhere.Namespace},
+		Data:       map[string]string{"targetCluster": "remote-b"},
+	}
+
+	queue := newMCQueue()
+	defer queue.ShutDown()
+
+	RemoteRequests(fanOut, watchTargetsFor(t, watchOwnerCR("remote-a"), secondCR))("remote-a", nil).
+		Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: watchChild(nil)}, queue)
+
+	g.Expect(queue.Len()).To(gomega.Equal(1))
+	got, _ := queue.Get()
+	g.Expect(got.Request).To(gomega.Equal(ownerRequest),
+		"only the CR projecting onto the cluster the event came from may be enqueued")
+}
+
+// The lookup every remote leg gates on reads the ref off the CR itself, which
+// is the only party to the claim a target cluster cannot write to.
+func TestTargetClusterOfReadsTheRefOffTheCR(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	local := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "local", Namespace: "openstack"}}
+	targets := watchTargetsFor(t, watchOwnerCR("remote-b"), local)
+	ctx := context.Background()
+
+	named, err := targets(ctx, ownerRequest.NamespacedName)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(named).To(gomega.Equal("remote-b"))
+
+	unnamed, err := targets(ctx, types.NamespacedName{Namespace: "openstack", Name: "local"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(unnamed).To(gomega.BeEmpty(),
+		"a CR naming no target cluster must match no engaged cluster")
+
+	_, err = targets(ctx, types.NamespacedName{Namespace: "openstack", Name: "gone"})
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+}
+
+// The adapter exists so a converted controller keeps its Reconcile signature.
+// It therefore has to be transparent in both directions: the inner reconciler
+// sees the request without the cluster name, and its result and error come back
+// exactly as it returned them.
+func TestLocalReconcilerForwardsTheRequestAndItsOutcome(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	failed := errors.New("the sub-reconciler chain stopped")
+	var seen []reconcile.Request
+	inner := reconcile.Func(func(_ context.Context, req reconcile.Request) (reconcile.Result, error) {
+		seen = append(seen, req)
+		return reconcile.Result{RequeueAfter: 42 * time.Second}, failed
+	})
+
+	request := mcreconcile.Request{Request: ownerRequest, ClusterName: "remote-a"}
+	result, err := LocalReconciler(inner).Reconcile(context.Background(), request)
+
+	g.Expect(seen).To(gomega.ConsistOf(ownerRequest))
+	g.Expect(result).To(gomega.Equal(reconcile.Result{RequeueAfter: 42 * time.Second}))
+	g.Expect(errors.Is(err, failed)).To(gomega.BeTrue())
+}
+
+// A target cluster is free to serve only part of the kind list an operator
+// projects. The filter is what keeps that from failing the cluster's whole
+// engagement, so it has to answer per cluster and not once for all of them.
+func TestClusterServesKind(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	serving := meta.NewDefaultRESTMapper([]schema.GroupVersion{httpRouteGVK.GroupVersion()})
+	serving.Add(httpRouteGVK, meta.RESTScopeNamespace)
+
+	filter := ClusterServesKind(httpRouteGVK)
+
+	g.Expect(filter("remote-a", mapperCluster{mapper: serving})).To(gomega.BeTrue())
+	g.Expect(filter("remote-b", mapperCluster{mapper: meta.NewDefaultRESTMapper(nil)})).To(gomega.BeFalse(),
+		"a cluster without the CRD must lose this leg alone")
+	// A cluster that has not built a mapper is as unusable for this leg as one
+	// missing the CRD, and must not panic the engagement.
+	g.Expect(filter("remote-c", mapperCluster{})).To(gomega.BeFalse())
+}
+
+// An error that is not a no-match says nothing about the kind, and the filter
+// has to answer anyway. It skips the leg, because engaging on a kind the
+// cluster does not serve fails the engagement of the whole cluster, and a
+// discovery failure that outlives the provider's backoff — an aggregated
+// APIService stuck on Available=False fails the group lookup for every group
+// the mapper has not cached — would make that permanent: every CR projecting
+// onto the cluster would lose every watch it has, over one optional kind.
+// Skipping costs this one leg until the cluster is engaged again.
+func TestClusterServesKindSkipsTheLegOnADiscoveryFailure(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(ClusterServesKind(httpRouteGVK)("remote-d", mapperCluster{mapper: erroringMapper{}})).
+		To(gomega.BeFalse(), "an ambiguous discovery answer must cost this leg alone, not the whole cluster")
+}
+
+// Each of the three options a remote leg carries is silent on its own: the
+// first two left off watch the wrong side of the fleet, and the filter left off
+// fails the whole engagement of a cluster missing the kind rather than just this
+// leg. Nothing else in the tree would notice one going missing.
+func TestRemoteWatchOptionsCarriesEveryOptionARemoteLegNeeds(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(RemoteWatchOptions(httpRouteGVK)).To(gomega.HaveLen(3),
+		"a remote leg needs all three of: no local cluster, provider clusters, and the kind filter")
+}
+
+// The kind driving the remote leg's cluster filter is resolved from the object
+// the leg watches, so the two cannot describe different kinds. A kind the
+// scheme does not know is a wiring mistake and has to fail setup rather than
+// register a leg filtered on nothing.
+func TestAddInputWatchResolvesTheWatchedKindThroughTheScheme(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	got, err := AddInputWatch(mcbuilder.ControllerManagedBy(nil), ownershipScheme(t), watchTargetsFor(t),
+		&corev1.Secret{}, ChildToOwner(watchOwnerKind))
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(got).NotTo(gomega.BeNil())
+
+	got, err = AddInputWatch(mcbuilder.ControllerManagedBy(nil), runtime.NewScheme(), watchTargetsFor(t),
+		&corev1.Secret{}, ChildToOwner(watchOwnerKind))
+
+	g.Expect(got).To(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving input kind for remote watch")))
+}
+
+// A CR that projects nothing onto a target cluster still runs through this, and
+// has to come back with the builder it handed in: a watch leg registered for an
+// empty list would engage provider clusters for nothing.
+func TestAddRemoteChildWatchesWithoutKindsLeavesTheBuilderAlone(t *testing.T) {
+	for name, kinds := range map[string][]schema.GroupVersionKind{
+		"nil kinds":   nil,
+		"empty kinds": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			builder := mcbuilder.ControllerManagedBy(nil)
+
+			// A nil extra map is the ordinary call: most operators need no
+			// per-kind options beyond the three this sets itself.
+			got, err := AddRemoteChildWatches(builder, ownershipScheme(t), testOwner(), watchTargetsFor(t), kinds, nil)
+
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(got).To(gomega.BeIdenticalTo(builder))
+		})
+	}
+}
+
+// The owner kind the child labels are matched against is the same value the
+// write side stamps, so it is resolved from the owner object rather than typed
+// out again. An owner the scheme does not know would otherwise be matched
+// against an empty kind, and every child would map to nothing.
+func TestAddRemoteChildWatchesRejectsAnOwnerTheSchemeDoesNotKnow(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	got, err := AddRemoteChildWatches(mcbuilder.ControllerManagedBy(nil), runtime.NewScheme(), testOwner(),
+		watchTargetsFor(t), []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")}, nil)
+
+	g.Expect(got).To(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("resolving GVK for owner openstack/example")))
+}
+
+// The extra options are keyed by kind and applied inside the loop over kinds, so
+// a key naming a kind outside that list is simply never read. Dropping a
+// predicate silently is the worst outcome available: setup succeeds, every test
+// passes, and the only symptom is reconcile churn in production.
+func TestAddRemoteChildWatchesRejectsExtraOptionsForAKindItDoesNotWatch(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	got, err := AddRemoteChildWatches(mcbuilder.ControllerManagedBy(nil), ownershipScheme(t), testOwner(),
+		watchTargetsFor(t), []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")},
+		map[schema.GroupVersionKind][]mcbuilder.WatchesOption{
+			corev1.SchemeGroupVersion.WithKind("ConfigMap"): {mcbuilder.WithEngageWithLocalCluster(true)},
+		})
+
+	g.Expect(got).To(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("is not a projected child kind")))
+}
+
+// The kind list is written by hand next to the operator's sweep list, so a kind
+// its scheme never registered is a wiring mistake. It has to surface while the
+// controller is being set up, not as a watch that quietly never fires.
+func TestAddRemoteChildWatchesRejectsAKindTheSchemeDoesNotKnow(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	got, err := AddRemoteChildWatches(mcbuilder.ControllerManagedBy(nil), ownershipScheme(t), testOwner(),
+		watchTargetsFor(t), []schema.GroupVersionKind{httpRouteGVK}, nil)
+
+	g.Expect(got).To(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("building remote watch object for")))
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(httpRouteGVK.String())))
+	// The scheme's own diagnosis survives the wrap, so the message still names
+	// the kind nobody registered.
+	g.Expect(runtime.IsNotRegisteredError(errors.Unwrap(err))).To(gomega.BeTrue())
+}

--- a/operators/barbican/internal/controller/barbican_controller.go
+++ b/operators/barbican/internal/controller/barbican_controller.go
@@ -24,12 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
 	"github.com/c5c3/forge/internal/common/database"
@@ -253,7 +254,7 @@ type BarbicanReconciler struct {
 	healthProbeCache healthcheck.ProbeCache
 }
 
-// barbicanRemoteChildKinds are the kinds a Barbican CR projects into the
+// BarbicanRemoteChildKinds are the kinds a Barbican CR projects into the
 // namespace of the target cluster it names, and the kinds
 // reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
 // deleted. Nothing on the target cluster collects them, so a kind missing from
@@ -262,7 +263,7 @@ type BarbicanReconciler struct {
 // The list is cross-checked against the create verbs of the kubebuilder RBAC
 // markers on this controller below: the operator can only leave behind what it
 // is allowed to create.
-var barbicanRemoteChildKinds = []schema.GroupVersionKind{
+var BarbicanRemoteChildKinds = []schema.GroupVersionKind{
 	appsv1.SchemeGroupVersion.WithKind("Deployment"),
 	corev1.SchemeGroupVersion.WithKind("Service"),
 	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
@@ -610,7 +611,7 @@ func (r *BarbicanReconciler) reconcileDelete(ctx context.Context, children clien
 // rest, selected on the ownership labels Claim stamped on them.
 func (r *BarbicanReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, barbican *barbicanv1alpha1.Barbican) error {
 	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
-		barbican, barbican.Spec.TargetClusterRef, children, barbicanRemoteChildKinds)
+		barbican, barbican.Spec.TargetClusterRef, children, BarbicanRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given
@@ -637,13 +638,15 @@ func setReadyCondition(barbican *barbicanv1alpha1.Barbican) {
 // controllers, so this reconciler MUST be set up before
 // BarbicanSecretStoreReconciler), and wires the owned resources and
 // cross-resource watches.
-func (r *BarbicanReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *BarbicanReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	local := mgr.GetLocalManager()
+
 	// Detect whether the Gateway API CRD is installed. spec.gateway is optional,
 	// so the operator must run on clusters without Gateway API. Adding
 	// Owns(HTTPRoute) unconditionally would fail at Start with "no matches for
 	// kind HTTPRoute" when the CRD is missing, blocking every Barbican CR.
-	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
-	r.apiReader = mgr.GetAPIReader()
+	r.gatewayAPIAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = local.GetAPIReader()
 	setupLog := ctrl.Log.WithName("barbican-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")
@@ -653,69 +656,115 @@ func (r *BarbicanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Register the Barbican field indexer before Watches so
 	// secretToBarbicanWithStoresMapper can rely on it for its MatchingFields
-	// lookup.
-	if err := registerBarbicanIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// lookup. The indexes go on the LOCAL field indexer, not mgr's: with a
+	// provider configured, the multicluster manager's field indexer registers
+	// against the provider clusters, which hold no Barbican CR. Indexing the
+	// fleet is issue #839's business.
+	if err := registerBarbicanIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 	// Register the BarbicanSecretStore indexes here — the single registration
 	// site for both controllers (this reconciler is set up before
 	// BarbicanSecretStoreReconciler in main.go and the envtest helper).
-	// reconcileSecretStores and the mappers rely on them.
-	if err := registerBarbicanSecretStoreIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// reconcileSecretStores and the mappers rely on them. They go on the LOCAL
+	// field indexer for the same reason as the Barbican indexes above.
+	if err := registerBarbicanSecretStoreIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
-	b := ctrl.NewControllerManagedBy(mgr).
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones some CR names, so it has to drop the events belonging to a CR that
+	// projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := commonmulticluster.TargetClusterOf(local.GetClient(),
+		func(barbican *barbicanv1alpha1.Barbican) *commonv1.TargetClusterRefSpec {
+			return barbican.Spec.TargetClusterRef
+		})
+
+	b := mcbuilder.ControllerManagedBy(mgr).
 		// Shared controller options: MaxConcurrentReconciles lets independent CRs
 		// reconcile in parallel, and the tuned RateLimiter caps per-item failure
-		// backoff at 30s (see bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+		// backoff at 30s (see bootstrap.TypedControllerOptions).
+		WithOptions(bootstrap.TypedControllerOptions[mcreconcile.Request](r.MaxConcurrentReconciles)).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&barbicanv1alpha1.Barbican{}, builder.WithPredicates(watch.CRUpdatePredicate())).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&batchv1.Job{}).
-		Owns(&batchv1.CronJob{})
+		For(&barbicanv1alpha1.Barbican{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
+		Owns(&appsv1.Deployment{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Service{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Secret{}, engageLocal, engageNoProviders).
+		Owns(&policyv1.PodDisruptionBudget{}, engageLocal, engageNoProviders).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, engageLocal, engageNoProviders).
+		Owns(&networkingv1.NetworkPolicy{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.Job{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.CronJob{}, engageLocal, engageNoProviders)
 
 	if r.gatewayAPIAvailable {
-		b = b.Owns(&gatewayv1.HTTPRoute{})
+		b = b.Owns(&gatewayv1.HTTPRoute{}, engageLocal, engageNoProviders)
+	}
+
+	// The same children, once more, on the clusters a CR can project onto. Owns
+	// cannot see them: an owner reference does not cross a cluster boundary, so
+	// the ownership labels are what maps a child back to its CR. No leg carries a
+	// predicate, mirroring what Owns admits locally.
+	b, err := commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &barbicanv1alpha1.Barbican{},
+		targets, BarbicanRemoteChildKinds, nil)
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets and map to the Barbican CRs that reference them (directly
+	// or via an attached BarbicanSecretStore's AppRole credentials/CA Secret).
+	// ESO-managed Secrets are owned by the ExternalSecret controller, not the
+	// Barbican CR, so EnqueueRequestForOwner would never match them.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &corev1.Secret{},
+		secretToBarbicanWithStoresMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
+	// the operator reflects upstream database outages in DatabaseReady without
+	// waiting for the next periodic requeue.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &mariadbv1alpha1.MariaDB{},
+		mariaDBToBarbicanMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch both the cluster-scoped ClusterSecretStore and the namespaced
+	// SecretStore a Barbican can select via spec.secretStoreRef, so the
+	// operator reflects upstream secret-backend outages in SecretsReady as soon
+	// as ESO flips the selected store's Ready condition.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.ClusterSecretStore{},
+		esoStoreToBarbicanMapper(local.GetClient(), commonv1.SecretStoreKindCluster))
+	if err != nil {
+		return err
+	}
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.SecretStore{},
+		esoStoreToBarbicanMapper(local.GetClient(), commonv1.SecretStoreKindNamespaced))
+	if err != nil {
+		return err
 	}
 
 	return b.
-		// Watch Secrets and map to the Barbican CRs that reference them (directly
-		// or via an attached BarbicanSecretStore's AppRole credentials/CA Secret).
-		// ESO-managed Secrets are owned by the ExternalSecret controller, not the
-		// Barbican CR, so EnqueueRequestForOwner would never match them.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			secretToBarbicanWithStoresMapper(mgr.GetClient()),
-		)).
 		// Watch BarbicanSecretStores and map to their parent Barbican: store
 		// status flips (CredentialsReady turning True) trigger projection,
 		// DeletionTimestamp flips trigger de-projection. No generation predicate —
-		// the status transitions ARE the signal.
-		Watches(&barbicanv1alpha1.BarbicanSecretStore{}, handler.EnqueueRequestsFromMapFunc(
+		// the status transitions ARE the signal. The leg stays local-only: a
+		// BarbicanSecretStore is a management-plane CR and lives nowhere else.
+		Watches(&barbicanv1alpha1.BarbicanSecretStore{}, commonmulticluster.LocalRequests(
 			barbicanSecretStoreToBarbicanMapper(),
-		)).
-		// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
-		// the operator reflects upstream database outages in DatabaseReady without
-		// waiting for the next periodic requeue.
-		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
-			mariaDBToBarbicanMapper(mgr.GetClient()),
-		)).
-		// Watch both the cluster-scoped ClusterSecretStore and the namespaced
-		// SecretStore a Barbican can select via spec.secretStoreRef, so the
-		// operator reflects upstream secret-backend outages in SecretsReady as soon
-		// as ESO flips the selected store's Ready condition.
-		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			esoStoreToBarbicanMapper(mgr.GetClient(), commonv1.SecretStoreKindCluster),
-		)).
-		Watches(&esov1.SecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			esoStoreToBarbicanMapper(mgr.GetClient(), commonv1.SecretStoreKindNamespaced),
-		)).
-		Complete(r)
+		), engageLocal, engageNoProviders).
+		// The default wrapper turns an error matching multicluster.ErrClusterNotFound
+		// into a successful reconcile. This operator instead surfaces an
+		// unresolvable cluster as a TargetClusterUnavailable condition and
+		// requeues, so the wrapper stays off and the error semantics remain
+		// byte-identical to the classic builder's.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/barbican/internal/controller/barbicansecretstore_controller.go
+++ b/operators/barbican/internal/controller/barbicansecretstore_controller.go
@@ -20,15 +20,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
@@ -1340,27 +1342,85 @@ func listStoreRequests(ctx context.Context, c client.Reader, namespace string, m
 	return requests
 }
 
+// storeTargetCluster is the lookup this controller's remote legs gate their
+// requests on (see commonmulticluster.RemoteRequests). A BarbicanSecretStore has
+// no target field of its own, so the cluster its children belong on is the one
+// its parent Barbican names — the same two hops resolveChildren walks for the
+// write side. A store whose parent does not exist has no known cluster, and its
+// events on every target are dropped until it does.
+func storeTargetCluster(c client.Reader) commonmulticluster.TargetClusterFunc {
+	return func(ctx context.Context, key client.ObjectKey) (string, error) {
+		var store barbicanv1alpha1.BarbicanSecretStore
+		if err := c.Get(ctx, key, &store); err != nil {
+			return "", err
+		}
+
+		var parent barbicanv1alpha1.Barbican
+		parentKey := client.ObjectKey{Namespace: key.Namespace, Name: store.Spec.BarbicanRef.Name}
+		if err := c.Get(ctx, parentKey, &parent); err != nil {
+			return "", err
+		}
+		if parent.Spec.TargetClusterRef == nil {
+			return "", nil
+		}
+		return parent.Spec.TargetClusterRef.Name, nil
+	}
+}
+
 // SetupWithManager registers the BarbicanSecretStoreReconciler with the
 // controller manager. The BarbicanSecretStore field indexes both mappers resolve
 // against are registered by BarbicanReconciler.SetupWithManager (the single
 // registration site — both controllers run in one manager and that reconciler is
 // set up first), so this controller registers none.
-func (r *BarbicanSecretStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+func (r *BarbicanSecretStoreReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	local := mgr.GetLocalManager()
+
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones a store's parent names, so it has to drop the events belonging to a
+	// store that projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := storeTargetCluster(local.GetClient())
+
+	b := mcbuilder.ControllerManagedBy(mgr).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&barbicanv1alpha1.BarbicanSecretStore{}, builder.WithPredicates(watch.CRUpdatePredicate())).
+		For(&barbicanv1alpha1.BarbicanSecretStore{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
 		// Watch the referenced Barbican WITHOUT a generation predicate: Barbican
 		// status flips (the store config landing in the Deployment) are exactly
 		// the wake signal the ConfigProjected gate waits on.
-		Watches(&barbicanv1alpha1.Barbican{}, handler.EnqueueRequestsFromMapFunc(
-			barbicanToSecretStoresMapper(mgr.GetClient()),
-		)).
-		// Watch the referenced OpenBaoCluster for the same reason: its Available
-		// condition is a status-only transition, and it is what a managed store
-		// waiting on WaitingForInstance needs to hear about.
-		Watches(&openbaov1alpha1.OpenBaoCluster{}, handler.EnqueueRequestsFromMapFunc(
-			openBaoClusterToSecretStoresMapper(mgr.GetClient()),
-		)).
-		Complete(r)
+		Watches(&barbicanv1alpha1.Barbican{}, commonmulticluster.LocalRequests(
+			barbicanToSecretStoresMapper(local.GetClient()),
+		), engageLocal, engageNoProviders)
+
+	// Watch the referenced OpenBaoCluster for the same reason: its Available
+	// condition is a status-only transition, and it is what a managed store
+	// waiting on WaitingForInstance needs to hear about. The leg is paired onto
+	// the clusters a store's parent can project onto because in the hardened
+	// topology the instance lives on the target.
+	b, err := commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &openbaov1alpha1.OpenBaoCluster{},
+		openBaoClusterToSecretStoresMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// The AppRole credentials Secret is this controller's own remote child: it
+	// writes it onto the target cluster, where no owner reference reaches back
+	// across the boundary, so the ownership labels map it to the store again.
+	b, err = commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &barbicanv1alpha1.BarbicanSecretStore{},
+		targets, []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")}, nil)
+	if err != nil {
+		return err
+	}
+
+	return b.
+		// The wrapper stays off for the same reason as on the Barbican
+		// controller: an unresolvable cluster is surfaced as a condition and
+		// requeued, not swallowed into a successful reconcile.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/barbican/main.go
+++ b/operators/barbican/main.go
@@ -65,7 +65,7 @@ func main() {
 				OperatorNamespace:       bootstrap.DetectOperatorNamespace(),
 				MaxConcurrentReconciles: maxConcurrentReconciles,
 				Resolver:                mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			// The dedicated BarbicanSecretStore controller runs in the same manager
@@ -78,7 +78,7 @@ func main() {
 				Scheme:   mgr.GetScheme(),
 				Recorder: mgr.GetEventRecorderFor("barbicansecretstore-controller"), //nolint:staticcheck // SA1019: reconciler consumes record.EventRecorder (old events API); GetEventRecorder returns the incompatible events/v1 type.
 				Resolver: mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			if webhooks {

--- a/operators/barbican/main_test.go
+++ b/operators/barbican/main_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Barbican operator entrypoint wiring. They assert against the
+// package-level scheme this binary hands to bootstrap.Run, without standing up
+// a cluster or envtest.
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/operators/barbican/internal/controller"
+)
+
+// The remote child kinds drive two things at once: SetupWithManager builds a
+// watch object per entry from this scheme, and the teardown sweep lists through
+// the same list. A kind this binary's scheme does not know therefore fails
+// SetupWithManager and the operator exits at startup.
+//
+// Nothing else in the tree catches that. The controller package's own tests run
+// against a scheme they build themselves, so a kind added to the list without
+// its AddToScheme in main.go passes every unit and integration test and only
+// surfaces on a real deploy.
+func TestRemoteChildKindsAreRegisteredInTheScheme(t *testing.T) {
+	for _, gvk := range controller.BarbicanRemoteChildKinds {
+		t.Run(gvk.String(), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			obj, err := scheme.New(gvk)
+
+			g.Expect(err).NotTo(HaveOccurred(),
+				"%s is swept and watched on target clusters, so this binary's scheme has to know it", gvk)
+
+			_, isObject := obj.(client.Object)
+			g.Expect(isObject).To(BeTrue(),
+				"%s must carry object metadata for the watch leg and the ownership labels", gvk)
+		})
+	}
+}

--- a/operators/glance/internal/controller/glance_controller.go
+++ b/operators/glance/internal/controller/glance_controller.go
@@ -23,12 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
 	"github.com/c5c3/forge/internal/common/database"
@@ -269,7 +270,7 @@ func markConfigFailed(glance *glancev1alpha1.Glance, err error) {
 	glanceSkeleton.MarkFailed(glance, "SecretsReady", conditionReasonConfigError, err)
 }
 
-// glanceRemoteChildKinds are the kinds a Glance CR projects into the namespace
+// GlanceRemoteChildKinds are the kinds a Glance CR projects into the namespace
 // of the target cluster it names, and the kinds reconcileDeleteRemoteChildren
 // sweeps by ownership label when that CR is deleted. Nothing on the target
 // cluster collects them, so a kind missing from this list is a kind that keeps
@@ -278,7 +279,7 @@ func markConfigFailed(glance *glancev1alpha1.Glance, err error) {
 // The list is cross-checked against the create verbs of the kubebuilder RBAC
 // markers on this controller below: the operator can only leave behind what it
 // is allowed to create.
-var glanceRemoteChildKinds = []schema.GroupVersionKind{
+var GlanceRemoteChildKinds = []schema.GroupVersionKind{
 	appsv1.SchemeGroupVersion.WithKind("Deployment"),
 	corev1.SchemeGroupVersion.WithKind("Service"),
 	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
@@ -615,7 +616,7 @@ func (r *GlanceReconciler) reconcileDelete(ctx context.Context, children client.
 // rest, selected on the ownership labels Claim stamped on them.
 func (r *GlanceReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, glance *glancev1alpha1.Glance) error {
 	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
-		glance, glance.Spec.TargetClusterRef, children, glanceRemoteChildKinds)
+		glance, glance.Spec.TargetClusterRef, children, GlanceRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given
@@ -655,13 +656,15 @@ func (r *GlanceReconciler) reconcileParallelGroup(
 // GlanceBackend field indexes (the single registration site for both
 // controllers, so this reconciler MUST be set up before GlanceBackendReconciler)
 // and wires the owned resources and cross-resource watches.
-func (r *GlanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *GlanceReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	local := mgr.GetLocalManager()
+
 	// Detect whether the Gateway API CRD is installed. spec.gateway is optional,
 	// so the operator must run on clusters without Gateway API. Adding
 	// Owns(HTTPRoute) unconditionally would fail at Start with "no matches for
 	// kind HTTPRoute" when the CRD is missing, blocking every Glance CR.
-	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
-	r.apiReader = mgr.GetAPIReader()
+	r.gatewayAPIAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = local.GetAPIReader()
 	setupLog := ctrl.Log.WithName("glance-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")
@@ -671,70 +674,116 @@ func (r *GlanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Register the Glance field indexer before Watches so
 	// secretToGlanceWithBackendsMapper can rely on it for its MatchingFields
-	// lookup.
-	if err := registerGlanceIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// lookup. The indexes go on the LOCAL field indexer, not mgr's: with a
+	// provider configured, the multicluster manager's field indexer registers
+	// against the provider clusters, which hold no Glance CR. Indexing the fleet
+	// is issue #839's business.
+	if err := registerGlanceIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 	// Register the GlanceBackend indexes here — the single registration site for
 	// both controllers (this reconciler is set up before GlanceBackendReconciler
 	// in main.go and the envtest helper). reconcileBackends and the mappers rely
-	// on them.
-	if err := registerGlanceBackendIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// on them. They go on the LOCAL field indexer for the same reason as the
+	// Glance indexes above.
+	if err := registerGlanceBackendIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
-	b := ctrl.NewControllerManagedBy(mgr).
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones some CR names, so it has to drop the events belonging to a CR that
+	// projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := commonmulticluster.TargetClusterOf(local.GetClient(),
+		func(glance *glancev1alpha1.Glance) *commonv1.TargetClusterRefSpec {
+			return glance.Spec.TargetClusterRef
+		})
+
+	b := mcbuilder.ControllerManagedBy(mgr).
 		// Shared controller options: MaxConcurrentReconciles lets independent CRs
 		// reconcile in parallel, and the tuned RateLimiter caps per-item failure
-		// backoff at 30s (see bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+		// backoff at 30s (see bootstrap.TypedControllerOptions).
+		WithOptions(bootstrap.TypedControllerOptions[mcreconcile.Request](r.MaxConcurrentReconciles)).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&glancev1alpha1.Glance{}, builder.WithPredicates(watch.CRUpdatePredicate())).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&batchv1.Job{}).
-		Owns(&batchv1.CronJob{})
+		For(&glancev1alpha1.Glance{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
+		Owns(&appsv1.Deployment{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Service{}, engageLocal, engageNoProviders).
+		Owns(&corev1.ConfigMap{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Secret{}, engageLocal, engageNoProviders).
+		Owns(&policyv1.PodDisruptionBudget{}, engageLocal, engageNoProviders).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, engageLocal, engageNoProviders).
+		Owns(&networkingv1.NetworkPolicy{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.Job{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.CronJob{}, engageLocal, engageNoProviders)
 
 	if r.gatewayAPIAvailable {
-		b = b.Owns(&gatewayv1.HTTPRoute{})
+		b = b.Owns(&gatewayv1.HTTPRoute{}, engageLocal, engageNoProviders)
+	}
+
+	// The same children, once more, on the clusters a CR can project onto. Owns
+	// cannot see them: an owner reference does not cross a cluster boundary, so
+	// the ownership labels are what maps a child back to its CR. No leg carries a
+	// predicate, mirroring what Owns admits locally.
+	b, err := commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &glancev1alpha1.Glance{},
+		targets, GlanceRemoteChildKinds, nil)
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets and map to the Glance CRs that reference them (directly or
+	// via an attached GlanceBackend's S3 credentials/CA Secret). ESO-managed
+	// Secrets are owned by the ExternalSecret controller, not the Glance CR, so
+	// EnqueueRequestForOwner would never match them.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &corev1.Secret{},
+		secretToGlanceWithBackendsMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
+	// the operator reflects upstream database outages in DatabaseReady without
+	// waiting for the next periodic requeue.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &mariadbv1alpha1.MariaDB{},
+		mariaDBToGlanceMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch both the cluster-scoped ClusterSecretStore and the namespaced
+	// SecretStore a Glance can select via spec.secretStoreRef, so the operator
+	// reflects upstream secret-backend outages in SecretsReady as soon as ESO
+	// flips the selected store's Ready condition.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.ClusterSecretStore{},
+		storeToGlanceMapper(local.GetClient(), commonv1.SecretStoreKindCluster))
+	if err != nil {
+		return err
+	}
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.SecretStore{},
+		storeToGlanceMapper(local.GetClient(), commonv1.SecretStoreKindNamespaced))
+	if err != nil {
+		return err
 	}
 
 	return b.
-		// Watch Secrets and map to the Glance CRs that reference them (directly or
-		// via an attached GlanceBackend's S3 credentials/CA Secret). ESO-managed
-		// Secrets are owned by the ExternalSecret controller, not the Glance CR, so
-		// EnqueueRequestForOwner would never match them.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			secretToGlanceWithBackendsMapper(mgr.GetClient()),
-		)).
 		// Watch GlanceBackends and map to their parent Glance: backend status flips
 		// (CredentialsReady turning True) trigger projection, DeletionTimestamp
 		// flips trigger de-projection. No generation predicate — the status
-		// transitions ARE the signal.
-		Watches(&glancev1alpha1.GlanceBackend{}, handler.EnqueueRequestsFromMapFunc(
+		// transitions ARE the signal. The leg stays local-only: a GlanceBackend is
+		// a management-plane CR and lives nowhere else.
+		Watches(&glancev1alpha1.GlanceBackend{}, commonmulticluster.LocalRequests(
 			glanceBackendToGlanceMapper(),
-		)).
-		// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
-		// the operator reflects upstream database outages in DatabaseReady without
-		// waiting for the next periodic requeue.
-		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
-			mariaDBToGlanceMapper(mgr.GetClient()),
-		)).
-		// Watch both the cluster-scoped ClusterSecretStore and the namespaced
-		// SecretStore a Glance can select via spec.secretStoreRef, so the operator
-		// reflects upstream secret-backend outages in SecretsReady as soon as ESO
-		// flips the selected store's Ready condition.
-		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToGlanceMapper(mgr.GetClient(), commonv1.SecretStoreKindCluster),
-		)).
-		Watches(&esov1.SecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToGlanceMapper(mgr.GetClient(), commonv1.SecretStoreKindNamespaced),
-		)).
-		Complete(r)
+		), engageLocal, engageNoProviders).
+		// The default wrapper turns an error matching multicluster.ErrClusterNotFound
+		// into a successful reconcile. This operator instead surfaces an
+		// unresolvable cluster as a TargetClusterUnavailable condition and
+		// requeues, so the wrapper stays off and the error semantics remain
+		// byte-identical to the classic builder's.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/glance/main.go
+++ b/operators/glance/main.go
@@ -61,7 +61,7 @@ func main() {
 				OperatorNamespace:       bootstrap.DetectOperatorNamespace(),
 				MaxConcurrentReconciles: maxConcurrentReconciles,
 				Resolver:                mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			// The dedicated GlanceBackend controller runs in the same manager (a

--- a/operators/glance/main_test.go
+++ b/operators/glance/main_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Glance operator entrypoint wiring. They assert against the
+// package-level scheme this binary hands to bootstrap.Run, without standing up
+// a cluster or envtest.
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/operators/glance/internal/controller"
+)
+
+// The remote child kinds drive two things at once: SetupWithManager builds a
+// watch object per entry from this scheme, and the teardown sweep lists through
+// the same list. A kind this binary's scheme does not know therefore fails
+// SetupWithManager and the operator exits at startup.
+//
+// Nothing else in the tree catches that. The controller package's own tests run
+// against a scheme they build themselves, so a kind added to the list without
+// its AddToScheme in main.go passes every unit and integration test and only
+// surfaces on a real deploy.
+func TestRemoteChildKindsAreRegisteredInTheScheme(t *testing.T) {
+	for _, gvk := range controller.GlanceRemoteChildKinds {
+		t.Run(gvk.String(), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			obj, err := scheme.New(gvk)
+
+			g.Expect(err).NotTo(HaveOccurred(),
+				"%s is swept and watched on target clusters, so this binary's scheme has to know it", gvk)
+
+			_, isObject := obj.(client.Object)
+			g.Expect(isObject).To(BeTrue(),
+				"%s must carry object metadata for the watch leg and the ownership labels", gvk)
+		})
+	}
+}

--- a/operators/horizon/internal/controller/horizon_controller.go
+++ b/operators/horizon/internal/controller/horizon_controller.go
@@ -30,12 +30,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
 	"github.com/c5c3/forge/internal/common/gateway"
@@ -158,7 +159,7 @@ var httpRouteGVK = schema.GroupVersionKind{
 	Kind:    "HTTPRoute",
 }
 
-// horizonRemoteChildKinds are the kinds a Horizon CR projects into the namespace
+// HorizonRemoteChildKinds are the kinds a Horizon CR projects into the namespace
 // of the target cluster it names, and the kinds reconcileDeleteRemoteChildren
 // sweeps by ownership label when that CR is deleted. Nothing on the target
 // cluster collects them, so a kind missing from this list is a kind that keeps
@@ -169,7 +170,7 @@ var httpRouteGVK = schema.GroupVersionKind{
 // is allowed to create. It is the shortest of the operators' lists, because
 // horizon composes no Secret, Job, CronJob, or MariaDB CR — it reads the
 // SECRET_KEY Secret that ESO materializes rather than writing one.
-var horizonRemoteChildKinds = []schema.GroupVersionKind{
+var HorizonRemoteChildKinds = []schema.GroupVersionKind{
 	appsv1.SchemeGroupVersion.WithKind("Deployment"),
 	corev1.SchemeGroupVersion.WithKind("Service"),
 	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
@@ -388,7 +389,7 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // etcd for it, as commonmulticluster.SweepRemoteChildren documents.
 func (r *HorizonReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, horizon *horizonv1alpha1.Horizon) error {
 	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
-		horizon, horizon.Spec.TargetClusterRef, children, horizonRemoteChildKinds)
+		horizon, horizon.Spec.TargetClusterRef, children, HorizonRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given
@@ -441,14 +442,16 @@ func (r *HorizonReconciler) reconcileParallelGroup(
 }
 
 // SetupWithManager registers the HorizonReconciler with the controller manager.
-func (r *HorizonReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *HorizonReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	local := mgr.GetLocalManager()
+
 	// Detect whether the Gateway API CRD is installed. spec.gateway is
 	// optional, so the operator must run on clusters without Gateway API.
 	// Adding Owns(HTTPRoute) unconditionally would cause the controller to
 	// fail at Start with "no matches for kind HTTPRoute" when the CRD is
 	// missing, preventing every Horizon CR from being reconciled.
-	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
-	r.apiReader = mgr.GetAPIReader()
+	r.gatewayAPIAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = local.GetAPIReader()
 	setupLog := ctrl.Log.WithName("horizon-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")
@@ -457,49 +460,92 @@ func (r *HorizonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Register the Horizon field indexer before Watches so
-	// secretToHorizonMapper can rely on it for its MatchingFields lookup.
-	if err := registerSecretNameIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// secretToHorizonMapper can rely on it for its MatchingFields lookup. The
+	// index goes on the LOCAL field indexer, not mgr's: with a provider
+	// configured, the multicluster manager's field indexer registers against
+	// the provider clusters, which hold no Horizon CR. Indexing the fleet is
+	// issue #839's business.
+	if err := registerSecretNameIndex(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
-	b := ctrl.NewControllerManagedBy(mgr).
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones some CR names, so it has to drop the events belonging to a CR that
+	// projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := commonmulticluster.TargetClusterOf(local.GetClient(),
+		func(horizon *horizonv1alpha1.Horizon) *commonv1.TargetClusterRefSpec {
+			return horizon.Spec.TargetClusterRef
+		})
+
+	b := mcbuilder.ControllerManagedBy(mgr).
 		// Shared controller options: MaxConcurrentReconciles lets independent
 		// CRs reconcile in parallel, and the tuned RateLimiter caps per-item
-		// failure backoff at 30s (see bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+		// failure backoff at 30s (see bootstrap.TypedControllerOptions).
+		WithOptions(bootstrap.TypedControllerOptions[mcreconcile.Request](r.MaxConcurrentReconciles)).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&horizonv1alpha1.Horizon{}, builder.WithPredicates(watch.CRUpdatePredicate())).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1.NetworkPolicy{})
+		For(&horizonv1alpha1.Horizon{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
+		Owns(&appsv1.Deployment{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Service{}, engageLocal, engageNoProviders).
+		Owns(&corev1.ConfigMap{}, engageLocal, engageNoProviders).
+		Owns(&policyv1.PodDisruptionBudget{}, engageLocal, engageNoProviders).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, engageLocal, engageNoProviders).
+		Owns(&networkingv1.NetworkPolicy{}, engageLocal, engageNoProviders)
 
 	if r.gatewayAPIAvailable {
-		b = b.Owns(&gatewayv1.HTTPRoute{})
+		b = b.Owns(&gatewayv1.HTTPRoute{}, engageLocal, engageNoProviders)
+	}
+
+	// The same children, once more, on the clusters a CR can project onto. Owns
+	// cannot see them: an owner reference does not cross a cluster boundary, so
+	// the ownership labels are what maps a child back to its CR. No leg carries
+	// a predicate, mirroring what Owns admits locally.
+	b, err := commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &horizonv1alpha1.Horizon{},
+		targets, HorizonRemoteChildKinds, nil)
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets and map to the Horizon CRs that reference them.
+	// The ESO-managed SECRET_KEY Secret is owned by the ExternalSecret
+	// controller, not by the Horizon CR, so EnqueueRequestForOwner would
+	// never match it. This MapFunc performs an indexed reverse lookup.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &corev1.Secret{},
+		secretToHorizonMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch both the cluster-scoped ClusterSecretStore and the namespaced
+	// SecretStore a Horizon can select via spec.secretStoreRef, so the
+	// operator reflects upstream secret-backend outages in SecretsReady as
+	// soon as ESO flips the selected store's Ready condition, rather than
+	// waiting for the next periodic requeue. Each mapper enqueues only the
+	// Horizons whose effective store ref matches the changed store.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.ClusterSecretStore{},
+		storeToHorizonMapper(local.GetClient(), commonv1.SecretStoreKindCluster))
+	if err != nil {
+		return err
+	}
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.SecretStore{},
+		storeToHorizonMapper(local.GetClient(), commonv1.SecretStoreKindNamespaced))
+	if err != nil {
+		return err
 	}
 
 	return b.
-		// Watch Secrets and map to the Horizon CRs that reference them.
-		// The ESO-managed SECRET_KEY Secret is owned by the ExternalSecret
-		// controller, not by the Horizon CR, so EnqueueRequestForOwner would
-		// never match it. This MapFunc performs an indexed reverse lookup.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			secretToHorizonMapper(mgr.GetClient()),
-		)).
-		// Watch both the cluster-scoped ClusterSecretStore and the namespaced
-		// SecretStore a Horizon can select via spec.secretStoreRef, so the
-		// operator reflects upstream secret-backend outages in SecretsReady as
-		// soon as ESO flips the selected store's Ready condition, rather than
-		// waiting for the next periodic requeue. Each mapper enqueues only the
-		// Horizons whose effective store ref matches the changed store.
-		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToHorizonMapper(mgr.GetClient(), commonv1.SecretStoreKindCluster),
-		)).
-		Watches(&esov1.SecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToHorizonMapper(mgr.GetClient(), commonv1.SecretStoreKindNamespaced),
-		)).
-		Complete(r)
+		// The default wrapper turns an error matching
+		// multicluster.ErrClusterNotFound into a successful reconcile. This
+		// operator instead surfaces an unresolvable cluster as a
+		// TargetClusterUnavailable condition and requeues, so the wrapper stays
+		// off and the error semantics remain byte-identical to the classic
+		// builder's.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/horizon/internal/controller/horizon_controller_test.go
+++ b/operators/horizon/internal/controller/horizon_controller_test.go
@@ -247,7 +247,7 @@ func TestReconcileDeleteRemoteChildren_SweepsEveryProjectedKind(t *testing.T) {
 		ownedRemoteChild(t, terminating,
 			&gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test-horizon", Namespace: "default"}}),
 	}
-	g.Expect(projected).To(HaveLen(len(horizonRemoteChildKinds)),
+	g.Expect(projected).To(HaveLen(len(HorizonRemoteChildKinds)),
 		"every kind the sweep covers needs a child here, or the list grew untested")
 
 	unlabelled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-ca", Namespace: "default"}}

--- a/operators/horizon/main.go
+++ b/operators/horizon/main.go
@@ -56,7 +56,7 @@ func main() {
 				OperatorNamespace:       bootstrap.DetectOperatorNamespace(),
 				MaxConcurrentReconciles: maxConcurrentReconciles,
 				Resolver:                mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			if webhooks {

--- a/operators/horizon/main_test.go
+++ b/operators/horizon/main_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Horizon operator entrypoint wiring. They assert against the
+// package-level scheme this binary hands to bootstrap.Run, without standing up
+// a cluster or envtest.
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/operators/horizon/internal/controller"
+)
+
+// The remote child kinds drive two things at once: SetupWithManager builds a
+// watch object per entry from this scheme, and the teardown sweep lists through
+// the same list. A kind this binary's scheme does not know therefore fails
+// SetupWithManager and the operator exits at startup.
+//
+// Nothing else in the tree catches that. The controller package's own tests run
+// against a scheme they build themselves, so a kind added to the list without
+// its AddToScheme in main.go passes every unit and integration test and only
+// surfaces on a real deploy.
+func TestRemoteChildKindsAreRegisteredInTheScheme(t *testing.T) {
+	for _, gvk := range controller.HorizonRemoteChildKinds {
+		t.Run(gvk.String(), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			obj, err := scheme.New(gvk)
+
+			g.Expect(err).NotTo(HaveOccurred(),
+				"%s is swept and watched on target clusters, so this binary's scheme has to know it", gvk)
+
+			_, isObject := obj.(client.Object)
+			g.Expect(isObject).To(BeTrue(),
+				"%s must carry object metadata for the watch leg and the ownership labels", gvk)
+		})
+	}
+}

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -29,12 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
 	"github.com/c5c3/forge/internal/common/database"
@@ -320,7 +322,7 @@ var certificateGVK = schema.GroupVersionKind{
 	Kind:    "Certificate",
 }
 
-// keystoneRemoteChildKinds are the kinds a Keystone CR projects into the
+// KeystoneRemoteChildKinds are the kinds a Keystone CR projects into the
 // namespace of the target cluster it names, and the kinds
 // reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
 // deleted. Nothing on the target cluster collects them, so a kind missing from
@@ -331,7 +333,7 @@ var certificateGVK = schema.GroupVersionKind{
 // is allowed to create. ExternalSecret is the one create verb deliberately not
 // swept: the marker grants it, but no code composes an ExternalSecret, so no
 // Keystone owns one.
-var keystoneRemoteChildKinds = []schema.GroupVersionKind{
+var KeystoneRemoteChildKinds = []schema.GroupVersionKind{
 	appsv1.SchemeGroupVersion.WithKind("Deployment"),
 	corev1.SchemeGroupVersion.WithKind("Service"),
 	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
@@ -885,7 +887,7 @@ func (r *KeystoneReconciler) hasLiveOpenBaoBackupPushSecrets(ctx context.Context
 // the rest, selected on the ownership labels Claim stamped on them.
 func (r *KeystoneReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone) error {
 	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
-		keystone, keystone.Spec.TargetClusterRef, children, keystoneRemoteChildKinds)
+		keystone, keystone.Spec.TargetClusterRef, children, KeystoneRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given
@@ -951,16 +953,31 @@ func (r *KeystoneReconciler) reconcileParallelGroup(
 	return keystoneSkeleton.RunParallelGroup(ctx, keystone, instrumenter.Instrument, subs)
 }
 
-// SetupWithManager registers the KeystoneReconciler with the controller manager.
-func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager registers the KeystoneReconciler with the controller
+// manager. The shared controller options it applies let independent CRs
+// reconcile in parallel instead of serialising at the controller-runtime
+// default of 1, and the tuned RateLimiter caps per-item failure backoff at 30s
+// rather than the default 1000s (see bootstrap.TypedControllerOptions).
+func (r *KeystoneReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	return r.setupWithOptions(mgr, bootstrap.TypedControllerOptions[mcreconcile.Request](r.MaxConcurrentReconciles))
+}
+
+// setupWithOptions carries the production watch wiring SetupWithManager
+// applies. The controller options are a parameter so the dual-envtest
+// integration suite can register this exact chain with SkipNameValidation set,
+// rather than a hand-built copy of it that drifts the moment a leg is added
+// here.
+func (r *KeystoneReconciler) setupWithOptions(mgr mcmanager.Manager, opts crcontroller.TypedOptions[mcreconcile.Request]) error {
+	local := mgr.GetLocalManager()
+
 	// Detect whether the Gateway API CRD is installed. spec.gateway is
 	// optional, so the operator must run on clusters without
 	// Gateway API. Adding Owns(HTTPRoute) unconditionally would cause the
 	// controller to fail at Start with "no matches for kind HTTPRoute"
 	// when the CRD is missing, preventing every Keystone CR from being
 	// reconciled — including those that do not use spec.gateway.
-	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
-	r.apiReader = mgr.GetAPIReader()
+	r.gatewayAPIAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = local.GetAPIReader()
 	setupLog := ctrl.Log.WithName("keystone-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")
@@ -973,7 +990,7 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// so reconcileDatabaseTLS knows whether a managed Certificate can exist on
 	// the TLS-disable path. spec.database.tls is optional, so the operator must
 	// run on clusters without cert-manager (issue #475).
-	r.certManagerAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), certificateGVK)
+	r.certManagerAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), certificateGVK)
 	if r.certManagerAvailable {
 		setupLog.Info("cert-manager detected; enabling Certificate watch for DatabaseTLSReady")
 	} else {
@@ -981,8 +998,12 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Register the Keystone field indexer before Watches so
-	// secretToKeystoneMapper can rely on it for its MatchingFields lookup
-	if err := registerSecretNameIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// secretToKeystoneMapper can rely on it for its MatchingFields lookup.
+	// The indexes go on the LOCAL field indexer, not mgr's: with a provider
+	// configured, the multicluster manager's field indexer registers against
+	// the provider clusters, which hold no Keystone CR. Indexing the fleet is
+	// issue #839's business.
+	if err := registerSecretNameIndex(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
@@ -990,73 +1011,110 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// registration site for both controllers (this reconciler is set up
 	// before KeystoneIdentityBackendReconciler in main.go and in the envtest
 	// helper). reconcileIdentityBackends and the mappers rely on them.
-	if err := registerIdentityBackendIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	if err := registerIdentityBackendIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
-	b := ctrl.NewControllerManagedBy(mgr).
-		// Shared controller options: MaxConcurrentReconciles lets independent
-		// CRs reconcile in parallel instead of serialising at the
-		// controller-runtime default of 1, and the tuned RateLimiter caps
-		// per-item failure backoff at 30s rather than the default 1000s (see
-		// bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones some CR names, so it has to drop the events belonging to a CR that
+	// projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := commonmulticluster.TargetClusterOf(local.GetClient(),
+		func(keystone *keystonev1alpha1.Keystone) *commonv1.TargetClusterRefSpec {
+			return keystone.Spec.TargetClusterRef
+		})
+
+	b := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(opts).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&keystonev1alpha1.Keystone{}, builder.WithPredicates(watch.CRUpdatePredicate())).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&batchv1.Job{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&batchv1.CronJob{})
+		For(&keystonev1alpha1.Keystone{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
+		Owns(&appsv1.Deployment{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Service{}, engageLocal, engageNoProviders).
+		Owns(&corev1.ConfigMap{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.Job{}, engageLocal, engageNoProviders).
+		Owns(&policyv1.PodDisruptionBudget{}, engageLocal, engageNoProviders).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, engageLocal, engageNoProviders).
+		Owns(&networkingv1.NetworkPolicy{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.CronJob{}, engageLocal, engageNoProviders)
 
 	if r.gatewayAPIAvailable {
-		b = b.Owns(&gatewayv1.HTTPRoute{})
+		b = b.Owns(&gatewayv1.HTTPRoute{}, engageLocal, engageNoProviders)
 	}
 
 	if r.certManagerAvailable {
-		b = b.Owns(&certmanagerv1.Certificate{})
+		b = b.Owns(&certmanagerv1.Certificate{}, engageLocal, engageNoProviders)
+	}
+
+	// The same children, once more, on the clusters a CR can project onto.
+	// Owns cannot see them: an owner reference does not cross a cluster
+	// boundary, so the ownership labels are what maps a child back to its CR.
+	// The PushSecret predicate keeps ESO's status-only ticks on the target from
+	// waking the CR, exactly as it does locally; the other remote legs carry no
+	// predicate, mirroring what Owns admits locally.
+	b, err := commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &keystonev1alpha1.Keystone{},
+		targets, KeystoneRemoteChildKinds,
+		map[schema.GroupVersionKind][]mcbuilder.WatchesOption{
+			esov1alpha1.SchemeGroupVersion.WithKind("PushSecret"): {mcbuilder.WithPredicates(pushSecretRelevantChangePredicate)},
+		})
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets and map to the Keystone CRs that reference them.
+	// ESO-managed secrets (spec.database.secretRef, spec.bootstrap.adminPasswordSecretRef)
+	// are owned by the ExternalSecret controller, not by the Keystone CR, so
+	// EnqueueRequestForOwner would never match them. This MapFunc performs a
+	// namespace-scoped lookup instead. The identity-backend leg additionally
+	// maps LDAP bind/CA Secrets to the attached Keystone so a rotated bind
+	// credential re-renders the content-hashed domains Secret.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &corev1.Secret{},
+		secretToKeystoneWithBackendsMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch KeystoneIdentityBackends and map to their Keystone: backend
+	// status flips (DomainReady) trigger projection, DeletionTimestamp
+	// flips trigger de-projection. No generation predicate — the status
+	// transitions ARE the signal. The leg stays local-only: a
+	// KeystoneIdentityBackend is a management-plane CR and lives nowhere else.
+	b = b.Watches(&keystonev1alpha1.KeystoneIdentityBackend{}, commonmulticluster.LocalRequests(
+		identityBackendToKeystoneMapper(),
+	), engageLocal, engageNoProviders)
+
+	// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
+	// that the operator reflects upstream database outages in DatabaseReady
+	// without waiting for the next periodic requeue.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &mariadbv1alpha1.MariaDB{},
+		mariaDBToKeystoneMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch both the cluster-scoped ClusterSecretStore and the namespaced
+	// SecretStore a Keystone can select via spec.secretStoreRef, so the
+	// operator reflects upstream secret-backend outages in SecretsReady as
+	// soon as ESO flips the selected store's Ready condition, rather than
+	// waiting for the next periodic requeue. Each mapper enqueues only the
+	// Keystones whose effective store ref matches the changed store.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.ClusterSecretStore{},
+		storeToKeystoneMapper(local.GetClient(), commonv1.SecretStoreKindCluster))
+	if err != nil {
+		return err
+	}
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.SecretStore{},
+		storeToKeystoneMapper(local.GetClient(), commonv1.SecretStoreKindNamespaced))
+	if err != nil {
+		return err
 	}
 
 	return b.
-		// Watch Secrets and map to the Keystone CRs that reference them.
-		// ESO-managed secrets (spec.database.secretRef, spec.bootstrap.adminPasswordSecretRef)
-		// are owned by the ExternalSecret controller, not by the Keystone CR, so
-		// EnqueueRequestForOwner would never match them. This MapFunc performs a
-		// namespace-scoped lookup instead. The identity-backend leg additionally
-		// maps LDAP bind/CA Secrets to the attached Keystone so a rotated bind
-		// credential re-renders the content-hashed domains Secret.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			secretToKeystoneWithBackendsMapper(mgr.GetClient()),
-		)).
-		// Watch KeystoneIdentityBackends and map to their Keystone: backend
-		// status flips (DomainReady) trigger projection, DeletionTimestamp
-		// flips trigger de-projection. No generation predicate — the status
-		// transitions ARE the signal.
-		Watches(&keystonev1alpha1.KeystoneIdentityBackend{}, handler.EnqueueRequestsFromMapFunc(
-			identityBackendToKeystoneMapper(),
-		)).
-		// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
-		// that the operator reflects upstream database outages in DatabaseReady
-		// without waiting for the next periodic requeue.
-		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
-			mariaDBToKeystoneMapper(mgr.GetClient()),
-		)).
-		// Watch both the cluster-scoped ClusterSecretStore and the namespaced
-		// SecretStore a Keystone can select via spec.secretStoreRef, so the
-		// operator reflects upstream secret-backend outages in SecretsReady as
-		// soon as ESO flips the selected store's Ready condition, rather than
-		// waiting for the next periodic requeue. Each mapper enqueues only the
-		// Keystones whose effective store ref matches the changed store.
-		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToKeystoneMapper(mgr.GetClient(), commonv1.SecretStoreKindCluster),
-		)).
-		Watches(&esov1.SecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToKeystoneMapper(mgr.GetClient(), commonv1.SecretStoreKindNamespaced),
-		)).
 		// Watch backup PushSecrets via a name-based mapper + predicate instead
 		// of Owns(). Owns() wakes Keystone on every status-only PushSecret tick
 		// ESO emits (SyncedResourceVersion, conditions); the explicit Watches
@@ -1069,8 +1127,15 @@ func (r *KeystoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Owns() wiring
 		Watches(
 			&esov1alpha1.PushSecret{},
-			handler.EnqueueRequestsFromMapFunc(pushSecretToKeystoneMapper(mgr.GetClient())),
-			builder.WithPredicates(pushSecretRelevantChangePredicate),
+			commonmulticluster.LocalRequests(pushSecretToKeystoneMapper(local.GetClient())),
+			mcbuilder.WithPredicates(pushSecretRelevantChangePredicate),
+			engageLocal, engageNoProviders,
 		).
-		Complete(r)
+		// The default wrapper turns an error matching multicluster.ErrClusterNotFound
+		// into a successful reconcile. This operator instead surfaces an
+		// unresolvable cluster as a TargetClusterUnavailable condition and
+		// requeues, so the wrapper stays off and the error semantics remain
+		// byte-identical to the classic builder's.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/keystone/internal/controller/keystone_controller_test.go
+++ b/operators/keystone/internal/controller/keystone_controller_test.go
@@ -4301,7 +4301,7 @@ func TestReconcileDeleteRemovesRotationAgeSeries(t *testing.T) {
 
 // remoteChildrenScheme is the scheme the target-cluster fake client is built
 // with: testScheme plus cert-manager, so every kind in
-// keystoneRemoteChildKinds is registered and the sweep's unstructured Lists
+// KeystoneRemoteChildKinds is registered and the sweep's unstructured Lists
 // all resolve. A target cluster that does not serve one of them is the
 // teardown helper's own concern and is covered there.
 func remoteChildrenScheme(t *testing.T) *runtime.Scheme {

--- a/operators/keystone/internal/controller/multicluster_integration_test.go
+++ b/operators/keystone/internal/controller/multicluster_integration_test.go
@@ -13,6 +13,13 @@
 // register. One manager, one provider, one function: the scenarios are ordered
 // subtests over the shared setup, and each one builds on the state the previous
 // left behind.
+//
+// The reconciler itself is registered through the production watch wiring
+// (setupWithOptions, the chain SetupWithManager applies) with
+// SkipNameValidation set. A skipped registration never claims the controller
+// name, so the constraint that only one registration per test binary may run
+// under the real name stays intact; it is documented with
+// TestSetupWithManager_StartsManagerWithAllWatches.
 
 package controller
 
@@ -40,14 +47,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 	kubeconfigprovider "sigs.k8s.io/multicluster-runtime/providers/kubeconfig"
 
 	"github.com/c5c3/forge/internal/common/apply"
+	"github.com/c5c3/forge/internal/common/bootstrap"
+	"github.com/c5c3/forge/internal/common/database"
 	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commonenvtest "github.com/c5c3/forge/internal/common/testutil/envtest"
@@ -63,8 +71,9 @@ import (
 // projects its children onto the target, a CR that keeps them local, a CR
 // naming an unregistered cluster, deregistration under a running CR, a
 // registration Secret the provider cannot parse, re-registration of the cluster
-// that was deregistered, and the deletion of a targeted CR sweeping every child
-// it projected off the target.
+// that was deregistered, the deletion of a targeted CR sweeping every child it
+// projected off the target, a child deleted on the target being put back, and a
+// rotated input Secret on the target re-rendering what was derived from it.
 func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 	testutil.SkipIfEnvTestUnavailable(t)
 
@@ -92,6 +101,18 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		// is observed against a namespace no earlier subtest wrote to.
 		teardownNamespace = "mc-teardown"
 		teardownKeystone  = "mc-teardown-keystone"
+
+		// The drift CR, likewise in a namespace of its own. Every earlier
+		// targeted CR has been deleted by the time it is created, so what
+		// happens in its namespace is its own doing. The last two subtests
+		// share it: the first settles it, the second rotates an input under it.
+		driftNamespace = "mc-drift"
+		driftKeystone  = "mc-drift-keystone"
+
+		// rotatedPassword replaces the "secret" the input fixture seeds, and is
+		// distinctive enough that finding it in the derived DSN cannot be an
+		// accident.
+		rotatedPassword = "rotated-password-4242"
 
 		// engageTimeout bounds cluster engagement: the provider has to parse
 		// the kubeconfig, build a cluster, and sync its cache before
@@ -165,35 +186,22 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 				// The Resolver is the whole point of this test: it turns
 				// spec.targetClusterRef into the client the children are
 				// written with.
-				Resolver:            mcMgr,
-				HTTPClient:          testHealthyHTTPClient(),
-				gatewayAPIAvailable: true,
+				Resolver:   mcMgr,
+				HTTPClient: testHealthyHTTPClient(),
 			}
-			// The sibling-backend list selects on a local cache field index,
-			// so both indexes go on the local manager, mirroring what
-			// SetupWithManager does in production.
-			if err := registerSecretNameIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
-				return err
-			}
-			if err := registerIdentityBackendIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
-				return err
-			}
-			// Only the children the local-cluster subtest waits on are owned
-			// here. A child on the target cluster produces no watch event on
-			// this manager at all, so that CR advances on the sub-reconcilers'
-			// own requeues.
-			return ctrl.NewControllerManagedBy(mgr).
-				For(&keystonev1alpha1.Keystone{}).
-				Owns(&appsv1.Deployment{}).
-				Owns(&corev1.Service{}).
-				Owns(&corev1.ConfigMap{}).
-				Owns(&batchv1.Job{}).
-				Owns(&batchv1.CronJob{}).
-				Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-					secretToKeystoneWithBackendsMapper(mgr.GetClient()),
-				)).
-				WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
-				Complete(r)
+			// The production watch wiring, shared with SetupWithManager: the
+			// legs pinned to the management cluster, the remote child legs
+			// keyed on the ownership labels, and the remote input legs. A child
+			// or an input object written on the target cluster therefore
+			// produces a watch event here, and the field indexes and the
+			// Gateway API / cert-manager RESTMapper probes come with the same
+			// call. The fake CRDs on the management environment latch both
+			// probes true. SkipNameValidation keeps the
+			// one-real-controller-name-per-test-binary constraint at the top of
+			// this file intact.
+			opts := bootstrap.TypedControllerOptions[mcreconcile.Request](1)
+			opts.SkipNameValidation = ptr.To(true)
+			return r.setupWithOptions(mcMgr, opts)
 		},
 	})
 
@@ -701,6 +709,168 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 			&corev1.Secret{})).To(Succeed(), "the admin password Secret should survive the teardown")
 		g.Expect(targetClient.Get(ctx, mariadbKey, &mariadbv1alpha1.MariaDB{})).
 			To(Succeed(), "the MariaDB cluster CR should survive the teardown")
+	})
+
+	t.Run("drift on the target cluster is corrected by the child watch", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// THE ACCEPTANCE RULE OF THIS SUBTEST: it never writes the Keystone CR.
+		// No annotation poke, no spec touch, nothing. Once the CR is settled the
+		// only write left is the Delete of one child on the target cluster, and
+		// the operator has to get from there to a fresh Deployment on its own. A
+		// version of this subtest that needs a poke to go green is a failed one:
+		// the remote child watch is what makes the poke unnecessary. The
+		// simulators below write children and never the CR, and the operator's
+		// own status writes are its business.
+		//
+		// The CR is driven all the way to Ready before the drift, and that is
+		// what makes the assertion discriminating. A Keystone short of Ready
+		// carries a standing requeue from whichever sub-reconciler is still
+		// waiting (10s from the deployment reconciler while the Deployment has
+		// no ready replicas, 15s from the Secret pollers), and any of those
+		// would repair the drift on a timer with no watch involved. At Ready
+		// every sub-reconciler returns a zero result, so the pipeline asks for
+		// no requeue at all: the fernet and credential rotation cadences live in
+		// CronJobs on the target cluster, and the health probe serves from its
+		// TTL cache and returns zero too. Nothing wakes this CR inside the
+		// budget below except an event. Take the remote child leg away and this
+		// subtest sits out the full budget and fails.
+		multiclusterEnsureNamespace(t, ctx, mgmtClient, driftNamespace)
+		multiclusterEnsureNamespace(t, ctx, targetClient, driftNamespace)
+		createPrerequisites(t, ctx, targetClient, driftNamespace)
+
+		mariadbKey := client.ObjectKey{Namespace: driftNamespace, Name: "mariadb"}
+		g.Expect(targetClient.Create(ctx, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{Name: mariadbKey.Name, Namespace: mariadbKey.Namespace},
+		})).To(Succeed(), "create the MariaDB cluster CR on the target cluster")
+		g.Expect(simulators.SimulateMariaDBReady(ctx, targetClient, mariadbKey, 1)).
+			To(Succeed(), "simulate the MariaDB cluster ready")
+
+		ks := integrationManagedKeystone(driftKeystone, driftNamespace)
+		ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: targetClusterName}
+		g.Expect(mgmtClient.Create(ctx, ks)).To(Succeed())
+
+		crKey := types.NamespacedName{Name: driftKeystone, Namespace: driftNamespace}
+		childKey := client.ObjectKey{Namespace: driftNamespace, Name: driftKeystone}
+
+		// Settle the CR: the same sequence the teardown subtest walks, each
+		// MariaDB CR gated on the previous one reporting ready.
+		waitForCondition(t, ctx, mgmtClient, crKey, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+		waitForCondition(t, ctx, mgmtClient, crKey, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Database{}, "MariaDB Database", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateDatabaseReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.User{}, "MariaDB User", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateUserReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Grant{}, "MariaDB Grant", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateGrantReady(ctx, targetClient, childKey)).To(Succeed())
+
+		dbSyncKey := client.ObjectKey{Namespace: driftNamespace, Name: fmt.Sprintf("%s-db-sync", driftKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, dbSyncKey, &batchv1.Job{}, "db-sync Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, dbSyncKey)).To(Succeed())
+
+		schemaCheckKey := client.ObjectKey{Namespace: driftNamespace, Name: fmt.Sprintf("%s-schema-check", driftKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, schemaCheckKey, &batchv1.Job{}, "schema-check Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, schemaCheckKey)).To(Succeed())
+
+		waitForCondition(t, ctx, mgmtClient, crKey, "DatabaseReady", metav1.ConditionTrue, eventuallyLongTimeout)
+
+		// The rest of the way to Ready, the same phases driveFullReconciliation
+		// walks on a single cluster: the workload readiness the envtest
+		// environment cannot produce on its own, then the bootstrap Job.
+		deployment := &appsv1.Deployment{}
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, deployment, "Deployment", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateDeploymentReady(ctx, targetClient, childKey, ptr.Deref(deployment.Spec.Replicas, 1))).
+			To(Succeed(), "simulate the Deployment ready on the target cluster")
+		waitForCondition(t, ctx, mgmtClient, crKey, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+		bootstrapKey := client.ObjectKey{Namespace: driftNamespace, Name: fmt.Sprintf("%s-bootstrap", driftKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, bootstrapKey, &batchv1.Job{}, "bootstrap Job", eventuallyTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, bootstrapKey)).To(Succeed())
+
+		waitForCondition(t, ctx, mgmtClient, crKey, "BootstrapReady", metav1.ConditionTrue, eventuallyTimeout)
+		waitForCondition(t, ctx, mgmtClient, crKey, "Ready", metav1.ConditionTrue, eventuallyTimeout)
+
+		// Read the Deployment once more, so the UID recorded here is the one the
+		// quiescent CR is standing on.
+		g.Expect(targetClient.Get(ctx, childKey, deployment)).To(Succeed())
+		deletedUID := deployment.UID
+		g.Expect(deletedUID).NotTo(BeEmpty(), "the settled Deployment should have been read back with its UID")
+
+		// The drift: somebody removes the workload on the target cluster.
+		g.Expect(targetClient.Delete(ctx, deployment)).To(Succeed(),
+			"delete the Deployment on the target cluster")
+
+		// The UID separates a recreation from a stale read of the deleted
+		// object, and the API server is what assigns it.
+		g.Eventually(func(ig Gomega) {
+			recreated := &appsv1.Deployment{}
+			ig.Expect(targetClient.Get(ctx, childKey, recreated)).To(Succeed())
+			ig.Expect(recreated.UID).NotTo(Equal(deletedUID))
+		}, eventuallyTimeout, pollInterval).Should(Succeed(),
+			"the deleted Deployment should be recreated on the target cluster with no write to the CR")
+	})
+
+	t.Run("rotating the target-side input Secret re-renders the derived db-connection Secret", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// This subtest runs on the CR the previous one settled. The suite's
+		// subtests are ordered and share state throughout, and settling a
+		// second Keystone here would only repeat the simulator sequence above.
+		//
+		// THE ACCEPTANCE RULE, once more: no write to the Keystone CR. The
+		// rotated Secret is an input rather than a child. ESO writes it in
+		// production, so the operator never stamped the ownership labels on it
+		// (the teardown subtest above proves the sweep leaves it standing), and
+		// ChildToOwner maps it to no request at all. The remote input leg, with
+		// its own Secret mapper, is the only wiring that can turn this rotation
+		// into a reconcile.
+		crKey := types.NamespacedName{Name: driftKeystone, Namespace: driftNamespace}
+		childKey := client.ObjectKey{Namespace: driftNamespace, Name: driftKeystone}
+
+		// The drift left a Deployment with no ready replicas behind, which put
+		// the deployment reconciler's 10s requeue back on the CR. Settle it
+		// again first, or that requeue would re-render the derived Secret on a
+		// timer and the assertion below would hold with no watch at all. Waiting
+		// out DeploymentReady=False first pins the CR to the post-drift status,
+		// so the True that follows cannot be the pre-drift one read early. The
+		// bootstrap Job does not re-run: it is gated on the admin-password
+		// digest, which nothing here touches.
+		waitForCondition(t, ctx, mgmtClient, crKey, "DeploymentReady", metav1.ConditionFalse, eventuallyTimeout)
+		recreated := &appsv1.Deployment{}
+		g.Expect(targetClient.Get(ctx, childKey, recreated)).To(Succeed())
+		g.Expect(simulators.SimulateDeploymentReady(ctx, targetClient, childKey, ptr.Deref(recreated.Spec.Replicas, 1))).
+			To(Succeed(), "simulate the recreated Deployment ready on the target cluster")
+		waitForCondition(t, ctx, mgmtClient, crKey, "Ready", metav1.ConditionTrue, eventuallyTimeout)
+
+		dbConnectionKey := client.ObjectKey{
+			Namespace: driftNamespace,
+			Name:      database.ConnectionSecretName(driftKeystone),
+		}
+
+		derived := &corev1.Secret{}
+		g.Expect(targetClient.Get(ctx, dbConnectionKey, derived)).To(Succeed(),
+			"the derived db-connection Secret should exist on the target cluster")
+		g.Expect(string(derived.Data[database.ConnectionSecretKey])).To(ContainSubstring(":secret@"),
+			"the DSN should carry the password the input fixture was seeded with")
+
+		input := &corev1.Secret{}
+		inputKey := client.ObjectKey{Namespace: driftNamespace, Name: "keystone-db"}
+		g.Expect(targetClient.Get(ctx, inputKey, input)).To(Succeed())
+		input.Data["password"] = []byte(rotatedPassword)
+		g.Expect(targetClient.Update(ctx, input)).To(Succeed(),
+			"rotate the database password in the input Secret on the target cluster")
+
+		g.Eventually(func(ig Gomega) {
+			rerendered := &corev1.Secret{}
+			ig.Expect(targetClient.Get(ctx, dbConnectionKey, rerendered)).To(Succeed())
+			dsn := string(rerendered.Data[database.ConnectionSecretKey])
+			ig.Expect(dsn).To(ContainSubstring(":" + rotatedPassword + "@"))
+			ig.Expect(dsn).NotTo(ContainSubstring(":secret@"))
+		}, eventuallyTimeout, pollInterval).Should(Succeed(),
+			"the rotated password should reach the derived db-connection Secret with no write to the CR")
 	})
 }
 

--- a/operators/keystone/internal/controller/setupwithmanager_integration_test.go
+++ b/operators/keystone/internal/controller/setupwithmanager_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	ctrl "sigs.k8s.io/controller-runtime"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 	"github.com/c5c3/forge/operators/keystone/internal/testutil"
@@ -60,7 +61,15 @@ func TestSetupWithManager_StartsManagerWithAllWatches(t *testing.T) {
 				Recorder:   mgr.GetEventRecorderFor("keystone-controller"),
 				HTTPClient: testHealthyHTTPClient(),
 			}
-			return r.SetupWithManager(mgr)
+			// A nil provider engages no remote cluster, so the remote legs add
+			// nothing and every local informer must still sync. That is the
+			// single-cluster default path: an operator started with an empty
+			// --clusters-namespace clears the provider the same way.
+			mcMgr, err := mcmanager.WithMultiCluster(mgr, nil)
+			if err != nil {
+				return err
+			}
+			return r.SetupWithManager(mcMgr)
 		},
 	)
 

--- a/operators/keystone/main.go
+++ b/operators/keystone/main.go
@@ -84,7 +84,7 @@ func main() {
 				MaxConcurrentReconciles:      maxConcurrentReconciles,
 				FederationMetadataAllowCIDRs: allowCIDRs,
 				Resolver:                     mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			// The dedicated identity-backend controller runs in the same

--- a/operators/keystone/main_test.go
+++ b/operators/keystone/main_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Keystone operator entrypoint wiring. They assert against the
+// package-level scheme this binary hands to bootstrap.Run, without standing up
+// a cluster or envtest.
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/operators/keystone/internal/controller"
+)
+
+// The remote child kinds drive two things at once: SetupWithManager builds a
+// watch object per entry from this scheme, and the teardown sweep lists through
+// the same list. A kind this binary's scheme does not know therefore fails
+// SetupWithManager and the operator exits at startup.
+//
+// Nothing else in the tree catches that. The controller package's own tests run
+// against a scheme they build themselves, so a kind added to the list without
+// its AddToScheme in main.go passes every unit and integration test and only
+// surfaces on a real deploy. This list is the longest of the converted
+// operators and spans five schemes, which is what makes the guard worth its own
+// test file here.
+func TestRemoteChildKindsAreRegisteredInTheScheme(t *testing.T) {
+	for _, gvk := range controller.KeystoneRemoteChildKinds {
+		t.Run(gvk.String(), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			obj, err := scheme.New(gvk)
+
+			g.Expect(err).NotTo(HaveOccurred(),
+				"%s is swept and watched on target clusters, so this binary's scheme has to know it", gvk)
+
+			_, isObject := obj.(client.Object)
+			g.Expect(isObject).To(BeTrue(),
+				"%s must carry object metadata for the watch leg and the ownership labels", gvk)
+		})
+	}
+}

--- a/operators/placement/internal/controller/placement_controller.go
+++ b/operators/placement/internal/controller/placement_controller.go
@@ -23,12 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/c5c3/forge/internal/common/bootstrap"
 	"github.com/c5c3/forge/internal/common/database"
@@ -196,7 +197,7 @@ type PlacementReconciler struct {
 	healthProbeCache healthcheck.ProbeCache
 }
 
-// placementRemoteChildKinds are the kinds a Placement CR projects into the
+// PlacementRemoteChildKinds are the kinds a Placement CR projects into the
 // namespace of the target cluster it names, and the kinds
 // reconcileDeleteRemoteChildren sweeps by ownership label when that CR is
 // deleted. Nothing on the target cluster collects them, so a kind missing from
@@ -207,7 +208,7 @@ type PlacementReconciler struct {
 // is allowed to create. CronJob is the one kind the sibling operators sweep and
 // this one does not: the markers grant create on jobs alone, because placement
 // renders no CronJob.
-var placementRemoteChildKinds = []schema.GroupVersionKind{
+var PlacementRemoteChildKinds = []schema.GroupVersionKind{
 	appsv1.SchemeGroupVersion.WithKind("Deployment"),
 	corev1.SchemeGroupVersion.WithKind("Service"),
 	corev1.SchemeGroupVersion.WithKind("ConfigMap"),
@@ -508,7 +509,7 @@ func (r *PlacementReconciler) reconcileDelete(ctx context.Context, children clie
 // rest, selected on the ownership labels Claim stamped on them.
 func (r *PlacementReconciler) reconcileDeleteRemoteChildren(ctx context.Context, children client.Client, placement *placementv1alpha1.Placement) error {
 	return commonmulticluster.SweepRemoteChildren(ctx, r.Client, r.Resolver, r.Recorder, r.Scheme,
-		placement, placement.Spec.TargetClusterRef, children, placementRemoteChildKinds)
+		placement, placement.Spec.TargetClusterRef, children, PlacementRemoteChildKinds)
 }
 
 // updateStatus persists the current status conditions and returns the given
@@ -546,13 +547,15 @@ func (r *PlacementReconciler) reconcileParallelGroup(
 // SetupWithManager registers the PlacementReconciler with the controller
 // manager. It probes Gateway API availability, registers the Placement field
 // index, and wires the owned resources and cross-resource watches.
-func (r *PlacementReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PlacementReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	local := mgr.GetLocalManager()
+
 	// Detect whether the Gateway API CRD is installed. spec.gateway is optional,
 	// so the operator must run on clusters without Gateway API. Adding
 	// Owns(HTTPRoute) unconditionally would fail at Start with "no matches for
 	// kind HTTPRoute" when the CRD is missing, blocking every Placement CR.
-	r.gatewayAPIAvailable = gateway.IsGVKAvailable(mgr.GetRESTMapper(), httpRouteGVK)
-	r.apiReader = mgr.GetAPIReader()
+	r.gatewayAPIAvailable = gateway.IsGVKAvailable(local.GetRESTMapper(), httpRouteGVK)
+	r.apiReader = local.GetAPIReader()
 	setupLog := ctrl.Log.WithName("placement-setup")
 	if r.gatewayAPIAvailable {
 		setupLog.Info("Gateway API detected; enabling HTTPRoute watch and reconciliation")
@@ -561,54 +564,99 @@ func (r *PlacementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Register the Placement field indexer before Watches so
-	// secretToPlacementMapper can rely on it for its MatchingFields lookup.
-	if err := registerPlacementIndexes(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	// secretToPlacementMapper can rely on it for its MatchingFields lookup. The
+	// index goes on the LOCAL field indexer, not mgr's: with a provider
+	// configured, the multicluster manager's field indexer registers against the
+	// provider clusters, which hold no Placement CR. Indexing the fleet is issue
+	// #839's business.
+	if err := registerPlacementIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}
 
-	b := ctrl.NewControllerManagedBy(mgr).
+	// Every leg watching the management cluster carries both engage options
+	// below; see their definition for why an unpinned leg would stop watching
+	// it once a provider is configured.
+	engageLocal := commonmulticluster.EngageLocalCluster
+	engageNoProviders := commonmulticluster.EngageNoProviderClusters
+
+	// Every leg watching a target cluster is engaged on all of them, not on the
+	// ones some CR names, so it has to drop the events belonging to a CR that
+	// projects somewhere else (see commonmulticluster.RemoteRequests).
+	targets := commonmulticluster.TargetClusterOf(local.GetClient(),
+		func(placement *placementv1alpha1.Placement) *commonv1.TargetClusterRefSpec {
+			return placement.Spec.TargetClusterRef
+		})
+
+	b := mcbuilder.ControllerManagedBy(mgr).
 		// Shared controller options: MaxConcurrentReconciles lets independent CRs
 		// reconcile in parallel, and the tuned RateLimiter caps per-item failure
-		// backoff at 30s (see bootstrap.ControllerOptions).
-		WithOptions(bootstrap.ControllerOptions(r.MaxConcurrentReconciles)).
+		// backoff at 30s (see bootstrap.TypedControllerOptions).
+		WithOptions(bootstrap.TypedControllerOptions[mcreconcile.Request](r.MaxConcurrentReconciles)).
 		// Filter the CR's own status-only updates so Status().Update does not
 		// re-wake the controller (see watch.CRUpdatePredicate).
-		For(&placementv1alpha1.Placement{}, builder.WithPredicates(watch.CRUpdatePredicate())).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&batchv1.Job{})
+		For(&placementv1alpha1.Placement{}, mcbuilder.WithPredicates(watch.CRUpdatePredicate()), engageLocal, engageNoProviders).
+		Owns(&appsv1.Deployment{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Service{}, engageLocal, engageNoProviders).
+		Owns(&corev1.ConfigMap{}, engageLocal, engageNoProviders).
+		Owns(&corev1.Secret{}, engageLocal, engageNoProviders).
+		Owns(&policyv1.PodDisruptionBudget{}, engageLocal, engageNoProviders).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, engageLocal, engageNoProviders).
+		Owns(&networkingv1.NetworkPolicy{}, engageLocal, engageNoProviders).
+		Owns(&batchv1.Job{}, engageLocal, engageNoProviders)
 
 	if r.gatewayAPIAvailable {
-		b = b.Owns(&gatewayv1.HTTPRoute{})
+		b = b.Owns(&gatewayv1.HTTPRoute{}, engageLocal, engageNoProviders)
+	}
+
+	// The same children, once more, on the clusters a CR can project onto. Owns
+	// cannot see them: an owner reference does not cross a cluster boundary, so
+	// the ownership labels are what maps a child back to its CR. No leg carries a
+	// predicate, mirroring what Owns admits locally.
+	b, err := commonmulticluster.AddRemoteChildWatches(b, local.GetScheme(), &placementv1alpha1.Placement{},
+		targets, PlacementRemoteChildKinds, nil)
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets and map to the Placement CRs that reference them.
+	// ESO-managed Secrets are owned by the ExternalSecret controller, not the
+	// Placement CR, so EnqueueRequestForOwner would never match them.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &corev1.Secret{},
+		secretToPlacementMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
+	// the operator reflects upstream database outages in DatabaseReady without
+	// waiting for the next periodic requeue.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &mariadbv1alpha1.MariaDB{},
+		mariaDBToPlacementMapper(local.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch both the cluster-scoped ClusterSecretStore and the namespaced
+	// SecretStore a Placement can select via spec.secretStoreRef, so the
+	// operator reflects upstream secret-backend outages in SecretsReady as soon
+	// as ESO flips the selected store's Ready condition.
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.ClusterSecretStore{},
+		storeToPlacementMapper(local.GetClient(), commonv1.SecretStoreKindCluster))
+	if err != nil {
+		return err
+	}
+	b, err = commonmulticluster.AddInputWatch(b, local.GetScheme(), targets, &esov1.SecretStore{},
+		storeToPlacementMapper(local.GetClient(), commonv1.SecretStoreKindNamespaced))
+	if err != nil {
+		return err
 	}
 
 	return b.
-		// Watch Secrets and map to the Placement CRs that reference them.
-		// ESO-managed Secrets are owned by the ExternalSecret controller, not the
-		// Placement CR, so EnqueueRequestForOwner would never match them.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			secretToPlacementMapper(mgr.GetClient()),
-		)).
-		// Watch the MariaDB cluster CR referenced by spec.database.clusterRef so
-		// the operator reflects upstream database outages in DatabaseReady without
-		// waiting for the next periodic requeue.
-		Watches(&mariadbv1alpha1.MariaDB{}, handler.EnqueueRequestsFromMapFunc(
-			mariaDBToPlacementMapper(mgr.GetClient()),
-		)).
-		// Watch both the cluster-scoped ClusterSecretStore and the namespaced
-		// SecretStore a Placement can select via spec.secretStoreRef, so the
-		// operator reflects upstream secret-backend outages in SecretsReady as soon
-		// as ESO flips the selected store's Ready condition.
-		Watches(&esov1.ClusterSecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToPlacementMapper(mgr.GetClient(), commonv1.SecretStoreKindCluster),
-		)).
-		Watches(&esov1.SecretStore{}, handler.EnqueueRequestsFromMapFunc(
-			storeToPlacementMapper(mgr.GetClient(), commonv1.SecretStoreKindNamespaced),
-		)).
-		Complete(r)
+		// The default wrapper turns an error matching multicluster.ErrClusterNotFound
+		// into a successful reconcile. This operator instead surfaces an
+		// unresolvable cluster as a TargetClusterUnavailable condition and
+		// requeues, so the wrapper stays off and the error semantics remain
+		// byte-identical to the classic builder's.
+		WithClusterNotFoundWrapper(false).
+		Complete(commonmulticluster.LocalReconciler(r))
 }

--- a/operators/placement/main.go
+++ b/operators/placement/main.go
@@ -60,7 +60,7 @@ func main() {
 				OperatorNamespace:       bootstrap.DetectOperatorNamespace(),
 				MaxConcurrentReconciles: maxConcurrentReconciles,
 				Resolver:                mcMgr,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mcMgr); err != nil {
 				return err
 			}
 			if webhooks {

--- a/operators/placement/main_test.go
+++ b/operators/placement/main_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the Placement operator entrypoint wiring. They assert against the
+// package-level scheme this binary hands to bootstrap.Run, without standing up
+// a cluster or envtest.
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/c5c3/forge/operators/placement/internal/controller"
+)
+
+// The remote child kinds drive two things at once: SetupWithManager builds a
+// watch object per entry from this scheme, and the teardown sweep lists through
+// the same list. A kind this binary's scheme does not know therefore fails
+// SetupWithManager and the operator exits at startup.
+//
+// Nothing else in the tree catches that. The controller package's own tests run
+// against a scheme they build themselves, so a kind added to the list without
+// its AddToScheme in main.go passes every unit and integration test and only
+// surfaces on a real deploy.
+func TestRemoteChildKindsAreRegisteredInTheScheme(t *testing.T) {
+	for _, gvk := range controller.PlacementRemoteChildKinds {
+		t.Run(gvk.String(), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			obj, err := scheme.New(gvk)
+
+			g.Expect(err).NotTo(HaveOccurred(),
+				"%s is swept and watched on target clusters, so this binary's scheme has to know it", gvk)
+
+			_, isObject := obj.(client.Object)
+			g.Expect(isObject).To(BeTrue(),
+				"%s must carry object metadata for the watch leg and the ownership labels", gvk)
+		})
+	}
+}


### PR DESCRIPTION
Closes #838

A converted operator went quiescent once its CR reached Ready: the projected
children live on the target cluster, no owner reference crosses the cluster
boundary, and nothing woke the CR when one of them drifted or disappeared. The
reconcile pipeline was already correct — only the cross-cluster trigger was
missing. This branch registers it: every converted controller builds through
`mcbuilder.ControllerManagedBy` and gains provider-cluster watch legs for the
kinds it projects and the inputs it reads.

## Walkthrough, in commit order

**`83670159` feat(bootstrap): make the controller options generic over the request**

`TypedControllerOptions[request comparable]` and `typedRateLimiter[request]`
replace their `reconcile.Request`-only predecessors, because the multicluster
builder takes `controller.TypedOptions[mcreconcile.Request]`. `ControllerOptions`
stays as the `reconcile.Request` instantiation, so every unconverted controller
compiles unchanged. Same worker-count fallback, same 30s per-item cap.

**`0a443520` feat(multicluster): add the cross-cluster watch vocabulary**

New `internal/common/multicluster/watch.go` with the vocabulary every converted
controller wires its legs through:

- `ChildToOwner(ownerKind)` maps a labelled child back to the CR its ownership
  labels name — the target-cluster counterpart of
  `handler.EnqueueRequestForOwner`, which has nothing to go on where no owner
  reference exists.
- `LocalRequests` pins every request to `ClusterName ""`, so the workqueue keeps
  one key per CR and a child event from cluster A cannot reconcile the same CR
  concurrently with a local CR event.
- `RemoteRequests` is `LocalRequests` for a target-cluster leg, plus the cluster
  gate described below.
- `LocalReconciler` forwards `req.Request` to a reconciler that keeps the
  signature it has.
- `ClusterServesKind` skips a leg on a cluster whose RESTMapper does not serve
  the kind. Without it, one absent CRD fails that cluster's whole engagement.
- `RemoteWatchOptions`, `EngageLocalCluster`, `EngageNoProviderClusters`,
  `AddInputWatch`, `AddRemoteChildWatches` assemble the legs.

**`7afb28d8` feat(keystone) · `29522f33` barbican · `d89a7f28` glance ·
`406ef19f` horizon · `b635e198` placement**

Six controllers convert (barbican brings `BarbicanSecretStoreReconciler` with
it). Each one:

- pins every pre-existing `For`/`Owns`/`Watches` leg to the local cluster
  explicitly — mandatory, since the builder's per-leg default inverts once a
  provider is configured and an unpinned leg would quietly stop watching the
  management cluster;
- registers one remote child leg per entry of its existing `<op>RemoteChildKinds`
  sweep list, so a kind added to a projection later gets its watch and its
  teardown from the same edit (keystone keeps `pushSecretRelevantChangePredicate`
  on the remote PushSecret leg via the `extra` map);
- registers remote input legs for the objects ESO and the infrastructure
  operators write — Secret everywhere, MariaDB where there is a database,
  SecretStore/ClusterSecretStore everywhere, plus OpenBaoCluster and the AppRole
  credentials Secret on the secret-store controller. Input Secrets carry no
  ownership labels, which is why they need legs of their own;
- keeps `Reconcile(ctx, ctrl.Request)` through `LocalReconciler`, and keeps the
  field indexes on the local field indexer (the multicluster one would register
  them against provider clusters, which hold no CR).

`WithClusterNotFoundWrapper(false)` preserves the classic error semantics: an
unresolvable cluster stays a `TargetClusterUnavailable` condition with a requeue
rather than a silently successful reconcile. `KeystoneIdentityBackend` and
`GlanceBackend` stay classic against `GetLocalManager()`, as do the webhooks.

**`ee5ad405` test(keystone): run the dual envtest on the production watch wiring**

Keystone's builder chain moves into an unexported `setupWithOptions`, so the
dual-envtest suite registers the production wiring with `SkipNameValidation`
instead of the inline classic copy it used to hand-build. Two subtests ride on
that: deleting the target-side Deployment and waiting for one with a different
UID, and rotating the database password in the target-side input Secret and
waiting for the derived db-connection Secret to carry it. Neither writes the
Keystone CR — both CRs are driven to Ready first, where every sub-reconciler
returns a zero result, so a watch event is the only thing that can wake them.

**`f508db01` docs: describe drift correction through cross-cluster child watches**

Replaces the requeue-only drift bullet under interim constraints and rewrites
the local-watch paragraph in `docs/reference/target-clusters.md`.

## Divergences from the issue

Three, all in the same direction — the issue's design left a trust gap the
implementation had to close:

1. **Cluster-scoped event gating (`RemoteRequests`, `TargetClusterFunc`,
   `TargetClusterOf`).** The issue specified `LocalRequests(ChildToOwner(...))`
   for the remote legs. But a leg is engaged on *every* registered provider
   cluster, not on the ones a CR names, and what it maps by — ownership labels,
   or an input object's name — is writable by anyone who can create an object on
   any registered cluster. Toggling such an object in a loop would pin somebody
   else's CR to continuous reconciliation. Every remote leg now reads the CR's
   own `targetClusterRef` from the management cluster and drops events from any
   other cluster. `ChildToOwner` additionally refuses an object claiming an owner
   in a different namespace, for the same reason.
2. **`AddRemoteChildWatches` signature.** Takes `owner client.Object` and
   resolves the kind through the scheme (rather than a hand-typed `ownerKind`
   string, which would be a second source of truth that fails silently), plus the
   `targets` func from (1). It also refuses an `extra` key naming a kind outside
   `kinds` instead of dropping it silently.
3. **`AddInputWatch`.** The issue described the input legs as per-controller
   wiring; they are identical across five operators, so the local/remote pair is
   built once and the GVK for the cluster filter is resolved from the object
   itself — a filter and a leg naming different kinds is exactly the
   whole-cluster engagement failure `ClusterServesKind` exists to prevent.

`ClusterServesKind` spells the RESTMapper probe out rather than calling
`gateway.IsGVKAvailable` (same check): the gateway package reaches this one
through `apply` and cannot be imported back. A non-`NoMatch` discovery error
(throttling, a broken aggregated APIService) skips the leg with a log rather
than engaging it, because a leg wrongly skipped costs one kind's drift correction
until re-engagement, while a leg wrongly engaged costs the whole cluster's.

The docs commit goes past the two passages the issue named: registering a
cluster now commits every service operator to a fleet-wide cache of the watched
kinds on it, so the prerequisites section states the RBAC and memory cost, and
what an operator's target credentials expose, before someone registers a cluster
rather than after. Cache scoping remains #841.

New `main_test.go` in each of the five operators asserts that every entry of the
operator's remote-child-kind list is registered in that *binary's* scheme. The
controller packages test against schemes they build themselves, so a kind added
to the list without its `AddToScheme` in `main.go` passes every existing test and
fails only on a real deploy.

## Not in scope

Per the issue's non-goals: no periodic-requeue fallback (the builder path is
workable), no per-cluster reconcile capability latches (#839), no cache scoping
or RBAC packaging (#841), no ControlPlane threading (#840), no two-cluster e2e
suite — the proof lives at dual-envtest level with a real provider and two real
API servers.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789219257&installation_model_id=18560&pr_number=848&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F848&signature=50cb818747e729455df8d7ba75f30365e0317c13c757b2cfebe5735aa110a77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->