### PR TITLE
feat(multicluster): replace setup-time cluster assumptions with per-cluster capability probes

### DIFF
--- a/docs/reference/barbican/barbican-reconciler.md
+++ b/docs/reference/barbican/barbican-reconciler.md
@@ -95,7 +95,7 @@ sub-conditions are `True`, and `False` (`NotAllReady`) otherwise.
 | `BarbicanAPIReady` | `APIHealthy` | `APIUnhealthy`, `HealthCheckTimeout`, `ConnectionFailed`, `HealthCheckFailed`, plus the shared pre-endpoint wait the probe flow sets before `status.endpoint` is stamped |
 | `HPAReady` | `HPAReady`, `HPANotRequired` | — (errors propagate) |
 | `NetworkPolicyReady` | `NetworkPolicyReady`, `NetworkPolicyNotRequired` | — (errors propagate) |
-| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled` |
+| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled`, `CapabilityProbeFailed` |
 
 `TargetClusterUnavailable` is set ahead of every sub-reconciler, when
 `spec.targetClusterRef` names a target cluster that is not registered or no
@@ -278,9 +278,13 @@ while the credential in the pods is still valid.
 The Barbican controller `Owns` its Deployment, Service, Secret,
 PodDisruptionBudget, HorizontalPodAutoscaler, NetworkPolicy, Job, and CronJob.
 The HTTPRoute is added to the `Owns` set only when the Gateway API CRD is
-installed, probed at setup through the RESTMapper; without it `spec.gateway`
-surfaces `HTTPRouteReady=False / GatewayAPINotInstalled` instead of failing the
-controller at start with an unknown kind. The CR's own status-only updates are
+installed on the management cluster, probed at setup through the RESTMapper;
+without it `spec.gateway` surfaces
+`HTTPRouteReady=False / GatewayAPINotInstalled` instead of failing the
+controller at start with an unknown kind. That setup probe answers for CRs
+without a `spec.targetClusterRef`; a CR that names a target cluster has the
+kind probed against that cluster's RESTMapper on every pass, so the verdict
+follows the cluster its children land on. The CR's own status-only updates are
 filtered out, so a status write does not re-wake the controller.
 
 Beyond the owned set it watches:

--- a/docs/reference/glance/glance-reconciler.md
+++ b/docs/reference/glance/glance-reconciler.md
@@ -64,7 +64,7 @@ nine sub-conditions are `True`; otherwise `False` (`NotAllReady`).
 | `GlanceAPIReady` | `APIHealthy` | `APIUnhealthy`, `EndpointNotReady`, `HealthCheckTimeout`, `ConnectionFailed`, `HealthCheckFailed` |
 | `HPAReady` | `HPAReady`, `HPANotRequired` | — (errors propagate) |
 | `NetworkPolicyReady` | `NetworkPolicyReady`, `NetworkPolicyNotRequired` | — (errors propagate) |
-| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled` |
+| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled`, `CapabilityProbeFailed` |
 | `DBPurgeReady` | `DBPurgeScheduled`, `DBPurgeSuspended` | `DBPurgeJobFailed` |
 
 `TargetClusterUnavailable` is set ahead of every sub-reconciler, when
@@ -229,9 +229,13 @@ PodDisruptionBudget, HorizontalPodAutoscaler, NetworkPolicy, and — for the
 db-sync migration — Job, plus the db-purge CronJob: its `status.active` list
 changes as each spawned run starts and finishes, which is what wakes the
 reconcile that refreshes `DBPurgeReady`. The HTTPRoute is added to the `Owns`
