### PR TITLE
chore(deps): update Go toolchain to 1.26.6

### DIFF
--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -110,7 +110,7 @@ to individual `go.mod` files.
 ### Worked example: 1.25.10 → 1.26.3
 
 An illustrative past minor upgrade (the workspace has since moved on — at the time of
-writing all four files are on `go 1.26.5`). Substitute the current and target versions
+writing all four files are on `go 1.26.6`). Substitute the current and target versions
 for your own bump; the mechanics below are unchanged.
 
 ```bash

--- a/docs/reference/ci-cd/ci-workflow.md
+++ b/docs/reference/ci-cd/ci-workflow.md
@@ -1354,7 +1354,7 @@ All Go-based jobs use `actions/setup-go@v6` with:
 go-version-file: go.work
 ```
 
-This reads the Go version from `go.work` (currently Go 1.26.5) rather than hardcoding a
+This reads the Go version from `go.work` (currently Go 1.26.6) rather than hardcoding a
 `go-version` value. The repository root contains `go.work` (not `go.mod`) because the
 project uses a Go Workspace with multiple modules (`internal/common`, `operators/keystone`,
 `operators/c5c3`). Module dependency caching is enabled by default in `actions/setup-go@v6`.

--- a/go.work
+++ b/go.work
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-go 1.26.5
+go 1.26.6
 
 use (
 	./internal/common

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/internal/common
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2

--- a/operators/Dockerfile
+++ b/operators/Dockerfile
@@ -8,7 +8,7 @@
 # only the module-manifest COPY lines below grow by one.
 
 # ---------- Stage 1: builder ----------
-FROM golang:1.26@sha256:5822931cf78fe98a97edcf73a0c54c29fa2386b99c8136468e274ae9fab8cfba AS builder
+FROM golang:1.26@sha256:26326682769ca980f8f1d3b1f52be2dd1c1d25270e3de3fe0c97d6bb65df3556 AS builder
 
 # ARG does not survive FROM; re-declare it in each stage that uses it.
 ARG OPERATOR

--- a/operators/barbican/go.mod
+++ b/operators/barbican/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/barbican
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0

--- a/operators/c5c3/go.mod
+++ b/operators/c5c3/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/c5c3
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0

--- a/operators/glance/go.mod
+++ b/operators/glance/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/glance
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0

--- a/operators/horizon/go.mod
+++ b/operators/horizon/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/horizon
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0

--- a/operators/keystone/go.mod
+++ b/operators/keystone/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/keystone
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0

--- a/operators/placement/go.mod
+++ b/operators/placement/go.mod
@@ -1,6 +1,6 @@
 module github.com/c5c3/forge/operators/placement
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/c5c3/forge/internal/common v0.0.0


### PR DESCRIPTION
## Summary

Bump the workspace Go toolchain from **1.26.5 → 1.26.6**. The Go vulnerability
database published six standard-library advisories on 2026-08-13 21:43 UTC and
amended a seventh with a stdlib range in the same batch. All seven are fixed in
Go 1.26.6 and all seven are reachable from every workspace module, so
`make govulncheck` fails on each of them:

| Advisory | CVE | Package |
| --- | --- | --- |
| GO-2026-5026 | CVE-2026-39821 | `golang.org/x/net/idna` (stdlib vendored copy) |
| GO-2026-5972 | CVE-2026-33818 | `encoding/asn1` |
| GO-2026-6088 | CVE-2026-56859 | stdlib |
| GO-2026-6089 | CVE-2026-56853 | `net/http` |
| GO-2026-6090 | CVE-2026-56862 | `crypto/tls` |
| GO-2026-6091 | CVE-2026-56858 | `html/template` |
| GO-2026-6218 | CVE-2026-56860 | `net/url` |

The failure is repository-wide, not specific to any branch. It went unnoticed on
`main` because the `govulncheck` job is path-filtered and was skipped on every
`main` run since the advisories landed.

Changes, following `docs/contributing/dependency-management.md`:

- `go.work` plus the seven per-module `go.mod` directives (`internal/common`,
  `keystone`, `c5c3`, `horizon`, `glance`, `placement`, `barbican`)
- Advanced the shared operator `Dockerfile` builder pin `golang:1.26@sha256:…`
  to `26326682…`, which carries go1.26.6. The previous digest `5822931c…` still
  shipped go1.26.5, so leaving it would lag the `go.mod` directive and force a
  toolchain download during the image build.
- Updated the two documentation references that quote the current version

CI needs no change: every `actions/setup-go` step reads the version via
`go-version-file: go.work`.

### Why `go work sync` is not in this diff

The procedure doc and the previous bump both ran `go work sync`. On this tree it
does more than refresh: it raises `Masterminds/semver` 3.4.0 → 3.5.0 and
`fsnotify` 1.9.0 → 1.10.1 and rewrites seven `go.sum` files. Running it on an
unmodified `main` under go1.26.5 produces the same diff, so the drift predates
this bump and is not a consequence of it. Pulling unrelated dependency upgrades
into a security bump would widen the review surface for no benefit. The drift is
worth its own change.

## Verification

Run locally with **go1.26.6** across all seven modules:

- `make govulncheck` — clean; only the allowlisted `GO-2026-5377` remains, down
  from seven reachable findings per module
- `go build ./...` and `go vet ./...` in every module — OK
- `make test-common` — all suites pass
- `make test-operator OPERATOR=keystone` — all suites pass
- `gofumpt -l` at the pinned `v0.11.0` — no unformatted files
- Builder digest cross-checked: `docker run golang@sha256:26326682… go version`
  → `go1.26.6`

## Test plan

- [x] `make govulncheck` passes on all seven modules
- [x] Build, vet and unit tests pass on go1.26.6
- [ ] CI green, including the image-build job on the go1.26.6 builder digest

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/C5C3/codesmith/forge/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789322881&installation_model_id=18560&pr_number=851&repository=C5C3%2Fforge&return_to=https%3A%2F%2Fgithub.com%2FC5C3%2Fforge%2Fpull%2F851&signature=bbdd1179f22cde60c4171bd996b5ccd5d1d1a12233233fe14c898013a9ff4866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->