-set only when the Gateway API CRD is installed (otherwise `spec.gateway`
-surfaces `HTTPRouteReady=False / GatewayAPINotInstalled` instead of crashing
-the controller). Beyond the owned set it watches:
+set only when the Gateway API CRD is installed on the management cluster
+(otherwise `spec.gateway` surfaces
+`HTTPRouteReady=False / GatewayAPINotInstalled` instead of crashing the
+controller). That setup probe answers for CRs without a
+`spec.targetClusterRef`; a CR that names a target cluster has the kind probed
+against that cluster's RESTMapper on every pass. Beyond the owned set it
+watches:
 
 - **Secrets**, mapped to the Glance CRs that reference them directly (via the
   `spec.serviceUser.secretRef.name` / `spec.database.secretRef.name` field

--- a/docs/reference/horizon/horizon-reconciler.md
+++ b/docs/reference/horizon/horizon-reconciler.md
@@ -43,7 +43,7 @@ all seven sub-conditions are `True`:
 | `SecretsReady` | `SecretsAvailable` | `TargetClusterUnavailable`, `SecretStoreNotReady`, `WaitingForSecretKey` |
 | `ConfigReady` | `ConfigRendered` | `ConfigError` |
 | `DeploymentReady` | `DeploymentReady` | `WaitingForDeployment` |
-| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled` |
+| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled`, `CapabilityProbeFailed` |
 | `HorizonAPIReady` | `APIHealthy` | `APIUnhealthy`, `EndpointNotReady`, `HealthCheckTimeout`, `ConnectionFailed`, `HealthCheckFailed` |
 | `HPAReady` | `HPAReady`, `HPANotRequired` | — (errors propagate) |
 | `NetworkPolicyReady` | `NetworkPolicyReady`, `NetworkPolicyNotRequired` | — (errors propagate) |
@@ -86,9 +86,12 @@ namespaced `SecretStore` — each bound to `storeToHorizonMapper` (the shared
 `spec.secretStoreRef` resolves to the changed store, so upstream
 credential and backend changes retrigger reconciliation without waiting for
 a periodic requeue. The HTTPRoute watch is registered only when the Gateway
-API CRD is installed; without it, `spec.gateway` surfaces
-`HTTPRouteReady=False` with reason `GatewayAPINotInstalled` instead of
-crashing the controller.
+API CRD is installed on the management cluster; without it, `spec.gateway`
+surfaces `HTTPRouteReady=False` with reason `GatewayAPINotInstalled` instead
+of crashing the controller. That setup probe answers for CRs without a
+`spec.targetClusterRef`; a CR that names a target cluster has the kind probed
+against that cluster's RESTMapper on every pass, so the verdict follows the
+cluster its children land on.
 
 ## WebSSO and multi-domain rendering
 

--- a/docs/reference/keystone/keystone-crd.md
+++ b/docs/reference/keystone/keystone-crd.md
@@ -767,9 +767,16 @@ CRD must be installed in the cluster before the Keystone operator starts. The
 operator probes for the CRD at startup (via the manager `RESTMapper`); when the
 CRD is missing it disables the HTTPRoute watch so Keystone CRs without
 `spec.gateway` still reconcile, and reports `HTTPRouteReady=False` with reason
-`GatewayAPINotInstalled` for any CR that sets `spec.gateway`. Installing the
-CRD after the operator has started requires restarting the operator for the
-watch to become active. The quickstart stack (`make deploy-infra`) installs
+`GatewayAPINotInstalled` for any CR that sets `spec.gateway`. A Keystone with
+`spec.targetClusterRef` is re-probed against its target cluster on every
+reconcile, so installing Gateway API there heals the CR on the next pass;
+restoring the `HTTPRoute` drift watch on that cluster still needs a rotation of
+its kubeconfig Secret (see
+[Target Clusters](../target-clusters.md#per-cluster-capabilities)). For a
+Keystone that names no target cluster the startup probe is the whole answer,
+and installing the CRD after the operator has started requires restarting the
+operator for the watch to become active. The quickstart stack
+(`make deploy-infra`) installs
 the upstream Gateway API standard CRDs for this reason; the pinned version is
 set via `GATEWAY_API_VERSION` in `hack/deploy-infra.sh` and tracks
 `sigs.k8s.io/gateway-api` in `operators/keystone/go.mod`. That pin is `v1.6.1`
@@ -1187,6 +1194,8 @@ condition using these typed reasons:
 | `ExternallyManaged` | `enabled=true` but the database is brownfield (`spec.database.host` set, no `clusterRef`) — the operator does not own the trust domain and expects the client keypair to be supplied out-of-band via `clientCertSecretRef`. |
 | `CertificatePending` | Managed mode; the operator has created the cert-manager `Certificate` but cert-manager has not yet issued it. The condition is `False` until issuance completes. |
 | `CertificateIssued` | Managed mode; the client `Certificate` is issued into Secret `<name>-db-client` and ready for mount. |
+| `CertificateError` | Managed mode; applying the `Certificate` to the cluster the children are written to failed — a target cluster without cert-manager answers `no matches for kind Certificate`. The condition is `False` and the pass returns the error. |
+| `CapabilityProbeFailed` | The cluster the children are written to could not be asked whether it serves the `cert-manager.io/v1 Certificate` kind (target API server unreachable, or throttling the discovery request). The condition is `False` and the pass returns the error, so a `DatabaseTLSReady` left at its previous verdict cannot report the CR converged at a spec that was never applied. |
 
 ### CacheSpec
 

--- a/docs/reference/keystone/keystone-reconciler.md
+++ b/docs/reference/keystone/keystone-reconciler.md
@@ -71,8 +71,8 @@ The controller watches the primary Keystone CR and all owned resources:
 | `PodDisruptionBudget` | `Owns()` | Triggers reconciliation when owned PDB changes |
 | `HorizontalPodAutoscaler` | `Owns()` | Triggers reconciliation when owned HPA changes |
 | `CronJob` | `Owns()` | Triggers reconciliation when owned CronJob changes |
-| `HTTPRoute` | `Owns()` (optional) | Registered only when the `gateway.networking.k8s.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. Triggers reconciliation when owned HTTPRoute changes (only created when `spec.gateway` is set). |
-| `Certificate` | `Owns()` (optional) | Registered only when the `cert-manager.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. Triggers reconciliation when the managed `<name>-db-client` Certificate changes, so later issuance failures surface in `DatabaseTLSReady` (only created when managed DB TLS is enabled). |
+| `HTTPRoute` | `Owns()` (optional) | Registered only when the `gateway.networking.k8s.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. That detection gates the local watch leg and answers for Keystone CRs whose children stay on the management cluster; a CR naming a target cluster is probed against that cluster's `RESTMapper` on every pass. Triggers reconciliation when owned HTTPRoute changes (only created when `spec.gateway` is set). |
+| `Certificate` | `Owns()` (optional) | Registered only when the `cert-manager.io/v1` CRD is installed; detected at startup via the manager's `RESTMapper`. As with the HTTPRoute leg, that detection gates the local watch and answers for CRs without a target cluster, while a CR that names one is probed against its target per pass. Triggers reconciliation when the managed `<name>-db-client` Certificate changes, so later issuance failures surface in `DatabaseTLSReady` (only created when managed DB TLS is enabled). |
 | `Secret` | `Watches()` | Maps Secret events to referencing Keystone CRs via the `KeystoneSecretNameIndexKey` field indexer, with an owner-ref fallback for rotation staging Secrets |
 | `MariaDB` | `Watches()` | Propagates upstream DB cluster health into `DatabaseReady` |
 | `ClusterSecretStore` | `Watches()` | Propagates OpenBao-backend health into `SecretsReady`; per-ref fan-out via `storeToKeystoneMapper` (bound to the shared `watch.StoreRefFanOut` for the cluster kind) enqueues only the Keystone CRs whose effective `spec.secretStoreRef` resolves to the changed cluster store |
@@ -1470,7 +1470,7 @@ after a full reconcile loop, every condition in the status carries the correct
 | `PolicyValidReady` | `reconcilePolicyValidation` | Policy override validation passed or not required |
 | `DeploymentReady` | `reconcileDeployment` | Deployment available and Service created |
 | `KeystoneAPIReady` | `reconcileHealthCheck` | Keystone API responding to HTTP health check |
-| `HTTPRouteReady` | `reconcileHTTPRoute` | HTTPRoute accepted by Gateway, not required (no `spec.gateway`), or Gateway API CRD missing (reason `GatewayAPINotInstalled`) |
+| `HTTPRouteReady` | `reconcileHTTPRoute` | HTTPRoute accepted by Gateway, not required (no `spec.gateway`), Gateway API CRD missing on the cluster the children land on (reason `GatewayAPINotInstalled`), or that cluster could not be probed for the kind (reason `CapabilityProbeFailed`) |
 | `HPAReady` | `reconcileHPA` | HPA configured or not required |
 | `BootstrapReady` | `reconcileBootstrap` | Bootstrap Job completed successfully |
 | `TrustFlushReady` | `reconcileTrustFlush` | Trust flush CronJob configured or not required |
@@ -2515,17 +2515,28 @@ Keystone API outside the cluster via a pre-existing `Gateway`. The
 Gateway is owned by the platform team; this sub-reconciler only ensures the
 route that attaches the Keystone Service to it. Four lifecycle paths:
 
-0. **Gateway API not installed** (`r.gatewayAPIAvailable` is false): The
-   CRD presence check in `SetupWithManager` found no mapping for
-   `HTTPRoute.gateway.networking.k8s.io/v1`, so the `Owns(HTTPRoute)` watch
-   was skipped. When `spec.gateway` is nil, set `HTTPRouteReady=True` with
-   reason `HTTPRouteNotRequired` (no delete attempt — `c.Delete` would fail
-   with `no matches for kind`). When `spec.gateway` is set, set
-   `HTTPRouteReady=False` with reason `GatewayAPINotInstalled` and a message
-   pointing the user at the missing CRD; the operator otherwise keeps
-   reconciling so that Keystone CRs without `spec.gateway` still become
-   Ready. Runtime installation of the CRD requires an operator restart for
-   the RESTMapper probe and the `Owns()` watch to pick it up.
+0. **The children's cluster does not serve the HTTPRoute kind**
+   (`commonmulticluster.ChildrenServeKind` answers false): When `spec.gateway`
+   is nil, set `HTTPRouteReady=True` with reason `HTTPRouteNotRequired` (no
+   delete attempt — `c.Delete` would fail with `no matches for kind`). When
+   `spec.gateway` is set, set `HTTPRouteReady=False` with reason
+   `GatewayAPINotInstalled`; the operator otherwise keeps reconciling so that
+   Keystone CRs without `spec.gateway` still become Ready. Where the answer
+   comes from, and what the message asks for, depends on the CR:
+   - **Without `spec.targetClusterRef`:** from `r.gatewayAPIAvailable`, the
+     latch `SetupWithManager` probed against the management cluster's
+     `RESTMapper`. It found no mapping for
+     `HTTPRoute.gateway.networking.k8s.io/v1`, so the `Owns(HTTPRoute)` watch
+     was skipped too. Installing the CRD at runtime requires an operator
+     restart for the probe and the watch to pick it up, and the message says
+     so.
+   - **With `spec.targetClusterRef`:** from the target cluster's own
+     `RESTMapper`, probed on every pass with nothing memoized, so a CRD
+     installed on the target is seen on the next reconcile. The drift watch is
+     fixed at cluster engagement and does not come back with it, so the message
+     asks for Gateway API on the target plus a rotation of the cluster's
+     kubeconfig Secret, which re-engages the cluster and restores the
+     `HTTPRoute` watch.
 1. **Gateway disabled** (`spec.gateway` is nil, CRD present): Delete any
    existing `{name}` HTTPRoute and set `HTTPRouteReady=True` with reason
    `HTTPRouteNotRequired`.
@@ -2537,7 +2548,11 @@ route that attaches the Keystone Service to it. Four lifecycle paths:
    reason `HTTPRouteAccepted`; otherwise condition `False` with reason
    `HTTPRouteNotAccepted` and a 10s requeue.
 3. **Error**: Propagate errors from ensure/delete/get operations with
-   descriptive context.
+   descriptive context. A capability probe that fails instead of answering
+   (the target API server unreachable, or throttling the discovery request)
+   belongs here as well: it sets `HTTPRouteReady=False` with reason
+   `CapabilityProbeFailed` and returns the wrapped error, so the pass is
+   retried with backoff.
 
 **Placement rationale:** Runs after `reconcileDeployment` + `pruneStaleConfigMaps`
 so the backend Service (`{name}`) is guaranteed to exist before the HTTPRoute

--- a/docs/reference/placement/placement-reconciler.md
+++ b/docs/reference/placement/placement-reconciler.md
@@ -68,7 +68,7 @@ sub-conditions are `True`, and `False` (`NotAllReady`) otherwise.
 | `PlacementAPIReady` | `APIHealthy` | `APIUnhealthy`, `EndpointNotReady`, `HealthCheckTimeout`, `ConnectionFailed`, `HealthCheckFailed` |
 | `HPAReady` | `HPAReady`, `HPANotRequired` | — (errors propagate) |
 | `NetworkPolicyReady` | `NetworkPolicyReady`, `NetworkPolicyNotRequired` | — (errors propagate) |
-| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled` |
+| `HTTPRouteReady` | `HTTPRouteAccepted`, `HTTPRouteNotRequired` | `HTTPRouteNotAccepted`, `GatewayAPINotInstalled`, `CapabilityProbeFailed` |
 
 `TargetClusterUnavailable` is set ahead of every sub-reconciler, when
 `spec.targetClusterRef` names a target cluster that is not registered or no
@@ -204,9 +204,13 @@ image the first one cannot read.
 The Placement controller `Owns` its Deployment, Service, ConfigMap, Secret,
 PodDisruptionBudget, HorizontalPodAutoscaler, NetworkPolicy, and, for the db-sync
 migration, Job. The HTTPRoute is added to the `Owns` set only when the Gateway
-API CRD is installed, probed at setup through the RESTMapper; without it
-`spec.gateway` surfaces `HTTPRouteReady=False / GatewayAPINotInstalled` instead
-of failing the controller at start with an unknown kind. The CR's own
+API CRD is installed on the management cluster, probed at setup through the
+RESTMapper; without it `spec.gateway` surfaces
+`HTTPRouteReady=False / GatewayAPINotInstalled` instead of failing the
+controller at start with an unknown kind. That setup probe answers for CRs
+without a `spec.targetClusterRef`; a CR that names a target cluster has the
+kind probed against that cluster's RESTMapper on every pass, so the verdict
+follows the cluster its children land on. The CR's own
 status-only updates are filtered out, so a status write does not re-wake the
 controller.
 

--- a/docs/reference/target-clusters.md
+++ b/docs/reference/target-clusters.md
@@ -329,8 +329,50 @@ child as an orphan. Delete such a CR and create it anew before the CRDs go onto
 its target cluster; everything it writes afterwards carries the labels alone.
 :::
 
+## Per-cluster capabilities
+
+Two of the kinds these operators project are optional: the Gateway API
+`HTTPRoute`, and the cert-manager `Certificate` Keystone issues for a managed
+database client keypair. Whether a kind can be written is a property of the
+cluster the children land on, so that is the cluster asked. A CR without
+`targetClusterRef` takes the answer from the latch its operator probed against
+the management cluster's `RESTMapper` at setup, and a CRD installed there
+afterwards is picked up on the next operator restart. A CR that names a target
+cluster is probed against that cluster's `RESTMapper` on every pass, with
+nothing memoized in between. Install Gateway API on the target and the next
+reconcile writes the route.
+
+The verdict decides what the pass does. A `spec.gateway` set against a cluster
+that does not serve `HTTPRoute` holds `HTTPRouteReady=False` with reason
+`GatewayAPINotInstalled`, under a message naming the cluster that lacks the
+CRD. Keystone's Certificate delete, the one that runs when database TLS is
+switched off or pointed at a brownfield database, is skipped on a target
+without cert-manager, where no Certificate can exist. A probe that fails
+instead of answering is its own outcome: a target API server that is
+unreachable, or throttling the discovery request, sets the sub-reconciler's own
+condition — `HTTPRouteReady` or `DatabaseTLSReady` — to `False` with reason
+`CapabilityProbeFailed`, and the pass is retried with backoff. That condition is
+what keeps an aborted pass honest, since the aggregate `Ready` is re-computed
+and `status.observedGeneration` stamped on every exit path.
+
+A watch leg is fixed when its cluster is engaged (see above); the probe is not.
+A CRD installed on a target after that takes effect on the next reconcile,
+while the drift watch for that kind stays absent until the registration Secret
+is rotated: an `HTTPRoute` deleted by hand on that cluster is corrected on the
+next periodic requeue instead of within watch latency.
+
+Field indexes are registered on the management cluster only. Every index is on
+a CR kind, and the CRs exist there alone; a remote event finds its CR through
+the local cache, because the mappers pin every request they emit to the
+management cluster. Registering the indexes on the fleet would break cluster
+engagement outright, since the kubeconfig provider applies its stored indexes
+while engaging a cluster.
+
+The API Service selector latch reads the target too: it goes through that
+cluster's own uncached API reader, so a lagging cache cannot re-widen the
+selector.
+
 ## Interim constraints
 
-- The capability probes (Gateway API, cert-manager) run against the management cluster, not the target (#839). The API Service selector latch does read the target: it goes through that cluster's own uncached API reader, so a lagging cache cannot re-widen the selector.
 - `KeystoneIdentityBackend` carries no `targetClusterRef`, and its reconciler stays management-side. A backend attached to a Keystone that names a target cluster looks for the parent's Deployment and projection Secret locally, where they do not exist, and holds `ConfigProjected=False` with reason `WaitingForProjection`.
 - RBAC and access packaging for a target cluster, together with the two-cluster development flow, are #841.

--- a/internal/common/gateway/flow.go
+++ b/internal/common/gateway/flow.go
@@ -29,17 +29,17 @@ const (
 )
 
 // RouteFlowParams carries everything ReconcileHTTPRoute needs. The
-// service-specific parts — whether the Gateway API is installed, whether
+// service-specific parts — the setup-time Gateway API latch, whether
 // spec.gateway is set, the built desired route, the route identity, the
 // exposure noun for the messages, and the condition type — are supplied by the
 // caller; the three-path flow itself is identical across operators.
 type RouteFlowParams struct {
-	// GatewayAPIAvailable reports whether the cluster holding the children
-	// serves the HTTPRoute CRD. For local children it is the management
-	// cluster's setup-time latch, probed once in SetupWithManager. For remote
-	// children it is the per-pass multicluster.ChildrenServeKind probe against
-	// the target cluster's RESTMapper.
-	GatewayAPIAvailable bool
+	// LocalGatewayAPIAvailable reports whether the management cluster serves
+	// the HTTPRoute CRD: the setup-time latch the operator probed once in
+	// SetupWithManager. It answers for local children alone; children on a
+	// target cluster are probed against that cluster's RESTMapper on every
+	// pass.
+	LocalGatewayAPIAvailable bool
 	// GatewayConfigured reports whether the CR requests external exposure
 	// (spec.gateway != nil).
 	GatewayConfigured bool
@@ -67,8 +67,9 @@ type RouteFlowParams struct {
 // Gateway matches the desired state. It is the shared body of every operator's
 // reconcileHTTPRoute sub-reconciler and implements three lifecycle paths:
 //
-//   - Gateway API CRD absent: skip the delete (which would fail with "no matches
-//     for kind HTTPRoute") and surface a clear condition.
+//   - Gateway API CRD absent on the cluster the children are written to: skip
+//     the delete (which would fail with "no matches for kind HTTPRoute") and
+//     surface a clear condition.
 //   - spec.gateway nil: delete any existing HTTPRoute and set the condition
 //     True/HTTPRouteNotRequired.
 //   - spec.gateway set: apply the route via SSA and reflect the parent Accepted
@@ -76,8 +77,23 @@ type RouteFlowParams struct {
 func ReconcileHTTPRoute(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, p RouteFlowParams) (ctrl.Result, error) {
 	notConfiguredMsg := fmt.Sprintf("External %s exposure via Gateway API is not configured", p.ExposureNoun)
 
-	// Path 0: Gateway API CRD is not installed.
-	if !p.GatewayAPIAvailable {
+	// The setup-time latch answers for the management cluster only, so it is the
+	// answer for local children alone; a CR that names a target cluster has its
+	// children's cluster probed on every pass.
+	available, err := multicluster.ChildrenServeKind(c, p.LocalGatewayAPIAvailable, httpRouteGVK)
+	if err != nil {
+		conditions.SetCondition(p.Conditions, metav1.Condition{
+			Type:               p.ConditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: p.Generation,
+			Reason:             multicluster.CapabilityProbeFailed,
+			Message:            fmt.Sprintf("Probing the target cluster for the HTTPRoute kind failed: %v", err),
+		})
+		return ctrl.Result{}, fmt.Errorf("probing the target cluster for the HTTPRoute kind: %w", err)
+	}
+
+	// Path 0: the children's cluster does not serve the HTTPRoute kind.
+	if !available {
 		if !p.GatewayConfigured {
 			conditions.SetCondition(p.Conditions, metav1.Condition{
 				Type:               p.ConditionType,

--- a/internal/common/gateway/flow.go
+++ b/internal/common/gateway/flow.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 // Condition reason constants for the HTTPRoute readiness condition, shared so
@@ -33,8 +34,11 @@ const (
 // exposure noun for the messages, and the condition type — are supplied by the
 // caller; the three-path flow itself is identical across operators.
 type RouteFlowParams struct {
-	// GatewayAPIAvailable reports whether the HTTPRoute CRD is installed (the
-	// watch was registered at startup).
+	// GatewayAPIAvailable reports whether the cluster holding the children
+	// serves the HTTPRoute CRD. For local children it is the management
+	// cluster's setup-time latch, probed once in SetupWithManager. For remote
+	// children it is the per-pass multicluster.ChildrenServeKind probe against
+	// the target cluster's RESTMapper.
 	GatewayAPIAvailable bool
 	// GatewayConfigured reports whether the CR requests external exposure
 	// (spec.gateway != nil).
@@ -84,14 +88,25 @@ func ReconcileHTTPRoute(ctx context.Context, c client.Client, scheme *runtime.Sc
 			})
 			return ctrl.Result{}, nil
 		}
+		// The remote message names the target cluster and its per-reconcile
+		// re-check, because the availability answer for remote children comes
+		// from a probe against the target's RESTMapper rather than from the
+		// setup-time latch a restart would refresh.
+		notInstalledMsg := fmt.Sprintf("spec.gateway is set but the gateway.networking.k8s.io/v1 HTTPRoute CRD is "+
+			"not installed in this cluster; install Gateway API and restart the operator to enable "+
+			"external %s exposure", p.ExposureNoun)
+		if multicluster.IsRemote(c) {
+			notInstalledMsg = "spec.gateway is set but the target cluster does not serve the " +
+				"gateway.networking.k8s.io/v1 HTTPRoute CRD; install Gateway API on the target cluster " +
+				"(the operator re-checks on every reconcile) and rotate the cluster's kubeconfig Secret " +
+				"to restore the HTTPRoute drift watch"
+		}
 		conditions.SetCondition(p.Conditions, metav1.Condition{
 			Type:               p.ConditionType,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: p.Generation,
 			Reason:             ReasonGatewayAPINotInstalled,
-			Message: fmt.Sprintf("spec.gateway is set but the gateway.networking.k8s.io/v1 HTTPRoute CRD is "+
-				"not installed in this cluster; install Gateway API and restart the operator to enable "+
-				"external %s exposure", p.ExposureNoun),
+			Message:            notInstalledMsg,
 		})
 		return ctrl.Result{}, nil
 	}

--- a/internal/common/gateway/flow_test.go
+++ b/internal/common/gateway/flow_test.go
@@ -18,6 +18,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	"github.com/c5c3/forge/internal/common/multicluster"
 )
 
 func flowScheme(t *testing.T) *runtime.Scheme {
@@ -66,6 +67,31 @@ func TestReconcileHTTPRoute_APIAbsentGatewaySet(t *testing.T) {
 	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).To(gomega.Equal(ReasonGatewayAPINotInstalled))
 	g.Expect(cond.Message).To(gomega.ContainSubstring("enable external API exposure"))
+	// Local children are answered by the setup-time latch, so the message names
+	// this cluster and the restart that refreshes it.
+	g.Expect(cond.Message).To(gomega.ContainSubstring("not installed in this cluster"))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("restart the operator"))
+}
+
+func TestReconcileHTTPRoute_APIAbsentGatewaySetRemote(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).Build())
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.GatewayAPIAvailable = false
+	p.GatewayConfigured = true
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).To(gomega.ContainSubstring("rotate the cluster's kubeconfig Secret"))
+	// The remote answer is re-probed every pass, so a restart fixes nothing.
+	g.Expect(cond.Message).NotTo(gomega.ContainSubstring("restart"))
 }
 
 func TestReconcileHTTPRoute_APIAbsentGatewayNil(t *testing.T) {

--- a/internal/common/gateway/flow_test.go
+++ b/internal/common/gateway/flow_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 )
 
 func flowScheme(t *testing.T) *runtime.Scheme {
@@ -57,7 +59,7 @@ func TestReconcileHTTPRoute_APIAbsentGatewaySet(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 	var conds []metav1.Condition
 	p := baseRouteParams(&conds)
-	p.GatewayAPIAvailable = false
+	p.LocalGatewayAPIAvailable = false
 	p.GatewayConfigured = true
 
 	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
@@ -79,7 +81,7 @@ func TestReconcileHTTPRoute_APIAbsentGatewaySetRemote(t *testing.T) {
 	c := multicluster.Remote(fake.NewClientBuilder().WithScheme(s).Build())
 	var conds []metav1.Condition
 	p := baseRouteParams(&conds)
-	p.GatewayAPIAvailable = false
+	p.LocalGatewayAPIAvailable = false
 	p.GatewayConfigured = true
 
 	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
@@ -100,7 +102,7 @@ func TestReconcileHTTPRoute_APIAbsentGatewayNil(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 	var conds []metav1.Condition
 	p := baseRouteParams(&conds)
-	p.GatewayAPIAvailable = false
+	p.LocalGatewayAPIAvailable = false
 	p.GatewayConfigured = false
 
 	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
@@ -119,7 +121,7 @@ func TestReconcileHTTPRoute_GatewayNilDeletes(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
 	var conds []metav1.Condition
 	p := baseRouteParams(&conds)
-	p.GatewayAPIAvailable = true
+	p.LocalGatewayAPIAvailable = true
 	p.GatewayConfigured = false
 
 	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
@@ -133,13 +135,39 @@ func TestReconcileHTTPRoute_GatewayNilDeletes(t *testing.T) {
 	g.Expect(cond.Reason).To(gomega.Equal(ReasonHTTPRouteNotRequired))
 }
 
+// The inversion the delete path turns on: the management cluster has no Gateway
+// API, the target cluster has, and the route revoked by removing spec.gateway
+// has to go from the target. Answering that sweep from the latch would leave the
+// route serving public traffic while the CR says the exposure is gone.
+func TestReconcileHTTPRoute_GatewayNilDeletesThroughRemoteChildrenDespiteTheLatch(t *testing.T) {
+	g := gomega.NewWithT(t)
+	s := flowScheme(t)
+	existing := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "ks", Namespace: "openstack"}}
+	target := mctestutil.TargetFake(fake.NewClientBuilder().WithScheme(s).WithObjects(existing), httpRouteGVK)
+	c := multicluster.Remote(target)
+	var conds []metav1.Condition
+	p := baseRouteParams(&conds)
+	p.LocalGatewayAPIAvailable = false
+	p.GatewayConfigured = false
+
+	res, err := ReconcileHTTPRoute(context.Background(), c, s, flowOwner(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(res.IsZero()).To(gomega.BeTrue())
+	err = target.Get(context.Background(), types.NamespacedName{Namespace: "openstack", Name: "ks"},
+		&gatewayv1.HTTPRoute{})
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue(),
+		"the target serves the kind, so the management latch must not skip the sweep")
+	cond := conditions.GetCondition(conds, p.ConditionType)
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonHTTPRouteNotRequired))
+}
+
 func TestReconcileHTTPRoute_GatewayEnabledNotAccepted(t *testing.T) {
 	g := gomega.NewWithT(t)
 	s := flowScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(flowOwner()).Build()
 	var conds []metav1.Condition
 	p := baseRouteParams(&conds)
-	p.GatewayAPIAvailable = true
+	p.LocalGatewayAPIAvailable = true
 	p.GatewayConfigured = true
 	p.Desired = BuildHTTPRoute(testGatewaySpec(), RouteParams{
 		Name: "ks", Namespace: "openstack", BackendService: "ks", BackendPort: 5000,

--- a/internal/common/gateway/gateway.go
+++ b/internal/common/gateway/gateway.go
@@ -31,6 +31,14 @@ import (
 // is empty.
 const defaultHTTPRoutePath = "/"
 
+// httpRouteGVK identifies the kind the route flow probes for on the cluster
+// the children are written to.
+var httpRouteGVK = schema.GroupVersionKind{
+	Group:   gatewayv1.GroupVersion.Group,
+	Version: gatewayv1.GroupVersion.Version,
+	Kind:    "HTTPRoute",
+}
+
 // IsGVKAvailable probes the given RESTMapper for the GVK. It returns false
 // when the mapper has no mapping (CRD not installed) and true when the
 // mapping exists. Other mapper errors are treated as "unknown"; returning

--- a/internal/common/gateway/gateway_test.go
+++ b/internal/common/gateway/gateway_test.go
@@ -18,12 +18,6 @@ import (
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 )
 
-var httpRouteGVK = schema.GroupVersionKind{
-	Group:   gatewayv1.GroupVersion.Group,
-	Version: gatewayv1.GroupVersion.Version,
-	Kind:    "HTTPRoute",
-}
-
 func TestIsGVKAvailable(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/internal/common/multicluster/capability.go
+++ b/internal/common/multicluster/capability.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CapabilityProbeFailed is the condition reason every service operator sets
+// when the capability probe itself fails, that is, when ChildrenServeKind
+// answers with an error instead of a verdict. It sits one step past
+// TargetClusterUnavailable: the cluster resolved, and what could not be
+// established is whether it serves the kind. Sharing the reason
+// keeps the failure recognizable across operators, whatever the CR's condition
+// type happens to be.
+const CapabilityProbeFailed = "CapabilityProbeFailed"
+
+// ChildrenServeKind reports whether the cluster the children client writes
+// to serves gvk. Local children answer from localAvailable, the latch the
+// caller probed at setup; remote children are probed live through their
+// cluster's RESTMapper on every call, so a CRD installed on a target after
+// engagement is seen on the next reconcile.
+//
+// A remote client without a mapper cannot be asked at all, which is a probe
+// failure and not a verdict. Callers act on false by skipping a delete, and
+// that inference holds only for a cluster that was asked and answered no —
+// answering false for one that could not be asked would silently leave an
+// operator-owned child running on the target after the CR stopped claiming it.
+// ClusterServesKind collapses the same case into false because its filter
+// signature carries no error; here the error is reportable, so it is reported.
+//
+// A no-match answer is the negative verdict this probe is for. Every other
+// error is returned unmodified, because it says nothing about gvk (the
+// target's API server briefly unreachable, a 429 under throttling, an
+// aggregated APIService reporting Available=False) and belongs in a status
+// condition under CapabilityProbeFailed, wrapped once by the caller.
+//
+// A target that serves the kind costs nothing in steady state: the mapping is
+// already in the mapper's cache and no API call is made. A target that does
+// not serve it costs one discovery round-trip per probing pass, bounded by the
+// watch-driven reconciles plus the operator's sync period (ten minutes by
+// default), and only for CRs that name a target cluster.
+//
+// The mapping probe is spelled out here rather than taken from
+// gateway.IsGVKAvailable, which is the same check: the gateway package reaches
+// this one through apply and so cannot be imported back.
+func ChildrenServeKind(children client.Client, localAvailable bool, gvk schema.GroupVersionKind) (bool, error) {
+	if !IsRemote(children) {
+		return localAvailable, nil
+	}
+
+	mapper := children.RESTMapper()
+	if mapper == nil {
+		return false, fmt.Errorf("the target cluster's client carries no RESTMapper, so it cannot be probed for %s", gvk)
+	}
+
+	if _, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/common/multicluster/capability_test.go
+++ b/internal/common/multicluster/capability_test.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package multicluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// probeClient answers with a mapper of the test's choosing, nil unless one was
+// set, and records that it was asked for one at all. The recording is what
+// tells an unasked mapper from one that answered nothing: every real client
+// carries a mapper, the fake one included, so a local client that probed
+// anyway would otherwise be indistinguishable from one that did not.
+//
+// Embedding the interface leaves every other method nil, so a probe reaching
+// past the RESTMapper panics rather than passing quietly.
+type probeClient struct {
+	client.Client
+	mapper meta.RESTMapper
+	asked  bool
+}
+
+func (c *probeClient) RESTMapper() meta.RESTMapper {
+	c.asked = true
+	return c.mapper
+}
+
+// failingMapper fails every mapping with one error value, held rather than
+// built per call so a test can assert the caller got that exact error back. A
+// plain error is not a no-match: it is the throttled or briefly unreachable
+// target cluster, whose answer says nothing about the kind.
+type failingMapper struct {
+	meta.RESTMapper
+	err error
+}
+
+func (m failingMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}
+
+// remoteChildrenServing builds the children client the production path hands a
+// reconciler: a target cluster's own client, resolved through the manager and
+// marked remote, whose RESTMapper knows the kinds passed here and no others.
+func remoteChildrenServing(t *testing.T, kinds ...schema.GroupVersionKind) client.Client {
+	t.Helper()
+
+	mapper := meta.NewDefaultRESTMapper(nil)
+	for _, gvk := range kinds {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+
+	resolver := &fakeResolver{cl: fakeCluster{
+		c: fake.NewClientBuilder().WithRESTMapper(mapper).Build(),
+	}}
+
+	children, err := ResolveChildrenClient(context.Background(), resolver, fake.NewClientBuilder().Build(),
+		&commonv1.TargetClusterRefSpec{Name: "remote-a"})
+	if err != nil {
+		t.Fatalf("resolving the children client: %v", err)
+	}
+	return children
+}
+
+// A CR that keeps its children on the management cluster is answered by the
+// latch its operator probed at setup, in both directions. Re-probing the
+// management cluster on every reconcile is the cost single-cluster deployments
+// must not pay for a feature they do not use.
+func TestChildrenServeKindLocalClientAnswersFromTheLatch(t *testing.T) {
+	for name, available := range map[string]bool{
+		"the kind is installed locally":     true,
+		"the kind is not installed locally": false,
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			children := &probeClient{}
+
+			serves, err := ChildrenServeKind(children, available, httpRouteGVK)
+
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(serves).To(gomega.Equal(available))
+			g.Expect(children.asked).To(gomega.BeFalse(),
+				"a local client must be answered from the latch alone, without touching its RESTMapper")
+		})
+	}
+}
+
+// A client with no mapper cannot be asked what its cluster serves, and the
+// local latch describes the wrong cluster. Neither answer is available, so the
+// probe fails rather than reporting the negative verdict its callers skip
+// deletes on.
+func TestChildrenServeKindRemoteClientWithoutAMapperIsAProbeFailure(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	stub := &probeClient{}
+
+	serves, err := ChildrenServeKind(Remote(stub), true, httpRouteGVK)
+
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("carries no RESTMapper")),
+		"a target that could not be asked must not be reported as one that answered no")
+	g.Expect(serves).To(gomega.BeFalse())
+	g.Expect(stub.asked).To(gomega.BeTrue(),
+		"a remote client is the case this probe exists for; it has to be asked")
+}
+
+func TestChildrenServeKindSeesAKindTheTargetClusterServes(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// The latch says the kind is absent on the management cluster, so only the
+	// target's own mapper can produce this answer.
+	serves, err := ChildrenServeKind(remoteChildrenServing(t, httpRouteGVK), false, httpRouteGVK)
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(serves).To(gomega.BeTrue())
+}
+
+func TestChildrenServeKindSeesAKindTheTargetClusterDoesNotServe(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// A no-match answer is a verdict, not a failure: the CRD is simply not
+	// installed on that cluster, and the caller skips the projection.
+	serves, err := ChildrenServeKind(remoteChildrenServing(t), true, httpRouteGVK)
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(serves).To(gomega.BeFalse())
+}
+
+// A discovery failure says nothing about the kind, so it is reported rather
+// than turned into a verdict. The caller wraps it once on its way into a status
+// condition under CapabilityProbeFailed, and a prefix added here would show up
+// in that message twice over.
+func TestChildrenServeKindReturnsADiscoveryFailureUnwrapped(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	boom := errors.New("boom")
+	children := Remote(&probeClient{mapper: failingMapper{err: boom}})
+
+	serves, err := ChildrenServeKind(children, true, httpRouteGVK)
+
+	g.Expect(serves).To(gomega.BeFalse())
+	g.Expect(err).To(gomega.BeIdenticalTo(boom))
+}

--- a/internal/common/testutil/multicluster/children.go
+++ b/internal/common/testutil/multicluster/children.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package multicluster provides the children-client fixtures a unit test needs
+// to drive a sub-reconciler as a CR with spec.targetClusterRef drives it: a
+// target cluster's client with a RESTMapper of the test's choosing, that client
+// resolved the production way so it carries the remote mark, and a target that
+// cannot be probed at all.
+//
+// The fixtures live here because every service operator needs the same three
+// and none of them owns the shape: the children client is resolved by
+// internal/common/multicluster, and a copy per operator drifts the moment the
+// resolution changes. The package internal/common/multicluster tests itself
+// with its own fixtures, since importing this one back would be a cycle.
+package multicluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	commonv1 "github.com/c5c3/forge/internal/common/types"
+)
+
+// TargetFake builds a target cluster's client from builder — the operator's own
+// scheme and seeded objects — behind a RESTMapper serving exactly the given
+// kinds. Passing none is the target cluster that carries neither the Gateway
+// API nor the cert-manager CRDs, which is what the capability probe has to tell
+// from one that does.
+func TargetFake(builder *fake.ClientBuilder, serves ...schema.GroupVersionKind) client.Client {
+	mapper := meta.NewDefaultRESTMapper(nil)
+	for _, gvk := range serves {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+	return builder.WithRESTMapper(mapper).Build()
+}
+
+// RemoteChildren resolves target as the children client of a CR naming a target
+// cluster, through the same ResolveChildrenClient the reconcilers call, so it
+// carries the remote mark the capability probe and the ownership claim read.
+func RemoteChildren(t *testing.T, local, target client.Client) client.Client {
+	t.Helper()
+
+	children, err := commonmulticluster.ResolveChildrenClient(context.Background(),
+		&oneClusterResolver{cl: fakeCluster{c: target}}, local,
+		&commonv1.TargetClusterRefSpec{Name: "remote-a"})
+	if err != nil {
+		t.Fatalf("resolving the children client: %v", err)
+	}
+	return children
+}
+
+// UnprobeableChildren is a target cluster that cannot say what it serves: its
+// mapper fails with an error that is not a no-match, which is what a throttled
+// or briefly unreachable API server looks like from the probe. It is marked
+// remote, because a local client is never probed at all.
+func UnprobeableChildren(inner client.Client) client.Client {
+	return commonmulticluster.Remote(brokenMapperClient{Client: inner})
+}
+
+// oneClusterResolver and fakeCluster stand in for the multicluster manager,
+// registering the one target cluster under every name.
+type oneClusterResolver struct{ cl cluster.Cluster }
+
+func (r *oneClusterResolver) GetCluster(context.Context, mcruntime.ClusterName) (cluster.Cluster, error) {
+	return r.cl, nil
+}
+
+type fakeCluster struct {
+	cluster.Cluster
+	c client.Client
+}
+
+func (f fakeCluster) GetClient() client.Client    { return f.c }
+func (f fakeCluster) GetAPIReader() client.Reader { return f.c }
+
+type brokenMapperClient struct {
+	client.Client
+}
+
+func (brokenMapperClient) RESTMapper() meta.RESTMapper { return failingMapper{} }
+
+type failingMapper struct {
+	meta.RESTMapper
+}
+
+func (failingMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, errors.New("discovery is unavailable")
+}

--- a/operators/barbican/internal/controller/barbican_controller.go
+++ b/operators/barbican/internal/controller/barbican_controller.go
@@ -241,10 +241,13 @@ type BarbicanReconciler struct {
 	// (read-your-writes) fake client.
 	apiReader client.Reader
 
-	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1 HTTPRoute
-	// CRD is installed. When false, the controller skips the HTTPRoute watch
-	// entirely so it does not crash on a missing kind.
+	// gatewayAPIAvailable is set during SetupWithManager from the management
+	// cluster's RESTMapper and indicates whether the
+	// gateway.networking.k8s.io/v1 HTTPRoute CRD is installed there. Two
+	// consumers read it: the local HTTPRoute watch leg, which SetupWithManager
+	// skips when false so the controller does not crash on a missing kind, and
+	// commonmulticluster.ChildrenServeKind, which answers with it for local
+	// children while probing the target cluster's RESTMapper for remote ones.
 	gatewayAPIAvailable bool
 
 	// healthProbeCache memoizes the last successful Barbican API probe per CR
@@ -658,8 +661,14 @@ func (r *BarbicanReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	// secretToBarbicanWithStoresMapper can rely on it for its MatchingFields
 	// lookup. The indexes go on the LOCAL field indexer, not mgr's: with a
 	// provider configured, the multicluster manager's field indexer registers
-	// against the provider clusters, which hold no Barbican CR. Indexing the
-	// fleet is issue #839's business.
+	// against the provider clusters, which hold no Barbican CR. Registration
+	// stays local by contract: the indexes are on CR kinds, which exist on the
+	// management cluster alone, and every request the watches emit is pinned to
+	// that cluster (LocalRequests / RemoteRequests,
+	// internal/common/multicluster/watch.go), so a remote event resolves to its
+	// CR through the local cache. Registering on the fleet would fail the
+	// engagement of every target cluster, because the kubeconfig provider
+	// applies its stored indexes while engaging one.
 	if err := registerBarbicanIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}

--- a/operators/barbican/internal/controller/reconcile_httproute.go
+++ b/operators/barbican/internal/controller/reconcile_httproute.go
@@ -52,16 +52,16 @@ func (r *BarbicanReconciler) reconcileHTTPRoute(ctx context.Context, children cl
 		desired = buildBarbicanHTTPRoute(barbican)
 	}
 	return gateway.ReconcileHTTPRoute(ctx, children, r.Scheme, barbican, gateway.RouteFlowParams{
-		GatewayAPIAvailable: r.gatewayAPIAvailable,
-		GatewayConfigured:   barbican.Spec.Gateway != nil,
-		Desired:             desired,
-		RouteName:           subResourceName(barbican),
-		RouteNamespace:      barbican.Namespace,
-		ExposureNoun:        "Barbican API",
-		Conditions:          &barbican.Status.Conditions,
-		Generation:          barbican.Generation,
-		ConditionType:       conditionTypeHTTPRouteReady,
-		RequeueAccepted:     requeueHTTPRouteAccepted,
+		LocalGatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:        barbican.Spec.Gateway != nil,
+		Desired:                  desired,
+		RouteName:                subResourceName(barbican),
+		RouteNamespace:           barbican.Namespace,
+		ExposureNoun:             "Barbican API",
+		Conditions:               &barbican.Status.Conditions,
+		Generation:               barbican.Generation,
+		ConditionType:            conditionTypeHTTPRouteReady,
+		RequeueAccepted:          requeueHTTPRouteAccepted,
 	})
 }
 

--- a/operators/barbican/internal/controller/reconcile_httproute_test.go
+++ b/operators/barbican/internal/controller/reconcile_httproute_test.go
@@ -10,8 +10,11 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	barbicanv1alpha1 "github.com/c5c3/forge/operators/barbican/api/v1alpha1"
 )
 
@@ -116,4 +119,107 @@ func TestInternalBarbicanURLIgnoresTheGateway(t *testing.T) {
 	g.Expect(internalBarbicanURL(barbican)).To(Equal(want))
 	g.Expect(barbicanPublicEndpoint(barbican)).To(Equal("https://barbican.127-0-0-1.nip.io"),
 		"the advertised endpoint does follow the gateway")
+}
+
+// --- Remote children: the Gateway API answer comes from the target cluster ---
+
+// hrTargetFake builds a target cluster's client like barbicanFakeClientBuilder
+// builds the management cluster's, behind the RESTMapper the capability probe
+// asks. servesHTTPRoute is what separates a target cluster carrying the Gateway
+// API CRDs from one without them.
+func hrTargetFake(servesHTTPRoute bool, objs ...client.Object) client.Client {
+	if servesHTTPRoute {
+		return mctestutil.TargetFake(barbicanFakeClientBuilder(objs...), httpRouteGVK)
+	}
+	return mctestutil.TargetFake(barbicanFakeClientBuilder(objs...))
+}
+
+// The management cluster has no Gateway API and the target cluster has, so only
+// the target's own answer can produce the route. Deciding from the latch would
+// leave a CR that names a target cluster exposed nowhere.
+func TestReconcileHTTPRoute_RemoteChildrenServeTheKindDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	barbican.Spec.Gateway = barbicanGatewaySpec()
+	r := newBarbicanTestReconciler(barbican)
+	r.gatewayAPIAvailable = false
+	target := hrTargetFake(true)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), barbican)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), barbicanRequest.NamespacedName, &route)).To(Succeed(),
+		"the route belongs on the cluster the children are written to")
+}
+
+// The latch says the management cluster serves the kind, the target does not,
+// and the message has to name the cluster the operator actually looked at — an
+// operator restart refreshes the latch, not the target's CRDs.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindNameTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	barbican.Spec.Gateway = barbicanGatewaySpec()
+	r := newBarbicanTestReconciler(barbican)
+	r.gatewayAPIAvailable = true
+
+	res, err := r.reconcileHTTPRoute(context.Background(),
+		mctestutil.RemoteChildren(t, r.Client, hrTargetFake(false)), barbican)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := barbicanCondition(barbican, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).NotTo(ContainSubstring("restart"),
+		"restarting the operator re-probes the management cluster, which is not the cluster at fault")
+}
+
+// A target cluster that does not serve the kind is never asked to delete it:
+// the delete would fail with "no matches for kind HTTPRoute", and the route the
+// test seeds proves the flow short-circuited before reaching it.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	// gateway is nil: the delete path, were it reached.
+	r := newBarbicanTestReconciler(barbican)
+	r.gatewayAPIAvailable = true
+	seeded := &gatewayv1.HTTPRoute{}
+	seeded.Name = testBarbicanName
+	seeded.Namespace = testNamespace
+	target := hrTargetFake(false, seeded)
+
+	res, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), barbican)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := barbicanCondition(barbican, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotRequired))
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), barbicanRequest.NamespacedName, &route)).To(Succeed(),
+		"no delete may be attempted against a cluster that does not serve the kind")
+}
+
+// A probe that fails establishes nothing, so it is neither treated as "the
+// target serves it" nor as "it does not": the pass fails and the CR says why.
+func TestReconcileHTTPRoute_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	barbican := testBarbican()
+	barbican.Spec.Gateway = barbicanGatewaySpec()
+	r := newBarbicanTestReconciler(barbican)
+	children := mctestutil.UnprobeableChildren(r.Client)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), children, barbican)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the HTTPRoute kind:"))
+	cond := barbicanCondition(barbican, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
 }

--- a/operators/glance/internal/controller/glance_controller.go
+++ b/operators/glance/internal/controller/glance_controller.go
@@ -214,12 +214,15 @@ type GlanceReconciler struct {
 	// (read-your-writes) fake client.
 	apiReader client.Reader
 
-	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1 HTTPRoute
-	// CRD is installed. When false, the controller skips the HTTPRoute watch
-	// entirely so it does not crash on a missing kind, and reconcileHTTPRoute
-	// surfaces a clear HTTPRouteReady=False condition if the user nonetheless sets
-	// spec.gateway.
+	// gatewayAPIAvailable is set during SetupWithManager from the management
+	// cluster's RESTMapper and indicates whether the
+	// gateway.networking.k8s.io/v1 HTTPRoute CRD is installed there. Two
+	// consumers read it: the local HTTPRoute watch leg, which SetupWithManager
+	// skips when false so the controller does not crash on a missing kind, and
+	// commonmulticluster.ChildrenServeKind, which answers with it for local
+	// children while probing the target cluster's RESTMapper for remote ones.
+	// reconcileHTTPRoute takes that verdict and surfaces a clear
+	// HTTPRouteReady=False condition if the user nonetheless sets spec.gateway.
 	gatewayAPIAvailable bool
 
 	// healthProbeCache memoizes the last successful Glance API probe per CR
@@ -676,8 +679,14 @@ func (r *GlanceReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	// secretToGlanceWithBackendsMapper can rely on it for its MatchingFields
 	// lookup. The indexes go on the LOCAL field indexer, not mgr's: with a
 	// provider configured, the multicluster manager's field indexer registers
-	// against the provider clusters, which hold no Glance CR. Indexing the fleet
-	// is issue #839's business.
+	// against the provider clusters, which hold no Glance CR. Registration
+	// stays local by contract: the indexes are on CR kinds, which exist on the
+	// management cluster alone, and every request the watches emit is pinned to
+	// that cluster (LocalRequests / RemoteRequests,
+	// internal/common/multicluster/watch.go), so a remote event resolves to its
+	// CR through the local cache. Registering on the fleet would fail the
+	// engagement of every target cluster, because the kubeconfig provider
+	// applies its stored indexes while engaging one.
 	if err := registerGlanceIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}

--- a/operators/glance/internal/controller/reconcile_httproute.go
+++ b/operators/glance/internal/controller/reconcile_httproute.go
@@ -70,16 +70,16 @@ func (r *GlanceReconciler) reconcileHTTPRoute(ctx context.Context, children clie
 		desired = buildGlanceHTTPRoute(glance)
 	}
 	return gateway.ReconcileHTTPRoute(ctx, children, r.Scheme, glance, gateway.RouteFlowParams{
-		GatewayAPIAvailable: r.gatewayAPIAvailable,
-		GatewayConfigured:   glance.Spec.Gateway != nil,
-		Desired:             desired,
-		RouteName:           subResourceName(glance),
-		RouteNamespace:      glance.Namespace,
-		ExposureNoun:        "Glance API",
-		Conditions:          &glance.Status.Conditions,
-		Generation:          glance.Generation,
-		ConditionType:       conditionTypeHTTPRouteReady,
-		RequeueAccepted:     requeueHTTPRouteAccepted,
+		LocalGatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:        glance.Spec.Gateway != nil,
+		Desired:                  desired,
+		RouteName:                subResourceName(glance),
+		RouteNamespace:           glance.Namespace,
+		ExposureNoun:             "Glance API",
+		Conditions:               &glance.Status.Conditions,
+		Generation:               glance.Generation,
+		ConditionType:            conditionTypeHTTPRouteReady,
+		RequeueAccepted:          requeueHTTPRouteAccepted,
 	})
 }
 

--- a/operators/glance/internal/controller/reconcile_httproute_test.go
+++ b/operators/glance/internal/controller/reconcile_httproute_test.go
@@ -11,9 +11,12 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	glancev1alpha1 "github.com/c5c3/forge/operators/glance/api/v1alpha1"
 )
 
@@ -126,4 +129,107 @@ func TestGlanceStatusEndpoint(t *testing.T) {
 
 	glance.Spec.Gateway = glanceGatewaySpec()
 	g.Expect(glanceStatusEndpoint(glance)).To(Equal("https://glance.127-0-0-1.nip.io/"))
+}
+
+// --- Remote children: the Gateway API answer comes from the target cluster ---
+
+// hrTargetFake builds a target cluster's client like glanceFakeClientBuilder
+// builds the management cluster's, behind the RESTMapper the capability probe
+// asks. servesHTTPRoute is what separates a target cluster carrying the Gateway
+// API CRDs from one without them.
+func hrTargetFake(servesHTTPRoute bool, objs ...client.Object) client.Client {
+	if servesHTTPRoute {
+		return mctestutil.TargetFake(glanceFakeClientBuilder(objs...), httpRouteGVK)
+	}
+	return mctestutil.TargetFake(glanceFakeClientBuilder(objs...))
+}
+
+// The management cluster has no Gateway API and the target cluster has, so only
+// the target's own answer can produce the route. Deciding from the latch would
+// leave a CR that names a target cluster exposed nowhere.
+func TestReconcileHTTPRoute_RemoteChildrenServeTheKindDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	glance.Spec.Gateway = glanceGatewaySpec()
+	r := newGlanceTestReconciler(glance)
+	r.gatewayAPIAvailable = false
+	target := hrTargetFake(true)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), glance)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-glance"},
+		&route)).To(Succeed(), "the route belongs on the cluster the children are written to")
+}
+
+// The latch says the management cluster serves the kind, the target does not,
+// and the message has to name the cluster the operator actually looked at — an
+// operator restart refreshes the latch, not the target's CRDs.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindNameTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	glance.Spec.Gateway = glanceGatewaySpec()
+	r := newGlanceTestReconciler(glance)
+	r.gatewayAPIAvailable = true
+
+	res, err := r.reconcileHTTPRoute(context.Background(),
+		mctestutil.RemoteChildren(t, r.Client, hrTargetFake(false)), glance)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(glance.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).NotTo(ContainSubstring("restart"),
+		"restarting the operator re-probes the management cluster, which is not the cluster at fault")
+}
+
+// A target cluster that does not serve the kind is never asked to delete it:
+// the delete would fail with "no matches for kind HTTPRoute", and the route the
+// test seeds proves the flow short-circuited before reaching it.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	// gateway is nil: the delete path, were it reached.
+	r := newGlanceTestReconciler(glance)
+	r.gatewayAPIAvailable = true
+	seeded := &gatewayv1.HTTPRoute{}
+	seeded.Name = "test-glance"
+	seeded.Namespace = "default"
+	target := hrTargetFake(false, seeded)
+
+	res, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), glance)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(glance.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotRequired))
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-glance"},
+		&route)).To(Succeed(), "no delete may be attempted against a cluster that does not serve the kind")
+}
+
+// A probe that fails establishes nothing, so it is neither treated as "the
+// target serves it" nor as "it does not": the pass fails and the CR says why.
+func TestReconcileHTTPRoute_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	glance := testGlance()
+	glance.Spec.Gateway = glanceGatewaySpec()
+	r := newGlanceTestReconciler(glance)
+	children := mctestutil.UnprobeableChildren(r.Client)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), children, glance)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the HTTPRoute kind:"))
+	cond := conditions.GetCondition(glance.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
 }

--- a/operators/horizon/internal/controller/horizon_controller.go
+++ b/operators/horizon/internal/controller/horizon_controller.go
@@ -126,12 +126,16 @@ type HorizonReconciler struct {
 	// fall back to the (read-your-writes) fake client.
 	apiReader client.Reader
 
-	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1
-	// HTTPRoute CRD is installed. When false, the controller skips the
-	// HTTPRoute watch entirely so it does not crash on a missing kind, and
-	// reconcileHTTPRoute surfaces a clear HTTPRouteReady=False condition if
-	// the user nonetheless sets spec.gateway.
+	// gatewayAPIAvailable is set during SetupWithManager from the
+	// management cluster's RESTMapper and indicates whether the
+	// gateway.networking.k8s.io/v1 HTTPRoute CRD is installed there. Two
+	// consumers read it: the local HTTPRoute watch leg, which
+	// SetupWithManager skips when false so the controller does not crash on
+	// a missing kind, and commonmulticluster.ChildrenServeKind, which
+	// answers with it for local children while probing the target cluster's
+	// RESTMapper for remote ones. reconcileHTTPRoute takes that verdict and
+	// surfaces a clear HTTPRouteReady=False condition if the user
+	// nonetheless sets spec.gateway.
 	gatewayAPIAvailable bool
 
 	// MaxConcurrentReconciles bounds how many Horizon CRs reconcile
@@ -463,8 +467,14 @@ func (r *HorizonReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	// secretToHorizonMapper can rely on it for its MatchingFields lookup. The
 	// index goes on the LOCAL field indexer, not mgr's: with a provider
 	// configured, the multicluster manager's field indexer registers against
-	// the provider clusters, which hold no Horizon CR. Indexing the fleet is
-	// issue #839's business.
+	// the provider clusters, which hold no Horizon CR. Registration stays
+	// local by contract: the indexes are on CR kinds, which exist on the
+	// management cluster alone, and every request the watches emit is
+	// pinned to that cluster (LocalRequests / RemoteRequests,
+	// internal/common/multicluster/watch.go), so a remote event resolves to
+	// its CR through the local cache. Registering on the fleet would fail
+	// the engagement of every target cluster, because the kubeconfig
+	// provider applies its stored indexes while engaging one.
 	if err := registerSecretNameIndex(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}

--- a/operators/horizon/internal/controller/reconcile_httproute.go
+++ b/operators/horizon/internal/controller/reconcile_httproute.go
@@ -65,16 +65,16 @@ func (r *HorizonReconciler) reconcileHTTPRoute(ctx context.Context, children cli
 		desired = buildHorizonHTTPRoute(horizon)
 	}
 	return gateway.ReconcileHTTPRoute(ctx, children, r.Scheme, horizon, gateway.RouteFlowParams{
-		GatewayAPIAvailable: r.gatewayAPIAvailable,
-		GatewayConfigured:   horizon.Spec.Gateway != nil,
-		Desired:             desired,
-		RouteName:           subResourceName(horizon),
-		RouteNamespace:      horizon.Namespace,
-		ExposureNoun:        "dashboard",
-		Conditions:          &horizon.Status.Conditions,
-		Generation:          horizon.Generation,
-		ConditionType:       conditionTypeHTTPRouteReady,
-		RequeueAccepted:     requeueHTTPRouteAccepted,
+		LocalGatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:        horizon.Spec.Gateway != nil,
+		Desired:                  desired,
+		RouteName:                subResourceName(horizon),
+		RouteNamespace:           horizon.Namespace,
+		ExposureNoun:             "dashboard",
+		Conditions:               &horizon.Status.Conditions,
+		Generation:               horizon.Generation,
+		ConditionType:            conditionTypeHTTPRouteReady,
+		RequeueAccepted:          requeueHTTPRouteAccepted,
 	})
 }
 

--- a/operators/horizon/internal/controller/reconcile_httproute_test.go
+++ b/operators/horizon/internal/controller/reconcile_httproute_test.go
@@ -10,10 +10,15 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	horizonv1alpha1 "github.com/c5c3/forge/operators/horizon/api/v1alpha1"
 )
 
@@ -120,4 +125,114 @@ func TestHorizonStatusEndpoint(t *testing.T) {
 
 	h.Spec.Gateway = gatewaySpec()
 	g.Expect(horizonStatusEndpoint(h)).To(Equal("https://horizon.127-0-0-1.nip.io/"))
+}
+
+// --- Remote children: the Gateway API answer comes from the target cluster ---
+
+// hrTargetFake builds a target cluster's client like newTestReconciler builds
+// the management cluster's, behind the RESTMapper the capability probe asks.
+// servesHTTPRoute is what separates a target cluster carrying the Gateway API
+// CRDs from one without them.
+func hrTargetFake(s *runtime.Scheme, servesHTTPRoute bool, objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&horizonv1alpha1.Horizon{})
+	if servesHTTPRoute {
+		return mctestutil.TargetFake(builder, httpRouteGVK)
+	}
+	return mctestutil.TargetFake(builder)
+}
+
+// The management cluster has no Gateway API and the target cluster has, so only
+// the target's own answer can produce the route. Deciding from the latch would
+// leave a CR that names a target cluster exposed nowhere.
+func TestReconcileHTTPRoute_RemoteChildrenServeTheKindDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+	h := testHorizon()
+	h.Spec.Gateway = gatewaySpec()
+	r := newTestReconciler(s, h)
+	r.gatewayAPIAvailable = false
+	target := hrTargetFake(s, true)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), h)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-horizon"},
+		&route)).To(Succeed(), "the route belongs on the cluster the children are written to")
+}
+
+// The latch says the management cluster serves the kind, the target does not,
+// and the message has to name the cluster the operator actually looked at — an
+// operator restart refreshes the latch, not the target's CRDs.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindNameTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+	h := testHorizon()
+	h.Spec.Gateway = gatewaySpec()
+	r := newTestReconciler(s, h)
+	r.gatewayAPIAvailable = true
+
+	res, err := r.reconcileHTTPRoute(context.Background(),
+		mctestutil.RemoteChildren(t, r.Client, hrTargetFake(s, false)), h)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(h.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).NotTo(ContainSubstring("restart"),
+		"restarting the operator re-probes the management cluster, which is not the cluster at fault")
+}
+
+// A target cluster that does not serve the kind is never asked to delete it:
+// the delete would fail with "no matches for kind HTTPRoute", and the route the
+// test seeds proves the flow short-circuited before reaching it.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+	h := testHorizon()
+	// gateway is nil: the delete path, were it reached.
+	r := newTestReconciler(s, h)
+	r.gatewayAPIAvailable = true
+	seeded := &gatewayv1.HTTPRoute{}
+	seeded.Name = "test-horizon"
+	seeded.Namespace = "default"
+	target := hrTargetFake(s, false, seeded)
+
+	res, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), h)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(h.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotRequired))
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-horizon"},
+		&route)).To(Succeed(), "no delete may be attempted against a cluster that does not serve the kind")
+}
+
+// A probe that fails establishes nothing, so it is neither treated as "the
+// target serves it" nor as "it does not": the pass fails and the CR says why.
+func TestReconcileHTTPRoute_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	h := testHorizon()
+	h.Spec.Gateway = gatewaySpec()
+	r := newTestReconciler(testScheme(), h)
+	children := mctestutil.UnprobeableChildren(r.Client)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), children, h)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the HTTPRoute kind:"))
+	cond := conditions.GetCondition(h.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
 }

--- a/operators/keystone/internal/controller/dbtls_mode.go
+++ b/operators/keystone/internal/controller/dbtls_mode.go
@@ -35,6 +35,7 @@ const (
 
 	reasonCertificateIssued  = "CertificateIssued"
 	reasonCertificatePending = "CertificatePending"
+	reasonCertificateError   = "CertificateError"
 	reasonNotRequired        = "NotRequired"
 	reasonExternallyManaged  = "ExternallyManaged"
 	reasonMissingCertRefs    = "MissingCertificateRefs"

--- a/operators/keystone/internal/controller/keystone_controller.go
+++ b/operators/keystone/internal/controller/keystone_controller.go
@@ -242,12 +242,16 @@ type KeystoneReconciler struct {
 	// determined, in which case no operator-namespace peer is added.
 	OperatorNamespace string
 
-	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1
-	// HTTPRoute CRD is installed. When false, the controller skips the
-	// HTTPRoute watch entirely so it does not crash on a missing kind, and
-	// reconcileHTTPRoute surfaces a clear HTTPRouteReady=False condition if
-	// the user nonetheless sets spec.gateway.
+	// gatewayAPIAvailable is set during SetupWithManager from the
+	// management cluster's RESTMapper and indicates whether the
+	// gateway.networking.k8s.io/v1 HTTPRoute CRD is installed there. Two
+	// consumers read it: the local HTTPRoute watch leg, which
+	// setupWithOptions skips when false so the controller does not crash on
+	// a missing kind, and commonmulticluster.ChildrenServeKind, which
+	// answers with it for local children while probing the target cluster's
+	// RESTMapper for remote ones. reconcileHTTPRoute takes that verdict and
+	// surfaces a clear HTTPRouteReady=False condition if the user
+	// nonetheless sets spec.gateway.
 	gatewayAPIAvailable bool
 
 	// apiReader is set during SetupWithManager from mgr.GetAPIReader(): a
@@ -259,13 +263,17 @@ type KeystoneReconciler struct {
 	// fall back to the (read-your-writes) fake client.
 	apiReader client.Reader
 
-	// certManagerAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the cert-manager.io/v1 Certificate CRD
-	// is installed. When false, the controller skips the Certificate watch and
-	// reconcileDatabaseTLS skips the disable-path Certificate delete (no
-	// Certificate can exist), so the default no-TLS configuration never errors
-	// with "no matches for kind Certificate" on clusters without cert-manager
-	// (issue #475).
+	// certManagerAvailable is set during SetupWithManager from the
+	// management cluster's RESTMapper and indicates whether the
+	// cert-manager.io/v1 Certificate CRD is installed there. Two consumers
+	// read it: the local Certificate watch leg, which setupWithOptions
+	// skips when false, and commonmulticluster.ChildrenServeKind, which
+	// answers with it for local children while probing the target cluster's
+	// RESTMapper for remote ones. deleteManagedDBClientCertificate takes
+	// that verdict and skips the disable-path Certificate delete where no
+	// Certificate can exist, so the default no-TLS configuration never
+	// errors with "no matches for kind Certificate" on a cluster without
+	// cert-manager (issue #475).
 	certManagerAvailable bool
 
 	// MaxConcurrentReconciles bounds how many Keystone CRs reconcile
@@ -1001,8 +1009,14 @@ func (r *KeystoneReconciler) setupWithOptions(mgr mcmanager.Manager, opts crcont
 	// secretToKeystoneMapper can rely on it for its MatchingFields lookup.
 	// The indexes go on the LOCAL field indexer, not mgr's: with a provider
 	// configured, the multicluster manager's field indexer registers against
-	// the provider clusters, which hold no Keystone CR. Indexing the fleet is
-	// issue #839's business.
+	// the provider clusters, which hold no Keystone CR. Registration stays
+	// local by contract: the indexes are on CR kinds, which exist on the
+	// management cluster alone, and every request the watches emit is
+	// pinned to that cluster (LocalRequests / RemoteRequests,
+	// internal/common/multicluster/watch.go), so a remote event resolves to
+	// its CR through the local cache. Registering on the fleet would fail
+	// the engagement of every target cluster, because the kubeconfig
+	// provider applies its stored indexes while engaging one.
 	if err := registerSecretNameIndex(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}

--- a/operators/keystone/internal/controller/multicluster_integration_test.go
+++ b/operators/keystone/internal/controller/multicluster_integration_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcruntime "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
@@ -72,8 +73,9 @@ import (
 // naming an unregistered cluster, deregistration under a running CR, a
 // registration Secret the provider cannot parse, re-registration of the cluster
 // that was deregistered, the deletion of a targeted CR sweeping every child it
-// projected off the target, a child deleted on the target being put back, and a
-// rotated input Secret on the target re-rendering what was derived from it.
+// projected off the target, a child deleted on the target being put back, a
+// rotated input Secret on the target re-rendering what was derived from it, and
+// a targeted CR whose HTTPRoute the management cluster could not serve.
 func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 	testutil.SkipIfEnvTestUnavailable(t)
 
@@ -108,6 +110,12 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 		// share it: the first settles it, the second rotates an input under it.
 		driftNamespace = "mc-drift"
 		driftKeystone  = "mc-drift-keystone"
+
+		// The gateway CR, in a namespace of its own as well. It is the only CR
+		// in this test that asks for external exposure, so the HTTPRoute found
+		// in this namespace is the one it projected.
+		gatewayNamespace = "mc-gateway"
+		gatewayKeystone  = "mc-gateway-keystone"
 
 		// rotatedPassword replaces the "secret" the input fixture seeds, and is
 		// distinctive enough that finding it in the derived DSN cannot be an
@@ -196,12 +204,27 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 			// produces a watch event here, and the field indexes and the
 			// Gateway API / cert-manager RESTMapper probes come with the same
 			// call. The fake CRDs on the management environment latch both
-			// probes true. SkipNameValidation keeps the
-			// one-real-controller-name-per-test-binary constraint at the top of
-			// this file intact.
+			// probes true; the flip below then takes the gateway latch back
+			// down, so only the cert-manager one stays true. SkipNameValidation
+			// keeps the one-real-controller-name-per-test-binary constraint at
+			// the top of this file intact.
 			opts := bootstrap.TypedControllerOptions[mcreconcile.Request](1)
 			opts.SkipNameValidation = ptr.To(true)
-			return r.setupWithOptions(mcMgr, opts)
+			if err := r.setupWithOptions(mcMgr, opts); err != nil {
+				return err
+			}
+
+			// A management cluster without Gateway API, simulated. The flip
+			// happens after setup and before the manager starts, so nothing
+			// reads the field while it changes. Setup probed the real mapper
+			// first, which leaves the local Owns(HTTPRoute) leg registered; the
+			// leg is inert here because no CR that keeps its children local sets
+			// spec.gateway in this test. The flip is what makes the gateway
+			// subtest at the end of this function discriminating: with the
+			// management latch false, an HTTPRoute on the target cluster can
+			// only come from the per-cluster probe overriding it.
+			r.gatewayAPIAvailable = false
+			return nil
 		},
 	})
 
@@ -871,6 +894,96 @@ func TestIntegration_Multicluster_KeystoneTargetCluster(t *testing.T) {
 			ig.Expect(dsn).NotTo(ContainSubstring(":secret@"))
 		}, eventuallyTimeout, pollInterval).Should(Succeed(),
 			"the rotated password should reach the derived db-connection Secret with no write to the CR")
+	})
+
+	t.Run("targeted CR gets its HTTPRoute although the management latch is false", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// The inversion this subtest exists for. The management cluster's
+		// setup-time latch reports no Gateway API (RegisterController forced it
+		// false above), and this CR still gets its HTTPRoute: its children live
+		// on the target cluster, and that cluster's RESTMapper is what the route
+		// flow probes for a CR that names one. Every other CR in this file
+		// leaves spec.gateway unset, so this is the only place the latch and the
+		// probe can disagree.
+		multiclusterEnsureNamespace(t, ctx, mgmtClient, gatewayNamespace)
+		multiclusterEnsureNamespace(t, ctx, targetClient, gatewayNamespace)
+		createPrerequisites(t, ctx, targetClient, gatewayNamespace)
+
+		mariadbKey := client.ObjectKey{Namespace: gatewayNamespace, Name: "mariadb"}
+		g.Expect(targetClient.Create(ctx, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{Name: mariadbKey.Name, Namespace: mariadbKey.Namespace},
+		})).To(Succeed(), "create the MariaDB cluster CR on the target cluster")
+		g.Expect(simulators.SimulateMariaDBReady(ctx, targetClient, mariadbKey, 1)).
+			To(Succeed(), "simulate the MariaDB cluster ready")
+
+		ks := integrationManagedKeystone(gatewayKeystone, gatewayNamespace)
+		ks.Spec.TargetClusterRef = &commonv1.TargetClusterRefSpec{Name: targetClusterName}
+		// spec.bootstrap.publicEndpoint stays unset: the webhook this manager
+		// serves cross-checks it against spec.gateway.hostname whenever both are
+		// given, and the hostname alone is everything the route needs.
+		ks.Spec.Gateway = &keystonev1alpha1.GatewaySpec{
+			ParentRef: keystonev1alpha1.GatewayParentRefSpec{Name: "public-gateway"},
+			Hostname:  "keystone.example.com",
+		}
+		g.Expect(mgmtClient.Create(ctx, ks)).To(Succeed())
+
+		crKey := types.NamespacedName{Name: gatewayKeystone, Namespace: gatewayNamespace}
+		childKey := client.ObjectKey{Namespace: gatewayNamespace, Name: gatewayKeystone}
+
+		// The simulator sequence of the targeted subtests above, unchanged: each
+		// MariaDB CR gated on the previous one reporting ready, then the two
+		// Jobs the database phase waits out.
+		waitForCondition(t, ctx, mgmtClient, crKey, "SecretsReady", metav1.ConditionTrue, eventuallyTimeout)
+		waitForCondition(t, ctx, mgmtClient, crKey, "FernetKeysReady", metav1.ConditionTrue, eventuallyTimeout)
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Database{}, "MariaDB Database", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateDatabaseReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.User{}, "MariaDB User", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateUserReady(ctx, targetClient, childKey)).To(Succeed())
+
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &mariadbv1alpha1.Grant{}, "MariaDB Grant", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateGrantReady(ctx, targetClient, childKey)).To(Succeed())
+
+		dbSyncKey := client.ObjectKey{Namespace: gatewayNamespace, Name: fmt.Sprintf("%s-db-sync", gatewayKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, dbSyncKey, &batchv1.Job{}, "db-sync Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, dbSyncKey)).To(Succeed())
+
+		schemaCheckKey := client.ObjectKey{Namespace: gatewayNamespace, Name: fmt.Sprintf("%s-schema-check", gatewayKeystone)}
+		multiclusterEventuallyExists(t, ctx, targetClient, schemaCheckKey, &batchv1.Job{}, "schema-check Job", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateJobComplete(ctx, targetClient, schemaCheckKey)).To(Succeed())
+
+		waitForCondition(t, ctx, mgmtClient, crKey, "DatabaseReady", metav1.ConditionTrue, eventuallyLongTimeout)
+
+		// The route sub-reconciler runs in the parallel group behind the
+		// Deployment step, and that step short-circuits the pipeline with a
+		// requeue while the Deployment reports no ready replicas. No kubelet
+		// runs on this envtest environment, so the readiness has to be simulated
+		// before the route flow is reached at all.
+		deployment := &appsv1.Deployment{}
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, deployment, "Deployment", eventuallyLongTimeout)
+		g.Expect(simulators.SimulateDeploymentReady(ctx, targetClient, childKey, ptr.Deref(deployment.Spec.Replicas, 1))).
+			To(Succeed(), "simulate the Deployment ready on the target cluster")
+		waitForCondition(t, ctx, mgmtClient, crKey, "DeploymentReady", metav1.ConditionTrue, eventuallyTimeout)
+
+		// The route lands on the target cluster, under the bare CR name, and
+		// nowhere else.
+		multiclusterEventuallyExists(t, ctx, targetClient, childKey, &gatewayv1.HTTPRoute{}, "HTTPRoute", eventuallyLongTimeout)
+		multiclusterExpectAbsent(t, ctx, mgmtClient, childKey, &gatewayv1.HTTPRoute{}, "HTTPRoute")
+
+		// And the condition names the acceptance that never comes rather than a
+		// missing CRD: envtest serves the HTTPRoute kind on the target cluster
+		// but runs no Gateway controller to accept the route.
+		waitForCondition(t, ctx, mgmtClient, crKey, conditionTypeHTTPRouteReady, metav1.ConditionFalse, eventuallyTimeout)
+		ksAfter := &keystonev1alpha1.Keystone{}
+		g.Expect(mgmtClient.Get(ctx, crKey, ksAfter)).To(Succeed())
+		cond := meta.FindStatusCondition(ksAfter.Status.Conditions, conditionTypeHTTPRouteReady)
+		g.Expect(cond).NotTo(BeNil(), "%s should be set on a CR that requests external exposure", conditionTypeHTTPRouteReady)
+		g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotAccepted),
+			"the management latch was forced false and the target cluster's probe answered instead, "+
+				"so the route was applied and the condition must report the missing acceptance, not %s",
+			conditionReasonGatewayAPINotInstalled)
 	})
 }
 

--- a/operators/keystone/internal/controller/reconcile_databasetls.go
+++ b/operators/keystone/internal/controller/reconcile_databasetls.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/c5c3/forge/internal/common/conditions"
 	"github.com/c5c3/forge/internal/common/database"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
 	commontls "github.com/c5c3/forge/internal/common/tls"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
@@ -133,12 +134,20 @@ func (r *KeystoneReconciler) reconcileDatabaseTLS(ctx context.Context, children 
 	}
 
 	// Managed: issue the client Certificate from the shared OpenStack DB CA
-	// issuer.
+	// issuer. The apply carries its own answer to the per-cluster capability
+	// question the delete paths have to probe for — a children's cluster
+	// without cert-manager rejects it with "no matches for kind Certificate" —
+	// so the failure is surfaced rather than pre-empted. It has to reach the
+	// condition either way: the pipeline aborts here, and an aggregate Ready
+	// re-computed from the still-True sub-conditions would otherwise report the
+	// CR as converged at a generation whose TLS material was never issued
+	// (issue #467).
 	cert := dbClientCertificate(keystone)
 	ready, err := commontls.EnsureCertificate(ctx, children, r.Scheme, keystone, cert)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring database client Certificate %s/%s: %w",
-			cert.Namespace, cert.Name, err)
+		err = fmt.Errorf("ensuring database client Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
+		keystoneSkeleton.MarkFailed(keystone, conditionTypeDatabaseTLSReady, reasonCertificateError, err)
+		return ctrl.Result{}, err
 	}
 
 	if !ready {
@@ -178,12 +187,30 @@ func dbClientCertificateName(keystone *keystonev1alpha1.Keystone) string {
 
 // deleteManagedDBClientCertificate deletes the operator-issued
 // <name>-db-client Certificate when DB TLS is disabled or switched to
-// brownfield mode. It is a no-op when cert-manager is not installed: no
-// Certificate can exist in that case, and an unconditional Delete would fail
-// with "no matches for kind Certificate" — the same CRD-availability gate
-// reconcileHTTPRoute applies before deleting an HTTPRoute (issue #475).
+// brownfield mode. The delete is skipped when the cluster the children are
+// written to does not serve the Certificate kind: for local children that is
+// the setup-time cert-manager latch, for remote children a probe of the target
+// cluster's RESTMapper on every pass. No Certificate can exist on a cluster
+// without the CRD, and an unconditional Delete there would fail with "no
+// matches for kind Certificate". reconcileHTTPRoute gates its HTTPRoute delete
+// on the same per-cluster probe (issue #475).
+//
+// A probe that fails instead of answering flips DatabaseTLSReady to False under
+// CapabilityProbeFailed before the wrapped error is returned, the same surface
+// reconcileHTTPRoute gives the identical failure. The condition is what keeps
+// the aborted pass honest: every caller returns straight into updateStatus,
+// whose Ready aggregation runs regardless of the reconcile error and stamps
+// status.observedGeneration, so a still-True DatabaseTLSReady would report the
+// CR as converged at a spec that was never applied past this step (issue #467).
 func (r *KeystoneReconciler) deleteManagedDBClientCertificate(ctx context.Context, children client.Client, keystone *keystonev1alpha1.Keystone) error {
-	if !r.certManagerAvailable {
+	serves, err := commonmulticluster.ChildrenServeKind(children, r.certManagerAvailable, certificateGVK)
+	if err != nil {
+		err = fmt.Errorf("probing the target cluster for the Certificate kind: %w", err)
+		keystoneSkeleton.MarkFailed(keystone, conditionTypeDatabaseTLSReady,
+			commonmulticluster.CapabilityProbeFailed, err)
+		return err
+	}
+	if !serves {
 		return nil
 	}
 	return deleteDBClientCertificate(ctx, children, keystone.Namespace, dbClientCertificateName(keystone))

--- a/operators/keystone/internal/controller/reconcile_databasetls_test.go
+++ b/operators/keystone/internal/controller/reconcile_databasetls_test.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -22,8 +23,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
 	commonreconcile "github.com/c5c3/forge/internal/common/reconcile"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -378,4 +382,187 @@ func TestReconcileDatabaseTLS_DisabledSkipsDeleteWhenCertManagerAbsent(t *testin
 	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Reason).To(Equal(reasonNotRequired))
+}
+
+// --- Remote children: the cert-manager answer comes from the target cluster ---
+
+// dbTLSTargetFake builds a target cluster's client the way dbTLSReconciler
+// builds the management cluster's, behind the RESTMapper the capability probe
+// asks. servesCertificate is what separates a target cluster carrying the
+// cert-manager CRDs from one without them.
+func dbTLSTargetFake(s *runtime.Scheme, servesCertificate bool, objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...)
+	if servesCertificate {
+		return mctestutil.TargetFake(builder, certificateGVK)
+	}
+	return mctestutil.TargetFake(builder)
+}
+
+// dbTLSStaleCertificate is the leftover managed Certificate a CR leaves on its
+// children's cluster when it moves off the managed path.
+func dbTLSStaleCertificate() *certmanagerv1.Certificate {
+	return &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone-db-client", Namespace: "default"},
+	}
+}
+
+// The management cluster has no cert-manager and the target cluster has, so the
+// latch would skip a delete the target needs. Left undeleted, the Certificate
+// keeps being renewed on the target for a CR that no longer wants TLS.
+func TestReconcileDatabaseTLS_DisabledDeletesThroughRemoteChildrenDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone() // TLS == nil → NotRequired
+	r := dbTLSReconciler(s, ks)
+	r.certManagerAvailable = false
+	target := dbTLSTargetFake(s, true, dbTLSStaleCertificate())
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	getErr := target.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}, &certmanagerv1.Certificate{})
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"the target cluster serves the kind, so the management latch must not skip the delete")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(reasonNotRequired))
+}
+
+// The same inversion on the brownfield path: the CR keeps TLS but hands the
+// keypair to an external issuer, and the operator-owned Certificate on the
+// target must go with it.
+func TestReconcileDatabaseTLS_BrownfieldDeletesThroughRemoteChildrenDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone()
+	ks.Spec.Database.Host = "db.example.com"
+	ks.Spec.Database.Port = 3306
+	ks.Spec.Database.TLS = &commonv1.DatabaseTLSSpec{
+		Mode:                "verify-full",
+		CABundleSecretRef:   commonv1.SecretRefSpec{Name: "db-server-ca"},
+		ClientCertSecretRef: commonv1.SecretRefSpec{Name: "external-db-client"},
+	}
+	r := dbTLSReconciler(s, ks)
+	r.certManagerAvailable = false
+	target := dbTLSTargetFake(s, true, dbTLSStaleCertificate())
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	getErr := target.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}, &certmanagerv1.Certificate{})
+	g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(),
+		"the target cluster serves the kind, so the management latch must not skip the delete")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(reasonExternallyManaged))
+}
+
+// The latch says the management cluster has cert-manager, the target does not,
+// and the delete against the target would fail with "no matches for kind
+// Certificate" on every pass, leaving DatabaseTLSReady unset. The seeded
+// Certificate proves the delete was never attempted.
+func TestReconcileDatabaseTLS_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone() // TLS == nil → NotRequired
+	r := dbTLSReconciler(s, ks)
+	target := dbTLSTargetFake(s, false, dbTLSStaleCertificate())
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(target.Get(context.Background(),
+		client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"},
+		&certmanagerv1.Certificate{})).To(Succeed(),
+		"no delete may be attempted against a cluster that does not serve the kind")
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(reasonNotRequired))
+}
+
+// A probe that fails establishes nothing about the target, so the pass fails
+// rather than guessing — and says so on the CR. The pipeline aborts at this
+// step while updateStatus still re-aggregates Ready and stamps
+// observedGeneration, so a DatabaseTLSReady left at its last conclusive verdict
+// would report the CR converged at a spec nothing past this step applied.
+func TestReconcileDatabaseTLS_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSBaseKeystone() // TLS == nil → NotRequired
+	// The verdict the last conclusive pass left behind: a failed probe must not
+	// be allowed to keep it.
+	meta.SetStatusCondition(&ks.Status.Conditions, metav1.Condition{
+		Type: conditionTypeDatabaseTLSReady, Status: metav1.ConditionTrue,
+		Reason: reasonNotRequired, ObservedGeneration: ks.Generation - 1,
+	})
+	r := dbTLSReconciler(s, ks)
+
+	_, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.UnprobeableChildren(r.Client), ks)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the Certificate kind:"))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse),
+		"a failed probe must not leave the aggregate Ready re-aggregating a stale True")
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
+	g.Expect(cond.ObservedGeneration).To(Equal(ks.Generation))
+}
+
+// The managed path writes to the children's cluster too, so the Certificate has
+// to land on the target rather than on the management cluster the reconciler
+// holds a client for.
+func TestReconcileDatabaseTLS_ManagedIssuesTheCertificateOnTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSManagedKeystone("verify-full")
+	r := dbTLSReconciler(s, ks)
+	target := dbTLSTargetFake(s, true)
+
+	result, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(commonreconcile.RequeueSecretPolling))
+
+	key := client.ObjectKey{Name: "test-keystone-db-client", Namespace: "default"}
+	g.Expect(target.Get(context.Background(), key, &certmanagerv1.Certificate{})).To(Succeed(),
+		"the Certificate belongs on the cluster the children are written to")
+	g.Expect(apierrors.IsNotFound(r.Get(context.Background(), key, &certmanagerv1.Certificate{}))).To(BeTrue(),
+		"nothing may be written to the management cluster for a CR that names a target")
+}
+
+// A managed apply that fails — a children's cluster without cert-manager
+// answers "no matches for kind Certificate" — aborts the pipeline, so it has to
+// leave a verdict behind for the same reason a failed probe does.
+func TestReconcileDatabaseTLS_ManagedApplyFailureSurfacesOnTheCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := dbTLSTestScheme()
+	ks := dbTLSManagedKeystone("verify-full")
+	r := dbTLSReconciler(s, ks)
+	boom := errors.New("no matches for kind \"Certificate\" in version \"cert-manager.io/v1\"")
+	target := fake.NewClientBuilder().WithScheme(s).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+			return boom
+		},
+	}).Build()
+
+	_, err := r.reconcileDatabaseTLS(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).To(MatchError(boom))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeDatabaseTLSReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse),
+		"an unissued Certificate must not leave the aggregate Ready re-aggregating a stale True")
+	g.Expect(cond.Reason).To(Equal(reasonCertificateError))
+	g.Expect(cond.ObservedGeneration).To(Equal(ks.Generation))
 }

--- a/operators/keystone/internal/controller/reconcile_httproute.go
+++ b/operators/keystone/internal/controller/reconcile_httproute.go
@@ -98,16 +98,16 @@ func (r *KeystoneReconciler) reconcileHTTPRoute(ctx context.Context, children cl
 		desired = buildKeystoneHTTPRoute(keystone)
 	}
 	return gateway.ReconcileHTTPRoute(ctx, children, r.Scheme, keystone, gateway.RouteFlowParams{
-		GatewayAPIAvailable: r.gatewayAPIAvailable,
-		GatewayConfigured:   keystone.Spec.Gateway != nil,
-		Desired:             desired,
-		RouteName:           subResourceName(keystone),
-		RouteNamespace:      keystone.Namespace,
-		ExposureNoun:        "API",
-		Conditions:          &keystone.Status.Conditions,
-		Generation:          keystone.Generation,
-		ConditionType:       conditionTypeHTTPRouteReady,
-		RequeueAccepted:     requeueHTTPRouteAccepted,
+		LocalGatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:        keystone.Spec.Gateway != nil,
+		Desired:                  desired,
+		RouteName:                subResourceName(keystone),
+		RouteNamespace:           keystone.Namespace,
+		ExposureNoun:             "API",
+		Conditions:               &keystone.Status.Conditions,
+		Generation:               keystone.Generation,
+		ConditionType:            conditionTypeHTTPRouteReady,
+		RequeueAccepted:          requeueHTTPRouteAccepted,
 	})
 }
 

--- a/operators/keystone/internal/controller/reconcile_httproute_test.go
+++ b/operators/keystone/internal/controller/reconcile_httproute_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	commonv1 "github.com/c5c3/forge/internal/common/types"
 	keystonev1alpha1 "github.com/c5c3/forge/operators/keystone/api/v1alpha1"
 )
@@ -847,4 +849,118 @@ func TestInternalAPIURL_UsesBareCRName(t *testing.T) {
 		"internalAPIURL must use the bare CR name")
 	g.Expect(url).NotTo(ContainSubstring(ks.Name+"-api."),
 		"internalAPIURL must not embed the legacy `-api` suffix in the host segment")
+}
+
+// --- Remote children: the Gateway API answer comes from the target cluster ---
+
+// hrTargetFake builds a target cluster's client exactly as newHRTestReconciler
+// builds the management cluster's, behind the RESTMapper the capability probe
+// asks. servesHTTPRoute is what separates a target cluster carrying the Gateway
+// API CRDs from one without them.
+func hrTargetFake(s *runtime.Scheme, servesHTTPRoute bool, objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&keystonev1alpha1.Keystone{}, &gatewayv1.HTTPRoute{}).
+		WithTypeConverters(managedfields.NewDeducedTypeConverter())
+	if servesHTTPRoute {
+		return mctestutil.TargetFake(builder, httpRouteGVK)
+	}
+	return mctestutil.TargetFake(builder)
+}
+
+// The management cluster has no Gateway API and the target cluster has, so only
+// the target's own answer can produce the route. Deciding from the latch would
+// leave a CR that names a target cluster exposed nowhere.
+func TestReconcileHTTPRoute_RemoteChildrenServeTheKindDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := hrTestScheme()
+	ks := hrTestKeystone()
+	ks.Spec.Gateway = hrTestGateway()
+	r := newHRTestReconciler(s, ks)
+	r.gatewayAPIAvailable = false
+	target := hrTargetFake(s, true)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{
+		Name: "test-keystone", Namespace: "default",
+	}, &route)).To(Succeed(), "the route belongs on the cluster the children are written to")
+}
+
+// The latch says the management cluster serves the kind, the target does not,
+// and the message has to name the cluster the operator actually looked at — an
+// operator restart refreshes the latch, not the target's CRDs.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindNameTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := hrTestScheme()
+	ks := hrTestKeystone()
+	ks.Spec.Gateway = hrTestGateway()
+	r := newHRTestReconciler(s, ks)
+	r.gatewayAPIAvailable = true
+
+	result, err := r.reconcileHTTPRoute(context.Background(),
+		mctestutil.RemoteChildren(t, r.Client, hrTargetFake(s, false)), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).NotTo(ContainSubstring("restart"),
+		"restarting the operator re-probes the management cluster, which is not the cluster at fault")
+}
+
+// A target cluster that does not serve the kind is never asked to delete it:
+// the delete would fail with "no matches for kind HTTPRoute", and the route the
+// test seeds proves the flow short-circuited before reaching it.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := hrTestScheme()
+	ks := hrTestKeystone()
+	// gateway is nil: the delete path, were it reached.
+	r := newHRTestReconciler(s, ks)
+	r.gatewayAPIAvailable = true
+	seeded := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-keystone", Namespace: "default"},
+	}
+	target := hrTargetFake(s, false, seeded)
+
+	result, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), ks)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotRequired))
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), types.NamespacedName{
+		Name: "test-keystone", Namespace: "default",
+	}, &route)).To(Succeed(), "no delete may be attempted against a cluster that does not serve the kind")
+}
+
+// A probe that fails establishes nothing, so it is neither treated as "the
+// target serves it" nor as "it does not": the pass fails and the CR says why.
+func TestReconcileHTTPRoute_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := hrTestScheme()
+	ks := hrTestKeystone()
+	ks.Spec.Gateway = hrTestGateway()
+	r := newHRTestReconciler(s, ks)
+	children := mctestutil.UnprobeableChildren(r.Client)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), children, ks)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the HTTPRoute kind:"))
+
+	cond := meta.FindStatusCondition(ks.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
 }

--- a/operators/placement/internal/controller/placement_controller.go
+++ b/operators/placement/internal/controller/placement_controller.go
@@ -184,10 +184,13 @@ type PlacementReconciler struct {
 	// (read-your-writes) fake client.
 	apiReader client.Reader
 
-	// gatewayAPIAvailable is set during SetupWithManager from the cluster's
-	// RESTMapper and indicates whether the gateway.networking.k8s.io/v1 HTTPRoute
-	// CRD is installed. When false, the controller skips the HTTPRoute watch
-	// entirely so it does not crash on a missing kind.
+	// gatewayAPIAvailable is set during SetupWithManager from the management
+	// cluster's RESTMapper and indicates whether the
+	// gateway.networking.k8s.io/v1 HTTPRoute CRD is installed there. Two
+	// consumers read it: the local HTTPRoute watch leg, which SetupWithManager
+	// skips when false so the controller does not crash on a missing kind, and
+	// commonmulticluster.ChildrenServeKind, which answers with it for local
+	// children while probing the target cluster's RESTMapper for remote ones.
 	gatewayAPIAvailable bool
 
 	// healthProbeCache memoizes the last successful Placement API probe per CR
@@ -567,8 +570,14 @@ func (r *PlacementReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	// secretToPlacementMapper can rely on it for its MatchingFields lookup. The
 	// index goes on the LOCAL field indexer, not mgr's: with a provider
 	// configured, the multicluster manager's field indexer registers against the
-	// provider clusters, which hold no Placement CR. Indexing the fleet is issue
-	// #839's business.
+	// provider clusters, which hold no Placement CR. Registration stays local
+	// by contract: the indexes are on CR kinds, which exist on the management
+	// cluster alone, and every request the watches emit is pinned to that
+	// cluster (LocalRequests / RemoteRequests,
+	// internal/common/multicluster/watch.go), so a remote event resolves to its
+	// CR through the local cache. Registering on the fleet would fail the
+	// engagement of every target cluster, because the kubeconfig provider
+	// applies its stored indexes while engaging one.
 	if err := registerPlacementIndexes(context.Background(), local.GetFieldIndexer()); err != nil {
 		return err
 	}

--- a/operators/placement/internal/controller/reconcile_httproute.go
+++ b/operators/placement/internal/controller/reconcile_httproute.go
@@ -63,16 +63,16 @@ func (r *PlacementReconciler) reconcileHTTPRoute(ctx context.Context, children c
 		desired = buildPlacementHTTPRoute(placement)
 	}
 	return gateway.ReconcileHTTPRoute(ctx, children, r.Scheme, placement, gateway.RouteFlowParams{
-		GatewayAPIAvailable: r.gatewayAPIAvailable,
-		GatewayConfigured:   placement.Spec.Gateway != nil,
-		Desired:             desired,
-		RouteName:           subResourceName(placement),
-		RouteNamespace:      placement.Namespace,
-		ExposureNoun:        "Placement API",
-		Conditions:          &placement.Status.Conditions,
-		Generation:          placement.Generation,
-		ConditionType:       conditionTypeHTTPRouteReady,
-		RequeueAccepted:     requeueHTTPRouteAccepted,
+		LocalGatewayAPIAvailable: r.gatewayAPIAvailable,
+		GatewayConfigured:        placement.Spec.Gateway != nil,
+		Desired:                  desired,
+		RouteName:                subResourceName(placement),
+		RouteNamespace:           placement.Namespace,
+		ExposureNoun:             "Placement API",
+		Conditions:               &placement.Status.Conditions,
+		Generation:               placement.Generation,
+		ConditionType:            conditionTypeHTTPRouteReady,
+		RequeueAccepted:          requeueHTTPRouteAccepted,
 	})
 }
 

--- a/operators/placement/internal/controller/reconcile_httproute_test.go
+++ b/operators/placement/internal/controller/reconcile_httproute_test.go
@@ -10,9 +10,12 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/c5c3/forge/internal/common/conditions"
+	commonmulticluster "github.com/c5c3/forge/internal/common/multicluster"
+	mctestutil "github.com/c5c3/forge/internal/common/testutil/multicluster"
 	placementv1alpha1 "github.com/c5c3/forge/operators/placement/api/v1alpha1"
 )
 
@@ -112,4 +115,107 @@ func TestPlacementStatusEndpoint(t *testing.T) {
 
 	placement.Spec.Gateway = placementGatewaySpec()
 	g.Expect(placementStatusEndpoint(placement)).To(Equal("https://placement.127-0-0-1.nip.io/"))
+}
+
+// --- Remote children: the Gateway API answer comes from the target cluster ---
+
+// hrTargetFake builds a target cluster's client like placementFakeClientBuilder
+// builds the management cluster's, behind the RESTMapper the capability probe
+// asks. servesHTTPRoute is what separates a target cluster carrying the Gateway
+// API CRDs from one without them.
+func hrTargetFake(servesHTTPRoute bool, objs ...client.Object) client.Client {
+	if servesHTTPRoute {
+		return mctestutil.TargetFake(placementFakeClientBuilder(objs...), httpRouteGVK)
+	}
+	return mctestutil.TargetFake(placementFakeClientBuilder(objs...))
+}
+
+// The management cluster has no Gateway API and the target cluster has, so only
+// the target's own answer can produce the route. Deciding from the latch would
+// leave a CR that names a target cluster exposed nowhere.
+func TestReconcileHTTPRoute_RemoteChildrenServeTheKindDespiteTheLatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	placement.Spec.Gateway = placementGatewaySpec()
+	r := newPlacementTestReconciler(placement)
+	r.gatewayAPIAvailable = false
+	target := hrTargetFake(true)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), placement)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), placementRequest.NamespacedName, &route)).To(Succeed(),
+		"the route belongs on the cluster the children are written to")
+}
+
+// The latch says the management cluster serves the kind, the target does not,
+// and the message has to name the cluster the operator actually looked at — an
+// operator restart refreshes the latch, not the target's CRDs.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindNameTheTargetCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	placement.Spec.Gateway = placementGatewaySpec()
+	r := newPlacementTestReconciler(placement)
+	r.gatewayAPIAvailable = true
+
+	res, err := r.reconcileHTTPRoute(context.Background(),
+		mctestutil.RemoteChildren(t, r.Client, hrTargetFake(false)), placement)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(placement.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(conditionReasonGatewayAPINotInstalled))
+	g.Expect(cond.Message).To(ContainSubstring("target cluster does not serve"))
+	g.Expect(cond.Message).NotTo(ContainSubstring("restart"),
+		"restarting the operator re-probes the management cluster, which is not the cluster at fault")
+}
+
+// A target cluster that does not serve the kind is never asked to delete it:
+// the delete would fail with "no matches for kind HTTPRoute", and the route the
+// test seeds proves the flow short-circuited before reaching it.
+func TestReconcileHTTPRoute_RemoteChildrenWithoutTheKindSkipTheDelete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	// gateway is nil: the delete path, were it reached.
+	r := newPlacementTestReconciler(placement)
+	r.gatewayAPIAvailable = true
+	seeded := &gatewayv1.HTTPRoute{}
+	seeded.Name = "test-placement"
+	seeded.Namespace = "default"
+	target := hrTargetFake(false, seeded)
+
+	res, err := r.reconcileHTTPRoute(context.Background(), mctestutil.RemoteChildren(t, r.Client, target), placement)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.IsZero()).To(BeTrue())
+	cond := conditions.GetCondition(placement.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(conditionReasonHTTPRouteNotRequired))
+
+	var route gatewayv1.HTTPRoute
+	g.Expect(target.Get(context.Background(), placementRequest.NamespacedName, &route)).To(Succeed(),
+		"no delete may be attempted against a cluster that does not serve the kind")
+}
+
+// A probe that fails establishes nothing, so it is neither treated as "the
+// target serves it" nor as "it does not": the pass fails and the CR says why.
+func TestReconcileHTTPRoute_RemoteProbeFailureSurfacesCapabilityProbeFailed(t *testing.T) {
+	g := NewGomegaWithT(t)
+	placement := testPlacement()
+	placement.Spec.Gateway = placementGatewaySpec()
+	r := newPlacementTestReconciler(placement)
+	children := mctestutil.UnprobeableChildren(r.Client)
+
+	_, err := r.reconcileHTTPRoute(context.Background(), children, placement)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("probing the target cluster for the HTTPRoute kind:"))
+	cond := conditions.GetCondition(placement.Status.Conditions, conditionTypeHTTPRouteReady)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(commonmulticluster.CapabilityProbeFailed))
 }


### PR DESCRIPTION
Closes #839

Capability probing was the last wrong-cluster latch from the D6 per-cluster-state inventory: `SetupWithManager` probes the management cluster's `RESTMapper` once for Gateway API (all five service operators) and for cert-manager (keystone only), and the reconcile flows consumed those latches for every CR, whatever cluster its children land on. On the optional legs — routes and certificates — that inverts the intended behavior, because a hardened target cluster is exactly what is likely to carry those CRDs while a slim management cluster does not.

The contract this branch lands: a CR without `spec.targetClusterRef` keeps answering from the setup-time latch, byte-identically to today, restart semantics included; a CR that names a target cluster is probed against that cluster's `RESTMapper` on every pass, with nothing memoized, so a CRD installed on the target heals the CR on the next reconcile.

## The change set, in commit order

**`fd0f76e6` feat(multicluster): add the per-cluster capability probe helper**

New `internal/common/multicluster/capability.go`. `ChildrenServeKind(children, localAvailable, gvk)` answers whether the cluster a CR's children are written to serves a kind: an unmarked (local) client returns `localAvailable` without touching any `RESTMapper`, a remote one is probed live. A `meta.IsNoMatchError` answer is the negative verdict; every other discovery error comes back unmodified for the caller to wrap once, under the shared `CapabilityProbeFailed` condition reason declared in the same file.

**`4b2e44d0` feat(gateway): split the path 0 message by children's cluster**

Path 0 of the shared HTTPRoute flow told every operator the CRD is "not installed in this cluster" and to "restart the operator". Both halves are wrong for a remote target: the cluster missing the CRD is the target, and the remote answer comes from a per-pass probe, so installing the CRD takes effect without a restart. The remote variant names the target cluster and asks for a kubeconfig-Secret rotation, which is what restores the HTTPRoute drift watch. The reason stays `GatewayAPINotInstalled` in both variants; a local client keeps the byte-identical message.

**`fe1559a1` feat(multicluster): probe the target cluster in the HTTPRoute flows**

The shared flow now calls `ChildrenServeKind` on every pass, of the children client it is already handed. A probe that fails establishes nothing, so it is not read as a verdict either way: the route condition goes `False` under `CapabilityProbeFailed` and the pass fails with a wrapped error. `RouteFlowParams.GatewayAPIAvailable` is renamed `LocalGatewayAPIAvailable` to name the cluster the caller's latch describes; all five operators keep passing `r.gatewayAPIAvailable` and nothing else.

**`23b2b260` feat(keystone): probe the target before the DB-TLS Certificate delete**

`deleteManagedDBClientCertificate` was gated on `r.certManagerAvailable`, which inverted both ways: cert-manager on the management cluster and none on the target made the delete fail with a no-match error on every pass, so `DatabaseTLSReady` never reached True/NotRequired; cert-manager only on the target left the managed `<name>-db-client` Certificate being renewed there for a CR that no longer wants it. The gate is now the per-cluster probe, with the same `CapabilityProbeFailed` surface on failure.

**`822a6d97` docs: settle the local-only index contract and latch comments**

Comments only, no executable line changes. The five deferring field-index comments become the settled contract — the indexes are on CR kinds, which exist on the management cluster alone; remote events resolve to their CRs through the local cache; and fleet registration would fail the engagement of every target cluster, since the kubeconfig provider applies its stored indexes while engaging one. The `gatewayAPIAvailable` / `certManagerAvailable` comments now name the management cluster and their two remaining consumers.

**`5e99df25` test(keystone): prove the gateway inversion on the dual envtest**

The dual-envtest suite forces `r.gatewayAPIAvailable` false right after `setupWithOptions` returns and before the manager starts (race-free; the local `Owns(HTTPRoute)` leg stays registered and is inert here). The appended subtest creates a targeted CR with `spec.gateway` and shows the HTTPRoute still materializing on the target cluster, with `HTTPRouteReady` settling at False/`HTTPRouteNotAccepted` rather than `GatewayAPINotInstalled`. Without the per-cluster probe, no route would be applied at all.

**`95dc70cf` docs: document per-cluster capability probing in the references**

`target-clusters.md` loses the interim-constraint bullet and gains a "Per-cluster capabilities" section: per-pass remote probing, watch legs fixed at engagement with kubeconfig-Secret rotation as the refresh, unchanged local restart semantics, and the local-only index contract. `CapabilityProbeFailed` is added to the HTTPRouteReady reason tables of all five service operators, and the keystone restart notes are scoped to CRs without a target cluster.

## Divergences from the issue

Five, all deliberate; four are simplifications that reduce the surface the issue sketched.

1. **The probe lives in the shared flow, not in five copies.** Boundary 2 put the `ChildrenServeKind` call, the `CapabilityProbeFailed` condition write, and the error wrap into each operator's `reconcile_httproute.go`. All five would have been identical, and the flow already holds the children client, so the call sits in `gateway.ReconcileHTTPRoute` once. Each caller's diff is the `LocalGatewayAPIAvailable` rename alone.
2. **No `RouteFlowParams.RemoteChildren` field.** Boundary 3 had all five callers pass remoteness in for the message split. `multicluster.IsRemote(c)`, asked of the client the flow already has, is the same fact without a field or five call-site edits.
3. **A remote client with a nil `RESTMapper()` returns an error, not `(false, nil)`.** The issue mirrored `ClusterServesKind` here. But callers act on `false` by skipping a delete, and that inference only holds for a cluster that was asked and answered no — answering false for one that could not be asked would leave an operator-owned child running on the target after the CR stopped claiming it. `ClusterServesKind` collapses the case because its filter signature carries no error; here the error is reportable, so it is reported. Documented at the helper.
4. **The DB-TLS probe error writes a condition.** Boundary 4 said to return the wrapped error "without writing a condition". `updateStatus` re-aggregates `Ready` and stamps `status.observedGeneration` regardless of the reconcile error, so a `DatabaseTLSReady` left at its last conclusive verdict would report the CR converged at a spec that nothing past this step applied. The condition goes False under `CapabilityProbeFailed`, matching the surface `reconcileHTTPRoute` gives the identical failure. The same reasoning pulled in one adjacent fix in `23b2b260`: a failing apply on the managed create path now reaches the condition too, under `CertificateError`. That path is otherwise unchanged, as the issue required.
5. **Shared test fixtures instead of a per-file stub copy.** Boundary 8 prescribed a file-local copy of the `fakeResolver`/`fakeCluster` stub per test file. Six copies of a client-resolution fixture drift the moment the resolution changes, so the fixtures are in `internal/common/testutil/multicluster/children.go`. `internal/common/multicluster` keeps testing itself with its own fixtures, since importing that package back would be a cycle.

## Verification

- Every pre-existing latch-driven unit test is green without edits, which is the local-path no-change claim.
- New remote-branch unit tests in all five `reconcile_httproute_test.go` files cover apply / `GatewayAPINotInstalled` / `HTTPRouteNotRequired` / `CapabilityProbeFailed`; `reconcile_databasetls_test.go` covers the remote delete, the skip, and the probe error; `capability_test.go` covers the helper's answer paths; `flow_test.go` asserts both path 0 message variants.
- `grep -rn "839" --include="*.go" operators/ internal/` returns no hits, and all six index registration sites still call `local.GetFieldIndexer()` unchanged.
- No CRD or API schema changes, no `hack/`, CI, or chainsaw e2e changes. The new envtest coverage sits behind the existing `integration` build tag.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789321591&installation_model_id=18560&pr_number=850&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F850&signature=f5894d55457ea27f917fca20a1fa85efb36c35d2570d5cb10e7d3a2e92944305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->